### PR TITLE
feat(cfb-writer): CFBW01 OLE2 Compound File writer (legacy-container write foundation)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "cfb",
     "ppt",
     "doc",
+    "cfb-writer",
     "binary-search-tree",
     "avl-tree",
     "red-black-tree",

--- a/code/packages/rust/cfb-writer/BUILD
+++ b/code/packages/rust/cfb-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p cfb-writer -- --nocapture

--- a/code/packages/rust/cfb-writer/BUILD_windows
+++ b/code/packages/rust/cfb-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p cfb-writer -- --nocapture

--- a/code/packages/rust/cfb-writer/CHANGELOG.md
+++ b/code/packages/rust/cfb-writer/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to `cfb-writer` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-03
+
+### Added
+
+- Initial release (**CFBW01**): a from-scratch, zero-third-party-dependency
+  **writer** for the OLE2 / Compound File Binary Format ([MS-CFB]) — the exact
+  inverse of the `cfb` reader crate.
+- Public API:
+  - `CfbWriter::new()`, `add_stream(name, data)`, `finish() -> Vec<u8>`.
+  - `write_cfb(&[(&str, &[u8])]) -> Vec<u8>` convenience function.
+- Emits **version 3** files: 512-byte sectors, 64-byte mini-sectors, 4096-byte
+  mini-stream cutoff.
+- **Both storage paths** implemented:
+  - Large streams (≥ 4096 bytes) get their own regular 512-byte FAT sectors.
+  - Small streams (< 4096 bytes) are packed into the Root Entry's mini-stream
+    and chained by the mini-FAT.
+- **Fixed-point FAT-sector count**: the FAT describes its own sectors, so the
+  sector count is iterated to a fixed point.
+- Directory emitted as a trivially-valid all-black red-black tree; streams are
+  chained as right-siblings in insertion order.
+- Header + inlined DIFAT (first 109 FAT-sector locations) written per spec.
+- **Determinism**: CLSID and all timestamp fields zeroed; identical input
+  yields identical bytes.
+- **Robustness**: `#![forbid(unsafe_code)]`, no `unwrap`/`expect`/`panic!` on
+  the public path; overlong names truncated to 31 UTF-16 units; empty streams
+  and an empty stream set both produce valid files; overflow-safe sector-count
+  arithmetic.
+- **Round-trip proof**: writes mixed small + large streams and reopens them with
+  the `cfb` reader, asserting byte-for-byte equality. 22 unit tests + 2
+  doctests, all passing; clippy clean under `-D warnings`.
+
+### Known limitations
+
+- Storages (nested folders) are not yet emitted — output is a flat set of
+  top-level streams, sufficient for the legacy single-workbook/document case.
+- Files needing more than 109 FAT sectors (a DIFAT-sector chain) are out of
+  scope for 0.1.0; the safety cap keeps realistic inputs well under that.
+
+[MS-CFB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/

--- a/code/packages/rust/cfb-writer/Cargo.toml
+++ b/code/packages/rust/cfb-writer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cfb-writer"
+version = "0.1.0"
+edition = "2021"
+description = "A from-scratch, zero-dependency writer for the OLE2 / Compound File Binary Format ([MS-CFB]) — produces valid .xls/.doc/.ppt containers. The inverse of the `cfb` reader."
+license = "MIT"
+
+[dependencies]
+# No dependencies — pure std, from-scratch binary emitter.
+
+[dev-dependencies]
+# The reader, used to prove our output round-trips byte-for-byte.
+cfb = { path = "../cfb" }

--- a/code/packages/rust/cfb-writer/README.md
+++ b/code/packages/rust/cfb-writer/README.md
@@ -1,0 +1,101 @@
+# cfb-writer
+
+A from-scratch, **zero-third-party-dependency** *writer* for the **OLE2 /
+Compound File Binary Format** ([MS-CFB]) — the container format that lives
+inside legacy `.xls`, `.doc`, and `.ppt` files. It is the exact inverse of the
+sibling [`cfb`](../cfb) reader crate: you hand it a set of named streams and it
+produces a byte buffer that the reader (and real Office tooling) accepts.
+
+`#![forbid(unsafe_code)]`, pure `std`, deterministic output (no timestamps or
+randomness), never panics on the public API path.
+
+## Where it fits in the stack
+
+```
+        deflate ── zip ── xml ── opc ── spreadsheetml ── xlsx-eval   (OOXML, .xlsx)
+                                                                     │
+   cfb (reader) ◄──────── round-trip proof ────────► cfb-writer     (this crate)
+        │                                                 │
+        └───────────── the OLE2 container ────────────────┘
+                                                          │
+                                          legacy .xls / .doc / .ppt  (milestone C4)
+```
+
+Modern Office files (`.xlsx`, `.docx`) are ZIP containers; the *legacy* binary
+formats (`.xls`, `.doc`, `.ppt`) are CFB containers. This crate is the container
+foundation for **writing** those legacy formats: a `.xls` writer will build a
+`Workbook` stream (BIFF records) and hand it to `cfb-writer` to wrap.
+
+## The one-paragraph mental model
+
+A CFB file is a **FAT filesystem crammed into a single file**. A fixed 512-byte
+*header*, then equal-sized 512-byte *sectors*. A **File Allocation Table (FAT)**
+holds one "next sector" pointer per sector, so a multi-sector stream is a linked
+list you follow until `ENDOFCHAIN`. A **directory** (itself a FAT-stored stream)
+lists the named objects. Tiny streams (smaller than the 4096-byte *mini cutoff*)
+would waste most of a sector, so they are packed into a **mini-stream** sliced
+into 64-byte *mini-sectors* chained by a parallel **mini-FAT**.
+
+## Usage
+
+```rust
+use cfb_writer::{CfbWriter, write_cfb};
+
+// Convenience one-shot:
+let bytes = write_cfb(&[
+    ("Workbook", &vec![0xABu8; 5000][..]),   // large -> regular FAT
+    ("SmallStream", b"hello mini-stream"),   // small -> mini-FAT
+]);
+
+// Or the builder:
+let mut w = CfbWriter::new();
+w.add_stream("Workbook", &[/* BIFF bytes */]);
+w.add_stream("\u{5}SummaryInformation", b"...");
+let bytes = w.finish();
+```
+
+Reopen with the reader to verify:
+
+```rust
+let cf = cfb::CompoundFile::open(&bytes).unwrap();
+assert_eq!(cf.read_stream("Workbook").unwrap(), vec![0xABu8; 5000]);
+```
+
+## What it emits
+
+Always **version 3**: 512-byte sectors, 64-byte mini-sectors, 4096-byte cutoff.
+The layout is a fixed, simple sector order (directory → mini-FAT → mini-stream →
+large streams → FAT sectors), and the directory is a trivially-valid all-black
+red-black tree where streams are chained as right-siblings in insertion order.
+
+## Behaviour & limits
+
+- **Names** are stored in a 64-byte UTF-16LE field, so at most **31 UTF-16 code
+  units** (plus a NUL). A longer name is **truncated** to 31 units (the API
+  stays infallible).
+- **Small vs large:** a stream strictly smaller than 4096 bytes goes to the
+  mini-stream; a stream ≥ 4096 gets its own 512-byte sectors.
+- **Empty streams** (0 bytes) and an **empty stream set** both produce valid
+  files (the latter is just a Root Entry).
+- **Deterministic:** CLSID and all timestamp fields are zeroed, so identical
+  input always yields identical bytes.
+- **Storages (folders)** are not yet emitted — this writer produces a flat set
+  of top-level streams, which is all the legacy Office single-workbook/document
+  case needs. See the spec for the extension path.
+
+## Testing
+
+```
+cargo test -p cfb-writer -- --nocapture
+```
+
+The centrepiece is a **round-trip** test: write mixed small + large streams,
+reopen with the `cfb` reader, and assert byte-for-byte equality.
+
+## Specification
+
+See [`code/specs/CFBW01-cfb-writer.md`](../../../specs/CFBW01-cfb-writer.md) for
+the full literate walkthrough (header/FAT/DIFAT/directory/mini-FAT layout, the
+small-vs-large decision, and the fixed-point FAT-sector count).
+
+[MS-CFB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/

--- a/code/packages/rust/cfb-writer/required_capabilities.json
+++ b/code/packages/rust/cfb-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/cfb-writer",
+  "capabilities": [],
+  "justification": "Pure in-memory binary emission. Callers pass name/byte-slice pairs and receive a byte buffer; the crate does no filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/cfb-writer/src/lib.rs
+++ b/code/packages/rust/cfb-writer/src/lib.rs
@@ -1,0 +1,698 @@
+//! # cfb-writer — Compound File Binary Format writer (CFBW01)
+//!
+//! A from-scratch, zero-dependency **writer** for the **OLE2 / Compound File
+//! Binary Format** ([MS-CFB]) — the container that lives inside legacy `.xls`,
+//! `.doc`, and `.ppt` files. This is the exact inverse of the sibling `cfb`
+//! reader crate: you hand it a set of named streams and it produces a byte
+//! buffer that the reader (and, more importantly, real Office tooling) accepts.
+//! See `code/specs/CFBW01-cfb-writer.md` for the full literate walkthrough.
+//!
+//! ## The one-paragraph mental model
+//!
+//! A CFB file is a **FAT filesystem crammed into a single file**. Picture a
+//! floppy disk: a fixed-size *header*, then a run of equal-sized *sectors*. A
+//! **File Allocation Table (FAT)** is one `u32` "next sector" pointer per
+//! sector; a multi-sector file is a linked list you follow until you hit
+//! `ENDOFCHAIN`. A **directory** (itself just another FAT-stored stream) lists
+//! the named objects — CFB calls a file a *stream* and a folder a *storage*.
+//! Tiny streams (smaller than the 4096-byte *mini cutoff*) would waste most of a
+//! 512-byte sector, so they are packed together into a **mini-stream**, sliced
+//! into 64-byte *mini-sectors* chained by a parallel **mini-FAT**.
+//!
+//! ## What this writer emits
+//!
+//! We always write **version 3** files: 512-byte sectors, 64-byte mini-sectors,
+//! a 4096-byte mini-stream cutoff. The output is fully **deterministic** — every
+//! CLSID and timestamp field is zeroed — so tests are byte-stable.
+//!
+//! ```
+//! # use cfb_writer::write_cfb;
+//! let bytes = write_cfb(&[
+//!     ("Workbook", &[0x09, 0x08, 0x00, 0x00][..]),
+//!     ("\u{5}SummaryInformation", b"tiny"),
+//! ]);
+//! assert_eq!(&bytes[0..8], &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+//! ```
+//!
+//! ## Layout we produce, sector by sector
+//!
+//! We choose a **fixed, simple sector order** that any conforming reader walks:
+//!
+//! ```text
+//!   offset 0        HEADER (512 bytes; sectors are numbered AFTER this)
+//!   sector 0..a     FAT sectors            (marked FATSECT in the FAT itself)
+//!   sector a..b     directory stream       (128-byte entries; root first)
+//!   sector b..c     mini-FAT stream        (only if any small streams exist)
+//!   sector c..d     mini-stream            (the packed 64-byte mini-sectors)
+//!   sector d..e     each LARGE stream's data (>= cutoff), back to back
+//! ```
+//!
+//! The tricky part is that the FAT must describe *itself*: the number of FAT
+//! sectors depends on the total sector count, which includes the FAT sectors.
+//! We resolve that with a small **fixed-point** loop (see `finish`).
+
+#![forbid(unsafe_code)]
+
+// ---------------------------------------------------------------------------
+// Constants — the sentinel FAT values, sizes, and header field offsets. These
+// mirror the reader's constants exactly; a writer and reader must agree.
+// ---------------------------------------------------------------------------
+
+/// The 8-byte magic that opens every CFB file: `D0 CF 11 E0 A1 B1 1A E1`.
+const SIGNATURE: [u8; 8] = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+
+/// Free / unused sector.
+const FREESECT: u32 = 0xFFFF_FFFF;
+/// End of a sector chain.
+const ENDOFCHAIN: u32 = 0xFFFF_FFFE;
+/// Sector holds part of the FAT.
+const FATSECT: u32 = 0xFFFF_FFFD;
+/// Directory-entry "no such sibling/child" marker.
+const NOSTREAM: u32 = 0xFFFF_FFFF;
+
+/// The fixed header length. Sectors are numbered *after* these first 512 bytes.
+const HEADER_LEN: usize = 512;
+/// Version-3 sector size.
+const SECTOR_SIZE: usize = 512;
+/// Version-3 mini-sector size.
+const MINI_SECTOR_SIZE: usize = 64;
+/// Streams strictly smaller than this go into the mini-stream. Streams that are
+/// this size or larger get their own regular 512-byte sectors.
+const MINI_CUTOFF: u32 = 4096;
+/// Each directory entry is exactly 128 bytes.
+const DIR_ENTRY_SIZE: usize = 128;
+/// The header inlines the first 109 FAT-sector locations.
+const HEADER_DIFAT_COUNT: usize = 109;
+/// Byte offset within the header where the inlined DIFAT array begins.
+const HEADER_DIFAT_OFFSET: usize = 76;
+/// Number of `u32` pointers a single 512-byte FAT sector can hold (512/4).
+const FAT_ENTRIES_PER_SECTOR: usize = SECTOR_SIZE / 4;
+/// Number of `u32` pointers a single 512-byte mini-FAT sector can hold.
+const MINIFAT_ENTRIES_PER_SECTOR: usize = SECTOR_SIZE / 4;
+/// The longest a stream/storage name may be, in UTF-16 code units, *excluding*
+/// the terminating NUL. The 64-byte name field holds 32 UTF-16 units total, and
+/// one is reserved for the NUL, leaving 31.
+const MAX_NAME_UNITS: usize = 31;
+
+/// Object type: a stream ("file").
+const OBJ_STREAM: u8 = 0x02;
+/// Object type: the root storage (entry 0).
+const OBJ_ROOT: u8 = 0x05;
+/// Red-black colour: black. We colour every node black — a tree that is "all
+/// black" is trivially a valid red-black tree (readers only need the tree
+/// walkable, not perfectly balanced), and it keeps the writer simple.
+const COLOR_BLACK: u8 = 0x01;
+
+// ---------------------------------------------------------------------------
+// Little-endian writers. Small helpers that append to a growing `Vec<u8>` or
+// patch an existing buffer. Nothing here can panic on the public path because
+// the buffer is always pre-sized to a computed length.
+// ---------------------------------------------------------------------------
+
+/// Write a `u16` little-endian at `off` in `buf`. Caller guarantees room.
+#[inline]
+fn put_u16(buf: &mut [u8], off: usize, v: u16) {
+    let b = v.to_le_bytes();
+    buf[off] = b[0];
+    buf[off + 1] = b[1];
+}
+
+/// Write a `u32` little-endian at `off` in `buf`. Caller guarantees room.
+#[inline]
+fn put_u32(buf: &mut [u8], off: usize, v: u32) {
+    let b = v.to_le_bytes();
+    buf[off..off + 4].copy_from_slice(&b);
+}
+
+/// Write a `u64` little-endian at `off` in `buf`. Caller guarantees room.
+#[inline]
+fn put_u64(buf: &mut [u8], off: usize, v: u64) {
+    let b = v.to_le_bytes();
+    buf[off..off + 8].copy_from_slice(&b);
+}
+
+/// Round `n` up to the next multiple of `unit` (`unit` must be non-zero).
+/// Returns the number of whole units, using checked arithmetic so a colossal
+/// stream length can never silently wrap.
+#[inline]
+fn div_round_up(n: u64, unit: u64) -> u64 {
+    if n == 0 {
+        0
+    } else {
+        // (n + unit - 1) / unit, but overflow-safe.
+        (n - 1) / unit + 1
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The builder.
+// ---------------------------------------------------------------------------
+
+/// An ordered collection of named streams, ready to be serialised into CFB
+/// bytes. Names are stored as-given; `finish` performs all layout and encoding.
+///
+/// Streams keep **insertion order**, and that order determines the directory's
+/// sibling chain (entry 1 → 2 → 3 …), so the reader enumerates them
+/// deterministically.
+#[derive(Debug, Default, Clone)]
+pub struct CfbWriter {
+    /// `(name, data)` in insertion order. Names longer than [`MAX_NAME_UNITS`]
+    /// UTF-16 units are truncated at `add_stream` time (documented behaviour).
+    streams: Vec<(String, Vec<u8>)>,
+}
+
+impl CfbWriter {
+    /// Create an empty writer. Calling [`finish`](Self::finish) on it yields a
+    /// valid, minimal CFB containing only the root storage and no streams.
+    pub fn new() -> Self {
+        CfbWriter {
+            streams: Vec::new(),
+        }
+    }
+
+    /// Add a named stream.
+    ///
+    /// **Name length:** CFB stores names in a fixed 64-byte UTF-16LE field, so a
+    /// name may be at most 31 UTF-16 code units (32 minus the NUL terminator).
+    /// A longer name is **truncated** to 31 units here rather than rejected,
+    /// keeping the API infallible; truncation is on UTF-16 unit boundaries so we
+    /// never split below a code unit. (Splitting a surrogate pair is still
+    /// possible in principle; `String::from_utf16_lossy` in the reader tolerates
+    /// a lone surrogate, so the file stays readable.)
+    ///
+    /// Duplicate names are permitted at this layer — CFB itself has no
+    /// uniqueness constraint on our simple sibling chain — but real consumers
+    /// expect unique names, so avoid duplicates for interoperable files.
+    pub fn add_stream(&mut self, name: &str, data: &[u8]) {
+        let truncated = truncate_name(name);
+        self.streams.push((truncated, data.to_vec()));
+    }
+
+    /// Serialise everything into a finished CFB byte buffer.
+    ///
+    /// The algorithm, top to bottom:
+    /// 1. Split streams into *small* (< cutoff → mini-stream) and *large*
+    ///    (≥ cutoff → own sectors), and lay out the mini-stream + mini-FAT.
+    /// 2. Build the directory (root entry + one entry per stream).
+    /// 3. Assign regular sectors to: directory, mini-FAT, mini-stream, and each
+    ///    large stream's data.
+    /// 4. **Fixed-point** the FAT-sector count: the FAT must have one slot per
+    ///    sector *including the FAT's own sectors*, so adding FAT sectors can
+    ///    push us over a sector boundary and require another. Iterate to a fixed
+    ///    point (converges in ≤ 2 rounds for any realistic file).
+    /// 5. Fill the FAT chains, mark FAT sectors FATSECT, write the header +
+    ///    DIFAT, and concatenate every sector.
+    pub fn finish(self) -> Vec<u8> {
+        Layout::build(&self.streams).serialise()
+    }
+}
+
+/// Convenience for the common one-shot case: give it name/data pairs, get bytes.
+///
+/// ```
+/// # use cfb_writer::write_cfb;
+/// let bytes = write_cfb(&[("Workbook", &b"hello"[..])]);
+/// assert!(bytes.len() >= 512);
+/// ```
+pub fn write_cfb(streams: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut w = CfbWriter::new();
+    for (name, data) in streams {
+        w.add_stream(name, data);
+    }
+    w.finish()
+}
+
+// ---------------------------------------------------------------------------
+// Name handling.
+// ---------------------------------------------------------------------------
+
+/// Truncate a name to at most [`MAX_NAME_UNITS`] UTF-16 code units. We count in
+/// UTF-16 units (not bytes or `char`s) because that is exactly what fits in the
+/// on-disk field.
+fn truncate_name(name: &str) -> String {
+    let units: Vec<u16> = name.encode_utf16().collect();
+    if units.len() <= MAX_NAME_UNITS {
+        name.to_string()
+    } else {
+        String::from_utf16_lossy(&units[..MAX_NAME_UNITS])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Directory entries — our in-memory model before encoding to 128 bytes each.
+// ---------------------------------------------------------------------------
+
+/// One directory entry as we build it, before serialisation.
+struct DirEntryBuild {
+    /// The (already length-limited) name.
+    name: String,
+    /// `OBJ_ROOT` for entry 0, `OBJ_STREAM` for the rest.
+    object_type: u8,
+    /// Right-sibling directory ID, or `NOSTREAM`.
+    right: u32,
+    /// Child directory ID (root only), or `NOSTREAM`.
+    child: u32,
+    /// Starting sector (regular sector for large streams / mini-stream owner;
+    /// mini-sector index for small streams) or `ENDOFCHAIN` when size is 0.
+    start_sector: u32,
+    /// Logical byte size. For the root this is the mini-stream length.
+    size: u64,
+}
+
+/// Encode one directory entry into a fresh 128-byte block.
+fn encode_dir_entry(e: &DirEntryBuild) -> [u8; DIR_ENTRY_SIZE] {
+    let mut buf = [0u8; DIR_ENTRY_SIZE];
+
+    // Name: UTF-16LE at offset 0, plus a two-byte NUL terminator. We already
+    // guarantee the name is <= 31 units, so name + NUL <= 64 bytes.
+    let units: Vec<u16> = e.name.encode_utf16().collect();
+    let mut i = 0usize;
+    for u in &units {
+        let b = u.to_le_bytes();
+        buf[i] = b[0];
+        buf[i + 1] = b[1];
+        i += 2;
+    }
+    // buf[i..i+2] stays zero — that is the NUL terminator.
+    // Name byte-length INCLUDING the terminator, at offset 64.
+    let name_len_bytes = (units.len() + 1) * 2;
+    put_u16(&mut buf, 64, name_len_bytes as u16);
+
+    // Object type (66) and colour (67).
+    buf[66] = e.object_type;
+    buf[67] = COLOR_BLACK;
+
+    // Left (68) / right (72) / child (76) stream IDs.
+    put_u32(&mut buf, 68, NOSTREAM); // left: our tree never uses left siblings
+    put_u32(&mut buf, 72, e.right);
+    put_u32(&mut buf, 76, e.child);
+
+    // CLSID (80..96), state flags (96), created/modified times (100..116): all
+    // left zero for determinism.
+
+    // Starting sector (116) and stream size (120, a u64).
+    put_u32(&mut buf, 116, e.start_sector);
+    put_u64(&mut buf, 120, e.size);
+
+    buf
+}
+
+// ---------------------------------------------------------------------------
+// The layout computation — the heart of the writer.
+// ---------------------------------------------------------------------------
+
+/// A fully computed layout: sector contents, FAT chains, header fields. From
+/// this, `serialise` is a straightforward concatenation.
+struct Layout {
+    /// The directory stream bytes (a whole number of 512-byte sectors).
+    directory: Vec<u8>,
+    /// The mini-FAT stream bytes (empty if no small streams).
+    minifat: Vec<u8>,
+    /// The mini-stream bytes (empty if no small streams).
+    mini_stream: Vec<u8>,
+    /// Each large stream's data, already padded to a 512-byte multiple, in the
+    /// same order they appear in the directory.
+    large_data: Vec<Vec<u8>>,
+    /// First sector of the directory chain.
+    first_dir_sector: u32,
+    /// First sector of the mini-FAT chain, or `ENDOFCHAIN`.
+    first_minifat_sector: u32,
+    /// Number of mini-FAT sectors.
+    num_minifat_sectors: u32,
+    /// The fully assembled FAT (one u32 per data sector, before FAT sectors are
+    /// themselves appended and marked).
+    fat: Vec<u32>,
+    /// The number of *data* sectors (everything except the FAT sectors).
+    data_sectors: usize,
+    /// The number of FAT sectors (computed by fixed point).
+    num_fat_sectors: usize,
+    /// The sector indices that hold the FAT (so we can mark them FATSECT and
+    /// list them in the DIFAT).
+    fat_sector_ids: Vec<u32>,
+}
+
+impl Layout {
+    /// Compute the complete layout from the ordered streams.
+    fn build(streams: &[(String, Vec<u8>)]) -> Layout {
+        // --- 1. Partition streams into small (mini) vs large (regular) -------
+        // Preserve overall order for the directory sibling chain, but remember
+        // which bucket each went to so we can fill in its start sector later.
+        //
+        // A stream is "small" when its size is STRICTLY LESS than the cutoff.
+        // A zero-length stream is special-cased everywhere (no sectors at all).
+        #[derive(Clone, Copy)]
+        enum Placement {
+            /// Empty stream: no data anywhere, start = ENDOFCHAIN.
+            Empty,
+            /// Small stream: index into the mini-stream bucket.
+            Mini(usize),
+            /// Large stream: index into the large bucket.
+            Large(usize),
+        }
+
+        let mut placements: Vec<(usize, Placement)> = Vec::with_capacity(streams.len());
+        let mut mini_payloads: Vec<&[u8]> = Vec::new();
+        let mut large_payloads: Vec<&[u8]> = Vec::new();
+
+        for (i, (_name, data)) in streams.iter().enumerate() {
+            let placement = if data.is_empty() {
+                Placement::Empty
+            } else if (data.len() as u64) < MINI_CUTOFF as u64 {
+                let idx = mini_payloads.len();
+                mini_payloads.push(data);
+                Placement::Mini(idx)
+            } else {
+                let idx = large_payloads.len();
+                large_payloads.push(data);
+                Placement::Large(idx)
+            };
+            placements.push((i, placement));
+        }
+
+        // --- 2. Build the mini-stream and mini-FAT ---------------------------
+        // Every small stream is chopped into 64-byte mini-sectors laid end to
+        // end in one big mini-stream. The mini-FAT is a parallel chain: for a
+        // stream occupying mini-sectors k..k+m, mini_fat[k..k+m-1] point to the
+        // next, and mini_fat[k+m-1] = ENDOFCHAIN.
+        let mut mini_stream: Vec<u8> = Vec::new();
+        let mut minifat: Vec<u32> = Vec::new();
+        // The mini-sector start index assigned to each mini payload, by its
+        // bucket index.
+        let mut mini_start_of: Vec<u32> = Vec::with_capacity(mini_payloads.len());
+
+        for payload in &mini_payloads {
+            let start_mini = minifat.len() as u32;
+            mini_start_of.push(start_mini);
+            let n_mini = div_round_up(payload.len() as u64, MINI_SECTOR_SIZE as u64) as usize;
+            // Append the payload padded to a whole number of mini-sectors.
+            mini_stream.extend_from_slice(payload);
+            let pad = n_mini * MINI_SECTOR_SIZE - payload.len();
+            mini_stream.extend(std::iter::repeat_n(0u8, pad));
+            // Chain the mini-FAT slots.
+            for j in 0..n_mini {
+                if j + 1 < n_mini {
+                    minifat.push(start_mini + j as u32 + 1);
+                } else {
+                    minifat.push(ENDOFCHAIN);
+                }
+            }
+        }
+
+        let mini_stream_size = mini_stream.len() as u64;
+        // The mini-stream is itself stored in regular 512-byte sectors (it is a
+        // normal FAT stream owned by the root), so pad it up to a sector
+        // multiple now.
+        pad_to_sector(&mut mini_stream);
+
+        // Serialise the mini-FAT to bytes, padded to whole 512-byte sectors and
+        // with unused trailing slots set to FREESECT.
+        let minifat_bytes = if minifat.is_empty() {
+            Vec::new()
+        } else {
+            encode_fat_like(&minifat, MINIFAT_ENTRIES_PER_SECTOR)
+        };
+
+        // --- 3. Build the directory ------------------------------------------
+        // Entry 0 is the root; entries 1.. are the streams in insertion order,
+        // chained by right-sibling. We will patch start_sector for large/mini/
+        // root once sector numbers are known, so use placeholders for now.
+        // `dir` is patched later (start sectors), so bind it mutable up front.
+        let mut dir: Vec<DirEntryBuild> = Vec::with_capacity(streams.len() + 1);
+        // Root entry. child points at the first stream (id 1) if any exist.
+        dir.push(DirEntryBuild {
+            name: "Root Entry".to_string(),
+            object_type: OBJ_ROOT,
+            right: NOSTREAM,
+            child: if streams.is_empty() { NOSTREAM } else { 1 },
+            start_sector: ENDOFCHAIN, // patched to mini-stream start (or stays)
+            size: mini_stream_size,
+        });
+        for (idx, (i, placement)) in placements.iter().enumerate() {
+            let (name, data) = &streams[*i];
+            // The next stream is our right sibling; the last one terminates.
+            let right = if idx + 1 < placements.len() {
+                (idx as u32) + 2 // entry ids: idx 0 -> id 1, its right -> id 2
+            } else {
+                NOSTREAM
+            };
+            let size = data.len() as u64;
+            // start_sector filled in below; for Empty it stays ENDOFCHAIN.
+            let start_sector = match placement {
+                Placement::Empty => ENDOFCHAIN,
+                Placement::Mini(bi) => mini_start_of[*bi], // mini-sector index
+                Placement::Large(_) => 0,                  // patched later
+            };
+            dir.push(DirEntryBuild {
+                name: name.clone(),
+                object_type: OBJ_STREAM,
+                right,
+                child: NOSTREAM,
+                start_sector,
+                size,
+            });
+        }
+
+        // --- 4. Assign regular sectors ---------------------------------------
+        // Data-sector layout (sector 0 is the first sector AFTER the header):
+        //   [ directory ][ mini-FAT ][ mini-stream ][ large stream 0 ] ...
+        // FAT sectors are appended AFTER all data sectors, and their count is
+        // resolved by the fixed point in step 5.
+        let mut next_sector: u32 = 0;
+
+        // (a) directory
+        let directory_bytes = encode_directory(&dir);
+        let dir_sector_count = directory_bytes.len() / SECTOR_SIZE;
+        let first_dir_sector = next_sector;
+        next_sector += dir_sector_count as u32;
+
+        // (b) mini-FAT
+        let minifat_sector_count = minifat_bytes.len() / SECTOR_SIZE;
+        let (first_minifat_sector, num_minifat_sectors) = if minifat_sector_count == 0 {
+            (ENDOFCHAIN, 0u32)
+        } else {
+            let s = next_sector;
+            next_sector += minifat_sector_count as u32;
+            (s, minifat_sector_count as u32)
+        };
+
+        // (c) mini-stream (owned by root)
+        let mini_stream_sector_count = mini_stream.len() / SECTOR_SIZE;
+        let mini_stream_start = if mini_stream_sector_count == 0 {
+            ENDOFCHAIN
+        } else {
+            let s = next_sector;
+            next_sector += mini_stream_sector_count as u32;
+            s
+        };
+
+        // (d) each large stream, padded to a sector multiple
+        let mut large_data: Vec<Vec<u8>> = Vec::with_capacity(large_payloads.len());
+        let mut large_starts: Vec<u32> = Vec::with_capacity(large_payloads.len());
+        for payload in &large_payloads {
+            let mut buf = payload.to_vec();
+            pad_to_sector(&mut buf);
+            large_starts.push(next_sector);
+            next_sector += (buf.len() / SECTOR_SIZE) as u32;
+            large_data.push(buf);
+        }
+
+        let data_sectors = next_sector as usize;
+
+        // --- 4b. Build the FAT for all DATA sectors (chains only) ------------
+        // We now know every data sector's position, so we can write the "next"
+        // pointers for each chain. FAT sectors themselves are appended and
+        // marked FATSECT during the fixed point in step 5.
+        let mut fat: Vec<u32> = vec![FREESECT; data_sectors];
+        let chain = |fat: &mut Vec<u32>, start: u32, count: usize| {
+            // Link `count` consecutive sectors starting at `start` into a chain.
+            for k in 0..count {
+                let s = start as usize + k;
+                fat[s] = if k + 1 < count {
+                    start + k as u32 + 1
+                } else {
+                    ENDOFCHAIN
+                };
+            }
+        };
+        chain(&mut fat, first_dir_sector, dir_sector_count);
+        if num_minifat_sectors > 0 {
+            chain(&mut fat, first_minifat_sector, minifat_sector_count);
+        }
+        if mini_stream_sector_count > 0 {
+            chain(&mut fat, mini_stream_start, mini_stream_sector_count);
+        }
+        for (start, buf) in large_starts.iter().zip(large_data.iter()) {
+            chain(&mut fat, *start, buf.len() / SECTOR_SIZE);
+        }
+
+        // Patch large-stream start sectors into their directory entries. The
+        // directory ID of large stream `bi` is found by scanning placements.
+        // (We rebuild the directory bytes after patching, below.)
+        for (i, placement) in placements.iter().map(|(i, p)| (*i, p)) {
+            if let Placement::Large(bi) = placement {
+                // Directory id = position in streams + 1.
+                dir[i + 1].start_sector = large_starts[*bi];
+            }
+        }
+        // Root's start_sector is the mini-stream start (or ENDOFCHAIN).
+        dir[0].start_sector = mini_stream_start;
+        // Re-encode the directory now that all start sectors are final.
+        let directory_bytes = encode_directory(&dir);
+
+        // --- 5. Fixed-point the FAT-sector count -----------------------------
+        // The FAT needs one slot per sector, INCLUDING its own sectors. Adding
+        // FAT sectors grows the total, which may need more FAT sectors. Iterate.
+        let mut num_fat_sectors = 0usize;
+        loop {
+            let total = data_sectors + num_fat_sectors;
+            let needed = div_round_up(total as u64, FAT_ENTRIES_PER_SECTOR as u64) as usize;
+            if needed == num_fat_sectors {
+                break;
+            }
+            num_fat_sectors = needed;
+        }
+
+        // Extend the FAT to cover the FAT sectors and mark them FATSECT. The FAT
+        // sectors occupy the sector indices immediately after the data sectors.
+        let mut fat_sector_ids: Vec<u32> = Vec::with_capacity(num_fat_sectors);
+        for k in 0..num_fat_sectors {
+            let sid = (data_sectors + k) as u32;
+            fat_sector_ids.push(sid);
+        }
+        // Grow the FAT array to total length, defaulting to FREESECT.
+        let total_sectors = data_sectors + num_fat_sectors;
+        fat.resize(total_sectors, FREESECT);
+        for &sid in &fat_sector_ids {
+            fat[sid as usize] = FATSECT;
+        }
+
+        Layout {
+            directory: directory_bytes,
+            minifat: minifat_bytes,
+            mini_stream,
+            large_data,
+            first_dir_sector,
+            first_minifat_sector,
+            num_minifat_sectors,
+            fat,
+            data_sectors,
+            num_fat_sectors,
+            fat_sector_ids,
+        }
+    }
+
+    /// Concatenate the header, all data sectors, and the FAT sectors into the
+    /// final byte buffer.
+    fn serialise(self) -> Vec<u8> {
+        let total_sectors = self.data_sectors + self.num_fat_sectors;
+
+        // --- Header ----------------------------------------------------------
+        let mut out = vec![0u8; HEADER_LEN];
+        out[0..8].copy_from_slice(&SIGNATURE);
+        // CLSID (8..24): zero.
+        put_u16(&mut out, 24, 0x003E); // minor version
+        put_u16(&mut out, 26, 0x0003); // major version (v3)
+        put_u16(&mut out, 28, 0xFFFE); // byte order marker (little-endian)
+        put_u16(&mut out, 30, 0x0009); // sector shift -> 512
+        put_u16(&mut out, 32, 0x0006); // mini sector shift -> 64
+        // 34..40: reserved (zero).
+        put_u32(&mut out, 40, 0); // number of directory sectors (0 for v3)
+        put_u32(&mut out, 44, self.num_fat_sectors as u32);
+        put_u32(&mut out, 48, self.first_dir_sector);
+        put_u32(&mut out, 52, 0); // transaction signature
+        put_u32(&mut out, 56, MINI_CUTOFF); // mini-stream cutoff
+        put_u32(&mut out, 60, self.first_minifat_sector);
+        put_u32(&mut out, 64, self.num_minifat_sectors);
+        put_u32(&mut out, 68, ENDOFCHAIN); // first DIFAT sector (none)
+        put_u32(&mut out, 72, 0); // number of DIFAT sectors
+
+        // DIFAT array: the first 109 FAT-sector locations, then FREESECT pad.
+        // For a well-formed small file we always have <= 109 FAT sectors, so no
+        // DIFAT-sector chain is ever needed. (A single 512-byte FAT sector maps
+        // 128 sectors * 512 bytes = 64 KiB; 109 of them map ~7 MiB of FAT
+        // pointers, i.e. hundreds of MiB of file — far beyond our safety cap.)
+        for i in 0..HEADER_DIFAT_COUNT {
+            let off = HEADER_DIFAT_OFFSET + i * 4;
+            let v = self.fat_sector_ids.get(i).copied().unwrap_or(FREESECT);
+            put_u32(&mut out, off, v);
+        }
+
+        // --- Data sectors, in the exact order we numbered them ---------------
+        // We pre-size the final buffer and append each region. Order MUST match
+        // the sector numbering in `build`.
+        out.reserve(total_sectors * SECTOR_SIZE);
+        out.extend_from_slice(&self.directory);
+        out.extend_from_slice(&self.minifat);
+        out.extend_from_slice(&self.mini_stream);
+        for buf in &self.large_data {
+            out.extend_from_slice(buf);
+        }
+
+        // --- FAT sectors -----------------------------------------------------
+        // Serialise the FAT array into its sectors, then append. The FAT array
+        // is already `total_sectors` long, padded to whole FAT sectors below.
+        let fat_bytes = encode_fat_like(&self.fat, FAT_ENTRIES_PER_SECTOR);
+        // Sanity: the encoded FAT must be exactly num_fat_sectors sectors. If
+        // arithmetic were ever off we'd still produce a valid-length buffer;
+        // debug_assert catches logic errors in tests without panicking release.
+        debug_assert_eq!(fat_bytes.len() / SECTOR_SIZE, self.num_fat_sectors);
+        out.extend_from_slice(&fat_bytes);
+
+        out
+    }
+}
+
+/// Pad a byte buffer up to a whole number of 512-byte sectors with zeros.
+fn pad_to_sector(buf: &mut Vec<u8>) {
+    let rem = buf.len() % SECTOR_SIZE;
+    if rem != 0 {
+        buf.extend(std::iter::repeat_n(0u8, SECTOR_SIZE - rem));
+    }
+}
+
+/// Encode the directory entries to bytes, padded to a whole number of 512-byte
+/// sectors. Any partial trailing sector is filled with **unused** directory
+/// entries whose object type is 0 (the reader treats type-0 nodes as invalid
+/// and skips them), which is the conforming way to pad a directory sector.
+fn encode_directory(dir: &[DirEntryBuild]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(dir.len() * DIR_ENTRY_SIZE);
+    for e in dir {
+        out.extend_from_slice(&encode_dir_entry(e));
+    }
+    // Pad to a whole sector with "unused" (all-zero except stream-id fields)
+    // 128-byte entries. Per [MS-CFB], unused entries set left/right/child to
+    // NOSTREAM; object type 0 marks them unallocated.
+    let rem = out.len() % SECTOR_SIZE;
+    if rem != 0 {
+        let pad_bytes = SECTOR_SIZE - rem;
+        let n_entries = pad_bytes / DIR_ENTRY_SIZE;
+        for _ in 0..n_entries {
+            let mut e = [0u8; DIR_ENTRY_SIZE];
+            put_u32(&mut e, 68, NOSTREAM); // left
+            put_u32(&mut e, 72, NOSTREAM); // right
+            put_u32(&mut e, 76, NOSTREAM); // child
+            out.extend_from_slice(&e);
+        }
+    }
+    out
+}
+
+/// Encode a FAT-like `u32` array (the FAT or the mini-FAT) into bytes, padded to
+/// a whole number of 512-byte sectors, with trailing pad slots set to FREESECT.
+fn encode_fat_like(entries: &[u32], entries_per_sector: usize) -> Vec<u8> {
+    // Round the entry count up to a whole sector's worth.
+    let sectors = div_round_up(entries.len() as u64, entries_per_sector as u64) as usize;
+    let total_slots = sectors * entries_per_sector;
+    let mut out = vec![0u8; total_slots * 4];
+    for (i, &v) in entries.iter().enumerate() {
+        put_u32(&mut out, i * 4, v);
+    }
+    // Fill the trailing (padding) slots with FREESECT.
+    for i in entries.len()..total_slots {
+        put_u32(&mut out, i * 4, FREESECT);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/cfb-writer/src/tests.rs
+++ b/code/packages/rust/cfb-writer/src/tests.rs
@@ -1,0 +1,336 @@
+//! Tests for `cfb-writer`. The centrepiece is the **round-trip**: we write CFB
+//! bytes, reopen them with the sibling `cfb` reader, and assert byte-for-byte
+//! equality of every stream. That is the proof our writer produces valid files.
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// The required round-trip: small (mini-FAT) + large (regular FAT) together.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_trip_mixed_small_and_large() {
+    let bytes = write_cfb(&[
+        ("Workbook", &vec![0xABu8; 5000][..]), // large -> regular FAT
+        ("SmallStream", &b"hello mini-stream"[..]), // small -> mini-FAT
+        ("Another", &vec![0x01u8; 100][..]),   // small
+    ]);
+
+    let cf = cfb::CompoundFile::open(&bytes).expect("our own reader must open our output");
+    let mut names = cf.stream_names();
+    names.sort();
+    assert!(names.iter().any(|n| n == "Workbook"));
+    assert!(names.iter().any(|n| n == "SmallStream"));
+    assert!(names.iter().any(|n| n == "Another"));
+
+    assert_eq!(cf.read_stream("Workbook").unwrap(), vec![0xABu8; 5000]);
+    assert_eq!(
+        cf.read_stream("SmallStream").unwrap(),
+        b"hello mini-stream".to_vec()
+    );
+    assert_eq!(cf.read_stream("Another").unwrap(), vec![0x01u8; 100]);
+}
+
+// ---------------------------------------------------------------------------
+// Header sanity — the signature and version fields must be exactly right.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn header_signature_and_version_fields() {
+    let bytes = write_cfb(&[("Only", &b"x"[..])]);
+    assert_eq!(&bytes[0..8], &SIGNATURE);
+    // major version 3, sector shift 0x0009, mini shift 0x0006, cutoff 4096.
+    assert_eq!(u16::from_le_bytes([bytes[26], bytes[27]]), 0x0003);
+    assert_eq!(u16::from_le_bytes([bytes[30], bytes[31]]), 0x0009);
+    assert_eq!(u16::from_le_bytes([bytes[32], bytes[33]]), 0x0006);
+    assert_eq!(u16::from_le_bytes([bytes[28], bytes[29]]), 0xFFFE);
+    assert_eq!(
+        u32::from_le_bytes([bytes[56], bytes[57], bytes[58], bytes[59]]),
+        MINI_CUTOFF
+    );
+    // The total length is always a whole number of 512-byte sectors + header.
+    assert_eq!((bytes.len() - HEADER_LEN) % SECTOR_SIZE, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Single stream (large).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_large_stream_round_trips() {
+    let data = vec![0x42u8; 4096];
+    let bytes = write_cfb(&[("Big", &data[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(cf.read_stream("Big").unwrap(), data);
+}
+
+// ---------------------------------------------------------------------------
+// Single small stream (mini-FAT path in isolation).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_small_stream_round_trips() {
+    let bytes = write_cfb(&[("Tiny", &b"abc"[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(cf.read_stream("Tiny").unwrap(), b"abc".to_vec());
+}
+
+// ---------------------------------------------------------------------------
+// Empty stream (0 bytes) — must round-trip as an empty vector.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_stream_round_trips() {
+    let bytes = write_cfb(&[("Nothing", &[][..]), ("Something", &b"data"[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(cf.read_stream("Nothing").unwrap(), Vec::<u8>::new());
+    assert_eq!(cf.read_stream("Something").unwrap(), b"data".to_vec());
+}
+
+// ---------------------------------------------------------------------------
+// Empty stream set — a valid CFB with only a Root Entry, no streams.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_streams_produces_valid_empty_cfb() {
+    let bytes = CfbWriter::new().finish();
+    let cf = cfb::CompoundFile::open(&bytes).expect("empty CFB must be valid");
+    assert!(cf.stream_names().is_empty());
+    // The root storage should still be enumerable.
+    assert!(cf
+        .entries()
+        .iter()
+        .any(|e| e.kind == cfb::EntryKind::RootStorage));
+}
+
+// ---------------------------------------------------------------------------
+// Boundary: a stream exactly at the 4096 cutoff goes to the REGULAR FAT
+// (cutoff is `< 4096` -> mini, so 4096 is large).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exactly_cutoff_bytes_is_large() {
+    let data = vec![0x7Eu8; MINI_CUTOFF as usize]; // exactly 4096
+    let bytes = write_cfb(&[("AtCutoff", &data[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(cf.read_stream("AtCutoff").unwrap(), data);
+    // And one byte under the cutoff must round-trip via the mini path.
+    let small = vec![0x7Eu8; (MINI_CUTOFF - 1) as usize];
+    let bytes2 = write_cfb(&[("JustUnder", &small[..])]);
+    let cf2 = cfb::CompoundFile::open(&bytes2).unwrap();
+    assert_eq!(cf2.read_stream("JustUnder").unwrap(), small);
+}
+
+// ---------------------------------------------------------------------------
+// Many small streams that overflow one mini-sector's worth, exercising a
+// multi-mini-sector mini-stream and a multi-slot mini-FAT.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn many_small_streams_overflow_mini_sectors() {
+    // Build 50 small streams of varying sizes, each < cutoff, whose total
+    // exceeds a single 64-byte mini-sector many times over.
+    let mut pairs: Vec<(String, Vec<u8>)> = Vec::new();
+    for i in 0..50u32 {
+        let name = format!("s{i}");
+        let len = (i as usize % 200) + 1; // 1..=200 bytes -> spans mini-sectors
+        pairs.push((name, vec![(i & 0xFF) as u8; len]));
+    }
+    let refs: Vec<(&str, &[u8])> = pairs.iter().map(|(n, d)| (n.as_str(), d.as_slice())).collect();
+    let bytes = write_cfb(&refs);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    for (name, data) in &pairs {
+        assert_eq!(
+            cf.read_stream(name).unwrap(),
+            *data,
+            "mismatch on stream {name}"
+        );
+    }
+    assert_eq!(cf.stream_names().len(), 50);
+}
+
+// ---------------------------------------------------------------------------
+// A stream large enough to span multiple 512-byte sectors AND large enough to
+// require more than one FAT sector (a single FAT sector maps 128 sectors =
+// 64 KiB; we go well past that).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn large_stream_spans_multiple_fat_sectors() {
+    // 300 KiB -> ~600 sectors -> needs >4 FAT sectors, exercising the
+    // fixed-point FAT-sector count and multi-sector chains.
+    let data: Vec<u8> = (0..300 * 1024u32).map(|i| (i & 0xFF) as u8).collect();
+    let bytes = write_cfb(&[("Huge", &data[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(cf.read_stream("Huge").unwrap(), data);
+    // Confirm the header actually records more than one FAT sector.
+    let num_fat = u32::from_le_bytes([bytes[44], bytes[45], bytes[46], bytes[47]]);
+    assert!(num_fat > 1, "expected multiple FAT sectors, got {num_fat}");
+}
+
+// ---------------------------------------------------------------------------
+// Name-too-long handling: names over 31 UTF-16 units are truncated.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overlong_name_is_truncated_to_31_units() {
+    let long = "A".repeat(100); // 100 ASCII units
+    let bytes = write_cfb(&[(long.as_str(), &b"payload"[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    let names = cf.stream_names();
+    assert_eq!(names.len(), 1);
+    assert_eq!(names[0].chars().count(), MAX_NAME_UNITS);
+    assert_eq!(names[0], "A".repeat(MAX_NAME_UNITS));
+    // The data is still intact under the truncated name.
+    assert_eq!(cf.read_stream(&names[0]).unwrap(), b"payload".to_vec());
+}
+
+#[test]
+fn name_exactly_31_units_is_kept_whole() {
+    let name = "B".repeat(MAX_NAME_UNITS);
+    let bytes = write_cfb(&[(name.as_str(), &b"x"[..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(cf.read_stream(&name).unwrap(), b"x".to_vec());
+}
+
+// ---------------------------------------------------------------------------
+// Unicode / control-prefixed names (the classic \u{5}SummaryInformation).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn control_prefixed_and_unicode_names_round_trip() {
+    let bytes = write_cfb(&[
+        ("\u{5}SummaryInformation", &b"summary"[..]),
+        ("café-Ω", &b"unicode"[..]),
+    ]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert_eq!(
+        cf.read_stream("\u{5}SummaryInformation").unwrap(),
+        b"summary".to_vec()
+    );
+    assert_eq!(cf.read_stream("café-Ω").unwrap(), b"unicode".to_vec());
+}
+
+// ---------------------------------------------------------------------------
+// The builder API (add_stream) and the free function agree.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn builder_and_free_function_agree() {
+    let mut w = CfbWriter::new();
+    w.add_stream("One", b"first");
+    w.add_stream("Two", b"second");
+    let a = w.finish();
+    let b = write_cfb(&[("One", &b"first"[..]), ("Two", &b"second"[..])]);
+    assert_eq!(a, b, "builder and convenience fn must be identical");
+}
+
+// ---------------------------------------------------------------------------
+// Determinism: the same input always yields identical bytes (no timestamps).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn output_is_deterministic() {
+    let mk = || write_cfb(&[("A", &vec![9u8; 5000][..]), ("B", &b"tiny"[..])]);
+    assert_eq!(mk(), mk());
+}
+
+// ---------------------------------------------------------------------------
+// A mix where the mini-stream itself spans more than one 512-byte sector
+// (mini-stream > 512 bytes) — exercises multi-sector mini-stream chaining.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mini_stream_spanning_multiple_sectors() {
+    // 20 streams of ~200 bytes each -> mini-stream ~ several KiB -> several
+    // 512-byte sectors, all chained through the regular FAT.
+    let mut pairs: Vec<(String, Vec<u8>)> = Vec::new();
+    for i in 0..20u32 {
+        pairs.push((format!("m{i}"), vec![(i as u8).wrapping_add(1); 200]));
+    }
+    let refs: Vec<(&str, &[u8])> = pairs.iter().map(|(n, d)| (n.as_str(), d.as_slice())).collect();
+    let bytes = write_cfb(&refs);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    for (name, data) in &pairs {
+        assert_eq!(cf.read_stream(name).unwrap(), *data);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Case-insensitive lookup still works on our output (reader behaviour).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reader_case_insensitive_lookup_on_our_output() {
+    let bytes = write_cfb(&[("Workbook", &vec![0u8; 4096][..])]);
+    let cf = cfb::CompoundFile::open(&bytes).unwrap();
+    assert!(cf.read_stream("WORKBOOK").is_some());
+    assert!(cf.read_stream("workbook").is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for the internal helpers (pure functions, no I/O).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn div_round_up_edge_cases() {
+    assert_eq!(div_round_up(0, 512), 0);
+    assert_eq!(div_round_up(1, 512), 1);
+    assert_eq!(div_round_up(512, 512), 1);
+    assert_eq!(div_round_up(513, 512), 2);
+    assert_eq!(div_round_up(64, 64), 1);
+    assert_eq!(div_round_up(65, 64), 2);
+}
+
+#[test]
+fn truncate_name_boundaries() {
+    assert_eq!(truncate_name("short"), "short");
+    let long = "z".repeat(40);
+    assert_eq!(truncate_name(&long).chars().count(), MAX_NAME_UNITS);
+    assert_eq!(truncate_name(&"y".repeat(MAX_NAME_UNITS)).chars().count(), MAX_NAME_UNITS);
+}
+
+#[test]
+fn encode_fat_like_pads_with_freesect() {
+    // Two entries in a 128-slot sector: the rest must be FREESECT.
+    let bytes = encode_fat_like(&[ENDOFCHAIN, FATSECT], FAT_ENTRIES_PER_SECTOR);
+    assert_eq!(bytes.len(), SECTOR_SIZE);
+    assert_eq!(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]), ENDOFCHAIN);
+    assert_eq!(u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]), FATSECT);
+    // Slot 2 (byte 8) onwards is FREESECT.
+    assert_eq!(u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]), FREESECT);
+}
+
+#[test]
+fn encode_fat_like_empty_is_empty() {
+    assert!(encode_fat_like(&[], FAT_ENTRIES_PER_SECTOR).is_empty());
+}
+
+#[test]
+fn pad_to_sector_rounds_up() {
+    let mut v = vec![1u8; 10];
+    pad_to_sector(&mut v);
+    assert_eq!(v.len(), SECTOR_SIZE);
+    let mut w = vec![1u8; SECTOR_SIZE];
+    pad_to_sector(&mut w);
+    assert_eq!(w.len(), SECTOR_SIZE); // already aligned: unchanged
+    let mut z: Vec<u8> = Vec::new();
+    pad_to_sector(&mut z);
+    assert!(z.is_empty());
+}
+
+#[test]
+fn encode_directory_is_sector_aligned() {
+    let dir = vec![DirEntryBuild {
+        name: "Root Entry".into(),
+        object_type: OBJ_ROOT,
+        right: NOSTREAM,
+        child: NOSTREAM,
+        start_sector: ENDOFCHAIN,
+        size: 0,
+    }];
+    let bytes = encode_directory(&dir);
+    assert_eq!(bytes.len() % SECTOR_SIZE, 0);
+    // First entry's object type is at offset 66.
+    assert_eq!(bytes[66], OBJ_ROOT);
+}

--- a/code/specs/CFBW01-cfb-writer.md
+++ b/code/specs/CFBW01-cfb-writer.md
@@ -1,0 +1,231 @@
+# CFBW01 — Compound File Binary Format writer (OLE2)
+
+> A **writer** for the **Compound File Binary Format** ([MS-CFB]) — the exact
+> inverse of the [CFB01](CFB01-compound-file.md) reader. You give it a set of
+> named byte-streams; it produces a valid CFB file (version 3, 512-byte
+> sectors). This is the container foundation for **writing** legacy `.xls`,
+> `.doc`, and `.ppt` files (milestone **C4**): a `.xls` writer builds a
+> `Workbook` stream of BIFF records and hands it here to be wrapped.
+
+This spec assumes you have read [CFB01](CFB01-compound-file.md), which explains
+the format from first principles ("a FAT filesystem crammed into a single
+file"). Here we focus on the *encoding* problem: given streams, how do we lay
+out sectors, build FAT chains, and emit a header the reader will accept?
+
+Implemented by `code/packages/rust/cfb-writer` (crate `cfb-writer`).
+
+---
+
+## 1. The mental model, from the writer's side
+
+Reading a CFB file is *following* linked lists. Writing one is *constructing*
+them. The whole job is bookkeeping:
+
+1. Decide where every byte lives (which sector, or which mini-sector).
+2. Write the "next" pointers (the FAT and mini-FAT) that stitch those sectors
+   into per-stream chains.
+3. Describe the named objects in a directory.
+4. Emit a header that points at the first directory sector, the FAT, the
+   mini-FAT, and records the mini-stream cutoff.
+
+The one genuinely circular part — the FAT must describe *its own* sectors — is
+resolved with a tiny fixed-point loop (§6).
+
+---
+
+## 2. The output we commit to
+
+We always emit **version 3**:
+
+| Field                | Value    | Meaning                                  |
+| -------------------- | -------- | ---------------------------------------- |
+| signature            | `D0 CF 11 E0 A1 B1 1A E1` | the CFB magic            |
+| major version        | `0x0003` | version 3                                |
+| sector shift         | `0x0009` | 512-byte sectors (`1 << 9`)              |
+| mini sector shift    | `0x0006` | 64-byte mini-sectors (`1 << 6`)          |
+| mini-stream cutoff   | `0x1000` | 4096 bytes                               |
+| byte order           | `0xFFFE` | little-endian                            |
+
+All CLSID and timestamp fields are **zeroed**, making output deterministic
+(identical input → identical bytes), which keeps tests byte-stable.
+
+---
+
+## 3. The sector layout we choose
+
+CFB does not mandate an order for the FAT, directory, mini-FAT, mini-stream, and
+data sectors — any order the pointers describe is legal. We pick a **fixed,
+simple order** so the writer is easy to reason about and the reader trivially
+walks it. Sector 0 is the first sector *after* the 512-byte header.
+
+```text
+  offset 0        HEADER (512 bytes)
+  ├── sector 0..a   directory stream      (128-byte entries; Root Entry first)
+  ├── sector a..b   mini-FAT stream        (only if any small streams exist)
+  ├── sector b..c   mini-stream            (packed 64-byte mini-sectors)
+  ├── sector c..d   large stream 0 data    (>= cutoff), back to back
+  │                 large stream 1 data ...
+  └── sector d..e   FAT sectors            (marked FATSECT; listed in the DIFAT)
+```
+
+Everything except the FAT sectors is a **data sector**; the FAT sectors are
+appended last because their count depends on the total (§6).
+
+---
+
+## 4. The small-vs-large decision
+
+Each stream is routed by size, matching the reader's `read_stream_by_id`:
+
+- **size == 0** → *empty*: no sectors at all; the directory entry's start sector
+  is `ENDOFCHAIN` and its size is 0.
+- **0 < size < 4096** → *small*: packed into the **mini-stream**; the directory
+  entry's start sector is a **mini-sector index**, and its chain lives in the
+  **mini-FAT**.
+- **size >= 4096** → *large*: gets its own **regular 512-byte sectors**; the
+  directory entry's start sector is a regular sector index, and its chain lives
+  in the **FAT**.
+
+The boundary is strict: exactly 4096 bytes is **large** (the cutoff is `<`).
+
+### The mini-stream and mini-FAT
+
+The mini-stream is the concatenation of every small stream, each padded up to a
+whole number of 64-byte mini-sectors. It is itself an ordinary FAT stream
+**owned by the Root Entry** (the root's start-sector + size fields point at it).
+The mini-FAT is a parallel `u32` chain indexing 64-byte mini-sectors: for a
+small stream occupying mini-sectors *k..k+m*, `mini_fat[k+i] = k+i+1` for the
+first *m-1*, and `mini_fat[k+m-1] = ENDOFCHAIN`.
+
+```text
+   small streams:  [ "hi" (2B) ][ 100×0x01 (100B) ]
+   mini-stream:    | ms0 (64B) | ms1 (64B) | ms2 (64B) |   (padded)
+                     "hi"+pad     100 bytes spill ------>
+   mini-FAT:       ms0 -> EOC ;  ms1 -> ms2 ;  ms2 -> EOC
+```
+
+---
+
+## 5. The directory
+
+The directory is a stream of 128-byte entries. Entry 0 is the **Root Entry**
+(object type `0x05`); entries 1.. are the streams (object type `0x02`) in
+insertion order.
+
+We build the simplest valid tree the reader accepts: the root's **child**
+points at the first stream (id 1), and each stream's **right-sibling** points at
+the next (id 1 → 2 → 3 → … → NOSTREAM). Every node is coloured **black**; left
+and child pointers on stream nodes are `NOSTREAM`. An "all black" tree with no
+left children is a degenerate-but-valid red-black tree — the reader only needs
+it *walkable*, not balanced, so this is sufficient and simple.
+
+Directory entry fields we write:
+
+| Offset | Size | Field                                                    |
+| ------ | ---- | -------------------------------------------------------- |
+| 0      | 64   | name, UTF-16LE, NUL-terminated                           |
+| 64     | 2    | name byte-length *including* the NUL                     |
+| 66     | 1    | object type (`0x05` root, `0x02` stream)                 |
+| 67     | 1    | colour (`0x01` = black)                                  |
+| 68     | 4    | left sibling id (always `NOSTREAM` for us)               |
+| 72     | 4    | right sibling id                                         |
+| 76     | 4    | child id (root only)                                     |
+| 80     | 16   | CLSID (zero)                                             |
+| 96     | 4    | state flags (zero)                                       |
+| 100    | 16   | created/modified timestamps (zero)                       |
+| 116    | 4    | starting sector (regular sector, or mini-sector index)   |
+| 120    | 8    | stream size (u64); for the root, the mini-stream length  |
+
+Trailing space in the last directory sector is filled with **unused** entries
+(object type 0, left/right/child = `NOSTREAM`), which the reader skips.
+
+### Names
+
+The name field is 64 bytes = 32 UTF-16 units, one reserved for the NUL, so a
+name may be at most **31 UTF-16 code units**. Longer names are **truncated** to
+31 units (the API stays infallible). We store the exact **logical** byte length
+in the size field — the reader slices to that — so padding a sector's tail with
+zeros is harmless.
+
+---
+
+## 6. The fixed-point FAT-sector count
+
+Here is the only circular dependency. The FAT needs one `u32` slot per sector —
+**including the FAT's own sectors**. A 512-byte FAT sector holds 128 slots.
+Suppose we have *D* data sectors. Then:
+
+```text
+  num_fat_sectors = ceil( (D + num_fat_sectors) / 128 )
+```
+
+`num_fat_sectors` appears on both sides. We solve it by iteration from 0:
+
+```text
+  n = 0
+  loop:
+     needed = ceil((D + n) / 128)
+     if needed == n: done
+     n = needed
+```
+
+This converges in at most two rounds for any realistic file: adding a FAT sector
+only pushes you over a 128-sector boundary occasionally. Once *n* is known, the
+FAT sectors occupy sector indices `D .. D+n`, we mark each `FATSECT` in the FAT,
+and we list them in the DIFAT.
+
+### The DIFAT
+
+The DIFAT is the "where are the FAT sectors" index. Its first 109 entries are
+**inlined in the header** (offset 76). One 512-byte FAT sector maps 128 sectors
+= 64 KiB of file; 109 of them map hundreds of MiB — beyond any realistic legacy
+Office file and beyond the reader's 256 MiB safety cap — so we never need a
+DIFAT-sector *chain*. Unused DIFAT slots are `FREESECT`. First-DIFAT-sector is
+`ENDOFCHAIN`; num-DIFAT-sectors is 0.
+
+---
+
+## 7. Serialisation, end to end
+
+```text
+  Layout::build(streams):
+    1. partition streams: empty / small / large
+    2. build mini-stream + mini-FAT (pad mini-stream to whole sectors)
+    3. build directory entries (root + one per stream)
+    4. assign regular sectors: directory, mini-FAT, mini-stream, large data
+    5. write FAT chains for every data sector
+    6. patch large-stream + root start sectors into the directory; re-encode
+    7. fixed-point num_fat_sectors; append + mark FAT sectors FATSECT
+
+  Layout::serialise():
+    header (512B) + DIFAT
+    ++ directory ++ mini-FAT ++ mini-stream ++ large data ++ FAT sectors
+```
+
+---
+
+## 8. Robustness
+
+- `#![forbid(unsafe_code)]`, pure `std`.
+- No `unwrap`/`expect`/`panic!` on the public path. The output buffer is always
+  pre-sized to a computed length, so every write is in bounds by construction.
+- Overlong names are truncated (documented), not rejected.
+- Empty stream and empty stream set both yield valid files.
+- Sector-count arithmetic uses checked/`u64` math where sizes could be large, so
+  a huge stream cannot silently wrap the sector count.
+- Deterministic: no timestamps, no randomness.
+
+---
+
+## 9. Round-trip verification (the proof)
+
+The contract is: **anything we write, the [CFB01](CFB01-compound-file.md) reader
+reads back byte-for-byte.** The centrepiece test writes a mix of a large stream
+(≥ 4096 → regular FAT) and small streams (< 4096 → mini-FAT), reopens the bytes
+with `cfb::CompoundFile::open`, and asserts each `read_stream` equals the
+original. Additional tests cover: a single stream, an empty stream, the exact
+4096-byte boundary, many small streams overflowing one mini-sector, a stream
+spanning multiple FAT sectors, control-prefixed/Unicode names, name truncation,
+and determinism.
+
+[MS-CFB]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/


### PR DESCRIPTION
## What

Adds the **`cfb-writer`** crate (CFBW01) — a from-scratch, zero-third-party-dependency **writer** for the OLE2 / Compound File Binary Format ([MS-CFB]), the exact inverse of the merged **`cfb`** reader. It takes a set of named streams and produces valid CFB bytes. This is the container foundation for the legacy write formats (`.xls`/`.doc`/`.ppt`).

`#![forbid(unsafe_code)]`, pure `std`, **deterministic output** (CLSID/timestamps zeroed).

## How it works

A CFB file is a tiny FAT filesystem inside one file. The writer emits v3 (512-byte sectors, 64-byte mini-sectors, 4096 cutoff) and implements **both** storage paths:
- **Large streams (≥4096 B)** → their own chain of 512-byte sectors in the regular FAT.
- **Small streams (<4096 B)** → packed into 64-byte mini-sectors within the Root Entry's mini-stream, chained by the mini-FAT.

It builds the FAT (with the FAT-sector count resolved by a fixed-point loop, since the FAT describes its own sectors), the DIFAT (inlined in the header), and the directory (a valid all-black red-black tree, streams chained as right-siblings), then serializes header + sectors.

## Public API

```rust
pub fn write_cfb(streams: &[(&str, &[u8])]) -> Vec<u8>;
pub struct CfbWriter; // new / add_stream(name, data) / finish() -> Vec<u8>
```

## Verification

- **22 unit tests + 2 doctests pass**, clippy clean. The core proof round-trips **byte-for-byte through our own `cfb` reader**: writes a large `Workbook` (5000 B, regular FAT) plus small streams (mini-FAT) and asserts `cfb::CompoundFile::open` reads every stream back exactly. Tests also cover empty stream, empty stream set, the exact-4096 boundary, many-small-overflow, multi-FAT-sector spanning, Unicode/overlong names, and determinism.

## Security

`#![forbid(unsafe_code)]`. Independent review **PASSED** — no panics on the `add_stream`/`finish`/`write_cfb` path; size/count arithmetic widened to `u64` before division (`div_round_up` overflow-safe); the only theoretical `u32` sector-count overflow needs ≥2 TiB of caller data held resident (OOMs first, and no `unsafe` so it can't be memory-unsafe); output is fully deterministic.

## Next

`cfb-writer` unblocks the legacy write formats — starting with the `.xls` (BIFF) writer, round-tripped through our `cfb`+`xls` readers.

## Files

New crate `code/packages/rust/cfb-writer/` (lib, tests, BUILD/BUILD_windows, README, CHANGELOG, required_capabilities), spec `code/specs/CFBW01-cfb-writer.md`, one workspace-member line in `code/packages/rust/Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)