### PR TITLE
feat(pptx-writer): C3 write .pptx via opc-writer (full master/layout/theme scaffold)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -350,6 +350,7 @@ members = [
     "opc",
     "opc-writer",
     "xlsx-writer",
+    "pptx-writer",
     "spreadsheetml",
     "wordprocessingml",
     "presentationml",

--- a/code/packages/rust/pptx-writer/BUILD
+++ b/code/packages/rust/pptx-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-pptx-writer -- --nocapture

--- a/code/packages/rust/pptx-writer/BUILD_windows
+++ b/code/packages/rust/pptx-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-pptx-writer -- --nocapture

--- a/code/packages/rust/pptx-writer/CHANGELOG.md
+++ b/code/packages/rust/pptx-writer/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to `coding-adventures-pptx-writer` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-07-03
+
+### Added
+
+- Initial release — milestone **C3** of the OOXML effort.
+- `Presentation` / `Slide` model with `Presentation::new`,
+  `Presentation::add_slide`, and `Slide::add_text`.
+- `write_pptx(&Presentation) -> Vec<u8>` serializes a deck to valid `.pptx`
+  bytes, packaged via `opc-writer`.
+- Emits the full PresentationML scaffold required by strict consumers
+  (PowerPoint, python-pptx): `presentation.xml`, one `slideN.xml` per slide, a
+  shared `slideMaster1.xml`, `slideLayout1.xml`, and `theme1.xml`, all wired by
+  the correct relationship graph, plus `[Content_Types].xml` and every `.rels`.
+- Slide text is written in the DrawingML (`a:`) namespace inside a shape's
+  `p:txBody`; all user text is escaped via `opc_writer::xml_escape`.
+- Handles edge cases without panicking: empty deck (empty `<p:sldIdLst/>` + full
+  scaffold), empty slide, arbitrary Unicode, and XML-special / illegal-control
+  characters.
+- `#![forbid(unsafe_code)]`.
+- Structural test suite: unzip via `zip::ZipReader`, parse slide parts via
+  `coding_adventures_xml_parser::parse_xml`, verify member presence, per-slide
+  text placement and ordering, escaping, id/rels alignment, and well-formedness
+  of every part.
+- Spec: `code/specs/PPTXW01-pptx-writer.md`.

--- a/code/packages/rust/pptx-writer/Cargo.toml
+++ b/code/packages/rust/pptx-writer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "coding-adventures-pptx-writer"
+version = "0.1.0"
+edition = "2021"
+description = "PresentationML (.pptx) writer — turns a simple in-memory slide-deck model into valid .pptx bytes by generating the PresentationML parts (presentation, slides, slide master, slide layout, theme) and packaging them via opc-writer (OOXML milestone C3)"
+license = "MIT"
+
+[dependencies]
+coding-adventures-opc-writer = { path = "../opc-writer" }
+
+[dev-dependencies]
+# Structural verification: re-open our output with this repo's OWN zero-dep
+# readers (the .pptx reader isn't on this branch, so we assert on the parts).
+zip = { path = "../zip" }
+coding-adventures-xml-parser = { path = "../xml-parser" }

--- a/code/packages/rust/pptx-writer/README.md
+++ b/code/packages/rust/pptx-writer/README.md
@@ -1,0 +1,105 @@
+# coding-adventures-pptx-writer
+
+**Milestone C3 of the OOXML effort.** A zero-third-party-dependency Rust crate
+that turns a simple in-memory slide-deck model into the bytes of a valid
+`.pptx` (PresentationML) file.
+
+## What it does
+
+```rust
+use coding_adventures_pptx_writer::{Presentation, write_pptx};
+
+let mut p = Presentation::new();
+
+let intro = p.add_slide();
+intro.add_text("Welcome");
+intro.add_text("A zero-dependency .pptx writer");
+
+let outro = p.add_slide();
+outro.add_text("Thanks!");
+
+let bytes = write_pptx(&p);          // valid .pptx bytes
+std::fs::write("deck.pptx", bytes).unwrap();
+```
+
+The result opens in PowerPoint, LibreOffice Impress, and python-pptx.
+
+## Where it fits in the stack
+
+`pptx-writer` knows the **PresentationML** vocabulary; it delegates all ZIP,
+content-type, and relationship packaging to the format-agnostic
+[`opc-writer`](../opc-writer) (which in turn builds on the [`zip`](../zip)
+crate). It is the presentation-side sibling of
+[`xlsx-writer`](../xlsx-writer) (SpreadsheetML) and
+[`wordprocessingml`](../wordprocessingml).
+
+```text
+  Presentation / Slide          (this crate's model)
+        │  write_pptx
+        ▼
+  PresentationML parts          (this crate)
+        │  opc_writer::PackageWriter
+        ▼
+  OPC package                   (opc-writer: content-types, .rels, ZIP)
+        ▼
+  .pptx bytes
+```
+
+## Why a deck is more than "slides in a zip"
+
+A conformant `.pptx` requires a whole scaffold wired by relationships —
+`presentation → slide master → slide layout → theme` — because slides inherit
+their placeholders, colour map, and fonts from that chain of parents. A package
+with only a `presentation.xml` and a `slide1.xml` is **rejected** by strict
+consumers. This writer always emits one shared master, one shared layout, and
+one shared theme (constant boilerplate) plus one `slideN.xml` per slide. The
+full part list and the relationship graph are documented in
+[`code/specs/PPTXW01-pptx-writer.md`](../../../specs/PPTXW01-pptx-writer.md).
+
+## The `a:` namespace gotcha
+
+A slide is `<p:sld>` in the PresentationML namespace, but the *text* lives in
+the **DrawingML** namespace (prefix `a:`):
+`<a:p><a:r><a:t>your text</a:t></a:r></a:p>`. Each `Slide::add_text` call adds
+one such paragraph. All user text is escaped via `opc_writer::xml_escape`.
+
+## Public API
+
+```rust
+pub struct Presentation;
+impl Presentation {
+    pub fn new() -> Self;
+    pub fn add_slide(&mut self) -> &mut Slide;
+    pub fn slides(&self) -> &[Slide];
+}
+
+pub struct Slide;
+impl Slide {
+    pub fn add_text(&mut self, text: &str);
+    pub fn paragraphs(&self) -> &[String];
+}
+
+pub fn write_pptx(p: &Presentation) -> Vec<u8>;
+```
+
+An empty deck (no slides) is still valid: it produces a `presentation.xml` with
+an empty `<p:sldIdLst/>` and the full scaffold.
+
+## Safety
+
+`#![forbid(unsafe_code)]`. No panics on model-driven paths — empty decks, empty
+slides, and arbitrary Unicode / XML-special text are all handled. Characters
+illegal in XML 1.0 (NUL, other C0 controls) are dropped by `xml_escape` so
+untrusted text can never make the package unparseable.
+
+## Testing
+
+Because the `.pptx` *reader* is not on this branch, tests verify the generated
+bytes structurally: they unzip with this repo's `zip::ZipReader` to assert the
+expected members exist, then parse slide parts with
+`coding_adventures_xml_parser::parse_xml` to check the `<a:t>` text nodes carry
+the right text (and only the right text, per slide). Run them with:
+
+```sh
+cargo test -p coding-adventures-pptx-writer
+```

--- a/code/packages/rust/pptx-writer/examples/gen_deck.rs
+++ b/code/packages/rust/pptx-writer/examples/gen_deck.rs
@@ -1,0 +1,23 @@
+//! Generate a sample deck for an external python-pptx cross-check.
+//!
+//! ```sh
+//! cargo run -p coding-adventures-pptx-writer --example gen_deck -- /tmp/sample.pptx
+//! ```
+use coding_adventures_pptx_writer::{write_pptx, Presentation};
+
+fn main() {
+    let mut p = Presentation::new();
+    let s1 = p.add_slide();
+    s1.add_text("Slide One Title");
+    s1.add_text("First slide body");
+    let s2 = p.add_slide();
+    s2.add_text("Slide Two Title");
+    s2.add_text("Second slide body with special & <chars>");
+
+    let bytes = write_pptx(&p);
+    let out = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "sample.pptx".to_string());
+    std::fs::write(&out, bytes).expect("write pptx");
+    println!("wrote {out}");
+}

--- a/code/packages/rust/pptx-writer/required_capabilities.json
+++ b/code/packages/rust/pptx-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/pptx-writer",
+  "capabilities": [],
+  "justification": "Pure computation. Serializes an in-memory slide-deck model into .pptx bytes via opc-writer. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/pptx-writer/src/lib.rs
+++ b/code/packages/rust/pptx-writer/src/lib.rs
@@ -1,0 +1,598 @@
+//! # PresentationML (`.pptx`) *writer* — milestone **C3**
+//!
+//! This crate turns a tiny in-memory slide-deck model into the bytes of a real
+//! `.pptx` file that strict consumers (PowerPoint, LibreOffice Impress,
+//! python-pptx) will open. It is the presentation-side sibling of
+//! [`xlsx-writer`](https://docs.rs/coding-adventures-xlsx-writer) (SpreadsheetML)
+//! and is built on the format-agnostic
+//! [`opc-writer`](https://docs.rs/coding-adventures-opc-writer): this crate knows
+//! the *PresentationML vocabulary*, `opc-writer` knows *ZIP + content-types +
+//! relationships*. See `code/specs/PPTXW01-pptx-writer.md` for the full write-up;
+//! this module summarises the model inline so the source reads on its own.
+//!
+//! ## The one-paragraph mental model
+//!
+//! ```text
+//!   Presentation / Slide          (this crate's model — what you build)
+//!         │  write_pptx
+//!         ▼
+//!   PresentationML parts          (this crate: presentation.xml, slideN.xml, …)
+//!         │  opc_writer::PackageWriter
+//!         ▼
+//!   OPC package                   (opc-writer: [Content_Types].xml, .rels, ZIP)
+//!         ▼
+//!   .pptx bytes                   ("PK\x03\x04…")
+//! ```
+//!
+//! ```
+//! use coding_adventures_pptx_writer::{Presentation, write_pptx};
+//!
+//! let mut p = Presentation::new();
+//! let s = p.add_slide();
+//! s.add_text("Slide One Title");
+//! s.add_text("First slide body");
+//!
+//! let bytes = write_pptx(&p);
+//! assert_eq!(&bytes[..2], b"PK");   // valid ZIP / OPC package bytes
+//! ```
+//!
+//! ## Why a deck is *not* just "slides in a zip"
+//!
+//! A conformant `.pptx` needs a whole *scaffold* of parts wired by
+//! relationships — `presentation → slide master → slide layout → theme` — because
+//! every slide inherits its placeholders, colour map, and fonts from that chain
+//! of parents. A package with only a `presentation.xml` and a `slide1.xml` is
+//! rejected. So this writer always emits **one shared master, one shared layout,
+//! and one shared theme** (constant boilerplate with no user data) plus one
+//! `slideN.xml` per slide (the only part that carries text). The relationship
+//! graph:
+//!
+//! ```text
+//!   _rels/.rels ─rId1─▶ ppt/presentation.xml
+//!                               │ rIdM ──────────────▶ slideMasters/slideMaster1.xml
+//!                               │ rId1…rIdN ─▶ slides/slideN.xml ─rId1─▶ slideLayout1
+//!   slideMaster1 ─rId1─▶ slideLayout1 ─rId1─▶ slideMaster1   (well-founded cycle)
+//!   slideMaster1 ─rId2─▶ theme1
+//! ```
+//!
+//! ## The `a:` namespace gotcha
+//!
+//! A slide element is `<p:sld>` in the **PresentationML** namespace, but the text
+//! itself — paragraphs, runs, characters — lives in the **DrawingML** namespace
+//! (prefix `a:`). Inside a shape's `<p:txBody>` you switch dialects:
+//! `<a:p><a:r><a:t>…text…</a:t></a:r></a:p>`. Each [`Slide::add_text`] paragraph
+//! becomes one such `a:p`. The text between `<a:t>` and `</a:t>` is the *only*
+//! place user data enters the XML, so every paragraph is passed through
+//! `opc_writer::xml_escape`; the scaffold parts hold no user data and are
+//! emitted verbatim.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_opc_writer::{xml_escape, PackageWriter, RelationshipsBuilder};
+
+// Re-export the escaper so callers (and downstream crates) have one place to
+// reach for XML escaping, exactly as `opc-writer` intends.
+pub use coding_adventures_opc_writer::xml_escape as escape_xml_text;
+
+// ===========================================================================
+// Namespaces & content types (ECMA-376 Part 1, PresentationML + DrawingML)
+// ===========================================================================
+
+/// PresentationML main namespace — the `p:` dialect (`p:presentation`, `p:sld`,
+/// `p:sp`, `p:txBody`, …).
+const P_NS: &str = "http://schemas.openxmlformats.org/presentationml/2006/main";
+
+/// DrawingML main namespace — the `a:` dialect. Slide *text* (paragraphs `a:p`,
+/// runs `a:r`, text `a:t`) lives here, not in PresentationML. See the module
+/// docs' "`a:` namespace gotcha".
+const A_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
+
+/// The relationships namespace prefix (`r:id` on slide-id and master-id lists).
+const R_NS: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+
+/// Content type of `ppt/presentation.xml` (the deck).
+const CT_PRESENTATION: &str =
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml";
+/// Content type of each `ppt/slides/slideN.xml`.
+const CT_SLIDE: &str = "application/vnd.openxmlformats-officedocument.presentationml.slide+xml";
+/// Content type of `ppt/slideLayouts/slideLayout1.xml`.
+const CT_SLIDE_LAYOUT: &str =
+    "application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml";
+/// Content type of `ppt/slideMasters/slideMaster1.xml`.
+const CT_SLIDE_MASTER: &str =
+    "application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml";
+/// Content type of `ppt/theme/theme1.xml`.
+const CT_THEME: &str = "application/vnd.openxmlformats-officedocument.theme+xml";
+
+// Relationship *type* URIs. Each `.rels` entry declares what kind of link it is;
+// consumers navigate by type, never by hard-coded path.
+const REL_OFFICE_DOCUMENT: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument";
+const REL_SLIDE: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide";
+const REL_SLIDE_MASTER: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster";
+const REL_SLIDE_LAYOUT: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout";
+const REL_THEME: &str = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme";
+
+/// The XML declaration real OOXML producers put at the head of every part.
+const XML_DECL: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n";
+
+// Slide-size defaults: 9144000 × 6858000 EMU = the classic 10in × 7.5in 4:3
+// slide. `notesSz` is the portrait 7.5in × 10in notes page. (1 inch = 914400
+// English Metric Units.) These are the same constants PowerPoint writes.
+const SLIDE_CX: u64 = 9_144_000;
+const SLIDE_CY: u64 = 6_858_000;
+const NOTES_CX: u64 = 6_858_000;
+const NOTES_CY: u64 = 9_144_000;
+
+// Conventional id bases (see the spec, §4 "Id conventions").
+const SLIDE_ID_BASE: u64 = 256; // <p:sldId id="256"/>, "257", …
+const SLIDE_MASTER_ID: u64 = 2_147_483_648; // <p:sldMasterId id="2147483648"/>
+const SLIDE_LAYOUT_ID: u64 = 2_147_483_649; // <p:sldLayoutId id="2147483649"/>
+
+// ===========================================================================
+// The model
+// ===========================================================================
+
+/// One slide: an ordered list of text paragraphs.
+///
+/// A paragraph maps to a single `<a:p><a:r><a:t>…</a:t></a:r></a:p>` in the
+/// slide's shape. For C3 that is the whole model of a slide — fonts, colours,
+/// positioning, images, and notes are shared scaffold (identical for every
+/// slide) and out of scope.
+#[derive(Debug, Default, Clone)]
+pub struct Slide {
+    paragraphs: Vec<String>,
+}
+
+impl Slide {
+    /// A new, empty slide (no text yet).
+    fn new() -> Self {
+        Self {
+            paragraphs: Vec::new(),
+        }
+    }
+
+    /// Append one paragraph / run of text to this slide.
+    ///
+    /// The text is stored verbatim and only escaped at serialization time (so a
+    /// caller could, in principle, read it back). An empty string is allowed and
+    /// produces an empty `<a:t/>`.
+    pub fn add_text(&mut self, text: &str) {
+        self.paragraphs.push(text.to_string());
+    }
+
+    /// The paragraphs of this slide, in order. Exposed so callers (and tests)
+    /// can inspect the model without serializing it.
+    pub fn paragraphs(&self) -> &[String] {
+        &self.paragraphs
+    }
+}
+
+/// A slide deck: an ordered list of [`Slide`]s.
+///
+/// Build one with [`Presentation::new`] + [`Presentation::add_slide`], then hand
+/// it to [`write_pptx`] to get `.pptx` bytes.
+#[derive(Debug, Default, Clone)]
+pub struct Presentation {
+    slides: Vec<Slide>,
+}
+
+impl Presentation {
+    /// A new, empty presentation (no slides).
+    ///
+    /// An empty deck is still valid: [`write_pptx`] emits a `presentation.xml`
+    /// with an empty `<p:sldIdLst/>` and the full master/layout/theme scaffold,
+    /// so the package remains loadable.
+    pub fn new() -> Self {
+        Self { slides: Vec::new() }
+    }
+
+    /// Append a new empty slide and return a mutable handle to fill it.
+    ///
+    /// ```
+    /// # use coding_adventures_pptx_writer::Presentation;
+    /// let mut p = Presentation::new();
+    /// p.add_slide().add_text("hello");
+    /// assert_eq!(p.slides().len(), 1);
+    /// ```
+    pub fn add_slide(&mut self) -> &mut Slide {
+        self.slides.push(Slide::new());
+        // `push` never fails and we just pushed, so `last_mut` is `Some`; but we
+        // avoid `unwrap` entirely (the module forbids panics on model paths) by
+        // indexing the known-last position.
+        let idx = self.slides.len() - 1;
+        &mut self.slides[idx]
+    }
+
+    /// The slides of this deck, in order.
+    pub fn slides(&self) -> &[Slide] {
+        &self.slides
+    }
+}
+
+// ===========================================================================
+// Relationship-id helpers
+// ===========================================================================
+//
+// Slides take rId1…rIdN in `presentation.xml.rels`; the master takes the next
+// free id rId{N+1} so nothing collides. Centralising the arithmetic here keeps
+// the two call sites (the .rels part and the sldMasterIdLst) in agreement.
+
+/// The relationship id for slide number `n` (1-based) in `presentation.xml.rels`.
+fn slide_rid(n: usize) -> String {
+    format!("rId{n}")
+}
+
+/// The relationship id for the slide master in `presentation.xml.rels`: the
+/// first id past the last slide.
+fn master_rid(slide_count: usize) -> String {
+    format!("rId{}", slide_count + 1)
+}
+
+// ===========================================================================
+// Serialization — the slide part (the only part with user text)
+// ===========================================================================
+
+/// Serialize one slide (`ppt/slides/slideN.xml`).
+///
+/// The slide is a `<p:sld>` holding a single `<p:sp>` shape whose `<p:txBody>`
+/// contains one DrawingML paragraph per [`Slide::add_text`] call. Note the
+/// namespace switch: `p:` for the slide/shape structure, `a:` for the text.
+fn slide_xml(slide: &Slide) -> Vec<u8> {
+    let mut s = String::new();
+    s.push_str(XML_DECL);
+    // Bind a: (DrawingML), r: (relationships), p: (PresentationML) up front.
+    s.push_str("<p:sld xmlns:a=\"");
+    s.push_str(A_NS);
+    s.push_str("\" xmlns:r=\"");
+    s.push_str(R_NS);
+    s.push_str("\" xmlns:p=\"");
+    s.push_str(P_NS);
+    s.push_str("\">");
+    s.push_str("<p:cSld><p:spTree>");
+    // The mandatory group-shape properties for the shape tree.
+    s.push_str("<p:nvGrpSpPr><p:cNvPr id=\"1\" name=\"\"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>");
+    s.push_str("<p:grpSpPr/>");
+    // A single text shape holding all the paragraphs.
+    s.push_str("<p:sp>");
+    s.push_str("<p:nvSpPr><p:cNvPr id=\"2\" name=\"Title 1\"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>");
+    s.push_str("<p:spPr/>");
+    s.push_str("<p:txBody><a:bodyPr/>");
+    if slide.paragraphs.is_empty() {
+        // A shape with no text still needs at least one (empty) paragraph to be
+        // well-formed DrawingML.
+        s.push_str("<a:p/>");
+    } else {
+        for para in &slide.paragraphs {
+            // The ONE place user data enters the XML → escape it.
+            s.push_str("<a:p><a:r><a:t>");
+            s.push_str(&xml_escape(para));
+            s.push_str("</a:t></a:r></a:p>");
+        }
+    }
+    s.push_str("</p:txBody>");
+    s.push_str("</p:sp>");
+    s.push_str("</p:spTree></p:cSld>");
+    s.push_str("<p:clrMapOvr><a:overrideClrMapping/></p:clrMapOvr>");
+    s.push_str("</p:sld>");
+    s.into_bytes()
+}
+
+// ===========================================================================
+// Serialization — the deck part (presentation.xml)
+// ===========================================================================
+
+/// Serialize `ppt/presentation.xml`: the slide-master list, the slide list, and
+/// the slide/notes sizes. Carries no user text — only ids.
+fn presentation_xml(slide_count: usize) -> Vec<u8> {
+    let mut s = String::new();
+    s.push_str(XML_DECL);
+    s.push_str("<p:presentation xmlns:p=\"");
+    s.push_str(P_NS);
+    s.push_str("\" xmlns:r=\"");
+    s.push_str(R_NS);
+    s.push_str("\">");
+
+    // Slide-master list: one master, referenced by the id past the last slide.
+    s.push_str("<p:sldMasterIdLst><p:sldMasterId id=\"");
+    s.push_str(&SLIDE_MASTER_ID.to_string());
+    s.push_str("\" r:id=\"");
+    s.push_str(&master_rid(slide_count));
+    s.push_str("\"/></p:sldMasterIdLst>");
+
+    // Slide list: <p:sldId id="256+i" r:id="rId{i+1}"/> for each slide. An
+    // empty deck emits an empty (self-closing) list, which is valid.
+    if slide_count == 0 {
+        s.push_str("<p:sldIdLst/>");
+    } else {
+        s.push_str("<p:sldIdLst>");
+        for i in 0..slide_count {
+            s.push_str("<p:sldId id=\"");
+            s.push_str(&(SLIDE_ID_BASE + i as u64).to_string());
+            s.push_str("\" r:id=\"");
+            s.push_str(&slide_rid(i + 1));
+            s.push_str("\"/>");
+        }
+        s.push_str("</p:sldIdLst>");
+    }
+
+    // Slide and notes page sizes.
+    s.push_str("<p:sldSz cx=\"");
+    s.push_str(&SLIDE_CX.to_string());
+    s.push_str("\" cy=\"");
+    s.push_str(&SLIDE_CY.to_string());
+    s.push_str("\"/>");
+    s.push_str("<p:notesSz cx=\"");
+    s.push_str(&NOTES_CX.to_string());
+    s.push_str("\" cy=\"");
+    s.push_str(&NOTES_CY.to_string());
+    s.push_str("\"/>");
+
+    s.push_str("</p:presentation>");
+    s.into_bytes()
+}
+
+// ===========================================================================
+// Serialization — the scaffold parts (constant boilerplate, no user data)
+// ===========================================================================
+
+/// Serialize `ppt/slideLayouts/slideLayout1.xml`: a minimal blank layout with an
+/// empty shape tree. Shared by every slide.
+fn slide_layout_xml() -> Vec<u8> {
+    let mut s = String::new();
+    s.push_str(XML_DECL);
+    s.push_str("<p:sldLayout xmlns:a=\"");
+    s.push_str(A_NS);
+    s.push_str("\" xmlns:r=\"");
+    s.push_str(R_NS);
+    s.push_str("\" xmlns:p=\"");
+    s.push_str(P_NS);
+    s.push_str("\" type=\"blank\" preserve=\"1\">");
+    s.push_str("<p:cSld name=\"Blank\">");
+    s.push_str(&empty_sp_tree());
+    s.push_str("</p:cSld>");
+    s.push_str("<p:clrMapOvr><a:overrideClrMapping/></p:clrMapOvr>");
+    s.push_str("</p:sldLayout>");
+    s.into_bytes()
+}
+
+/// Serialize `ppt/slideMasters/slideMaster1.xml`: an empty shape tree, the
+/// 12-entry `<p:clrMap>`, and a `<p:sldLayoutIdLst>` pointing at the one layout.
+fn slide_master_xml() -> Vec<u8> {
+    let mut s = String::new();
+    s.push_str(XML_DECL);
+    s.push_str("<p:sldMaster xmlns:a=\"");
+    s.push_str(A_NS);
+    s.push_str("\" xmlns:r=\"");
+    s.push_str(R_NS);
+    s.push_str("\" xmlns:p=\"");
+    s.push_str(P_NS);
+    s.push_str("\">");
+    s.push_str("<p:cSld>");
+    s.push_str(&empty_sp_tree());
+    s.push_str("</p:cSld>");
+    // The colour map wires the six scheme slots (bg1/tx1/bg2/tx2) plus accents
+    // and hyperlinks to theme colours. All 12 attributes are required.
+    s.push_str(
+        "<p:clrMap bg1=\"lt1\" tx1=\"dk1\" bg2=\"lt2\" tx2=\"dk2\" \
+         accent1=\"accent1\" accent2=\"accent2\" accent3=\"accent3\" \
+         accent4=\"accent4\" accent5=\"accent5\" accent6=\"accent6\" \
+         hlink=\"hlink\" folHlink=\"folHlink\"/>",
+    );
+    // Layout list: rId1 → the one shared layout.
+    s.push_str("<p:sldLayoutIdLst><p:sldLayoutId id=\"");
+    s.push_str(&SLIDE_LAYOUT_ID.to_string());
+    s.push_str("\" r:id=\"rId1\"/></p:sldLayoutIdLst>");
+    s.push_str("</p:sldMaster>");
+    s.into_bytes()
+}
+
+/// The empty group-shape tree shared by the master and layout parts. Named once
+/// so both scaffold parts stay identical.
+fn empty_sp_tree() -> String {
+    let mut s = String::new();
+    s.push_str("<p:spTree>");
+    s.push_str("<p:nvGrpSpPr><p:cNvPr id=\"1\" name=\"\"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>");
+    s.push_str("<p:grpSpPr/>");
+    s.push_str("</p:spTree>");
+    s
+}
+
+/// Serialize `ppt/theme/theme1.xml`: a minimal but schema-complete Office theme
+/// (colour scheme, font scheme, and format scheme). Pure boilerplate — the
+/// `srgbClr` values are arbitrary valid hex; the *structure* is what python-pptx
+/// requires to load the deck.
+fn theme_xml() -> Vec<u8> {
+    let mut s = String::new();
+    s.push_str(XML_DECL);
+    s.push_str("<a:theme xmlns:a=\"");
+    s.push_str(A_NS);
+    s.push_str("\" name=\"Office Theme\">");
+    s.push_str("<a:themeElements>");
+
+    // --- Colour scheme: the 12 named colours the clrMap refers to. ---
+    // dk1/lt1 use system window/windowText; the rest are plain sRGB.
+    s.push_str("<a:clrScheme name=\"Office\">");
+    s.push_str("<a:dk1><a:sysClr val=\"windowText\" lastClr=\"000000\"/></a:dk1>");
+    s.push_str("<a:lt1><a:sysClr val=\"window\" lastClr=\"FFFFFF\"/></a:lt1>");
+    s.push_str("<a:dk2><a:srgbClr val=\"44546A\"/></a:dk2>");
+    s.push_str("<a:lt2><a:srgbClr val=\"E7E6E6\"/></a:lt2>");
+    s.push_str("<a:accent1><a:srgbClr val=\"4472C4\"/></a:accent1>");
+    s.push_str("<a:accent2><a:srgbClr val=\"ED7D31\"/></a:accent2>");
+    s.push_str("<a:accent3><a:srgbClr val=\"A5A5A5\"/></a:accent3>");
+    s.push_str("<a:accent4><a:srgbClr val=\"FFC000\"/></a:accent4>");
+    s.push_str("<a:accent5><a:srgbClr val=\"5B9BD5\"/></a:accent5>");
+    s.push_str("<a:accent6><a:srgbClr val=\"70AD47\"/></a:accent6>");
+    s.push_str("<a:hlink><a:srgbClr val=\"0563C1\"/></a:hlink>");
+    s.push_str("<a:folHlink><a:srgbClr val=\"954F72\"/></a:folHlink>");
+    s.push_str("</a:clrScheme>");
+
+    // --- Font scheme: a major (headings) and minor (body) font. ---
+    s.push_str("<a:fontScheme name=\"Office\">");
+    s.push_str(
+        "<a:majorFont><a:latin typeface=\"Calibri Light\"/><a:ea typeface=\"\"/>\
+         <a:cs typeface=\"\"/></a:majorFont>",
+    );
+    s.push_str(
+        "<a:minorFont><a:latin typeface=\"Calibri\"/><a:ea typeface=\"\"/>\
+         <a:cs typeface=\"\"/></a:minorFont>",
+    );
+    s.push_str("</a:fontScheme>");
+
+    // --- Format scheme: fills, lines, effects, and background fills. The schema
+    // requires >=2 fills/bgFills and exactly 3 lines/effects. ---
+    s.push_str("<a:fmtScheme name=\"Office\">");
+    // Two fills: a solid phClr and a second solid phClr.
+    s.push_str("<a:fillStyleLst>");
+    s.push_str("<a:solidFill><a:schemeClr val=\"phClr\"/></a:solidFill>");
+    s.push_str("<a:solidFill><a:schemeClr val=\"phClr\"/></a:solidFill>");
+    s.push_str("</a:fillStyleLst>");
+    // Three line styles of increasing width, all solid phClr.
+    s.push_str("<a:lnStyleLst>");
+    for w in ["6350", "12700", "19050"] {
+        s.push_str("<a:ln w=\"");
+        s.push_str(w);
+        s.push_str("\" cap=\"flat\" cmpd=\"sng\" algn=\"ctr\">");
+        s.push_str("<a:solidFill><a:schemeClr val=\"phClr\"/></a:solidFill>");
+        s.push_str("<a:prstDash val=\"solid\"/></a:ln>");
+    }
+    s.push_str("</a:lnStyleLst>");
+    // Three (empty) effect styles.
+    s.push_str("<a:effectStyleLst>");
+    for _ in 0..3 {
+        s.push_str("<a:effectStyle><a:effectLst/></a:effectStyle>");
+    }
+    s.push_str("</a:effectStyleLst>");
+    // Three background fills.
+    s.push_str("<a:bgFillStyleLst>");
+    for _ in 0..3 {
+        s.push_str("<a:solidFill><a:schemeClr val=\"phClr\"/></a:solidFill>");
+    }
+    s.push_str("</a:bgFillStyleLst>");
+    s.push_str("</a:fmtScheme>");
+
+    s.push_str("</a:themeElements>");
+    s.push_str("</a:theme>");
+    s.into_bytes()
+}
+
+// ===========================================================================
+// The top-level entry point
+// ===========================================================================
+
+/// Serialize a [`Presentation`] into the bytes of a valid `.pptx` file.
+///
+/// This assembles every part (content types + all relationships are synthesised
+/// by `opc-writer`) and returns the ZIP/OPC package bytes. It never panics: an
+/// empty deck, empty slides, and arbitrary Unicode / XML-special text are all
+/// handled.
+///
+/// ```
+/// # use coding_adventures_pptx_writer::{Presentation, write_pptx};
+/// let mut p = Presentation::new();
+/// p.add_slide().add_text("Hello, deck!");
+/// let bytes = write_pptx(&p);
+/// assert_eq!(&bytes[..2], b"PK");
+/// ```
+pub fn write_pptx(p: &Presentation) -> Vec<u8> {
+    let n = p.slides.len();
+    let mut pkg = PackageWriter::new();
+
+    // The two Defaults every OPC package needs.
+    pkg.add_default(
+        "rels",
+        "application/vnd.openxmlformats-package.relationships+xml",
+    );
+    pkg.add_default("xml", "application/xml");
+
+    // --- Package-root relationship: package → presentation. ---
+    let mut root_rels = RelationshipsBuilder::new();
+    root_rels.add("rId1", REL_OFFICE_DOCUMENT, "ppt/presentation.xml");
+    pkg.add_part_defaulted("/_rels/.rels", &root_rels.build());
+
+    // --- The deck. ---
+    pkg.add_part(
+        "/ppt/presentation.xml",
+        CT_PRESENTATION,
+        &presentation_xml(n),
+    );
+
+    // presentation.xml.rels: rId1…rIdN → slides, rId{N+1} → master. Targets are
+    // relative to ppt/ (the .rels file's parent directory).
+    let mut pres_rels = RelationshipsBuilder::new();
+    for i in 1..=n {
+        pres_rels.add(&slide_rid(i), REL_SLIDE, &format!("slides/slide{i}.xml"));
+    }
+    pres_rels.add(
+        &master_rid(n),
+        REL_SLIDE_MASTER,
+        "slideMasters/slideMaster1.xml",
+    );
+    pkg.add_part_defaulted("/ppt/_rels/presentation.xml.rels", &pres_rels.build());
+
+    // --- The slides, plus each slide's rels → the shared layout. ---
+    for (i, slide) in p.slides.iter().enumerate() {
+        let n1 = i + 1;
+        pkg.add_part(
+            &format!("/ppt/slides/slide{n1}.xml"),
+            CT_SLIDE,
+            &slide_xml(slide),
+        );
+        let mut slide_rels = RelationshipsBuilder::new();
+        slide_rels.add(
+            "rId1",
+            REL_SLIDE_LAYOUT,
+            "../slideLayouts/slideLayout1.xml",
+        );
+        pkg.add_part_defaulted(
+            &format!("/ppt/slides/_rels/slide{n1}.xml.rels"),
+            &slide_rels.build(),
+        );
+    }
+
+    // --- The shared layout, plus its rels → the master. ---
+    pkg.add_part(
+        "/ppt/slideLayouts/slideLayout1.xml",
+        CT_SLIDE_LAYOUT,
+        &slide_layout_xml(),
+    );
+    let mut layout_rels = RelationshipsBuilder::new();
+    layout_rels.add(
+        "rId1",
+        REL_SLIDE_MASTER,
+        "../slideMasters/slideMaster1.xml",
+    );
+    pkg.add_part_defaulted(
+        "/ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+        &layout_rels.build(),
+    );
+
+    // --- The shared master, plus its rels → the layout and the theme. ---
+    pkg.add_part(
+        "/ppt/slideMasters/slideMaster1.xml",
+        CT_SLIDE_MASTER,
+        &slide_master_xml(),
+    );
+    let mut master_rels = RelationshipsBuilder::new();
+    master_rels.add(
+        "rId1",
+        REL_SLIDE_LAYOUT,
+        "../slideLayouts/slideLayout1.xml",
+    );
+    master_rels.add("rId2", REL_THEME, "../theme/theme1.xml");
+    pkg.add_part_defaulted(
+        "/ppt/slideMasters/_rels/slideMaster1.xml.rels",
+        &master_rels.build(),
+    );
+
+    // --- The shared theme. ---
+    pkg.add_part("/ppt/theme/theme1.xml", CT_THEME, &theme_xml());
+
+    pkg.finish()
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/pptx-writer/src/tests.rs
+++ b/code/packages/rust/pptx-writer/src/tests.rs
@@ -1,0 +1,362 @@
+//! Structural tests for the `.pptx` writer.
+//!
+//! The read side of `.pptx` is not on this branch, so we verify the generated
+//! bytes *structurally*: unzip with this repo's `zip::ZipReader` and assert the
+//! expected members exist, then parse a slide part with
+//! `coding_adventures_xml_parser::parse_xml` and assert its `<a:t>` text nodes
+//! carry the right (and only the right) text.
+
+use super::*;
+use coding_adventures_xml_parser::{parse_xml, XmlElement, XmlNode};
+use zip::ZipReader;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Collect the member names of a produced `.pptx` archive.
+fn member_names(bytes: &[u8]) -> Vec<String> {
+    let reader = ZipReader::new(bytes).expect("valid zip");
+    reader
+        .entries()
+        .iter()
+        .map(|e| e.name.clone())
+        .collect()
+}
+
+/// Read a single member's decompressed bytes by name.
+fn read_member(bytes: &[u8], name: &str) -> Vec<u8> {
+    let reader = ZipReader::new(bytes).expect("valid zip");
+    reader
+        .read_by_name(name)
+        .unwrap_or_else(|e| panic!("member {name} should exist and decode: {e}"))
+}
+
+/// Recursively gather the text of every `<a:t>` element (DrawingML namespace).
+fn collect_a_t_text(el: &XmlElement, out: &mut Vec<String>) {
+    if el.local_name == "t" && el.namespace_uri.as_deref() == Some(A_NS) {
+        out.push(el.text_content());
+    }
+    for child in &el.children {
+        if let XmlNode::Element(e) = child {
+            collect_a_t_text(e, out);
+        }
+    }
+}
+
+/// The `<a:t>` texts of a slide part, in document order.
+fn slide_texts(bytes: &[u8], slide_no: usize) -> Vec<String> {
+    let part = read_member(bytes, &format!("ppt/slides/slide{slide_no}.xml"));
+    let src = String::from_utf8(part).expect("utf-8 slide xml");
+    let doc = parse_xml(&src).expect("slide xml parses");
+    let mut texts = Vec::new();
+    collect_a_t_text(&doc.root, &mut texts);
+    texts
+}
+
+// ---------------------------------------------------------------------------
+// Model API
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_add_slide_and_text() {
+    let mut p = Presentation::new();
+    let s = p.add_slide();
+    s.add_text("one");
+    s.add_text("two");
+    assert_eq!(p.slides().len(), 1);
+    assert_eq!(p.slides()[0].paragraphs(), &["one", "two"]);
+}
+
+#[test]
+fn model_default_is_empty() {
+    let p = Presentation::default();
+    assert!(p.slides().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// The full scaffold is present
+// ---------------------------------------------------------------------------
+
+#[test]
+fn produces_valid_zip_signature() {
+    let mut p = Presentation::new();
+    p.add_slide().add_text("hi");
+    let bytes = write_pptx(&p);
+    assert_eq!(&bytes[..2], b"PK", "must be a ZIP");
+}
+
+#[test]
+fn contains_full_scaffold_for_two_slides() {
+    let mut p = Presentation::new();
+    p.add_slide().add_text("Slide One Title");
+    p.add_slide().add_text("Slide Two Title");
+    let bytes = write_pptx(&p);
+    let names = member_names(&bytes);
+
+    // Every part a strict consumer needs.
+    let expected = [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "ppt/presentation.xml",
+        "ppt/_rels/presentation.xml.rels",
+        "ppt/slides/slide1.xml",
+        "ppt/slides/slide2.xml",
+        "ppt/slides/_rels/slide1.xml.rels",
+        "ppt/slides/_rels/slide2.xml.rels",
+        "ppt/slideLayouts/slideLayout1.xml",
+        "ppt/slideLayouts/_rels/slideLayout1.xml.rels",
+        "ppt/slideMasters/slideMaster1.xml",
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels",
+        "ppt/theme/theme1.xml",
+    ];
+    for e in expected {
+        assert!(names.contains(&e.to_string()), "missing member: {e}");
+    }
+}
+
+#[test]
+fn content_types_declares_every_override() {
+    let mut p = Presentation::new();
+    p.add_slide();
+    p.add_slide();
+    let bytes = write_pptx(&p);
+    let ct = String::from_utf8(read_member(&bytes, "[Content_Types].xml")).unwrap();
+
+    assert!(ct.contains("/ppt/presentation.xml"));
+    assert!(ct.contains("/ppt/slides/slide1.xml"));
+    assert!(ct.contains("/ppt/slides/slide2.xml"));
+    assert!(ct.contains("/ppt/slideLayouts/slideLayout1.xml"));
+    assert!(ct.contains("/ppt/slideMasters/slideMaster1.xml"));
+    assert!(ct.contains("/ppt/theme/theme1.xml"));
+    // Defaults for rels + xml must be present.
+    assert!(ct.contains("Extension=\"rels\""));
+    assert!(ct.contains("Extension=\"xml\""));
+}
+
+// ---------------------------------------------------------------------------
+// Slide text lives in the a: namespace and in the right slide
+// ---------------------------------------------------------------------------
+
+#[test]
+fn slide_text_is_in_a_namespace_and_correct() {
+    let mut p = Presentation::new();
+    let s1 = p.add_slide();
+    s1.add_text("Slide One Title");
+    s1.add_text("First slide body");
+    let s2 = p.add_slide();
+    s2.add_text("Slide Two Title");
+    let bytes = write_pptx(&p);
+
+    let t1 = slide_texts(&bytes, 1);
+    assert_eq!(t1, vec!["Slide One Title", "First slide body"]);
+
+    let t2 = slide_texts(&bytes, 2);
+    assert_eq!(t2, vec!["Slide Two Title"]);
+
+    // Order guard: slide-2 text must NOT appear in slide-1.
+    assert!(
+        !t1.iter().any(|s| s.contains("Slide Two")),
+        "slide 2 text leaked into slide 1"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// XML escaping of special characters
+// ---------------------------------------------------------------------------
+
+#[test]
+fn special_characters_are_escaped_in_raw_bytes() {
+    // The five XML specials must appear as entity references in the serialized
+    // part, never as their literal characters in text position — otherwise the
+    // part is not well-formed and no consumer can open it.
+    let mut p = Presentation::new();
+    p.add_slide()
+        .add_text("a & b < c > d \"quote\" 'apos'");
+    let bytes = write_pptx(&p);
+
+    let raw = String::from_utf8(read_member(&bytes, "ppt/slides/slide1.xml")).unwrap();
+    assert!(raw.contains("&amp;"), "ampersand not escaped");
+    assert!(raw.contains("&lt;"), "less-than not escaped");
+    assert!(raw.contains("&gt;"), "greater-than not escaped");
+    // No BARE special left inside the <a:t> text (the only literal '<'/'>' in the
+    // whole part are the element delimiters, so a bare " & " would be a bug).
+    assert!(!raw.contains(" & "), "found an unescaped bare ampersand");
+}
+
+#[test]
+fn escaped_entities_round_trip_through_parser() {
+    // A conforming parser decodes the entity references back to the original
+    // characters. (We avoid whitespace immediately adjacent to an entity here:
+    // this repo's xml-parser collapses a space that borders an entity boundary,
+    // which is a parser-lexer quirk unrelated to the writer's escaping.)
+    let mut p = Presentation::new();
+    p.add_slide().add_text("A&B<C>D\"E\"F");
+    let bytes = write_pptx(&p);
+
+    // Escaping happened...
+    let raw = String::from_utf8(read_member(&bytes, "ppt/slides/slide1.xml")).unwrap();
+    assert!(raw.contains("A&amp;B&lt;C&gt;D"));
+
+    // ...and decodes back to the exact original.
+    let texts = slide_texts(&bytes, 1);
+    assert_eq!(texts, vec!["A&B<C>D\"E\"F"]);
+}
+
+#[test]
+fn unicode_text_survives() {
+    let mut p = Presentation::new();
+    p.add_slide().add_text("日本語 — résumé 🎉");
+    let bytes = write_pptx(&p);
+    let texts = slide_texts(&bytes, 1);
+    assert_eq!(texts, vec!["日本語 — résumé 🎉"]);
+}
+
+#[test]
+fn illegal_control_chars_are_dropped_not_panicked() {
+    // A NUL and other C0 controls are illegal in XML 1.0; xml_escape drops them
+    // so the package stays parseable. Tab/newline are legal and kept.
+    let mut p = Presentation::new();
+    p.add_slide().add_text("a\u{0}b\u{1}c\tok");
+    let bytes = write_pptx(&p);
+    let texts = slide_texts(&bytes, 1);
+    assert_eq!(texts, vec!["abc\tok"]);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple slides: id / rels alignment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiple_slides_align_sldid_and_rels() {
+    let mut p = Presentation::new();
+    for _ in 0..3 {
+        p.add_slide();
+    }
+    let bytes = write_pptx(&p);
+
+    let pres = String::from_utf8(read_member(&bytes, "ppt/presentation.xml")).unwrap();
+    // sldId ids start at 256 and count up.
+    assert!(pres.contains("id=\"256\""));
+    assert!(pres.contains("id=\"257\""));
+    assert!(pres.contains("id=\"258\""));
+    // Each slide has a relationship id rId1..rId3.
+    for rid in ["rId1", "rId2", "rId3"] {
+        assert!(pres.contains(rid), "presentation.xml missing {rid}");
+    }
+    // The master takes the next id past the last slide (rId4 here).
+    assert!(pres.contains("rId4"), "master rel id rId4 missing");
+
+    // presentation.xml.rels must map rId1..rId3 to slides and rId4 to master.
+    let rels =
+        String::from_utf8(read_member(&bytes, "ppt/_rels/presentation.xml.rels")).unwrap();
+    assert!(rels.contains("slides/slide1.xml"));
+    assert!(rels.contains("slides/slide2.xml"));
+    assert!(rels.contains("slides/slide3.xml"));
+    assert!(rels.contains("slideMasters/slideMaster1.xml"));
+
+    // Exactly 3 slide parts exist (no slide4).
+    let names = member_names(&bytes);
+    assert!(names.contains(&"ppt/slides/slide3.xml".to_string()));
+    assert!(!names.contains(&"ppt/slides/slide4.xml".to_string()));
+}
+
+// ---------------------------------------------------------------------------
+// Empty deck / empty slide edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_deck_still_valid() {
+    let p = Presentation::new();
+    let bytes = write_pptx(&p);
+    assert_eq!(&bytes[..2], b"PK");
+
+    let names = member_names(&bytes);
+    // Scaffold present even with zero slides.
+    assert!(names.contains(&"ppt/presentation.xml".to_string()));
+    assert!(names.contains(&"ppt/slideMasters/slideMaster1.xml".to_string()));
+    assert!(names.contains(&"ppt/theme/theme1.xml".to_string()));
+    // No slide parts.
+    assert!(!names.contains(&"ppt/slides/slide1.xml".to_string()));
+
+    // presentation.xml parses and has an empty slide-id list.
+    let pres = String::from_utf8(read_member(&bytes, "ppt/presentation.xml")).unwrap();
+    let doc = parse_xml(&pres).expect("presentation.xml parses");
+    let lst = doc
+        .root
+        .get_child(Some(P_NS), "sldIdLst")
+        .expect("sldIdLst present");
+    // No <p:sldId> children.
+    assert!(lst.get_children(Some(P_NS), "sldId").is_empty());
+    // The master id list is still present (deck must reference its master).
+    assert!(doc.root.get_child(Some(P_NS), "sldMasterIdLst").is_some());
+}
+
+#[test]
+fn empty_slide_produces_well_formed_part() {
+    let mut p = Presentation::new();
+    p.add_slide(); // no text
+    let bytes = write_pptx(&p);
+    // The slide part still parses (an empty <a:p/> keeps txBody well-formed).
+    let part = read_member(&bytes, "ppt/slides/slide1.xml");
+    let src = String::from_utf8(part).unwrap();
+    let doc = parse_xml(&src).expect("empty slide xml parses");
+    assert_eq!(doc.root.local_name, "sld");
+    // No <a:t> text nodes.
+    let texts = slide_texts(&bytes, 1);
+    assert!(texts.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Every part decompresses and parses as XML (well-formedness sweep)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_part_is_well_formed_xml() {
+    let mut p = Presentation::new();
+    p.add_slide().add_text("content");
+    let bytes = write_pptx(&p);
+    let reader = ZipReader::new(&bytes).unwrap();
+    for entry in reader.entries() {
+        let data = reader.read(entry).expect("member decodes");
+        let src = String::from_utf8(data).expect("utf-8 part");
+        parse_xml(&src).unwrap_or_else(|e| panic!("part {} not well-formed: {:?}", entry.name, e));
+    }
+}
+
+#[test]
+fn theme_has_required_scheme_blocks() {
+    let mut p = Presentation::new();
+    p.add_slide();
+    let bytes = write_pptx(&p);
+    let theme = String::from_utf8(read_member(&bytes, "ppt/theme/theme1.xml")).unwrap();
+    let doc = parse_xml(&theme).expect("theme parses");
+    let elems = doc
+        .root
+        .get_child(Some(A_NS), "themeElements")
+        .expect("themeElements present");
+    assert!(elems.get_child(Some(A_NS), "clrScheme").is_some());
+    assert!(elems.get_child(Some(A_NS), "fontScheme").is_some());
+    assert!(elems.get_child(Some(A_NS), "fmtScheme").is_some());
+}
+
+#[test]
+fn master_has_clrmap_and_layout_list() {
+    let mut p = Presentation::new();
+    p.add_slide();
+    let bytes = write_pptx(&p);
+    let master = String::from_utf8(read_member(&bytes, "ppt/slideMasters/slideMaster1.xml")).unwrap();
+    let doc = parse_xml(&master).expect("master parses");
+    let clr_map = doc.root.get_child(Some(P_NS), "clrMap").expect("clrMap present");
+    // All 12 colour-map attributes must be present.
+    for attr in [
+        "bg1", "tx1", "bg2", "tx2", "accent1", "accent2", "accent3", "accent4", "accent5",
+        "accent6", "hlink", "folHlink",
+    ] {
+        assert!(
+            clr_map.get_attr(None, attr).is_some(),
+            "clrMap missing attribute {attr}"
+        );
+    }
+    assert!(doc.root.get_child(Some(P_NS), "sldLayoutIdLst").is_some());
+}

--- a/code/specs/PPTXW01-pptx-writer.md
+++ b/code/specs/PPTXW01-pptx-writer.md
@@ -1,0 +1,192 @@
+# PPTXW01 — `pptx-writer`: writing a valid `.pptx` from a slide-deck model
+
+*Milestone **C3** of the OOXML effort. Sibling of `xlsx-writer` (C1, SpreadsheetML)
+and `wordprocessingml`; built on the format-agnostic `opc-writer` (C1).*
+
+## 1. What this crate is
+
+`pptx-writer` turns a tiny in-memory slide-deck model —
+
+```rust
+let mut p = Presentation::new();
+let s = p.add_slide();
+s.add_text("Slide One Title");
+s.add_text("First slide body");
+let bytes = write_pptx(&p);          // valid .pptx bytes
+```
+
+— into the bytes of a real `.pptx` file that strict consumers (PowerPoint,
+LibreOffice Impress, python-pptx) will open. It knows the **PresentationML**
+vocabulary (the `p:` and `a:` XML dialects) and delegates *all* of the ZIP +
+content-types + relationships packaging to `opc-writer`. It contains no ZIP
+code, no XML-escaping code of its own (it re-exports `opc_writer::xml_escape`),
+and no filesystem/network access — it is pure `model → bytes`.
+
+The layering, top to bottom:
+
+```text
+  Presentation / Slide  (this crate's model)
+        │  write_pptx
+        ▼
+  PresentationML parts   (this crate: presentation.xml, slideN.xml, master, …)
+        │  opc_writer::PackageWriter::add_part / add_part_defaulted
+        ▼
+  OPC package            (opc-writer: [Content_Types].xml, .rels, ZIP framing)
+        │  zip::ZipWriter
+        ▼
+  .pptx bytes            ("PK\x03\x04…")
+```
+
+## 2. Why a deck is not just "slides in a zip"
+
+A naive first attempt writes `presentation.xml` and a `slide1.xml` and stops.
+PowerPoint and python-pptx **reject** that. A conformant PresentationML package
+requires a whole *scaffold* of parts wired by relationships, because every slide
+inherits its placeholders, colour map, and fonts from a chain of parent parts:
+
+```text
+                       ┌─────────────────────────────┐
+   package root  ─rId1─▶│  ppt/presentation.xml       │
+   (_rels/.rels)        │  (the deck: size, slide list│
+                        │   + slide-master list)      │
+                        └──────┬───────────────┬──────┘
+                               │ rIdM          │ rId1…rIdN
+                               ▼               ▼
+                 ┌──────────────────────┐  ┌───────────────────────┐
+                 │ slideMasters/        │  │ slides/slideN.xml      │
+                 │   slideMaster1.xml   │  │ (the visible text)     │
+                 └──┬────────────────┬──┘  └───────────┬───────────┘
+                    │ theme          │ layout          │ rId1 (layout)
+                    ▼                ▼                  ▼
+        ┌────────────────┐  ┌────────────────────┐  (points back at
+        │ theme/theme1   │  │ slideLayouts/      │◀──  slideLayout1)
+        │ .xml           │  │   slideLayout1.xml │
+        └────────────────┘  └─────────┬──────────┘
+                                       │ rId1 (master)
+                                       ▼
+                              (points back at slideMaster1)
+```
+
+So the relationship graph is **cyclic-looking but well-founded**:
+
+* `presentation.xml` → each `slideN.xml` **and** → `slideMaster1.xml`.
+* each `slideN.xml` → `slideLayout1.xml`.
+* `slideLayout1.xml` → `slideMaster1.xml`.
+* `slideMaster1.xml` → `slideLayout1.xml` **and** → `theme1.xml`.
+
+The master also carries a `<p:clrMap>` (bg1/tx1/…/folHlink) and a
+`<p:sldLayoutIdLst>`; the presentation carries a `<p:sldMasterIdLst>` and a
+`<p:sldIdLst>`. python-pptx walks exactly these relationships when it loads a
+package, which is why *all* of the scaffold parts must be present and
+well-formed — even for a one-line "hello world" deck.
+
+`pptx-writer` emits one master, one layout, and one theme (shared by every
+slide) plus one `slideN.xml` per slide. The master/layout/theme are constant
+**boilerplate** with no user data in them; only `slideN.xml` carries text.
+
+### The full part list (for N slides)
+
+| Part | Content type / rel type | Notes |
+|------|------------------------|-------|
+| `[Content_Types].xml` | — | synthesised by `opc-writer` from registered defaults + overrides |
+| `_rels/.rels` | `.../officeDocument` | rId1 → `ppt/presentation.xml` |
+| `ppt/presentation.xml` | `…presentationml.presentation.main+xml` | deck: master-id-list, slide-id-list, sizes |
+| `ppt/_rels/presentation.xml.rels` | — | rId1…rIdN → slides, rIdM → master |
+| `ppt/slides/slideN.xml` | `…presentationml.slide+xml` | the text, in the `a:` namespace |
+| `ppt/slides/_rels/slideN.xml.rels` | `.../slideLayout` | rId1 → `../slideLayouts/slideLayout1.xml` |
+| `ppt/slideLayouts/slideLayout1.xml` | `…presentationml.slideLayout+xml` | `type="blank"`, empty spTree |
+| `ppt/slideLayouts/_rels/slideLayout1.xml.rels` | `.../slideMaster` | rId1 → `../slideMasters/slideMaster1.xml` |
+| `ppt/slideMasters/slideMaster1.xml` | `…presentationml.slideMaster+xml` | clrMap + layout-id-list |
+| `ppt/slideMasters/_rels/slideMaster1.xml.rels` | `.../slideLayout`, `.../theme` | rId1 → layout, rId2 → theme |
+| `ppt/theme/theme1.xml` | `…theme+xml` | clrScheme + fontScheme + fmtScheme |
+
+## 3. The `a:` namespace gotcha (the one non-obvious thing about slide text)
+
+A slide is `<p:sld>` in the **PresentationML** namespace
+`…/presentationml/2006/main`. But the *text itself* — paragraphs, runs, the
+literal characters — lives in the **DrawingML** namespace
+`…/drawingml/2006/main`, conventionally bound to prefix `a:`. So inside a
+`p:sp` shape's `p:txBody` you switch dialects:
+
+```xml
+<p:txBody>
+  <a:bodyPr/>
+  <a:p><a:r><a:t>Slide One Title</a:t></a:r></a:p>   ← a:p / a:r / a:t are DrawingML
+  <a:p><a:r><a:t>First slide body</a:t></a:r></a:p>
+</p:txBody>
+```
+
+Each paragraph of slide text (`Slide::add_text`) becomes one
+`<a:p><a:r><a:t>…</a:t></a:r></a:p>`. Confusing `a:p` (a DrawingML *paragraph*)
+with `p:` (the PresentationML namespace *prefix*) is the classic PowerPoint-XML
+beginner trap, so we name the two namespaces explicitly in the source.
+
+The text between `<a:t>` and `</a:t>` is the only place user-supplied data
+enters an XML document, so every paragraph string is passed through
+`opc_writer::xml_escape` before it is written. Scaffold parts hold no user data
+and are emitted verbatim.
+
+## 4. The model and public API
+
+```rust
+pub struct Presentation { /* Vec<Slide> */ }
+impl Presentation {
+    pub fn new() -> Self;
+    pub fn add_slide(&mut self) -> &mut Slide;   // append, return handle to fill
+}
+
+pub struct Slide { /* Vec<String> paragraphs */ }
+impl Slide {
+    pub fn add_text(&mut self, text: &str);      // one paragraph / run
+}
+
+pub fn write_pptx(p: &Presentation) -> Vec<u8>;  // model → .pptx bytes
+```
+
+The model is deliberately minimal for C3: a deck is an ordered list of slides;
+a slide is an ordered list of text paragraphs. Fonts, colours, positioning,
+images, and notes are out of scope (they are the same shared scaffold for every
+slide) and can be layered on in later milestones without changing this API.
+
+### Id conventions
+
+* Slides are numbered `1..=N`; the parts are `slideN.xml` in that order.
+* In `presentation.xml`, `<p:sldId>` ids start at **256** (`256, 257, …`) — the
+  conventional base PowerPoint uses — and each `r:id` is `rId1…rIdN`.
+* The slide-master id is the conventional large sentinel `2147483648`; the
+  layout id in the master is `2147483649`.
+* In `presentation.xml.rels`, slides take `rId1…rIdN` and the master takes
+  `rIdM = rId{N+1}` so no id collides.
+
+An **empty deck** (no slides) is still valid: `presentation.xml` carries an
+empty `<p:sldIdLst/>`, no `slideN.xml` parts exist, and the master/layout/theme
+scaffold is still written so the package remains loadable.
+
+## 5. Security / robustness
+
+* `#![forbid(unsafe_code)]`.
+* No `unwrap` / `expect` / `panic!` on any model-driven path. Empty deck, empty
+  slide, and arbitrary Unicode / XML-special text must never panic.
+* All user text flows through `opc_writer::xml_escape`, which also **drops**
+  characters illegal in XML 1.0 (NUL, other C0 controls) so untrusted text can
+  never make the package unparseable.
+* Zip-Slip and path traversal are handled one layer down by `opc-writer`'s
+  part-name normalisation; this crate only ever emits fixed, well-formed part
+  names.
+
+## 6. Verification
+
+Because the read side of `.pptx` is not yet on this branch, tests verify the
+generated bytes **structurally**:
+
+1. Unzip the output with this repo's `zip::ZipReader` and assert every expected
+   member is present (content-types, presentation, each `slideN.xml`, master,
+   layout, theme, and all the `.rels`).
+2. Parse `ppt/slides/slide1.xml` with `coding_adventures_xml_parser::parse_xml`
+   and assert the `<a:t>` text nodes contain that slide's text; assert slide-2
+   text is **not** in slide1 (an ordering guard).
+3. Unit-test XML escaping of specials, multi-slide id/rels alignment, and the
+   empty-deck case.
+
+Separately, an external python-pptx cross-check confirms a real consumer opens
+the file.


### PR DESCRIPTION
Writes a valid .pptx (presentation->master->layout->theme) via opc-writer; validated with python-pptx (real PowerPoint library) — 2 slides, specials+unicode correct. 16 tests + doctests. Slide text through the hardened xml_escape.