### PR TITLE
test(html-parser): lock form interactive cross-axis evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_form_interactive_audit_test.rs
@@ -5,8 +5,220 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_CHARACTER_REFERENCE_AUDIT: &str =
+    include_str!("fixtures/whatwg-character-reference-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FOREIGN_AUDIT: &str = include_str!("fixtures/whatwg-foreign-audit.json");
 const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
     include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
+const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
+    include_str!("fixtures/whatwg-fragment-context-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_LIST_ITEM_AUDIT: &str = include_str!("fixtures/whatwg-list-item-audit.json");
+const WHATWG_NOSCRIPT_AUDIT: &str = include_str!("fixtures/whatwg-noscript-audit.json");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_TEXT_CONTROL_AUDIT: &str = include_str!("fixtures/whatwg-text-control-audit.json");
+const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+struct FormInteractiveCrossAxisCase {
+    id: &'static str,
+    form_axis: &'static str,
+    data_snippet: &'static str,
+    fragment_context: Option<&'static str>,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
+const INTERACTIVE_FORMATTING_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-table-boundary",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "foster-parenting"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "adoption-agency",
+    ),
+];
+const BUTTON_BOUNDARY_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-form-boundary",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-form-boundary",
+    ),
+];
+const FORM_CONTROL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    ("foreign", WHATWG_FOREIGN_AUDIT, "table-foreign-boundary"),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "row-group-boundary"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "adoption-agency",
+    ),
+    ("void-element", WHATWG_VOID_ELEMENT_AUDIT, "void-in-table"),
+];
+const SELECT_OPTION_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    ("foreign", WHATWG_FOREIGN_AUDIT, "html-integration-point"),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "adoption-agency-formatting",
+    ),
+    ("select-list", WHATWG_SELECT_LIST_AUDIT, "select-in-table"),
+    ("table", WHATWG_TABLE_AUDIT, "select-in-table"),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "table-insertion",
+    ),
+];
+const TEXTAREA_RAWTEXT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "character-reference",
+        WHATWG_CHARACTER_REFERENCE_AUDIT,
+        "character-reference-rcdata-boundary",
+    ),
+    ("text-control", WHATWG_TEXT_CONTROL_AUDIT, "rcdata-controls"),
+];
+const FRAGMENT_CONTEXT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "fragment-context",
+        WHATWG_FRAGMENT_CONTEXT_AUDIT,
+        "fragment-select-context",
+    ),
+    (
+        "select-list",
+        WHATWG_SELECT_LIST_AUDIT,
+        "select-fragment-context",
+    ),
+    (
+        "tree-insertion",
+        WHATWG_TREE_INSERTION_AUDIT,
+        "html-fragment",
+    ),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "void-fragment-context",
+    ),
+];
+const STRAY_INTERACTIVE_END_TAG_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "html-element-boundary",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "list-definition-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "noframes-content"),
+    ("list-item", WHATWG_LIST_ITEM_AUDIT, "list-with-formatting"),
+    ("noscript", WHATWG_NOSCRIPT_AUDIT, "stray-noscript-end-tag"),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-formatting-boundary",
+    ),
+    (
+        "select-list",
+        WHATWG_SELECT_LIST_AUDIT,
+        "stray-select-end-tags",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "caption-colgroup"),
+    (
+        "text-control",
+        WHATWG_TEXT_CONTROL_AUDIT,
+        "stray-text-control-end-tags",
+    ),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "stray-void-end-tags",
+    ),
+];
+const FORM_INTERACTIVE_CROSS_AXIS_CASES: &[FormInteractiveCrossAxisCase] = &[
+    FormInteractiveCrossAxisCase {
+        id: "adoption01-dat-6",
+        form_axis: "interactive-formatting",
+        data_snippet: "<table><a>1<p>2</a>3</p>",
+        fragment_context: None,
+        suites: INTERACTIVE_FORMATTING_CROSS_AXIS_SUITES,
+    },
+    FormInteractiveCrossAxisCase {
+        id: "tests20-dat-2",
+        form_axis: "button-boundary",
+        data_snippet: "<!doctype html><p><button><address>",
+        fragment_context: None,
+        suites: BUTTON_BOUNDARY_CROSS_AXIS_SUITES,
+    },
+    FormInteractiveCrossAxisCase {
+        id: "adoption01-dat-13",
+        form_axis: "form-control",
+        data_snippet: "<a><svg><tr><input></a>",
+        fragment_context: None,
+        suites: FORM_CONTROL_CROSS_AXIS_SUITES,
+    },
+    FormInteractiveCrossAxisCase {
+        id: "tables01-dat-453",
+        form_axis: "select-option",
+        data_snippet: "<div><table><svg><foreignObject><select><table><s>",
+        fragment_context: None,
+        suites: SELECT_OPTION_CROSS_AXIS_SUITES,
+    },
+    FormInteractiveCrossAxisCase {
+        id: "tests16-dat-860",
+        form_axis: "textarea-rawtext",
+        data_snippet: "<!doctype html><textarea>&lt;/textarea></textarea>",
+        fragment_context: None,
+        suites: TEXTAREA_RAWTEXT_CROSS_AXIS_SUITES,
+    },
+    FormInteractiveCrossAxisCase {
+        id: "tests-innerhtml-1-dat-76",
+        form_axis: "fragment-context",
+        data_snippet: "<input><option>",
+        fragment_context: Some("select"),
+        suites: FRAGMENT_CONTEXT_CROSS_AXIS_SUITES,
+    },
+    FormInteractiveCrossAxisCase {
+        id: "tests1-dat-675",
+        form_axis: "stray-interactive-end-tags",
+        data_snippet: "</strong></b></em></i></u></strike></s></blink></tt></pre>",
+        fragment_context: None,
+        suites: STRAY_INTERACTIVE_END_TAG_CROSS_AXIS_SUITES,
+    },
+];
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[
     ("tests26-dat-4", "interactive-formatting"),
     ("tests26-dat-1251", "interactive-formatting"),
@@ -28,6 +240,19 @@ struct FormInteractiveAuditSuite {
 
 #[derive(Debug, Deserialize)]
 struct FormInteractiveAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -77,6 +302,85 @@ fn whatwg_form_interactive_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_form_interactive_audit_keeps_form_axis_cases_cross_axis() {
+    let suite = load_suite();
+    let form_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in FORM_INTERACTIVE_CROSS_AXIS_CASES {
+        let form_case = form_cases
+            .get(evidence.id)
+            .unwrap_or_else(|| panic!("form/interactive audit should include `{}`", evidence.id));
+        assert_eq!(
+            form_case.axis, evidence.form_axis,
+            "form/interactive row `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !form_case.reason.is_empty(),
+            "form/interactive row `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.source, form_case.source,
+                "`{suite_name}` should point form/interactive row `{}` at the same html5lib row as the form audit",
+                evidence.id
+            );
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep form/interactive row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for form/interactive row `{}`",
+                evidence.id
+            );
+        }
+
+        let source_case = smoke_cases
+            .get(&form_case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "form/interactive row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        if let Some(fragment_context) = evidence.fragment_context {
+            assert_eq!(
+                source_case.fragment_context.as_deref(),
+                Some(fragment_context),
+                "form/interactive row `{}` should keep its html5lib fragment context",
+                evidence.id
+            );
+        }
+
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                form_case.id, form_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis form/interactive evidence case `{}` ({}) failed for input {:?}",
+            form_case.id, form_case.axis, source_case.data
         );
     }
 }
@@ -132,4 +436,14 @@ fn assert_axis_count(suite: &FormInteractiveAuditSuite, axis: &str, minimum: usi
         count >= minimum,
         "expected at least {minimum} `{axis}` cases, found {count}"
     );
+}
+
+fn generic_audit_case(raw_fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(raw_fixture)
+        .unwrap_or_else(|error| panic!("{suite_name} audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("{suite_name} audit should include `{case_id}`"))
 }


### PR DESCRIPTION
## Summary
- add a cross-axis guard for the WHATWG form/interactive audit
- lock representative interactive-formatting, button-boundary, form-control, select-option, textarea-rawtext, fragment-context, and stray interactive end-tag rows against sibling audit fixtures
- keep each row tied to html5lib smoke input/context and parser DOM output

## Tests
- cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit_keeps_form_axis_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_form_interactive_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check