### PR TITLE
[codex] Lock tree insertion cross-axis evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_tree_insertion_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_tree_insertion_audit_test.rs
@@ -5,7 +5,149 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 
 const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_BLOCK_BOUNDARY_AUDIT: &str = include_str!("fixtures/whatwg-block-boundary-audit.json");
+const WHATWG_DOCUMENT_SHELL_AUDIT: &str = include_str!("fixtures/whatwg-document-shell-audit.json");
+const WHATWG_FOREIGN_AUDIT: &str = include_str!("fixtures/whatwg-foreign-audit.json");
+const WHATWG_FORM_INTERACTIVE_AUDIT: &str =
+    include_str!("fixtures/whatwg-form-interactive-audit.json");
+const WHATWG_FORMATTING_AUDIT: &str = include_str!("fixtures/whatwg-formatting-audit.json");
+const WHATWG_FRAGMENT_CONTEXT_AUDIT: &str =
+    include_str!("fixtures/whatwg-fragment-context-audit.json");
+const WHATWG_FRAMESET_AUDIT: &str = include_str!("fixtures/whatwg-frameset-audit.json");
+const WHATWG_HEAD_BODY_AUDIT: &str = include_str!("fixtures/whatwg-head-body-audit.json");
+const WHATWG_PARAGRAPH_AUDIT: &str = include_str!("fixtures/whatwg-paragraph-audit.json");
+const WHATWG_SELECT_LIST_AUDIT: &str = include_str!("fixtures/whatwg-select-list-audit.json");
+const WHATWG_TABLE_AUDIT: &str = include_str!("fixtures/whatwg-table-audit.json");
+const WHATWG_TEMPLATE_AUDIT: &str = include_str!("fixtures/whatwg-template-audit.json");
 const WHATWG_TREE_INSERTION_AUDIT: &str = include_str!("fixtures/whatwg-tree-insertion-audit.json");
+const WHATWG_VOID_ELEMENT_AUDIT: &str = include_str!("fixtures/whatwg-void-element-audit.json");
+struct TreeInsertionCrossAxisCase {
+    id: &'static str,
+    tree_axis: &'static str,
+    data_snippet: &'static str,
+    fragment_context: Option<&'static str>,
+    suites: &'static [(&'static str, &'static str, &'static str)],
+}
+
+const TREE_ADOPTION_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "interactive-formatting",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "interactive-formatting-boundary",
+    ),
+    (
+        "paragraph",
+        WHATWG_PARAGRAPH_AUDIT,
+        "paragraph-table-boundary",
+    ),
+    ("table", WHATWG_TABLE_AUDIT, "foster-parenting"),
+];
+const TREE_TABLE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "block-boundary",
+        WHATWG_BLOCK_BOUNDARY_AUDIT,
+        "block-table-boundary",
+    ),
+    ("foreign", WHATWG_FOREIGN_AUDIT, "html-integration-point"),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "select-option",
+    ),
+    (
+        "formatting",
+        WHATWG_FORMATTING_AUDIT,
+        "adoption-agency-formatting",
+    ),
+    ("select-list", WHATWG_SELECT_LIST_AUDIT, "select-in-table"),
+    ("table", WHATWG_TABLE_AUDIT, "select-in-table"),
+];
+const TREE_TEMPLATE_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "head-element-boundary",
+    ),
+    ("frameset", WHATWG_FRAMESET_AUDIT, "template-boundary"),
+    (
+        "head-body",
+        WHATWG_HEAD_BODY_AUDIT,
+        "body-frameset-transition",
+    ),
+    ("template", WHATWG_TEMPLATE_AUDIT, "frameset-template"),
+    (
+        "void-element",
+        WHATWG_VOID_ELEMENT_AUDIT,
+        "legacy-void-elements",
+    ),
+];
+const TREE_FOREIGN_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    ("foreign", WHATWG_FOREIGN_AUDIT, "foreign-fragment"),
+    (
+        "form-interactive",
+        WHATWG_FORM_INTERACTIVE_AUDIT,
+        "interactive-formatting",
+    ),
+    (
+        "fragment-context",
+        WHATWG_FRAGMENT_CONTEXT_AUDIT,
+        "fragment-foreign-context",
+    ),
+];
+const TREE_HTML_FRAGMENT_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
+    (
+        "document-shell",
+        WHATWG_DOCUMENT_SHELL_AUDIT,
+        "shell-fragment-context",
+    ),
+    (
+        "fragment-context",
+        WHATWG_FRAGMENT_CONTEXT_AUDIT,
+        "fragment-shell-context",
+    ),
+];
+const TREE_INSERTION_CROSS_AXIS_CASES: &[TreeInsertionCrossAxisCase] = &[
+    TreeInsertionCrossAxisCase {
+        id: "adoption01-dat-6",
+        tree_axis: "adoption-agency",
+        data_snippet: "<table><a>1<p>2</a>3</p>",
+        fragment_context: None,
+        suites: TREE_ADOPTION_CROSS_AXIS_SUITES,
+    },
+    TreeInsertionCrossAxisCase {
+        id: "tables01-dat-453",
+        tree_axis: "table-insertion",
+        data_snippet: "<div><table><svg><foreignObject><select><table><s>",
+        fragment_context: None,
+        suites: TREE_TABLE_CROSS_AXIS_SUITES,
+    },
+    TreeInsertionCrossAxisCase {
+        id: "template-dat-494",
+        tree_axis: "template-insertion",
+        data_snippet: "<frameset><template><frame></frame></template></frameset>",
+        fragment_context: None,
+        suites: TREE_TEMPLATE_CROSS_AXIS_SUITES,
+    },
+    TreeInsertionCrossAxisCase {
+        id: "foreign-fragment-dat-1",
+        tree_axis: "foreign-fragment",
+        data_snippet: "<nobr>X",
+        fragment_context: Some("svg path"),
+        suites: TREE_FOREIGN_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+    TreeInsertionCrossAxisCase {
+        id: "tests-innerhtml-1-dat-1",
+        tree_axis: "html-fragment",
+        data_snippet: "<body><span>",
+        fragment_context: Some("body"),
+        suites: TREE_HTML_FRAGMENT_CROSS_AXIS_SUITES,
+    },
+];
 const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str, &str)] = &[
     ("adoption01-dat-1", "adoption01.dat:1", "adoption-agency"),
     ("tables01-dat-436", "tables01.dat:436", "table-insertion"),
@@ -34,6 +176,19 @@ struct TreeInsertionSuite {
 
 #[derive(Debug, Deserialize)]
 struct TreeInsertionCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditSuite {
+    cases: Vec<GenericAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericAuditCase {
     id: String,
     source: String,
     axis: String,
@@ -81,6 +236,85 @@ fn whatwg_tree_insertion_audit_cases_match_parser_dom_dump() {
             actual, source_case.document,
             "case `{}` ({}) failed for input {:?}",
             case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_tree_insertion_audit_keeps_tree_axis_cases_cross_axis() {
+    let suite = load_suite();
+    let tree_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in TREE_INSERTION_CROSS_AXIS_CASES {
+        let tree_case = tree_cases
+            .get(evidence.id)
+            .unwrap_or_else(|| panic!("tree-insertion audit should include `{}`", evidence.id));
+        assert_eq!(
+            tree_case.axis, evidence.tree_axis,
+            "tree-insertion row `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+        assert!(
+            !tree_case.reason.is_empty(),
+            "tree-insertion row `{}` should keep a fixture reason",
+            evidence.id
+        );
+
+        for (suite_name, fixture, expected_axis) in evidence.suites {
+            let audit_case = generic_audit_case(fixture, suite_name, evidence.id);
+            assert_eq!(
+                audit_case.source, tree_case.source,
+                "`{suite_name}` should point tree-insertion row `{}` at the same html5lib row as the tree-insertion audit",
+                evidence.id
+            );
+            assert_eq!(
+                audit_case.axis, *expected_axis,
+                "`{suite_name}` should keep tree-insertion row `{}` on its focused axis",
+                evidence.id
+            );
+            assert!(
+                !audit_case.reason.is_empty(),
+                "`{suite_name}` should keep a reason for tree-insertion row `{}`",
+                evidence.id
+            );
+        }
+
+        let source_case = smoke_cases
+            .get(&tree_case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "tree-insertion row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        if let Some(fragment_context) = evidence.fragment_context {
+            assert_eq!(
+                source_case.fragment_context.as_deref(),
+                Some(fragment_context),
+                "tree-insertion row `{}` should keep its html5lib fragment context",
+                evidence.id
+            );
+        }
+
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                tree_case.id, tree_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "cross-axis tree-insertion evidence case `{}` ({}) failed for input {:?}",
+            tree_case.id, tree_case.axis, source_case.data
         );
     }
 }
@@ -140,4 +374,14 @@ fn assert_axis_count(suite: &TreeInsertionSuite, axis: &str, minimum: usize) {
         count >= minimum,
         "expected at least {minimum} `{axis}` cases, found {count}"
     );
+}
+
+fn generic_audit_case(raw_fixture: &str, suite_name: &str, case_id: &str) -> GenericAuditCase {
+    let suite = serde_json::from_str::<GenericAuditSuite>(raw_fixture)
+        .unwrap_or_else(|error| panic!("{suite_name} audit fixture should parse: {error}"));
+    suite
+        .cases
+        .into_iter()
+        .find(|case| case.id == case_id)
+        .unwrap_or_else(|| panic!("{suite_name} audit should include `{case_id}`"))
 }


### PR DESCRIPTION
## Summary
- add a tree-insertion cross-axis evidence guard covering adoption-agency, table-insertion, template-insertion, foreign-fragment, and html-fragment audit rows
- assert each representative html5lib row stays linked to the same source across the overlapping audit suites
- verify the tied html5lib input/context still executes through the parser DOM dump

## Validation
- cargo test -p coding-adventures-html-parser whatwg_tree_insertion_audit_keeps_tree_axis_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_tree_insertion_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check