### PR TITLE
feat(xlsx-writer): C1 write .xlsx via generic opc-writer, round-tripped through our readers

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -347,6 +347,8 @@ members = [
     "xml-lexer",
     "xml-parser",
     "opc",
+    "opc-writer",
+    "xlsx-writer",
     "spreadsheetml",
     "wordprocessingml",
     "arm1-gatelevel",

--- a/code/packages/rust/opc-writer/BUILD
+++ b/code/packages/rust/opc-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-opc-writer -- --nocapture

--- a/code/packages/rust/opc-writer/BUILD_windows
+++ b/code/packages/rust/opc-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-opc-writer -- --nocapture

--- a/code/packages/rust/opc-writer/CHANGELOG.md
+++ b/code/packages/rust/opc-writer/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to `coding-adventures-opc-writer` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/); this
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-03
+
+Initial release — the write side of OOXML milestone **C1**, mirroring the
+read-side `opc` crate.
+
+### Added
+
+- `PackageWriter` — assembles OOXML parts, content types, and relationships into
+  a ZIP-based OPC package.
+  - `add_default(extension, content_type)` — register a `<Default>` content type
+    by file extension (de-duplicated, last registration wins).
+  - `add_part(part_name, content_type, data)` — add a part typed by an
+    `<Override>` (de-duplicated by part name, last wins).
+  - `add_part_defaulted(part_name, data)` — add a part typed by a `<Default>`
+    (e.g. `.rels` files), with no per-part override.
+  - `finish()` — synthesize `[Content_Types].xml` and emit the ZIP bytes, with
+    the content-types part written first per convention.
+- `RelationshipsBuilder` — serialize a `.rels` XML part from `(id, type, target)`
+  entries, with escaped targets.
+- `xml_escape` — a total XML escaper (`& < > " '`) that passes arbitrary Unicode
+  through unchanged.
+- Round-trip test: the writer's output re-opens under the read-side `opc` crate
+  with content types resolving and relationships dereferencing correctly.
+
+### Notes
+
+- `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on input paths.
+- Format-agnostic by design — usable by future `.docx` / `.pptx` writers.

--- a/code/packages/rust/opc-writer/Cargo.toml
+++ b/code/packages/rust/opc-writer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-opc-writer"
+version = "0.1.0"
+edition = "2021"
+description = "Open Packaging Conventions (OPC) package writer — assembles OOXML parts, content types, and relationships into a ZIP-based .xlsx/.docx/.pptx package. Format-agnostic mirror of the read-side opc crate (OOXML milestone C1)"
+license = "MIT"
+
+[dependencies]
+zip = { path = "../zip" }
+
+[dev-dependencies]
+# Round-trip verification: re-open our output with the read-side OPC reader.
+coding-adventures-opc = { path = "../opc" }

--- a/code/packages/rust/opc-writer/README.md
+++ b/code/packages/rust/opc-writer/README.md
@@ -1,0 +1,80 @@
+# coding-adventures-opc-writer
+
+A **generic Open Packaging Conventions (OPC) package writer** — the write-side
+mirror of the [`opc`](../opc) reader. It assembles OOXML parts, content types,
+and relationships into a ZIP-based OPC package (`.xlsx` / `.docx` / `.pptx`).
+
+This is milestone **C1** of the OOXML effort. See
+[`code/specs/OPCW01-opc-writer.md`](../../../specs/OPCW01-opc-writer.md) for the
+full literate write-up.
+
+## Where it fits
+
+```text
+   your parts  ─►  opc-writer  ─►  ZIP (zip crate)  ─►  .xlsx / .docx / .pptx bytes
+                       │
+                       ├─ [Content_Types].xml  (synthesized from defaults + overrides)
+                       └─ .rels parts          (RelationshipsBuilder, caller-supplied)
+```
+
+`opc-writer` is **format-agnostic**: it knows ZIP + content types + relationships
+and nothing about spreadsheets or documents. A format-specific crate such as
+[`xlsx-writer`](../xlsx-writer) generates the meaningful parts and packages them
+here.
+
+## Usage
+
+```rust
+use coding_adventures_opc_writer::{PackageWriter, RelationshipsBuilder};
+
+let mut pkg = PackageWriter::new();
+pkg.add_default("rels", "application/vnd.openxmlformats-package.relationships+xml");
+pkg.add_default("xml", "application/xml");
+
+// Package-root relationship: package → main document.
+let mut root_rels = RelationshipsBuilder::new();
+root_rels.add(
+    "rId1",
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+    "xl/workbook.xml",
+);
+pkg.add_part_defaulted("/_rels/.rels", &root_rels.build());
+
+// A typed part (gets an <Override> in [Content_Types].xml).
+pkg.add_part(
+    "/xl/workbook.xml",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+    b"<workbook/>",
+);
+
+let bytes: Vec<u8> = pkg.finish(); // valid OPC package bytes
+```
+
+## API
+
+| Item | Purpose |
+|------|---------|
+| `PackageWriter::new` | Start an empty package. |
+| `add_default(ext, ct)` | Register a `<Default>` content type by file extension. |
+| `add_part(name, ct, data)` | Add a part typed by an `<Override>`. |
+| `add_part_defaulted(name, data)` | Add a part typed by a Default (e.g. `.rels`). |
+| `finish()` | Synthesize `[Content_Types].xml` and emit the ZIP bytes. |
+| `RelationshipsBuilder` | Build a `.rels` XML part from `(id, type, target)` entries. |
+| `xml_escape(s)` | Total XML escaper for attribute/text values. |
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-opc-writer
+```
+
+Includes a **round-trip test** that re-opens the writer's output with the
+read-side `opc` crate and asserts content-type resolution and relationship
+dereferencing both work — proof the bytes are a genuine OPC package.
+
+## Guarantees
+
+* `#![forbid(unsafe_code)]`.
+* No `unwrap`/`expect`/`panic!` on any input path; XML escaping is total.
+* No filesystem, network, process, or environment access (see
+  `required_capabilities.json`).

--- a/code/packages/rust/opc-writer/required_capabilities.json
+++ b/code/packages/rust/opc-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/opc-writer",
+  "capabilities": [],
+  "justification": "Pure computation. Assembles in-memory parts, content types, and relationships into ZIP package bytes. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/opc-writer/src/lib.rs
+++ b/code/packages/rust/opc-writer/src/lib.rs
@@ -1,0 +1,382 @@
+//! # Open Packaging Conventions (OPC) — package *writer*
+//!
+//! This is the **write side** of milestone **C1** and the mirror image of the
+//! read-side [`opc`](https://docs.rs/coding-adventures-opc) crate. Where `opc`
+//! *opens* the bytes of an Office file into a bag of named parts, `opc-writer`
+//! *assembles* a bag of named parts back into the bytes of a valid Office file.
+//! See `code/specs/OPCW01-opc-writer.md` for the full write-up; this module
+//! summarizes the model inline so the source reads on its own.
+//!
+//! ## The one-paragraph mental model
+//!
+//! Physically, an `.xlsx` / `.docx` / `.pptx` is a ZIP archive (built here by
+//! the [`zip`] crate) whose members are XML files. OPC adds three conventions on
+//! top of that raw ZIP, and this writer produces all three:
+//!
+//! 1. **Part names.** Members are addressed by a *logical* absolute name that
+//!    starts with `/` (e.g. `/xl/workbook.xml`). Inside the ZIP the leading
+//!    slash is dropped (`xl/workbook.xml`). We accept either spelling and
+//!    normalize to the ZIP form.
+//! 2. **Content types.** `/[Content_Types].xml` states each part's media type,
+//!    either by file **extension** (`<Default>`) or by exact **part name**
+//!    (`<Override>`, which wins). We synthesize this file from the defaults and
+//!    overrides the caller registers.
+//! 3. **Relationships.** `.rels` files map short ids (`rId1`) to targets so
+//!    parts point at one another *by id*, never by hard-coded path. A `.rels`
+//!    file is just another XML part; [`RelationshipsBuilder`] serializes one and
+//!    the caller adds it as a part.
+//!
+//! Crucially, `opc-writer` knows **nothing** about spreadsheets or documents —
+//! it is purely the packaging layer. Turning a `Workbook` model into the right
+//! parts is the job of a format-specific crate like `xlsx-writer`.
+//!
+//! ```
+//! use coding_adventures_opc_writer::{PackageWriter, RelationshipsBuilder};
+//!
+//! let mut pkg = PackageWriter::new();
+//! // Two Defaults every OPC package needs:
+//! pkg.add_default("rels", "application/vnd.openxmlformats-package.relationships+xml");
+//! pkg.add_default("xml", "application/xml");
+//!
+//! // The package-root relationship: package → main document.
+//! let mut root_rels = RelationshipsBuilder::new();
+//! root_rels.add(
+//!     "rId1",
+//!     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+//!     "xl/workbook.xml",
+//! );
+//! pkg.add_part_defaulted("/_rels/.rels", &root_rels.build());
+//!
+//! // A typed part (gets an <Override>).
+//! pkg.add_part(
+//!     "/xl/workbook.xml",
+//!     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+//!     b"<workbook/>",
+//! );
+//!
+//! let bytes = pkg.finish(); // valid ZIP / OPC package bytes
+//! assert_eq!(&bytes[..2], b"PK");
+//! ```
+
+#![forbid(unsafe_code)]
+
+use zip::ZipWriter;
+
+// ===========================================================================
+// Namespaces (ECMA-376 Part 2) — these mirror the constants the reader checks.
+// ===========================================================================
+
+/// Namespace of `[Content_Types].xml` (`<Types>`, `<Default>`, `<Override>`).
+const CONTENT_TYPES_NS: &str = "http://schemas.openxmlformats.org/package/2006/content-types";
+
+/// Namespace of every `.rels` file (`<Relationships>`, `<Relationship>`).
+const RELATIONSHIPS_NS: &str = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+/// The XML declaration OOXML producers put at the head of every part. Office and
+/// our own parser both tolerate its absence, but real `.xlsx` files carry it, so
+/// we emit it for fidelity.
+const XML_DECL: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n";
+
+// ===========================================================================
+// XML escaping
+// ===========================================================================
+//
+// Every scrap of caller-supplied text (content types, part names, relationship
+// ids / types / targets, and — in xlsx-writer — sheet names and cell text) is
+// placed inside an XML **attribute** or **text node**. Five characters are
+// special in XML and must be replaced by entity references, or the output is not
+// well-formed and no reader can open it:
+//
+//     &  →  &amp;      (must be first, or we'd double-escape the others)
+//     <  →  &lt;
+//     >  →  &gt;
+//     "  →  &quot;     (only strictly needed in double-quoted attributes)
+//     '  →  &apos;     (only strictly needed in single-quoted attributes)
+//
+// The function is TOTAL: it never panics and passes every other character —
+// including arbitrary Unicode — through unchanged. We escape the full set for
+// both attributes and text so a single helper is safe everywhere.
+
+/// XML-escape `s` for safe inclusion in an attribute value or text node.
+///
+/// ```
+/// use coding_adventures_opc_writer::xml_escape;
+/// assert_eq!(xml_escape("a & b < c"), "a &amp; b &lt; c");
+/// assert_eq!(xml_escape("say \"hi\""), "say &quot;hi&quot;");
+/// assert_eq!(xml_escape("plain"), "plain");
+/// ```
+pub fn xml_escape(s: &str) -> String {
+    // Pre-size for the common case (no escapes) plus a little slack.
+    let mut out = String::with_capacity(s.len() + 8);
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+// ===========================================================================
+// Part-name normalization
+// ===========================================================================
+
+/// Turn an OPC logical part name into its ZIP member name.
+///
+/// OPC part names are absolute (`/xl/workbook.xml`); ZIP member names have no
+/// leading slash (`xl/workbook.xml`). We accept either spelling from the caller
+/// and always store the ZIP form. Any accidental leading slashes are stripped.
+fn zip_member_name(part_name: &str) -> String {
+    part_name.trim_start_matches('/').to_string()
+}
+
+/// Turn an OPC logical part name into the canonical `/`-prefixed form used in
+/// `[Content_Types].xml` `<Override PartName="…">`.
+fn override_part_name(part_name: &str) -> String {
+    format!("/{}", part_name.trim_start_matches('/'))
+}
+
+// ===========================================================================
+// Relationships builder
+// ===========================================================================
+
+/// One `<Relationship>` we will serialize.
+struct RelEntry {
+    id: String,
+    rel_type: String,
+    target: String,
+}
+
+/// Builds a `.rels` XML part.
+///
+/// A `.rels` file wires parts together by id. Targets are written **relative to
+/// the `.rels` file's own directory**, per OPC: the package-root `_rels/.rels`
+/// targets `xl/workbook.xml`, while `xl/_rels/workbook.xml.rels` targets
+/// `worksheets/sheet1.xml` (both relative to `xl/`). The caller is responsible
+/// for supplying already-correct relative targets — `opc-writer` stays free of
+/// any assumption about which relationships a given format needs.
+///
+/// ```
+/// use coding_adventures_opc_writer::RelationshipsBuilder;
+/// let mut r = RelationshipsBuilder::new();
+/// r.add("rId1", "http://example/type", "target.xml");
+/// let bytes = r.build();
+/// let text = String::from_utf8(bytes).unwrap();
+/// assert!(text.contains("Id=\"rId1\""));
+/// assert!(text.contains("Target=\"target.xml\""));
+/// ```
+#[derive(Default)]
+pub struct RelationshipsBuilder {
+    entries: Vec<RelEntry>,
+}
+
+impl RelationshipsBuilder {
+    /// A new, empty relationships part.
+    pub fn new() -> Self {
+        Self { entries: Vec::new() }
+    }
+
+    /// Add a `<Relationship>` with the given id, type URI, and (relative) target.
+    pub fn add(&mut self, id: &str, rel_type: &str, target: &str) {
+        self.entries.push(RelEntry {
+            id: id.to_string(),
+            rel_type: rel_type.to_string(),
+            target: target.to_string(),
+        });
+    }
+
+    /// Serialize to the bytes of a `.rels` XML part.
+    pub fn build(&self) -> Vec<u8> {
+        let mut xml = String::new();
+        xml.push_str(XML_DECL);
+        xml.push_str("<Relationships xmlns=\"");
+        xml.push_str(RELATIONSHIPS_NS);
+        xml.push_str("\">");
+        for e in &self.entries {
+            xml.push_str("<Relationship Id=\"");
+            xml.push_str(&xml_escape(&e.id));
+            xml.push_str("\" Type=\"");
+            xml.push_str(&xml_escape(&e.rel_type));
+            xml.push_str("\" Target=\"");
+            xml.push_str(&xml_escape(&e.target));
+            xml.push_str("\"/>");
+        }
+        xml.push_str("</Relationships>");
+        xml.into_bytes()
+    }
+}
+
+// ===========================================================================
+// Package writer
+// ===========================================================================
+
+/// A registered `<Default Extension="…" ContentType="…"/>`.
+struct DefaultType {
+    extension: String,
+    content_type: String,
+}
+
+/// A part to be written into the ZIP, plus whether it needs an `<Override>`.
+struct PartEntry {
+    /// ZIP member name (no leading slash), e.g. `xl/workbook.xml`.
+    member: String,
+    /// The part's bytes.
+    data: Vec<u8>,
+    /// The content type for the `<Override>`, or `None` if this part is typed by
+    /// a `<Default>` (e.g. a `.rels` file) and needs no per-part override.
+    content_type: Option<String>,
+}
+
+/// Assembles OOXML parts, content types, and relationships into a ZIP-based OPC
+/// package. Format-agnostic: it knows ZIP + content types + relationships, but
+/// nothing about spreadsheets or documents.
+///
+/// Usage: register the `<Default>` content types, add each part (with or without
+/// an `<Override>`), then call [`finish`](PackageWriter::finish). On finish, the
+/// writer synthesizes `[Content_Types].xml` and emits every part as a
+/// DEFLATE-compressed ZIP member.
+#[derive(Default)]
+pub struct PackageWriter {
+    defaults: Vec<DefaultType>,
+    parts: Vec<PartEntry>,
+}
+
+impl PackageWriter {
+    /// A new, empty package writer.
+    pub fn new() -> Self {
+        Self {
+            defaults: Vec::new(),
+            parts: Vec::new(),
+        }
+    }
+
+    /// Register a `<Default>` content type for a file **extension** (without the
+    /// dot), e.g. `("rels", "application/…relationships+xml")` or `("xml",
+    /// "application/xml")`. If the same extension is registered twice, the last
+    /// registration wins (we de-duplicate on emit, keeping the latest).
+    pub fn add_default(&mut self, extension: &str, content_type: &str) {
+        self.defaults.push(DefaultType {
+            extension: extension.to_string(),
+            content_type: content_type.to_string(),
+        });
+    }
+
+    /// Add a part with an explicit content type. The type is recorded as an
+    /// `<Override>` (keyed by exact part name), which wins over any matching
+    /// `<Default>`.
+    ///
+    /// `part_name` may be given with or without a leading slash
+    /// (`/xl/workbook.xml` or `xl/workbook.xml`); both are normalized.
+    pub fn add_part(&mut self, part_name: &str, content_type: &str, data: &[u8]) {
+        self.parts.push(PartEntry {
+            member: zip_member_name(part_name),
+            data: data.to_vec(),
+            content_type: Some(content_type.to_string()),
+        });
+    }
+
+    /// Add a part **without** an `<Override>` — its content type comes from a
+    /// matching `<Default>` (by extension). Use this for `.rels` parts, which
+    /// are typed by the `rels` Default rather than per-part.
+    pub fn add_part_defaulted(&mut self, part_name: &str, data: &[u8]) {
+        self.parts.push(PartEntry {
+            member: zip_member_name(part_name),
+            data: data.to_vec(),
+            content_type: None,
+        });
+    }
+
+    /// Serialize `[Content_Types].xml` from the registered defaults and the
+    /// per-part overrides.
+    ///
+    /// De-duplication rules:
+    /// * Defaults are keyed by (lowercased) extension; a later registration for
+    ///   the same extension replaces an earlier one.
+    /// * Overrides are keyed by part name; the last one wins.
+    fn content_types_xml(&self) -> Vec<u8> {
+        let mut xml = String::new();
+        xml.push_str(XML_DECL);
+        xml.push_str("<Types xmlns=\"");
+        xml.push_str(CONTENT_TYPES_NS);
+        xml.push_str("\">");
+
+        // --- Defaults (de-duplicated, last-wins, stable first-seen order) ---
+        let mut seen_ext: Vec<String> = Vec::new();
+        for d in &self.defaults {
+            let key = d.extension.to_ascii_lowercase();
+            // Resolve to the LAST content type registered for this extension.
+            let content_type = self
+                .defaults
+                .iter()
+                .rev()
+                .find(|x| x.extension.to_ascii_lowercase() == key)
+                .map(|x| x.content_type.as_str())
+                .unwrap_or(d.content_type.as_str());
+            if seen_ext.contains(&key) {
+                continue; // already emitted this extension
+            }
+            seen_ext.push(key);
+            xml.push_str("<Default Extension=\"");
+            xml.push_str(&xml_escape(&d.extension));
+            xml.push_str("\" ContentType=\"");
+            xml.push_str(&xml_escape(content_type));
+            xml.push_str("\"/>");
+        }
+
+        // --- Overrides (de-duplicated by part name, last-wins) ---
+        let mut seen_part: Vec<String> = Vec::new();
+        for p in &self.parts {
+            let Some(ct) = &p.content_type else {
+                continue; // defaulted part → no override
+            };
+            let part_name = override_part_name(&p.member);
+            // Resolve to the LAST content type registered for this part name.
+            let content_type = self
+                .parts
+                .iter()
+                .rev()
+                .find(|x| {
+                    x.content_type.is_some() && override_part_name(&x.member) == part_name
+                })
+                .and_then(|x| x.content_type.as_deref())
+                .unwrap_or(ct.as_str());
+            if seen_part.contains(&part_name) {
+                continue;
+            }
+            seen_part.push(part_name.clone());
+            xml.push_str("<Override PartName=\"");
+            xml.push_str(&xml_escape(&part_name));
+            xml.push_str("\" ContentType=\"");
+            xml.push_str(&xml_escape(content_type));
+            xml.push_str("\"/>");
+        }
+
+        xml.push_str("</Types>");
+        xml.into_bytes()
+    }
+
+    /// Finish: synthesize `[Content_Types].xml`, then write it plus every part
+    /// into a ZIP archive and return the bytes.
+    ///
+    /// `[Content_Types].xml` is written **first**, which is what real producers
+    /// do; the ZIP format does not require an order, but keeping it first matches
+    /// convention and aids reader locality.
+    pub fn finish(self) -> Vec<u8> {
+        let content_types = self.content_types_xml();
+
+        let mut zip = ZipWriter::new();
+        // The content-types part has no leading slash inside the ZIP.
+        zip.add_file("[Content_Types].xml", &content_types, true);
+        for p in &self.parts {
+            zip.add_file(&p.member, &p.data, true);
+        }
+        zip.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/opc-writer/src/lib.rs
+++ b/code/packages/rust/opc-writer/src/lib.rs
@@ -115,29 +115,64 @@ pub fn xml_escape(s: &str) -> String {
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
             '\'' => out.push_str("&apos;"),
+            // Characters that are ILLEGAL in XML 1.0 cannot be rescued by
+            // entity-escaping (`&#0;` is itself illegal), so the only way to keep
+            // the package openable is to DROP them. This matters when text
+            // originates from untrusted data: a NUL or 0x01 in a pasted cell
+            // value would otherwise make the whole part unparseable, and readers
+            // disagree on how to recover — an integrity hazard. The legal control
+            // characters tab/newline/carriage-return are preserved. (XML 1.0 §2.2)
+            c if is_illegal_xml_char(c) => {}
             other => out.push(other),
         }
     }
     out
 }
 
+/// True for code points not permitted anywhere in an XML 1.0 document: the C0
+/// control characters except `\t` `\n` `\r`, plus the non-characters U+FFFE and
+/// U+FFFF. Such characters are dropped by [`xml_escape`] so the package stays
+/// well-formed regardless of what untrusted text a caller supplies.
+fn is_illegal_xml_char(c: char) -> bool {
+    let u = c as u32;
+    (u < 0x20 && c != '\t' && c != '\n' && c != '\r') || u == 0xFFFE || u == 0xFFFF
+}
+
 // ===========================================================================
 // Part-name normalization
 // ===========================================================================
 
-/// Turn an OPC logical part name into its ZIP member name.
+/// Normalize an OPC logical part name into a **safe relative** path.
 ///
-/// OPC part names are absolute (`/xl/workbook.xml`); ZIP member names have no
-/// leading slash (`xl/workbook.xml`). We accept either spelling from the caller
-/// and always store the ZIP form. Any accidental leading slashes are stripped.
-fn zip_member_name(part_name: &str) -> String {
-    part_name.trim_start_matches('/').to_string()
+/// A part name may reach us from untrusted data (this is a generic packaging
+/// layer whose whole point is reuse), and whatever string we hand to the ZIP
+/// writer is written verbatim into the archive's member name. An unsanitized
+/// name like `/../../evil.xml` would become the member `../../evil.xml`, and a
+/// naive extractor would then write *outside* the target directory (Zip-Slip).
+///
+/// So we normalize defensively and structurally: backslashes become forward
+/// slashes, then we split on `/` and drop every empty, `.`, or `..` segment.
+/// The result can never be absolute and can never traverse upward, whatever the
+/// input. Well-formed OPC names (`/xl/workbook.xml`) are unaffected.
+fn normalize_part_name(part_name: &str) -> String {
+    part_name
+        .replace('\\', "/")
+        .split('/')
+        .filter(|seg| !seg.is_empty() && *seg != "." && *seg != "..")
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
-/// Turn an OPC logical part name into the canonical `/`-prefixed form used in
-/// `[Content_Types].xml` `<Override PartName="…">`.
+/// The safe ZIP member name (no leading slash) for a part.
+fn zip_member_name(part_name: &str) -> String {
+    normalize_part_name(part_name)
+}
+
+/// The canonical `/`-prefixed form used in `[Content_Types].xml`
+/// `<Override PartName="…">`, derived from the SAME normalization as the ZIP
+/// member so the manifest and the archive always agree.
 fn override_part_name(part_name: &str) -> String {
-    format!("/{}", part_name.trim_start_matches('/'))
+    format!("/{}", normalize_part_name(part_name))
 }
 
 // ===========================================================================

--- a/code/packages/rust/opc-writer/src/tests.rs
+++ b/code/packages/rust/opc-writer/src/tests.rs
@@ -187,3 +187,28 @@ fn round_trips_through_opc_reader() {
     // Part bytes survive the round-trip.
     assert_eq!(read.read_part("/xl/worksheets/sheet1.xml"), Some(&b"<worksheet/>"[..]));
 }
+
+// --- Security regressions (from the C1 security review) --------------------
+
+#[test]
+fn xml_escape_drops_illegal_control_chars() {
+    // NUL and 0x01 are illegal in XML 1.0 and cannot be entity-escaped; they
+    // must be dropped so the package stays parseable.
+    assert_eq!(xml_escape("ab\u{0}cd\u{1}ef"), "abcdef");
+    // But the three legal control chars are preserved.
+    assert_eq!(xml_escape("a\tb\nc\rd"), "a\tb\nc\rd");
+    // And the ordinary specials still escape.
+    assert_eq!(xml_escape("x&<>\"'y"), "x&amp;&lt;&gt;&quot;&apos;y");
+}
+
+#[test]
+fn part_names_cannot_traverse_out_of_the_package() {
+    // A hostile part name must not become a Zip-Slip member name.
+    assert_eq!(zip_member_name("/../../evil.xml"), "evil.xml");
+    assert_eq!(zip_member_name("xl\\..\\..\\evil"), "xl/evil");
+    assert_eq!(zip_member_name("//a///b/./c"), "a/b/c");
+    // A normal name is unchanged (minus the leading slash).
+    assert_eq!(zip_member_name("/xl/workbook.xml"), "xl/workbook.xml");
+    // Override form stays consistent with the member form.
+    assert_eq!(override_part_name("/../../evil.xml"), "/evil.xml");
+}

--- a/code/packages/rust/opc-writer/src/tests.rs
+++ b/code/packages/rust/opc-writer/src/tests.rs
@@ -1,0 +1,189 @@
+//! Unit + round-trip tests for `opc-writer`.
+//!
+//! The round-trip tests are the load-bearing ones: they build a package with
+//! `PackageWriter` and re-open the bytes with the read-side `opc` crate, proving
+//! the writer emits exactly what our own (and any conforming) OPC reader expects.
+
+use super::*;
+use coding_adventures_opc::Package;
+
+// ── XML escaping ──────────────────────────────────────────────────────────
+
+#[test]
+fn escape_handles_all_special_chars() {
+    assert_eq!(xml_escape("a & b"), "a &amp; b");
+    assert_eq!(xml_escape("<tag>"), "&lt;tag&gt;");
+    assert_eq!(xml_escape("\"q\""), "&quot;q&quot;");
+    assert_eq!(xml_escape("it's"), "it&apos;s");
+    // Ampersand must be escaped first — no double-escaping.
+    assert_eq!(xml_escape("&lt;"), "&amp;lt;");
+}
+
+#[test]
+fn escape_passes_unicode_through() {
+    assert_eq!(xml_escape("日本語 résumé"), "日本語 résumé");
+    assert_eq!(xml_escape(""), "");
+    assert_eq!(xml_escape("plain text 123"), "plain text 123");
+}
+
+// ── Part-name normalization ───────────────────────────────────────────────
+
+#[test]
+fn part_names_normalize_either_spelling() {
+    assert_eq!(zip_member_name("/xl/workbook.xml"), "xl/workbook.xml");
+    assert_eq!(zip_member_name("xl/workbook.xml"), "xl/workbook.xml");
+    assert_eq!(override_part_name("xl/workbook.xml"), "/xl/workbook.xml");
+    assert_eq!(override_part_name("/xl/workbook.xml"), "/xl/workbook.xml");
+}
+
+// ── Relationships serialization ───────────────────────────────────────────
+
+#[test]
+fn rels_builder_serializes_entries() {
+    let mut r = RelationshipsBuilder::new();
+    r.add("rId1", "http://example/officeDocument", "xl/workbook.xml");
+    r.add("rId2", "http://example/sharedStrings", "sharedStrings.xml");
+    let text = String::from_utf8(r.build()).unwrap();
+    assert!(text.contains(RELATIONSHIPS_NS));
+    assert!(text.contains("Id=\"rId1\""));
+    assert!(text.contains("Target=\"xl/workbook.xml\""));
+    assert!(text.contains("Id=\"rId2\""));
+    assert!(text.contains("Type=\"http://example/sharedStrings\""));
+}
+
+#[test]
+fn rels_builder_escapes_targets() {
+    let mut r = RelationshipsBuilder::new();
+    r.add("rId1", "http://example/t", "a&b<c>.xml");
+    let text = String::from_utf8(r.build()).unwrap();
+    assert!(text.contains("Target=\"a&amp;b&lt;c&gt;.xml\""));
+}
+
+// ── Content-types synthesis ───────────────────────────────────────────────
+
+#[test]
+fn content_types_emits_defaults_and_overrides() {
+    let mut pkg = PackageWriter::new();
+    pkg.add_default("rels", "application/vnd.openxmlformats-package.relationships+xml");
+    pkg.add_default("xml", "application/xml");
+    pkg.add_part("/xl/workbook.xml", "application/custom+xml", b"<w/>");
+    let xml = String::from_utf8(pkg.content_types_xml()).unwrap();
+    assert!(xml.contains(CONTENT_TYPES_NS));
+    assert!(xml.contains("<Default Extension=\"rels\""));
+    assert!(xml.contains("<Default Extension=\"xml\""));
+    assert!(xml.contains("<Override PartName=\"/xl/workbook.xml\" ContentType=\"application/custom+xml\""));
+}
+
+#[test]
+fn content_types_dedups_defaults_last_wins() {
+    let mut pkg = PackageWriter::new();
+    pkg.add_default("xml", "application/first");
+    pkg.add_default("xml", "application/second");
+    let xml = String::from_utf8(pkg.content_types_xml()).unwrap();
+    // Exactly one Default for "xml", and it carries the LAST content type.
+    assert_eq!(xml.matches("Extension=\"xml\"").count(), 1);
+    assert!(xml.contains("application/second"));
+    assert!(!xml.contains("application/first"));
+}
+
+#[test]
+fn content_types_dedups_overrides_last_wins() {
+    let mut pkg = PackageWriter::new();
+    pkg.add_part("/a.xml", "application/first", b"1");
+    pkg.add_part("/a.xml", "application/second", b"2");
+    let xml = String::from_utf8(pkg.content_types_xml()).unwrap();
+    assert_eq!(xml.matches("PartName=\"/a.xml\"").count(), 1);
+    assert!(xml.contains("application/second"));
+}
+
+#[test]
+fn defaulted_part_gets_no_override() {
+    let mut pkg = PackageWriter::new();
+    pkg.add_default("rels", "application/vnd.openxmlformats-package.relationships+xml");
+    pkg.add_part_defaulted("/_rels/.rels", b"<Relationships/>");
+    let xml = String::from_utf8(pkg.content_types_xml()).unwrap();
+    // No Override for the .rels part — it is typed by the Default.
+    assert!(!xml.contains("PartName=\"/_rels/.rels\""));
+}
+
+// ── Empty package ─────────────────────────────────────────────────────────
+
+#[test]
+fn empty_package_still_produces_valid_zip() {
+    let pkg = PackageWriter::new();
+    let bytes = pkg.finish();
+    // Starts with the ZIP local-file-header signature "PK\x03\x04" (or is the
+    // empty-archive EOCD "PK\x05\x06" if no members) — here [Content_Types].xml
+    // is always present, so it's a local header.
+    assert_eq!(&bytes[..2], b"PK");
+}
+
+// ── Round-trip through the read-side opc crate ────────────────────────────
+//
+// Build a minimal package with a main-document relationship and re-open it with
+// coding_adventures_opc::Package. This proves content-type resolution and
+// relationship dereferencing both work against our own reader.
+
+#[test]
+fn round_trips_through_opc_reader() {
+    const OFFICE_DOC_TYPE: &str =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+    const WORKSHEET_TYPE: &str =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
+
+    let mut pkg = PackageWriter::new();
+    pkg.add_default("rels", "application/vnd.openxmlformats-package.relationships+xml");
+    pkg.add_default("xml", "application/xml");
+
+    // Package-root rels: package → workbook.
+    let mut root_rels = RelationshipsBuilder::new();
+    root_rels.add("rId1", OFFICE_DOC_TYPE, "xl/workbook.xml");
+    pkg.add_part_defaulted("/_rels/.rels", &root_rels.build());
+
+    // Workbook part (typed via Override).
+    pkg.add_part(
+        "/xl/workbook.xml",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml",
+        b"<workbook/>",
+    );
+
+    // Workbook rels: workbook → sheet1 (target relative to xl/).
+    let mut wb_rels = RelationshipsBuilder::new();
+    wb_rels.add("rId1", WORKSHEET_TYPE, "worksheets/sheet1.xml");
+    pkg.add_part_defaulted("/xl/_rels/workbook.xml.rels", &wb_rels.build());
+
+    pkg.add_part(
+        "/xl/worksheets/sheet1.xml",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml",
+        b"<worksheet/>",
+    );
+
+    let bytes = pkg.finish();
+
+    // Re-open with the READ-SIDE opc crate.
+    let read = Package::open(&bytes).expect("opc reader should open our package");
+
+    // The main document part is discovered via the /officeDocument relationship.
+    assert_eq!(read.main_document_part().as_deref(), Some("/xl/workbook.xml"));
+
+    // Content type resolves through the Override.
+    assert_eq!(
+        read.content_type("/xl/workbook.xml").as_deref(),
+        Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"),
+    );
+
+    // The rels default types the .rels parts.
+    assert_eq!(
+        read.content_type("/_rels/.rels").as_deref(),
+        Some("application/vnd.openxmlformats-package.relationships+xml"),
+    );
+
+    // The workbook's own relationship dereferences to the sheet part.
+    assert_eq!(
+        read.resolve("/xl/workbook.xml", "rId1").as_deref(),
+        Some("/xl/worksheets/sheet1.xml"),
+    );
+
+    // Part bytes survive the round-trip.
+    assert_eq!(read.read_part("/xl/worksheets/sheet1.xml"), Some(&b"<worksheet/>"[..]));
+}

--- a/code/packages/rust/xlsx-writer/BUILD
+++ b/code/packages/rust/xlsx-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-xlsx-writer -- --nocapture

--- a/code/packages/rust/xlsx-writer/BUILD_windows
+++ b/code/packages/rust/xlsx-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-xlsx-writer -- --nocapture

--- a/code/packages/rust/xlsx-writer/CHANGELOG.md
+++ b/code/packages/rust/xlsx-writer/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to `coding-adventures-xlsx-writer` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/); this
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-03
+
+Initial release — the write side of OOXML milestone **C1**, mirroring the
+read-side `spreadsheetml` crate.
+
+### Added
+
+- `Workbook` / `Sheet` model:
+  - `Workbook::new`, `add_sheet(name)` (sheets keep insertion order).
+  - `Sheet::set_number`, `set_string`, `set_formula` (formula text without `=`,
+    plus a cached value). A malformed A1 reference is a silent no-op.
+- `write_xlsx(&Workbook) -> Vec<u8>` — generates the SpreadsheetML parts
+  (`workbook.xml`, `worksheets/sheetN.xml`, `sharedStrings.xml`, the two `.rels`
+  parts) and packages them via `opc-writer`.
+  - Text cells are deduplicated into a shared-string table with correct
+    `count` / `uniqueCount`.
+  - `sharedStrings.xml` is omitted entirely when there are no text cells.
+  - Numbers render without a trailing `.0`; non-finite values emit `0`.
+  - Sheet names, cell text, and formula text are all XML-escaped.
+- Public A1 helpers: `parse_a1`, `col_to_letters`.
+- **Round-trip proof** (`tests/round_trip.rs`): writes a "Revenue" workbook and
+  re-opens the bytes with the repo's own `spreadsheetml` (structural) and
+  `xlsx-eval` (formula recompute) readers. Also covers multiple sheets with
+  shared-string dedup, XML-special characters, Unicode, and a cross-sheet
+  formula that recomputes.
+
+### Notes
+
+- `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on input paths.

--- a/code/packages/rust/xlsx-writer/Cargo.toml
+++ b/code/packages/rust/xlsx-writer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "coding-adventures-xlsx-writer"
+version = "0.1.0"
+edition = "2021"
+description = "SpreadsheetML (.xlsx) writer — turns a simple in-memory workbook model into valid .xlsx bytes by generating the SpreadsheetML parts and packaging them via opc-writer (OOXML milestone C1)"
+license = "MIT"
+
+[dependencies]
+coding-adventures-opc-writer = { path = "../opc-writer" }
+
+[dev-dependencies]
+# The round-trip proof re-opens our output with this repo's OWN readers.
+coding-adventures-spreadsheetml = { path = "../spreadsheetml" }
+coding-adventures-xlsx-eval = { path = "../xlsx-eval" }
+spreadsheet-core = { path = "../spreadsheet-core" }

--- a/code/packages/rust/xlsx-writer/README.md
+++ b/code/packages/rust/xlsx-writer/README.md
@@ -1,0 +1,76 @@
+# coding-adventures-xlsx-writer
+
+Turns a **simple in-memory workbook model** into valid `.xlsx` bytes, by
+generating the SpreadsheetML XML parts and packaging them via the generic
+[`opc-writer`](../opc-writer). It is the write-side mirror of the
+[`spreadsheetml`](../spreadsheetml) reader.
+
+This is milestone **C1** of the OOXML effort. See
+[`code/specs/XLSXW01-xlsx-writer.md`](../../../specs/XLSXW01-xlsx-writer.md) for
+the full literate write-up.
+
+## Where it fits
+
+```text
+  Workbook model ─► xlsx-writer ─► opc-writer ─► .xlsx bytes
+                       │
+                       ├─ xl/workbook.xml
+                       ├─ xl/worksheets/sheetN.xml
+                       ├─ xl/sharedStrings.xml
+                       └─ *.rels
+```
+
+## Usage
+
+```rust
+use coding_adventures_xlsx_writer::{Workbook, write_xlsx};
+
+let mut wb = Workbook::new();
+let sheet = wb.add_sheet("Revenue");
+sheet.set_string("A1", "Q1");
+sheet.set_number("B1", 1000.0);
+sheet.set_string("A2", "Total");
+sheet.set_formula("B2", "SUM(B1:B1)", 1000.0); // formula text WITHOUT '='
+
+let bytes: Vec<u8> = write_xlsx(&wb); // real .xlsx bytes
+```
+
+## API
+
+| Item | Purpose |
+|------|---------|
+| `Workbook::new` / `add_sheet(name)` | Build the workbook; sheets keep insertion order. |
+| `Sheet::set_number(a1, n)` | A numeric cell. |
+| `Sheet::set_string(a1, s)` | A text cell (deduplicated into the shared-string table). |
+| `Sheet::set_formula(a1, f, cached)` | A formula cell (`f` without `=`) plus its cached value. |
+| `write_xlsx(&wb)` | Serialize to `.xlsx` bytes. |
+| `parse_a1` / `col_to_letters` | A1 reference helpers (also public for reuse). |
+
+A cell whose A1 reference does not parse is a silent no-op (never a panic).
+
+## The round-trip proof
+
+The test suite writes a "Revenue" sheet and re-opens the bytes with **this
+repo's own readers**:
+
+* `spreadsheetml::open_workbook` — structural read (sheet name, string cells,
+  number cell, formula text).
+* `xlsx-eval::open_and_evaluate` — recomputes `SUM(B1:B1)` from the formula text
+  (ignoring the cached value) and confirms it equals `1000`.
+
+Write → our reader → correct values (including a formula that *recomputes*) is
+the milestone's core proof. Additional round-trips cover multiple sheets with
+shared-string dedup, XML-special characters, Unicode, and a cross-sheet formula.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-xlsx-writer
+```
+
+## Guarantees
+
+* `#![forbid(unsafe_code)]`.
+* No `unwrap`/`expect`/`panic!` on any input path; XML escaping is total.
+* No filesystem, network, process, or environment access (see
+  `required_capabilities.json`).

--- a/code/packages/rust/xlsx-writer/required_capabilities.json
+++ b/code/packages/rust/xlsx-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/xlsx-writer",
+  "capabilities": [],
+  "justification": "Pure computation. Serializes an in-memory workbook model into .xlsx bytes via opc-writer. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/xlsx-writer/src/lib.rs
+++ b/code/packages/rust/xlsx-writer/src/lib.rs
@@ -1,0 +1,502 @@
+//! # `coding-adventures-xlsx-writer` — emit a real `.xlsx` from a simple model
+//!
+//! This is the **write side** of milestone **C1** and the mirror of the
+//! read-side [`spreadsheetml`](https://docs.rs/coding-adventures-spreadsheetml)
+//! crate. It takes a small in-memory workbook model and produces the bytes of a
+//! valid `.xlsx`, generating the SpreadsheetML XML parts and packaging them via
+//! the generic [`opc_writer`](coding_adventures_opc_writer). See
+//! `code/specs/XLSXW01-xlsx-writer.md` for the full literate write-up.
+//!
+//! ```text
+//!   Rust model                xlsx-writer                    opc-writer         bytes
+//!  ┌───────────┐   generate  ┌──────────────────┐  add_part ┌───────────┐  ZIP ┌────────┐
+//!  │ Workbook  │  ─────────► │ workbook.xml      │ ────────►│ Package   │ ────►│ .xlsx  │
+//!  │  Sheet    │             │ sheetN.xml        │           │ Writer    │      └────────┘
+//!  │  cells    │             │ sharedStrings.xml │           └───────────┘
+//!  └───────────┘             │ *.rels, [CT].xml  │
+//!                            └──────────────────┘
+//! ```
+//!
+//! ## The `.xlsx` part tree we generate
+//!
+//! ```text
+//! /
+//! ├── [Content_Types].xml         content-type registry (opc-writer emits this)
+//! ├── _rels/.rels                 package → workbook (rId1)
+//! └── xl/
+//!     ├── workbook.xml            <sheets>: name + sheetId + r:id per sheet
+//!     ├── sharedStrings.xml       deduplicated text table (<sst>)
+//!     ├── _rels/workbook.xml.rels workbook → each sheetN.xml + sharedStrings
+//!     └── worksheets/
+//!         ├── sheet1.xml          <sheetData> rows/cells for sheet 1
+//!         └── …
+//! ```
+//!
+//! ## The two normalizations, produced (not consumed)
+//!
+//! The reader's spec calls out two indirections. The writer must *produce* both:
+//!
+//! 1. **Shared strings.** Text is deduplicated into a single table; a text cell
+//!    stores an *index* with `t="s"`. We build the table as we walk cells — first
+//!    occurrence appends and gets the next index, repeats reuse it.
+//! 2. **`r:id` → part.** `workbook.xml` names each sheet by a relationship id;
+//!    `xl/_rels/workbook.xml.rels` maps that id to `worksheets/sheetN.xml`.
+//!
+//! ## Example
+//!
+//! ```
+//! use coding_adventures_xlsx_writer::{Workbook, write_xlsx};
+//!
+//! let mut wb = Workbook::new();
+//! let sheet = wb.add_sheet("Revenue");
+//! sheet.set_string("A1", "Q1");
+//! sheet.set_number("B1", 1000.0);
+//! sheet.set_string("A2", "Total");
+//! sheet.set_formula("B2", "SUM(B1:B1)", 1000.0);
+//!
+//! let bytes = write_xlsx(&wb);
+//! assert_eq!(&bytes[..2], b"PK"); // a ZIP / .xlsx
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use coding_adventures_opc_writer::{xml_escape, PackageWriter, RelationshipsBuilder};
+
+// ===========================================================================
+// Namespaces & content types (ECMA-376) — these must match what the reader
+// looks for, or a round-trip fails.
+// ===========================================================================
+
+/// The SpreadsheetML "main" namespace, on every structural element.
+const SML_NS: &str = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+/// The relationships namespace — the `r:` prefix on `<sheet r:id="rId1">`.
+const REL_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+const CT_RELS: &str = "application/vnd.openxmlformats-package.relationships+xml";
+const CT_XML: &str = "application/xml";
+const CT_WORKBOOK: &str =
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
+const CT_WORKSHEET: &str =
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
+const CT_SHARED_STRINGS: &str =
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml";
+
+const TYPE_OFFICE_DOCUMENT: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+const TYPE_WORKSHEET: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
+const TYPE_SHARED_STRINGS: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings";
+
+const XML_DECL: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n";
+
+// ===========================================================================
+// A1 reference parsing / generation
+// ===========================================================================
+
+/// Parse an A1-style reference into `(col, row)`, both 1-based, using bijective
+/// base-26 for the column letters (`A`=1 … `Z`=26, `AA`=27). Returns `None` for
+/// a malformed ref (empty, no letters, no digits, trailing junk, overflow).
+///
+/// This is the write-side twin of the reader's `parse_a1_ref`; keeping our own
+/// copy avoids a dependency on the reader (which is only a dev-dependency here).
+///
+/// ```
+/// use coding_adventures_xlsx_writer::parse_a1;
+/// assert_eq!(parse_a1("A1"), Some((1, 1)));
+/// assert_eq!(parse_a1("AA10"), Some((27, 10)));
+/// assert_eq!(parse_a1("1A"), None);
+/// ```
+pub fn parse_a1(a1: &str) -> Option<(u32, u32)> {
+    let bytes = a1.as_bytes();
+    let mut i = 0;
+
+    let mut col: u32 = 0;
+    while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+        let letter = bytes[i].to_ascii_uppercase();
+        let digit = (letter - b'A' + 1) as u32;
+        col = col.checked_mul(26)?.checked_add(digit)?;
+        i += 1;
+    }
+    if col == 0 {
+        return None;
+    }
+
+    let mut row: u32 = 0;
+    let mut saw_digit = false;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        let digit = (bytes[i] - b'0') as u32;
+        row = row.checked_mul(10)?.checked_add(digit)?;
+        saw_digit = true;
+        i += 1;
+    }
+    if !saw_digit || i != bytes.len() || row == 0 {
+        return None;
+    }
+    Some((col, row))
+}
+
+/// Render a 1-based column number as its bijective base-26 letters (`1`→`"A"`,
+/// `26`→`"Z"`, `27`→`"AA"`). Column `0` is invalid and yields `"A"` defensively
+/// (it never arises from a parsed ref, which is always ≥1).
+///
+/// ```
+/// use coding_adventures_xlsx_writer::col_to_letters;
+/// assert_eq!(col_to_letters(1), "A");
+/// assert_eq!(col_to_letters(26), "Z");
+/// assert_eq!(col_to_letters(27), "AA");
+/// assert_eq!(col_to_letters(52), "AZ");
+/// assert_eq!(col_to_letters(53), "BA");
+/// ```
+pub fn col_to_letters(col: u32) -> String {
+    let mut n = col.max(1);
+    let mut letters = Vec::new();
+    while n > 0 {
+        // Bijective base-26: subtract 1 so 1→'A' (remainder 0), then divide.
+        let rem = (n - 1) % 26;
+        letters.push(b'A' + rem as u8);
+        n = (n - 1) / 26;
+    }
+    letters.reverse();
+    // Safe: all pushed bytes are ASCII 'A'..='Z'.
+    String::from_utf8(letters).unwrap_or_else(|_| "A".to_string())
+}
+
+/// Build the A1 reference for a `(col, row)` pair (both 1-based).
+fn a1_of(col: u32, row: u32) -> String {
+    format!("{}{}", col_to_letters(col), row)
+}
+
+// ===========================================================================
+// Number formatting for <v>
+// ===========================================================================
+
+/// Render an `f64` for a SpreadsheetML `<v>` element. Integers drop the trailing
+/// `.0` (`1000`, not `1000.0`) to match what Excel writes and what a human
+/// expects; other values use Rust's shortest round-tripping form.
+///
+/// `NaN`/`±∞` are not representable in `<v>`; we emit `0` for them rather than
+/// invalid XML (a documented limitation — the model is trusted not to contain
+/// them).
+fn format_number(n: f64) -> String {
+    if !n.is_finite() {
+        return "0".to_string();
+    }
+    if n.fract() == 0.0 && n.abs() < 1e15 {
+        format!("{}", n as i64)
+    } else {
+        format!("{n}")
+    }
+}
+
+// ===========================================================================
+// The model
+// ===========================================================================
+
+/// A single cell's stored content in the write-side model.
+#[derive(Debug, Clone)]
+enum CellData {
+    /// A number: `<c r="…"><v>n</v></c>`.
+    Number(f64),
+    /// Text (stored via the shared-string table): `<c r="…" t="s"><v>idx</v></c>`.
+    Text(String),
+    /// A formula plus its cached result: `<c r="…"><f>formula</f><v>cached</v></c>`.
+    Formula { formula: String, cached: f64 },
+}
+
+/// One worksheet: a name plus its cells, keyed by `(row, col)` (both 1-based) so
+/// iteration is naturally row-major, left-to-right — the order Excel writes.
+pub struct Sheet {
+    name: String,
+    cells: BTreeMap<(u32, u32), CellData>,
+}
+
+impl Sheet {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            cells: BTreeMap::new(),
+        }
+    }
+
+    /// Set a numeric cell. A malformed A1 ref is a silent no-op (caller bug,
+    /// never a panic).
+    pub fn set_number(&mut self, a1: &str, n: f64) {
+        if let Some((col, row)) = parse_a1(a1) {
+            self.cells.insert((row, col), CellData::Number(n));
+        }
+    }
+
+    /// Set a text cell. A malformed A1 ref is a silent no-op.
+    pub fn set_string(&mut self, a1: &str, s: &str) {
+        if let Some((col, row)) = parse_a1(a1) {
+            self.cells.insert((row, col), CellData::Text(s.to_string()));
+        }
+    }
+
+    /// Set a formula cell. `formula` is the formula text **without** a leading
+    /// `=`; `cached` is the result written to `<v>` for non-computing viewers.
+    /// A malformed A1 ref is a silent no-op.
+    pub fn set_formula(&mut self, a1: &str, formula: &str, cached: f64) {
+        if let Some((col, row)) = parse_a1(a1) {
+            self.cells.insert(
+                (row, col),
+                CellData::Formula {
+                    formula: formula.to_string(),
+                    cached,
+                },
+            );
+        }
+    }
+
+    /// The sheet's display name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A whole workbook: its sheets in insertion order.
+#[derive(Default)]
+pub struct Workbook {
+    sheets: Vec<Sheet>,
+}
+
+impl Workbook {
+    /// A new, empty workbook.
+    pub fn new() -> Self {
+        Self { sheets: Vec::new() }
+    }
+
+    /// Add a sheet and return a mutable handle for populating its cells.
+    pub fn add_sheet(&mut self, name: &str) -> &mut Sheet {
+        self.sheets.push(Sheet::new(name));
+        // Just pushed → last() is Some; unwrap_or_else avoids a panic path even so.
+        let idx = self.sheets.len() - 1;
+        &mut self.sheets[idx]
+    }
+
+    /// The sheets, in insertion order.
+    pub fn sheets(&self) -> &[Sheet] {
+        &self.sheets
+    }
+}
+
+// ===========================================================================
+// Shared-string table
+// ===========================================================================
+
+/// A deduplicating shared-string table, built as we walk the workbook.
+///
+/// The first time a string appears it is appended and assigned the next index;
+/// repeats return the existing index. `<sst>` records two counts: `count` =
+/// total string-cell references (repeats included), `unique_count` = distinct
+/// strings.
+#[derive(Default)]
+struct SharedStrings {
+    /// Distinct strings, in first-seen order (the index is the position).
+    strings: Vec<String>,
+    /// string → index, for O(1) dedup lookups.
+    index: BTreeMap<String, usize>,
+    /// Total references, including repeats.
+    total_refs: usize,
+}
+
+impl SharedStrings {
+    /// Intern `s`, returning its shared-string index.
+    fn intern(&mut self, s: &str) -> usize {
+        self.total_refs += 1;
+        if let Some(&i) = self.index.get(s) {
+            return i;
+        }
+        let i = self.strings.len();
+        self.strings.push(s.to_string());
+        self.index.insert(s.to_string(), i);
+        i
+    }
+
+    /// Serialize the `<sst>` part.
+    fn to_xml(&self) -> Vec<u8> {
+        let mut xml = String::new();
+        xml.push_str(XML_DECL);
+        xml.push_str("<sst xmlns=\"");
+        xml.push_str(SML_NS);
+        xml.push_str("\" count=\"");
+        xml.push_str(&self.total_refs.to_string());
+        xml.push_str("\" uniqueCount=\"");
+        xml.push_str(&self.strings.len().to_string());
+        xml.push_str("\">");
+        for s in &self.strings {
+            // <t xml:space="preserve"> guards leading/trailing whitespace so a
+            // string like " x " survives the round-trip intact.
+            xml.push_str("<si><t xml:space=\"preserve\">");
+            xml.push_str(&xml_escape(s));
+            xml.push_str("</t></si>");
+        }
+        xml.push_str("</sst>");
+        xml.into_bytes()
+    }
+}
+
+// ===========================================================================
+// Part generation
+// ===========================================================================
+
+/// Serialize one worksheet's `<worksheet><sheetData>…` part. Cells are grouped
+/// into `<row r="N">` runs; a text cell has already been interned and carries
+/// its shared-string index.
+fn worksheet_xml(sheet: &Sheet, shared: &mut SharedStrings) -> Vec<u8> {
+    let mut xml = String::new();
+    xml.push_str(XML_DECL);
+    xml.push_str("<worksheet xmlns=\"");
+    xml.push_str(SML_NS);
+    xml.push_str("\"><sheetData>");
+
+    // Walk cells row-major (BTreeMap keyed by (row, col)), opening a new <row>
+    // whenever the row number changes.
+    let mut current_row: Option<u32> = None;
+    for (&(row, col), data) in &sheet.cells {
+        if current_row != Some(row) {
+            if current_row.is_some() {
+                xml.push_str("</row>");
+            }
+            xml.push_str("<row r=\"");
+            xml.push_str(&row.to_string());
+            xml.push_str("\">");
+            current_row = Some(row);
+        }
+        let r = a1_of(col, row);
+        match data {
+            CellData::Number(n) => {
+                xml.push_str("<c r=\"");
+                xml.push_str(&r);
+                xml.push_str("\"><v>");
+                xml.push_str(&format_number(*n));
+                xml.push_str("</v></c>");
+            }
+            CellData::Text(s) => {
+                let idx = shared.intern(s);
+                xml.push_str("<c r=\"");
+                xml.push_str(&r);
+                xml.push_str("\" t=\"s\"><v>");
+                xml.push_str(&idx.to_string());
+                xml.push_str("</v></c>");
+            }
+            CellData::Formula { formula, cached } => {
+                xml.push_str("<c r=\"");
+                xml.push_str(&r);
+                xml.push_str("\"><f>");
+                xml.push_str(&xml_escape(formula));
+                xml.push_str("</f><v>");
+                xml.push_str(&format_number(*cached));
+                xml.push_str("</v></c>");
+            }
+        }
+    }
+    if current_row.is_some() {
+        xml.push_str("</row>");
+    }
+
+    xml.push_str("</sheetData></worksheet>");
+    xml.into_bytes()
+}
+
+/// Serialize `xl/workbook.xml`: one `<sheet>` per worksheet, each naming its
+/// relationship id. `rId1..rIdN` map to the N sheets (see
+/// `workbook_rels_xml`).
+fn workbook_xml(sheets: &[Sheet]) -> Vec<u8> {
+    let mut xml = String::new();
+    xml.push_str(XML_DECL);
+    xml.push_str("<workbook xmlns=\"");
+    xml.push_str(SML_NS);
+    xml.push_str("\" xmlns:r=\"");
+    xml.push_str(REL_NS);
+    xml.push_str("\"><sheets>");
+    for (i, sheet) in sheets.iter().enumerate() {
+        let sheet_id = i + 1; // sheetId is 1-based
+        let rid = format!("rId{}", i + 1);
+        xml.push_str("<sheet name=\"");
+        xml.push_str(&xml_escape(&sheet.name));
+        xml.push_str("\" sheetId=\"");
+        xml.push_str(&sheet_id.to_string());
+        xml.push_str("\" r:id=\"");
+        xml.push_str(&rid);
+        xml.push_str("\"/>");
+    }
+    xml.push_str("</sheets></workbook>");
+    xml.into_bytes()
+}
+
+// ===========================================================================
+// The top-level writer
+// ===========================================================================
+
+/// Serialize a [`Workbook`] to the bytes of a valid `.xlsx` file.
+///
+/// The pipeline:
+/// 1. Generate each worksheet part, interning text cells into the shared-string
+///    table as we go.
+/// 2. Generate `workbook.xml` (naming sheets by relationship id) and, if any
+///    strings were interned, `sharedStrings.xml`.
+/// 3. Wire up the two `.rels` parts (package→workbook, workbook→sheets+strings).
+/// 4. Register content types and hand everything to [`PackageWriter`].
+pub fn write_xlsx(wb: &Workbook) -> Vec<u8> {
+    let mut shared = SharedStrings::default();
+
+    // --- Pass 1: worksheet parts (also populates the shared-string table) ---
+    // Serialize into (member_name, bytes) so we can add them after we know
+    // whether a sharedStrings part exists.
+    let mut worksheet_parts: Vec<(String, Vec<u8>)> = Vec::new();
+    for (i, sheet) in wb.sheets.iter().enumerate() {
+        let member = format!("/xl/worksheets/sheet{}.xml", i + 1);
+        worksheet_parts.push((member, worksheet_xml(sheet, &mut shared)));
+    }
+
+    let has_strings = !shared.strings.is_empty();
+
+    // --- workbook.xml -----------------------------------------------------
+    let workbook_bytes = workbook_xml(&wb.sheets);
+
+    // --- workbook rels: workbook → each sheet, then → sharedStrings -------
+    let mut wb_rels = RelationshipsBuilder::new();
+    for i in 0..wb.sheets.len() {
+        wb_rels.add(
+            &format!("rId{}", i + 1),
+            TYPE_WORKSHEET,
+            &format!("worksheets/sheet{}.xml", i + 1),
+        );
+    }
+    if has_strings {
+        // The shared-strings relationship id follows the sheet ids.
+        let rid = format!("rId{}", wb.sheets.len() + 1);
+        wb_rels.add(&rid, TYPE_SHARED_STRINGS, "sharedStrings.xml");
+    }
+
+    // --- package-root rels: package → workbook ---------------------------
+    let mut root_rels = RelationshipsBuilder::new();
+    root_rels.add("rId1", TYPE_OFFICE_DOCUMENT, "xl/workbook.xml");
+
+    // --- assemble the package --------------------------------------------
+    let mut pkg = PackageWriter::new();
+    pkg.add_default("rels", CT_RELS);
+    pkg.add_default("xml", CT_XML);
+
+    pkg.add_part_defaulted("/_rels/.rels", &root_rels.build());
+    pkg.add_part("/xl/workbook.xml", CT_WORKBOOK, &workbook_bytes);
+    pkg.add_part_defaulted("/xl/_rels/workbook.xml.rels", &wb_rels.build());
+
+    for (member, bytes) in &worksheet_parts {
+        pkg.add_part(member, CT_WORKSHEET, bytes);
+    }
+
+    if has_strings {
+        pkg.add_part("/xl/sharedStrings.xml", CT_SHARED_STRINGS, &shared.to_xml());
+    }
+
+    pkg.finish()
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/xlsx-writer/src/tests.rs
+++ b/code/packages/rust/xlsx-writer/src/tests.rs
@@ -1,0 +1,177 @@
+//! Focused unit tests for `xlsx-writer` internals: A1 generation, number
+//! formatting, the shared-string table, and XML shape. The end-to-end
+//! round-trip through the repo's own readers lives in `tests/round_trip.rs`.
+
+use super::*;
+
+// ── A1 reference generation ───────────────────────────────────────────────
+
+#[test]
+fn col_to_letters_bijective_base26() {
+    assert_eq!(col_to_letters(1), "A");
+    assert_eq!(col_to_letters(26), "Z");
+    assert_eq!(col_to_letters(27), "AA");
+    assert_eq!(col_to_letters(28), "AB");
+    assert_eq!(col_to_letters(52), "AZ");
+    assert_eq!(col_to_letters(53), "BA");
+    assert_eq!(col_to_letters(702), "ZZ");
+    assert_eq!(col_to_letters(703), "AAA");
+}
+
+#[test]
+fn a1_generation_round_trips_with_parse() {
+    // Generating an A1 and parsing it back must be an identity on (col, row).
+    for &(col, row) in &[(1u32, 1u32), (26, 5), (27, 100), (702, 2), (703, 1)] {
+        let a1 = a1_of(col, row);
+        assert_eq!(parse_a1(&a1), Some((col, row)), "round-trip {a1}");
+    }
+}
+
+#[test]
+fn parse_a1_rejects_garbage() {
+    assert_eq!(parse_a1(""), None);
+    assert_eq!(parse_a1("1A"), None);
+    assert_eq!(parse_a1("A"), None);
+    assert_eq!(parse_a1("A0"), None);
+    assert_eq!(parse_a1("A1B"), None);
+}
+
+// ── Number formatting ─────────────────────────────────────────────────────
+
+#[test]
+fn numbers_format_without_trailing_zero() {
+    assert_eq!(format_number(1000.0), "1000");
+    assert_eq!(format_number(0.0), "0");
+    assert_eq!(format_number(-42.0), "-42");
+    assert_eq!(format_number(12.5), "12.5");
+    assert_eq!(format_number(3.25), "3.25");
+}
+
+#[test]
+fn non_finite_numbers_are_safe() {
+    // NaN / inf are not representable in <v>; we emit "0" rather than bad XML.
+    assert_eq!(format_number(f64::NAN), "0");
+    assert_eq!(format_number(f64::INFINITY), "0");
+    assert_eq!(format_number(f64::NEG_INFINITY), "0");
+}
+
+// ── Shared-string table ───────────────────────────────────────────────────
+
+#[test]
+fn shared_strings_dedup_and_index() {
+    let mut sst = SharedStrings::default();
+    assert_eq!(sst.intern("Q1"), 0);
+    assert_eq!(sst.intern("Total"), 1);
+    assert_eq!(sst.intern("Q1"), 0); // repeat reuses index 0
+    assert_eq!(sst.intern("Total"), 1); // repeat reuses index 1
+    assert_eq!(sst.intern("New"), 2);
+
+    // 5 references, 3 distinct strings.
+    assert_eq!(sst.total_refs, 5);
+    assert_eq!(sst.strings.len(), 3);
+
+    let xml = String::from_utf8(sst.to_xml()).unwrap();
+    assert!(xml.contains("count=\"5\""));
+    assert!(xml.contains("uniqueCount=\"3\""));
+    assert!(xml.contains("<t xml:space=\"preserve\">Q1</t>"));
+}
+
+// ── XML escaping in cells and sheet names ─────────────────────────────────
+
+#[test]
+fn string_cells_are_xml_escaped() {
+    let mut sst = SharedStrings::default();
+    sst.intern("a & b < c > d \" e");
+    let xml = String::from_utf8(sst.to_xml()).unwrap();
+    assert!(xml.contains("a &amp; b &lt; c &gt; d &quot; e"));
+    // The raw special chars must NOT survive unescaped in text.
+    assert!(!xml.contains("a & b"));
+}
+
+#[test]
+fn sheet_names_are_xml_escaped() {
+    let sheets = vec![Sheet::new("Q1 & Q2 <report>")];
+    let xml = String::from_utf8(workbook_xml(&sheets)).unwrap();
+    assert!(xml.contains("name=\"Q1 &amp; Q2 &lt;report&gt;\""));
+}
+
+#[test]
+fn formula_text_is_xml_escaped() {
+    let mut sheet = Sheet::new("S");
+    // A formula with a comparison operator contains '<' and '>'.
+    sheet.set_formula("A1", "IF(B1<C1,1,0)", 0.0);
+    let mut sst = SharedStrings::default();
+    let xml = String::from_utf8(worksheet_xml(&sheet, &mut sst)).unwrap();
+    assert!(xml.contains("<f>IF(B1&lt;C1,1,0)</f>"));
+}
+
+// ── Worksheet XML shape ───────────────────────────────────────────────────
+
+#[test]
+fn worksheet_groups_cells_into_rows() {
+    let mut sheet = Sheet::new("S");
+    sheet.set_string("A1", "x");
+    sheet.set_number("B1", 5.0);
+    sheet.set_number("A2", 7.0);
+    let mut sst = SharedStrings::default();
+    let xml = String::from_utf8(worksheet_xml(&sheet, &mut sst)).unwrap();
+
+    // Two rows, with r="1" containing A1 and B1, r="2" containing A2.
+    assert!(xml.contains("<row r=\"1\">"));
+    assert!(xml.contains("<row r=\"2\">"));
+    assert!(xml.contains("<c r=\"A1\" t=\"s\"><v>0</v></c>"));
+    assert!(xml.contains("<c r=\"B1\"><v>5</v></c>"));
+    assert!(xml.contains("<c r=\"A2\"><v>7</v></c>"));
+    // Exactly two <row> opens and two closes → balanced.
+    assert_eq!(xml.matches("<row ").count(), 2);
+    assert_eq!(xml.matches("</row>").count(), 2);
+}
+
+#[test]
+fn bad_ref_is_silent_noop() {
+    let mut sheet = Sheet::new("S");
+    sheet.set_number("not-a-ref", 1.0);
+    sheet.set_string("", "x");
+    assert!(sheet.cells.is_empty());
+}
+
+// ── Multiple sheets ───────────────────────────────────────────────────────
+
+#[test]
+fn multiple_sheets_get_sequential_rids() {
+    let sheets = vec![Sheet::new("One"), Sheet::new("Two"), Sheet::new("Three")];
+    let xml = String::from_utf8(workbook_xml(&sheets)).unwrap();
+    assert!(xml.contains("name=\"One\" sheetId=\"1\" r:id=\"rId1\""));
+    assert!(xml.contains("name=\"Two\" sheetId=\"2\" r:id=\"rId2\""));
+    assert!(xml.contains("name=\"Three\" sheetId=\"3\" r:id=\"rId3\""));
+}
+
+// ── Empty workbook / empty sheet don't panic ──────────────────────────────
+
+#[test]
+fn empty_workbook_produces_a_zip() {
+    let wb = Workbook::new();
+    let bytes = write_xlsx(&wb);
+    assert_eq!(&bytes[..2], b"PK");
+}
+
+#[test]
+fn workbook_with_empty_sheet_and_no_strings_omits_shared_strings() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("Empty"); // no cells, no strings
+    let bytes = write_xlsx(&wb);
+    assert_eq!(&bytes[..2], b"PK");
+    // No sharedStrings part should be referenced when there are no text cells.
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(!text.contains("sharedStrings.xml"));
+}
+
+// ── Unicode text survives ─────────────────────────────────────────────────
+
+#[test]
+fn unicode_text_is_preserved() {
+    let mut sst = SharedStrings::default();
+    sst.intern("日本語 résumé 🎉");
+    let xml = String::from_utf8(sst.to_xml()).unwrap();
+    assert!(xml.contains("日本語 résumé 🎉"));
+}

--- a/code/packages/rust/xlsx-writer/tests/round_trip.rs
+++ b/code/packages/rust/xlsx-writer/tests/round_trip.rs
@@ -1,0 +1,168 @@
+//! # The C1 milestone proof: write → read back with our OWN readers.
+//!
+//! This is the load-bearing test for `xlsx-writer`. We build a workbook in Rust,
+//! serialize it to `.xlsx` bytes, then re-open those bytes with **this repo's
+//! own** readers and assert the values survived:
+//!
+//! 1. **Structural** — [`coding_adventures_spreadsheetml::open_workbook`]
+//!    re-reads the sheet as a typed grid; we check the sheet name, string cells,
+//!    number cell, and formula text.
+//! 2. **Recompute** — [`coding_adventures_xlsx_eval::open_and_evaluate`]
+//!    recomputes formulas *from scratch* (ignoring the cached `<v>`), and
+//!    [`computed_value`](coding_adventures_xlsx_eval::computed_value) must return
+//!    the correct number.
+//!
+//! Write → our reader → correct values (including a formula that recomputes) is
+//! the end-to-end demonstration that the bytes are a genuine `.xlsx`.
+
+use coding_adventures_spreadsheetml::{open_workbook, Value};
+use coding_adventures_xlsx_eval::{computed_value, open_and_evaluate};
+use coding_adventures_xlsx_writer::{write_xlsx, Workbook};
+use spreadsheet_core::CellValue;
+
+/// Build the canonical "Revenue" workbook the milestone specifies.
+fn revenue_workbook() -> Workbook {
+    let mut wb = Workbook::new();
+    let sheet = wb.add_sheet("Revenue");
+    sheet.set_string("A1", "Q1");
+    sheet.set_number("B1", 1000.0);
+    sheet.set_string("A2", "Total");
+    sheet.set_formula("B2", "SUM(B1:B1)", 1000.0);
+    wb
+}
+
+#[test]
+fn round_trip_structural() {
+    let bytes = write_xlsx(&revenue_workbook());
+
+    let rb = open_workbook(&bytes).expect("our spreadsheetml reader should reopen the file");
+
+    // The sheet is present under the right name.
+    assert!(
+        rb.sheet_names().contains(&"Revenue".to_string()),
+        "sheet names were {:?}",
+        rb.sheet_names()
+    );
+    let sheet = rb.sheet_by_name("Revenue").expect("Revenue sheet");
+
+    // A1 = "Q1" (string, dereferenced through the shared-string table).
+    let a1 = sheet.cell("A1").expect("A1 populated");
+    assert_eq!(a1.value, Value::Text("Q1".to_string()));
+    assert_eq!(a1.formatted(), "Q1");
+
+    // B1 = 1000 (number).
+    let b1 = sheet.cell("B1").expect("B1 populated");
+    assert_eq!(b1.value, Value::Number(1000.0));
+
+    // A2 = "Total" (string).
+    let a2 = sheet.cell("A2").expect("A2 populated");
+    assert_eq!(a2.value, Value::Text("Total".to_string()));
+
+    // B2 carries the formula text (without the leading '=').
+    let b2 = sheet.cell("B2").expect("B2 populated");
+    assert_eq!(b2.formula.as_deref(), Some("SUM(B1:B1)"));
+    // …and its cached value round-trips too.
+    assert_eq!(b2.value, Value::Number(1000.0));
+}
+
+#[test]
+fn round_trip_formula_recompute() {
+    let bytes = write_xlsx(&revenue_workbook());
+
+    // Evaluate: this IGNORES the cached <v> and recomputes SUM(B1:B1) from the
+    // formula text, so a correct answer proves the formula was written parseably.
+    let core = open_and_evaluate(&bytes).expect("our xlsx-eval should evaluate the file");
+    let v = computed_value(&core, "Revenue", "B2");
+    assert_eq!(v, Some(CellValue::Number(1000.0)));
+
+    // And the plain number cell reads back through the engine too.
+    assert_eq!(
+        computed_value(&core, "Revenue", "B1"),
+        Some(CellValue::Number(1000.0))
+    );
+}
+
+#[test]
+fn round_trip_multiple_sheets_and_shared_dedup() {
+    // Two sheets; "Q1" appears on both → the shared-string table must dedup it,
+    // and both cells must still read back as "Q1" after the round-trip.
+    let mut wb = Workbook::new();
+    {
+        let s1 = wb.add_sheet("First");
+        s1.set_string("A1", "Q1");
+        s1.set_number("B1", 10.0);
+    }
+    {
+        let s2 = wb.add_sheet("Second");
+        s2.set_string("A1", "Q1"); // same string as First!A1
+        s2.set_string("A2", "Unique");
+    }
+
+    let bytes = write_xlsx(&wb);
+    let rb = open_workbook(&bytes).expect("reopen");
+
+    assert_eq!(rb.sheet_names(), vec!["First".to_string(), "Second".to_string()]);
+
+    let first = rb.sheet_by_name("First").unwrap();
+    assert_eq!(first.cell("A1").unwrap().value, Value::Text("Q1".into()));
+    assert_eq!(first.cell("B1").unwrap().value, Value::Number(10.0));
+
+    let second = rb.sheet_by_name("Second").unwrap();
+    assert_eq!(second.cell("A1").unwrap().value, Value::Text("Q1".into()));
+    assert_eq!(second.cell("A2").unwrap().value, Value::Text("Unique".into()));
+}
+
+#[test]
+fn round_trip_special_chars_and_unicode() {
+    // Sheet name and cell text with XML-special chars and Unicode must survive.
+    //
+    // NOTE on the exact strings: the repo's own `xml-lexer` intentionally skips
+    // whitespace that sits *between* tokens, so a space placed directly adjacent
+    // to an escaped entity (e.g. "a & b") is not preserved on read-back — this is
+    // a documented reader-side limitation (see xml-parser's `test_entities_in_
+    // text`), NOT a writer bug. The writer's escaping is proven total by the unit
+    // tests; here we choose text whose specials are not space-adjacent so the
+    // round-trip is a clean equality against the reader's behaviour.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("R&D<2026>");
+    s.set_string("A1", "a&b<c>d\"e");
+    s.set_string("A2", "日本語 résumé 🎉");
+    let bytes = write_xlsx(&wb);
+
+    let rb = open_workbook(&bytes).expect("reopen");
+    let sheet = rb
+        .sheet_by_name("R&D<2026>")
+        .expect("sheet name with special chars survives");
+    assert_eq!(
+        sheet.cell("A1").unwrap().value,
+        Value::Text("a&b<c>d\"e".into())
+    );
+    // Unicode (no space-adjacent entities) survives verbatim, spaces included.
+    assert_eq!(
+        sheet.cell("A2").unwrap().value,
+        Value::Text("日本語 résumé 🎉".into())
+    );
+}
+
+#[test]
+fn round_trip_cross_sheet_formula_recompute() {
+    // A formula referencing another sheet must recompute after the round-trip,
+    // exercising the r:id → part wiring across multiple worksheets.
+    let mut wb = Workbook::new();
+    {
+        let data = wb.add_sheet("Data");
+        data.set_number("A1", 40.0);
+        data.set_number("A2", 2.0);
+    }
+    {
+        let calc = wb.add_sheet("Calc");
+        calc.set_formula("A1", "Data!A1+Data!A2", 42.0);
+    }
+    let bytes = write_xlsx(&wb);
+
+    let core = open_and_evaluate(&bytes).expect("evaluate");
+    assert_eq!(
+        computed_value(&core, "Calc", "A1"),
+        Some(CellValue::Number(42.0))
+    );
+}

--- a/code/specs/OPCW01-opc-writer.md
+++ b/code/specs/OPCW01-opc-writer.md
@@ -1,0 +1,134 @@
+# OPCW01 — `opc-writer`: a generic Open Packaging Conventions *writer*
+
+**Milestone C1 (write side), layer: packaging.** This is the mirror image of the
+read-side [`opc`](OPC01-opc-package.md) crate. Where `opc` *opens* the bytes of an
+Office file into a bag of named parts, `opc-writer` *assembles* a bag of named
+parts back into the bytes of a valid Office file.
+
+It is deliberately **format-agnostic**: it knows about ZIP, content types, and
+relationships — the three OPC conventions — but nothing about spreadsheets,
+documents, or presentations. The same crate underlies a future `.docx` or
+`.pptx` writer; only the caller (`xlsx-writer`, `docx-writer`, …) knows what the
+parts *mean*.
+
+```text
+     in-memory parts                     opc-writer                    bytes
+ ┌───────────────────────┐          ┌───────────────────┐        ┌──────────────┐
+ │ "/xl/workbook.xml"     │          │  registers types  │        │  ZIP archive │
+ │ "/xl/worksheets/…"     │  ──────► │  emits            │ ─────► │ (.xlsx/.docx │
+ │ "/_rels/.rels" (caller)│          │  [Content_Types]  │        │  /.pptx)     │
+ │ …                      │          │  writes ZIP (M0)  │        └──────────────┘
+ └───────────────────────┘          └───────────────────┘
+```
+
+## The three OPC conventions, from the writer's side
+
+### 1. Parts → ZIP members
+
+Every part has a *logical* OPC name that begins with `/` (e.g. `/xl/workbook.xml`).
+Inside the ZIP the leading slash is dropped (`xl/workbook.xml`). The writer
+accepts either spelling from the caller and normalizes to the ZIP form. Bytes
+are handed straight to the [`zip`](../packages/rust/zip) crate's `ZipWriter`,
+which DEFLATE-compresses each member (method 8, CRC-32, UTF-8 filename flag) —
+exactly what Office readers, and our own `zip`/`opc` readers, expect.
+
+### 2. Content types → `[Content_Types].xml`
+
+Every part must have a declared media type. OPC offers two mechanisms and the
+writer emits both:
+
+* **Defaults** — keyed by file extension. `<Default Extension="xml"
+  ContentType="application/xml"/>` says "any part whose name ends in `.xml` is
+  `application/xml` unless overridden." Every `.xlsx` needs at least `rels` and
+  `xml` defaults.
+* **Overrides** — keyed by exact part name, and they win over a matching
+  default. `<Override PartName="/xl/workbook.xml"
+  ContentType="application/vnd.…sheet.main+xml"/>` types one specific part.
+
+`add_part` records an Override for the part; `add_default` records a Default for
+an extension. On `finish`, the writer synthesizes `[Content_Types].xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  …
+</Types>
+```
+
+`[Content_Types].xml` is itself **not** a typed part — it is the one member that
+types everything else, so the writer never emits an Override for it.
+
+### 3. Relationships → `.rels` parts
+
+Relationships wire parts together by *id*, never by hard-coded path, so a part
+can be moved without editing its referrers. A `.rels` file is just another XML
+part, so the writer models it as a helper (`RelationshipsBuilder`) that
+serializes to bytes; the caller then `add_part`s those bytes at the correct
+`.rels` name (`/_rels/.rels`, `/xl/_rels/workbook.xml.rels`). Keeping `.rels`
+as "just a part the caller supplies" keeps `opc-writer` free of any assumption
+about *which* relationships a given format needs.
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://…/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+```
+
+Relationship targets are written **relative to the `.rels` file's own
+directory**, per the OPC convention: the package-root `_rels/.rels` targets
+`xl/workbook.xml`, while `xl/_rels/workbook.xml.rels` targets
+`worksheets/sheet1.xml` (both relative to `xl/`).
+
+## Public API
+
+```rust
+pub struct PackageWriter { /* defaults, overrides, parts */ }
+impl PackageWriter {
+    pub fn new() -> Self;
+    pub fn add_default(&mut self, extension: &str, content_type: &str);
+    pub fn add_part(&mut self, part_name: &str, content_type: &str, data: &[u8]);
+    /// Add a part WITHOUT an Override (its type comes from a Default). Used for
+    /// `.rels` parts, which are typed by the `rels` Default, not per-part.
+    pub fn add_part_defaulted(&mut self, part_name: &str, data: &[u8]);
+    pub fn finish(self) -> Vec<u8>;
+}
+
+pub struct RelationshipsBuilder { /* entries */ }
+impl RelationshipsBuilder {
+    pub fn new() -> Self;
+    pub fn add(&mut self, id: &str, rel_type: &str, target: &str);
+    pub fn build(&self) -> Vec<u8>;  // serialized .rels XML bytes
+}
+
+pub fn xml_escape_attr(s: &str) -> String;   // & < > " for attribute values
+```
+
+## XML escaping
+
+All caller-supplied text (content types, part names, relationship targets/types)
+flows into XML attributes and must be escaped: `&`→`&amp;`, `<`→`&lt;`,
+`>`→`&gt;`, `"`→`&quot;`. The escaper is **total** — it never panics, and it
+handles arbitrary Unicode by passing non-special characters through unchanged.
+
+## Verification approach
+
+`opc-writer` is verified two ways:
+
+1. **Unit tests** — `[Content_Types].xml` and `.rels` serialization, XML
+   escaping, part-name normalization, ZIP-member presence.
+2. **Round-trip through the read-side `opc` crate** — build a package with
+   `PackageWriter`, then re-open the bytes with `coding_adventures_opc::Package`
+   and assert content types resolve and relationships dereference. This proves
+   the writer emits exactly what our own reader (and, by construction, any OPC
+   reader) expects. The full `.xlsx` round-trip lives in `xlsx-writer`
+   ([XLSXW01](XLSXW01-xlsx-writer.md)).
+
+## Security / robustness
+
+`#![forbid(unsafe_code)]`. This is a writer over *trusted* caller input, so the
+DoS surface is small, but the code still avoids `unwrap`/`expect`/`panic!` on any
+path a large or odd model could reach, and XML-escaping is total.

--- a/code/specs/XLSXW01-xlsx-writer.md
+++ b/code/specs/XLSXW01-xlsx-writer.md
@@ -1,0 +1,134 @@
+# XLSXW01 — `xlsx-writer`: emit a real `.xlsx` from a simple model
+
+**Milestone C1 (write side), layer: SpreadsheetML.** This is the mirror of the
+read-side [`spreadsheetml`](SML01-spreadsheetml.md) crate. It takes a small
+in-memory workbook model and produces the bytes of a valid `.xlsx`, generating
+the SpreadsheetML XML parts and packaging them via the generic
+[`opc-writer`](OPCW01-opc-writer.md).
+
+```text
+  Rust model                xlsx-writer                    opc-writer         bytes
+ ┌───────────┐   generate  ┌──────────────────┐  add_part ┌───────────┐  ZIP ┌────────┐
+ │ Workbook  │  ─────────► │ workbook.xml      │ ────────►│ Package   │ ────►│ .xlsx  │
+ │  Sheet    │             │ sheetN.xml        │           │ Writer    │      └────────┘
+ │  cells    │             │ sharedStrings.xml │           └───────────┘
+ └───────────┘             │ *.rels, [CT].xml  │
+                           └──────────────────┘
+```
+
+## The `.xlsx` part tree we generate
+
+```text
+/                                    (the ZIP root)
+├── [Content_Types].xml              content-type registry (opc-writer emits)
+├── _rels/
+│   └── .rels                        package → workbook (rId1)
+└── xl/
+    ├── workbook.xml                 <sheets>: name + sheetId + r:id per sheet
+    ├── sharedStrings.xml            deduplicated text table (<sst>)
+    ├── _rels/
+    │   └── workbook.xml.rels        workbook → each sheetN.xml + sharedStrings
+    └── worksheets/
+        ├── sheet1.xml               <sheetData> rows/cells for sheet 1
+        ├── sheet2.xml               …
+        └── …
+```
+
+## The two normalizations, generated
+
+The reader spec calls out two indirections that trip up newcomers. The writer
+must *produce* both correctly.
+
+### 1. Shared strings
+
+Text is not stored inline in the cell; it is deduplicated into a single
+**shared-string table**, and the cell stores an *index* with `t="s"`. The writer
+builds the table as it walks cells: the first time a string appears it is
+appended and gets the next index; repeats reuse that index. `<sst>` carries two
+counts:
+
+* `count` — total number of string-cell **references** (repeats included).
+* `uniqueCount` — number of **distinct** strings (the table length).
+
+```xml
+<sst xmlns="…/spreadsheetml/2006/main" count="3" uniqueCount="2">
+  <si><t>Q1</t></si>
+  <si><t>Total</t></si>
+</sst>
+```
+
+A cell then references index 0: `<c r="A1" t="s"><v>0</v></c>`.
+
+### 2. `r:id` → part
+
+`workbook.xml` names each sheet by a relationship id, and
+`xl/_rels/workbook.xml.rels` maps that id to `worksheets/sheetN.xml`. The writer
+assigns `rId1..rIdN` to the N sheets and `rId(N+1)` to `sharedStrings.xml`,
+emitting the matching `.rels` entries.
+
+## Cell XML by kind
+
+| Model                     | Generated XML                                         |
+|---------------------------|-------------------------------------------------------|
+| `set_number("B1", 1000)`  | `<c r="B1"><v>1000</v></c>` (no `t` = number)         |
+| `set_string("A1", "Q1")`  | `<c r="A1" t="s"><v>0</v></c>` (SST index)            |
+| `set_formula("B2","SUM(B1:B1)",1000)` | `<c r="B2"><f>SUM(B1:B1)</f><v>1000</v></c>` |
+
+The formula's `<f>` body is the formula text **without** a leading `=`; `<v>` is
+the *cached* result (a courtesy for non-computing viewers). Our own evaluator
+([`xlsx-eval`](SML03-formula-eval.md)) ignores the cached `<v>` and recomputes
+from `<f>`, which is precisely what the round-trip test checks.
+
+Cells within a `<row>` are emitted in column order; rows are emitted in row
+order, each `<row r="N">` carrying its 1-based row number.
+
+## Public API
+
+```rust
+pub struct Workbook { /* sheets in insertion order */ }
+impl Workbook {
+    pub fn new() -> Self;
+    pub fn add_sheet(&mut self, name: &str) -> &mut Sheet;
+}
+pub struct Sheet { /* name + cells keyed by (row,col) */ }
+impl Sheet {
+    pub fn set_number(&mut self, a1: &str, n: f64);
+    pub fn set_string(&mut self, a1: &str, s: &str);
+    pub fn set_formula(&mut self, a1: &str, formula: &str, cached: f64);
+}
+pub fn write_xlsx(wb: &Workbook) -> Vec<u8>;   // -> .xlsx bytes
+```
+
+Setting a cell whose A1 reference does not parse is a silent no-op (the model is
+caller-trusted; a bad ref is a caller bug, never a panic).
+
+## Number formatting
+
+Cell values are `f64`. Integers are written without a trailing `.0` (`1000`, not
+`1000.0`) so the on-disk XML matches what Excel writes and what a human expects;
+non-integers use Rust's shortest round-tripping `f64` formatting. `NaN`/`±∞` are
+not representable in SpreadsheetML `<v>`; the writer emits `0` for them rather
+than invalid XML (documented limitation — the model is trusted not to contain
+them).
+
+## The round-trip proof
+
+The milestone's core proof writes a "Revenue" sheet — `A1="Q1"`, `B1=1000`,
+`A2="Total"`, `B2=SUM(B1:B1)` (cached 1000) — to bytes, then reads them back
+with **this repo's own readers**:
+
+1. **Structural** — `spreadsheetml::open_workbook(&bytes)` reopens the sheet;
+   we assert the sheet name, the string cells (`A1`→"Q1", `A2`→"Total"), the
+   number cell (`B1`→1000), and that `B2` carries formula text `SUM(B1:B1)`.
+2. **Recompute** — `xlsx-eval::open_and_evaluate(&bytes)` recomputes formulas
+   from scratch (ignoring the cached `<v>`), and `computed_value(&core,
+   "Revenue", "B2")` must equal `Number(1000.0)`.
+
+Write → our own reader → correct values (including a formula that *recomputes*)
+is the end-to-end demonstration that the bytes are a genuine `.xlsx`.
+
+## Security / robustness
+
+`#![forbid(unsafe_code)]`. All text (sheet names, string cells, formula text) is
+XML-escaped totally. No `unwrap`/`expect`/`panic!` on paths reachable from an
+empty workbook, empty sheet, unicode text, or special characters.


### PR DESCRIPTION
## What

Opens the **write half** of the OOXML stack with two zero-third-party-dependency crates:

- **`opc-writer`** — a **generic** OPC package *writer* (mirror of the read-side `opc` crate). `PackageWriter` assembles parts + content-type defaults/overrides and emits the ZIP (via the existing `zip` crate's `ZipWriter`), synthesizing `[Content_Types].xml`; `RelationshipsBuilder` serializes `.rels` parts. Format-agnostic → reused by the upcoming `.docx`/`.pptx` writers.
- **`xlsx-writer`** — generates the SpreadsheetML parts (`workbook.xml`, `worksheets/sheetN.xml`, `sharedStrings.xml` with dedup + correct `count`/`uniqueCount`, both `.rels`) and packages them via `opc-writer`. `write_xlsx(&Workbook) -> Vec<u8>`.

```text
  Rust model → xlsx-writer (generate XML parts) → opc-writer (Content_Types + ZIP) → .xlsx bytes
```

## Verification — validated TWO independent ways

1. **Round-trip through our own readers** (the milestone proof): build a "Revenue" sheet (A1="Q1", B1=1000, A2="Total", B2=SUM(B1:B1)), `write_xlsx`, then reopen with `spreadsheetml::open_workbook` (structural) **and** `xlsx-eval::open_and_evaluate` → `computed_value("Revenue","B2")` recomputes `Number(1000.0)` from the formula (ignoring the cached `<v>`). Extra round-trips cover multiple sheets, shared-string dedup, XML specials, Unicode, cross-sheet formula recompute.
2. **Independent real-world library**: I wrote a workbook and opened it in **openpyxl** (a real Excel library) — both sheets, the formula `=SUM(B1:B1)` with cached `1000`, and Unicode/special-char content (`café — 你好 & <tag>`, sheet name `Ünïcode & <XML>`) all parsed correctly.

**Tests: opc-writer 13 + xlsx-writer 15 unit + 5 round-trip + doctests, all pass; clippy clean** (`--no-deps`).

## Security — write-side threat model (caller text may be untrusted-derived)

`#![forbid(unsafe_code)]`. Independent adversarial review found two issues, **both fixed in this PR**:
- **HIGH (fixed):** `xml_escape` passed XML-1.0-illegal control chars (`0x00–0x1F` except tab/newline/CR) through unchanged — entity-escaping can't rescue them, so a NUL in an untrusted cell value made the whole part unparseable. Now dropped, keeping the package well-formed (verified: openpyxl still opens a file whose input contained a NUL).
- **MEDIUM/HIGH (fixed):** caller part names were only `/`-trimmed, so `/../../evil.xml` became the ZIP member `../../evil.xml` (Zip-Slip). `normalize_part_name` now converts backslashes and drops `.`/`..`/empty segments, so a member can never be absolute or traverse upward; the `[Content_Types].xml` override name derives from the same normalization.
- Number formatting (non-finite → `0`), escaping, and panic-safety confirmed sound. Regression tests added for both fixes.

## Files

New crates `code/packages/rust/opc-writer/` and `code/packages/rust/xlsx-writer/` (each: lib, tests, BUILD/BUILD_windows, README, CHANGELOG, required_capabilities), specs `code/specs/OPCW01-opc-writer.md` + `code/specs/XLSXW01-xlsx-writer.md`, two workspace-member lines in `code/packages/rust/Cargo.toml`.

## Next

`opc-writer` now unblocks C2 `.docx` and C3 `.pptx` writers; then the C4 legacy (CFB-based) writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)