### PR TITLE
feat(docx-writer): C2 write .docx via opc-writer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -353,6 +353,7 @@ members = [
     "spreadsheetml",
     "wordprocessingml",
     "presentationml",
+    "docx-writer",
     "arm1-gatelevel",
     "arm1-simulator",
     "immutable-list",

--- a/code/packages/rust/docx-writer/BUILD
+++ b/code/packages/rust/docx-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-docx-writer -- --nocapture

--- a/code/packages/rust/docx-writer/BUILD_windows
+++ b/code/packages/rust/docx-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-docx-writer -- --nocapture

--- a/code/packages/rust/docx-writer/CHANGELOG.md
+++ b/code/packages/rust/docx-writer/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to `coding-adventures-docx-writer` are documented here. The
+format follows [Keep a Changelog](https://keepachangelog.com/), and this project
+adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-03
+
+### Added
+
+- Initial release — milestone **C2** of the OOXML effort.
+- `Document` model with `new`, `add_paragraph` (single-run), `add_paragraph_runs`
+  (multi-run), and `add_table` (rows of cell text).
+- `write_docx(&Document) -> Vec<u8>`: serializes the model to WordprocessingML
+  `word/document.xml`, then packages it — `[Content_Types].xml`, `_rels/.rels`
+  with the `/officeDocument` relationship, and the document part — into a valid
+  `.docx` via the generic `coding-adventures-opc-writer` layer.
+- `xml:space="preserve"` on every `<w:t>` so significant whitespace survives; all
+  user text routed through `opc-writer`'s `xml_escape` (five specials escaped,
+  XML-illegal control characters dropped).
+- `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on model-driven paths.
+- Round-trip test proving the output reopens through
+  `coding-adventures-wordprocessingml` with paragraphs, multi-run concatenation,
+  and table cells intact; unit tests for XML escaping, Unicode, empty document,
+  empty table, whitespace preservation, and paragraph ordering.
+- Spec: `code/specs/DOCXW01-docx-writer.md`.

--- a/code/packages/rust/docx-writer/Cargo.toml
+++ b/code/packages/rust/docx-writer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-docx-writer"
+version = "0.1.0"
+edition = "2021"
+description = "WordprocessingML (.docx) writer — turns a simple Document → paragraph/run/table model into valid .docx bytes via the generic opc-writer packaging layer. Write-side sibling of the wordprocessingml reader (OOXML milestone C2)"
+license = "MIT"
+
+[dependencies]
+coding-adventures-opc-writer = { path = "../opc-writer" }
+
+[dev-dependencies]
+# Round-trip proof: re-open our output with the read-side WordprocessingML reader.
+coding-adventures-wordprocessingml = { path = "../wordprocessingml" }

--- a/code/packages/rust/docx-writer/README.md
+++ b/code/packages/rust/docx-writer/README.md
@@ -1,0 +1,74 @@
+# coding-adventures-docx-writer
+
+Turn a simple document model into a valid `.docx` file. This is milestone **C2**
+of the OOXML effort — the word-processing *write* sibling of the spreadsheet
+`xlsx-writer`, and the mirror image of the read-side
+[`coding-adventures-wordprocessingml`](../wordprocessingml) reader.
+
+## Where it fits
+
+```text
+Document model → docx-writer (C2) → opc-writer (C1) → zip → bytes
+```
+
+`docx-writer` knows exactly one thing: the **WordprocessingML** vocabulary — how
+a document body is spelled as `<w:body>` full of `<w:p>` paragraphs (each a
+sequence of `<w:r>` runs wrapping `<w:t>` text) and `<w:tbl>` tables. Everything
+below — synthesizing `[Content_Types].xml`, wiring the package-root
+relationship, DEFLATE-compressing each part into a ZIP — is delegated to the
+generic [`coding-adventures-opc-writer`](../opc-writer) packaging layer. It has
+**no third-party dependencies**.
+
+## What it produces
+
+A minimal three-part OPC package:
+
+```text
+example.docx  (a ZIP archive)
+├── [Content_Types].xml     ← media type of each part (synthesized by opc-writer)
+├── _rels/.rels             ← rId1 …/officeDocument → word/document.xml
+└── word/document.xml       ← the body: paragraphs, runs, tables
+```
+
+## Usage
+
+```rust
+use coding_adventures_docx_writer::{Document, write_docx};
+
+let mut doc = Document::new();
+doc.add_paragraph("Hello, DOCX!");                       // single-run paragraph
+doc.add_paragraph_runs(&["Second ", "paragraph."]);      // multi-run paragraph
+doc.add_table(&[
+    vec!["A1cell".to_string(), "B1cell".to_string()],    // rows of cell text
+]);
+
+let bytes = write_docx(&doc);
+std::fs::write("example.docx", bytes).unwrap();
+```
+
+`write_docx` returns the complete `.docx` as a `Vec<u8>` — open it in Word, or
+reopen it with the sibling `wordprocessingml` reader.
+
+## Notes on fidelity
+
+* **Runs and whitespace.** A multi-run paragraph becomes one `<w:r>` per run;
+  the reader rejoins them with no separator, so `["Second ", "paragraph."]`
+  reads back as `"Second paragraph."`. Every `<w:t>` carries
+  `xml:space="preserve"`, so leading/trailing spaces survive.
+* **Escaping and safety.** All user text passes through `opc-writer`'s
+  `xml_escape`, which escapes the five XML specials and drops XML-illegal control
+  characters. The crate is `#![forbid(unsafe_code)]` and never panics on model
+  input — empty documents, empty tables, and arbitrary Unicode are all valid.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-docx-writer
+```
+
+The headline test builds a document, writes it, and **round-trips** it through
+`coding-adventures-wordprocessingml`, asserting the model comes back intact —
+proving the whole write path against an independent reader.
+
+See [`code/specs/DOCXW01-docx-writer.md`](../../../specs/DOCXW01-docx-writer.md)
+for the full literate write-up.

--- a/code/packages/rust/docx-writer/required_capabilities.json
+++ b/code/packages/rust/docx-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/docx-writer",
+  "capabilities": [],
+  "justification": "Pure computation. Serializes an in-memory document model into WordprocessingML XML and delegates ZIP packaging to opc-writer, returning bytes. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/docx-writer/src/lib.rs
+++ b/code/packages/rust/docx-writer/src/lib.rs
@@ -1,0 +1,266 @@
+//! # `coding-adventures-docx-writer` — build a valid `.docx` from a model
+//!
+//! Milestone **C2** of the OOXML effort (see `code/specs/DOCXW01-docx-writer.md`).
+//! This is the word-processing *write* sibling of the spreadsheet `xlsx-writer`,
+//! and the mirror image of the read-side [`wordprocessingml`] crate: where that
+//! crate *opens* a `.docx`'s bytes into a `Document → Block → Paragraph/Table`
+//! model, this crate *assembles* such a model back into a valid `.docx`.
+//!
+//! ## Where it sits
+//!
+//! ```text
+//! Document model → docx-writer (C2, HERE) → opc-writer (C1) → zip → bytes
+//! ```
+//!
+//! `docx-writer` knows exactly one thing: the **WordprocessingML** vocabulary —
+//! how a document body is spelled as `<w:body>` full of `<w:p>` paragraphs (each
+//! a run of `<w:r>` → `<w:t>` text) and `<w:tbl>` tables. Everything below that —
+//! synthesizing `[Content_Types].xml`, wiring the package-root relationship,
+//! DEFLATE-compressing each part into a ZIP — is delegated to the generic
+//! [`coding_adventures_opc_writer`] packaging layer. We never touch ZIP bytes
+//! ourselves.
+//!
+//! ## The part tree we emit
+//!
+//! ```text
+//! example.docx  (a ZIP archive)
+//! ├── [Content_Types].xml     ← media type of each part (synthesized by opc-writer)
+//! ├── _rels/.rels             ← rId1 …/officeDocument → word/document.xml
+//! └── word/document.xml       ← the body: paragraphs, runs, tables
+//! ```
+//!
+//! The reader's `open_docx` follows the `/officeDocument` relationship in
+//! `_rels/.rels` to *find* `word/document.xml`, so emitting that relationship is
+//! precisely what makes our output openable by the reader — this is the pact the
+//! round-trip test verifies.
+//!
+//! ## The paragraph → run → text model
+//!
+//! A word processor lets you bold one word mid-sentence. WordprocessingML records
+//! that by splitting a paragraph's text into **runs** — maximal spans of uniform
+//! formatting. "Second **paragraph**." is therefore two runs, `"Second "` and
+//! `"paragraph."`. The reader concatenates runs with *no* separator, so they
+//! rejoin to exactly `"Second paragraph."` — provided the trailing space of the
+//! first run survives. That survival is guaranteed by `xml:space="preserve"` on
+//! every `<w:t>`, which we always emit.
+//!
+//! ## Example
+//!
+//! ```
+//! use coding_adventures_docx_writer::{Document, write_docx};
+//!
+//! let mut doc = Document::new();
+//! doc.add_paragraph("Hello, DOCX!");
+//! doc.add_paragraph_runs(&["Second ", "paragraph."]);
+//! doc.add_table(&[vec!["A1cell".to_string(), "B1cell".to_string()]]);
+//!
+//! let bytes = write_docx(&doc);
+//! assert_eq!(&bytes[..2], b"PK"); // a ZIP, hence an OPC package
+//! ```
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_opc_writer::{xml_escape, PackageWriter, RelationshipsBuilder};
+
+// ===========================================================================
+// Constants — the fixed vocabulary of a minimal `.docx`
+// ===========================================================================
+
+/// The WordprocessingML "main" namespace, bound to the `w:` prefix on
+/// `<w:document>`. Every structural element (`body`, `p`, `r`, `t`, `tbl`, `tr`,
+/// `tc`) lives here; the reader checks for exactly this URI.
+const W_NS: &str = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+/// The content type registered as an `<Override>` for `/word/document.xml`. The
+/// `.main+xml` suffix marks it as *the* WordprocessingML document part.
+const DOCUMENT_CONTENT_TYPE: &str =
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml";
+
+/// The relationship type URI for the package → main-document link. The reader's
+/// `main_document_part()` locates the body by finding the relationship whose Type
+/// ends with `/officeDocument`, so this exact string is load-bearing.
+const OFFICE_DOCUMENT_REL_TYPE: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+
+/// Content type of every `.rels` part, registered as a `<Default>` for the
+/// `rels` extension.
+const RELS_CONTENT_TYPE: &str =
+    "application/vnd.openxmlformats-package.relationships+xml";
+
+/// Content type registered as the `<Default>` for the `xml` extension.
+const XML_CONTENT_TYPE: &str = "application/xml";
+
+/// The XML declaration OOXML producers put at the head of `document.xml`.
+const XML_DECL: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n";
+
+// ===========================================================================
+// The document model
+// ===========================================================================
+//
+// This mirrors — deliberately simplified — the read-side model: a document is an
+// ordered list of block-level items, each a paragraph (a list of run strings) or
+// a table (rows of cell strings). We keep only *text*; formatting is out of
+// scope at this milestone, exactly as the reader keeps only run text.
+
+/// One block-level item in the body.
+enum Block {
+    /// A paragraph: an ordered list of run texts. A single-run paragraph has one
+    /// element; a multi-run paragraph has several, which the reader rejoins.
+    Paragraph(Vec<String>),
+    /// A table: rows of cells, each cell a single string of text.
+    Table(Vec<Vec<String>>),
+}
+
+/// A word-processing document under construction: its body's blocks in order.
+///
+/// Build one with [`new`](Document::new), push content with
+/// [`add_paragraph`](Document::add_paragraph),
+/// [`add_paragraph_runs`](Document::add_paragraph_runs), and
+/// [`add_table`](Document::add_table), then serialize with [`write_docx`].
+#[derive(Default)]
+pub struct Document {
+    blocks: Vec<Block>,
+}
+
+impl Document {
+    /// A new, empty document. Serializing it yields a valid `.docx` with an empty
+    /// body — degenerate but well-formed, never an error.
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+
+    /// Append a **single-run** paragraph carrying `text`.
+    ///
+    /// The text is stored verbatim and escaped only at serialization time (so the
+    /// model holds the *logical* string, not XML). `"a & b"` round-trips to
+    /// `"a & b"`, not `"a &amp; b"`.
+    pub fn add_paragraph(&mut self, text: &str) {
+        self.blocks.push(Block::Paragraph(vec![text.to_string()]));
+    }
+
+    /// Append a **multi-run** paragraph: one `<w:r>` per element of `runs`, in
+    /// order. The reader concatenates them with no separator, so
+    /// `add_paragraph_runs(&["Second ", "paragraph."])` reads back as the single
+    /// string `"Second paragraph."`.
+    ///
+    /// An empty slice yields an empty paragraph (a `<w:p/>` with no runs), which
+    /// is valid and reads back as empty text.
+    pub fn add_paragraph_runs(&mut self, runs: &[&str]) {
+        self.blocks
+            .push(Block::Paragraph(runs.iter().map(|r| r.to_string()).collect()));
+    }
+
+    /// Append a table: `rows` of cells, each cell a string of text. Each cell
+    /// becomes a `<w:tc>` holding one single-run paragraph. An empty `rows`
+    /// yields an empty `<w:tbl>`; a row with no cells yields an empty `<w:tr>` —
+    /// both valid.
+    pub fn add_table(&mut self, rows: &[Vec<String>]) {
+        self.blocks.push(Block::Table(rows.to_vec()));
+    }
+}
+
+// ===========================================================================
+// Serialization: model → document.xml
+// ===========================================================================
+
+/// Serialize the whole document into the bytes of `word/document.xml`.
+///
+/// We build the XML by string concatenation — no allocation-per-node tree, just
+/// a growing `String` — because the structure is small and fixed. Every scrap of
+/// user text passes through [`xml_escape`]; nothing else is caller-controlled.
+fn document_xml(doc: &Document) -> Vec<u8> {
+    let mut xml = String::new();
+    xml.push_str(XML_DECL);
+    xml.push_str("<w:document xmlns:w=\"");
+    xml.push_str(W_NS);
+    xml.push_str("\"><w:body>");
+
+    for block in &doc.blocks {
+        match block {
+            Block::Paragraph(runs) => push_paragraph(&mut xml, runs),
+            Block::Table(rows) => push_table(&mut xml, rows),
+        }
+    }
+
+    xml.push_str("</w:body></w:document>");
+    xml.into_bytes()
+}
+
+/// Append one `<w:p>` built from an ordered list of run texts.
+///
+/// Each run is `<w:r><w:t xml:space="preserve">…escaped…</w:t></w:r>`. The
+/// `xml:space="preserve"` attribute stops an XML processor from collapsing
+/// leading/trailing whitespace, so a run like `"Second "` keeps its trailing
+/// space when the reader rejoins runs.
+fn push_paragraph(xml: &mut String, runs: &[String]) {
+    xml.push_str("<w:p>");
+    for run in runs {
+        push_run(xml, run);
+    }
+    xml.push_str("</w:p>");
+}
+
+/// Append one `<w:r><w:t xml:space="preserve">…</w:t></w:r>` for `text`.
+fn push_run(xml: &mut String, text: &str) {
+    xml.push_str("<w:r><w:t xml:space=\"preserve\">");
+    xml.push_str(&xml_escape(text));
+    xml.push_str("</w:t></w:r>");
+}
+
+/// Append one `<w:tbl>` built from rows of cell strings. Each cell is a `<w:tc>`
+/// wrapping a single-run paragraph — the minimal valid cell content.
+fn push_table(xml: &mut String, rows: &[Vec<String>]) {
+    xml.push_str("<w:tbl>");
+    for row in rows {
+        xml.push_str("<w:tr>");
+        for cell in row {
+            xml.push_str("<w:tc>");
+            // A cell must contain at least one paragraph to be valid; we give it
+            // exactly one single-run paragraph carrying the cell's text.
+            push_paragraph(xml, std::slice::from_ref(cell));
+            xml.push_str("</w:tc>");
+        }
+        xml.push_str("</w:tr>");
+    }
+    xml.push_str("</w:tbl>");
+}
+
+// ===========================================================================
+// Packaging: document.xml → .docx bytes
+// ===========================================================================
+
+/// Serialize `doc` into the bytes of a complete, valid `.docx` file.
+///
+/// The three-step assembly:
+/// 1. Register the two `<Default>` content types (`rels`, `xml`) every OPC
+///    package needs.
+/// 2. Add the package-root `_rels/.rels` relationship (`rId1` →
+///    `word/document.xml`) so the reader can find the body.
+/// 3. Add `word/document.xml` with its `<Override>` content type, then let
+///    `opc-writer` synthesize `[Content_Types].xml` and ZIP everything up.
+///
+/// Total and panic-free: it performs pure in-memory computation over the model
+/// and returns the resulting bytes.
+pub fn write_docx(doc: &Document) -> Vec<u8> {
+    let mut pkg = PackageWriter::new();
+
+    // (1) The two Defaults every OPC package needs.
+    pkg.add_default("rels", RELS_CONTENT_TYPE);
+    pkg.add_default("xml", XML_CONTENT_TYPE);
+
+    // (2) The package-root relationship: package → main document. The Target is
+    // relative to `_rels/.rels`'s directory (the package root), hence no leading
+    // slash. The reader keys off the Type suffix `/officeDocument`.
+    let mut root_rels = RelationshipsBuilder::new();
+    root_rels.add("rId1", OFFICE_DOCUMENT_REL_TYPE, "word/document.xml");
+    pkg.add_part_defaulted("/_rels/.rels", &root_rels.build());
+
+    // (3) The body, with an <Override> marking it as the main document part.
+    let body = document_xml(doc);
+    pkg.add_part("/word/document.xml", DOCUMENT_CONTENT_TYPE, &body);
+
+    pkg.finish()
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/docx-writer/src/tests.rs
+++ b/code/packages/rust/docx-writer/src/tests.rs
@@ -1,0 +1,194 @@
+//! Tests for `docx-writer`.
+//!
+//! The headline is the **round-trip proof**: build a document with the public
+//! API, serialize it, then reopen the bytes with the independent read-side
+//! `wordprocessingml` crate and assert the model comes back intact. Passing it
+//! exercises the entire write path — WordprocessingML serialization, OPC
+//! packaging, content types, relationships, ZIP — end to end.
+//!
+//! The remaining unit tests pin down escaping, Unicode, degenerate inputs
+//! (empty document), and paragraph ordering.
+
+use super::*;
+use coding_adventures_wordprocessingml::{open_docx, Block as RBlock};
+
+/// Every `.docx` must begin with the ZIP local-file-header magic `PK`.
+#[test]
+fn output_is_a_zip() {
+    let doc = Document::new();
+    let bytes = write_docx(&doc);
+    assert_eq!(&bytes[..2], b"PK", "output must be a ZIP / OPC package");
+}
+
+/// THE PROOF. Build paragraph "Hello, DOCX!"; a two-run paragraph
+/// "Second " + "paragraph."; a one-row table "A1cell"/"B1cell". Write, reopen
+/// with the reader, and assert everything comes back.
+#[test]
+fn round_trips_through_wordprocessingml() {
+    let mut doc = Document::new();
+    doc.add_paragraph("Hello, DOCX!");
+    doc.add_paragraph_runs(&["Second ", "paragraph."]);
+    doc.add_table(&[vec!["A1cell".to_string(), "B1cell".to_string()]]);
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("reader must open our .docx");
+
+    // --- whole-document text extraction ---
+    let text = read.text();
+    assert!(text.contains("Hello, DOCX!"), "text was: {text:?}");
+    assert!(
+        text.contains("Second paragraph."),
+        "the two runs must concatenate; text was: {text:?}"
+    );
+    assert!(text.contains("A1cell"), "text was: {text:?}");
+    assert!(text.contains("B1cell"), "text was: {text:?}");
+
+    // --- paragraph-by-paragraph ---
+    let paras: Vec<_> = read.paragraphs().collect();
+    assert_eq!(paras.len(), 2, "two top-level paragraphs (table excluded)");
+    assert_eq!(paras[0].text, "Hello, DOCX!");
+    assert_eq!(
+        paras[1].text, "Second paragraph.",
+        "two runs joined, trailing space of 'Second ' preserved"
+    );
+    // The second paragraph really is stored as two runs.
+    assert_eq!(paras[1].runs.len(), 2);
+    assert_eq!(paras[1].runs[0].text, "Second ");
+    assert_eq!(paras[1].runs[1].text, "paragraph.");
+
+    // --- the table ---
+    let tables: Vec<_> = read.tables().collect();
+    assert_eq!(tables.len(), 1);
+    let row0 = &tables[0].rows[0];
+    assert_eq!(row0.len(), 2, "two cells in row 0");
+    assert_eq!(row0[0].text, "A1cell");
+    assert_eq!(row0[1].text, "B1cell");
+}
+
+/// XML special characters in paragraph text must survive escaping and decode
+/// back to the exact original string.
+///
+/// We deliberately write the specials *without* surrounding spaces. The reader's
+/// xml-lexer has a documented limitation — it drops whitespace that sits at a
+/// token boundary adjacent to an entity reference (see xml-parser's
+/// `test_entities_in_text`). That is a property of the *reader*, not of our
+/// output, which escapes correctly. Using adjacent specials exercises our
+/// escaping of all five characters while staying inside what the reader can
+/// faithfully decode.
+#[test]
+fn escapes_xml_specials() {
+    let mut doc = Document::new();
+    doc.add_paragraph("x&y<z>w\"v'u");
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("open");
+    let paras: Vec<_> = read.paragraphs().collect();
+    assert_eq!(paras[0].text, "x&y<z>w\"v'u");
+}
+
+/// Sanity-check the escaping at the *bytes* level too, independent of the
+/// reader: the serialized `document.xml` must contain the entity references, and
+/// must NOT contain a raw `&`/`<`/`>` from the user text.
+#[test]
+fn document_xml_contains_entity_references() {
+    let mut doc = Document::new();
+    doc.add_paragraph("a & b < c");
+    // The word/document.xml part is DEFLATE-compressed inside the ZIP, so we
+    // can't grep the packaged bytes directly. Verify escaping at the serializer
+    // seam by calling the private `document_xml` helper.
+    let xml = String::from_utf8(super::document_xml(&doc)).expect("utf8");
+    assert!(xml.contains("a &amp; b &lt; c"), "xml was: {xml}");
+}
+
+/// Unicode (including multi-byte code points and emoji) passes through unchanged.
+#[test]
+fn preserves_unicode() {
+    let mut doc = Document::new();
+    doc.add_paragraph("héllo — 世界 — 🦀");
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("open");
+    let paras: Vec<_> = read.paragraphs().collect();
+    assert_eq!(paras[0].text, "héllo — 世界 — 🦀");
+}
+
+/// An empty document is valid: it opens and has an empty body (no blocks).
+#[test]
+fn empty_document_is_valid() {
+    let doc = Document::new();
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("empty doc must still open");
+    assert!(read.blocks.is_empty(), "empty body → no blocks");
+    assert_eq!(read.text(), "");
+}
+
+/// Multiple paragraphs come back in insertion order.
+#[test]
+fn preserves_paragraph_order() {
+    let mut doc = Document::new();
+    doc.add_paragraph("first");
+    doc.add_paragraph("second");
+    doc.add_paragraph("third");
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("open");
+    let texts: Vec<&str> = read.paragraphs().map(|p| p.text.as_str()).collect();
+    assert_eq!(texts, vec!["first", "second", "third"]);
+}
+
+/// A run's **trailing** space survives — this is the case the round-trip relies
+/// on ("Second " + "paragraph." → "Second paragraph."). A trailing space sits
+/// inside the single TEXT token right before `</w:t>`, so the reader's lexer
+/// keeps it.
+///
+/// (A *leading* space directly after `>` is consumed by the reader's lexer, a
+/// documented xml-parser limitation — not a defect in our `xml:space="preserve"`
+/// output — so we don't assert that here.)
+#[test]
+fn preserves_trailing_whitespace_across_runs() {
+    let mut doc = Document::new();
+    doc.add_paragraph_runs(&["alpha ", "beta ", "gamma"]);
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("open");
+    let paras: Vec<_> = read.paragraphs().collect();
+    assert_eq!(paras[0].text, "alpha beta gamma");
+    // And the whitespace lives inside `xml:space="preserve"` in our output.
+    let xml = String::from_utf8(super::document_xml(&doc)).expect("utf8");
+    assert!(xml.contains("xml:space=\"preserve\""));
+}
+
+/// An empty table is valid and round-trips as a table with no rows.
+#[test]
+fn empty_table_is_valid() {
+    let mut doc = Document::new();
+    doc.add_table(&[]);
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("open");
+    // The block exists as a table (not a paragraph) with zero rows.
+    assert_eq!(read.blocks.len(), 1);
+    match &read.blocks[0] {
+        RBlock::Table(t) => assert!(t.rows.is_empty()),
+        other => panic!("expected an empty table, got {other:?}"),
+    }
+}
+
+/// A multi-row, multi-cell table round-trips with grid structure intact.
+#[test]
+fn multi_row_table_round_trips() {
+    let mut doc = Document::new();
+    doc.add_table(&[
+        vec!["r0c0".to_string(), "r0c1".to_string()],
+        vec!["r1c0".to_string(), "r1c1".to_string()],
+    ]);
+
+    let bytes = write_docx(&doc);
+    let read = open_docx(&bytes).expect("open");
+    let tables: Vec<_> = read.tables().collect();
+    assert_eq!(tables[0].rows.len(), 2);
+    assert_eq!(tables[0].rows[0][0].text, "r0c0");
+    assert_eq!(tables[0].rows[0][1].text, "r0c1");
+    assert_eq!(tables[0].rows[1][0].text, "r1c0");
+    assert_eq!(tables[0].rows[1][1].text, "r1c1");
+}

--- a/code/specs/DOCXW01-docx-writer.md
+++ b/code/specs/DOCXW01-docx-writer.md
@@ -1,0 +1,158 @@
+# DOCXW01 — `docx-writer`: turn a document model into a valid `.docx`
+
+Milestone **C2** of the OOXML effort. This is the word-processing *write* sibling
+of the spreadsheet-side `xlsx-writer`, and the mirror image of the read-side
+[`wordprocessingml`](WML01-wordprocessingml.md) crate. Where `wordprocessingml`
+*opens* the bytes of a `.docx` into a `Document → Block → Paragraph/Table`
+model, `docx-writer` *assembles* such a model back into the bytes of a valid
+`.docx`.
+
+It knows nothing about ZIP, content types, or relationships — that packaging
+work belongs to the generic [`opc-writer`](OPCW01-opc-writer.md) crate (milestone
+C1), which `docx-writer` sits directly on top of:
+
+```text
+Document model → docx-writer (C2, HERE) → opc-writer (C1) → zip → bytes
+```
+
+`docx-writer`'s single job is to know the **WordprocessingML** vocabulary: how a
+document body is spelled as `<w:body>` full of `<w:p>` paragraphs (each a
+sequence of `<w:r>` runs wrapping `<w:t>` text) and `<w:tbl>` tables (rows of
+cells). Everything below that — synthesizing `[Content_Types].xml`, wiring the
+package-root relationship, DEFLATE-compressing each part into a ZIP — is
+delegated to `opc-writer`.
+
+## The part tree of a `.docx`
+
+A `.docx` is an OPC package (a ZIP with three conventions layered on top). The
+minimal word-processing package `docx-writer` emits has exactly three parts:
+
+```text
+example.docx  (a ZIP archive)
+├── [Content_Types].xml     ← what media type is each part?
+│     • Default  rels → application/vnd.openxmlformats-package.relationships+xml
+│     • Default  xml  → application/xml
+│     • Override /word/document.xml
+│                    → …wordprocessingml.document.main+xml
+├── _rels/
+│    └── .rels              ← the package-root relationships
+│          • rId1  …/officeDocument  →  word/document.xml
+└── word/
+     └── document.xml       ← the body: paragraphs, runs, tables
+```
+
+Three conventions, three responsibilities:
+
+1. **Content types.** `[Content_Types].xml` states each part's media type, by
+   file *extension* (`<Default>`) or by exact *part name* (`<Override>`, which
+   wins). `.rels` files and stray `.xml` are typed by defaults; the main
+   document part gets an explicit override so a reader knows it is *the*
+   WordprocessingML document. `docx-writer` registers these with `opc-writer`'s
+   `add_default` / `add_part` and lets `opc-writer` synthesize the file.
+
+2. **Relationships.** `_rels/.rels` maps the short id `rId1` to the target
+   `word/document.xml` under the type URI ending `/officeDocument`. The read-side
+   `wordprocessingml` crate follows exactly this relationship (`main_document_part()`
+   looks for a Type ending `/officeDocument`) to locate the body, so emitting it
+   is what makes our output openable *by that reader*. Built with `opc-writer`'s
+   `RelationshipsBuilder` and added as the `_rels/.rels` part (typed by the
+   `rels` default — no override needed).
+
+3. **The document body.** `word/document.xml` carries the actual prose. This is
+   the only part with format-specific structure, described next.
+
+## WordprocessingML body structure
+
+The body is a flat, ordered list of **block-level** items: paragraphs and
+tables. The vocabulary, prefix `w:` bound to
+`http://schemas.openxmlformats.org/wordprocessingml/2006/main`:
+
+| element   | meaning                                             |
+|-----------|-----------------------------------------------------|
+| `w:document` | root; declares the `w:` namespace                |
+| `w:body`  | the block container                                 |
+| `w:p`     | a **paragraph** — a sequence of runs                |
+| `w:r`     | a **run** — a maximal span of uniform formatting    |
+| `w:t`     | the **text** of a run (a leaf, holds characters)    |
+| `w:tbl`   | a **table**                                         |
+| `w:tr`    | a table **row**                                     |
+| `w:tc`    | a table **cell** — itself contains paragraphs       |
+
+### Paragraph → run → text
+
+A word processor lets you bold one word mid-sentence. WordprocessingML records
+that by splitting a paragraph's text into **runs** — maximal spans sharing
+formatting. So "Second **paragraph**." is *two* runs, `"Second "` and
+`"paragraph."`. The reader concatenates runs with no separator (run boundaries
+are formatting boundaries, not word boundaries), so the two rejoin to exactly
+`"Second paragraph."` — the trailing space survives.
+
+That survival depends on **`xml:space="preserve"`** on every `<w:t>`. Without it,
+an XML processor is free to collapse leading/trailing whitespace, and the space
+after `"Second"` would vanish. We therefore always emit it on user-text runs.
+
+### A sample `document.xml`
+
+For a document of: a paragraph `"Hello, DOCX!"`; a two-run paragraph
+`"Second "` + `"paragraph."`; and a one-row table with cells `"A1cell"`,
+`"B1cell"`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t xml:space="preserve">Hello, DOCX!</w:t></w:r></w:p>
+    <w:p><w:r><w:t xml:space="preserve">Second </w:t></w:r><w:r><w:t xml:space="preserve">paragraph.</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr>
+        <w:tc><w:p><w:r><w:t xml:space="preserve">A1cell</w:t></w:r></w:p></w:tc>
+        <w:tc><w:p><w:r><w:t xml:space="preserve">B1cell</w:t></w:r></w:p></w:tc>
+      </w:tr>
+    </w:tbl>
+  </w:body>
+</w:document>
+```
+
+## Escaping and robustness
+
+Five characters are special in XML (`& < > " '`) and every scrap of caller text
+lands inside a `<w:t>` text node, so all of it goes through `opc-writer`'s
+`xml_escape`. That function is *total*: it escapes the five specials and silently
+**drops** XML-illegal control characters (a NUL in pasted text would otherwise
+make the whole part unparseable). By routing all user text through it we inherit
+that safety for free and never panic on hostile input.
+
+The crate is `#![forbid(unsafe_code)]` and takes no `unwrap`/`expect`/`panic!` on
+any model-driven path. Degenerate inputs are valid, not fatal: an empty document
+produces a well-formed empty `<w:body/>`; an empty table produces an empty
+`<w:tbl>`; Unicode passes through unchanged.
+
+## Public API
+
+```rust
+pub struct Document { /* blocks in order */ }
+impl Document {
+    pub fn new() -> Self;
+    pub fn add_paragraph(&mut self, text: &str);         // single-run paragraph
+    pub fn add_paragraph_runs(&mut self, runs: &[&str]); // multi-run paragraph
+    pub fn add_table(&mut self, rows: &[Vec<String>]);   // rows of cell text
+}
+pub fn write_docx(doc: &Document) -> Vec<u8>;
+```
+
+## The round-trip proof
+
+The headline test builds the sample document above with the API, calls
+`write_docx`, then reopens the bytes with
+`coding_adventures_wordprocessingml::open_docx` and asserts:
+
+* `doc.text()` contains `"Hello, DOCX!"`, `"Second paragraph."`, `"A1cell"`,
+  `"B1cell"`.
+* the first paragraph's `.text` == `"Hello, DOCX!"`; the second == `"Second
+  paragraph."` (the two runs concatenated);
+* the table's row-0 cells are `"A1cell"` / `"B1cell"`.
+
+Passing this proves the whole write path — WordprocessingML serialization, OPC
+packaging, content types, relationships, ZIP — against an independent reader.
+Unit tests additionally cover escaping of `& < > "`, Unicode, an empty document,
+and paragraph ordering.


### PR DESCRIPTION
Writes .docx via the generic opc-writer; round-trips through our wordprocessingml reader AND validated with python-docx. All user text through the hardened xml_escape (control-char stripping + Zip-Slip-safe part names from C1). 10 tests + doctest.