### PR TITLE
feat(adj-lang): constrain asciimath "…" — second frontend reaches the constraint surface

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -32,6 +32,7 @@ statement   = prior_decl
             | let_decl
             | symbol_decl
             | constrain_latex_decl
+            | constrain_asciimath_decl
             | constrain_decl
             | solve_decl
             | check_decl
@@ -208,9 +209,21 @@ symbol_decl    = "symbol" IDENT COLON term ;
 
 constrain_latex_decl = "constrain" latex_relation ;
 
+# The AsciiMath counterpart of `constrain_latex_decl`. A model that writes its
+# equations in AsciiMath (`x^2 = 4`, `a <= b`) may state the constraint in that
+# surface: `constrain asciimath "x^2 = 4"`. The adapter parses the string with
+# the SAME AsciiMath `MathFrontend` already used for `asciimath "..."` factors,
+# yielding the neutral `MathExpr::Rel(op, lhs, rhs)`, and lowers both sides
+# through the EXACT `latex_math_to_expr_ast` lowering `constrain latex` uses — so
+# the two constraint surfaces are one code path with one frontend swapped, no new
+# tree-walker and no new relation semantics.
+constrain_asciimath_decl = "constrain" asciimath_relation ;
+
 constrain_decl = "constrain" expr relop expr ;
 
 latex_relation = "latex" STRING ;
+
+asciimath_relation = "asciimath" STRING ;
 
 relop          = GE | LE | GT | LT | EQEQ | EQUALS | NE ;
 

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.49.0] - 2026-07-03 — `constrain asciimath "…"` — a second frontend reaches the constraint surface
+
+### Added
+
+- **`constrain asciimath "<relation>"`** is now accepted anywhere `constrain latex "…"` is. Until now
+  only the LaTeX surface could state a *constraint* (`constrain latex "x^2 = 4"`); a model that writes
+  its equations in AsciiMath had to fall back to the bare `constrain <expr> <relop> <expr>` form. Now
+  the AsciiMath relation surface reaches the constraint sublanguage too: `constrain asciimath "x^2 = 4"`
+  and inequalities like `constrain asciimath "a <= b"` lower to a `Statement::Constrain` and feed the
+  solver (`solve for { … }` / `check`) exactly as the LaTeX form does.
+- **One code path, one frontend swapped.** The new `adapt_constrain_asciimath` is a verbatim mirror of
+  `adapt_constrain_latex` — it parses the string with the SAME AsciiMath `MathFrontend` already used for
+  `asciimath "…"` expression factors (`parse_asciimath_math`), yielding the neutral
+  `MathExpr::Rel(op, lhs, rhs)`, then lowers the operator through the SAME `lower_latex_relop` and both
+  sides through the SAME `latex_math_to_expr_ast`. So `x^2` becomes the identical single
+  `ComputeOp::Pow` node the LaTeX surface produces — no new relation semantics, **no new tree-walker**,
+  and therefore no new stack-overflow/DoS surface (the AsciiMath crate owns its own `MAX_DEPTH`
+  discipline and `#![forbid(unsafe_code)]`).
+- New grammar productions `constrain_asciimath_decl = "constrain" asciimath_relation ;` and
+  `asciimath_relation = "asciimath" STRING ;` (regenerated `_parser_grammar.rs`; no new tokens, so
+  `_lexer_grammar.rs` is unchanged). Unsupported/non-relation AsciiMath still surfaces via the shared
+  `AdapterError::UnsupportedLatexMath`.
+- Two new e2e tests: `native_asciimath_relation_lowers_to_constraint` (equality → `ComputeOp::Pow`
+  quadratic) and `native_asciimath_inequality_relation_lowers` (`a <= b` → `RelOp::Le`).
+
 ## [0.48.0] - 2026-07-03 — a FOURTH math frontend: `unicodemath "…"` — PFE01 quartet complete
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -34,6 +34,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"let_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"symbol_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"constrain_latex_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"constrain_asciimath_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"constrain_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"solve_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"check_decl"#.to_string() },
@@ -55,7 +56,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 51,
+            line_number: 52,
         },
         GrammarRule {
             name: r#"contributes_decl"#.to_string(),
@@ -68,7 +69,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 53,
+            line_number: 54,
         },
         GrammarRule {
             name: r#"evidence"#.to_string(),
@@ -76,7 +77,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 64,
+            line_number: 65,
         },
         GrammarRule {
             name: r#"predicate"#.to_string(),
@@ -91,7 +92,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 66,
+            line_number: 67,
         },
         GrammarRule {
             name: r#"interacts_decl"#.to_string(),
@@ -110,7 +111,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 68,
+            line_number: 69,
         },
         GrammarRule {
             name: r#"uncertain_decl"#.to_string(),
@@ -127,7 +128,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 70,
+            line_number: 71,
         },
         GrammarRule {
             name: r#"observe_decl"#.to_string(),
@@ -135,7 +136,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 72,
+            line_number: 73,
         },
         GrammarRule {
             name: r#"relate_decl"#.to_string(),
@@ -144,7 +145,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 85,
+            line_number: 86,
         },
         GrammarRule {
             name: r#"rule_decl"#.to_string(),
@@ -174,7 +175,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 107,
+            line_number: 108,
         },
         GrammarRule {
             name: r#"body_literal"#.to_string(),
@@ -182,7 +183,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 109,
+            line_number: 110,
         },
         GrammarRule {
             name: r#"context_order_decl"#.to_string(),
@@ -200,7 +201,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 120,
+            line_number: 121,
         },
         GrammarRule {
             name: r#"functional_decl"#.to_string(),
@@ -208,7 +209,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"functional"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 131,
+            line_number: 132,
         },
         GrammarRule {
             name: r#"query_decl"#.to_string(),
@@ -216,7 +217,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 133,
+            line_number: 134,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -226,7 +227,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 147,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -240,7 +241,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 149,
+            line_number: 150,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -254,7 +255,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 151,
+            line_number: 152,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -272,7 +273,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 153,
+            line_number: 154,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -288,7 +289,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 155,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"latex_expr"#.to_string(),
@@ -296,7 +297,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 162,
+            line_number: 163,
         },
         GrammarRule {
             name: r#"asciimath_expr"#.to_string(),
@@ -304,7 +305,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 173,
+            line_number: 174,
         },
         GrammarRule {
             name: r#"mathml_expr"#.to_string(),
@@ -312,7 +313,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"mathml"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 185,
+            line_number: 186,
         },
         GrammarRule {
             name: r#"unicodemath_expr"#.to_string(),
@@ -320,7 +321,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"unicodemath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 197,
+            line_number: 198,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -330,7 +331,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 207,
+            line_number: 208,
         },
         GrammarRule {
             name: r#"constrain_latex_decl"#.to_string(),
@@ -338,7 +339,15 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
             ] },
-            line_number: 209,
+            line_number: 210,
+        },
+        GrammarRule {
+            name: r#"constrain_asciimath_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"constrain"#.to_string() },
+                GrammarElement::RuleReference { name: r#"asciimath_relation"#.to_string() },
+            ] },
+            line_number: 220,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -348,7 +357,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 211,
+            line_number: 222,
         },
         GrammarRule {
             name: r#"latex_relation"#.to_string(),
@@ -356,7 +365,15 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 213,
+            line_number: 224,
+        },
+        GrammarRule {
+            name: r#"asciimath_relation"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"asciimath"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 226,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -369,7 +386,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 215,
+            line_number: 228,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -384,12 +401,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 217,
+            line_number: 230,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 219,
+            line_number: 232,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -400,7 +417,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 226,
+            line_number: 239,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -411,7 +428,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 238,
+            line_number: 251,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -422,7 +439,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 240,
+            line_number: 253,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -450,7 +467,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 242,
+            line_number: 255,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -462,7 +479,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 248,
+            line_number: 261,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -473,7 +490,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 265,
+            line_number: 278,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -481,7 +498,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 267,
+            line_number: 280,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -489,7 +506,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 283,
+            line_number: 296,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -499,7 +516,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
             ] },
-            line_number: 295,
+            line_number: 308,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -507,7 +524,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 301,
+            line_number: 314,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -515,7 +532,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 302,
+            line_number: 315,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -523,7 +540,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 303,
+            line_number: 316,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -533,7 +550,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 304,
+            line_number: 317,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -544,7 +561,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 306,
+            line_number: 319,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -568,7 +585,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 328,
+            line_number: 341,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -147,6 +147,7 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "let_decl" => adapt_let(child),
         "symbol_decl" => adapt_symbol(child),
         "constrain_latex_decl" => adapt_constrain_latex(child),
+        "constrain_asciimath_decl" => adapt_constrain_asciimath(child),
         "constrain_decl" => adapt_constrain(child),
         "solve_decl" => adapt_solve(child),
         "check_decl" => Ok(Statement::Check),
@@ -157,7 +158,7 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "use_decl" => adapt_use(child),
         "import_decl" => adapt_import(child),
         other => Err(AdapterError::UnexpectedRule {
-            expected: "one of prior_decl / contributes_decl / interacts_decl / uncertain_decl / observe_decl / query_decl / let_decl / symbol_decl / constrain_latex_decl / constrain_decl / solve_decl / check_decl / optimize_decl / dictionary_decl / define_decl / rulebook_decl / use_decl / import_decl",
+            expected: "one of prior_decl / contributes_decl / interacts_decl / uncertain_decl / observe_decl / query_decl / let_decl / symbol_decl / constrain_latex_decl / constrain_asciimath_decl / constrain_decl / solve_decl / check_decl / optimize_decl / dictionary_decl / define_decl / rulebook_decl / use_decl / import_decl",
             actual: other.to_string(),
         }),
     }
@@ -542,6 +543,38 @@ fn adapt_constrain_latex(node: &GrammarASTNode) -> Result<Statement, AdapterErro
         return Err(AdapterError::UnsupportedLatexMath {
             source,
             detail: "expected a LaTeX relation such as x^2 = 4".into(),
+        });
+    };
+    let op = lower_latex_relop(*op, &source)?;
+    Ok(Statement::Constrain {
+        lhs: latex_math_to_expr_ast(lhs, &source)?,
+        op,
+        rhs: latex_math_to_expr_ast(rhs, &source)?,
+    })
+}
+
+/// Lower `constrain asciimath "x^2 = 4"` to a `Statement::Constrain`.
+///
+/// This is the exact mirror of [`adapt_constrain_latex`]: the ONLY difference is
+/// which frontend parses the string. The AsciiMath frontend yields the SAME
+/// neutral `MathExpr::Rel(op, lhs, rhs)`, so the relation operator lowers through
+/// the same `lower_latex_relop` and both sides through the same
+/// `latex_math_to_expr_ast` used by every other math surface. No new relation
+/// semantics, no new tree-walker — one constraint code path, one frontend swap.
+fn adapt_constrain_asciimath(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // constrain_asciimath_decl = "constrain" asciimath_relation
+    // asciimath_relation = "asciimath" STRING
+    let relation =
+        first_named_child(node, "asciimath_relation").ok_or(AdapterError::MissingChild {
+            rule: "constrain_asciimath_decl".into(),
+            position: "asciimath relation",
+        })?;
+    let source = latex_string_from_node(relation, "asciimath_relation")?;
+    let math = parse_asciimath_math(&source)?;
+    let MathExpr::Rel(op, lhs, rhs) = &math else {
+        return Err(AdapterError::UnsupportedLatexMath {
+            source,
+            detail: "expected an AsciiMath relation such as x^2 = 4".into(),
         });
     };
     let op = lower_latex_relop(*op, &source)?;

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1932,6 +1932,38 @@ contributes 1000000 from answer == 60 to correct
     }
 
     #[test]
+    fn native_asciimath_relation_lowers_to_constraint() {
+        // `constrain asciimath "x^2 = 4"` lowers through the SAME path as
+        // `constrain latex`: the AsciiMath frontend yields MathExpr::Rel(Eq, ..),
+        // the operator lowers via lower_latex_relop, and both sides via
+        // latex_math_to_expr_ast — so `x^2` becomes the same single ComputeOp::Pow
+        // node the LaTeX surface produces (proving the two constraint surfaces are
+        // one code path with the frontend swapped).
+        let lowered =
+            compile("symbol x : scalar\nconstrain asciimath \"x^2 = 4\"\nsolve for { x }\n")
+                .unwrap();
+        let c = &lowered.constraints.constraints[0];
+        assert_eq!(c.op, crate::ast::RelOp::Eq);
+        assert!(matches!(
+            c.lhs,
+            logic_engine::ComputeExpr::Bin(logic_engine::ComputeOp::Pow, _, _)
+        ));
+    }
+
+    #[test]
+    fn native_asciimath_inequality_relation_lowers() {
+        // A non-equality AsciiMath relation (`a <= b`) lowers to the matching
+        // engine RelOp, confirming lower_latex_relop is reused verbatim — the
+        // AsciiMath surface is not limited to equalities.
+        let lowered = compile(
+            "symbol a : scalar\nsymbol b : scalar\nconstrain asciimath \"a <= b\"\ncheck\n",
+        )
+        .unwrap();
+        let c = &lowered.constraints.constraints[0];
+        assert_eq!(c.op, crate::ast::RelOp::Le);
+    }
+
+    #[test]
     fn native_latex_power_computes_as_one_node_without_the_old_cap() {
         // `x^{10}` used to be rejected (expansion capped at exponent 8); it now
         // lowers to a single ComputeOp::Pow node and computes: 2^10 = 1024.


### PR DESCRIPTION
## adj-lang: `constrain asciimath "…"` — a second frontend reaches the constraint surface (PFE01)

The PFE01 **expression** quartet is complete: `latex`, `asciimath`, `mathml`, and `unicodemath` all
compute through the same neutral `MathExpr → ExprAst` lowering as arithmetic factors. But only **one**
of those surfaces — LaTeX — could state a *constraint* (`constrain latex "x^2 = 4"`). This PR extends
the **constraint/relation position** to a second frontend, so AsciiMath authors are no longer forced
back to the bare `constrain <expr> <relop> <expr>` form.

### What's added
`constrain asciimath "<relation>"` is now accepted anywhere `constrain latex "…"` is:

```
symbol x : scalar
constrain asciimath "x^2 = 4"
solve for { x }
```

and inequalities lower too: `constrain asciimath "a <= b"` → `check`.

### One code path, one frontend swapped
`adapt_constrain_asciimath` is a **verbatim mirror** of `adapt_constrain_latex`. The only
frontend-specific step is the parse call: it uses the SAME AsciiMath `MathFrontend`
(`parse_asciimath_math`) already used for `asciimath "…"` expression factors, which yields the neutral
`MathExpr::Rel(op, lhs, rhs)`. From there it reuses:
- `lower_latex_relop` — the exact operator lowering `constrain latex` uses (so `=`, `<=`, `>=`, `!=`, … all work), and
- `latex_math_to_expr_ast` — the exact side lowering, so `x^2` becomes the identical single
  `ComputeOp::Pow` node the LaTeX surface produces (the constraint solver's polynomial path reads it as
  a quadratic unchanged).

No new relation semantics, **no new tree-walker**.

### Grammar
```
constrain_asciimath_decl = "constrain" asciimath_relation ;
asciimath_relation       = "asciimath" STRING ;
```
Added to the decl alternation and regenerated (`_parser_grammar.rs`). No new tokens
(`constrain` / `asciimath` / `STRING` already exist), so `_lexer_grammar.rs` is unchanged. This mirrors
the proven `constrain_latex_decl` disambiguation — a lone frontend string with no `relop` cannot match
`constrain_decl`, so there is no ambiguity.

### Security
No new DoS surface: the adapter adds no recursion — it delegates parsing to the AsciiMath crate, which
is `#![forbid(unsafe_code)]` and charges a `MAX_DEPTH = 64` guard per nesting level (adversarial nesting
returns a spanned error, not a stack overflow). Non-relation AsciiMath surfaces the shared
`AdapterError::UnsupportedLatexMath`. Reviewed inline; PASSED.

### Verification
```
cargo test -p adj-lang -p adj-lang-cli -p adj-constraint-solver -p logic-engine   # all green
```
New e2e tests: `native_asciimath_relation_lowers_to_constraint` (equality → `ComputeOp::Pow`) and
`native_asciimath_inequality_relation_lowers` (`a <= b` → `RelOp::Le`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
