### PR TITLE
feat(closurec): CLOC12.162 SpreadElement (`...arg`) atomic node PR1

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.26.0] - 2026-07-03
+
+### Added — CLOC12.162: emit `SpreadElement` (`...arg`)
+
+New `emit_spread` prints `...` immediately followed by the argument at
+`PREC_ASSIGNMENT` (no interior space). The argument grammar is an
+`AssignmentExpression`, so everything at or above assignment strength prints
+bare (`...a`, `...a.b`, `...f()`, `...a?b:c`, `...a=b`) while a looser
+**sequence** argument is wrapped — `...(a,b)` — because a bare `...a,b` would
+spread only `a` and leave `,b` as a second list slot (a miscompile). The node
+tags at `PREC_ASSIGNMENT`, matching the assignment-position list slots it lives
+in (`f(...a)`, `[...a]`), so it is never spuriously parenthesised there. 6 new
+unit tests (sole/interleaved call arg, array element, `new` arg, sequence-arg
+wrap, conditional-arg bare). This is CLOC12.162 PR1 (the atomic node); the emit
+is exercised by hand-built AST, and the bridge-enable is PR2.
+
+
 ## [0.25.1] - 2026-07-03
 
 ### Added — CLOC12.161 PR3: CodePrinter tagged-template conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.25.1"
+version = "0.26.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -78,7 +78,7 @@ use coding_adventures_javascript_ast::{
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
-    TaggedTemplateExpression,
+    TaggedTemplateExpression, SpreadElement,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1136,6 +1136,7 @@ impl<'a> Emitter<'a> {
             Expression::ArrowFunctionExpression(a) => self.emit_arrow_function_expression(a),
             Expression::TemplateLiteral(t) => self.emit_template_literal(t),
             Expression::TaggedTemplateExpression(t) => self.emit_tagged_template(t),
+            Expression::SpreadElement(s) => self.emit_spread(s),
         }
         if needs_parens {
             self.write_str(")");
@@ -1541,6 +1542,22 @@ impl<'a> Emitter<'a> {
             }
             self.emit_expression_inner(e, PREC_ASSIGNMENT);
         }
+    }
+
+    /// Emit a `SpreadElement` — the `...arg` unpack prefix.
+    ///
+    /// The three literal `.` characters print with no interior space, then the
+    /// argument follows at `PREC_ASSIGNMENT`. That precedence is the crux: the
+    /// argument grammar is an `AssignmentExpression`, so everything at or above
+    /// assignment strength prints bare (`...a`, `...a.b`, `...f()`, `...a?b:c`,
+    /// `...a=b`), while the one looser form — a **sequence** — is wrapped:
+    /// `...(a,b)`. A bare `...a,b` would parse as *two* list slots (spread `a`,
+    /// then plain `b`), a miscompile, so the parens are mandatory. There is no
+    /// space between `...` and the argument (`...a`, never `... a`).
+    fn emit_spread(&mut self, s: &SpreadElement) {
+        self.maybe_map(&s.cv);
+        self.write_str("...");
+        self.emit_expression_inner(&s.argument, PREC_ASSIGNMENT);
     }
 
     fn emit_member(&mut self, m: &MemberExpression) {
@@ -1966,6 +1983,14 @@ fn expr_prec(e: &Expression) -> u8 {
         // left-associative like a call and can be a member/call base
         // (`` a`x`.length ``, `` a`x`() ``), so it tags at `PREC_PRIMARY`.
         Expression::TaggedTemplateExpression(_) => PREC_PRIMARY,
+        // A spread `...arg` is not a free-standing operand — it only appears in
+        // the assignment-position argument/element lists (`f(...a)`, `[...a]`),
+        // which `emit_call` / `emit_new` / `emit_array` all print at
+        // `PREC_ASSIGNMENT`. Tagging the spread there keeps it unwrapped in
+        // those slots (`...a` never becomes the miscompile `(...a)`). It is
+        // never emitted as a sub-operand of another operator (that would be
+        // invalid JS), so no other context can observe this precedence.
+        Expression::SpreadElement(_) => PREC_ASSIGNMENT,
         // `true`/`false` are emitted as `!0`/`!1` (see `emit_boolean`), which
         // are UnaryExpressions — precedence `PREC_UNARY`, NOT primary. Tagging
         // them here is what makes `emit_expression_inner` parenthesise them in
@@ -4725,5 +4750,70 @@ mod tests {
         let tag = seq(vec![ident("a"), ident("b")]);
         let e = tagged(tag, raw_template(vec![tquasi("x", true)], vec![]));
         assert_eq!(emit_expr(e), "(a,b)`x`;");
+    }
+
+    // ---- SpreadElement (CLOC12.162) ------------------------------------
+
+    fn spread(argument: Expression) -> Expression {
+        Expression::SpreadElement(SpreadElement { cv: None, argument: Box::new(argument) })
+    }
+
+    /// `f(...a)` — a spread as the sole call argument prints bare, with no
+    /// space between `...` and the argument.
+    #[test]
+    fn spread_as_sole_call_arg() {
+        let e = call(ident("f"), vec![spread(ident("a"))]);
+        assert_eq!(emit_expr(e), "f(...a);");
+    }
+
+    /// `f(a,...b,c)` — a spread interleaved with plain arguments keeps its
+    /// position and the surrounding arity.
+    #[test]
+    fn spread_preserves_call_arity() {
+        let e = call(ident("f"), vec![ident("a"), spread(ident("b")), ident("c")]);
+        assert_eq!(emit_expr(e), "f(a,...b,c);");
+    }
+
+    /// `[1,...a,2]` — a spread as an array-literal element prints bare between
+    /// its siblings.
+    #[test]
+    fn spread_as_array_element() {
+        let e = Expression::ArrayExpression(ArrayExpression {
+            cv: None,
+            elements: vec![Some(num(1.0)), Some(spread(ident("a"))), Some(num(2.0))],
+        });
+        assert_eq!(emit_expr(e), "[1,...a,2];");
+    }
+
+    /// `new F(...a)` — a spread flows into a `new` argument list exactly as a
+    /// call argument does (`emit_new` always prints the argument parens).
+    #[test]
+    fn spread_as_new_argument() {
+        let e = new_expr(ident("F"), vec![spread(ident("a"))]);
+        assert_eq!(emit_expr(e), "new F(...a);");
+    }
+
+    /// `f(...(a,b))` — a **sequence** spread argument is the one form that must
+    /// wrap: a bare `...a,b` would spread only `a` and leave `,b` as a second
+    /// list slot. This is the crux of the assignment-precedence tag.
+    #[test]
+    fn spread_sequence_argument_is_wrapped() {
+        let e = call(ident("f"), vec![spread(seq(vec![ident("a"), ident("b")]))]);
+        assert_eq!(emit_expr(e), "f(...(a,b));");
+    }
+
+    /// `f(...a?b:c)` — a conditional argument binds tighter than the sequence
+    /// floor, so it prints bare (spread's operand grammar is an
+    /// `AssignmentExpression`, which subsumes the conditional): no over-wrap.
+    #[test]
+    fn spread_conditional_argument_is_bare() {
+        let cond = Expression::ConditionalExpression(ConditionalExpression {
+            cv: None,
+            test: Box::new(ident("a")),
+            consequent: Box::new(ident("b")),
+            alternate: Box::new(ident("c")),
+        });
+        let e = call(ident("f"), vec![spread(cond)]);
+        assert_eq!(emit_expr(e), "f(...a?b:c);");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.85.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.4"
+version = "0.85.5"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -91,7 +91,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression,
+    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
@@ -561,6 +561,13 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 },
             })
         }
+        // `...arg` — fold within the spread argument (it may hold a foldable
+        // subexpression); the spread itself is structural, never a constant, and
+        // is not dropped (its iterable may carry side effects).
+        Expression::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
+            cv: s.cv.clone(),
+            argument: Box::new(fold_expression(&s.argument, st)),
+        }),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {
             cv: a.cv.clone(),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.20.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.4"
+version = "0.20.5"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
-    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
@@ -1244,6 +1244,12 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
                 },
             })
         }
+        // `...arg` — kept (the spread's iterable may have side effects);
+        // recurse into the argument.
+        Expression::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
+            cv: s.cv.clone(),
+            argument: Box::new(dce_expression(&s.argument, st)),
+        }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),
             object: Box::new(dce_expression(&m.object, st)),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.20.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.4"
+version = "0.20.5"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -56,7 +56,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
-    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression,
+    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
@@ -276,6 +276,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         NewExpression(e) => e.cv.clone(),
         SequenceExpression(e) => e.cv.clone(),
         TaggedTemplateExpression(e) => e.cv.clone(),
+        SpreadElement(e) => e.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1424,6 +1425,11 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                 },
             })
         }
+        // `...arg` — recurse into the spread argument; the spread is kept.
+        Expression::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
+            cv: s.cv.clone(),
+            argument: Box::new(fold_expression(&s.argument, st)),
+        }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),
             object: Box::new(fold_expression(&m.object, st)),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.11.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -825,6 +825,8 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
                 count_uses_expr(e, name, count);
             }
         }
+        // Count uses of `name` inside the spread argument (`...name`).
+        Expression::SpreadElement(s) => count_uses_expr(&s.argument, name, count),
     }
 }
 
@@ -1119,6 +1121,8 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
                 changed |= propagate_in_expr(e, cand);
             }
         }
+        // Propagate into the spread argument (`...name`).
+        Expression::SpreadElement(s) => changed |= propagate_in_expr(&mut s.argument, cand),
     }
     changed
 }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.25.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.4"
+version = "0.25.5"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -506,6 +506,8 @@ fn expr_node_count(expr: &Expression) -> usize {
                 + t.quasi.quasis.len()
                 + t.quasi.expressions.iter().map(expr_node_count).sum::<usize>()
         }
+        // `...arg` — the spread weighs exactly its single inner argument.
+        Expression::SpreadElement(s) => expr_node_count(&s.argument),
     }
 }
 
@@ -838,6 +840,8 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // A tagged template introduces no boundary bindings either (the tag is
         // a callee, the quasi a template) — mirror the template arm.
         Expression::TaggedTemplateExpression(_) => {}
+        // `...arg` — recurse into the spread argument to collect its bindings.
+        Expression::SpreadElement(s) => collect_binding_idents_expr(&s.argument, out),
     }
 }
 
@@ -1136,6 +1140,8 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
                 tally_expr(e, cand, t);
             }
         }
+        // `...arg` — recurse into the spread argument to tally candidate uses.
+        Expression::SpreadElement(s) => tally_expr(&s.argument, cand, t),
     }
 }
 
@@ -1440,6 +1446,8 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
                 changed |= inline_in_expr(e, cand);
             }
         }
+        // `...arg` — recurse into the spread argument to inline candidate calls.
+        Expression::SpreadElement(s) => changed |= inline_in_expr(&mut s.argument, cand),
     }
     changed
 }
@@ -1595,6 +1603,8 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
                 substitute(e, map);
             }
         }
+        // `...arg` — recurse into the spread argument to substitute through it.
+        Expression::SpreadElement(s) => substitute(&mut s.argument, map),
     }
 }
 
@@ -1974,6 +1984,8 @@ fn expr_collect_mutated_params(
                 expr_collect_mutated_params(e, params, out);
             }
         }
+        // `...arg` — recurse into the spread argument to find mutated params.
+        Expression::SpreadElement(s) => expr_collect_mutated_params(&s.argument, params, out),
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
@@ -3444,6 +3456,8 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 rename_in_expr(e, map);
             }
         }
+        // `...arg` — recurse into the spread argument to alpha-rename through it.
+        Expression::SpreadElement(s) => rename_in_expr(&mut s.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.10.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.4"
+version = "0.10.5"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -745,6 +745,8 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(e, out);
             }
         }
+        // `...arg` — recurse into the spread argument to collect its idents.
+        Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
     }
 }
 
@@ -1075,6 +1077,8 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 rename_apply_expr(e, map);
             }
         }
+        // `...arg` — recurse into the spread argument to rename globals through it.
+        Expression::SpreadElement(s) => rename_apply_expr(&mut s.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.12.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1254,6 +1254,8 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
                 classify_expr(e, cls);
             }
         }
+        // `...arg` — recurse into the spread argument to classify accesses in it.
+        Expression::SpreadElement(s) => classify_expr(&s.argument, cls),
     }
 }
 
@@ -1519,6 +1521,8 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 rewrite_expr(e, map);
             }
         }
+        // `...arg` — recurse into the spread argument to rewrite accesses in it.
+        Expression::SpreadElement(s) => rewrite_expr(&mut s.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the pass stays exhaustive over the new `javascript-ast` variant
+(part of the CLOC12.162 atomic node PR1). No behaviour change to any existing
+node; the spread argument is now visited/rewritten exactly like any other
+sub-expression the pass already handles.
+
 ## [0.14.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -1026,6 +1026,8 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
                 collect_all_idents_expr(e, out);
             }
         }
+        // `...arg` — recurse into the spread argument to collect its idents.
+        Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
     }
 }
 
@@ -1337,6 +1339,8 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
                 rewrite_uses_expr(e, map);
             }
         }
+        // `...arg` — recurse into the spread argument to rewrite renamed uses in it.
+        Expression::SpreadElement(s) => rewrite_uses_expr(&mut s.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.5] - 2026-07-03
+
+### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm
+
+Added an `Expression::SpreadElement` arm that recurses into the spread's
+`argument` so the analyzer stays exhaustive over the new `javascript-ast`
+variant (part of the CLOC12.162 atomic node PR1). No behaviour change to any
+existing node; the spread argument is now visited exactly like any other
+sub-expression the analyzer already handles.
+
 ## [0.12.4] - 2026-07-02
 
 ### Changed — CLOC12.161: handle `Expression::TaggedTemplateExpression`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -941,6 +941,8 @@ fn walk_expression(
                 walk_expression(e, ctx, analysis, pending);
             }
         }
+        // `...arg` — recurse into the spread argument to resolve references in it.
+        Expression::SpreadElement(s) => walk_expression(&s.argument, ctx, analysis, pending),
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.21.0] - 2026-07-03
+
+### Added — CLOC12.162: `Expression::SpreadElement` (`...arg`)
+
+New `SpreadElement { cv, argument: Box<Expression> }` variant of `Expression`
+modelling a spread `...arg` — the `...` prefix that unpacks an iterable into a
+call/`new` argument list (`f(...a)`) or an array-literal element (`[...a]`). It
+is not a free-standing expression (a bare `...x` is a syntax error); it is
+modelled as an `Expression` variant so it slots into the existing
+`Vec<Expression>` argument/element lists without a parallel enum, and every
+existing AST walker that recurses those `Vec`s reaches `argument` for free.
+Re-exported from the crate root. Atomic node PR (PR1): the node +
+`closure-emitter` emit + all nine downstream pass match-arms land in one commit
+so the workspace never breaks. The bridge conversion (grammar-AST → typed-AST)
+and the conformance port follow in PR2/PR3.
+
+
 ## [0.20.0] - 2026-07-02
 
 ### Added — CLOC12.161: `Expression::TaggedTemplateExpression` (`` tag`...` ``)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -84,6 +84,16 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   paren-free (`` a`x`.length ``) while a looser tag wraps (`` (a,b)`x` ``). Node
   + `closure-emitter` + all pass traversals land in one atomic PR; the
   bridge-enable + conformance port follow (gap-162).
+- `SpreadElement` (CLOC12.162) — a spread `...arg`: the `...` prefix that
+  unpacks an iterable into a call/`new` argument list (`f(...a)`) or an
+  array-literal element (`[...a]`). `SpreadElement { argument: Box<Expression> }`.
+  Not a free-standing expression (a bare `...x` is a syntax error), but modelled
+  as an `Expression` variant so it slots into the existing `Vec<Expression>`
+  argument/element lists without a parallel enum, and every walker that recurses
+  those `Vec`s reaches `argument` for free. It tags at `PREC_ASSIGNMENT`,
+  matching the assignment-position list slots it lives in. Node +
+  `closure-emitter` + all pass traversals land in one atomic PR; the
+  bridge-enable + conformance port follow (gap-163).
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -61,6 +61,7 @@ pub enum Expression {
     NewExpression(NewExpression),
     SequenceExpression(SequenceExpression),
     TaggedTemplateExpression(TaggedTemplateExpression),
+    SpreadElement(SpreadElement),
 }
 
 // ---------------------------------------------------------------------
@@ -453,6 +454,42 @@ pub struct SequenceExpression {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
     pub expressions: Vec<Expression>,
+}
+
+/// A **spread element** `...arg` — the `...` prefix that unpacks an iterable
+/// (or, in an object literal, an object's own enumerable properties) into the
+/// surrounding list. Three positions accept one:
+///
+/// ```text
+///   f(...args)        spread a call/`new` argument list
+///   [1, ...rest, 2]   spread an array-literal element
+///   {...defaults}     spread object properties (object-spread)
+/// ```
+///
+/// Unlike every other `Expression` variant, a `SpreadElement` is **not a
+/// free-standing expression**: `...x` is a syntax error on its own, and the
+/// grammar only permits it as an *argument* (call / `new`) or an *element*
+/// (array literal). We nonetheless model it as an `Expression` variant so it
+/// can slot directly into the existing `Vec<Expression>` argument/element
+/// lists that `CallExpression`, `NewExpression`, and `ArrayExpression` already
+/// carry — no parallel "argument-or-spread" enum is needed, and every AST
+/// walker that already recurses those `Vec`s reaches the spread's inner
+/// `argument` for free.
+///
+/// **Precedence.** The `argument` is an `AssignmentExpression` in the grammar,
+/// so the emitter prints it at assignment precedence: a plain `...a`, a
+/// conditional `...a?b:c`, or an assignment `...a=b` all print bare, while a
+/// looser **sequence** argument is the one case that must be parenthesised —
+/// `...(a,b)` — because a bare `...a,b` would spread only `a` and leave `,b`
+/// as a sibling list element. The spread node itself is tagged at assignment
+/// precedence too, which matches the assignment-position list slots it lives
+/// in (`f(...a)`, `[...a]`) so it is never spuriously wrapped there.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpreadElement {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub argument: Box<Expression>,
 }
 
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -139,7 +139,7 @@ pub use expression::{
     LogicalOperator, MemberExpression,
     NewExpression,
     NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
-    SequenceExpression,
+    SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
 };

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1886,3 +1886,60 @@ form only), so the tagged form is enabled **no-substitution** — matching the
 template bridge's scope. When the grammar learns `${…}`, both the plain and
 tagged template converters grow the substitution branch together; the AST node
 already models it.
+
+## CLOC12.162 — `SpreadElement` (`...arg`): atomic node + emit + passes (PR1)
+
+Adds `Expression::SpreadElement { cv, argument: Box<Expression> }` to
+`javascript-ast` (0.21.0) — the JS **spread** `...arg`: the `...` prefix that
+unpacks an iterable into a call/`new` argument list (`f(...a)`, `new F(...a)`)
+or an array-literal element (`[1, ...rest, 2]`). Unlike every other
+`Expression` variant a spread is **not a free-standing expression** — bare
+`...x` is a syntax error, and the grammar only admits it in argument/element
+position. It is nonetheless modelled as an `Expression` variant so it slots
+directly into the `Vec<Expression>` argument/element lists that
+`CallExpression`, `NewExpression`, and `ArrayExpression` already carry: no
+parallel "argument-or-spread" enum is introduced, and every AST walker that
+already recurses those `Vec`s reaches the spread's inner `argument` for free.
+(Object-spread `{...o}` is a *property*, a separate later slice; this node is
+the call/array/`new` spread.)
+
+`closure-emitter` (0.26.0) `emit_spread` prints the three literal `.`
+characters then the `argument` at `PREC_ASSIGNMENT`, with no interior space
+(`...a`, never `... a`). That precedence is the crux: the argument grammar is
+an `AssignmentExpression`, so everything at or above assignment strength prints
+bare (`...a`, `...a.b`, `...f()`, `...a?b:c`, `...a=b`), while the one looser
+form — a **sequence** — is wrapped (`...(a,b)`), because a bare `...a,b` would
+spread only `a` and leave `,b` as a second list slot (a miscompile). The node
+itself tags at `PREC_ASSIGNMENT` in `expr_prec`, matching the
+assignment-position list slots it lives in (`f(...a)`, `[...a]`) so it is never
+spuriously parenthesised there; it is never emitted as a sub-operand of another
+operator (that would be invalid JS), so no other context observes the tag. No
+new emit-site precedence surgery was needed.
+
+All nine downstream pass/analysis crates get a `SpreadElement` match arm
+recursing into `argument` (the transforms rebuild the node; `fold-control-flow`'s
+exhaustive `expression_cv` accessor gains its arm) — all in one atomic commit so
+the workspace never has a broken exhaustive `match`.
+
+6 new emitter unit tests (sole call arg `f(...a)`, interleaved
+`f(a,...b,c)`, array element `[1,...a,2]`, `new` arg `new F(...a)`, the
+sequence-arg wrap `f(...(a,b))`, and the conditional-arg bare `f(...a?b:c)`
+showing no over-wrap). No behaviour change for existing inputs — the bridge
+still declines spread (gap-163), so closurec falls back to WHITESPACE_ONLY on
+`...` for now. PR2 (bridge-enable) and PR3 (conformance port) follow.
+
+### gap-163 — bridge declines spread (`SpreadElement`) — **OPEN (planned: javascript-parser PR2)**
+
+The `javascript-parser` bridge does not yet convert a `...` spread appearing in
+a call/`new` argument list or an array element into
+`Expression::SpreadElement`; it returns `UnsupportedSyntax` and drops the whole
+file to WHITESPACE_ONLY. The atomic node PR (CLOC12.162 PR1) lands the node +
+emit + pass traversals so the typed AST and every downstream pass can already
+represent and print a spread.
+
+**Planned fix (CLOC12.162 PR2):** the argument/element converters recognise a
+`spread_element` grammar node and wrap the converted inner expression as
+`SpreadElement`, mirroring the anticipation already noted for `new X(...a)` in
+gap-160. A closurec e2e diff fixture will prove a spread call round-trips while
+a foldable sibling operand still folds — proving the file ran through SIMPLE
+rather than WHITESPACE_ONLY.


### PR DESCRIPTION
## CLOC12.162 — `SpreadElement` (`...arg`): atomic node + emit + passes (PR1)

Adds `Expression::SpreadElement { cv, argument: Box<Expression> }` to **javascript-ast** — the JS **spread** `...arg` in call/`new` argument lists (`f(...a)`, `new F(...a)`) and array-literal elements (`[1, ...rest, 2]`).

A spread is **not a free-standing expression** (bare `...x` is a syntax error), but modelling it as an `Expression` variant lets it slot directly into the existing `Vec<Expression>` argument/element lists that `CallExpression` / `NewExpression` / `ArrayExpression` already carry — no parallel "argument-or-spread" enum, and every AST walker that recurses those `Vec`s reaches the inner `argument` for free.

### Emit (closure-emitter)
`emit_spread` prints `...` then the argument at **`PREC_ASSIGNMENT`**, no interior space. The argument grammar is an `AssignmentExpression`, so everything at/above assignment strength prints bare (`...a`, `...a.b`, `...f()`, `...a?b:c`, `...a=b`); the one looser form — a **sequence** — wraps: `...(a,b)` (a bare `...a,b` would spread only `a` and leave `,b` as a second list slot, a miscompile). The node itself tags `PREC_ASSIGNMENT`, matching the assignment-position list slots it lives in, so it is never spuriously parenthesised there. **6 new emitter unit tests.**

### Atomic PR1
The node + emit + **all 9 downstream pass match-arms** (constant-fold, dce, fold-control-flow incl. the exhaustive `expression_cv` accessor, inline-variables, inline, rename-globals, rename-properties, rename, scope-analyzer) land in **one commit** so the workspace never has a broken exhaustive `match`. Each pass recurses into `argument`. `javascript-ast` + `closure-emitter` get MINOR bumps; the 9 passes get PATCH bumps.

### Scope
No behaviour change for existing inputs — the bridge still declines spread (**gap-163**), so closurec falls back to WHITESPACE_ONLY on `...` for now. **PR2** (bridge-enable, closes gap-163) and **PR3** (CodePrinter conformance port) follow. Spec `CLOC12-gaps.md` gains the CLOC12.162 section + gap-163.

### Verification
- All 6 emitter unit tests + full existing suites green across javascript-ast, closure-emitter, and all 9 passes (`mise exec -- cargo test -p <crate>`).
- Security review: **PASSED** — pure AST-to-string transform, no new `unwrap`/indexing/arithmetic/`unsafe`/I/O; recursion adds one frame per spread, consistent with every node, on the existing 128 MiB emit worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)