### PR TITLE
[codex] Propagate Engram native host error details

### DIFF
--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Preserved Engram Anki import/export host-side error details in Qt, SwiftUI,
+  and Compose `hostResult` statuses so generated shells show actionable read,
+  import, export, and write failures instead of generic status text.
 - Wired the generated HTML, WebComponent, and React Engram web hosts to handle
   Anki import/export `hostIntent` payloads with browser file input/download
   helpers and the `engram-wasm` APKG byte API, surfacing `hostResult` errors

--- a/code/programs/mosaic/engram-app/README.md
+++ b/code/programs/mosaic/engram-app/README.md
@@ -45,6 +45,8 @@ editing, and save/delete/cancel controls.
 - The web, Electron, Qt, SwiftUI, Compose, Flutter, and XAML host adapters
   merge their Anki import/export `hostResult` status back into those shared
   status slots.
+- The Electron, web, and native host adapters preserve host-side error details
+  in those status messages when a package read/import/export/write step fails.
 - The generated React and Electron renderer shells mount `EngramApp` through
   `window.mosaicHost.getProps` and `window.mosaicHost.handleEvent`, with sample
   slot values as a fallback when no host is installed.

--- a/code/programs/mosaic/engram-app/host/compose/MosaicHost.kt
+++ b/code/programs/mosaic/engram-app/host/compose/MosaicHost.kt
@@ -66,7 +66,7 @@ class MosaicHost {
             ?: return hostResultResponse(response, hostIntent, "cancelled")
         val bytes = runCatching { file.readBytes() }.getOrElse {
             println("Engram Compose MosaicHost could not read Anki package: ${it.message}")
-            return hostResultResponse(response, hostIntent, "read-error", file.path)
+            return hostResultResponse(response, hostIntent, "read-error", file.path, it.message)
         }
 
         val imported = hostResponseFromJson(
@@ -74,7 +74,7 @@ class MosaicHost {
         )
         if (imported.containsKey("error")) {
             println("Engram Compose MosaicHost could not import Anki package: ${imported["error"]}")
-            return hostResultResponse(response, hostIntent, "import-error", file.path)
+            return hostResultResponse(response, hostIntent, "import-error", file.path, imported["error"])
         }
 
         persistSnapshot()
@@ -104,16 +104,23 @@ class MosaicHost {
         val exported = runCatching { JSONObject(takeCString(api.eg_export_anki_apkg(handle), api)) }
             .getOrElse {
                 println("Engram Compose MosaicHost could not parse exported Anki package: ${it.message}")
-                return hostResultResponse(response, hostIntent, "export-error", outputFile.path)
+                return hostResultResponse(response, hostIntent, "export-error", outputFile.path, it.message)
             }
         if (!exported.optBoolean("ok", true)) {
-            println("Engram Compose MosaicHost could not export Anki package: ${jsonValue(exported.opt("error"))}")
-            return hostResultResponse(response, hostIntent, "export-error", outputFile.path)
+            val error = jsonValue(exported.opt("error"))
+            println("Engram Compose MosaicHost could not export Anki package: $error")
+            return hostResultResponse(response, hostIntent, "export-error", outputFile.path, error)
         }
 
         val bytes = jsonByteArray(exported, "apkg")
         if (bytes.isEmpty()) {
-            return hostResultResponse(response, hostIntent, "export-error", outputFile.path)
+            return hostResultResponse(
+                response,
+                hostIntent,
+                "export-error",
+                outputFile.path,
+                "Engram native host returned an empty APKG"
+            )
         }
 
         val wrote = runCatching {
@@ -122,7 +129,13 @@ class MosaicHost {
         }
         if (wrote.isFailure) {
             println("Engram Compose MosaicHost could not save Anki package: ${wrote.exceptionOrNull()?.message}")
-            return hostResultResponse(response, hostIntent, "write-error", outputFile.path)
+            return hostResultResponse(
+                response,
+                hostIntent,
+                "write-error",
+                outputFile.path,
+                wrote.exceptionOrNull()?.message
+            )
         }
 
         return hostResultResponse(response, hostIntent, "exported", outputFile.path)
@@ -257,13 +270,17 @@ class MosaicHost {
         response: Map<String, Any?>,
         hostIntent: Map<*, *>,
         status: String,
-        path: String? = null
+        path: String? = null,
+        error: Any? = null
     ): Map<String, Any?> {
         val out = response.toMutableMap()
         out["hostIntent"] = jsonMap(hostIntent)
         val hostResult = mutableMapOf<String, Any?>("status" to status)
         if (!path.isNullOrBlank()) {
             hostResult["path"] = path
+        }
+        if (error != null && error.toString().isNotBlank()) {
+            hostResult["error"] = error.toString()
         }
         out["hostResult"] = hostResult
         return withHostStatusProps(out, hostResult)
@@ -307,29 +324,38 @@ class MosaicHost {
 
     private fun hostStatusMessage(hostResult: Map<String, Any?>, status: String): String {
         val file = hostResultFile(hostResult)
+        val error = hostResult["error"]?.toString().orEmpty()
         return when (status) {
             "imported" -> if (file.isBlank()) "Anki package imported." else "Imported $file."
             "exported" -> if (file.isBlank()) "Anki package exported." else "Saved $file."
             "cancelled" -> "No Anki package was selected."
             "read-error" -> if (file.isBlank()) {
-                "Could not read the selected file."
+                if (error.isBlank()) "Could not read the selected file." else "Could not read the selected file: $error"
             } else {
-                "Could not read $file."
+                if (error.isBlank()) "Could not read $file." else "Could not read $file: $error"
             }
             "import-error" -> if (file.isBlank()) {
-                "Could not import the selected package."
+                if (error.isBlank()) "Could not import the selected package." else "Could not import the selected package: $error"
             } else {
-                "Could not import $file."
+                if (error.isBlank()) "Could not import $file." else "Could not import $file: $error"
             }
-            "export-error" -> "Could not export Anki package."
-            "write-error" -> if (file.isBlank()) {
-                "Could not save the Anki package."
+            "export-error" -> if (error.isBlank()) {
+                "Could not export Anki package."
             } else {
-                "Could not save $file."
+                "Could not export Anki package: $error"
+            }
+            "write-error" -> if (file.isBlank()) {
+                if (error.isBlank()) "Could not save the Anki package." else "Could not save the Anki package: $error"
+            } else {
+                if (error.isBlank()) "Could not save $file." else "Could not save $file: $error"
             }
             "unavailable" -> "Engram native host is unavailable."
             "unsupported" -> "This host does not support native Anki file dialogs yet."
-            else -> if (file.isBlank()) status else file
+            else -> if (error.isBlank()) {
+                if (file.isBlank()) status else file
+            } else {
+                error
+            }
         }
     }
 

--- a/code/programs/mosaic/engram-app/host/qt/MosaicHost.cpp
+++ b/code/programs/mosaic/engram-app/host/qt/MosaicHost.cpp
@@ -241,8 +241,9 @@ QVariantMap MosaicHost::importAnkiPackage(
 
   QFile file(path);
   if (!file.open(QIODevice::ReadOnly)) {
-    qWarning() << "Engram MosaicHost could not read Anki package:" << file.errorString();
-    return hostResultResponse(response, hostIntent, QStringLiteral("read-error"), path);
+    const QString error = file.errorString();
+    qWarning() << "Engram MosaicHost could not read Anki package:" << error;
+    return hostResultResponse(response, hostIntent, QStringLiteral("read-error"), path, error);
   }
 
   const QByteArray data = file.readAll();
@@ -252,9 +253,9 @@ QVariantMap MosaicHost::importAnkiPackage(
       static_cast<std::size_t>(data.size())));
   const QVariantMap imported = hostResponseFromJson(json);
   if (imported.contains(QStringLiteral("error"))) {
-    qWarning() << "Engram MosaicHost could not import Anki package:"
-               << imported.value(QStringLiteral("error")).toString();
-    return hostResultResponse(response, hostIntent, QStringLiteral("import-error"), path);
+    const QString error = imported.value(QStringLiteral("error")).toString();
+    qWarning() << "Engram MosaicHost could not import Anki package:" << error;
+    return hostResultResponse(response, hostIntent, QStringLiteral("import-error"), path, error);
   }
 
   persistSnapshot();
@@ -292,29 +293,31 @@ QVariantMap MosaicHost::exportAnkiPackage(
   QJsonParseError parseError;
   const QJsonDocument document = QJsonDocument::fromJson(json.toUtf8(), &parseError);
   if (parseError.error != QJsonParseError::NoError || !document.isObject()) {
-    qWarning() << "Engram MosaicHost could not parse exported Anki package JSON:"
-               << parseError.errorString();
-    return hostResultResponse(response, hostIntent, QStringLiteral("export-error"), path);
+    const QString error = parseError.errorString();
+    qWarning() << "Engram MosaicHost could not parse exported Anki package JSON:" << error;
+    return hostResultResponse(response, hostIntent, QStringLiteral("export-error"), path, error);
   }
 
   const QJsonObject root = document.object();
   if (root.value(QStringLiteral("ok")).toBool(true) == false) {
-    qWarning() << "Engram MosaicHost could not export Anki package:"
-               << root.value(QStringLiteral("error")).toString();
-    return hostResultResponse(response, hostIntent, QStringLiteral("export-error"), path);
+    const QString error = root.value(QStringLiteral("error")).toString(QStringLiteral("unknown error"));
+    qWarning() << "Engram MosaicHost could not export Anki package:" << error;
+    return hostResultResponse(response, hostIntent, QStringLiteral("export-error"), path, error);
   }
 
   const QByteArray data = jsonByteArray(root, QStringLiteral("apkg"));
   QFile file(path);
   if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-    qWarning() << "Engram MosaicHost could not save Anki package:" << file.errorString();
-    return hostResultResponse(response, hostIntent, QStringLiteral("write-error"), path);
+    const QString error = file.errorString();
+    qWarning() << "Engram MosaicHost could not save Anki package:" << error;
+    return hostResultResponse(response, hostIntent, QStringLiteral("write-error"), path, error);
   }
   file.write(data);
   file.close();
   if (file.error() != QFile::NoError) {
-    qWarning() << "Engram MosaicHost could not finish saving Anki package:" << file.errorString();
-    return hostResultResponse(response, hostIntent, QStringLiteral("write-error"), path);
+    const QString error = file.errorString();
+    qWarning() << "Engram MosaicHost could not finish saving Anki package:" << error;
+    return hostResultResponse(response, hostIntent, QStringLiteral("write-error"), path, error);
   }
 
   return hostResultResponse(response, hostIntent, QStringLiteral("exported"), path);
@@ -324,13 +327,17 @@ QVariantMap MosaicHost::hostResultResponse(
     const QVariantMap &response,
     const QVariantMap &hostIntent,
     const QString &status,
-    const QString &path) const {
+    const QString &path,
+    const QString &error) const {
   QVariantMap out = response;
   out.insert(QStringLiteral("hostIntent"), hostIntent);
   QVariantMap hostResult;
   hostResult.insert(QStringLiteral("status"), status);
   if (!path.isEmpty()) {
     hostResult.insert(QStringLiteral("path"), path);
+  }
+  if (!error.isEmpty()) {
+    hostResult.insert(QStringLiteral("error"), error);
   }
   out.insert(QStringLiteral("hostResult"), hostResult);
   return withHostStatusProps(out, hostResult);
@@ -386,6 +393,7 @@ QString MosaicHost::hostStatusMessage(
     const QVariantMap &hostResult,
     const QString &status) const {
   const QString file = hostResultFile(hostResult);
+  const QString error = hostResult.value(QStringLiteral("error")).toString();
   if (status == QStringLiteral("imported")) {
     return file.isEmpty() ? QStringLiteral("Anki package imported.")
                           : QStringLiteral("Imported %1.").arg(file);
@@ -398,19 +406,26 @@ QString MosaicHost::hostStatusMessage(
     return QStringLiteral("No Anki package was selected.");
   }
   if (status == QStringLiteral("read-error")) {
-    return file.isEmpty() ? QStringLiteral("Could not read the selected file.")
-                          : QStringLiteral("Could not read %1.").arg(file);
+    const QString subject = file.isEmpty() ? QStringLiteral("the selected file") : file;
+    return error.isEmpty() ? QStringLiteral("Could not read %1.").arg(subject)
+                           : QStringLiteral("Could not read %1: %2").arg(subject, error);
   }
   if (status == QStringLiteral("import-error")) {
-    return file.isEmpty() ? QStringLiteral("Could not import the selected package.")
-                          : QStringLiteral("Could not import %1.").arg(file);
+    const QString subject = file.isEmpty() ? QStringLiteral("the selected package") : file;
+    return error.isEmpty() ? QStringLiteral("Could not import %1.").arg(subject)
+                           : QStringLiteral("Could not import %1: %2").arg(subject, error);
   }
   if (status == QStringLiteral("export-error")) {
-    return QStringLiteral("Could not export Anki package.");
+    return error.isEmpty() ? QStringLiteral("Could not export Anki package.")
+                           : QStringLiteral("Could not export Anki package: %1").arg(error);
   }
   if (status == QStringLiteral("write-error")) {
-    return file.isEmpty() ? QStringLiteral("Could not save the Anki package.")
-                          : QStringLiteral("Could not save %1.").arg(file);
+    const QString subject = file.isEmpty() ? QStringLiteral("the Anki package") : file;
+    return error.isEmpty() ? QStringLiteral("Could not save %1.").arg(subject)
+                           : QStringLiteral("Could not save %1: %2").arg(subject, error);
+  }
+  if (!error.isEmpty()) {
+    return error;
   }
   return file.isEmpty() ? status : file;
 }

--- a/code/programs/mosaic/engram-app/host/qt/MosaicHost.h
+++ b/code/programs/mosaic/engram-app/host/qt/MosaicHost.h
@@ -45,7 +45,8 @@ private:
       const QVariantMap &response,
       const QVariantMap &hostIntent,
       const QString &status,
-      const QString &path = QString()) const;
+      const QString &path = QString(),
+      const QString &error = QString()) const;
   QVariantMap withHostStatusProps(QVariantMap response, const QVariantMap &hostResult) const;
   QVariantMap hostStatusProps(const QVariantMap &hostResult) const;
   QString hostStatusLabel(const QString &status) const;

--- a/code/programs/mosaic/engram-app/host/swiftui/MosaicHost.swift
+++ b/code/programs/mosaic/engram-app/host/swiftui/MosaicHost.swift
@@ -156,12 +156,14 @@ import AppKit
             }
             guard let imported = decodeJsonObject(json),
                   (imported["ok"] as? Bool) != false else {
-                print("Engram Anki import failed: \(decodeJsonObject(json)?["error"] ?? "unknown error")")
+                let error = decodeJsonObject(json)?["error"] as? String ?? "unknown error"
+                print("Engram Anki import failed: \(error)")
                 return hostResultResponse(
                     response,
                     hostIntent: hostIntent,
                     status: "import-error",
-                    path: url.path)
+                    path: url.path,
+                    error: error)
             }
 
             persistSnapshot()
@@ -179,7 +181,8 @@ import AppKit
                 response,
                 hostIntent: hostIntent,
                 status: "read-error",
-                path: url.path)
+                path: url.path,
+                error: String(describing: error))
         }
         #else
         return hostResultResponse(response, hostIntent: hostIntent, status: "unsupported")
@@ -202,12 +205,14 @@ import AppKit
         let json = takeCString(eg_export_anki_apkg(session))
         guard let root = decodeJsonObject(json),
               (root["ok"] as? Bool) != false else {
-            print("Engram Anki export failed: \(decodeJsonObject(json)?["error"] ?? "unknown error")")
+            let error = decodeJsonObject(json)?["error"] as? String ?? "unknown error"
+            print("Engram Anki export failed: \(error)")
             return hostResultResponse(
                 response,
                 hostIntent: hostIntent,
                 status: "export-error",
-                path: url.path)
+                path: url.path,
+                error: error)
         }
 
         let data = jsonByteArray(root, property: "apkg")
@@ -216,7 +221,8 @@ import AppKit
                 response,
                 hostIntent: hostIntent,
                 status: "export-error",
-                path: url.path)
+                path: url.path,
+                error: "Engram native host returned an empty APKG")
         }
 
         do {
@@ -232,7 +238,8 @@ import AppKit
                 response,
                 hostIntent: hostIntent,
                 status: "write-error",
-                path: url.path)
+                path: url.path,
+                error: String(describing: error))
         }
         #else
         return hostResultResponse(response, hostIntent: hostIntent, status: "unsupported")
@@ -243,13 +250,17 @@ import AppKit
         _ response: [String: Any],
         hostIntent: [String: Any],
         status: String,
-        path: String? = nil
+        path: String? = nil,
+        error: String? = nil
     ) -> NSDictionary {
         var out = response
         out["hostIntent"] = hostIntent
         var hostResult: [String: Any] = ["status": status]
         if let path, !path.isEmpty {
             hostResult["path"] = path
+        }
+        if let error, !error.isEmpty {
+            hostResult["error"] = error
         }
         out["hostResult"] = hostResult
         return withHostStatusProps(out, hostResult: hostResult)
@@ -305,6 +316,7 @@ import AppKit
 
     private func hostStatusMessage(_ hostResult: [String: Any], status: String) -> String {
         let file = hostResultFile(hostResult)
+        let error = hostResult["error"] as? String ?? ""
         switch status {
         case "imported":
             return file.isEmpty ? "Anki package imported." : "Imported \(file)."
@@ -313,19 +325,22 @@ import AppKit
         case "cancelled":
             return "No Anki package was selected."
         case "read-error":
-            return file.isEmpty ? "Could not read the selected file." : "Could not read \(file)."
+            let subject = file.isEmpty ? "the selected file" : file
+            return error.isEmpty ? "Could not read \(subject)." : "Could not read \(subject): \(error)"
         case "import-error":
-            return file.isEmpty ? "Could not import the selected package." : "Could not import \(file)."
+            let subject = file.isEmpty ? "the selected package" : file
+            return error.isEmpty ? "Could not import \(subject)." : "Could not import \(subject): \(error)"
         case "export-error":
-            return "Could not export Anki package."
+            return error.isEmpty ? "Could not export Anki package." : "Could not export Anki package: \(error)"
         case "write-error":
-            return file.isEmpty ? "Could not save the Anki package." : "Could not save \(file)."
+            let subject = file.isEmpty ? "the Anki package" : file
+            return error.isEmpty ? "Could not save \(subject)." : "Could not save \(subject): \(error)"
         case "unavailable":
             return "Engram native host is unavailable."
         case "unsupported":
             return "This host does not support native Anki file dialogs yet."
         default:
-            return file.isEmpty ? status : file
+            return error.isEmpty ? (file.isEmpty ? status : file) : error
         }
     }
 

--- a/code/programs/mosaic/engram-app/tests/package_compiles.rs
+++ b/code/programs/mosaic/engram-app/tests/package_compiles.rs
@@ -2635,6 +2635,9 @@ fn source_tree_has_expected_shape() {
     assert_contains(&swiftui_host, "eg_load_snapshot");
     assert_contains(&swiftui_host, "withHostStatusProps");
     assert_contains(&swiftui_host, "\"host-status-visible\": true");
+    assert_contains(&swiftui_host, "hostResult[\"error\"] = error");
+    assert_contains(&swiftui_host, "Could not import \\(subject): \\(error)");
+    assert_contains(&swiftui_host, "Could not export Anki package: \\(error)");
 
     let qt_host = fs::read_to_string(package_root().join("host/qt/MosaicHost.cpp"))
         .expect("qt host template");
@@ -2659,6 +2662,9 @@ fn source_tree_has_expected_shape() {
     assert_contains(&qt_host, "eg_load_snapshot");
     assert_contains(&qt_host, "withHostStatusProps");
     assert_contains(&qt_host, "QStringLiteral(\"hostStatusVisible\")");
+    assert_contains(&qt_host, "hostResult.insert(QStringLiteral(\"error\"), error)");
+    assert_contains(&qt_host, "Could not import %1: %2");
+    assert_contains(&qt_host, "Could not export Anki package: %1");
 
     let compose_host = fs::read_to_string(package_root().join("host/compose/MosaicHost.kt"))
         .expect("compose host template");
@@ -2684,6 +2690,9 @@ fn source_tree_has_expected_shape() {
     assert_contains(&compose_host, "eg_load_snapshot");
     assert_contains(&compose_host, "withHostStatusProps");
     assert_contains(&compose_host, "\"host-status-visible\" to true");
+    assert_contains(&compose_host, "hostResult[\"error\"] = error.toString()");
+    assert_contains(&compose_host, "Could not import $file: $error");
+    assert_contains(&compose_host, "Could not export Anki package: $error");
 
     let flutter_host = fs::read_to_string(package_root().join("host/flutter/mosaic_host.dart"))
         .expect("flutter host template");


### PR DESCRIPTION
## Summary
- propagate Qt, SwiftUI, and Compose host-side error details into Engram Anki import/export hostResult payloads
- include those details in host-status messages for read, import, export, and write failures
- document the native/web/electron error-detail parity and pin smoke-test assertions for the host templates

## Validation
- git diff --check
- cargo test --manifest-path code\programs\mosaic\engram-app\Cargo.toml source_tree_has_expected_shape -- --nocapture
- cargo test --manifest-path code\programs\mosaic\engram-app\Cargo.toml -- --nocapture