### PR TITLE
feat(adj-lang): fourth math frontend — unicodemath "…" (PFE01 quartet complete)

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -150,7 +150,7 @@ expr      = term_expr { ( PLUS | MINUS ) term_expr } ;
 
 term_expr = factor { ( STAR | SLASH ) factor } ;
 
-factor    = latex_expr | asciimath_expr | mathml_expr | agg | NUMBER | IDENT | LPAREN expr RPAREN ;
+factor    = latex_expr | asciimath_expr | mathml_expr | unicodemath_expr | agg | NUMBER | IDENT | LPAREN expr RPAREN ;
 
 agg       = ( "sum" | "count" | "min" | "max" | "avg" ) LPAREN IDENT RPAREN ;
 
@@ -183,6 +183,18 @@ asciimath_expr = "asciimath" STRING ;
 # lowering and no new engine op. Unsupported math is a compile error, not a
 # host-language fallback, exactly as for the other two surfaces.
 mathml_expr = "mathml" STRING ;
+
+# Native Unicode plain-math input — a FOURTH math frontend behind the same
+# neutral `MathExpr` tree (PFE01), completing the quartet. A model that emits the
+# real glyphs people type — `x² + y²`, `√x`, `6 ÷ 2`, `3 × 4`, `π·α` — may write
+# `unicodemath "(3+4) ÷ 2"` anywhere an ADJ arithmetic expression is accepted;
+# the adj-lang frontend parses the string with the repo's Unicode-math
+# `MathFrontend` and lowers it through the EXACT SAME `MathExpr -> ExprAst`
+# lowering used for the other three surfaces. `÷` here means the same as LaTeX
+# `\div` / AsciiMath+MathML division — so the whole arithmetic subset is
+# available for free, no new lowering and no new engine op. Unsupported math is a
+# compile error, not a host-language fallback, exactly as for the other surfaces.
+unicodemath_expr = "unicodemath" STRING ;
 
 # ----------------------------------------------------------------
 # Constraint sublanguage (ADJ constraints track B1). The model

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.48.0] - 2026-07-03 — a FOURTH math frontend: `unicodemath "…"` — PFE01 quartet complete
+
+### Added
+
+- **`unicodemath "<math>"`** is now accepted anywhere an ADJ arithmetic expression is (as an `expr`
+  factor), alongside `latex "…"`, `asciimath "…"`, and `mathml "…"`. Unicode plain-math is what
+  people and models actually *type* with real glyphs — e.g. `(3+4) ÷ 2`, `3 × 4`, `x² + y²`, `√x`,
+  `π·α` — and the repo already ships a `unicode-math` `MathFrontend` that parses it to the **same
+  neutral `MathExpr`** the other three frontends produce.
+- This **completes the pluggable-frontends quartet (PFE01)**: four genuinely different notations (a
+  macro language, a terse ASCII syntax, an XML tree, and raw Unicode) all compute through the
+  **identical, unchanged** `latex_math_to_expr_ast` lowering. The adapter's only frontend-specific
+  step is the parse call (`parse_unicodemath_math`). So the whole arithmetic + named-function surface
+  is available to Unicode-math **for free** — no new lowering, and **no new engine op**. (`÷` means
+  the same as LaTeX `\div` / AsciiMath+MathML division.)
+- New grammar production `unicodemath_expr = "unicodemath" STRING ;` (regenerated `_lexer_grammar.rs`
+  / `_parser_grammar.rs`); new `AdapterError::UnicodeMathParse` for parse failures (unsupported
+  *nodes* still surface via the shared `UnsupportedLatexMath`).
+- Three end-to-end tests through `compile_and_decide`: `unicodemath "(3+4) ÷ 2"` = 3.5,
+  `unicodemath "3 × 4"` = 12, and an observed slot binding inside Unicode-math
+  (`observe x(2)` + `unicodemath "x × x"` = 4).
+- **Security/DoS:** the adapter adds **no new recursive tree-walker** — it reuses the existing
+  `latex_math_to_expr_ast` lowering. The Unicode-math parser owns its own recursion guard
+  (`MAX_DEPTH = 64`) and `#![forbid(unsafe_code)]` in its crate, so no new stack-overflow surface is
+  introduced here (no new deep-input regression test is warranted on the adapter side).
+
 ## [0.47.0] - 2026-07-03 — a THIRD math frontend: `mathml "…"` (pluggable frontends, PFE01)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 
@@ -14,3 +14,4 @@ logic-engine = { path = "../logic-engine" }
 math-frontend = { path = "../math-frontend" }
 mathml = { path = "../mathml" }
 parser = { path = "../parser" }
+unicode-math = { path = "../unicode-math" }

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -262,6 +262,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"latex_expr"#.to_string() },
                 GrammarElement::RuleReference { name: r#"asciimath_expr"#.to_string() },
                 GrammarElement::RuleReference { name: r#"mathml_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"unicodemath_expr"#.to_string() },
                 GrammarElement::RuleReference { name: r#"agg"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
@@ -314,6 +315,14 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 185,
         },
         GrammarRule {
+            name: r#"unicodemath_expr"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"unicodemath"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 197,
+        },
+        GrammarRule {
             name: r#"symbol_decl"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"symbol"#.to_string() },
@@ -321,7 +330,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 195,
+            line_number: 207,
         },
         GrammarRule {
             name: r#"constrain_latex_decl"#.to_string(),
@@ -329,7 +338,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
             ] },
-            line_number: 197,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -339,7 +348,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 199,
+            line_number: 211,
         },
         GrammarRule {
             name: r#"latex_relation"#.to_string(),
@@ -347,7 +356,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 201,
+            line_number: 213,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -360,7 +369,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 203,
+            line_number: 215,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -375,12 +384,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 205,
+            line_number: 217,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 207,
+            line_number: 219,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -391,7 +400,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 214,
+            line_number: 226,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -402,7 +411,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 226,
+            line_number: 238,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -413,7 +422,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 228,
+            line_number: 240,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -441,7 +450,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 230,
+            line_number: 242,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -453,7 +462,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 236,
+            line_number: 248,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -464,7 +473,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 253,
+            line_number: 265,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -472,7 +481,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 255,
+            line_number: 267,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -480,7 +489,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 271,
+            line_number: 283,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -490,7 +499,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
             ] },
-            line_number: 283,
+            line_number: 295,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -498,7 +507,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 289,
+            line_number: 301,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -506,7 +515,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 290,
+            line_number: 302,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -514,7 +523,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 291,
+            line_number: 303,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -524,7 +533,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 292,
+            line_number: 304,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -535,7 +544,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 294,
+            line_number: 306,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -559,7 +568,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 316,
+            line_number: 328,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -91,6 +91,14 @@ pub enum AdapterError {
     /// surfaces as [`AdapterError::UnsupportedLatexMath`] — the shared
     /// neutral-tree lowering names its errors after that first frontend.
     MathMlParse { source: String, detail: String },
+    /// A `unicodemath "<math>"` expression could not be parsed by the repo's
+    /// Unicode-math MathFrontend. Unicode-math is a FOURTH math frontend that
+    /// lowers through the same neutral `MathExpr` pipeline as
+    /// `latex`/`asciimath`/`mathml`; only the parse step is frontend-specific, so
+    /// this is its counterpart to [`AdapterError::LatexParse`]. Once parsed, an
+    /// unsupported node still surfaces as [`AdapterError::UnsupportedLatexMath`] —
+    /// the shared neutral-tree lowering names its errors after that first frontend.
+    UnicodeMathParse { source: String, detail: String },
     /// LaTeX parsed successfully, but used math outside the ADJ arithmetic /
     /// constraint subset this surface can lower faithfully.
     UnsupportedLatexMath { source: String, detail: String },
@@ -871,6 +879,14 @@ fn adapt_factor(node: &GrammarASTNode) -> Result<ExprAst, AdapterError> {
         let math = parse_mathml_math(&source)?;
         return latex_math_to_expr_ast(&math, &source);
     }
+    // A FOURTH math frontend on the same factor position: `unicodemath "<...>"`.
+    // Same story — only the parse step differs; the neutral `MathExpr` flows
+    // through the identical `latex_math_to_expr_ast` lowering (PFE01).
+    if let Some(um) = first_named_child(node, "unicodemath_expr") {
+        let source = latex_string_from_node(um, "unicodemath_expr")?;
+        let math = parse_unicodemath_math(&source)?;
+        return latex_math_to_expr_ast(&math, &source);
+    }
     if let Some(agg) = first_named_child(node, "agg") {
         return adapt_agg(agg);
     }
@@ -959,6 +975,28 @@ fn parse_mathml_math(source: &str) -> Result<MathExpr, AdapterError> {
     mathml::MathMl
         .parse(math)
         .map_err(|e| AdapterError::MathMlParse {
+            source: source.to_string(),
+            detail: e.message,
+        })
+}
+
+/// Parse a `unicodemath "..."` string with the repo's Unicode-math `MathFrontend`.
+///
+/// The Unicode-math counterpart to the other `parse_*_math` helpers — the only
+/// frontend-specific step. Its output is the same neutral [`MathExpr`] the LaTeX
+/// frontend produces, lowered by the shared [`latex_math_to_expr_ast`]. (We reuse
+/// `strip_math_delimiters` for symmetry with the sibling surfaces; raw Unicode
+/// math never carries `$…$`-style delimiters, so it is a no-op.)
+///
+/// The Unicode-math parser lives in its own crate with its own recursion guard
+/// (`MAX_DEPTH`) and `#![forbid(unsafe_code)]`; this adapter adds no new
+/// tree-walker, so it introduces no new stack-overflow surface here.
+fn parse_unicodemath_math(source: &str) -> Result<MathExpr, AdapterError> {
+    use math_frontend::MathFrontend;
+    let math = strip_math_delimiters(source);
+    unicode_math::UnicodeMath
+        .parse(math)
+        .map_err(|e| AdapterError::UnicodeMathParse {
             source: source.to_string(),
             detail: e.message,
         })

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1868,6 +1868,54 @@ contributes 1000000 from answer == 60 to correct
         assert!(d.ranked[0].posterior > 0.99, "{d:?}");
     }
 
+    // --- Unicode-math: a FOURTH math frontend — PFE01 quartet complete ---
+    // Raw Unicode glyphs (÷, ×) parse to the SAME neutral MathExpr the other three
+    // surfaces produce, flowing through the identical lowering; the ONLY difference
+    // is which MathFrontend parses the string.
+
+    #[test]
+    fn native_unicodemath_division_computes_inside_let() {
+        // `(3+4) ÷ 2` — the Unicode division sign lowers to the same division as
+        // LaTeX `\div` / AsciiMath+MathML `/`, so it computes 7/2 = 3.5.
+        let d = crate::compile_and_decide(
+            "let answer = unicodemath \"(3+4) ÷ 2\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 3.5 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_unicodemath_times_computes_inside_let() {
+        // `3 × 4` — the Unicode multiplication sign is the same Mul the other
+        // frontends' `*`/`×`/`\times` lowered to: = 12.
+        let d = crate::compile_and_decide(
+            "let answer = unicodemath \"3 × 4\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 12 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
+    #[test]
+    fn native_unicodemath_observed_symbol_binds() {
+        // An observed slot referenced from inside a Unicode-math expression binds
+        // exactly as for the sibling surfaces: with x=2 observed, `x × x` = 4.
+        let d = crate::compile_and_decide(
+            "observe x(2)\n\
+             let answer = unicodemath \"x × x\"\n\
+             prior 0.10 for correct\n\
+             contributes 1000000 from answer == 4 to correct\n\
+             ? correct\n",
+        )
+        .unwrap();
+        assert!(d.ranked[0].posterior > 0.99, "{d:?}");
+    }
+
     #[test]
     fn native_latex_relation_lowers_to_constraint() {
         let lowered =


### PR DESCRIPTION
## adj-lang: a FOURTH math frontend — `unicodemath "…"` — PFE01 quartet complete

After `latex "…"`, `asciimath "…"`, and `mathml "…"`, this wires the **fourth** and final math dialect —
**raw Unicode plain-math** — through the exact same neutral pipeline, completing the pluggable-frontends
quartet (PFE01): four genuinely different notations (a macro language, a terse ASCII syntax, an XML tree,
and raw Unicode glyphs) all compute on **one** `MathExpr → ExprAst` lowering.

### What changed

- **New surface `unicodemath "<math>"`** — accepted anywhere an ADJ arithmetic expression is (as an `expr`
  factor). Unicode plain-math is what people/models actually *type* with real glyphs: `(3+4) ÷ 2`, `3 × 4`,
  `x² + y²`, `√x`, `π·α`.
- The repo already ships a `unicode-math` `MathFrontend` that parses to the **same neutral
  `math_frontend::MathExpr`** the other three frontends produce. So the adapter's **only**
  frontend-specific step is the parse call — `parse_unicodemath_math`. The resulting `MathExpr` flows
  through the **identical, unchanged** `latex_math_to_expr_ast` lowering.
- **Result:** the whole arithmetic + named-function surface is available to Unicode-math **for free** —
  no new lowering, and **no new engine op**. (`÷` = LaTeX `\div` = AsciiMath/MathML division.)

### Files

| file | change |
|---|---|
| `code/grammars/adj_lang/adj_lang.grammar` | `factor` gains `unicodemath_expr`; new `unicodemath_expr = "unicodemath" STRING ;` |
| `…/adj-lang/src/_parser_grammar.rs` | regenerated (`regen_grammars`) |
| `…/adj-lang/src/adapter.rs` | `AdapterError::UnicodeMathParse`; `adapt_factor` branch; `parse_unicodemath_math` helper |
| `…/adj-lang/src/lower.rs` | 3 end-to-end tests |
| `…/adj-lang/Cargo.toml` | `unicode-math` path dep; 0.47.0 → 0.48.0 |
| `…/adj-lang/CHANGELOG.md` | 0.48.0 entry |

### Proof (end-to-end through `compile_and_decide`)

```
unicodemath "(3+4) ÷ 2"            == 3.5   # Unicode ÷ → the same division LaTeX \div lowers to
unicodemath "3 × 4"               == 12    # Unicode × → Mul
observe x(2); unicodemath "x × x"  == 4     # observed slot binds inside Unicode-math
```

### Security / DoS

The adapter adds **no new recursive tree-walker** — it reuses the existing `latex_math_to_expr_ast`
lowering. The Unicode-math parser owns its own recursion guard (`MAX_DEPTH = 64`) and
`#![forbid(unsafe_code)]` in its crate (documented total/panic-free), so this diff introduces no new
stack-overflow surface. Parse is pure/offline over an in-DSL string literal: no I/O, shell, or network.
Security review: PASSED.

### Verification

- `cargo test -p adj-lang -p adj-lang-cli -p adj-constraint-solver` — all green (new unicodemath tests
  3/3; no regressions in the regenerated-grammar consumers).
- `cargo test -p adj-lang --doc` — 0 doctests.
- Merged current origin/main; diff = exactly the 6 files above.
