### PR TITLE
test(html-parser): lock foreign cross-axis evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_foreign_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_foreign_audit_test.rs
@@ -5,7 +5,159 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
 const WHATWG_FOREIGN_AUDIT: &str = include_str!("fixtures/whatwg-foreign-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
+const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
+    include_str!("fixtures/whatwg-fragment-context-audit.json");
+const WHATWG_LEGACY_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-legacy-element-audit.json");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+struct ForeignCrossAxisCase {
+    id: &'static str,
+    foreign_axis: &'static str,
+    data_snippet: &'static str,
+    fragment_context: Option<&'static str>,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
+const SVG_BOUNDARY_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-foreign-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "interactive-formatting",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    (
+        "legacy-element",
+        WHATWG_LEGACY_ELEMENT_AUDIT,
+        "main-element-boundary",
+    ),
+];
+const MATHML_BOUNDARY_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-foreign-boundary",
+    ),
+    ("formatting", WHATWG_FORMATTING_AUDIT, "heading-boundary"),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-heading-boundary",
+    ),
+];
+const HTML_INTEGRATION_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "select-option",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "adoption-agency-formatting",
+    ),
+    ("select-list", WHATWG_SELECT_LIST_AUDIT, "select-in-table"),
+    ("table", WHATWG_TABLE_AUDIT, "select-in-table"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "table-insertion",
+    ),
+];
+const TABLE_FOREIGN_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "form-control",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "row-group-boundary"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "adoption-agency",
+    ),
+    ("void-element", WHATWG_VOID_ELEMENT_AUDIT, "void-in-table"),
+];
+const FOREIGN_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-fragment-context",
+    ),
+    (
+        "fragment-context",
+        WHATWG_FRAGMENT_CONTEXT_AUDIT,
+        "fragment-foreign-context",
+    ),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "foreign-fragment",
+    ),
+];
+const FOREIGN_CROSS_AXIS_CASES: &[ForeignCrossAxisCase] = &[
+    ForeignCrossAxisCase {
+        id: "main-element-dat-305",
+        foreign_axis: "svg-boundary",
+        data_snippet: "<!DOCTYPE html>xxx<svg><x><g><a><main><b>",
+        fragment_context: None,
+        suites: SVG_BOUNDARY_CROSS_AXIS_SUITES,
+    },
+    ForeignCrossAxisCase {
+        id: "tests19-dat-1044",
+        foreign_axis: "mathml-boundary",
+        data_snippet: "<!doctype html><p><math><mi><p><h1>",
+        fragment_context: None,
+        suites: MATHML_BOUNDARY_CROSS_AXIS_SUITES,
+    },
+    ForeignCrossAxisCase {
+        id: "tables01-dat-453",
+        foreign_axis: "html-integration-point",
+        data_snippet: "<div><table><svg><foreignObject><select><table><s>",
+        fragment_context: None,
+        suites: HTML_INTEGRATION_CROSS_AXIS_SUITES,
+    },
+    ForeignCrossAxisCase {
+        id: "adoption01-dat-13",
+        foreign_axis: "table-foreign-boundary",
+        data_snippet: "<a><svg><tr><input></a>",
+        fragment_context: None,
+        suites: TABLE_FOREIGN_CROSS_AXIS_SUITES,
+    },
+    ForeignCrossAxisCase {
+        id: "foreign-fragment-dat-21",
+        foreign_axis: "foreign-fragment",
+        data_snippet: "<div></div>",
+        fragment_context: Some("math ms"),
+        suites: FOREIGN_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+];
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("domjs-unsafe-dat-121", "svg-boundary"),
     ("html5test-com-dat-294", "mathml-boundary"),
@@ -26,6 +178,19 @@ struct ForeignAuditSuite {
 
 #[derive(Debug, Deserialize)]
 struct ForeignAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -73,6 +238,85 @@ fn whatwg_foreign_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_foreign_audit_keeps_foreign_axis_cases_cross_axis() {
+    let suite = load_suite();
+    let foreign_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in FOREIGN_CROSS_AXIS_CASES {
+        let foreign_case = foreign_cases
+            .get(evidence.id)
+            .unwrap_or_else(|| panic!("foreign audit should include `{}`", evidence.id));
+        assert_eq!(
+            foreign_case.axis, evidence.foreign_axis,
+            "foreign row `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !foreign_case.reason.is_empty(),
+            "foreign row `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.source, foreign_case.source,
+                "`{suite_name}` should point foreign row `{}` at the same html5lib row as the foreign audit",
+                evidence.id
+            );
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep foreign row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for foreign row `{}`",
+                evidence.id
+            );
+        }
+
+        let source_case = smoke_cases
+            .get(&foreign_case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "foreign row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        if let Some(fragment_context) = evidence.fragment_context {
+            assert_eq!(
+                source_case.fragment_context.as_deref(),
+                Some(fragment_context),
+                "foreign row `{}` should keep its html5lib fragment context",
+                evidence.id
+            );
+        }
+
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                foreign_case.id, foreign_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis foreign evidence case `{}` ({}) failed for input {:?}",
+            foreign_case.id, foreign_case.axis, source_case.data
         );
     }
 }
@@ -127,4 +371,18 @@ fn assert_axis_count(suite: &ForeignAuditSuite, axis: &str, minimum: usize) {
         count >= minimum,
         "expected at least {minimum} `{axis}` cases, found {count}"
     );
+}
+
+fn generic_audit_case<'a>(
+    raw_fixture: &'a str,
+    suite_name: &str,
+    case_id: &str,
+) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(raw_fixture)
+        .unwrap_or_else(|error| panic!("{suite_name} audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("{suite_name} audit should include `{case_id}`"))
 }


### PR DESCRIPTION
## Summary
- add a cross-axis guard for the WHATWG foreign-content audit
- lock representative SVG, MathML, HTML integration-point, table/foreign-boundary, and foreign-fragment rows against sibling audit fixtures
- keep each row tied to html5lib smoke input/context and parser DOM output

## Tests
- cargo test -p coding-adventures-html-parser whatwg_foreign_audit_keeps_foreign_axis_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_foreign_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check