### PR TITLE
[codex] Propagate Engram native host status

### DIFF
--- a/code/programs/mosaic/engram-app/README.md
+++ b/code/programs/mosaic/engram-app/README.md
@@ -42,6 +42,9 @@ editing, and save/delete/cancel controls.
 - The app shell includes host-status slots so import/export completion,
   cancellation, and host-side file errors can appear in every generated Mosaic
   UI instead of only in host adapter return objects.
+- The web, Electron, Qt, SwiftUI, Compose, Flutter, and XAML host adapters
+  merge their Anki import/export `hostResult` status back into those shared
+  status slots.
 - The generated React and Electron renderer shells mount `EngramApp` through
   `window.mosaicHost.getProps` and `window.mosaicHost.handleEvent`, with sample
   slot values as a fallback when no host is installed.

--- a/code/programs/mosaic/engram-app/host/compose/MosaicHost.kt
+++ b/code/programs/mosaic/engram-app/host/compose/MosaicHost.kt
@@ -80,11 +80,12 @@ class MosaicHost {
         persistSnapshot()
         val refreshed = props().toMutableMap()
         refreshed["hostIntent"] = jsonMap(hostIntent)
-        refreshed["hostResult"] = mapOf(
+        val hostResult = mapOf(
             "status" to "imported",
             "path" to file.path
         )
-        return refreshed
+        refreshed["hostResult"] = hostResult
+        return withHostStatusProps(refreshed, hostResult)
     }
 
     private fun exportAnkiPackage(
@@ -265,7 +266,76 @@ class MosaicHost {
             hostResult["path"] = path
         }
         out["hostResult"] = hostResult
+        return withHostStatusProps(out, hostResult)
+    }
+
+    private fun withHostStatusProps(
+        response: Map<String, Any?>,
+        hostResult: Map<String, Any?>
+    ): Map<String, Any?> {
+        val statusProps = hostStatusProps(hostResult)
+        if (statusProps.isEmpty()) return response
+        val out = response.toMutableMap()
+        val props = (out["props"] as? Map<*, *>)?.let(::jsonMap)?.toMutableMap()
+            ?: mutableMapOf()
+        props.putAll(statusProps)
+        out["props"] = props
         return out
+    }
+
+    private fun hostStatusProps(hostResult: Map<String, Any?>): Map<String, Any?> {
+        val status = hostResult["status"] as? String ?: return emptyMap()
+        if (status.isBlank()) return emptyMap()
+        return mapOf(
+            "host-status-visible" to true,
+            "host-status-kind" to status,
+            "host-status-label" to hostStatusLabel(status),
+            "host-status-message" to hostStatusMessage(hostResult, status)
+        )
+    }
+
+    private fun hostStatusLabel(status: String): String =
+        when (status) {
+            "imported" -> "Import complete"
+            "exported" -> "Export complete"
+            "cancelled" -> "Import cancelled"
+            "read-error", "import-error" -> "Import failed"
+            "export-error", "write-error" -> "Export failed"
+            "unavailable", "unsupported" -> "Host unavailable"
+            else -> "Host status"
+        }
+
+    private fun hostStatusMessage(hostResult: Map<String, Any?>, status: String): String {
+        val file = hostResultFile(hostResult)
+        return when (status) {
+            "imported" -> if (file.isBlank()) "Anki package imported." else "Imported $file."
+            "exported" -> if (file.isBlank()) "Anki package exported." else "Saved $file."
+            "cancelled" -> "No Anki package was selected."
+            "read-error" -> if (file.isBlank()) {
+                "Could not read the selected file."
+            } else {
+                "Could not read $file."
+            }
+            "import-error" -> if (file.isBlank()) {
+                "Could not import the selected package."
+            } else {
+                "Could not import $file."
+            }
+            "export-error" -> "Could not export Anki package."
+            "write-error" -> if (file.isBlank()) {
+                "Could not save the Anki package."
+            } else {
+                "Could not save $file."
+            }
+            "unavailable" -> "Engram native host is unavailable."
+            "unsupported" -> "This host does not support native Anki file dialogs yet."
+            else -> if (file.isBlank()) status else file
+        }
+    }
+
+    private fun hostResultFile(hostResult: Map<String, Any?>): String {
+        val path = hostResult["path"] as? String ?: return ""
+        return File(path).name
     }
 
     private fun hostIntentExtensions(

--- a/code/programs/mosaic/engram-app/host/electron/host.js
+++ b/code/programs/mosaic/engram-app/host/electron/host.js
@@ -55,6 +55,10 @@ function withSnapshotPersistence(host, engine) {
         const refreshed = await host.getProps({ component: request?.component ?? "EngramApp" });
         return {
           ...refreshed,
+          props: {
+            ...(refreshed?.props ?? {}),
+            ...hostStatusProps(result.hostResult),
+          },
           hostIntent: result.hostIntent,
           hostResult: result.hostResult,
         };
@@ -199,6 +203,78 @@ function sidecarError(status, path, result) {
     path,
     error: result?.error ?? "Engram native sidecar failed",
   };
+}
+
+function hostStatusProps(hostResult) {
+  const status = typeof hostResult?.status === "string" ? hostResult.status : "";
+  if (!status) {
+    return {};
+  }
+  return {
+    hostStatusVisible: true,
+    hostStatusKind: status,
+    hostStatusLabel: hostStatusLabel(status),
+    hostStatusMessage: hostStatusMessage(hostResult, status),
+  };
+}
+
+function hostStatusLabel(status) {
+  switch (status) {
+    case "imported":
+      return "Import complete";
+    case "exported":
+      return "Export complete";
+    case "cancelled":
+      return "Import cancelled";
+    case "read-error":
+    case "import-error":
+    case "snapshot-error":
+      return "Import failed";
+    case "export-error":
+    case "write-error":
+      return "Export failed";
+    case "captured":
+      return "Host action";
+    default:
+      return "Host status";
+  }
+}
+
+function hostStatusMessage(hostResult, status) {
+  const file = hostResultPath(hostResult);
+  const error = typeof hostResult?.error === "string" ? hostResult.error : "";
+  switch (status) {
+    case "imported":
+      return file ? `Imported ${file}.` : "Anki package imported.";
+    case "exported":
+      return file ? `Saved ${file}.` : "Anki package exported.";
+    case "cancelled":
+      return "No Anki package was selected.";
+    case "read-error":
+      return error
+        ? `Could not read ${file || "the selected file"}: ${error}`
+        : `Could not read ${file || "the selected file"}.`;
+    case "import-error":
+    case "snapshot-error":
+      return error
+        ? `Could not import ${file || "the selected package"}: ${error}`
+        : `Could not import ${file || "the selected package"}.`;
+    case "export-error":
+      return error ? `Could not export Anki package: ${error}` : "Could not export Anki package.";
+    case "write-error":
+      return error
+        ? `Could not save ${file || "the Anki package"}: ${error}`
+        : `Could not save ${file || "the Anki package"}.`;
+    case "captured":
+      return "Host intent captured.";
+    default:
+      return error || file || status;
+  }
+}
+
+function hostResultPath(hostResult) {
+  const path = typeof hostResult?.path === "string" ? hostResult.path : "";
+  return path.split(/[\\/]/).filter(Boolean).at(-1) || path;
 }
 
 function hostIntentExtensions(intent, property, fallback) {

--- a/code/programs/mosaic/engram-app/host/flutter/mosaic_host.dart
+++ b/code/programs/mosaic/engram-app/host/flutter/mosaic_host.dart
@@ -198,14 +198,15 @@ class MosaicHost {
 
     _persistSnapshot();
     final refreshed = props() ?? const <String, Object?>{};
-    return <String, Object?>{
+    final hostResult = <String, Object?>{
+      'status': 'imported',
+      'path': path,
+    };
+    return _withHostStatusProps(<String, Object?>{
       ...refreshed,
       'hostIntent': hostIntent,
-      'hostResult': <String, Object?>{
-        'status': 'imported',
-        'path': path,
-      },
-    };
+      'hostResult': hostResult,
+    }, hostResult);
   }
 
   Future<Map<String, Object?>?> _exportAnkiPackage(
@@ -482,7 +483,93 @@ Map<String, Object?> _hostResultResponse(
     hostResult['error'] = error.toString();
   }
   out['hostResult'] = hostResult;
-  return out;
+  return _withHostStatusProps(out, hostResult);
+}
+
+Map<String, Object?> _withHostStatusProps(
+  Map<String, Object?> response,
+  Map<String, Object?> hostResult,
+) {
+  final statusProps = _hostStatusProps(hostResult);
+  if (statusProps.isEmpty) return response;
+  final props = <String, Object?>{
+    ..._mosaicMap(response['props']),
+    ...statusProps,
+  };
+  return <String, Object?>{
+    ...response,
+    'props': props,
+  };
+}
+
+Map<String, Object?> _hostStatusProps(Map<String, Object?> hostResult) {
+  final status = hostResult['status']?.toString() ?? '';
+  if (status.isEmpty) return const <String, Object?>{};
+  return <String, Object?>{
+    'host-status-visible': true,
+    'host-status-kind': status,
+    'host-status-label': _hostStatusLabel(status),
+    'host-status-message': _hostStatusMessage(hostResult, status),
+  };
+}
+
+String _hostStatusLabel(String status) {
+  switch (status) {
+    case 'imported':
+      return 'Import complete';
+    case 'exported':
+      return 'Export complete';
+    case 'cancelled':
+      return 'Import cancelled';
+    case 'read-error':
+    case 'import-error':
+      return 'Import failed';
+    case 'export-error':
+    case 'write-error':
+      return 'Export failed';
+    case 'unsupported':
+      return 'Host unavailable';
+    default:
+      return 'Host status';
+  }
+}
+
+String _hostStatusMessage(Map<String, Object?> hostResult, String status) {
+  final file = _hostResultFile(hostResult);
+  final error = hostResult['error']?.toString() ?? '';
+  switch (status) {
+    case 'imported':
+      return file.isEmpty ? 'Anki package imported.' : 'Imported $file.';
+    case 'exported':
+      return file.isEmpty ? 'Anki package exported.' : 'Saved $file.';
+    case 'cancelled':
+      return 'No Anki package was selected.';
+    case 'read-error':
+      return error.isNotEmpty
+          ? 'Could not read ${file.isEmpty ? 'the selected file' : file}: $error'
+          : 'Could not read ${file.isEmpty ? 'the selected file' : file}.';
+    case 'import-error':
+      return error.isNotEmpty
+          ? 'Could not import ${file.isEmpty ? 'the selected package' : file}: $error'
+          : 'Could not import ${file.isEmpty ? 'the selected package' : file}.';
+    case 'export-error':
+      return error.isNotEmpty
+          ? 'Could not export Anki package: $error'
+          : 'Could not export Anki package.';
+    case 'write-error':
+      return error.isNotEmpty
+          ? 'Could not save ${file.isEmpty ? 'the Anki package' : file}: $error'
+          : 'Could not save ${file.isEmpty ? 'the Anki package' : file}.';
+    case 'unsupported':
+      return 'This host does not support native Anki file dialogs yet.';
+    default:
+      return error.isNotEmpty ? error : (file.isEmpty ? status : file);
+  }
+}
+
+String _hostResultFile(Map<String, Object?> hostResult) {
+  final path = hostResult['path']?.toString() ?? '';
+  return path.isEmpty ? '' : _baseName(path);
 }
 
 List<String> hostIntentExtensions(

--- a/code/programs/mosaic/engram-app/host/qt/MosaicHost.cpp
+++ b/code/programs/mosaic/engram-app/host/qt/MosaicHost.cpp
@@ -264,7 +264,7 @@ QVariantMap MosaicHost::importAnkiPackage(
   hostResult.insert(QStringLiteral("status"), QStringLiteral("imported"));
   hostResult.insert(QStringLiteral("path"), path);
   refreshed.insert(QStringLiteral("hostResult"), hostResult);
-  return refreshed;
+  return withHostStatusProps(refreshed, hostResult);
 }
 
 QVariantMap MosaicHost::exportAnkiPackage(
@@ -333,7 +333,91 @@ QVariantMap MosaicHost::hostResultResponse(
     hostResult.insert(QStringLiteral("path"), path);
   }
   out.insert(QStringLiteral("hostResult"), hostResult);
-  return out;
+  return withHostStatusProps(out, hostResult);
+}
+
+QVariantMap MosaicHost::withHostStatusProps(
+    QVariantMap response,
+    const QVariantMap &hostResult) const {
+  const QVariantMap statusProps = hostStatusProps(hostResult);
+  if (statusProps.isEmpty()) {
+    return response;
+  }
+  QVariantMap props = response.value(QStringLiteral("props")).toMap();
+  for (auto it = statusProps.cbegin(); it != statusProps.cend(); ++it) {
+    props.insert(it.key(), it.value());
+  }
+  response.insert(QStringLiteral("props"), props);
+  return response;
+}
+
+QVariantMap MosaicHost::hostStatusProps(const QVariantMap &hostResult) const {
+  const QString status = hostResult.value(QStringLiteral("status")).toString();
+  if (status.isEmpty()) {
+    return {};
+  }
+  return {
+      {QStringLiteral("hostStatusVisible"), true},
+      {QStringLiteral("hostStatusKind"), status},
+      {QStringLiteral("hostStatusLabel"), hostStatusLabel(status)},
+      {QStringLiteral("hostStatusMessage"), hostStatusMessage(hostResult, status)}};
+}
+
+QString MosaicHost::hostStatusLabel(const QString &status) const {
+  if (status == QStringLiteral("imported")) {
+    return QStringLiteral("Import complete");
+  }
+  if (status == QStringLiteral("exported")) {
+    return QStringLiteral("Export complete");
+  }
+  if (status == QStringLiteral("cancelled")) {
+    return QStringLiteral("Import cancelled");
+  }
+  if (status == QStringLiteral("read-error") || status == QStringLiteral("import-error")) {
+    return QStringLiteral("Import failed");
+  }
+  if (status == QStringLiteral("export-error") || status == QStringLiteral("write-error")) {
+    return QStringLiteral("Export failed");
+  }
+  return QStringLiteral("Host status");
+}
+
+QString MosaicHost::hostStatusMessage(
+    const QVariantMap &hostResult,
+    const QString &status) const {
+  const QString file = hostResultFile(hostResult);
+  if (status == QStringLiteral("imported")) {
+    return file.isEmpty() ? QStringLiteral("Anki package imported.")
+                          : QStringLiteral("Imported %1.").arg(file);
+  }
+  if (status == QStringLiteral("exported")) {
+    return file.isEmpty() ? QStringLiteral("Anki package exported.")
+                          : QStringLiteral("Saved %1.").arg(file);
+  }
+  if (status == QStringLiteral("cancelled")) {
+    return QStringLiteral("No Anki package was selected.");
+  }
+  if (status == QStringLiteral("read-error")) {
+    return file.isEmpty() ? QStringLiteral("Could not read the selected file.")
+                          : QStringLiteral("Could not read %1.").arg(file);
+  }
+  if (status == QStringLiteral("import-error")) {
+    return file.isEmpty() ? QStringLiteral("Could not import the selected package.")
+                          : QStringLiteral("Could not import %1.").arg(file);
+  }
+  if (status == QStringLiteral("export-error")) {
+    return QStringLiteral("Could not export Anki package.");
+  }
+  if (status == QStringLiteral("write-error")) {
+    return file.isEmpty() ? QStringLiteral("Could not save the Anki package.")
+                          : QStringLiteral("Could not save %1.").arg(file);
+  }
+  return file.isEmpty() ? status : file;
+}
+
+QString MosaicHost::hostResultFile(const QVariantMap &hostResult) const {
+  const QString path = hostResult.value(QStringLiteral("path")).toString();
+  return path.isEmpty() ? QString() : QFileInfo(path).fileName();
 }
 
 QVariantMap MosaicHost::camelCaseProps(const QVariantMap &props) const {

--- a/code/programs/mosaic/engram-app/host/qt/MosaicHost.h
+++ b/code/programs/mosaic/engram-app/host/qt/MosaicHost.h
@@ -46,6 +46,11 @@ private:
       const QVariantMap &hostIntent,
       const QString &status,
       const QString &path = QString()) const;
+  QVariantMap withHostStatusProps(QVariantMap response, const QVariantMap &hostResult) const;
+  QVariantMap hostStatusProps(const QVariantMap &hostResult) const;
+  QString hostStatusLabel(const QString &status) const;
+  QString hostStatusMessage(const QVariantMap &hostResult, const QString &status) const;
+  QString hostResultFile(const QVariantMap &hostResult) const;
   QVariantMap camelCaseProps(const QVariantMap &props) const;
   QString mosaicPropName(const QString &name) const;
   QStringList hostIntentExtensions(

--- a/code/programs/mosaic/engram-app/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/engram-app/host/swiftui/MosaicHost.swift
@@ -166,12 +166,13 @@ import AppKit
 
             persistSnapshot()
             var refreshed = applyProps() as? [String: Any] ?? [:]
-            refreshed["hostIntent"] = hostIntent
-            refreshed["hostResult"] = [
+            let hostResult: [String: Any] = [
                 "status": "imported",
                 "path": url.path,
             ]
-            return refreshed as NSDictionary
+            refreshed["hostIntent"] = hostIntent
+            refreshed["hostResult"] = hostResult
+            return withHostStatusProps(refreshed, hostResult: hostResult)
         } catch {
             print("Engram could not import Anki package: \(error)")
             return hostResultResponse(
@@ -251,7 +252,88 @@ import AppKit
             hostResult["path"] = path
         }
         out["hostResult"] = hostResult
+        return withHostStatusProps(out, hostResult: hostResult)
+    }
+
+    private func withHostStatusProps(
+        _ response: [String: Any],
+        hostResult: [String: Any]
+    ) -> NSDictionary {
+        let statusProps = hostStatusProps(hostResult)
+        if statusProps.isEmpty {
+            return response as NSDictionary
+        }
+        var out = response
+        var props = out["props"] as? [String: Any] ?? [:]
+        for (key, value) in statusProps {
+            props[key] = value
+        }
+        out["props"] = props
         return out as NSDictionary
+    }
+
+    private func hostStatusProps(_ hostResult: [String: Any]) -> [String: Any] {
+        guard let status = hostResult["status"] as? String, !status.isEmpty else {
+            return [:]
+        }
+        return [
+            "host-status-visible": true,
+            "host-status-kind": status,
+            "host-status-label": hostStatusLabel(status),
+            "host-status-message": hostStatusMessage(hostResult, status: status),
+        ]
+    }
+
+    private func hostStatusLabel(_ status: String) -> String {
+        switch status {
+        case "imported":
+            return "Import complete"
+        case "exported":
+            return "Export complete"
+        case "cancelled":
+            return "Import cancelled"
+        case "read-error", "import-error":
+            return "Import failed"
+        case "export-error", "write-error":
+            return "Export failed"
+        case "unavailable", "unsupported":
+            return "Host unavailable"
+        default:
+            return "Host status"
+        }
+    }
+
+    private func hostStatusMessage(_ hostResult: [String: Any], status: String) -> String {
+        let file = hostResultFile(hostResult)
+        switch status {
+        case "imported":
+            return file.isEmpty ? "Anki package imported." : "Imported \(file)."
+        case "exported":
+            return file.isEmpty ? "Anki package exported." : "Saved \(file)."
+        case "cancelled":
+            return "No Anki package was selected."
+        case "read-error":
+            return file.isEmpty ? "Could not read the selected file." : "Could not read \(file)."
+        case "import-error":
+            return file.isEmpty ? "Could not import the selected package." : "Could not import \(file)."
+        case "export-error":
+            return "Could not export Anki package."
+        case "write-error":
+            return file.isEmpty ? "Could not save the Anki package." : "Could not save \(file)."
+        case "unavailable":
+            return "Engram native host is unavailable."
+        case "unsupported":
+            return "This host does not support native Anki file dialogs yet."
+        default:
+            return file.isEmpty ? status : file
+        }
+    }
+
+    private func hostResultFile(_ hostResult: [String: Any]) -> String {
+        guard let path = hostResult["path"] as? String, !path.isEmpty else {
+            return ""
+        }
+        return URL(fileURLWithPath: path).lastPathComponent
     }
 
     private func hostIntentExtensions(

--- a/code/programs/mosaic/engram-app/host/xaml/MosaicHost.cs
+++ b/code/programs/mosaic/engram-app/host/xaml/MosaicHost.cs
@@ -46,8 +46,8 @@ public static class MosaicHost
         return hostIntent.Type switch
         {
             "importAnki" => await ImportAnkiPackage(owner, component, hostIntent),
-            "exportAnki" => await ExportAnkiPackage(owner, hostIntent),
-            _ => new MosaicHostResult($"Status: host intent captured: {hostIntent.Type}", hostIntent),
+            "exportAnki" => await ExportAnkiPackage(owner, component, hostIntent),
+            _ => WithAppliedHostStatus(component, "captured", hostIntent),
         };
     }
 
@@ -268,7 +268,7 @@ public static class MosaicHost
         var file = await PickAnkiImportFile(owner, hostIntent);
         if (file is null)
         {
-            return new MosaicHostResult("Status: Anki import cancelled", hostIntent);
+            return WithAppliedHostStatus(component, "cancelled", hostIntent);
         }
 
         var buffer = await FileIO.ReadBufferAsync(file);
@@ -288,18 +288,23 @@ public static class MosaicHost
                 using var document = JsonDocument.Parse(json);
                 if (IsErrorRoot(document.RootElement))
                 {
-                    return new MosaicHostResult(
-                        $"Status: Anki import failed: {JsonString(document.RootElement, "error", "unknown error")}",
-                        hostIntent);
+                    return WithAppliedHostStatus(
+                        component,
+                        "import-error",
+                        hostIntent,
+                        file.Name,
+                        JsonString(document.RootElement, "error", "unknown error"));
                 }
 
                 PersistSnapshot(session);
                 var propsJson = Native.TakeString(
                     Native.eg_engram_app_props(session, CurrentDeckId(), CurrentTimeMillis()));
-                return ApplyPropsFromJson(
+                var result = ApplyPropsFromJson(
                     component,
                     propsJson,
                     $"Status: Imported Anki package {file.Name}");
+                ApplyHostStatus(component, "imported", file.Name);
+                return new MosaicHostResult($"{result.Status}; host status: imported", hostIntent);
             }
             catch (Exception ex) when (IsNativeAvailabilityFailure(ex))
             {
@@ -312,12 +317,13 @@ public static class MosaicHost
 
     private static async Task<MosaicHostResult> ExportAnkiPackage(
         Window owner,
+        EngramApp component,
         MosaicHostIntent hostIntent)
     {
         var file = await PickAnkiExportFile(owner, hostIntent);
         if (file is null)
         {
-            return new MosaicHostResult("Status: Anki export cancelled", hostIntent);
+            return WithAppliedHostStatus(component, "cancelled", hostIntent);
         }
 
         byte[] data;
@@ -334,9 +340,12 @@ public static class MosaicHost
                 using var document = JsonDocument.Parse(json);
                 if (IsErrorRoot(document.RootElement))
                 {
-                    return new MosaicHostResult(
-                        $"Status: Anki export failed: {JsonString(document.RootElement, "error", "unknown error")}",
-                        hostIntent);
+                    return WithAppliedHostStatus(
+                        component,
+                        "export-error",
+                        hostIntent,
+                        file.Name,
+                        JsonString(document.RootElement, "error", "unknown error"));
                 }
 
                 data = JsonByteArray(document.RootElement, "apkg");
@@ -350,7 +359,77 @@ public static class MosaicHost
         }
 
         await FileIO.WriteBytesAsync(file, data);
-        return new MosaicHostResult($"Status: Exported Anki package {file.Name}");
+        return WithAppliedHostStatus(component, "exported", hostIntent, file.Name);
+    }
+
+    private static MosaicHostResult WithAppliedHostStatus(
+        EngramApp component,
+        string status,
+        MosaicHostIntent? hostIntent,
+        string? file = null,
+        string? error = null)
+    {
+        ApplyHostStatus(component, status, file, error);
+        var message = $"Status: {HostStatusLabel(status)}";
+        return hostIntent is null
+            ? new MosaicHostResult(message)
+            : new MosaicHostResult($"{message}; host intent: {hostIntent.Type}", hostIntent);
+    }
+
+    private static void ApplyHostStatus(
+        EngramApp component,
+        string status,
+        string? file = null,
+        string? error = null)
+    {
+        component.HostStatusVisible = true;
+        component.HostStatusKind = status;
+        component.HostStatusLabel = HostStatusLabel(status);
+        component.HostStatusMessage = HostStatusMessage(status, file, error);
+    }
+
+    private static string HostStatusLabel(string status)
+    {
+        return status switch
+        {
+            "imported" => "Import complete",
+            "exported" => "Export complete",
+            "cancelled" => "Import cancelled",
+            "read-error" or "import-error" => "Import failed",
+            "export-error" or "write-error" => "Export failed",
+            "captured" => "Host action",
+            _ => "Host status",
+        };
+    }
+
+    private static string HostStatusMessage(string status, string? file, string? error)
+    {
+        var name = string.IsNullOrWhiteSpace(file) ? "" : Path.GetFileName(file);
+        return status switch
+        {
+            "imported" => string.IsNullOrEmpty(name) ? "Anki package imported." : $"Imported {name}.",
+            "exported" => string.IsNullOrEmpty(name) ? "Anki package exported." : $"Saved {name}.",
+            "cancelled" => "No Anki package was selected.",
+            "read-error" => string.IsNullOrEmpty(error)
+                ? $"Could not read {FileOrFallback(name, "the selected file")}."
+                : $"Could not read {FileOrFallback(name, "the selected file")}: {error}",
+            "import-error" => string.IsNullOrEmpty(error)
+                ? $"Could not import {FileOrFallback(name, "the selected package")}."
+                : $"Could not import {FileOrFallback(name, "the selected package")}: {error}",
+            "export-error" => string.IsNullOrEmpty(error)
+                ? "Could not export Anki package."
+                : $"Could not export Anki package: {error}",
+            "write-error" => string.IsNullOrEmpty(error)
+                ? $"Could not save {FileOrFallback(name, "the Anki package")}."
+                : $"Could not save {FileOrFallback(name, "the Anki package")}: {error}",
+            "captured" => "Host intent captured.",
+            _ => status,
+        };
+    }
+
+    private static string FileOrFallback(string file, string fallback)
+    {
+        return string.IsNullOrEmpty(file) ? fallback : file;
     }
 
     private static async Task<StorageFile?> PickAnkiImportFile(Window owner, MosaicHostIntent hostIntent)

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -2582,6 +2582,12 @@ fn source_tree_has_expected_shape() {
     assert_contains(&xaml_host, "PersistSnapshot");
     assert_contains(&xaml_host, "eg_snapshot");
     assert_contains(&xaml_host, "eg_load_snapshot");
+    assert_contains(&xaml_host, "ApplyHostStatus(component, \"imported\"");
+    assert_contains(&xaml_host, "component.HostStatusVisible = true");
+    assert_contains(
+        &xaml_host,
+        "component.HostStatusMessage = HostStatusMessage",
+    );
     assert!(
         !xaml_host.contains("private static IntPtr Session = Native.eg_session_new()"),
         "xaml host template must not load the native library from a static field initializer"
@@ -2601,6 +2607,8 @@ fn source_tree_has_expected_shape() {
     assert_contains(&electron_host, "export-apkg");
     assert_contains(&electron_host, "loadPersistedSnapshot");
     assert_contains(&electron_host, "persistSnapshot(engine)");
+    assert_contains(&electron_host, "hostStatusProps(result.hostResult)");
+    assert_contains(&electron_host, "hostStatusVisible: true");
 
     let swiftui_host = fs::read_to_string(package_root().join("host/swiftui/MosaicHost.swift"))
         .expect("swiftui host template");
@@ -2625,6 +2633,8 @@ fn source_tree_has_expected_shape() {
     assert_contains(&swiftui_host, "persistSnapshot");
     assert_contains(&swiftui_host, "eg_snapshot");
     assert_contains(&swiftui_host, "eg_load_snapshot");
+    assert_contains(&swiftui_host, "withHostStatusProps");
+    assert_contains(&swiftui_host, "\"host-status-visible\": true");
 
     let qt_host = fs::read_to_string(package_root().join("host/qt/MosaicHost.cpp"))
         .expect("qt host template");
@@ -2647,6 +2657,8 @@ fn source_tree_has_expected_shape() {
     assert_contains(&qt_host, "persistSnapshot");
     assert_contains(&qt_host, "eg_snapshot");
     assert_contains(&qt_host, "eg_load_snapshot");
+    assert_contains(&qt_host, "withHostStatusProps");
+    assert_contains(&qt_host, "QStringLiteral(\"hostStatusVisible\")");
 
     let compose_host = fs::read_to_string(package_root().join("host/compose/MosaicHost.kt"))
         .expect("compose host template");
@@ -2670,6 +2682,8 @@ fn source_tree_has_expected_shape() {
     assert_contains(&compose_host, "persistSnapshot");
     assert_contains(&compose_host, "eg_snapshot");
     assert_contains(&compose_host, "eg_load_snapshot");
+    assert_contains(&compose_host, "withHostStatusProps");
+    assert_contains(&compose_host, "\"host-status-visible\" to true");
 
     let flutter_host = fs::read_to_string(package_root().join("host/flutter/mosaic_host.dart"))
         .expect("flutter host template");
@@ -2692,6 +2706,8 @@ fn source_tree_has_expected_shape() {
     assert_contains(&flutter_host, "_persistSnapshot");
     assert_contains(&flutter_host, "eg_snapshot");
     assert_contains(&flutter_host, "eg_load_snapshot");
+    assert_contains(&flutter_host, "_withHostStatusProps");
+    assert_contains(&flutter_host, "'host-status-visible': true");
 
     let build_script =
         fs::read_to_string(package_root().join("scripts/build-all.ps1")).expect("build-all.ps1");


### PR DESCRIPTION
## Summary

- Propagates Engram Anki import/export `hostResult` statuses into the shared `host-status-*` app slots for Electron and native hosts.
- Preserves host-status props across successful import refresh paths for Qt, SwiftUI, Compose, Flutter, XAML, and Electron.
- Extends the Engram package host-contract smoke test and README coverage for native host status parity.

## Validation

- `git diff --check`
- `node --check code\programs\mosaic\engram-app\host\electron\host.js`
- `cargo test --manifest-path code\programs\mosaic\engram-app\Cargo.toml native_project_shells_expose_engram_host_contract -- --nocapture`
- `cargo test --manifest-path code\programs\mosaic\engram-app\Cargo.toml -- --nocapture`