### PR TITLE
feat(lang-full): E4-dyn foothold — first runtime (non-foldable) string matrix cell

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — `lang-aot`
 
+## 0.171.0 — 2026-07-03 — E4-dyn foothold: first runtime (non-foldable) string matrix cell
+
+First matrix proof of a **runtime** string (`code/specs/lang-full-e4-dyn-strings.md`):
+
+```basic
+10 INPUT N
+20 IF N > 0 THEN 50
+30 LET A$ = "LO"
+40 GOTO 60
+50 LET A$ = "HI"
+60 PRINT A$
+70 END
+```
+
+Because `N` is read at run time, *which* literal `A$` holds at line 60 is **not
+known at compile time** — `A$` is a genuinely dynamic string, unlike every prior
+E4 cell where the compiler folds the string to a constant. Stdin `1` → `N=1>0` →
+`A$="HI"` → prints `HI`.
+
+Tagged on the **four already-dynamic backends** (`Vm`, `Jit`, `Jvm`, `Clr`),
+which carry a reassigned-across-branches string slot natively (tagged value /
+`java.lang.String` / `System.String`). The four static backends
+(`NativeAot`/`Llvm`/`Wasm`) fold strings to compile-time constants and cannot yet
+represent this value; the E4-dyn backend PRs (E4d-2 LLVM → E4d-3 WASM → E4d-4
+native) extend **this cell's `backends` list** column-by-column as each lands its
+runtime heap-string lowering on the E4d-1 `__twig_str_*` helpers.
+
+This establishes the shared matrix cell the backend PRs prove themselves against
+— resolving the ordering constraint that a static-backend runtime-string lowering
+can't be matrix-proven until a frontend emits a non-foldable string.
+
 ## 0.170.0 — 2026-07-02 — AL-pow: ALGOL 60 exponentiation operator (all 7 backends)
 
 **New matrix proof cell** (`lang_matrix.rs`): ALGOL 60's `↑` exponentiation

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.170.0"
+version = "0.171.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.170.0 (AL-pow): ALGOL 60 exponentiation `10 + 2 ^ 5` = 42 (integer unroll) runs on all 7 backends.  v0.169.0 (AL-multidim-bounds): ALGOL 60 2D array with arbitrary/negative lower bounds.  v0.168.0 (BA-DIM-2D): Dartmouth BASIC 2D DIM array cell.  v0.167.0 (AL-multidim-3D): ALGOL 60 3D integer array cell."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.171.0 (E4-dyn foothold): first RUNTIME (non-foldable) string matrix cell — a BASIC branch-selected string (`INPUT N` picks `HI`/`LO`) proven on the 4 already-dynamic backends (Vm/Jit/Jvm/Clr); static backends extend it in E4d-2..4.  v0.170.0 (AL-pow): ALGOL 60 exponentiation.  v0.169.0 (AL-multidim-bounds): ALGOL 60 2D array with arbitrary/negative lower bounds."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -2280,6 +2280,28 @@ const PROGRAMS: &[Prog] = &[
         expect: Expect::Stdout("42"),
         backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
+    // Dartmouth BASIC — a *runtime (non-foldable) string* chosen by control flow
+    // (LANG-FULL E4-dyn foothold). `INPUT N` reads an integer at run time, so
+    // which string literal `A$` holds at line 60 — `"HI"` (N>0) or `"LO"` — is
+    // **not known at compile time**: `A$` is a genuinely dynamic string value,
+    // unlike every prior E4 cell where the compiler could fold the string to a
+    // constant. This is the first matrix proof of a runtime string, and it runs
+    // today on the four **already-dynamic** columns — VM/JIT (tagged value),
+    // JVM (`java.lang.String` local), CLR (`System.String` local) — which carry
+    // a reassigned-across-branches string slot natively. The four static
+    // backends (NativeAot/Llvm/Wasm) fold strings to compile-time constants and
+    // cannot yet represent this value; they are added column-by-column by the
+    // E4-dyn backend PRs (E4d-2 LLVM → E4d-3 WASM → E4d-4 native), each of which
+    // extends THIS cell's `backends` list once its runtime heap-string lowering
+    // (on the E4d-1 `__twig_str_*` helpers) lands. Stdin `1` → N=1>0 → `A$="HI"`
+    // → prints `HI`.
+    Prog {
+        lang: Language::DartmouthBasic,
+        ext: "bas",
+        src: "10 INPUT N\n20 IF N > 0 THEN 50\n30 LET A$ = \"LO\"\n40 GOTO 60\n50 LET A$ = \"HI\"\n60 PRINT A$\n70 END\n",
+        expect: Expect::Stdout("HI"),
+        backends: &[Jvm, Clr, Vm, Jit],
+    },
 ];
 
 /// Is a usable native linker present on this host? On Linux/macOS the AOT path uses
@@ -2351,6 +2373,8 @@ fn program_stdin(p: &Prog) -> &'static [u8] {
         (Language::DartmouthBasic, "10 INPUT X\n20 PRINT X\n30 END\n") => b"42\n",
         // BA-INPUT: two INPUTs — reads "10\n32\n", PRINT A + B ⇒ "42"
         (Language::DartmouthBasic, "10 INPUT A\n20 INPUT B\n30 PRINT A + B\n40 END\n") => b"10\n32\n",
+        // E4-dyn foothold: `INPUT N` = 1 (>0) selects the `"HI"` branch for `A$`.
+        (Language::DartmouthBasic, "10 INPUT N\n20 IF N > 0 THEN 50\n30 LET A$ = \"LO\"\n40 GOTO 60\n50 LET A$ = \"HI\"\n60 PRINT A$\n70 END\n") => b"1\n",
         _ => b"",
     }
 }

--- a/code/specs/lang-full-e4-dyn-strings.md
+++ b/code/specs/lang-full-e4-dyn-strings.md
@@ -149,15 +149,30 @@ two literals still folds), so nothing regresses; the runtime path is what's new.
    (The VM/JIT already execute runtime `str_concat` over registers — e.g. BASIC
    variable concat — so those semantics were already proven; this PR is the
    static-backend substrate.) *(blocks 2–5)*
-2. **E4d-2 — LLVM runtime strings.** Relax the `iir-to-llvm` validator; lower
-   non-literal `str_concat`/`str_slice`/`str_index`/`str_len`/`str_cmp`/`print_str`
-   to the heap-block helpers + guarded loads. Matrix cell adds `Llvm`. *(needs 1)*
+1a. **E4d-foothold — first runtime-string matrix cell.** ✅ **Landed**
+   (`lang-aot` 0.171.0). A BASIC branch-selected string (`INPUT N` picks
+   `"HI"`/`"LO"`, so the value is non-foldable) proven on the **four
+   already-dynamic backends** `Vm`/`Jit`/`Jvm`/`Clr`. **This is the shared cell
+   the backend PRs below extend** — it resolves the ordering constraint that a
+   static-backend runtime-string lowering can't be matrix-proven until a frontend
+   emits a non-foldable string. (Discovered during E4d-2 scoping: iir-to-llvm
+   string support is pure compile-time literal folding, and no frontend emitted a
+   runtime string to the static columns, so those columns had nothing to prove
+   against. The foothold supplies it.)
+2. **E4d-2 — LLVM runtime strings.** Relax the `iir-to-llvm` validator so a
+   `str`-typed **register** (not just `Operand::Str`) is legal; give each str
+   slot a runtime path (when it carries no compile-time `str_values`/`str_lens`
+   metadata) that lowers `str_concat`/`str_slice`/`str_index`/`str_len`/`str_cmp`/
+   `print_str` to the E4d-1 `__twig_str_*` helpers + guarded loads over the
+   `[i64 len][i8]` block (mirror how the file lowers E5 `array_*`). Keep literal
+   folding as the fast path. **Extend the E4d-foothold cell's `backends` with
+   `Llvm`.** *(needs 1, 1a)*
 3. **E4d-3 — WASM runtime strings.** Same for `iir-to-wasm`, inlined over linear
-   memory (mirror E5 `array_*`). Matrix cell adds `Wasm`. *(needs 1)*
+   memory (mirror E5 `array_*`). Extend the foothold cell with `Wasm`. *(needs 1, 1a)*
 4. **E4d-4 — native runtime strings.** `aarch64-backend` + `x86_64-backend` lower
    the ops to `__twig_alloc_bytes` blocks + `bl/call` helpers + `udf/ud2` bounds
-   traps (mirror E5 arrays). Run-verify aarch64 locally + x86_64 on CI. Matrix
-   cell reaches **all 7 backends**. *(needs 1)*
+   traps (mirror E5 arrays). Run-verify aarch64 locally + x86_64 on CI. Extend the
+   foothold cell with `NativeAot` → **all 7 backends**. *(needs 1, 1a)*
 5. **Frontend payoffs** *(each needs 1–4 for the backends it targets)*:
    - **E4d-AL — ALGOL string procedures.** Lift the `string procedures`
      `Unsupported` (algol-iir-compiler:886): a `string procedure` returns a


### PR DESCRIPTION
## Summary

The first matrix proof of a **runtime string** for the E4-dyn arc (design
#7516). Establishes the shared cell the backend PRs (E4d-2…4) prove themselves
against.

```basic
10 INPUT N
20 IF N > 0 THEN 50
30 LET A$ = "LO"
40 GOTO 60
50 LET A$ = "HI"
60 PRINT A$
70 END
```

Because `N` is read at run time, **which** literal `A$` holds at line 60 is *not
known at compile time* — `A$` is a genuinely dynamic string, unlike every prior
E4 cell where the compiler folds the string to a constant. Stdin `1` → `N=1>0` →
`A$="HI"` → prints `HI`.

Tagged on the **four already-dynamic backends** (`Vm`, `Jit`, `Jvm`, `Clr`),
which carry a reassigned-across-branches string slot natively (tagged value /
`java.lang.String` / `System.String`). The four static backends
(`NativeAot`/`Llvm`/`Wasm`) fold strings to compile-time constants and cannot yet
represent this value; the E4-dyn backend PRs extend **this cell's `backends`
list** column-by-column as each lands its runtime heap-string lowering on the
E4d-1 `__twig_str_*` helpers (merged #7526).

## Why this PR exists (a sequencing finding)

Scoping E4d-2 (LLVM) revealed that iir-to-llvm string support is **pure
compile-time literal folding**, and **no frontend emitted a non-foldable string
to the static columns** — so a static-backend runtime-string lowering had nothing
to be matrix-proven against. This foothold supplies that proof on the already-dynamic
backends, so each subsequent backend PR is a clean, self-proving "add my column"
change. (Design spec §5 updated with the reordering.)

## Verification
- `cargo test -p lang-aot --test lang_matrix proven_columns_do_not_silently_skip` — pass (Vm/Jit, always present, genuinely run it → `HI`; JVM/CLR run where the toolchain is installed)
- `cargo test -p lang-aot --test lang_matrix matrix_every_proven_cell_agrees` — pass
- **Security review passed** (test-only + docs).

Test-only + docs; `lang-aot` 0.171.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)