### PR TITLE
test(closurec): CLOC12.162 PR3 — CodePrinter spread conformance port

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.26.1] - 2026-07-03
+
+### Added — CLOC12.162 PR3: CodePrinter spread conformance port
+
+New upstream-cited test file `tests/upstream/code_printer_spread_test.rs`
+(registered as the `upstream_code_printer_spread` `[[test]]` target) porting the
+Closure Compiler `CodePrinterTest` spread (`...arg`) printing cases against
+`emit_spread`. 10 active `#[test]`s, **0 `#[ignore]`** — spread call arguments
+(sole `f(...a)`, interleaved `f(a,...b,c)`, two adjacent `f(...a,...b)`, member
+argument `f(...a.b)`), array elements (sole `[...a]`, interleaved `[1,...a,2]`),
+`new` arguments (`new F(...a)`, interleaved `new F(a,...b)`), and the
+`PREC_ASSIGNMENT` precedence cases (sequence argument wraps `f(...(a,b))`,
+conditional argument stays bare `f(...a?b:c)`). Inputs are hand-constructed
+typed AST; the bridge conversion of the spread form is exercised separately
+(CLOC12.162 PR2, gap-163, in `javascript-parser`). ATTRIBUTION.md updated.
+
 ## [0.26.0] - 2026-07-03
 
 ### Added — CLOC12.162: emit `SpreadElement` (`...arg`)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -76,3 +76,7 @@ path = "tests/upstream/code_printer_sequence_test.rs"
 [[test]]
 name = "upstream_code_printer_tagged_template"
 path = "tests/upstream/code_printer_tagged_template_test.rs"
+
+[[test]]
+name = "upstream_code_printer_spread"
+path = "tests/upstream/code_printer_spread_test.rs"

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -108,6 +108,22 @@ under the Apache License, Version 2.0:
       conversion of the comma operator (CLOC12.160 PR2, gap-161) is exercised
       separately in `javascript-parser`.
 
+- `code_printer_spread_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the spread `...arg` printing cases — bare argument/element positions and
+      the assignment-position wrap)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_spread` + the `PREC_ASSIGNMENT` classification that landed
+      with `Expression::SpreadElement` (CLOC12.162). 10 active `#[test]`s and
+      **0 `#[ignore]`** — the covered shapes: spread call arguments (sole
+      `f(...a)`, interleaved `f(a,...b,c)`, two adjacent `f(...a,...b)`, member
+      argument `f(...a.b)`), array elements (sole `[...a]`, interleaved
+      `[1,...a,2]`), `new` arguments (`new F(...a)`, interleaved
+      `new F(a,...b)`), and the precedence cases (sequence argument wraps
+      `f(...(a,b))`, conditional argument stays bare `f(...a?b:c)`). Inputs are
+      hand-constructed AST; the bridge conversion of the spread form
+      (CLOC12.162 PR2, gap-163) is exercised separately in `javascript-parser`.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_spread_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_spread_test.rs
@@ -1,0 +1,220 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **spread** printing cases — the `SpreadElement`
+//! `...arg`. This is the fifteenth CodePrinter port into `closure-emitter`
+//! (after core / declarations / trailing-comma / numbers / string-escape /
+//! ascii-escape / object-literal / function-expression / arrow-function /
+//! template / update / new / sequence / tagged-template) and isolates
+//! `emit_spread` + the `PREC_ASSIGNMENT` classification that landed with
+//! `Expression::SpreadElement` (CLOC12.162).
+//!
+//! # How the emitter prints a spread (recap)
+//!
+//! ```text
+//!   f(...a)          → f(...a)         spread a call argument, no `... a` space
+//!   f(a, ...b, c)    → f(a,...b,c)     interleaved, arity preserved
+//!   [1, ...a, 2]     → [1,...a,2]      spread an array element
+//!   new F(...a)      → new F(...a)     spread a `new` argument
+//! ```
+//!
+//! The `...` prefix has no interior space, and the argument prints at
+//! `PREC_ASSIGNMENT`:
+//!
+//! ```text
+//!   f(...a?b:c)      a conditional argument binds tighter than the floor → bare
+//!   f(...(a,b))      a LOOSER sequence argument WRAPS, or `...a,b` would spread
+//!                    only `a` and leave `,b` as a second list slot
+//! ```
+//!
+//! The spread node itself tags at `PREC_ASSIGNMENT`, matching the
+//! assignment-position argument/element slots it lives in, so it is never
+//! spuriously parenthesised there.
+//!
+//! # Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (upstream lex/parses
+//! source). The emitter is the unit under test here — the bridge conversion of
+//! the spread form (CLOC12.162 PR2, gap-163) is exercised separately in
+//! `javascript-parser`.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    ArrayExpression, CallExpression, ConditionalExpression, Expression, ExpressionStatement,
+    Identifier, MemberExpression, NewExpression, NumericLiteral, Program, ProgramItem,
+    SequenceExpression, SourceType, SpreadElement, Statement,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn num(value: f64, raw: &str) -> Expression {
+    Expression::NumericLiteral(NumericLiteral { cv: None, value, raw: raw.to_string() })
+}
+
+fn spread(argument: Expression) -> Expression {
+    Expression::SpreadElement(SpreadElement { cv: None, argument: Box::new(argument) })
+}
+
+fn call(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::CallExpression(CallExpression { cv: None, callee: Box::new(callee), arguments })
+}
+
+fn new_expr(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::NewExpression(NewExpression { cv: None, callee: Box::new(callee), arguments })
+}
+
+fn array(elements: Vec<Option<Expression>>) -> Expression {
+    Expression::ArrayExpression(ArrayExpression { cv: None, elements })
+}
+
+fn member(object: Expression, property: &str) -> Expression {
+    Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(object),
+        property: Box::new(ident(property)),
+        computed: false,
+    })
+}
+
+fn seq(operands: Vec<Expression>) -> Expression {
+    Expression::SequenceExpression(SequenceExpression { cv: None, expressions: operands })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "spread emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — spread in a call argument list
+// =====================================================================
+
+/// `f(...a)` — a spread as the sole call argument prints bare, with no space
+/// between `...` and the argument.
+#[test]
+fn spread_sole_call_arg() {
+    assert_emits(call(ident("f"), vec![spread(ident("a"))]), "f(...a);");
+}
+
+/// `f(a, ...b, c)` — a spread interleaved with plain arguments keeps position
+/// and arity.
+#[test]
+fn spread_interleaved_call_args() {
+    let e = call(ident("f"), vec![ident("a"), spread(ident("b")), ident("c")]);
+    assert_emits(e, "f(a,...b,c);");
+}
+
+/// `f(...a, ...b)` — two adjacent spreads both print bare.
+#[test]
+fn spread_two_adjacent_call_args() {
+    let e = call(ident("f"), vec![spread(ident("a")), spread(ident("b"))]);
+    assert_emits(e, "f(...a,...b);");
+}
+
+/// `f(...a.b)` — the spread argument may be a member chain (member binds
+/// tighter than assignment, so it prints bare).
+#[test]
+fn spread_member_argument() {
+    let e = call(ident("f"), vec![spread(member(ident("a"), "b"))]);
+    assert_emits(e, "f(...a.b);");
+}
+
+// =====================================================================
+// Active — spread in an array literal
+// =====================================================================
+
+/// `[...a]` — a spread as the sole array element prints bare.
+#[test]
+fn spread_sole_array_element() {
+    assert_emits(array(vec![Some(spread(ident("a")))]), "[...a];");
+}
+
+/// `[1, ...a, 2]` — a spread interleaved with literals keeps element count and
+/// order.
+#[test]
+fn spread_interleaved_array_elements() {
+    let e = array(vec![Some(num(1.0, "1")), Some(spread(ident("a"))), Some(num(2.0, "2"))]);
+    assert_emits(e, "[1,...a,2];");
+}
+
+// =====================================================================
+// Active — spread in a `new` argument list
+// =====================================================================
+
+/// `new F(...a)` — a spread flows into a `new` argument list exactly as a call
+/// argument does.
+#[test]
+fn spread_new_argument() {
+    assert_emits(new_expr(ident("F"), vec![spread(ident("a"))]), "new F(...a);");
+}
+
+/// `new F(a, ...b)` — interleaved with a plain `new` argument.
+#[test]
+fn spread_interleaved_new_arguments() {
+    let e = new_expr(ident("F"), vec![ident("a"), spread(ident("b"))]);
+    assert_emits(e, "new F(a,...b);");
+}
+
+// =====================================================================
+// Active — precedence (spread argument prints at PREC_ASSIGNMENT)
+// =====================================================================
+
+/// `f(...(a,b))` — a **sequence** spread argument is the one form that must
+/// wrap: a bare `...a,b` would spread only `a` and leave `,b` as a second list
+/// slot.
+#[test]
+fn spread_sequence_argument_is_wrapped() {
+    let e = call(ident("f"), vec![spread(seq(vec![ident("a"), ident("b")]))]);
+    assert_emits(e, "f(...(a,b));");
+}
+
+/// `f(...a?b:c)` — a conditional argument binds tighter than the sequence
+/// floor, so it prints bare (spread's operand grammar is an
+/// `AssignmentExpression`, which subsumes the conditional): no over-wrap.
+#[test]
+fn spread_conditional_argument_is_bare() {
+    let cond = Expression::ConditionalExpression(ConditionalExpression {
+        cv: None,
+        test: Box::new(ident("a")),
+        consequent: Box::new(ident("b")),
+        alternate: Box::new(ident("c")),
+    });
+    assert_emits(call(ident("f"), vec![spread(cond)]), "f(...a?b:c);");
+}


### PR DESCRIPTION
## CLOC12.162 PR3 — CodePrinter spread conformance port

Ports the Closure Compiler `CodePrinterTest` **spread** (`...arg`) printing cases into `closure-emitter` as a new upstream-cited conformance test, exercising `emit_spread` + the `PREC_ASSIGNMENT` classification that landed in PR1 ([#7515](https://github.com/adhithyan15/coding-adventures/pull/7515)).

### What
New `tests/upstream/code_printer_spread_test.rs` (registered as the `upstream_code_printer_spread` `[[test]]` target). **10 active `#[test]`s, 0 `#[ignore]`**:
- **Call arguments** — sole `f(...a)`, interleaved `f(a,...b,c)`, two adjacent `f(...a,...b)`, member argument `f(...a.b)`
- **Array elements** — sole `[...a]`, interleaved `[1,...a,2]`
- **`new` arguments** — `new F(...a)`, interleaved `new F(a,...b)`
- **Precedence** (`PREC_ASSIGNMENT`) — sequence argument wraps `f(...(a,b))`, conditional argument stays bare `f(...a?b:c)`

Inputs are hand-constructed typed AST (the emitter is the unit under test); the bridge conversion of the spread form is exercised separately in `javascript-parser` (CLOC12.162 PR2, gap-163, [#7530](https://github.com/adhithyan15/coding-adventures/pull/7530)).

### Changes
- **closure-emitter 0.26.0 → 0.26.1** (PATCH, conformance-only) + CHANGELOG.
- `tests/upstream/ATTRIBUTION.md` — new port entry citing the tracked upstream SHA.

### Verification
- `cargo test -p coding-adventures-closure-emitter --test upstream_code_printer_spread` → 10 passed, 0 failed.
- Security review: **PASSED** — test + docs only, no production `src/` change, no untrusted input / I/O / `unsafe`.
- Diff is exactly the 4 intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)