### PR TITLE
feat(engram): light-theme stylesheets for all Engram components

### DIFF
--- a/code/packages/mosaic/mosaic-pkg-card-browser/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-card-browser/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a light-theme stylesheet (`CardBrowser.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
 - Added browser result metadata slots for card IDs, note IDs, template IDs,
   state labels, and selected-row values so host apps can target browser
   actions without parsing labels.

--- a/code/packages/mosaic/mosaic-pkg-card-browser/src/CardBrowser.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-card-browser/src/CardBrowser.light.msl
@@ -1,0 +1,266 @@
+// CardBrowser.light.msl - light card-browser theme.
+
+style CardBrowser {
+  part card-browser {
+    background    : "#f8fafc" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 14 ;
+  }
+
+  part browser-title {
+    color          : "#0f172a" ;
+    font-size      : 20 ;
+    font-weight    : 800 ;
+    padding-bottom : 10 ;
+  }
+
+  part browser-search-row {
+    padding-bottom : 10 ;
+  }
+
+  part query-column {
+    padding : 2 ;
+  }
+
+  part query-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part filter-column {
+    padding : 2 ;
+  }
+
+  part filter-label {
+    color       : "#155e75" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part filter-toggle-button {
+    background    : "#cffafe" ;
+    border-width  : 1 ;
+    border-color  : "#a5f3fc" ;
+    border-radius : 6 ;
+    color         : "#155e75" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part filter-options-list {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#a5f3fc" ;
+    border-radius : 6 ;
+    padding       : 4 ;
+  }
+
+  part filter-option-button {
+    background    : "#cffafe" ;
+    border-width  : 1 ;
+    border-color  : "#a5f3fc" ;
+    border-radius : 6 ;
+    color         : "#155e75" ;
+    padding       : 6 ;
+  }
+
+  part search-button {
+    background    : "#dbeafe" ;
+    border-width  : 1 ;
+    border-color  : "#93c5fd" ;
+    border-radius : 6 ;
+    color         : "#1e40af" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part results-label {
+    color       : "#5b21b6" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part results-summary {
+    color          : "#334155" ;
+    font-size      : 14 ;
+    padding-bottom : 8 ;
+  }
+
+  part browser-actions {
+    padding-top : 10 ;
+  }
+
+  part browser-flag-row {
+    padding-top    : 10 ;
+    padding-bottom : 2 ;
+  }
+
+  part flag-picker-column {
+    padding : 2 ;
+  }
+
+  part flag-label {
+    color       : "#92400e" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part selected-flag-label {
+    color       : "#92400e" ;
+    font-size   : 12 ;
+    font-weight : 700 ;
+    padding     : 8 ;
+  }
+
+  part browser-tag-row {
+    padding-top    : 10 ;
+    padding-bottom : 2 ;
+  }
+
+  part tag-edit-column {
+    padding : 2 ;
+  }
+
+  part tag-edit-label {
+    color       : "#166534" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part tag-edit-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part add-tag-button {
+    background    : "#dcfce7" ;
+    border-width  : 1 ;
+    border-color  : "#86efac" ;
+    border-radius : 6 ;
+    color         : "#166534" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part remove-tag-button {
+    background    : "#fee2e2" ;
+    border-width  : 1 ;
+    border-color  : "#fca5a5" ;
+    border-radius : 6 ;
+    color         : "#991b1b" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part custom-study-row {
+    background     : "#ffffff" ;
+    border-width   : 1 ;
+    border-color   : "#cbd5e1" ;
+    border-radius  : 6 ;
+    padding        : 10 ;
+    padding-top    : 10 ;
+    padding-bottom : 10 ;
+  }
+
+  part custom-study-limit-column {
+    padding : 2 ;
+  }
+
+  part custom-study-label {
+    color       : "#a21caf" ;
+    font-size   : 11 ;
+    font-weight : 800 ;
+  }
+
+  part custom-study-limit-label {
+    color       : "#475569" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part custom-study-limit-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part custom-study-reschedule-column {
+    padding : 8 ;
+  }
+
+  part custom-study-reschedule-checkbox {
+    color       : "#334155" ;
+    font-size   : 12 ;
+    font-weight : 700 ;
+  }
+
+  part rebuild-filtered-deck-button {
+    background    : "#ede9fe" ;
+    border-width  : 1 ;
+    border-color  : "#c4b5fd" ;
+    border-radius : 6 ;
+    color         : "#5b21b6" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part empty-filtered-deck-button {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part open-button {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part edit-button {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#5eead4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part suspend-button {
+    background    : "#ffedd5" ;
+    border-width  : 1 ;
+    border-color  : "#fdba74" ;
+    border-radius : 6 ;
+    color         : "#92400e" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part mark-button {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fda4af" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-card/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-card/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`Card.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 Initial release. Exports a single Card component built from Box + Column + Text — primitives that are stable in every Mosaic backend today.

--- a/code/packages/mosaic/mosaic-pkg-card/src/Card.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-card/src/Card.light.msl
@@ -1,0 +1,49 @@
+// Card.light.msl — light-theme stylesheet for the Card component.
+//
+// Targets the four parts declared by Card.mll:
+//
+//   card-root    the outer Column wrapper — owns the surface fill,
+//                border, and padding around the whole card
+//   card-title   bold, darker, larger — the visual anchor of the card
+//   card-body    body copy — softer, comfortable reading colour
+//   card-footer  muted caption-style metadata — quietest part of the card
+//
+// Palette
+// -------
+//   #ffffff  surface fill, a clean elevated light card surface
+//   #e2e8f0  hairline border, a soft slate edge on light panels
+//   #0f172a  primary title text — maximum contrast against #ffffff
+//   #334155  body text — comfortable for paragraphs without being harsh
+//   #64748b  caption / footer — clearly subordinate to body copy
+//
+// All units are explicit px values.  The Mosaic style grammar requires a
+// unit suffix on length values; bare numbers are reserved for unitless
+// properties (line-height, flex, etc.).
+
+style Card {
+  part card-root {
+    background:   #ffffff ;
+    border-width: 1px ;
+    border-style: solid ;
+    border-color: #e2e8f0 ;
+    padding:      12px ;
+  }
+
+  part card-title {
+    color:          #0f172a ;
+    font-weight:    bold ;
+    font-size:      16px ;
+    padding-bottom: 8px ;
+  }
+
+  part card-body {
+    color:          #334155 ;
+    font-size:      13px ;
+    padding-bottom: 8px ;
+  }
+
+  part card-footer {
+    color:     #64748b ;
+    font-size: 11px ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-collection-actions/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-collection-actions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`CollectionActions.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Add `CollectionActions`, a target-neutral collection status and workflow

--- a/code/packages/mosaic/mosaic-pkg-collection-actions/src/CollectionActions.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-collection-actions/src/CollectionActions.light.msl
@@ -1,0 +1,219 @@
+// CollectionActions.light.msl - light collection action panel style.
+
+style CollectionActions {
+  part collection-actions {
+    background : "#ffffff" ;
+    border-color : "#a5f3fc" ;
+    border-width : 1 ;
+    padding : 14 ;
+  }
+
+  part collection-title {
+    color : "#0f172a" ;
+    font-size : 18 ;
+    font-weight : 700 ;
+    padding-bottom : 10 ;
+  }
+
+  part collection-counts {
+    padding-bottom : 10 ;
+  }
+
+  part media-health-counts {
+    padding-bottom : 8 ;
+  }
+
+  part note-count {
+    padding : 8 ;
+  }
+
+  part note-type-count {
+    padding : 8 ;
+  }
+
+  part media-count {
+    padding : 8 ;
+  }
+
+  part referenced-media-count {
+    padding : 8 ;
+  }
+
+  part missing-media-count {
+    padding : 8 ;
+  }
+
+  part unused-media-count {
+    padding : 8 ;
+  }
+
+  part note-count-value {
+    color : "#155e75" ;
+    font-size : 22 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-count-value {
+    color : "#166534" ;
+    font-size : 22 ;
+    font-weight : 700 ;
+  }
+
+  part media-count-value {
+    color : "#92400e" ;
+    font-size : 22 ;
+    font-weight : 700 ;
+  }
+
+  part referenced-media-value {
+    color : "#1e40af" ;
+    font-size : 18 ;
+    font-weight : 700 ;
+  }
+
+  part missing-media-value {
+    color : "#9f1239" ;
+    font-size : 18 ;
+    font-weight : 700 ;
+  }
+
+  part unused-media-value {
+    color : "#92400e" ;
+    font-size : 18 ;
+    font-weight : 700 ;
+  }
+
+  part note-count-label {
+    color : "#64748b" ;
+    font-size : 12 ;
+  }
+
+  part note-type-count-label {
+    color : "#64748b" ;
+    font-size : 12 ;
+  }
+
+  part media-count-label {
+    color : "#64748b" ;
+    font-size : 12 ;
+  }
+
+  part referenced-media-label {
+    color : "#64748b" ;
+    font-size : 12 ;
+  }
+
+  part missing-media-label {
+    color : "#64748b" ;
+    font-size : 12 ;
+  }
+
+  part unused-media-label {
+    color : "#64748b" ;
+    font-size : 12 ;
+  }
+
+  part media-missing-list {
+    padding-bottom : 4 ;
+  }
+
+  part media-unused-list {
+    padding-bottom : 8 ;
+  }
+
+  part missing-media-item {
+    color : "#9f1239" ;
+    font-size : 12 ;
+    padding : 2 ;
+  }
+
+  part unused-media-item {
+    color : "#92400e" ;
+    font-size : 12 ;
+    padding : 2 ;
+  }
+
+  part import-export-actions {
+    gap : 8 ;
+    padding-bottom : 8 ;
+  }
+
+  part note-actions {
+    gap : 8 ;
+    padding-bottom : 8 ;
+  }
+
+  part destructive-actions {
+    gap : 8 ;
+  }
+
+  part import-button {
+    background    : "#cffafe" ;
+    border-width  : 1 ;
+    border-color  : "#a5f3fc" ;
+    border-radius : 6 ;
+    color         : "#155e75" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part export-button {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part prune-unused-media-button {
+    background    : "#fef3c7" ;
+    border-width  : 1 ;
+    border-color  : "#fde68a" ;
+    border-radius : 6 ;
+    color         : "#92400e" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part add-note-button {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#99f6e4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part add-note-type-button {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#99f6e4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part delete-note-button {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fecdd3" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part delete-note-type-button {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fecdd3" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-deck-options/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-deck-options/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a light-theme stylesheet (`DeckOptionsPanel.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
 - Added the initial `DeckOptionsPanel` Mosaic component for shared Anki-style
   deck scheduler option controls, including learning/relearning step lists and
   daily-limit/interval/multiplier fields.

--- a/code/packages/mosaic/mosaic-pkg-deck-options/src/DeckOptionsPanel.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-deck-options/src/DeckOptionsPanel.light.msl
@@ -1,0 +1,505 @@
+// DeckOptionsPanel.light.msl - light deck options theme.
+
+style DeckOptionsPanel {
+  part deck-options-panel {
+    background : "#f8fafc" ;
+    border-color : "#b45309" ;
+    border-width : 1 ;
+    padding : 14 ;
+  }
+
+  part settings-title {
+    color : "#92400e" ;
+    font-size : 18 ;
+    font-weight : 700 ;
+    padding-bottom : 10 ;
+  }
+
+  part learning-step-options {
+    padding-bottom : 10 ;
+  }
+
+  part deck-option-limits {
+    padding-bottom : 10 ;
+  }
+
+  part graduation-options {
+    padding-bottom : 10 ;
+  }
+
+  part review-factor-options {
+    padding-bottom : 10 ;
+  }
+
+  part fsrs-options {
+    padding-bottom : 10 ;
+  }
+
+  part fsrs-filter-options {
+    padding-bottom : 10 ;
+  }
+
+  part leech-options {
+    padding-bottom : 10 ;
+  }
+
+  part sibling-bury-options {
+    padding-bottom : 4 ;
+  }
+
+  part learning-steps-field {
+    padding : 6 ;
+  }
+
+  part relearning-steps-field {
+    padding : 6 ;
+  }
+
+  part new-cards-field {
+    padding : 6 ;
+  }
+
+  part reviews-field {
+    padding : 6 ;
+  }
+
+  part graduating-interval-field {
+    padding : 6 ;
+  }
+
+  part easy-interval-field {
+    padding : 6 ;
+  }
+
+  part maximum-interval-field {
+    padding : 6 ;
+  }
+
+  part initial-ease-field {
+    padding : 6 ;
+  }
+
+  part interval-modifier-field {
+    padding : 6 ;
+  }
+
+  part hard-multiplier-field {
+    padding : 6 ;
+  }
+
+  part easy-bonus-field {
+    padding : 6 ;
+  }
+
+  part lapse-multiplier-field {
+    padding : 6 ;
+  }
+
+  part leech-threshold-field {
+    padding : 6 ;
+  }
+
+  part desired-retention-field {
+    padding : 6 ;
+  }
+
+  part historical-retention-field {
+    padding : 6 ;
+  }
+
+  part fsrs-parameters-field {
+    padding : 6 ;
+  }
+
+  part fsrs-search-field {
+    padding : 6 ;
+  }
+
+  part ignore-review-history-before-field {
+    padding : 6 ;
+  }
+
+  part easy-days-percentages-field {
+    padding : 6 ;
+  }
+
+  part leech-action-field {
+    padding : 6 ;
+  }
+
+  part leech-action-choices {
+    padding-top : 4 ;
+  }
+
+  part bury-new-siblings-field {
+    padding : 6 ;
+  }
+
+  part bury-review-siblings-field {
+    padding : 6 ;
+  }
+
+  part bury-interday-learning-siblings-field {
+    padding : 6 ;
+  }
+
+  part learning-steps-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part relearning-steps-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part new-cards-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part reviews-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part graduating-interval-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part easy-interval-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part maximum-interval-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part initial-ease-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part interval-modifier-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part hard-multiplier-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part easy-bonus-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part lapse-multiplier-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part leech-threshold-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part desired-retention-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part historical-retention-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part fsrs-parameters-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part fsrs-search-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part ignore-review-history-before-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part easy-days-percentages-input {
+    padding : 8 ;
+    border-radius : 4 ;
+    background : "#ffffff" ;
+    color : "#0f172a" ;
+    border-width : 1 ;
+    border-color : "#e2e8f0" ;
+    font-size : 14 ;
+  }
+
+  part learning-steps-label {
+    color : "#92400e" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part relearning-steps-label {
+    color : "#92400e" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part new-cards-label {
+    color : "#92400e" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part reviews-label {
+    color : "#115e59" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part graduating-interval-label {
+    color : "#1e40af" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part easy-interval-label {
+    color : "#5b21b6" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part maximum-interval-label {
+    color : "#9f1239" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part initial-ease-label {
+    color : "#1e40af" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part interval-modifier-label {
+    color : "#155e75" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part hard-multiplier-label {
+    color : "#9f1239" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part easy-bonus-label {
+    color : "#166534" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part lapse-multiplier-label {
+    color : "#5b21b6" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part leech-threshold-label {
+    color : "#9f1239" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part desired-retention-label {
+    color : "#1e40af" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part historical-retention-label {
+    color : "#166534" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part fsrs-parameters-label {
+    color : "#92400e" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part fsrs-search-label {
+    color : "#155e75" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part ignore-review-history-before-label {
+    color : "#5b21b6" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part easy-days-percentages-label {
+    color : "#9f1239" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part leech-action-label {
+    color : "#5b21b6" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 4 ;
+  }
+
+  part leech-action-suspend-radio {
+    color : "#9f1239" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+
+  part leech-action-tag-only-radio {
+    color : "#5b21b6" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+
+  part bury-new-siblings-checkbox {
+    color : "#92400e" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+
+  part bury-review-siblings-checkbox {
+    color : "#1e40af" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+
+  part bury-interday-learning-siblings-checkbox {
+    color : "#166534" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-deck-stats/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-deck-stats/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`DeckStatsPanel.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Added the `DeckStatsPanel` Mosaic component package for deck-scoped total,

--- a/code/packages/mosaic/mosaic-pkg-deck-stats/src/DeckStatsPanel.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-deck-stats/src/DeckStatsPanel.light.msl
@@ -1,0 +1,140 @@
+// DeckStatsPanel.light.msl - light deck-stat panel theme.
+
+style DeckStatsPanel {
+  part deck-stats-panel {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 14 ;
+  }
+
+  part deck-stats-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-stats-name {
+    color          : "#0f172a" ;
+    font-size      : 20 ;
+    font-weight    : 800 ;
+    padding-bottom : 10 ;
+  }
+
+  part deck-list-label {
+    color       : "#155e75" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-list-row {
+    padding-top    : 4 ;
+    padding-bottom : 8 ;
+  }
+
+  part deck-option-button {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#5eead4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 7 ;
+  }
+
+  part deck-stats-grid {
+    padding : 2 ;
+    padding-top : 10 ;
+  }
+
+  part deck-stat-total {
+    background    : "#dbeafe" ;
+    border-radius : 6 ;
+    padding       : 9 ;
+  }
+
+  part deck-stat-new {
+    background    : "#dcfce7" ;
+    border-radius : 6 ;
+    padding       : 9 ;
+  }
+
+  part deck-stat-due {
+    background    : "#fee2e2" ;
+    border-radius : 6 ;
+    padding       : 9 ;
+  }
+
+  part deck-stat-learning {
+    background    : "#ede9fe" ;
+    border-radius : 6 ;
+    padding       : 9 ;
+  }
+
+  part deck-stat-hidden {
+    background    : "#f1f5f9" ;
+    border-radius : 6 ;
+    padding       : 9 ;
+  }
+
+  part deck-total-value {
+    color       : "#1e40af" ;
+    font-size   : 18 ;
+    font-weight : 800 ;
+  }
+
+  part deck-new-value {
+    color       : "#166534" ;
+    font-size   : 18 ;
+    font-weight : 800 ;
+  }
+
+  part deck-due-value {
+    color       : "#991b1b" ;
+    font-size   : 18 ;
+    font-weight : 800 ;
+  }
+
+  part deck-learning-value {
+    color       : "#5b21b6" ;
+    font-size   : 18 ;
+    font-weight : 800 ;
+  }
+
+  part deck-hidden-value {
+    color       : "#0f172a" ;
+    font-size   : 18 ;
+    font-weight : 800 ;
+  }
+
+  part deck-total-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-new-label {
+    color       : "#166534" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-due-label {
+    color       : "#991b1b" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-learning-label {
+    color       : "#5b21b6" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-hidden-label {
+    color       : "#0f172a" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-note-editor/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-note-editor/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`NoteEditor.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Add `NoteEditor`, a reusable focused-field note editor component with field

--- a/code/packages/mosaic/mosaic-pkg-note-editor/src/NoteEditor.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-note-editor/src/NoteEditor.light.msl
@@ -1,0 +1,216 @@
+// NoteEditor.light.msl - light note editor theme.
+
+style NoteEditor {
+  part note-editor {
+    background    : "#f8fafc" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 14 ;
+  }
+
+  part editor-title {
+    color          : "#0f172a" ;
+    font-size      : 20 ;
+    font-weight    : 800 ;
+    padding-bottom : 10 ;
+  }
+
+  part note-metadata {
+    padding-bottom : 12 ;
+  }
+
+  part note-id-meta {
+    padding : 8 ;
+  }
+
+  part note-type-meta {
+    padding : 8 ;
+  }
+
+  part deck-meta {
+    padding : 8 ;
+  }
+
+  part note-id-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part deck-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-id-value {
+    color       : "#334155" ;
+    font-size   : 14 ;
+    font-weight : 600 ;
+  }
+
+  part note-type-value {
+    color       : "#334155" ;
+    font-size   : 14 ;
+    font-weight : 600 ;
+  }
+
+  part deck-value {
+    color       : "#334155" ;
+    font-size   : 14 ;
+    font-weight : 600 ;
+  }
+
+  part note-choice-row {
+    padding-bottom : 12 ;
+  }
+
+  part note-editor-note-type-list-column {
+    padding : 2 ;
+  }
+
+  part note-editor-deck-list-column {
+    padding : 2 ;
+  }
+
+  part note-editor-note-type-options-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-editor-deck-options-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-editor-note-type-list {
+    padding-top : 6 ;
+  }
+
+  part note-editor-deck-list {
+    padding-top : 6 ;
+  }
+
+  part note-editor-note-type-option {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-editor-deck-option {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part editor-body {
+    padding-bottom : 12 ;
+  }
+
+  part field-list-column {
+    padding : 2 ;
+  }
+
+  part fields-label {
+    color       : "#5b21b6" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-field-list {
+    padding-top : 6 ;
+  }
+
+  part note-field-option {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part focused-field-column {
+    padding : 2 ;
+  }
+
+  part selected-field-label {
+    color       : "#166534" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part selected-field-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part tags-label {
+    color       : "#92400e" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+    padding-top : 8 ;
+  }
+
+  part tags-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part editor-actions {
+    padding-top : 2 ;
+  }
+
+  part save-button {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#99f6e4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part delete-button {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fecdd3" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part cancel-button {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-note-type-editor/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-note-type-editor/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`NoteTypeEditor.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Add `NoteTypeEditor`, a reusable note-type editor component with note-type

--- a/code/packages/mosaic/mosaic-pkg-note-type-editor/src/NoteTypeEditor.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-note-type-editor/src/NoteTypeEditor.light.msl
@@ -1,0 +1,264 @@
+// NoteTypeEditor.light.msl - light note-type editor theme.
+
+style NoteTypeEditor {
+  part note-type-editor {
+    background    : "#f8fafc" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 14 ;
+  }
+
+  part note-type-editor-title {
+    color          : "#0f172a" ;
+    font-size      : 20 ;
+    font-weight    : 800 ;
+    padding-bottom : 10 ;
+  }
+
+  part note-type-editor-body {
+    padding-bottom : 12 ;
+  }
+
+  part note-type-list-column {
+    padding : 2 ;
+  }
+
+  part note-types-label {
+    color       : "#1e40af" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-list {
+    padding-top : 6 ;
+  }
+
+  part note-type-option {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-detail-column {
+    padding : 2 ;
+  }
+
+  part note-type-metadata {
+    padding-bottom : 8 ;
+  }
+
+  part note-type-id-meta {
+    padding : 6 ;
+  }
+
+  part note-type-id-label {
+    color       : "#5b21b6" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-id-value {
+    color       : "#334155" ;
+    font-size   : 14 ;
+    font-weight : 600 ;
+  }
+
+  part note-type-name-label {
+    color       : "#166534" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-name-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-schema-summary {
+    padding-top    : 10 ;
+    padding-bottom : 10 ;
+  }
+
+  part field-summary-column {
+    padding : 2 ;
+  }
+
+  part template-summary-column {
+    padding : 2 ;
+  }
+
+  part note-type-fields-label {
+    color       : "#92400e" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-templates-label {
+    color       : "#9f1239" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-field-list {
+    padding-top : 6 ;
+  }
+
+  part note-type-template-list {
+    padding-top : 6 ;
+  }
+
+  part note-type-field-option {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 6 ;
+  }
+
+  part note-type-field-name-label {
+    color       : "#92400e" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+    padding-top : 8 ;
+  }
+
+  part note-type-field-name-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-field-required-checkbox {
+    color       : "#334155" ;
+    font-size   : 13 ;
+    padding-top : 6 ;
+  }
+
+  part note-type-template-option {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 6 ;
+  }
+
+  part note-type-template-name-label {
+    color       : "#9f1239" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+    padding-top : 8 ;
+  }
+
+  part note-type-template-name-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-front-template-label {
+    color       : "#9f1239" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+    padding-top : 8 ;
+  }
+
+  part note-type-front-template-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-back-template-label {
+    color       : "#9f1239" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+    padding-top : 8 ;
+  }
+
+  part note-type-back-template-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-stylesheet-label {
+    color       : "#155e75" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part note-type-stylesheet-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    padding       : 8 ;
+  }
+
+  part note-type-editor-actions {
+    padding-top : 2 ;
+  }
+
+  part note-type-new-button {
+    background    : "#dbeafe" ;
+    border-width  : 1 ;
+    border-color  : "#93c5fd" ;
+    border-radius : 6 ;
+    color         : "#1e40af" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part note-type-save-button {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#5eead4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part note-type-delete-button {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fda4af" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part note-type-cancel-button {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-rating-controls/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-rating-controls/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`RatingControls.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Added the `RatingControls` Mosaic component package for spaced-repetition

--- a/code/packages/mosaic/mosaic-pkg-rating-controls/src/RatingControls.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-rating-controls/src/RatingControls.light.msl
@@ -1,0 +1,47 @@
+// RatingControls.light.msl - light rating-control theme.
+
+style RatingControls {
+  part rating-row {
+    padding : 4 ;
+  }
+
+  part rating-again {
+    background    : "#fee2e2" ;
+    border-width  : 1 ;
+    border-color  : "#fecaca" ;
+    border-radius : 6 ;
+    color         : "#991b1b" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part rating-hard {
+    background    : "#ffedd5" ;
+    border-width  : 1 ;
+    border-color  : "#fed7aa" ;
+    border-radius : 6 ;
+    color         : "#9a3412" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part rating-good {
+    background    : "#dcfce7" ;
+    border-width  : 1 ;
+    border-color  : "#bbf7d0" ;
+    border-radius : 6 ;
+    color         : "#166534" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part rating-easy {
+    background    : "#dbeafe" ;
+    border-width  : 1 ;
+    border-color  : "#bfdbfe" ;
+    border-radius : 6 ;
+    color         : "#1d4ed8" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-review-actions/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-review-actions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`ReviewActions.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Added the `ReviewActions` Mosaic component package for Anki-style undo, bury,

--- a/code/packages/mosaic/mosaic-pkg-review-actions/src/ReviewActions.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-review-actions/src/ReviewActions.light.msl
@@ -1,0 +1,57 @@
+// ReviewActions.light.msl - light review-action theme.
+
+style ReviewActions {
+  part review-actions-row {
+    padding : 4 ;
+  }
+
+  part action-undo {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part action-bury-card {
+    background    : "#ede9fe" ;
+    border-width  : 1 ;
+    border-color  : "#ddd6fe" ;
+    border-radius : 6 ;
+    color         : "#5b21b6" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part action-bury-siblings {
+    background    : "#ccfbf1" ;
+    border-width  : 1 ;
+    border-color  : "#99f6e4" ;
+    border-radius : 6 ;
+    color         : "#115e59" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part action-suspend-card {
+    background    : "#ffedd5" ;
+    border-width  : 1 ;
+    border-color  : "#fed7aa" ;
+    border-radius : 6 ;
+    color         : "#92400e" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part action-toggle-mark {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fecdd3" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-review-card/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-review-card/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a light-theme stylesheet (`ReviewCard.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
 - Composed `ReviewCard` from the reusable `mosaic-pkg-rating-controls`
   package instead of owning the answer grading button row directly.
 - Switched multi-backend smoke coverage to the package artifact builder so

--- a/code/packages/mosaic/mosaic-pkg-review-card/src/ReviewCard.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-review-card/src/ReviewCard.light.msl
@@ -1,0 +1,113 @@
+// ReviewCard.light.msl - light review-card theme.
+
+style ReviewCard {
+  part review-card {
+    background    : "#f8fafc" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 24 ;
+  }
+
+  part deck-name {
+    color       : "#64748b" ;
+    font-size   : 13 ;
+    font-weight : 600 ;
+  }
+
+  part prompt-panel {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 18 ;
+  }
+
+  part prompt-label {
+    color          : "#9f1239" ;
+    font-size      : 11 ;
+    font-weight    : 700 ;
+    padding-bottom : 8 ;
+  }
+
+  part prompt-text {
+    color       : "#0f172a" ;
+    font-size   : 24 ;
+    font-weight : 600 ;
+  }
+
+  part type-answer-panel {
+    background    : "#f1f5f9" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 14 ;
+  }
+
+  part type-answer-label {
+    color          : "#1e40af" ;
+    font-size      : 11 ;
+    font-weight    : 700 ;
+    padding-bottom : 8 ;
+  }
+
+  part type-answer-input {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#cbd5e1" ;
+    border-radius : 6 ;
+    color         : "#0f172a" ;
+    font-size     : 16 ;
+    padding       : 10 ;
+  }
+
+  part type-answer-comparison-label {
+    color          : "#155e75" ;
+    font-size      : 11 ;
+    font-weight    : 700 ;
+    padding-top    : 10 ;
+    padding-bottom : 4 ;
+  }
+
+  part type-answer-comparison-value {
+    color       : "#334155" ;
+    font-size   : 14 ;
+    font-weight : 500 ;
+  }
+
+  part answer-panel {
+    background    : "#dbeafe" ;
+    border-width  : 1 ;
+    border-color  : "#fda4af" ;
+    border-radius : 8 ;
+    padding       : 18 ;
+  }
+
+  part answer-label {
+    color          : "#9f1239" ;
+    font-size      : 11 ;
+    font-weight    : 700 ;
+    padding-bottom : 8 ;
+  }
+
+  part answer-text {
+    color       : "#0f172a" ;
+    font-size   : 22 ;
+    font-weight : 500 ;
+  }
+
+  part reveal-button {
+    background    : "#ffe4e6" ;
+    border-width  : 1 ;
+    border-color  : "#fb7185" ;
+    border-radius : 6 ;
+    color         : "#9f1239" ;
+    font-weight   : 700 ;
+    padding       : 10 ;
+  }
+
+  part progress-label {
+    color     : "#64748b" ;
+    font-size : 12 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-review-history/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-review-history/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## Unreleased
 
+- Added a light-theme stylesheet (`ReviewHistoryPanel.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
 - Added the initial `ReviewHistoryPanel` Mosaic component for shared
   Anki-style review history summary controls.

--- a/code/packages/mosaic/mosaic-pkg-review-history/src/ReviewHistoryPanel.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-review-history/src/ReviewHistoryPanel.light.msl
@@ -1,0 +1,207 @@
+// ReviewHistoryPanel.light.msl - light review-history theme.
+
+style ReviewHistoryPanel {
+  part review-history-panel {
+    background : "#ffffff" ;
+    border-color : "#14b8a6" ;
+    border-width : 1 ;
+    border-radius : 8 ;
+    padding : 14 ;
+  }
+
+  part history-title {
+    color : "#0f172a" ;
+    font-size : 18 ;
+    font-weight : 800 ;
+    padding-bottom : 4 ;
+  }
+
+  part history-window {
+    color : "#115e59" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+    padding-bottom : 10 ;
+  }
+
+  part history-summary-grid {
+    padding-bottom : 10 ;
+  }
+
+  part rating-summary-grid {
+    padding-bottom : 10 ;
+  }
+
+  part history-total {
+    background : "#ccfbf1" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-correct {
+    background : "#dbeafe" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-unique {
+    background : "#ede9fe" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-accuracy {
+    background : "#fef3c7" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-rating-again {
+    background : "#fee2e2" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-rating-hard {
+    background : "#ffedd5" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-rating-good {
+    background : "#dcfce7" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-rating-easy {
+    background : "#cffafe" ;
+    border-radius : 6 ;
+    padding : 9 ;
+  }
+
+  part history-first {
+    padding : 6 ;
+  }
+
+  part history-last {
+    padding : 6 ;
+  }
+
+  part history-total-value {
+    color : "#115e59" ;
+    font-size : 18 ;
+    font-weight : 800 ;
+  }
+
+  part history-correct-value {
+    color : "#1e40af" ;
+    font-size : 18 ;
+    font-weight : 800 ;
+  }
+
+  part history-unique-value {
+    color : "#5b21b6" ;
+    font-size : 18 ;
+    font-weight : 800 ;
+  }
+
+  part history-accuracy-value {
+    color : "#92400e" ;
+    font-size : 18 ;
+    font-weight : 800 ;
+  }
+
+  part history-again-value {
+    color : "#9f1239" ;
+    font-size : 16 ;
+    font-weight : 800 ;
+  }
+
+  part history-hard-value {
+    color : "#92400e" ;
+    font-size : 16 ;
+    font-weight : 800 ;
+  }
+
+  part history-good-value {
+    color : "#166534" ;
+    font-size : 16 ;
+    font-weight : 800 ;
+  }
+
+  part history-easy-value {
+    color : "#155e75" ;
+    font-size : 16 ;
+    font-weight : 800 ;
+  }
+
+  part history-total-label {
+    color : "#115e59" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-correct-label {
+    color : "#1e40af" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-unique-label {
+    color : "#5b21b6" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-accuracy-label {
+    color : "#92400e" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-again-label {
+    color : "#9f1239" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-hard-label {
+    color : "#92400e" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-good-label {
+    color : "#166534" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-easy-label {
+    color : "#155e75" ;
+    font-size : 11 ;
+    font-weight : 700 ;
+  }
+
+  part history-first-label {
+    color : "#115e59" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+
+  part history-last-label {
+    color : "#1e40af" ;
+    font-size : 12 ;
+    font-weight : 700 ;
+  }
+
+  part history-first-value {
+    color : "#0f172a" ;
+    font-size : 13 ;
+  }
+
+  part history-last-value {
+    color : "#0f172a" ;
+    font-size : 13 ;
+  }
+}

--- a/code/packages/mosaic/mosaic-pkg-session-progress/CHANGELOG.md
+++ b/code/packages/mosaic/mosaic-pkg-session-progress/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a light-theme stylesheet (`SessionProgress.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
+
+
 ## 0.1.0
 
 - Added the `SessionProgress` Mosaic component package for review-session

--- a/code/packages/mosaic/mosaic-pkg-session-progress/src/SessionProgress.light.msl
+++ b/code/packages/mosaic/mosaic-pkg-session-progress/src/SessionProgress.light.msl
@@ -1,0 +1,83 @@
+// SessionProgress.light.msl - light review-session counter theme.
+
+style SessionProgress {
+  part progress-strip {
+    background    : "#ffffff" ;
+    border-width  : 1 ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 8 ;
+    padding       : 12 ;
+  }
+
+  part metric-current {
+    background    : "#ccfbf1" ;
+    border-radius : 6 ;
+    padding       : 10 ;
+  }
+
+  part metric-remaining {
+    background    : "#ede9fe" ;
+    border-radius : 6 ;
+    padding       : 10 ;
+  }
+
+  part metric-correct {
+    background    : "#dcfce7" ;
+    border-radius : 6 ;
+    padding       : 10 ;
+  }
+
+  part metric-total {
+    background    : "#fef3c7" ;
+    border-radius : 6 ;
+    padding       : 10 ;
+  }
+
+  part current-label {
+    color       : "#115e59" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part remaining-label {
+    color       : "#5b21b6" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part correct-label {
+    color       : "#166534" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part total-label {
+    color       : "#92400e" ;
+    font-size   : 11 ;
+    font-weight : 700 ;
+  }
+
+  part current-value {
+    color       : "#115e59" ;
+    font-size   : 20 ;
+    font-weight : 800 ;
+  }
+
+  part remaining-value {
+    color       : "#5b21b6" ;
+    font-size   : 20 ;
+    font-weight : 800 ;
+  }
+
+  part correct-value {
+    color       : "#166534" ;
+    font-size   : 20 ;
+    font-weight : 800 ;
+  }
+
+  part total-value {
+    color       : "#92400e" ;
+    font-size   : 20 ;
+    font-weight : 800 ;
+  }
+}

--- a/code/programs/mosaic/engram-app/CHANGELOG.md
+++ b/code/programs/mosaic/engram-app/CHANGELOG.md
@@ -15,6 +15,7 @@
   `EngramApp.touch` artifacts. Verified across all nine backends
   (react/html/webcomponent/swiftui/qt/flutter/compose/xaml); the emitted React
   differs from desktop only in the two `flexDirection: row → column` containers.
+- Added a light-theme stylesheet (`EngramApp.light.msl`) mirroring the dark theme's structure with a light palette. Selected at build time via `mosaic-compile pkg --theme light` (the style analogue of the layout `--variant`).
 - Wired the generated HTML, WebComponent, and React Engram web hosts to handle
   Anki import/export `hostIntent` payloads with browser file input/download
   helpers and the `engram-wasm` APKG byte API, surfacing `hostResult` errors

--- a/code/programs/mosaic/engram-app/src/EngramApp.light.msl
+++ b/code/programs/mosaic/engram-app/src/EngramApp.light.msl
@@ -1,0 +1,235 @@
+// EngramApp.light.msl - light app-shell style for the Engram Mosaic app.
+
+style EngramApp {
+  part app-shell {
+    background  : "#f8fafc" ;
+    color       : "#0f172a" ;
+    font-family : "system-ui, sans-serif" ;
+    padding     : 24 ;
+    gap         : 18 ;
+  }
+
+  part app-header {
+    align-items     : center ;
+    background      : "#ffffff" ;
+    border-color    : "#e2e8f0" ;
+    border-radius   : 8 ;
+    border-width    : 1 ;
+    flex-wrap       : wrap ;
+    gap             : 16 ;
+    justify-content : space-between ;
+    padding         : 12 ;
+  }
+
+  part app-title {
+    color          : "#0f172a" ;
+    font-size      : 28 ;
+    font-weight    : 700 ;
+  }
+
+  part app-nav {
+    flex-wrap : wrap ;
+    gap       : 8 ;
+  }
+
+  part host-status {
+    align-items   : center ;
+    background    : "#cffafe" ;
+    border-color  : "#0891b2" ;
+    border-radius : 8 ;
+    border-width  : 1 ;
+    flex-wrap     : wrap ;
+    gap           : 8 ;
+    max-width     : "980px" ;
+    padding       : 10 ;
+  }
+
+  part host-status-label {
+    color       : "#155e75" ;
+    font-weight : 800 ;
+  }
+
+  part host-status-message {
+    color : "#0f172a" ;
+  }
+
+  part nav-decks-button {
+    background    : "#ffffff" ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#334155" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part nav-study-button {
+    background    : "#ffffff" ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#334155" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part nav-browse-button {
+    background    : "#ffffff" ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#334155" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part nav-add-button {
+    background    : "#ffffff" ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#334155" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part nav-stats-button {
+    background    : "#ffffff" ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#334155" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part nav-options-button {
+    background    : "#ffffff" ;
+    border-color  : "#e2e8f0" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#334155" ;
+    font-weight   : 700 ;
+    padding       : 8 ;
+  }
+
+  part nav-decks-active {
+    background    : "#dbeafe" ;
+    border-color  : "#1e40af" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#1e40af" ;
+    font-weight   : 800 ;
+    padding       : 8 ;
+  }
+
+  part nav-study-active {
+    background    : "#dbeafe" ;
+    border-color  : "#1e40af" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#1e40af" ;
+    font-weight   : 800 ;
+    padding       : 8 ;
+  }
+
+  part nav-browse-active {
+    background    : "#dbeafe" ;
+    border-color  : "#1e40af" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#1e40af" ;
+    font-weight   : 800 ;
+    padding       : 8 ;
+  }
+
+  part nav-add-active {
+    background    : "#dbeafe" ;
+    border-color  : "#1e40af" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#1e40af" ;
+    font-weight   : 800 ;
+    padding       : 8 ;
+  }
+
+  part nav-stats-active {
+    background    : "#dbeafe" ;
+    border-color  : "#1e40af" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#1e40af" ;
+    font-weight   : 800 ;
+    padding       : 8 ;
+  }
+
+  part nav-options-active {
+    background    : "#dbeafe" ;
+    border-color  : "#1e40af" ;
+    border-radius : 6 ;
+    border-width  : 1 ;
+    color         : "#1e40af" ;
+    font-weight   : 800 ;
+    padding       : 8 ;
+  }
+
+  part decks-screen {
+    gap       : 14 ;
+    max-width : "980px" ;
+  }
+
+  part study-screen {
+    gap       : 14 ;
+    max-width : "760px" ;
+  }
+
+  part browse-screen {
+    max-width : "1100px" ;
+  }
+
+  part add-screen {
+    max-width : "860px" ;
+  }
+
+  part stats-screen {
+    max-width : "860px" ;
+  }
+
+  part options-screen {
+    gap       : 14 ;
+    max-width : "960px" ;
+  }
+
+  part stats-region {
+    padding-bottom : 0 ;
+  }
+
+  part deck-options-region {
+    padding-bottom : 0 ;
+  }
+
+  part review-history-region {
+    padding-bottom : 0 ;
+  }
+
+  part collection-region {
+    padding-bottom : 0 ;
+  }
+
+  part browser-region {
+    padding-bottom : 0 ;
+  }
+
+  part note-editor-region {
+    padding-bottom : 0 ;
+  }
+
+  part note-type-editor-region {
+    padding-bottom : 0 ;
+  }
+
+  part review-region {
+    padding-top : 16 ;
+    padding : 4 ;
+  }
+}


### PR DESCRIPTION
**Stacked on #7539 (the theme axis).** Base is `feat/mosaic-pkg-theme-axis`; retarget to `main` once #7539 merges. The diff here is only the new light stylesheets.

## Why

Engram shipped **dark-only**. With the `--theme` axis in place ([#7539](https://github.com/adhithyan15/coding-adventures/pull/7539)), this authors the light half of the desktop/touch × dark/light matrix — so Engram can render as a light app on any backend off the same engine.

## What

A `<Component>.light.msl` beside every `<Component>.dark.msl` — **13 files**: the 12 Engram component packages (Card, CardBrowser, CollectionActions, DeckOptionsPanel, DeckStatsPanel, NoteEditor, NoteTypeEditor, RatingControls, ReviewActions, ReviewCard, ReviewHistoryPanel, SessionProgress) plus the `EngramApp` shell, each with a CHANGELOG entry.

Each light file **mirrors its dark sibling's structure exactly** — same `part` blocks in the same order, identical padding/font/border/radius/weight values and quoting — and only remaps the palette **by role** for a light background:
- dark neutral surfaces → white / slate-50 (`#ffffff` / `#f8fafc` / `#f1f5f9`)
- light text → dark slate (`#0f172a` / `#334155`)
- colored semantic chips flip from *saturated-dark-bg + light-tint-text* to *light-tint-bg + dark-hue-shade-text* (e.g. teal `#0f766e`/`#ccfbf1` → `#ccfbf1`/`#115e59`)

so contrast is preserved everywhere (no light-on-light).

## Verification

- **Part-count parity** with every dark sibling (DeckOptionsPanel 78/78, EngramApp 33/33, all others match).
- Building the **EngramApp package** with `--theme light` succeeds on **all 9 backends** (react/html/qt/swiftui/flutter/compose/webcomponent/xaml) — every light.msl parses and flows through the dependency-style chain.
- Emitted lattice carries light surfaces (`#ffffff`/`#f8fafc`) with **zero dark-background leakage** and **zero white/low-contrast body text** (audited).
- Integrity-scanned: all 13 files are pure declarative style syntax (no code/URLs/paths).

Default (theme-agnostic) builds still resolve the dark stylesheets, so existing demos are unchanged.

## Next
PR-3: `.touch.mll` layouts. PR-4: live 4-way switcher + per-backend visual verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)