### PR TITLE
fix(ruby-sir): sequential local assignment (x = a where a is an earlier local)

### DIFF
--- a/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/ruby-to-semantic-ir/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the `ruby-to-semantic-ir` crate will be documented in this file.
 
+## [0.6.3] - 2026-07-03
+
+### Fixed (FC — sequential local assignments: `x = a` where `a` is an earlier local)
+
+Ruby assignments are SEQUENTIAL (`let*`): `a = 5; b = a + 1` binds `b` using
+`a`'s value. The frontend, however, lowered every first-sighting `name = value`
+to a PARALLEL `Stmt::LetBinding`, and the SIR validator treats a *run* of
+consecutive `LetBinding`s as one parallel-`let` group — every RHS is evaluated
+BEFORE any of the run's names are bound. So `[LetBinding(a); LetBinding(b = a+1)]`
+was rejected with `var-ref scope=local references unknown name 'a'`: any
+`newvar = <expr reading an earlier local>` (`x = a`, `b = a + 1`, `v = h["k"]`,
+destructuring `a, b = arr`, `y = obj.meth`, `y = -x`, a hash/heredoc reading a
+prior local, …) failed to compile on EVERY backend. Discovered while
+investigating the array-index conformance gap.
+
+- New `sequentialize_let_bindings` post-pass: after a block's statements are
+  lowered, a `LetBinding` whose value reads a name bound by an EARLIER statement
+  in the block is rewritten to a `LetStarBinding` (identical fields). `let*` is
+  sequential — the validator binds its name immediately and it breaks the
+  parallel run — so the reference resolves. Independent bindings (`i = 0;
+  sum = 0`) keep `LetBinding`, so nothing else changes. Both variants lower to
+  the same sequential variable declaration on every backend, so the rewrite is
+  behaviour-preserving.
+- Applied at every sequential body: program (main), `if`/`unless`/`case` branch
+  bodies, method (`def`) bodies, and block/lambda bodies.
+- Shape tests that asserted the buggy `LetBinding` form for such programs updated
+  to accept either variant (via new `binding_name`/`binding_value` test helpers);
+  verified end-to-end by the sir-conformance `seq_assign` program.
+
+NOTE: array/hash *index reads* themselves (`a[1]`, `h["k"]`) remain a separate,
+open Ruby-frontend PARSER-precedence gap — `a[1]` still mis-parses as `a` + a
+bare `[1]` array literal; only the assignment-scoping half is fixed here.
+
 ## [0.6.2] - 2026-07-02
 
 ### Added (FC — implicit return of a trailing `case` from a method body)

--- a/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/ruby-to-semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruby-to-semantic-ir"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Ruby AST → narrow-waist Semantic IR. Phase 5 of the Ruby parser project — first frontend for the ruby-parser → SIR pipeline."
 

--- a/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lib.rs
@@ -76,6 +76,27 @@ mod tests {
         &f.body
     }
 
+    /// Name bound by a first-sighting assignment — a `LetBinding` (parallel
+    /// `let`) OR a `LetStarBinding` (sequential `let*`).  The frontend emits
+    /// `let*` when the RHS reads an earlier local in the same block (Ruby
+    /// assignments are sequential); both are "a binding" for shape assertions.
+    fn binding_name(s: &Stmt) -> Option<&str> {
+        match s {
+            Stmt::LetBinding { name, .. } | Stmt::LetStarBinding { name, .. } => {
+                Some(name.as_str())
+            }
+            _ => None,
+        }
+    }
+
+    /// The RHS value of a `LetBinding` / `LetStarBinding` (see [`binding_name`]).
+    fn binding_value(s: &Stmt) -> Option<&Expr> {
+        match s {
+            Stmt::LetBinding { value, .. } | Stmt::LetStarBinding { value, .. } => Some(value),
+            _ => None,
+        }
+    }
+
     // -----------------------------------------------------------------
     // Phase P7 (Ruby 1.0) — default / optional parameters.
     //
@@ -487,17 +508,11 @@ mod tests {
         let m = lower("x = 1\ny = 2\nz = x + y\n");
         let b = main_body(&m);
         assert_eq!(b.stmts.len(), 3);
-        let names: Vec<&str> = b
-            .stmts
-            .iter()
-            .filter_map(|s| match s {
-                Stmt::LetBinding { name, .. } => Some(name.as_str()),
-                _ => None,
-            })
-            .collect();
+        let names: Vec<&str> = b.stmts.iter().filter_map(binding_name).collect();
         assert_eq!(names, vec!["x", "y", "z"]);
-        // The third RHS references x and y as locals.
-        if let Stmt::LetBinding { value, .. } = &b.stmts[2] {
+        // The third RHS references x and y as locals, so it is a sequential
+        // `LetStarBinding` (`let*`), not a parallel `LetBinding`.
+        if let Some(value) = binding_value(&b.stmts[2]) {
             match value {
                 Expr::BuiltinCall { name, args, .. } => {
                     assert_eq!(name, "+");
@@ -2804,7 +2819,8 @@ mod tests {
         let m = lower("x = 1\ny = -x\n");
         let b = main_body(&m);
         match &b.stmts[1] {
-            Stmt::LetBinding { value: Expr::BuiltinCall { name, args, .. }, .. } => {
+            Stmt::LetBinding { value: Expr::BuiltinCall { name, args, .. }, .. }
+            | Stmt::LetStarBinding { value: Expr::BuiltinCall { name, args, .. }, .. } => {
                 assert_eq!(name, "neg");
                 assert!(matches!(
                     &args[0],
@@ -2902,7 +2918,7 @@ mod tests {
         let b = main_body(&m);
         // Second stmt = `x = foo.bar`
         match &b.stmts[1] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "x");
                 match value {
                     Expr::BuiltinCall { name, args, .. } => {
@@ -2930,7 +2946,7 @@ mod tests {
         let m = lower("foo = 1\ny = foo.bar.baz\n");
         let b = main_body(&m);
         let value = match &b.stmts[1] {
-            Stmt::LetBinding { value, .. } => value,
+            Stmt::LetBinding { value, .. } | Stmt::LetStarBinding { value, .. } => value,
             other => panic!("expected LetBinding, got {:?}", other),
         };
         match value {
@@ -2966,7 +2982,7 @@ mod tests {
         let m = lower("obj = 1\nr = obj.add(1, 2)\n");
         let b = main_body(&m);
         let value = match &b.stmts[1] {
-            Stmt::LetBinding { value, .. } => value,
+            Stmt::LetBinding { value, .. } | Stmt::LetStarBinding { value, .. } => value,
             other => panic!("expected LetBinding, got {:?}", other),
         };
         match value {
@@ -4468,7 +4484,7 @@ mod tests {
         );
         // Stmt[3] binds `a` to temp 0 (= IntLit 1).
         match &body.stmts[3] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "a");
                 assert!(
                     matches!(value, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
@@ -4480,7 +4496,7 @@ mod tests {
         }
         // Stmt[4] binds `b` to SeqLit of temps 1..3.
         match &body.stmts[4] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "b");
                 match value {
                     Expr::SeqLit { items, .. } => {
@@ -4508,7 +4524,7 @@ mod tests {
         assert_eq!(body.stmts.len(), 5);
         // Stmt[3] binds `a` to SeqLit of temps 0..2.
         match &body.stmts[3] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "a");
                 match value {
                     Expr::SeqLit { items, .. } => {
@@ -4521,7 +4537,7 @@ mod tests {
         }
         // Stmt[4] binds `b` to temp 2 (the last temp).
         match &body.stmts[4] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "b");
                 assert!(
                     matches!(value, Expr::VarRef { name: n, .. } if n.starts_with("__multi_assign_t")),
@@ -4539,10 +4555,10 @@ mod tests {
         // 4 temps + 3 LHS bindings = 7 stmts.
         assert_eq!(body.stmts.len(), 7);
         // Stmt[4] binds `a` to temp 0.
-        assert!(matches!(&body.stmts[4], Stmt::LetBinding { name, .. } if name == "a"));
+        assert!(matches!(&body.stmts[4], Stmt::LetBinding { name, .. } | Stmt::LetStarBinding { name, .. } if name == "a"));
         // Stmt[5] binds `b` to SeqLit of 2 items (the middle 2 temps).
         match &body.stmts[5] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "b");
                 match value {
                     Expr::SeqLit { items, .. } => assert_eq!(items.len(), 2),
@@ -4552,7 +4568,7 @@ mod tests {
             other => panic!("expected LetBinding(b, SeqLit), got {:?}", other),
         }
         // Stmt[6] binds `c` to the last temp.
-        assert!(matches!(&body.stmts[6], Stmt::LetBinding { name, .. } if name == "c"));
+        assert!(matches!(&body.stmts[6], Stmt::LetBinding { name, .. } | Stmt::LetStarBinding { name, .. } if name == "c"));
     }
 
     #[test]
@@ -4648,7 +4664,7 @@ mod tests {
         }
         // Stmt[2] binds `a` to `temp[0]`.
         match &body.stmts[2] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "a");
                 match value {
                     Expr::SeqIndex { seq, index, .. } => {
@@ -4672,7 +4688,7 @@ mod tests {
         }
         // Stmt[3] binds `b` to `temp[1]`.
         match &body.stmts[3] {
-            Stmt::LetBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 assert_eq!(name, "b");
                 match value {
                     Expr::SeqIndex { index, .. } => assert!(
@@ -4698,7 +4714,8 @@ mod tests {
         for (i, expected) in expected_indices.iter().enumerate() {
             // body.stmts[i + 2] is the i-th LHS binding.
             match &body.stmts[i + 2] {
-                Stmt::LetBinding { value: Expr::SeqIndex { index, .. }, .. } => {
+                Stmt::LetBinding { value: Expr::SeqIndex { index, .. }, .. }
+                | Stmt::LetStarBinding { value: Expr::SeqIndex { index, .. }, .. } => {
                     match index.as_ref() {
                         Expr::IntLit { value: v, .. } => assert_eq!(
                             v, expected,
@@ -4739,7 +4756,8 @@ mod tests {
             other => panic!("expected LetStarBinding(temp, rhs), got {:?}", other),
         }
         for i in 1..=2 {
-            if let Stmt::LetBinding { value: Expr::SeqIndex { seq, .. }, .. } =
+            if let Stmt::LetBinding { value: Expr::SeqIndex { seq, .. }, .. }
+            | Stmt::LetStarBinding { value: Expr::SeqIndex { seq, .. }, .. } =
                 &body.stmts[i]
             {
                 assert!(
@@ -4799,7 +4817,9 @@ mod tests {
             other => panic!("expected Assign(a, ...) for re-bind, got {:?}", other),
         }
         match &body.stmts[4] {
-            Stmt::LetBinding { name, .. } => assert_eq!(name, "b"),
+            Stmt::LetBinding { name, .. } | Stmt::LetStarBinding { name, .. } => {
+                assert_eq!(name, "b")
+            }
             other => panic!("expected LetBinding(b, ...) for first-sighting, got {:?}", other),
         }
         assert!(
@@ -7180,7 +7200,11 @@ b = "y"
         let b = main_body(&m);
         // stmts[0] binds `name`; stmts[1] binds `y` to the heredoc.
         let value = match &b.stmts[1] {
-            Stmt::LetBinding { name, value, .. } if name == "y" => value,
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. }
+                if name == "y" =>
+            {
+                value
+            }
             other => panic!("expected LetBinding y, got {:?}", other),
         };
         match value {
@@ -7802,7 +7826,11 @@ b = "y"
         let m = lower("x = 1\ny = defined?(x)\n");
         let b = main_body(&m);
         let value = match &b.stmts[1] {
-            Stmt::LetBinding { name, value, .. } if name == "y" => value,
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. }
+                if name == "y" =>
+            {
+                value
+            }
             other => panic!("expected LetBinding y, got {:?}", other),
         };
         match value {
@@ -8567,6 +8595,7 @@ b = "y"
             .iter()
             .find_map(|s| match s {
                 Stmt::LetBinding { name: n, value: Expr::MapLit { entries, .. }, .. }
+                | Stmt::LetStarBinding { name: n, value: Expr::MapLit { entries, .. }, .. }
                     if n == "h" =>
                 {
                     Some(entries)
@@ -8635,6 +8664,7 @@ b = "y"
             .iter()
             .find_map(|s| match s {
                 Stmt::LetBinding { name: n, value: Expr::MapLit { entries, .. }, .. }
+                | Stmt::LetStarBinding { name: n, value: Expr::MapLit { entries, .. }, .. }
                     if n == "h" =>
                 {
                     Some(entries)

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -397,6 +397,62 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
     false
 }
 
+/// Phase FC — restore **sequential** (`let*`) semantics for Ruby local
+/// assignments whose RHS reads an earlier local in the same block.
+///
+/// Ruby evaluates statements top-to-bottom, so `a = 5; x = a` binds `x` to
+/// `a`'s value — assignments are sequential.  The frontend, however, lowers
+/// each first-sighting `name = value` to a **parallel** [`Stmt::LetBinding`],
+/// and the SIR validator treats a *run* of consecutive `LetBinding`s as one
+/// parallel-`let` group: every RHS is evaluated in the scope BEFORE any of the
+/// run's names are bound (see `validator::check_stmt_seq`).  That makes
+/// `[LetBinding(a); LetBinding(x = a)]` reject the read of `a`
+/// (`var-ref ... unknown name 'a'`) — a real bug: `x = a`, `y = h["k"]`, and
+/// any `newvar = <expr using an earlier local>` fail to compile.
+///
+/// This post-pass walks a block's statements and rewrites a `LetBinding` to a
+/// [`Stmt::LetStarBinding`] (identical fields) exactly when its `value` reads a
+/// name already bound by an EARLIER statement in the block.  `LetStarBinding`
+/// is sequential — the validator adds its name immediately and it *breaks the
+/// parallel run* — so the reference resolves.  Independent bindings (the common
+/// case, e.g. `i = 0; sum = 0`) keep their `LetBinding` form, so nothing else
+/// changes and existing shape-tests still hold.  Both variants lower to the
+/// same target code (a sequential variable declaration) on every backend, so
+/// the rewrite is behaviour-preserving.
+fn sequentialize_let_bindings(stmts: &mut [Stmt]) {
+    let mut bound: HashSet<String> = HashSet::new();
+    for s in stmts.iter_mut() {
+        // Decide before mutating: does THIS `LetBinding` read an earlier local?
+        let convert = matches!(
+            s,
+            Stmt::LetBinding { value, .. } if expr_references_any_name(value, &bound)
+        );
+        if convert {
+            // Swap the variant in place, preserving every field.  The dummy is
+            // overwritten on the very next line, so it is never observed.
+            let taken = std::mem::replace(
+                s,
+                Stmt::ExprStmt {
+                    expr: Expr::NilLit { span: Span::synthetic() },
+                    span: Span::synthetic(),
+                },
+            );
+            if let Stmt::LetBinding { name, sir_type, value, span } = taken {
+                *s = Stmt::LetStarBinding { name, sir_type, value, span };
+            }
+        }
+        // Record the name this statement binds, so later statements see it.
+        match s {
+            Stmt::LetBinding { name, .. }
+            | Stmt::LetStarBinding { name, .. }
+            | Stmt::Assign { name, .. } => {
+                bound.insert(name.clone());
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Phase 19a (FC) — if `value` is a verbatim regex-literal lexeme
 /// (`/pattern/flags`), split it into `(pattern, flags)`; otherwise
 /// `None`.
@@ -808,6 +864,9 @@ impl Lowerer {
         }
 
         let value = value.unwrap_or(Expr::NilLit { span: self.span_of(program) });
+        // Ruby assignments are sequential: rewrite any `LetBinding` whose RHS
+        // reads an earlier local to a `LetStarBinding` (see the fn's doc).
+        sequentialize_let_bindings(&mut stmts_out);
         Ok(Block {
             stmts: stmts_out,
             value,
@@ -1394,6 +1453,8 @@ impl Lowerer {
         let value = value.unwrap_or(Expr::NilLit { span: self.span_of(node) });
         // Restore the outer scope's declared locals.
         self.declared_locals = saved_locals;
+        // Sequential-assignment fix-up (see `sequentialize_let_bindings`).
+        sequentialize_let_bindings(&mut stmts_out);
         Ok(Block {
             stmts: stmts_out,
             value,
@@ -4748,7 +4809,7 @@ impl Lowerer {
                 if n.rule_name == "rescue_clause" || n.rule_name == "ensure_clause")
         });
 
-        let (stmts_out, value): (Vec<Stmt>, Expr) = if has_exception_clauses {
+        let (mut stmts_out, value): (Vec<Stmt>, Expr) = if has_exception_clauses {
             self.features_used.insert(Feature::Exceptions);
             let try_body = self.lower_flat_statements(node)?;
             let (rescues, ensure_body) = self.lower_rescue_ensure_clauses(node)?;
@@ -4808,6 +4869,11 @@ impl Lowerer {
         self.current_params = saved_params;
         // O2 — restore the enclosing method name (usually `None`).
         self.current_method = saved_method;
+
+        // Sequential-assignment fix-up for the method body (see
+        // `sequentialize_let_bindings`) — `def f; a = 1; x = a; end` must
+        // resolve the read of `a`.
+        sequentialize_let_bindings(&mut stmts_out);
 
         // Phase Q9e — if the method body `yield`s, thread the explicit
         // trailing block parameter and rewrite each `yield` into an
@@ -6528,6 +6594,10 @@ impl Lowerer {
         self.current_params = saved_params;
         self.in_block_body = saved_in_block;
 
+        // Sequential-assignment fix-up for the block body (see
+        // `sequentialize_let_bindings`).
+        sequentialize_let_bindings(&mut stmts_out);
+
         // Assemble the block body so the RB2 yield-capture rewrite can run
         // over it as a unit.
         let mut body = Block {
@@ -6810,6 +6880,10 @@ impl Lowerer {
         // Restore outer scope.
         self.declared_locals = saved_locals;
         self.current_params = saved_params;
+
+        // Sequential-assignment fix-up for this block body (see
+        // `sequentialize_let_bindings`).
+        sequentialize_let_bindings(&mut stmts_out);
 
         // Mint a synthetic function name (shares the same counter as
         // method_with_block-hoisted blocks).

--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.5.0] - 2026-07-03
+
+### Added — `seq_assign` (14 -> 15 programs)
+
+Sequential local assignments that read an earlier local (`a = 5; b = a + 1;
+c = b + a`) — previously rejected by the SIR validator as a parallel-`let`
+violation, now fixed in the frontend. Verified across all four backends.
+
 ## [0.4.0] - 2026-07-03
 
 ### Added — `string_case` (13 -> 14 programs)

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/README.md
+++ b/code/packages/rust/sir-conformance/README.md
@@ -68,6 +68,7 @@ across backends, a separate formatting concern). Current programs:
 | `logical_ops` | short-circuit `||`/`&&` returning the operand | `a\nb\ny` |
 | `multi_when` | multi-value `when 1, 2, 3` (folds through `or`) | `small\nbig` |
 | `string_case` | `String#upcase`/`#downcase`/`#strip` (Ruby→JS renames) | `HELLO\nworld\nhi` |
+| `seq_assign` | sequential assignment reading an earlier local (`b = a + 1`) | `5\n6\n11` |
 
 Adding a program is one `Program { name, ruby, expected }` entry in
 `tests/conformance.rs`.
@@ -79,9 +80,11 @@ backends" bug. Programs that hit an **unfixed** gap are kept *out* of the corpus
 (with a pointer to `lessons.md`) so the suite stays green while the gap stays
 visible. Currently tracked:
 
-- **Array/hash index** (`a[i]`, `h[k]`) — frontend parse + lowering bugs
-  (`puts a[1]` mis-parses, `puts(a[1])` won't parse, `x = a[1]` fails
-  validation).
+- **Array/hash index reads** (`a[i]`, `h[k]`) — a frontend PARSER-precedence
+  gap: `a[1]` mis-parses as `a` followed by a bare `[1]` array literal
+  (`puts a[1]` → `(puts a)[1]`; `puts(a[1])` fails to parse). Needs a grammar
+  fix. (The *scoping* half — `x = a[1]` failing SIR validation — turned out to
+  be the general sequential-assignment bug and is now fixed; see `seq_assign`.)
 
 Fixed since (now IN the suite):
 - The `or`/`and` builtin gap — `||`/`&&` and multi-value `when` threw

--- a/code/packages/rust/sir-conformance/tests/conformance.rs
+++ b/code/packages/rust/sir-conformance/tests/conformance.rs
@@ -126,6 +126,16 @@ const CORPUS: &[Program] = &[
         ruby: "puts(\"hello\".upcase)\nputs(\"WORLD\".downcase)\nputs(\"  hi  \".strip)\n",
         expected: "HELLO\nworld\nhi",
     },
+    // Sequential local assignments where a later binding READS an earlier one
+    // (`b = a + 1`, `c = b + a`). Ruby is sequential (`let*`); the frontend
+    // previously lowered these to parallel `LetBinding`s, which the SIR
+    // validator rejected ("var-ref ... unknown name `a`") — so `newvar =
+    // existing_local` failed to compile on every backend. Now fixed.
+    Program {
+        name: "seq_assign",
+        ruby: "a = 5\nb = a + 1\nc = b + a\nputs a\nputs b\nputs c\n",
+        expected: "5\n6\n11",
+    },
 ];
 
 /// Every program must produce its reference output on every available backend.

--- a/lessons.md
+++ b/lessons.md
@@ -1155,3 +1155,40 @@ hit an *unfixed* gap are kept OUT of the corpus (with a comment pointing here)
 until the gap is fixed, so the suite stays green and the gaps stay visible.
 
 Discovered: 2026-07-02, expanding the conformance corpus (PR after the harness landed).
+
+## Ruby assignments are sequential (`let*`), not parallel (`let`) — `x = a` was broken
+
+Investigating the conformance "array index" gap (`x = a[1]` fails SIR
+validation) revealed the real bug is NOT about indexing: **any first-sighting
+`newvar = <expr that reads an earlier local>` failed to compile on every
+backend.** `a = 5\nb = a + 1` was rejected with `var-ref scope=local references
+unknown name 'a'`.
+
+Root cause: the SIR distinguishes `LetBinding` (parallel `let` — all RHSs
+evaluate BEFORE any name binds) from `LetStarBinding` (sequential `let*` — each
+RHS sees prior bindings). The validator (`validator::check_stmt_seq`) correctly
+treats a *run of consecutive `LetBinding`s* as one parallel-`let` group. But the
+Ruby frontend lowered EVERY first-sighting assignment to a parallel `LetBinding`,
+even though Ruby assignments are sequential. So `[LetBinding(a); LetBinding(b =
+a+1)]` put `b`'s RHS in a scope that didn't yet include `a`.
+
+Fix (frontend, `sequentialize_let_bindings` post-pass): after a block's
+statements are lowered, rewrite a `LetBinding` to a `LetStarBinding` (identical
+fields) exactly when its value reads a name bound by an EARLIER statement in the
+block. `let*` binds immediately and breaks the parallel run, so the reference
+resolves. Independent bindings stay `LetBinding` (minimal churn). Both variants
+lower to the same sequential declaration on every backend — behaviour-preserving.
+
+**Lessons:**
+- Shape-only frontend tests (asserting `Stmt::LetBinding {…}`) do NOT run the
+  SIR validator, so they happily locked in a shape the validator would reject.
+  ~16 such tests asserted the buggy parallel-`let` form; they were updated to
+  accept either variant. When adding a frontend feature, run a program through
+  `semantic_ir::validate` (or the conformance harness), not just a shape assert.
+- Don't "fix" this in the validator by making `LetBinding` sequential — that
+  would break genuine parallel-`let` frontends (Lisp `let`). The frontend that
+  emits the wrong binding kind is what's wrong.
+- The array/hash INDEX-READ parser bug (`a[1]` → `a` + `[1]`) is separate and
+  still open (grammar precedence); only the assignment-scoping half is fixed.
+
+Discovered: 2026-07-03, expanding the conformance corpus toward array indexing.


### PR DESCRIPTION
## The bug (found while investigating the array-index conformance gap)

The gap wasn't about indexing. **Any first-sighting `newvar = <expr that reads an earlier local>` fails to compile on every backend:**

```ruby
a = 5
b = a + 1   # SIR validation error: var-ref scope=local references unknown name `a`
```

Ruby assignments are **sequential** (`let*`) — `b` sees `a`. But the frontend lowered every first-sighting `name = value` to a **parallel** `Stmt::LetBinding`, and the SIR validator correctly treats a *run of consecutive `LetBinding`s* as one parallel-`let` group whose RHSs all evaluate *before* any name binds. So `b`'s RHS couldn't see `a`. This broke `x = a`, `b = a + 1`, `v = h["k"]`, destructuring `a, b = arr`, `y = obj.meth`, `y = -x`, a hash/heredoc reading a prior local — all of it.

## Fix

A `sequentialize_let_bindings` post-pass: after a block's statements are lowered, rewrite a `LetBinding` to a `LetStarBinding` (identical fields) **exactly when its value reads a name bound by an earlier statement in the block**. `let*` binds its name immediately and breaks the parallel run, so the reference resolves. Independent bindings (`i = 0; sum = 0`) keep `LetBinding`, so churn is minimal. Both variants lower to the **same** sequential variable declaration on every backend — behaviour-preserving. Applied at all sequential bodies: program, `if`/`unless`/`case` branches, `def` bodies, and block/lambda bodies.

Not fixed in the validator: making `LetBinding` sequential would break genuine parallel-`let` frontends (Lisp `let`). The frontend emitting the wrong binding kind is what's wrong.

## Verified

- **427 frontend tests pass.** ~16 shape-tests that asserted the buggy parallel-`let` form (they never ran the validator, so they locked in a rejectable shape) updated to accept either variant via new `binding_name`/`binding_value` helpers.
- **All five backend suites pass** (no downstream regression).
- **End-to-end**: new `sir-conformance` `seq_assign` program (`a=5; b=a+1; c=b+a` → `5/6/11`) → **15 corpus × 4 backends = 60 runs, 0 skipped, all agree**.
- Clippy clean; versions bumped; CHANGELOGs + README + **lessons.md** (the `let` vs `let*` trap). Security review: **passed** (in-place variant swap proven safe; no new recursion/panics/injection).

## Scope note

The array/hash **index-read parser bug** (`a[1]` mis-parses as `a` + a bare `[1]` array literal; `puts(a[1])` won't parse) is a **separate, still-open** grammar-precedence gap. Only the assignment-*scoping* half — which turned out to be this general sequential-assignment bug — is fixed here. Documented in the README gap list and lessons.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)