### PR TITLE
feat(sir): or/and builtins (Ruby ||/&&) on JS/Go/Rust emitters

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.13.2
+
+### Fixed — `or`/`and` builtins (Ruby `||`/`&&`) were unimplemented
+
+Ruby `&&`/`and` and `||`/`or` lower (in the frontend) to
+`BuiltinCall("and"/"or", [lhs, rhs])` — the fold covers BOTH the 2-operand
+`a || b` form and a multi-value `when 1, 2, 3` chain. Only the Python backend's
+emitter handled them; this backend fell through to the eager runtime dispatcher,
+which has no `or`/`and` entry, so ANY `||`/`&&` (and every multi-value `when`)
+crashed at runtime with `unknown builtin: or` / `and`. A case_eq-style gap: no
+compile-time gate catches a frontend-emitted builtin the backend never handled.
+
+- The emitter now special-cases `BuiltinCall("or"/"and", [a, b])`, emitting the
+  SAME truthy-guarded short-circuit form as `Expr::LogicalOr`/`LogicalAnd`: rhs
+  is not evaluated once lhs decides, SIR truthiness is used, and the deciding
+  OPERAND is returned (Ruby semantics — `nil || "b"` is `"b"`, `"a" || "b"` is
+  `"a"`), never a bare bool.
+- Emit-shape regression test; verified end-to-end via the sir-conformance
+  `logical_ops` + `multi_when` programs (13 corpus x 4 backends, all agree).
+
+
 ## 0.13.1
 
 ### Fixed — `case_eq` builtin (Ruby case-equality `===`) was unimplemented

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -1144,6 +1144,30 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         }
         return;
     }
+    // Ruby `&&`/`and` and `||`/`or` lower to `BuiltinCall("and"/"or",
+    // [lhs, rhs])` — the frontend folds BOTH the 2-operand `a || b` form and a
+    // multi-value `when 1, 2, 3` chain through them.  They MUST short-circuit
+    // (rhs not evaluated once lhs decides) and use SIR truthiness, returning the
+    // deciding OPERAND (not a bare bool).  So they emit the same truthy-guarded
+    // IIFE as `Expr::LogicalOr`/`LogicalAnd` rather than routing through the
+    // eager `_sir_call_builtin_by_name` dispatch — which has no `or`/`and` entry
+    // and would evaluate both operands, losing Ruby semantics.
+    if name == "and" && args.len() == 2 {
+        out.push_str("func() Value { __l := ");
+        emit_expr(out, &args[0], indent);
+        out.push_str("; if _sir_truthy(__l) { return ");
+        emit_expr(out, &args[1], indent);
+        out.push_str(" } else { return __l } }()");
+        return;
+    }
+    if name == "or" && args.len() == 2 {
+        out.push_str("func() Value { __l := ");
+        emit_expr(out, &args[0], indent);
+        out.push_str("; if _sir_truthy(__l) { return __l } else { return ");
+        emit_expr(out, &args[1], indent);
+        out.push_str(" } }()");
+        return;
+    }
     // All variadic-ish builtins in the Go runtime take []Value and
     // return Value.  Same calling shape for fixed-arity ones to keep
     // the emitter simple.
@@ -1641,6 +1665,51 @@ mod tests {
             out,
             "func() Value { __l := Value(true); if _sir_truthy(__l) { return Value(int64(5)) } else { return __l } }()"
         );
+    }
+
+    #[test]
+    fn emit_or_and_builtins_short_circuit() {
+        // Ruby `a || b` / `a && b` lower to `BuiltinCall("or"/"and", [a, b])` and
+        // must emit the SAME short-circuit IIFE as `LogicalOr`/`LogicalAnd` — NOT
+        // the eager `_sir_call_builtin_by_name` fallback (which has no `or`/`and`
+        // entry and would panic `unknown builtin` at runtime).
+        let mut and = String::new();
+        emit_expr(
+            &mut and,
+            &Expr::BuiltinCall {
+                name: "and".into(),
+                args: vec![
+                    Expr::BoolLit { value: true, span: s() },
+                    Expr::IntLit { value: 5, span: s() },
+                ],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(
+            and,
+            "func() Value { __l := Value(true); if _sir_truthy(__l) { return Value(int64(5)) } else { return __l } }()"
+        );
+        let mut or = String::new();
+        emit_expr(
+            &mut or,
+            &Expr::BuiltinCall {
+                name: "or".into(),
+                args: vec![
+                    Expr::BoolLit { value: false, span: s() },
+                    Expr::IntLit { value: 7, span: s() },
+                ],
+                effects: EffectSet::PURE,
+                span: s(),
+            },
+            0,
+        );
+        assert_eq!(
+            or,
+            "func() Value { __l := Value(false); if _sir_truthy(__l) { return __l } else { return Value(int64(7)) } }()"
+        );
+        assert!(!or.contains("_sir_call_builtin_by_name"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.11.2
+
+### Fixed — `or`/`and` builtins (Ruby `||`/`&&`) were unimplemented
+
+Ruby `&&`/`and` and `||`/`or` lower (in the frontend) to
+`BuiltinCall("and"/"or", [lhs, rhs])` — the fold covers BOTH the 2-operand
+`a || b` form and a multi-value `when 1, 2, 3` chain. Only the Python backend's
+emitter handled them; this backend fell through to the eager runtime dispatcher,
+which has no `or`/`and` entry, so ANY `||`/`&&` (and every multi-value `when`)
+crashed at runtime with `unknown builtin: or` / `and`. A case_eq-style gap: no
+compile-time gate catches a frontend-emitted builtin the backend never handled.
+
+- The emitter now special-cases `BuiltinCall("or"/"and", [a, b])`, emitting the
+  SAME truthy-guarded short-circuit form as `Expr::LogicalOr`/`LogicalAnd`: rhs
+  is not evaluated once lhs decides, SIR truthiness is used, and the deciding
+  OPERAND is returned (Ruby semantics — `nil || "b"` is `"b"`, `"a" || "b"` is
+  `"a"`), never a bare bool.
+- Emit-shape regression test; verified end-to-end via the sir-conformance
+  `logical_ops` + `multi_when` programs (13 corpus x 4 backends, all agree).
+
+
 ## 0.11.1
 
 ### Fixed — `case_eq` builtin (Ruby case-equality `===`) was unimplemented

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -1064,6 +1064,31 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push(')');
         return;
     }
+    // Ruby `&&`/`and` and `||`/`or` lower to `BuiltinCall("and"/"or",
+    // [lhs, rhs])` — the frontend folds BOTH the 2-operand `a || b` form and a
+    // multi-value `when 1, 2, 3` chain through them.  They MUST short-circuit
+    // (rhs not evaluated once lhs decides) and use SIR truthiness, returning the
+    // deciding OPERAND (not a bare bool).  So they emit the same truthy-guarded
+    // arrow IIFE as `Expr::LogicalOr`/`LogicalAnd` rather than routing through
+    // the eager `callBuiltin` dispatch — which has no `or`/`and` entry and would
+    // evaluate both operands, losing Ruby semantics.  The `__l` param scopes each
+    // occurrence so nested `&&`/`||` never collide.
+    if name == "and" && args.len() == 2 {
+        out.push_str("((__l) => __Sir.truthy(__l) ? (");
+        emit_expr(out, &args[1], indent);
+        out.push_str(") : __l)(");
+        emit_expr(out, &args[0], indent);
+        out.push(')');
+        return;
+    }
+    if name == "or" && args.len() == 2 {
+        out.push_str("((__l) => __Sir.truthy(__l) ? __l : (");
+        emit_expr(out, &args[1], indent);
+        out.push_str("))(");
+        emit_expr(out, &args[0], indent);
+        out.push(')');
+        return;
+    }
     // 2-argument `+` / `*` are POLYMORPHIC in Ruby (numeric add/mul, but
     // also String/Array concat, repeat, and join — see the
     // sir-polymorphic-operators spec).  Native JS infix would be *wrong*
@@ -1955,6 +1980,32 @@ mod tests {
             span: s(),
         };
         assert_eq!(emit_e(&e), r#"((d).get("k") ?? null)"#);
+    }
+
+    #[test]
+    fn emit_or_and_builtins_short_circuit() {
+        // Ruby `a || b` / `a && b` lower to `BuiltinCall("or"/"and", [a, b])` and
+        // must emit the SAME truthy-guarded short-circuit IIFE as
+        // `Expr::LogicalOr`/`LogicalAnd` — NOT the eager `__Sir.callBuiltin`
+        // fallback (which has no `or`/`and` entry and would evaluate both
+        // operands, throwing `unknown builtin` at runtime).
+        let a = Expr::StrLit { value: "a".into(), span: s() };
+        let b = Expr::StrLit { value: "b".into(), span: s() };
+        let or = Expr::BuiltinCall {
+            name: "or".into(),
+            args: vec![a.clone(), b.clone()],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&or), r#"((__l) => __Sir.truthy(__l) ? __l : ("b"))("a")"#);
+        assert!(!emit_e(&or).contains("callBuiltin"));
+        let and = Expr::BuiltinCall {
+            name: "and".into(),
+            args: vec![a, b],
+            effects: EffectSet::PURE,
+            span: s(),
+        };
+        assert_eq!(emit_e(&and), r#"((__l) => __Sir.truthy(__l) ? ("b") : __l)("a")"#);
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.13.2
+
+### Fixed — `or`/`and` builtins (Ruby `||`/`&&`) were unimplemented
+
+Ruby `&&`/`and` and `||`/`or` lower (in the frontend) to
+`BuiltinCall("and"/"or", [lhs, rhs])` — the fold covers BOTH the 2-operand
+`a || b` form and a multi-value `when 1, 2, 3` chain. Only the Python backend's
+emitter handled them; this backend fell through to the eager runtime dispatcher,
+which has no `or`/`and` entry, so ANY `||`/`&&` (and every multi-value `when`)
+crashed at runtime with `unknown builtin: or` / `and`. A case_eq-style gap: no
+compile-time gate catches a frontend-emitted builtin the backend never handled.
+
+- The emitter now special-cases `BuiltinCall("or"/"and", [a, b])`, emitting the
+  SAME truthy-guarded short-circuit form as `Expr::LogicalOr`/`LogicalAnd`: rhs
+  is not evaluated once lhs decides, SIR truthiness is used, and the deciding
+  OPERAND is returned (Ruby semantics — `nil || "b"` is `"b"`, `"a" || "b"` is
+  `"a"`), never a bare bool.
+- Emit-shape regression test; verified end-to-end via the sir-conformance
+  `logical_ops` + `multi_when` programs (13 corpus x 4 backends, all agree).
+
+
 ## 0.13.1
 
 ### Fixed — `case_eq` builtin (Ruby case-equality `===`) was unimplemented

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -1350,6 +1350,32 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         return;
     }
 
+    // Ruby `&&`/`and` and `||`/`or` lower to `BuiltinCall("and"/"or",
+    // [lhs, rhs])` — the frontend folds BOTH the 2-operand `a || b` form and a
+    // multi-value `when 1, 2, 3` chain through them.  They MUST short-circuit
+    // (rhs not evaluated once lhs decides) and use SIR truthiness, returning the
+    // deciding OPERAND (not a bare bool).  So they emit the same truthy-guarded
+    // block as `Expr::LogicalOr`/`LogicalAnd` rather than routing through the
+    // eager `__sir::call_builtin_by_name` dispatch — which has no `or`/`and`
+    // entry and would evaluate both operands, losing Ruby semantics.  `__l`
+    // shadows cleanly so nested `&&`/`||` never collide.
+    if name == "and" && args.len() == 2 {
+        out.push_str("({ let __l = (");
+        emit_expr(out, &args[0], indent);
+        out.push_str("); if __sir::truthy(&__l) { (");
+        emit_expr(out, &args[1], indent);
+        out.push_str(") } else { __l } })");
+        return;
+    }
+    if name == "or" && args.len() == 2 {
+        out.push_str("({ let __l = (");
+        emit_expr(out, &args[0], indent);
+        out.push_str("); if __sir::truthy(&__l) { __l } else { (");
+        emit_expr(out, &args[1], indent);
+        out.push_str(") } })");
+        return;
+    }
+
     // Variadic helpers take a Vec<Value>; fixed-arity helpers take
     // positional Value arguments.  This matches the inlined runtime
     // signatures.
@@ -3570,6 +3596,25 @@ mod tests {
         // a string literal, never a runtime constant read.
         let e2 = builtin("__new__", vec![constref("Dog")]);
         assert_eq!(emit_e(&e2), r#"__sir::call_new("Dog", vec![])"#);
+    }
+
+    #[test]
+    fn emit_or_and_builtins_short_circuit() {
+        // Ruby `a || b` / `a && b` lower to `builtin("or"/"and", [a, b])` and must
+        // emit the SAME short-circuit block as `LogicalOr`/`LogicalAnd` — NOT the
+        // eager `call_builtin_by_name` fallback (which has no `or`/`and` entry and
+        // would panic `unknown builtin` at runtime).
+        let or = builtin("or", vec![int(5), int(7)]);
+        assert_eq!(
+            emit_e(&or),
+            "({ let __l = (__sir::Value::Int(5i64)); if __sir::truthy(&__l) { __l } else { (__sir::Value::Int(7i64)) } })"
+        );
+        assert!(!emit_e(&or).contains("call_builtin_by_name"));
+        let and = builtin("and", vec![int(5), int(7)]);
+        assert_eq!(
+            emit_e(&and),
+            "({ let __l = (__sir::Value::Int(5i64)); if __sir::truthy(&__l) { (__sir::Value::Int(7i64)) } else { __l } })"
+        );
     }
 
     #[test]

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.3.0] - 2026-07-03
+
+### Added — `logical_ops` + `multi_when` (11 -> 13 programs)
+
+The `or`/`and` cross-backend gap this corpus surfaced is now fixed (JS/Go/Rust
+emitters implement short-circuit `||`/`&&`), so two programs join the suite:
+
+- `logical_ops` — `"a" || "b"` -> `a`, `nil || "b"` -> `b`, `"x" && "y"` -> `y`
+  (short-circuit, returning the deciding operand).
+- `multi_when` — a multi-value `when 1, 2, 3` (folds through the `or` builtin),
+  re-enabled from the tracked-gap list.
+
+Verified: **13 corpus x 4 backends = 52 runs, 0 skipped, all agree.**
+
 ## [0.2.0] - 2026-07-02
 
 ### Added — corpus expansion (6 -> 11 programs) + three latent gaps found

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -65,6 +65,8 @@ across backends, a separate formatting concern). Current programs:
 | `string_length` | `String#length` | `5` |
 | `counter_state` | `@ivar` state across method calls | `2` |
 | `mixin_include` | `module` mixed into a class via `include` | `hi` |
+| `logical_ops` | short-circuit `||`/`&&` returning the operand | `a\nb\ny` |
+| `multi_when` | multi-value `when 1, 2, 3` (folds through `or`) | `small\nbig` |
 
 Adding a program is one `Program { name, ruby, expected }` entry in
 `tests/conformance.rs`.
@@ -81,8 +83,10 @@ visible. Currently tracked:
   validation).
 - **`String#upcase`/`#downcase` on JavaScript** — the JS backend's emit-time
   Ruby→native method rename is missing the case pair.
-- **`or`/`and` builtin on JavaScript** — a multi-value `when 1, 2, 3` lowers to
-  a `BuiltinCall("or", …)` the JS runtime doesn't implement.
+
+Fixed since (now IN the suite): the `or`/`and` builtin gap — `||`/`&&` and
+multi-value `when` threw `unknown builtin` on Go/Rust/JS; the emitters now emit
+the short-circuit form. Covered by `logical_ops` + `multi_when`.
 
 ## Usage
 

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -99,6 +99,23 @@ const CORPUS: &[Program] = &[
         ruby: "module Greet\n  def hi\n    \"hi\"\n  end\nend\n\nclass P\n  include Greet\nend\n\nputs P.new.hi\n",
         expected: "hi",
     },
+    // Short-circuit `||` / `&&` returning the deciding OPERAND (Ruby semantics),
+    // exercising both a truthy and a falsy left-hand side. `"a" || "b"` → "a";
+    // `nil || "b"` → "b"; `"x" && "y"` → "y". Previously these lowered to a
+    // `BuiltinCall("or"/"and")` that Go/Rust/JS emitters didn't handle, so any
+    // `||`/`&&` threw `unknown builtin` at runtime on three of five backends.
+    Program {
+        name: "logical_ops",
+        ruby: "puts(\"a\" || \"b\")\nputs(nil || \"b\")\nputs(\"x\" && \"y\")\n",
+        expected: "a\nb\ny",
+    },
+    // A `case` with a multi-value `when` (`when 1, 2, 3`), which folds through
+    // the same `or` builtin. Re-enabled now that `or`/`and` work on all backends.
+    Program {
+        name: "multi_when",
+        ruby: "def sz(n)\n  case n\n  when 1, 2, 3\n    \"small\"\n  else\n    \"big\"\n  end\nend\n\nputs sz(2)\nputs sz(9)\n",
+        expected: "small\nbig",
+    },
 ];
 
 /// Every program must produce its reference output on every available backend.


### PR DESCRIPTION
## Problem

Ruby `&&`/`and` and `||`/`or` lower (in the frontend, `lower_logical_chain`) to `BuiltinCall("and"/"or", [lhs, rhs])` — the fold covers **both** the 2-operand `a || b` form **and** a multi-value `when 1, 2, 3` chain. Only the **Python** emitter special-cased them; the **JS, Go, and Rust** emitters fell through to their eager runtime dispatcher, which has no `or`/`and` entry:

```
TypeError: unknown builtin: or     # JavaScript
panic: unknown builtin: or         # Go / Rust
```

So **every** `||`/`&&` (and every multi-value `when`) crashed at runtime on 3 of 5 backends — a `case_eq`-shape gap with no compile-time gate. Found via the `sir-conformance` harness (the `multi_when` program).

## Fix

Each emitter now special-cases `BuiltinCall("or"/"and", [a, b])`, emitting the **same truthy-guarded short-circuit form** as the already-shipping `Expr::LogicalOr`/`LogicalAnd` in the same file:
- rhs is **not** evaluated once lhs decides;
- **SIR truthiness** is used;
- the deciding **operand** is returned (Ruby semantics: `nil || "b"` → `"b"`, `"a" || "b"` → `"a"`), never a bare bool.

Each occurrence binds `__l` in its own fresh IIFE/block scope, so nested `&&`/`||` never collide.

## Verified

- Per-backend **emit-shape regression test** (asserts the short-circuit form, not the `callBuiltin`/`call_builtin_by_name` fallback).
- **End-to-end** via `sir-conformance`: added a `logical_ops` program (`"a" || "b"`→`a`, `nil || "b"`→`b`, `"x" && "y"`→`y`) and re-enabled `multi_when` → **13 corpus × 4 backends = 52 runs, 0 skipped, all agree**.
- Clippy clean. Versions: js 0.11.1→0.11.2, go/rust 0.13.1→0.13.2, conformance 0.2.0→0.3.0; CHANGELOGs + README updated.
- Security review: **passed** (byte-identical to the shipping LogicalOr/And arms; operands via the same `emit_expr`; `args.len()==2` guarded; no new surface).

## Context

Second of the harness-found gaps fixed (after `case_eq` #7463). Remaining: JS `upcase`/`downcase` rename, frontend array-index bugs, then the SIR21 typed-integer cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)