### PR TITLE
spec(hml01,sir22,sir23): math languages -> Semantic IR roadmap

### DIFF
--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -1,0 +1,204 @@
+# HML01 — Math Languages → Semantic IR → any backend
+
+## Status
+
+Active roadmap spec. Extends
+[`HML00`](HML00-historical-math-languages-roadmap.md) (the historical
+math-languages effort — Macsyma/Maxima, MATLAB/Octave, Wolfram, and future
+APL/J/Reduce/Derive/Maple/…) with a second compilation target: the
+narrow-waist [Semantic IR](SIR10-narrow-waist-semantic-ir.md) already used to
+translate Twig, Python, Ruby, and JavaScript to each other and to
+TypeScript/Rust/Go.
+
+This spec does not replace anything HML00 built. Every math language keeps
+its existing native pipeline — `<lang>-lexer` → `<lang>-parser` →
+`<lang>-runtime` (+ REPL) — for interactive/REPL use exactly as today. This
+spec adds a **second, independent** lowering off the same parse tree:
+`<lang>-to-semantic-ir`, so a math-language program can *also* be compiled to
+any SIR backend (JavaScript today; TypeScript/Rust/Go/Python for free,
+subject to each backend declaring the new features — see §4).
+
+```
+                              ┌─→ <lang>-runtime (+ repl)      [existing, unchanged]
+<lang> source → GrammarASTNode┤
+                              └─→ <lang>-to-semantic-ir → semantic_ir::Module → any SIR backend   [NEW]
+```
+
+## §1 Why this is additive, not a rewrite
+
+Every math-language parser in this repo (`matlab-parser`, `wolfram-parser`,
+`macsyma-parser`, and future ones) already emits the same generic
+`GrammarASTNode` concrete syntax tree that `python-to-semantic-ir` walks
+today (rule-name-tagged nodes with ordered children — see
+`parser::grammar_parser::GrammarASTNode`). So `<lang>-to-semantic-ir` is a
+**second consumer** of an artifact that already exists; it requires no
+changes to any `<lang>-lexer` or `<lang>-parser` crate.
+
+What *is* new: the Semantic IR itself has no math vocabulary. It models
+closures, calls, and blocks for general-purpose languages — no matrices, no
+N-D arrays, no symbolic expression trees, no pattern-matching/rewrite-rule
+semantics. Two sibling specs add that vocabulary, additively, exactly the way
+[`SIR16`](SIR16-ir-extensions-for-python-and-javascript.md) added loops and
+sequences for Python/JS without breaking Twig:
+
+- [`SIR22`](SIR22-array-matrix-semantic-ir.md) — the numeric/array domain
+  (N-D arrays, matrix ops, ranges, indexing), for MATLAB/Octave and every
+  future array-family language (APL, J, Scilab, IDL, …).
+- [`SIR23`](SIR23-symbolic-pattern-semantic-ir.md) — the symbolic/CAS domain
+  (symbolic expression application, patterns, rewrite rules), for
+  Wolfram/Macsyma/Maxima and every future symbolic-CAS-family language
+  (Reduce, Derive, Maple, …).
+
+These two domains are independent — different `Expr`/`SirType`/`Feature`
+additions, different frontends, different backend runtime packages — and are
+designed and shipped in parallel streams (§5).
+
+## §2 The per-language pattern, amended
+
+[`HML00` §6](HML00-historical-math-languages-roadmap.md#6-the-per-language-pattern)
+described:
+
+```
+spec → grammar/lexer/parser → <lang>-runtime (+ repl) → <lang> binary
+```
+
+Every **future** math-language item (APL, J, Reduce, Derive, Maple, …) adds
+one more stage to that pattern, built alongside the runtime rather than
+bolted on afterward:
+
+```
+spec → grammar/lexer/parser → <lang>-runtime (+ repl) → <lang> binary
+                              → <lang>-to-semantic-ir
+```
+
+`<lang>-to-semantic-ir` is a thin, separate crate (mirroring
+`python-to-semantic-ir`'s shape — see §3) that walks the same
+`GrammarASTNode` the runtime already parses and emits a `semantic_ir::Module`
+instead of evaluating. It shares no code with `<lang>-runtime` beyond the
+parser; the two are independent consumers of one parse tree, exactly as
+`python-to-semantic-ir` and CPython's own interpreter both consume Python
+source without depending on each other.
+
+## §3 Frontend recipe (retrofit for MATLAB/Octave/Wolfram/Macsyma/Maxima)
+
+Each new frontend crate follows the established
+`compile`/`compile_source` shape (`python-to-semantic-ir`'s public API):
+
+```rust
+pub fn compile(tree: &GrammarASTNode, module_name: &str)
+    -> Result<semantic_ir::Module, <Lang>LowerError>;
+pub fn compile_source(source: &str, module_name: &str)
+    -> Result<semantic_ir::Module, <Lang>LowerError>;
+```
+
+- **`matlab-to-semantic-ir`** — walks the `matlab-parser` CST, emits SIR22
+  (array/matrix domain) nodes. 1-based-to-0-based index translation happens
+  here, at lowering time — per SIR10's "disambiguation is the frontend's
+  job," the IR never carries a language's indexing convention implicitly.
+- **`octave-to-semantic-ir`** — a thin wrapper: run `octave-runtime`'s
+  existing `octavify` source-rewrite shim, then delegate to
+  `matlab-to-semantic-ir::compile_source`. Mirrors how `octave-runtime`
+  itself reuses `matlab-runtime` wholesale today (no new grammar).
+- **`wolfram-to-semantic-ir`** — walks the `wolfram-parser` CST, emits SIR23
+  (symbolic/pattern domain) nodes. Reuses the existing surface-to-head
+  desugaring table already in `wolfram-runtime/src/lower.rs` (`+`→`Add`,
+  `*`→`Mul`, `/.`→ReplaceAll, etc.) but targets `semantic_ir::Expr` instead
+  of `symbolic_ir::IRNode`.
+- **`macsyma-to-semantic-ir`** — walks the `macsyma-parser` CST using the
+  same rule-name dispatch already proven in `macsyma-compiler` (`"assign"`,
+  `"additive"`, `"postfix"`, …), emits SIR23 nodes.
+- **`maxima-to-semantic-ir`** — a thin alias reusing
+  `macsyma-to-semantic-ir` wholesale, mirroring Maxima's existing reuse of
+  `macsyma-runtime`.
+
+## §4 Backend recipe: extend the existing JS/TS backends, don't fork
+
+`semantic-ir-to-javascript` and `semantic-ir-to-typescript` gain new `match`
+arms for the SIR22/SIR23 node kinds and declare the corresponding `Feature`s
+in `accepts_features()`. New runtime behavior ships as new npm packages,
+following the existing import-header precedent (`sir-runtime-core`,
+`sir-runtime-oop` — pasted as an `import` line, not inlined):
+
+- **`sir-runtime-array`** — a thin `Float64Array` wrapper with explicit
+  column-major indexing, matmul, elementwise ops, broadcasting, and range
+  materialization. Backs SIR22.
+- **`sir-runtime-symbolic`** — a small term-rewriting engine (term-tree
+  representation, structural equality, the Blank/Pattern matcher,
+  substitution, and the `ReplaceAll`/`ReplaceRepeated` fixed-point loop) —
+  a direct port of `cas-pattern-matching`'s existing algorithm to
+  JS/TS, not a reimplementation from scratch. Backs SIR23.
+
+Emit logic gates each import on the module's manifest exactly like the
+existing `uses_oop`/`uses_exceptions` checks: a pure-numeric MATLAB module
+never imports the symbolic runtime and vice versa.
+
+Other backends (Rust/Go/Python) are **not required** to support SIR22/SIR23
+in this first wave — per SIR10's backend-capability model, a backend that
+doesn't declare a feature in `accepts_features()` cleanly rejects a module
+that needs it, rather than emitting wrong code. JS/TS is the first target
+because it's what motivated this work; other backends can add support later
+without any change to the IR or the frontends.
+
+## §5 Rollout — two parallel streams, one shared serialization point
+
+**Stream A (array/matrix, backs MATLAB/Octave and future APL/J/Scilab/IDL):**
+`SIR22` spec → `semantic-ir` core additions → `matlab-to-semantic-ir` →
+`octave-to-semantic-ir` → `sir-runtime-array` → JS/TS backend codegen →
+golden/oracle tests.
+
+**Stream B (symbolic/CAS, backs Wolfram/Macsyma/Maxima and future
+Reduce/Derive/Maple):** `SIR23` spec → `semantic-ir` core additions →
+`wolfram-to-semantic-ir` → `macsyma-to-semantic-ir` → `maxima-to-semantic-ir`
+→ `sir-runtime-symbolic` → JS/TS backend codegen → golden/oracle tests.
+
+The streams touch disjoint crates except `semantic-ir` core and the two JS
+backends — a short serialization point, not a merge of the whole effort.
+Each item is one PR, following the repo's established one-PR-per-item
+discipline; `/security-review` before every push, `/babysit-pr` after.
+
+This track does not block, and is not blocked by, the existing HML00 backlog
+(Wolfram's `cas-*` function-surface item, Macsyma's remaining Frobenius /
+general-factoring / hypergeometric-summation gaps, or the not-yet-started
+languages) — those continue independently, and per repo direction this
+track deliberately **alternates** with that backlog rather than running to
+completion in isolation (see §6).
+
+## §6 Sequencing discipline: alternate across three fronts
+
+This track is one of three fronts the math-languages effort runs
+simultaneously, rotating rather than exhausting one before starting another:
+
+1. **Existing-language feature completeness** — Wolfram's `cas-*` function
+   surface, Macsyma's remaining gaps (general multivariate factoring,
+   Frobenius ODEs, hypergeometric summation, TS/Rust `Apart` port).
+2. **New math-language additions** — HML00 Wave 4+ (APL, J, K/Q, Scilab,
+   IDL, Reduce, Derive, Maple, Axiom, Julia), none of which exist yet.
+3. **This track (Semantic IR compilation).**
+
+A reasonable cadence: land one PR-sized unit here, then pick up one item from
+front 1 or front 2, before returning. No front should go quiet for long.
+
+## §7 Verification
+
+- **Oracle/golden testing per language**: run the same source through (a) the
+  existing `<lang>-runtime` (ground truth) and (b) `<lang>-to-semantic-ir` →
+  JS backend → `node`; diff results. Mirrors the Python/TS/Rust parity
+  testing already used across the Macsyma port.
+- Extend the existing `sir-conformance` crate's corpus-vs-reference model
+  (already built for cross-backend SIR conformance — see its lesson in
+  `lessons.md` about builtins silently missing from one backend runtime)
+  to cover the new node kinds. Any new builtin name a frontend emits must be
+  checked against **every** backend runtime it targets before being assumed
+  supported.
+- `cargo test --workspace` after any `semantic-ir` core change — the crate is
+  shared by every existing frontend/backend; `--lib` alone will not catch
+  ripples into `python-to-semantic-ir`, `ruby-to-semantic-ir`, etc.
+
+## §8 References
+
+Internal: [`HML00`](HML00-historical-math-languages-roadmap.md),
+[`SIR10`](SIR10-narrow-waist-semantic-ir.md),
+[`SIR16`](SIR16-ir-extensions-for-python-and-javascript.md) (the precedent
+this spec's extension mechanics follow),
+[`SIR22`](SIR22-array-matrix-semantic-ir.md),
+[`SIR23`](SIR23-symbolic-pattern-semantic-ir.md).

--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -1,0 +1,190 @@
+# SIR22 — Array/matrix IR extension (numeric-array math languages)
+
+## Motivation
+
+[`SIR10`](SIR10-narrow-waist-semantic-ir.md) has no numeric-array vocabulary:
+no N-D array type, no matrix multiply, no ranges, no MATLAB-style indexing.
+This spec adds that vocabulary, additively — exactly the discipline
+[`SIR16`](SIR16-ir-extensions-for-python-and-javascript.md) used to add loops
+and sequences for Python/JS without touching Twig. Every SIR10/SIR16 module
+remains valid; this spec only adds new `Expr` variants, `SirType` variants,
+and `Feature` flags.
+
+This is Stream A of [`HML01`](HML01-math-to-semantic-ir.md) — the substrate
+for `matlab-to-semantic-ir` and `octave-to-semantic-ir` today, and for every
+future array-family frontend (APL, J, K/Q, Scilab, IDL) per
+[`HML00`](HML00-historical-math-languages-roadmap.md).
+
+Every new node kind is deliberately mapped **1:1** onto an existing
+`array_runtime::execute()` op shape (see `array-runtime`'s public API), so
+that lowering a MATLAB parse tree into these nodes is mechanical — the
+frontend's job is picking the right node, not inventing new semantics.
+
+## Scope
+
+**In scope:**
+
+- Dense N-D numeric arrays (the MATLAB/Octave "everything is a matrix" model)
+- Matrix literals (`[1 2; 3 4]`), ranges (`1:5`, `0:2:10`)
+- Matrix ops: matmul, elementwise arithmetic, transpose (plain + conjugate)
+- 1-based-at-the-frontend / 0-based-in-the-IR indexing (get and set),
+  including whole-row/column (`:`) and `end`-relative forms — all resolved to
+  concrete `IndexGet`/`IndexSet` nodes by the frontend
+- Exact rational and complex scalars (`SirType::Rational`, `SirType::Complex`)
+  — shared with [`SIR23`](SIR23-symbolic-pattern-semantic-ir.md), landed once
+
+**Explicitly out of scope (deferred):**
+
+- Sparse matrices, N-D arrays beyond what `array-runtime` already models
+- GPU-specific SIR nodes — GPU dispatch stays entirely inside
+  `matrix-runtime`'s cost-based planner on the Rust side of each frontend's
+  own evaluation; the *SIR* only ever sees "do a matmul," never "on which
+  device." A JS backend runs everything on `sir-runtime-array`'s CPU-only
+  `Float64Array` path; that is a backend limitation, not an IR concern.
+- Cell arrays, structs, classdef — same things MATLAB itself defers today
+  (see [`MA01`](MA01-matlab-language.md) §2)
+
+## New `SirType` variants
+
+```text
+SirType::NDArray { elem: Box<SirType>, rank: Option<usize> }
+    -- rank: None means "unknown/dynamic rank" (a frontend that can't prove
+       rank statically leaves it absent; backends must handle the absent
+       case, they never infer it)
+SirType::Rational   -- exact numerator/denominator pair, arbitrary precision
+                        left to the backend's runtime (shared with SIR23)
+SirType::Complex     -- { re: f64, im: f64 } pair (shared with SIR23)
+```
+
+## New `Expr` variants
+
+All new variants carry `span` like every existing node.
+
+```text
+ArrayLit {
+    rows: Vec<Vec<Expr>>,      -- row-major in the literal syntax; the
+                                  frontend's job to reconcile with the
+                                  storage-convention attribute below
+    span,
+}
+
+Range {
+    start: Box<Expr>,
+    step:  Option<Box<Expr>>,  -- None means step = 1
+    stop:  Box<Expr>,
+    span,
+}
+
+MatMul { lhs: Box<Expr>, rhs: Box<Expr>, span }
+
+ElementwiseOp {
+    op:   ElementwiseOpKind,   -- Add | Sub | Mul | Div | Pow
+    lhs:  Box<Expr>,
+    rhs:  Box<Expr>,
+    span,
+}
+
+Transpose { target: Box<Expr>, conjugate: bool, span }
+
+IndexGet {
+    target:  Box<Expr>,
+    indices: Vec<IndexArg>,
+    span,
+}
+
+IndexSet {
+    target:  Box<Expr>,
+    indices: Vec<IndexArg>,
+    value:   Box<Expr>,
+    span,
+}
+
+IndexArg =
+    | Scalar(Box<Expr>)   -- a[3] — already 0-based, frontend translated
+    | Whole               -- a[:, k] — the ":" meaning "every element on
+                             this axis"
+    | Range(Box<Expr>)    -- a[1:5] — a Range expr reused as an index arg
+```
+
+`Transpose { conjugate: true }` is MATLAB `'`; `conjugate: false` is `.'`.
+Both map onto `array_runtime::execute(Transpose, …)`; the frontend decides
+which at lowering time (per the `'` transpose-vs-string lexer decision
+already made in [`MA01`](MA01-matlab-language.md) §3 — that decision is
+orthogonal to and unaffected by this spec).
+
+`end`-relative indices (MATLAB `A(end)`, `A(end-1)`) are **not** a separate
+IR concept — the frontend resolves `end` to a concrete expression (a call to
+a `size`/`length`-equivalent builtin minus an offset) before emitting
+`IndexArg::Scalar`. The IR never sees `end`; per SIR10 discipline,
+disambiguation is the frontend's job.
+
+## Storage convention
+
+`array_runtime::Array` is column-major internally (Fortran/MATLAB order),
+but that convention is currently *implicit* — baked into the Rust struct's
+memory layout, invisible to any consumer that isn't `array-runtime` itself.
+A JS backend owns its own representation and needs the convention stated
+explicitly, so it becomes a manifest-level fact:
+
+```text
+Feature::ArrayColumnMajor
+```
+
+present in a module's manifest whenever any `ArrayLit`/matrix op appears.
+`sir-runtime-array` (the JS runtime, see §"Backend" in
+[`HML01`](HML01-math-to-semantic-ir.md) §4) stores its `Float64Array` buffer
+column-major to match, so index arithmetic in the emitted JS is a direct
+translation of the same formula `array-runtime` already uses
+(`(r, c) → c * nrows + r`) rather than a silent transpose at the boundary.
+
+## New `Feature` flags
+
+```text
+Feature::NDArrays
+Feature::MatrixOps
+Feature::Rationals
+Feature::Complex
+Feature::ArrayColumnMajor
+```
+
+A backend that doesn't declare `NDArrays`/`MatrixOps` in
+`accepts_features()` cleanly rejects any module using these nodes (SIR10's
+existing capability-check mechanism — no new mechanism needed).
+
+## Effects
+
+All new `Expr` variants are `Pure` — array construction, indexing, and
+arithmetic have no observable side effects distinct from the value they
+compute. `IndexSet` is the one exception with a mutation-shaped effect; it
+is lowered as a `Stmt`-position operation (like `Assign`), not a value-producing
+`Expr`, consistent with how SIR16's `Assign` is a `Stmt`.
+
+## Backend impact
+
+- **JS/TS** (`semantic-ir-to-javascript`/`-to-typescript`): new `match` arms
+  emit calls into `sir-runtime-array` (`__SirArray.matmul(...)`,
+  `__SirArray.elementwise(...)`, `__SirArray.range(...)`,
+  `__SirArray.indexGet(...)`/`indexSet(...)`), imported only when
+  `Feature::MatrixOps`/`NDArrays` is in the manifest — same gating pattern as
+  the existing OOP/exception runtime imports.
+- **Rust/Go/Python backends**: not required to support this in the first
+  wave; they reject modules declaring `NDArrays`/`MatrixOps` per the existing
+  capability-rejection path. No code changes required to these backends for
+  this spec to land safely.
+
+## Versioning
+
+This is an additive extension within the SIR line (same discipline as
+SIR16/SIR18/KW1 before it) — no existing module or backend match arm needs
+to change; backends simply gain new arms or explicitly decline the new
+features. Modules using SIR22 nodes bump `metadata.sir_version` to record
+that fact for validators.
+
+## References
+
+Internal: [`HML01`](HML01-math-to-semantic-ir.md),
+[`SIR10`](SIR10-narrow-waist-semantic-ir.md),
+[`SIR16`](SIR16-ir-extensions-for-python-and-javascript.md) (extension
+precedent), [`MA00`](MA00-array-runtime.md) (`array-runtime`'s `Array` value
+model and `execute()` op shapes this spec mirrors 1:1),
+[`MA01`](MA01-matlab-language.md) (the frontend that will emit these nodes).

--- a/code/specs/SIR23-symbolic-pattern-semantic-ir.md
+++ b/code/specs/SIR23-symbolic-pattern-semantic-ir.md
@@ -1,0 +1,206 @@
+# SIR23 — Symbolic expression + pattern/rewrite IR extension (CAS math languages)
+
+## Motivation
+
+[`SIR10`](SIR10-narrow-waist-semantic-ir.md) has no symbolic-expression
+vocabulary: no "apply a head to args as data" concept, no pattern variables,
+no rewrite rules. This spec adds that vocabulary, additively, following the
+same discipline [`SIR16`](SIR16-ir-extensions-for-python-and-javascript.md)
+used for Python/JS. Every existing module and backend match arm stays valid;
+this only adds new `Expr` variants and `Feature` flags.
+
+This is Stream B of [`HML01`](HML01-math-to-semantic-ir.md) — the substrate
+for `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`, and
+`maxima-to-semantic-ir`, and for every future symbolic-CAS-family frontend
+(Reduce, Derive, Maple) per
+[`HML00`](HML00-historical-math-languages-roadmap.md).
+
+**The fidelity decision this spec commits to:** the IR carries **full
+rewrite semantics** — patterns and rules are first-class data, and
+`ReplaceAll`/`ReplaceRepeated` are IR-level operations a backend must
+actually execute (via a real pattern matcher in its runtime), not a
+frontend-side operation that only ever lowers a precomputed answer. This
+was an explicit repo-owner choice over the cheaper "evaluate with the
+existing CAS engine, then lower only the final `IRNode` result as inert
+data" alternative — the cheaper path can't compile an *uncomputed* Wolfram
+function body (one that pattern-matches at call time) into equivalent JS
+logic; this spec's path can.
+
+Every new node kind is mapped **1:1** onto `symbolic_ir::IRNode`'s existing
+five-variant shape (`Symbol`/`Integer`/`Rational`/`Float`/`Str`/`Apply`), so
+lowering a Wolfram or Macsyma parse tree into these nodes is mechanical.
+
+## Scope
+
+**In scope:**
+
+- Symbolic expression application: `head[args…]` / `head(args…)` as data,
+  not just as a call — the same expression can appear as a value, a pattern
+  target, or a rewrite-rule left-hand side
+- Pattern blanks: `_` (`Blank`), `x_` (named `Pattern`), `_h` / `x_h`
+  (head-constrained blank)
+- Rules: `a -> b` (`Rule`, eager RHS) and `a :> b` (`RuleDelayed`, RHS
+  re-evaluated per match)
+- Replacement: `expr /. rules` (`ReplaceAll`, one pass) and `expr //. rules`
+  (`ReplaceRepeated`, fixed point)
+- Exact rational and complex scalars (`SirType::Rational`/`SirType::Complex`
+  — shared with [`SIR22`](SIR22-array-matrix-semantic-ir.md), landed once)
+
+**Explicitly out of scope (deferred):**
+
+- Sequence patterns (`__`/`___`, `BlankSequence`/`BlankNullSequence`),
+  `Repeated`, `Except`, `Longest`/`Shortest`, `Replace` level-specs — these
+  are still open even in Wolfram's *native* pipeline per
+  [`MA04`](MA04-wolfram-language.md) (W-20's own deferred list); SIR23
+  tracks that scope exactly rather than getting ahead of the native frontend.
+- Arbitrary assumption contexts (`assume(x >= 0)`) as IR-level data — the
+  frontend resolves what it can at lowering time; an unresolved assumption
+  stays an unevaluated `SymApply`, exactly as the native runtimes do today.
+- The `cas-*` algorithm surface itself (`Expand`/`Factor`/`Solve`/`D`/
+  `Integrate`, …) is **not** new IR — those are ordinary `SymApply` nodes
+  with well-known heads (`"Expand"`, `"Factor"`, …); whether a *backend*
+  can evaluate them is a runtime-library question (does
+  `sir-runtime-symbolic` implement a `Factor` evaluator?), not an IR
+  question. First cut ships pattern-matching + rewriting infrastructure;
+  wiring the full `cas-*` algorithm library into `sir-runtime-symbolic` is
+  separate, later work, matching how the native Wolfram frontend itself
+  still has this as an open "Future" item.
+
+## New `SirType` variants
+
+```text
+SirType::SymExpr    -- an opaque symbolic-expression handle; carries no
+                        static shape (mirrors symbolic_ir::IRNode's own
+                        dynamically-shaped tree)
+SirType::Rational    -- shared with SIR22
+SirType::Complex     -- shared with SIR22
+```
+
+## New `Expr` variants
+
+All new variants carry `span`. The five core variants are named to mirror
+`symbolic_ir::IRNode` one-for-one:
+
+```text
+SymSymbol { name: String, span }                  -- IRNode::Symbol
+SymRational { numer: i64, denom: i64, span }      -- IRNode::Rational
+                                                      (reduced form; frontend
+                                                      normalizes exactly as
+                                                      IRNode::rational does)
+SymApply {
+    head: Box<Expr>,       -- usually a SymSymbol, but a computed head
+                              (`f[x][y]`) is legal — head is an Expr, not
+                              a bare string, unlike SIR22's simpler shapes
+    args: Vec<Expr>,
+    span,
+}
+```
+
+(`IntLit`/`FloatLit`/`StrLit` already exist in SIR10/SIR16 and are reused
+directly for `IRNode::Integer`/`Float`/`Str` — no new literal nodes needed
+for those three.)
+
+### Patterns
+
+```text
+SymPatternBlank { head: Option<Box<Expr>>, span }
+    -- Wolfram `_` (head: None) or `_h` (head: Some(SymSymbol("h")))
+
+SymPatternNamed { name: String, pattern: Box<Expr>, span }
+    -- Wolfram `x_` desugars to SymPatternNamed { name: "x",
+       pattern: SymPatternBlank { head: None } }; `x_h` to
+       SymPatternNamed { name: "x", pattern: SymPatternBlank { head: Some(h) } }
+```
+
+### Rules and replacement
+
+```text
+SymRule { lhs: Box<Expr>, rhs: Box<Expr>, delayed: bool, span }
+    -- delayed: false is `->` (Rule); true is `:>` (RuleDelayed)
+
+SymReplaceAll {
+    expr:     Box<Expr>,
+    rules:    Vec<Expr>,   -- each element is a SymRule (or a SymApply
+                              evaluating to a list of rules — the frontend
+                              may leave this as a runtime concern)
+    repeated: bool,        -- false: `/.` one pass; true: `//.` fixed point
+    span,
+}
+```
+
+## Matcher semantics (binding contract every backend must honor)
+
+A backend implementing `SymReplaceAll` must:
+
+1. Walk `expr`'s tree in the same traversal order `cas-pattern-matching`
+   uses today (top-down, left-to-right over `args`).
+2. At each subtree, try each `rules[i].lhs` in order; the first structural
+   match wins (no backtracking across rules — matches the reference CAS
+   behavior).
+3. A `SymPatternBlank { head: None }` matches any subtree; `head: Some(h)`
+   matches only a `SymApply` whose `head` structurally equals `h` (or a bare
+   `SymSymbol`/literal whose "head" is its own type tag, matching Wolfram's
+   `Head[]` convention).
+4. A `SymPatternNamed` binds `name` to the matched subtree for the rest of
+   that match attempt; a second occurrence of the same `name` elsewhere in
+   `lhs` requires structural equality with the first binding (not just any
+   match) — this is the one place a matcher needs backtracking-free
+   consistency checking, not full unification.
+5. On match, substitute bound names into `rhs` and replace the subtree.
+   `delayed: false` rules substitute into an already-evaluated `rhs` (built
+   once, at rule-construction time, per Wolfram `Rule` semantics); `delayed:
+   true` rules re-run substitution fresh per match (`RuleDelayed`).
+6. `repeated: true` reruns the whole pass until no rule fires (a fixed
+   point) or a backend-defined iteration cap is hit — every backend **must**
+   enforce a cap here; an unbounded `//.` is a guaranteed non-terminating
+   program for some inputs and every runtime in this repo enforces DoS caps
+   on unbounded constructs (see `Range`/list-op caps already used by the
+   native Wolfram runtime, `MA04` §10.3/§13.3/§19.5, for the established
+   convention this must match).
+
+This contract is deliberately identical to `cas-pattern-matching`'s existing
+`match_pattern`/`rewrite` algorithm — `sir-runtime-symbolic` is a **port**,
+not a reimplementation from a blank slate.
+
+## New `Feature` flags
+
+```text
+Feature::SymbolicExpr
+Feature::PatternMatching
+Feature::Rationals    -- shared with SIR22
+Feature::Complex      -- shared with SIR22
+```
+
+## Effects
+
+`SymApply`, `SymRule`, `SymReplaceAll` are all `Pure` — pattern matching and
+substitution are deterministic and side-effect-free. (A CAS session-level
+side effect, like Macsyma's `assume`/`kill`, stays entirely inside each
+frontend's own runtime and is out of scope for the IR — same "session state
+isn't SIR" boundary the native runtimes already draw.)
+
+## Backend impact
+
+- **JS/TS**: new `match` arms construct/consume a tagged term-tree value at
+  runtime via `sir-runtime-symbolic` (`__SirSym.apply(head, args)`,
+  `__SirSym.replaceAll(expr, rules)`, `__SirSym.replaceRepeated(expr, rules,
+  cap)`), imported only when `Feature::SymbolicExpr`/`PatternMatching` is in
+  the manifest.
+- **Rust/Go/Python backends**: not required in this first wave; they reject
+  modules declaring `SymbolicExpr`/`PatternMatching` per the existing
+  capability-rejection path.
+
+## Versioning
+
+Additive extension, same discipline as SIR16/SIR18/KW1/SIR22. Modules using
+SIR23 nodes bump `metadata.sir_version`.
+
+## References
+
+Internal: [`HML01`](HML01-math-to-semantic-ir.md),
+[`SIR10`](SIR10-narrow-waist-semantic-ir.md),
+[`SIR22`](SIR22-array-matrix-semantic-ir.md) (sibling domain, shared
+`Rational`/`Complex`), `symbolic-ir` (the `IRNode` shape this spec mirrors
+1:1), `cas-pattern-matching` (the matcher algorithm `sir-runtime-symbolic`
+ports), [`MA04`](MA04-wolfram-language.md) (the frontend that will emit
+these nodes; also the source of the deferred sequence-pattern scope list).


### PR DESCRIPTION
## Summary
- Adds `HML01` — a roadmap spec extending `HML00` so every math language (Macsyma/Maxima, MATLAB/Octave, Wolfram, and future APL/J/Reduce/Derive/Maple) also lowers into the narrow-waist Semantic IR (`SIR10`), enabling compilation to JS/TS (and any future SIR backend) by reuse rather than a bespoke transpiler per language.
- Adds `SIR22` — the array/matrix domain extension (NDArray, MatMul, ElementwiseOp, Range, IndexGet/Set, Transpose), mapped 1:1 onto `array-runtime::execute()`'s existing op shapes.
- Adds `SIR23` — the symbolic/pattern domain extension (SymApply, pattern blanks, Rule/RuleDelayed, ReplaceAll/ReplaceRepeated with full rewrite semantics and a mandatory DoS-cap matcher contract), mapped 1:1 onto `symbolic-ir::IRNode`.
- Both domains share `Rational`/`Complex` `SirType` variants, landed once.
- HML01 states the sequencing discipline: this SIR track alternates with closing existing-language gaps (Wolfram's `cas-*` surface, Macsyma's remaining gaps) and starting new not-yet-begun languages (APL/J/etc.) — no single front runs to exhaustion in isolation.

Spec-only PR — no implementation code yet, per the repo's specs-before-implementation convention. Implementation (semantic-ir core additions, `matlab-to-semantic-ir`, `wolfram-to-semantic-ir`, `sir-runtime-array`, `sir-runtime-symbolic`, etc.) follows in subsequent PRs per the rollout plan in HML01 §5.

## Test plan
- [x] Spec-only change; no code to test.
- [x] `/security-review` run against the diff — passed, no findings.
- [ ] `/babysit-pr` to green/merge.