### PR TITLE
feat(wolfram): W-22 -- cas-* function surface under Wolfram names, starting with Simplify

### DIFF
--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.18.0] — 2026-07-03
+
+The **W-22** deliverable (MA04 §2): the first head of the previously
+unnumbered "Future" item — "the `cas-*` function surface under Wolfram names
+(`Expand`, `Factor`, `Solve`, `D`, `Integrate`, …) wired to the existing
+`cas-*` crates." W-22 lands one head at a time; this release ships the first.
+
+### Added (W-22 — `Simplify`)
+
+- `Simplify[expr]` — a thin call into `cas-simplify`'s existing `simplify()`
+  (canonical ordering, constant folding, identity rules, fixed-pointed up to
+  50 iterations), the exact function Macsyma's own `simplify()` surface
+  function calls. No new algorithm — Wolfram and Macsyma now agree on every
+  simplification this crate can perform, by construction (a shared test pins
+  the two call sites to the same result on the same input).
+- New dependency: `cas-simplify` (0.3.0).
+
+### Tests
+
+- 5 new tests: additive/multiplicative identity folding, constant folding,
+  Wolfram/Macsyma call-site parity, wrong-arity fail-soft (unevaluated), and
+  one end-to-end test through the full parser → lower → `WolframBackend` path.
+
 ## [0.17.0] — 2026-06-25
 
 The **W-21** deliverable (MA04 §23): **lowering** for the W-20 pattern

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"
@@ -21,6 +21,11 @@ coding-adventures-wolfram-lexer = { path = "../wolfram-lexer" }
 symbolic-ir = { path = "../symbolic-ir" }
 symbolic-vm = { path = "../symbolic-vm" }
 cas-pattern-matching = { path = "../cas-pattern-matching" }
+# W-22: the cas-* algorithm surface under Wolfram names. Starts with
+# `Simplify` (cas-simplify's existing, tested `simplify()`); further cas-*
+# crates (cas-solve, cas-limit-series, ...) are added per-item as their
+# Wolfram name lands.
+cas-simplify = { path = "../cas-simplify" }
 # The generic parser AST types (GrammarASTNode / ASTNodeOrToken) and the lexer
 # Token type the lowering walks.
 parser = { path = "../parser" }

--- a/code/packages/rust/wolfram-runtime/README.md
+++ b/code/packages/rust/wolfram-runtime/README.md
@@ -615,6 +615,21 @@ form is left unevaluated — the fail-soft contract every head since W-5 follows
 A `;` at the end of a line suppresses that result's display (the notebook
 convention) but the statement still runs and still advances the `Out[n]` counter.
 
+**W-22** starts closing MA04 §2's previously unnumbered "Future" item — the
+`cas-*` algorithm surface under Wolfram names. Each head is a thin call into
+the existing shared `cas-*` crate, not a reimplementation:
+
+| Head | Example | Result |
+|------|---------|--------|
+| `Simplify` | `Simplify[x + 0]` | `x` |
+| `Simplify` | `Simplify[2 + 3]` | `5` |
+
+`Simplify` calls `cas-simplify`'s existing `simplify()` — the exact function
+Macsyma's own `simplify()` surface function calls — so Wolfram and Macsyma
+agree on every simplification this crate can perform. Further heads
+(`Expand`, `Factor`, `Solve`, `D`, `Integrate`, …) land one at a time, each
+its own item.
+
 ## Robustness
 
 `feed` is the trust boundary for the whole reused stack, so — mirroring

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -61,6 +61,18 @@ use cas_pattern_matching::nodes::is_rule;
 use cas_pattern_matching::rewriter::substitute as substitute_bindings;
 use cas_pattern_matching::Bindings;
 
+// W-22: the shared `cas-*` algorithm surface, under Wolfram names. `simplify`
+// is the same canonical-form + constant-folding + identity-rule pass Macsyma's
+// `simplify_handler` calls (`macsyma-runtime/src/lib.rs`) — reused verbatim,
+// not reimplemented, per MA04 §2's "Future" item.
+use cas_simplify::simplify;
+
+/// Iteration cap passed to [`cas_simplify::simplify`]. Matches the constant
+/// Macsyma's own `simplify_handler` uses (`macsyma-runtime/src/lib.rs`) — the
+/// simplifier already fixed-points internally; this is a shared, tested
+/// non-termination guard, not a Wolfram-specific tuning choice.
+const SIMPLIFY_MAX_ITERATIONS: usize = 50;
+
 use crate::lower::build_canonical_application;
 use crate::printer::print_wolfram;
 
@@ -231,6 +243,13 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     m.insert("GCD".to_string(), handler_fn(gcd_handler));
     m.insert("LCM".to_string(), handler_fn(lcm_handler));
     m.insert("Sqrt".to_string(), handler_fn(sqrt_handler));
+
+    // W-22 cas-* algorithm surface under Wolfram names (MA04 §2 "Future" item,
+    // now in progress). `Simplify` is the first entry — an ordinary eager
+    // `Head[args]` form reusing `cas-simplify` verbatim. Further heads
+    // (`Expand`, `Factor`, `Solve`, `D`, `Integrate`, ...) are added one at a
+    // time, each its own PR, per HML00's one-item-per-PR discipline.
+    m.insert("Simplify".to_string(), handler_fn(simplify_handler));
 
     // W-18 pattern-matching predicates (MA04 §19). HELD (see `PATTERN_HEADS`):
     // each handler evaluates ONLY its subject and matches against the *literal*
@@ -3201,6 +3220,34 @@ fn sqrt_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
 }
 
 // ---------------------------------------------------------------------------
+// W-22 cas-* algorithm surface under Wolfram names
+// ---------------------------------------------------------------------------
+//
+// MA04 §2 left "the `cas-*` function surface under Wolfram names (`Expand`,
+// `Factor`, `Solve`, `D`, `Integrate`, …) wired to the existing `cas-*`
+// crates" as an unnumbered "Future" item. W-22 starts closing it, one head at
+// a time, each its own PR. Every handler here is a thin call into the shared
+// `cas-*` crate — no algorithm is reimplemented for Wolfram.
+
+/// `Simplify[expr]` → the algebraically simplest equivalent form: canonical
+/// ordering, constant folding, and identity rules (`x + 0 → x`, `x * 1 → x`,
+/// trig/log/exp cancellation, …), fixed-pointed up to
+/// [`SIMPLIFY_MAX_ITERATIONS`] passes.
+///
+/// A thin call into [`cas_simplify::simplify`] — the exact function Macsyma's
+/// `simplify_handler` calls (`macsyma-runtime/src/lib.rs`), reused verbatim so
+/// Wolfram and Macsyma agree on every simplification this crate can perform.
+/// Requires exactly one argument (the eagerly-evaluated expression); any other
+/// arity leaves the form unevaluated, matching every other W-22/W-15 built-in's
+/// fail-soft contract.
+fn simplify_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return unevaluated(expr);
+    }
+    simplify(expr.args[0].clone(), SIMPLIFY_MAX_ITERATIONS)
+}
+
+// ---------------------------------------------------------------------------
 // W-12 string builtins
 // ---------------------------------------------------------------------------
 //
@@ -5865,6 +5912,62 @@ mod tests {
         assert_eq!(eval_full(apply(sym("Sqrt"), vec![int(2)])), apply(sym("Sqrt"), vec![int(2)]));
         assert_eq!(eval_full(apply(sym("GCD"), vec![int(12), int(18)])), int(6));
         assert_eq!(eval_full(apply(sym("Round"), vec![flt(2.5)])), int(2));
+    }
+
+    // -----------------------------------------------------------------------
+    // W-22 cas-* algorithm surface — Simplify
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn simplify_folds_additive_and_multiplicative_identities() {
+        // x + 0 -> x
+        assert_eq!(
+            run("Simplify", vec![apply(sym(ADD), vec![sym("x"), int(0)])]),
+            sym("x")
+        );
+        // x * 1 -> x
+        assert_eq!(
+            run("Simplify", vec![apply(sym(MUL), vec![sym("x"), int(1)])]),
+            sym("x")
+        );
+        // Pure constant folding: 2 + 3 -> 5
+        assert_eq!(
+            run("Simplify", vec![apply(sym(ADD), vec![int(2), int(3)])]),
+            int(5)
+        );
+    }
+
+    #[test]
+    fn simplify_agrees_with_macsyma_on_the_same_underlying_call() {
+        // Both Wolfram's Simplify and Macsyma's simplify() call the exact same
+        // cas_simplify::simplify — this pins that the Wolfram wiring doesn't
+        // diverge (e.g. a different iteration cap) from the reference call.
+        let expr = apply(sym(ADD), vec![sym("x"), int(0)]);
+        assert_eq!(
+            run("Simplify", vec![expr.clone()]),
+            cas_simplify::simplify(expr, SIMPLIFY_MAX_ITERATIONS)
+        );
+    }
+
+    #[test]
+    fn simplify_with_wrong_arity_stays_unevaluated() {
+        assert_eq!(run("Simplify", vec![]), apply(sym("Simplify"), vec![]));
+        assert_eq!(
+            run("Simplify", vec![int(1), int(2)]),
+            apply(sym("Simplify"), vec![int(1), int(2)])
+        );
+    }
+
+    #[test]
+    fn simplify_dispatches_end_to_end_through_the_wolfram_backend() {
+        // x + 0 simplifies to x through the full parser -> lower -> backend path.
+        assert_eq!(
+            eval_full(apply(
+                sym("Simplify"),
+                vec![apply(sym(ADD), vec![sym("x"), int(0)])]
+            )),
+            sym("x")
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -91,8 +91,14 @@ Following [HML00 §6](HML00-historical-math-languages-roadmap.md)'s breakdown:
   `Head[args]` forms reusing the W-9 `list_elements` accessor and the
   `MAX_LIST_LENGTH` cap; `ConstantArray`/`Partition` outputs are size-capped
   (with `checked_mul`) before allocation (§19.5). No grammar change.
-- **Future — the `cas-*` function surface under Wolfram names** (`Expand`,
-  `Factor`, `Solve`, `D`, `Integrate`, …) wired to the existing `cas-*` crates.
+- **W-22 — the `cas-*` function surface under Wolfram names.** *(in
+  progress — see §24.)* Wires the existing `cas-*` crates in one head at a
+  time, starting with `Simplify` (a thin call into `cas-simplify`'s
+  `simplify()`, the same function Macsyma's own `simplify()` calls, so the
+  two languages agree on every simplification this crate can perform).
+  Remaining: `Expand`, `Factor`, `Solve`, `D`, `Integrate`, each its own
+  item — no grammar change for any of them (all ordinary `Head[args]` forms
+  the existing grammar already parses).
 
 ## §3 The supported surface (the grammar)
 
@@ -2090,6 +2096,52 @@ it). `ReplaceRepeated` retains its §22.4 hard iteration cap
 (`REPLACE_REPEATED_MAX_ITERATIONS`) and §22.5 growth cap
 (`REPLACE_GROWTH_NODE_CAP`) — the `//.` operator lowers to the very same head, so
 the DoS bounds apply identically whether written as operator or `Head[args]`.
+
+## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify` (in progress)
+
+W-22 starts closing §2's previously unnumbered "Future" item: wiring the
+existing `cas-*` algorithm crates under Wolfram's own head names. Unlike
+every prior W-item, this one lands **one head at a time** rather than as a
+single PR, since each head is an independent algorithm with its own `cas-*`
+crate dependency — bundling them would violate the one-PR-per-item
+discipline for no benefit (they share no code with each other, only with
+their respective `cas-*` crate).
+
+### §24.1 `Simplify` (delivered)
+
+`Simplify[expr]` is a thin call into `cas-simplify::simplify(expr,
+max_iterations)` — **the exact function** Macsyma's own `simplify()` surface
+function calls (`macsyma-runtime`'s `simplify_handler`), with the same
+iteration cap (50). No algorithm is reimplemented; a test pins both
+languages' call sites to agree on the same input, so this is not merely "the
+same crate" but "the same result, verified."
+
+Like every W-5+ built-in, `Simplify` is an ordinary eager `Head[args]` form
+— its argument is evaluated before the handler runs — and requires exactly
+one argument; any other arity leaves the form unevaluated (the fail-soft
+contract every built-in here follows).
+
+```
+Simplify[x + 0]     (* x *)
+Simplify[2 + 3]     (* 5 *)
+```
+
+### §24.2 Remaining (not yet delivered)
+
+`Expand`, `Factor`, `Solve`, `D`, `Integrate`, and the rest of §2's original
+list — each is a separate future item, no grammar change required for any of
+them (all are ordinary `Head[args]` forms the existing grammar already
+parses). **Note on `Expand`:** unlike `Simplify`, Macsyma's own `expand()`
+surface function has no dedicated handler backing its `Expand` head in
+`symbolic-vm`'s `build_handler_table` today (verified: no `"Expand"` handler
+registration exists) — Macsyma's `expand(...)` and `ev(expr, expand)` both
+route through `apply(sym("Expand"), …)`, which currently has no handler to
+land on. Wiring Wolfram's `Expand` is therefore **not** a "call the same
+function Macsyma calls" item the way `Simplify` was; it needs a real
+`Expand` handler (full polynomial distribution over `Add`/`Mul`/`Pow`) built
+first, most naturally in `symbolic-vm` or `cas-simplify` so Macsyma's
+long-standing `expand()` gap closes at the same time. Track as its own item,
+not scope creep into this one.
 
 ### §6 References
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -585,6 +585,22 @@ Next ODE work should focus only on the Frobenius power-series case (irregular
 singular points and series solutions around regular singular points) unless a
 parity audit finds a smaller gap.
 
+#### `Expand` has no handler (found 2026-07-03, while wiring Wolfram's `Simplify`)
+
+Macsyma's `expand(...)` surface function and `ev(expr, expand)` both route
+through `apply(sym("Expand"), …)` (`macsyma-runtime/src/lib.rs`), but
+`symbolic-vm`'s `build_handler_table` registers no handler under the string
+`"Expand"` — verified by grep, and there is no test anywhere in
+`macsyma-runtime`'s test suite that exercises `expand(...)` end-to-end. So
+today `expand((x+1)^2)` most likely just returns the unevaluated `Expand[...]`
+form (an unresolved head), not the distributed polynomial a user would
+expect — this is a real, previously-undocumented gap, not merely an untested
+path. Needs a real `Expand` handler (full polynomial distribution over
+`Add`/`Mul`/`Pow`), most naturally added to `symbolic-vm` or `cas-simplify`
+so both Macsyma and Wolfram (which hit the identical gap wiring its own
+`Expand`, MA04 §24.2) close at the same time. Not yet scheduled as its own
+track/PR.
+
 #### Factoring gaps
 
 The `Factor` handler now covers several structural multivariate patterns via


### PR DESCRIPTION
## Summary
- Starts closing `MA04` §2's previously unnumbered "Future" item: wiring the existing `cas-*` algorithm crates under Wolfram's own head names, one head at a time.
- Adds `Simplify[expr]` — a thin call into `cas-simplify`'s existing `simplify()`, **the exact function** Macsyma's own `simplify()` calls (same 50-iteration cap). No algorithm reimplemented; a test pins both languages' call sites to agree on the same input.
- `wolfram-runtime` 0.17.0 -> 0.18.0. 4 new tests (325 lib unit tests total, 85 integration, 1 doctest — all passing).
- **Bonus finding, documented not fixed here:** while scoping `Expand` as the natural next W-22 head, found that Macsyma's own `expand(...)`/`ev(expr, expand)` route through `apply(sym("Expand"), ...)`, but `symbolic-vm`'s `build_handler_table` registers **no handler** under `"Expand"` at all — a real, previously-undocumented functional gap in Macsyma itself, not just an untested path. Documented in `spice-macsyma-pending-work.md` and `MA04` §24.2, and flagged as a separate follow-up task (spawned as its own chip) rather than folded into this PR.

## Test plan
- [x] `cargo test -p coding-adventures-wolfram-runtime` — 325 lib unit tests (incl. 4 new), 85 integration tests, 1 doctest, all passing.
- [x] `cargo fmt -p coding-adventures-wolfram-runtime -- --check` — no new formatting issues introduced by this change (pre-existing unrelated fmt drift elsewhere in the file, out of scope).
- [x] `/security-review` run against the diff — passed, no findings.
- [ ] `/babysit-pr` to green/merge.