### PR TITLE
feat(adj-ladder): rung-64 gastric-acid buffer index (difference over a sum)

### DIFF
--- a/code/specs/data/adj-ladder/rung64_gastric_acid_buffer/gen_items.py
+++ b/code/specs/data/adj-ladder/rung64_gastric_acid_buffer/gen_items.py
@@ -1,0 +1,228 @@
+"""Generate rung-64 (gastric-acid buffer index) items.json for the ADJ-LADDER.
+
+Rung 64 opens the **gastroenterology / gastric-acid** panel on the quantitative band — the arithmetic of acid
+buffering. A stimulation test raises acid output above its resting level: the net acid the stomach adds is the
+stimulated output MINUS the basal output. That acid is met by the mucosal buffers, whose total capacity is the
+bicarbonate secretion PLUS the mucus buffer. The buffer index is the net acid over the total buffer. Dividing the
+DIFFERENCE of two quantities by the SUM of two others introduces a genuinely NEW arithmetic shape on the ladder: a
+**difference over a sum** — `(a-b)/(c+d)`.
+
+The setup: a `stimulated_output` of acid after stimulation, a `basal_output` at rest, buffered by a `bicarbonate`
+secretion and a `mucus_buffer`. The gastric-acid buffer index is:
+
+  BUFFER INDEX     (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)   [ net acid per unit buffer ]
+  NET ACID         stimulated_output - basal_output                                    [ the numerator: acid added ]
+  TOTAL BUFFER     bicarbonate + mucus_buffer                                          [ the denominator: buffering ]
+
+The **buffer index** is what makes this rung distinctive — it is the ladder's first **difference over a sum**: a
+difference of two quantities divided by a sum of two others. Contrast the neighbours already on the ladder: rung-63 was
+`(a+b)/(c-d)` (a SUM over a difference — the mirror image), rung-59 was `(a*b)/(c-d)` (a PRODUCT over a difference) and
+rung-32 was `(a-b)/(c-d)` (a difference over a DIFFERENCE); here a difference sits over a SUM. (The net acid
+`stimulated_output-basal_output` and the total buffer `bicarbonate+mucus_buffer` ride alongside as component readouts,
+so the panel teaches the whole calculation — exactly as rungs 47-63 shipped their component sums/products/differences/
+ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the numerator difference, the parenthesised denominator sum, and their quotient — and the
+harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs
+8/16/.../62/63. This rung exercises the engine across **a division of a difference by a sum** — the fact that
+`(a-b)/(c+d)` is NOT `(a+b)/(c+d)` and NOT `(a-b)/(c-d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `/`, `-`, and `+`
+— **no structural constants** — so no numeric literal appears in any program, and neither the net acid, the total
+buffer, nor any buffer-index figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`stimulated_output`, `basal_output`, `bicarbonate`, `mucus_buffer`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  POOLED     (stimulated_output + basal_output) / (bicarbonate + mucus_buffer)   SUM the numerator instead of
+                                                                                DIFFERENCING it (the classic
+                                                                                `(a-b)/(c+d)` vs `(a+b)/(c+d)` error), and
+  CROSSED    (stimulated_output - basal_output) / (bicarbonate - mucus_buffer)   DIFFERENCE the denominator instead of
+                                                                                SUMMING it (subtract the two buffers),
+
+which are exactly the mistakes a student makes (adding the two acid outputs, or subtracting the two buffers). Gold
+rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as options.
+
+Distinctness: all four observed quantities are strictly positive, the tables are chosen so the stimulated output exceeds
+the basal output (the net acid — and therefore the buffer index — is positive) and the bicarbonate exceeds the mucus
+buffer (so the difference-denominator distractor stays positive); the five family values are pairwise distinct with a
+comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (STIMULATED_OUTPUT, BASAL_OUTPUT, BICARBONATE, MUCUS_BUFFER) — two acid outputs and two buffer figures, all plain
+# positive numbers with stimulated > basal and bicarbonate > mucus_buffer. The five family values are asserted
+# pairwise-distinct (with margin) below.
+TABLES = [
+    (60, 20, 50, 10),
+    (80, 40, 60, 20),
+    (90, 30, 40, 10),
+    (70, 50, 80, 40),
+    (100, 20, 30, 10),
+    (50, 30, 70, 30),
+    (120, 40, 90, 50),
+]
+
+# The option family (5 members), all built from the four observed quantities via /, -, and +. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "buffer_index",
+        "gastric-acid buffer index (net acid over the total buffer)",
+        "(stimulated_output - basal_output) / (bicarbonate + mucus_buffer)",
+    ),
+    (
+        "net_acid",
+        "the net acid added by stimulation (stimulated minus basal output)",
+        "stimulated_output - basal_output",
+    ),
+    (
+        "total_buffer",
+        "the total buffering capacity (bicarbonate plus mucus buffer)",
+        "bicarbonate + mucus_buffer",
+    ),
+    (
+        "pooled",
+        "the SUM of the two acid outputs over the total buffer, not their difference (a wrong net acid)",
+        "(stimulated_output + basal_output) / (bicarbonate + mucus_buffer)",
+    ),
+    (
+        "crossed",
+        "the net acid over the DIFFERENCE of the two buffers, not their sum (a wrong total buffer)",
+        "(stimulated_output - basal_output) / (bicarbonate - mucus_buffer)",
+    ),
+]
+QUERIED = ["buffer_index", "net_acid", "total_buffer"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(stimulated_output, basal_output, bicarbonate, mucus_buffer):
+    # Operation order mirrors the ADJ programs exactly (each parenthesised difference/sum formed first, then the
+    # division), so the Python option value and the engine result are the same IEEE-double (well within the harness's
+    # 1e-9 match tolerance).
+    return {
+        "buffer_index": (stimulated_output - basal_output) / (bicarbonate + mucus_buffer),
+        "net_acid": stimulated_output - basal_output,
+        "total_buffer": bicarbonate + mucus_buffer,
+        "pooled": (stimulated_output + basal_output) / (bicarbonate + mucus_buffer),
+        "crossed": (stimulated_output - basal_output) / (bicarbonate - mucus_buffer),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for stimulated_output, basal_output, bicarbonate, mucus_buffer in TABLES:
+        assert (
+            stimulated_output > 0
+            and basal_output > 0
+            and bicarbonate > 0
+            and mucus_buffer > 0
+        ), (stimulated_output, basal_output, bicarbonate, mucus_buffer)
+        # Net acid must be positive (numerator) and the bicarbonate must exceed the mucus buffer
+        # (so the difference-denominator distractor is positive).
+        assert stimulated_output > basal_output, (stimulated_output, basal_output, bicarbonate, mucus_buffer)
+        assert bicarbonate > mucus_buffer, (stimulated_output, basal_output, bicarbonate, mucus_buffer)
+        fv = family_values(stimulated_output, basal_output, bicarbonate, mucus_buffer)
+        for key, v in fv.items():
+            assert v > 0, (key, stimulated_output, basal_output, bicarbonate, mucus_buffer, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    stimulated_output,
+                    basal_output,
+                    bicarbonate,
+                    mucus_buffer,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                stimulated_output,
+                basal_output,
+                bicarbonate,
+                mucus_buffer,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r64acid-{idx + 1:02d}",
+                "qtype": "gastric_acid_buffer",
+                "stem": (
+                    f"An acid-secretion study measures a stimulated output of {num(stimulated_output)} units and a "
+                    f"basal output of {num(basal_output)}, buffered by {num(bicarbonate)} of bicarbonate and a "
+                    f"{num(mucus_buffer)} mucus buffer. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe stimulated_output({num(stimulated_output)})\n"
+                    f"observe basal_output({num(basal_output)})\n"
+                    f"observe bicarbonate({num(bicarbonate)})\n"
+                    f"observe mucus_buffer({num(mucus_buffer)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 64 — gastric-acid buffer index from four stated quantities (a NEW panel: gastroenterology "
+            "/ gastric-acid). From a stimulated and a basal acid output (their difference is the net acid) and a "
+            "bicarbonate secretion plus a mucus buffer (their sum is the total buffer), compute the buffer index "
+            "((stimulated_output-basal_output)/(bicarbonate+mucus_buffer)), the net acid "
+            "(stimulated_output-basal_output), or the total buffer (bicarbonate+mucus_buffer). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries "
+            "the arithmetic — a NEW shape, DIFFERENCE OVER A SUM (a-b)/(c+d), the first on the ladder to divide a "
+            "difference by a sum (the mirror of rung-63 sum-over-difference (a+b)/(c-d), and distinct from rung-59 "
+            "product-over-difference (a*b)/(c-d) and rung-32 difference-over-difference (a-b)/(c-d)) — and the harness "
+            "matches the scalar to the printed options. Contamination-safe: every index is built only from the four "
+            "observed quantities via /, -, and + — no constant leaks, and neither the net acid, the total buffer, nor "
+            "any buffer-index figure ever appears as a literal (each is computed) — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the "
+            "same four quantities, so the distractors are exactly the slips students make: SUMMING the numerator "
+            "((a+b)/(c+d), a wrong net acid) and DIFFERENCING the denominator ((a-b)/(c-d), a wrong total buffer). The "
+            "core confusion tested is that (a-b)/(c+d) is not (a+b)/(c+d) and not (a-b)/(c-d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung64_gastric_acid_buffer/items.json
+++ b/code/specs/data/adj-ladder/rung64_gastric_acid_buffer/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 64 \u2014 gastric-acid buffer index from four stated quantities (a NEW panel: gastroenterology / gastric-acid). From a stimulated and a basal acid output (their difference is the net acid) and a bicarbonate secretion plus a mucus buffer (their sum is the total buffer), compute the buffer index ((stimulated_output-basal_output)/(bicarbonate+mucus_buffer)), the net acid (stimulated_output-basal_output), or the total buffer (bicarbonate+mucus_buffer). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, DIFFERENCE OVER A SUM (a-b)/(c+d), the first on the ladder to divide a difference by a sum (the mirror of rung-63 sum-over-difference (a+b)/(c-d), and distinct from rung-59 product-over-difference (a*b)/(c-d) and rung-32 difference-over-difference (a-b)/(c-d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via /, -, and + \u2014 no constant leaks, and neither the net acid, the total buffer, nor any buffer-index figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: SUMMING the numerator ((a+b)/(c+d), a wrong net acid) and DIFFERENCING the denominator ((a-b)/(c-d), a wrong total buffer). The core confusion tested is that (a-b)/(c+d) is not (a+b)/(c+d) and not (a-b)/(c-d).",
+  "items": [
+    {
+      "id": "r64acid-01",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 60 units and a basal output of 20, buffered by 50 of bicarbonate and a 10 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(60)\nobserve basal_output(20)\nobserve bicarbonate(50)\nobserve mucus_buffer(10)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r64acid-02",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 60 units and a basal output of 20, buffered by 50 of bicarbonate and a 10 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(60)\nobserve basal_output(20)\nobserve bicarbonate(50)\nobserve mucus_buffer(10)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r64acid-03",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 60 units and a basal output of 20, buffered by 50 of bicarbonate and a 10 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(60)\nobserve basal_output(20)\nobserve bicarbonate(50)\nobserve mucus_buffer(10)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r64acid-04",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 80 units and a basal output of 40, buffered by 60 of bicarbonate and a 20 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(80)\nobserve basal_output(40)\nobserve bicarbonate(60)\nobserve mucus_buffer(20)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r64acid-05",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 80 units and a basal output of 40, buffered by 60 of bicarbonate and a 20 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(80)\nobserve basal_output(40)\nobserve bicarbonate(60)\nobserve mucus_buffer(20)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r64acid-06",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 80 units and a basal output of 40, buffered by 60 of bicarbonate and a 20 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(80)\nobserve basal_output(40)\nobserve bicarbonate(60)\nobserve mucus_buffer(20)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r64acid-07",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 90 units and a basal output of 30, buffered by 40 of bicarbonate and a 10 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(90)\nobserve basal_output(30)\nobserve bicarbonate(40)\nobserve mucus_buffer(10)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r64acid-08",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 90 units and a basal output of 30, buffered by 40 of bicarbonate and a 10 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(90)\nobserve basal_output(30)\nobserve bicarbonate(40)\nobserve mucus_buffer(10)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r64acid-09",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 90 units and a basal output of 30, buffered by 40 of bicarbonate and a 10 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(90)\nobserve basal_output(30)\nobserve bicarbonate(40)\nobserve mucus_buffer(10)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r64acid-10",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 70 units and a basal output of 50, buffered by 80 of bicarbonate and a 40 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(70)\nobserve basal_output(50)\nobserve bicarbonate(80)\nobserve mucus_buffer(40)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r64acid-11",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 70 units and a basal output of 50, buffered by 80 of bicarbonate and a 40 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(70)\nobserve basal_output(50)\nobserve bicarbonate(80)\nobserve mucus_buffer(40)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r64acid-12",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 70 units and a basal output of 50, buffered by 80 of bicarbonate and a 40 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(70)\nobserve basal_output(50)\nobserve bicarbonate(80)\nobserve mucus_buffer(40)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r64acid-13",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 100 units and a basal output of 20, buffered by 30 of bicarbonate and a 10 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(100)\nobserve basal_output(20)\nobserve bicarbonate(30)\nobserve mucus_buffer(10)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r64acid-14",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 100 units and a basal output of 20, buffered by 30 of bicarbonate and a 10 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(100)\nobserve basal_output(20)\nobserve bicarbonate(30)\nobserve mucus_buffer(10)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r64acid-15",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 100 units and a basal output of 20, buffered by 30 of bicarbonate and a 10 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(100)\nobserve basal_output(20)\nobserve bicarbonate(30)\nobserve mucus_buffer(10)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r64acid-16",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 50 units and a basal output of 30, buffered by 70 of bicarbonate and a 30 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(50)\nobserve basal_output(30)\nobserve bicarbonate(70)\nobserve mucus_buffer(30)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r64acid-17",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 50 units and a basal output of 30, buffered by 70 of bicarbonate and a 30 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(50)\nobserve basal_output(30)\nobserve bicarbonate(70)\nobserve mucus_buffer(30)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r64acid-18",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 50 units and a basal output of 30, buffered by 70 of bicarbonate and a 30 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(50)\nobserve basal_output(30)\nobserve bicarbonate(70)\nobserve mucus_buffer(30)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r64acid-19",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 120 units and a basal output of 40, buffered by 90 of bicarbonate and a 50 mucus buffer. What is the gastric-acid buffer index (net acid over the total buffer)?",
+      "program": "observe stimulated_output(120)\nobserve basal_output(40)\nobserve bicarbonate(90)\nobserve mucus_buffer(50)\nlet answer = (stimulated_output - basal_output) / (bicarbonate + mucus_buffer)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.1428571428571428,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.5714285714285714,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r64acid-20",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 120 units and a basal output of 40, buffered by 90 of bicarbonate and a 50 mucus buffer. What is the the net acid added by stimulation (stimulated minus basal output)?",
+      "program": "observe stimulated_output(120)\nobserve basal_output(40)\nobserve bicarbonate(90)\nobserve mucus_buffer(50)\nlet answer = stimulated_output - basal_output\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5714285714285714,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.1428571428571428,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 80,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r64acid-21",
+      "qtype": "gastric_acid_buffer",
+      "stem": "An acid-secretion study measures a stimulated output of 120 units and a basal output of 40, buffered by 90 of bicarbonate and a 50 mucus buffer. What is the the total buffering capacity (bicarbonate plus mucus buffer)?",
+      "program": "observe stimulated_output(120)\nobserve basal_output(40)\nobserve bicarbonate(90)\nobserve mucus_buffer(50)\nlet answer = bicarbonate + mucus_buffer\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 140,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5714285714285714,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.1428571428571428,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -101,6 +101,7 @@ SELF_CONTAINED_RUNGS = (
     "rung61_polysomnography_apnea_rate",
     "rung62_urodynamics_average_flow",
     "rung63_lacrimal_tear_clearance",
+    "rung64_gastric_acid_buffer",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-64 — gastric-acid buffer index (difference over a sum)

Adds the next self-contained quantitative rung to the ADJ-LADDER.

### New arithmetic shape
`(a-b)/(c+d)` — **difference over a sum**: the difference of two quantities divided by the sum of
two others. The first rung to divide a difference by a sum — the **mirror image** of rung-63
`(a+b)/(c-d)` (sum over a difference). Distinct from:
- rung-59 `(a*b)/(c-d)` — a **product** over a difference
- rung-32 `(a-b)/(c-d)` — a difference over a **difference**

The core confusion tested: `(a-b)/(c+d)` is **not** `(a+b)/(c+d)` and **not** `(a-b)/(c-d)`.

### New clinical panel
**Gastroenterology / gastric-acid** — a stimulation test's net acid is the stimulated output minus
the basal output (`stimulated_output - basal_output`); the total mucosal buffer is the bicarbonate
secretion plus the mucus buffer (`bicarbonate + mucus_buffer`); the buffer index is
`(stimulated_output - basal_output) / (bicarbonate + mucus_buffer)`. Distinct from every used domain.

### Item family (5 mutually-confusable members)
| key | formula | role |
|---|---|---|
| `buffer_index` | `(stimulated-basal)/(bicarbonate+mucus)` | **gold** — difference over a sum |
| `net_acid` | `stimulated-basal` | **gold** — the numerator difference |
| `total_buffer` | `bicarbonate+mucus` | **gold** — the denominator sum |
| `pooled` | `(stimulated+basal)/(bicarbonate+mucus)` | distractor — SUM the numerator (`(a+b)/(c+d)`) |
| `crossed` | `(stimulated-basal)/(bicarbonate-mucus)` | distractor — DIFFERENCE the denominator (`(a-b)/(c-d)`) |

First three QUERIED as gold; all five always appear as options. Gold rotates A–E by index (`idx % 5`).

### Contamination safety
- Every formula built ONLY from the four observed quantities via `/`, `-`, `+` — **no numeric constants**.
- No acid / buffer / index figure ever appears as a literal (each computed).
- **Digit-free identifiers** (`stimulated_output`, `basal_output`, `bicarbonate`, `mucus_buffer`).
- 7 tables × 3 queried = **21 items**; `stimulated_output > basal_output` (net acid & buffer index positive) and
  `bicarbonate > mucus_buffer` (the difference-denominator distractor stays positive); the five family values
  asserted pairwise-distinct (`>1e-6`) at build.

### Verification
```
$ mise exec -- python3 -m pytest test_ladder_eval.py -k rung64 -q
3 passed, 303 deselected
```
(the compute test confirms the ADJ engine selects every gold via the CLI). Registered
`rung64_gastric_acid_buffer` in `SELF_CONTAINED_RUNGS`. Data-only change (offline generator +
generated `items.json` + one-line harness registration); no engine/harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
