### PR TITLE
feat(xls-writer): C4 write legacy .xls (BIFF8) via cfb-writer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "ppt",
     "doc",
     "cfb-writer",
+    "xls-writer",
     "binary-search-tree",
     "avl-tree",
     "red-black-tree",

--- a/code/packages/rust/xls-writer/BUILD
+++ b/code/packages/rust/xls-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p xls-writer -- --nocapture

--- a/code/packages/rust/xls-writer/BUILD_windows
+++ b/code/packages/rust/xls-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p xls-writer -- --nocapture

--- a/code/packages/rust/xls-writer/CHANGELOG.md
+++ b/code/packages/rust/xls-writer/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to `xls-writer` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-03
+
+### Added
+
+- Initial release (**XLSW01**): a from-scratch, zero-third-party-dependency
+  **writer** for the legacy `.xls` / BIFF8 format ([MS-XLS]). Emits BIFF records
+  and wraps them in an OLE2 Compound File via the `cfb-writer` crate. Milestone
+  **C4** (legacy write).
+- Public API:
+  - `Workbook::new()`, `Workbook::add_sheet(name) -> &mut Sheet`.
+  - `Sheet::set_string(row, col, s)`, `Sheet::set_number(row, col, n)`.
+  - `write_xls(&Workbook) -> Vec<u8>` producing `.xls` bytes.
+- **BIFF records** emitted: `BOF`/`EOF` (substream framing), `BOUNDSHEET`,
+  `SST`, `LABELSST` (string cells), `NUMBER` (numeric cells).
+- **Substream layout**: one globals substream (BOUNDSHEET per sheet + SST) and
+  one worksheet substream per sheet.
+- **Shared strings**: identical string values are de-duplicated into one SST
+  entry; `cstTotal`/`cstUnique` tracked correctly; `LABELSST` references by
+  index.
+- **`BOUNDSHEET.lbPlyPos` two-pass**: worksheet BOF offsets are backfilled into
+  each BOUNDSHEET after all substreams are sized, so `lbPlyPos` is exact.
+- **String encoding**: per-string `fHighByte` choice — compact 8-bit for
+  all-Latin-1 strings, 16-bit UTF-16LE otherwise. Applies to SST strings
+  (`XLUnicodeRichExtendedString`) and sheet names (`ShortXLUnicodeString`).
+- **Robustness**: `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on the
+  public path; `checked`/`try_from` guards on every `u16`/`u32` size or address
+  field; deterministic output. Cells beyond the `u16` grid and overflowing SST
+  bodies are clamped/skipped (documented) rather than corrupting a record.
+
+### Tests
+
+- **Round-trip proof**: build a workbook, `write_xls`, re-open with the `cfb`
+  reader, extract the `Workbook` stream, and walk BIFF records to assert the
+  BOUNDSHEET name + `lbPlyPos` (→ worksheet BOF), the SST contents, and every
+  cell's address/type/value.
+- Unit tests: SST dedup (`cstTotal=2`/`cstUnique=1`), non-ASCII forces the
+  16-bit path, Latin-1 stays compressed, multiple sheets get distinct
+  `lbPlyPos`, empty workbook / empty sheet don't panic, out-of-range cells are
+  skipped, exact `f64` preservation, deterministic output.
+
+### Known limitations
+
+- No `CONTINUE`-record splitting of a huge SST (kept small; clamped otherwise).
+- Numeric cells always use `NUMBER`, never the space-saving `RK` record.

--- a/code/packages/rust/xls-writer/Cargo.toml
+++ b/code/packages/rust/xls-writer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "xls-writer"
+version = "0.1.0"
+edition = "2021"
+description = "A from-scratch, zero-third-party-dependency writer for the legacy .xls / BIFF8 spreadsheet format ([MS-XLS]): emits BIFF records and wraps them in an OLE2 Compound File via cfb-writer. Milestone C4 (legacy write)."
+license = "MIT"
+
+[dependencies]
+# The OLE2 container writer. This crate builds the `Workbook` BIFF stream and
+# hands it to cfb-writer to be wrapped into the final .xls file.
+cfb-writer = { path = "../cfb-writer" }
+
+[dev-dependencies]
+# The reader, used to prove our output round-trips: open the .xls we wrote,
+# extract the Workbook stream, and re-parse the BIFF records.
+cfb = { path = "../cfb" }

--- a/code/packages/rust/xls-writer/README.md
+++ b/code/packages/rust/xls-writer/README.md
@@ -1,0 +1,84 @@
+# xls-writer
+
+A from-scratch, **zero-third-party-dependency** writer for the legacy
+**`.xls` / BIFF8** spreadsheet format ([MS-XLS]). You build a simple model —
+sheets of string and number cells — and it produces the bytes of a real `.xls`
+file: a stream of **BIFF records** wrapped in an **OLE2 Compound File** via the
+sibling [`cfb-writer`](../cfb-writer) crate. This is milestone **C4** (legacy
+write) of the OOXML/BIFF stack.
+
+`#![forbid(unsafe_code)]`, pure `std` + `cfb-writer`, deterministic output (no
+timestamps or randomness), never panics on the public API path.
+
+## Where it fits in the stack
+
+```
+        deflate ── zip ── xml ── opc ── spreadsheetml ── xlsx-eval   (OOXML, .xlsx)
+
+   cfb (reader) ◄──────── round-trip proof ────────► cfb-writer     (OLE2 container)
+                                                          │
+                                                     xls-writer      (this crate — BIFF8)
+```
+
+`xls-writer` sits on top of `cfb-writer`: it builds one `Workbook` BIFF stream
+and hands it to `cfb-writer` to be wrapped into the final `.xls`. The round-trip
+test then re-opens that `.xls` with the `cfb` reader and re-parses the BIFF
+records, closing the loop `model → BIFF → CFB → cfb reader → BIFF → model`.
+
+## What a `.xls` is (one paragraph)
+
+A `.xls` is an OLE2 Compound File containing a single stream named `Workbook`,
+which holds a flat sequence of **BIFF records** (`u16 type`, `u16 size`, body).
+Records are grouped into substreams bracketed by `BOF`…`EOF`: one **globals**
+substream (declaring sheets via `BOUNDSHEET` and holding the shared-string table
+`SST`), then one **worksheet** substream per sheet (the cell records `LABELSST`
+for strings and `NUMBER` for numbers). See `code/specs/XLSW01-xls-writer.md` for
+the full literate walkthrough, including the `BOUNDSHEET.lbPlyPos` two-pass.
+
+## Usage
+
+```rust
+use xls_writer::{Workbook, write_xls};
+
+let mut wb = Workbook::new();
+let sheet = wb.add_sheet("Revenue");
+sheet.set_string(0, 0, "Q1");
+sheet.set_number(0, 1, 1000.0);
+sheet.set_string(1, 0, "Total");
+sheet.set_number(1, 1, 1234.5);
+
+let bytes: Vec<u8> = write_xls(&wb);
+std::fs::write("revenue.xls", &bytes).unwrap();
+```
+
+All rows/cols are **0-based**. Identical string values are automatically shared
+(de-duplicated) into a single SST entry, and each string cell references it by
+index.
+
+## Design notes
+
+- **`NUMBER`, not `RK`.** Every numeric cell is a `NUMBER` record (an 8-byte
+  `f64`). `RK` is only a space optimization for certain values; `NUMBER` is
+  total and trivially verifiable. See the spec §2.1.
+- **String encoding.** Strings that are entirely Latin-1 (every code unit
+  ≤ `0xFF`) use the compact 8-bit form; anything else uses 16-bit UTF-16LE
+  (the `fHighByte` flag).
+
+## Limitations
+
+- **No `CONTINUE` splitting.** The SST is emitted as a single record; a workbook
+  with enough distinct strings to overflow one BIFF record (64 KiB body) would,
+  in a full implementation, spill into `CONTINUE` records. We keep the SST small
+  and clamp rather than emit a corrupt record; splitting is future work.
+- **`u16` grid.** Cells beyond row/col `65535` cannot be addressed in BIFF and
+  are skipped (documented, never wrapped into a wrong address).
+
+## Testing
+
+```
+cargo test -p xls-writer -- --nocapture
+```
+
+The headline test writes a `.xls`, re-opens it with the `cfb` reader, and walks
+the BIFF records to assert the sheet name, the `lbPlyPos` offsets, the SST
+contents, and every cell's address/type/value.

--- a/code/packages/rust/xls-writer/required_capabilities.json
+++ b/code/packages/rust/xls-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/xls-writer",
+  "capabilities": [],
+  "justification": "Pure in-memory binary emission. Callers build a spreadsheet model and receive a byte buffer of a .xls file; the crate does no filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/xls-writer/src/lib.rs
+++ b/code/packages/rust/xls-writer/src/lib.rs
@@ -1,0 +1,538 @@
+//! # xls-writer — legacy `.xls` (BIFF8 / [MS-XLS]) writer (XLSW01)
+//!
+//! A from-scratch, **zero-third-party-dependency** writer for the legacy
+//! **`.xls`** spreadsheet format. You build a simple model — sheets of string
+//! and number cells — and [`write_xls`] hands you the bytes of a real `.xls`
+//! file. See `code/specs/XLSW01-xls-writer.md` for the full literate walkthrough.
+//!
+//! ## The two-layer mental model
+//!
+//! A `.xls` file is an **OLE2 Compound File** (a "FAT filesystem crammed into a
+//! single file"; see the `cfb`/`cfb-writer` crates) that contains **one** named
+//! stream called `Workbook`. That stream is a flat sequence of **BIFF records**.
+//! So writing a `.xls` is:
+//!
+//! 1. **This crate:** turn the model into a `Vec<u8>` of BIFF records.
+//! 2. **`cfb-writer`:** wrap that `Vec<u8>` as the `Workbook` stream.
+//!
+//! ```
+//! # use xls_writer::{Workbook, write_xls};
+//! let mut wb = Workbook::new();
+//! let sheet = wb.add_sheet("Revenue");
+//! sheet.set_string(0, 0, "Q1");
+//! sheet.set_number(0, 1, 1000.0);
+//! let bytes = write_xls(&wb);
+//! // It's a Compound File: it opens with the OLE2 magic.
+//! assert_eq!(&bytes[0..8], &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+//! ```
+//!
+//! ## A BIFF record
+//!
+//! Every BIFF record is a tiny type-length-value:
+//!
+//! ```text
+//!   ┌──────────┬──────────┬──────────────────────┐
+//!   │ u16 type │ u16 size │  `size` body bytes    │   (all integers little-endian)
+//!   └──────────┴──────────┴──────────────────────┘
+//! ```
+//!
+//! Records are grouped into **substreams** bracketed by `BOF`…`EOF`. We emit one
+//! **globals** substream (declaring the sheets and the shared-string table) and
+//! one **worksheet** substream per sheet (the cells).
+//!
+//! ## Robustness
+//!
+//! `#![forbid(unsafe_code)]`, deterministic (no timestamps/randomness), and no
+//! `unwrap`/`expect`/`panic!` on the public path. Because BIFF size fields are
+//! `u16` and cell addresses are `u16`, a colossal model can't fit; we **clamp or
+//! skip** the offending piece (documented) rather than wrap it into a corrupt
+//! record. See the `limits` notes on [`Sheet::set_string`] etc.
+
+#![forbid(unsafe_code)]
+
+// ---------------------------------------------------------------------------
+// BIFF record type numbers. See §1.1 of the spec for the table.
+// ---------------------------------------------------------------------------
+
+/// Beginning of a substream. Body carries the BIFF version and substream kind.
+const REC_BOF: u16 = 0x0809;
+/// End of a substream. Empty body.
+const REC_EOF: u16 = 0x000A;
+/// Declares one worksheet: its byte offset in the stream plus its name.
+const REC_BOUNDSHEET: u16 = 0x0085;
+/// The shared string table: every distinct string value, stored once.
+const REC_SST: u16 = 0x00FC;
+/// A string cell: references a string by index into the SST.
+const REC_LABELSST: u16 = 0x00FD;
+/// A numeric cell: an IEEE-754 `f64`.
+const REC_NUMBER: u16 = 0x0203;
+
+/// BIFF version marker written into every `BOF`: `0x0600` = BIFF8.
+const BIFF8_VERSION: u16 = 0x0600;
+/// `BOF` substream kind: the workbook globals.
+const DT_GLOBALS: u16 = 0x0005;
+/// `BOF` substream kind: a worksheet.
+const DT_WORKSHEET: u16 = 0x0010;
+
+/// The largest a single BIFF record *body* may be — the `size` field is a `u16`.
+/// (Bodies larger than this need `CONTINUE` records, which we do not emit; see
+/// the SST limitation in the spec.)
+const MAX_RECORD_BODY: usize = u16::MAX as usize;
+
+// ---------------------------------------------------------------------------
+// Little-endian append helpers. Appending to a `Vec<u8>` never panics, so these
+// are total by construction.
+// ---------------------------------------------------------------------------
+
+/// Append a `u16` little-endian.
+#[inline]
+fn push_u16(buf: &mut Vec<u8>, v: u16) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+/// Append a `u32` little-endian.
+#[inline]
+fn push_u32(buf: &mut Vec<u8>, v: u32) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+/// Append an `f64` little-endian (IEEE-754).
+#[inline]
+fn push_f64(buf: &mut Vec<u8>, v: f64) {
+    buf.extend_from_slice(&v.to_le_bytes());
+}
+
+/// Append a whole BIFF record: `type`, `size`, then the body.
+///
+/// If `body` is somehow longer than a `u16` can express, the size field is
+/// **clamped** to `u16::MAX`. On the public path this never happens — every body
+/// we build is bounded (the SST is kept small; see [`encode_sst`]) — but clamping
+/// keeps the function total rather than panicking on a `try_into`.
+fn push_record(buf: &mut Vec<u8>, record_type: u16, body: &[u8]) {
+    let size = body.len().min(MAX_RECORD_BODY) as u16;
+    push_u16(buf, record_type);
+    push_u16(buf, size);
+    // Only write the bytes we declared (defensive; equal in the normal case).
+    buf.extend_from_slice(&body[..size as usize]);
+}
+
+// ---------------------------------------------------------------------------
+// String encoding — the `fHighByte` scheme (spec §5).
+// ---------------------------------------------------------------------------
+
+/// The two BIFF8 string encodings. `fHighByte` bit0 of the `grbit` flags picks
+/// between them.
+///
+/// - `Compressed` (bit clear): one byte per character — the low byte of each
+///   UTF-16 code unit. Valid only when every code unit is ≤ `0xFF`.
+/// - `Wide` (bit set): two bytes per character, little-endian UTF-16LE.
+struct EncodedString {
+    /// Number of UTF-16 code units (this is `cch`).
+    cch: usize,
+    /// `grbit` bit0: 1 for wide (16-bit) encoding, 0 for compressed (8-bit).
+    high_byte: bool,
+    /// The already-encoded character bytes (1×cch or 2×cch bytes).
+    chars: Vec<u8>,
+}
+
+/// Encode a `&str` into the BIFF8 character bytes, choosing the compact 8-bit
+/// form when every code unit fits in a byte, else 16-bit UTF-16LE.
+///
+/// We count in **UTF-16 code units**, because that is what the on-disk `cch`
+/// field means (a character above the BMP is two units). This mirrors how the
+/// `cfb` reader / Excel interpret the field.
+fn encode_string(s: &str) -> EncodedString {
+    let units: Vec<u16> = s.encode_utf16().collect();
+    let all_latin1 = units.iter().all(|&u| u <= 0x00FF);
+    let chars = if all_latin1 {
+        // Compressed: the low byte of each unit.
+        units.iter().map(|&u| u as u8).collect()
+    } else {
+        // Wide: UTF-16LE, two bytes per unit.
+        let mut out = Vec::with_capacity(units.len() * 2);
+        for &u in &units {
+            out.extend_from_slice(&u.to_le_bytes());
+        }
+        out
+    };
+    EncodedString {
+        cch: units.len(),
+        high_byte: !all_latin1,
+        chars,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The public model: Workbook → Sheet → cells.
+// ---------------------------------------------------------------------------
+
+/// A single cell's value. Rows/cols are stored separately in [`Cell`].
+enum CellValue {
+    /// A string cell. The string is de-duplicated into the SST at write time.
+    Str(String),
+    /// A numeric cell (IEEE-754 `f64`).
+    Num(f64),
+}
+
+/// One placed cell: its 0-based row, 0-based column, and value.
+struct Cell {
+    row: u32,
+    col: u32,
+    value: CellValue,
+}
+
+/// One worksheet: a name and a list of placed cells.
+///
+/// Cells are stored in **insertion order** and emitted in that order, so output
+/// is deterministic. We do not sort or de-duplicate by address — setting the
+/// same `(row, col)` twice emits two records, and a reader keeps the last; that
+/// is a caller error, not ours to police, and staying order-preserving keeps the
+/// bytes predictable.
+pub struct Sheet {
+    name: String,
+    cells: Vec<Cell>,
+}
+
+impl Sheet {
+    /// Place a **string** value at 0-based `(row, col)`.
+    ///
+    /// **Limits:** BIFF cell addresses are `u16`. A `row` or `col` greater than
+    /// `u16::MAX` (65535) cannot be represented and the cell is **skipped** at
+    /// write time (documented; never truncated into a wrong address). The string
+    /// is shared via the SST, so repeats cost nothing.
+    pub fn set_string(&mut self, row: u32, col: u32, s: &str) {
+        self.cells.push(Cell {
+            row,
+            col,
+            value: CellValue::Str(s.to_string()),
+        });
+    }
+
+    /// Place a **numeric** value at 0-based `(row, col)`.
+    ///
+    /// Same `u16` address limit as [`set_string`](Self::set_string): a cell
+    /// beyond 65535 in either axis is skipped at write time. Any `f64`
+    /// (including NaN/∞) is stored verbatim via a `NUMBER` record.
+    pub fn set_number(&mut self, row: u32, col: u32, n: f64) {
+        self.cells.push(Cell {
+            row,
+            col,
+            value: CellValue::Num(n),
+        });
+    }
+}
+
+/// A workbook: an ordered collection of [`Sheet`]s. Build it, then call
+/// [`write_xls`] to serialise it into `.xls` bytes.
+pub struct Workbook {
+    sheets: Vec<Sheet>,
+}
+
+impl Default for Workbook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Workbook {
+    /// Create an empty workbook (no sheets). Writing it yields a valid, minimal
+    /// `.xls` with an empty globals substream and no worksheets.
+    pub fn new() -> Self {
+        Workbook { sheets: Vec::new() }
+    }
+
+    /// Append a new sheet with the given name and return a mutable handle to it
+    /// so cells can be added:
+    ///
+    /// ```
+    /// # use xls_writer::Workbook;
+    /// let mut wb = Workbook::new();
+    /// let s = wb.add_sheet("Sheet1");
+    /// s.set_number(0, 0, 42.0);
+    /// ```
+    pub fn add_sheet(&mut self, name: &str) -> &mut Sheet {
+        self.sheets.push(Sheet {
+            name: name.to_string(),
+            cells: Vec::new(),
+        });
+        // `push` guarantees at least one element, so `last_mut` is `Some`; the
+        // `expect` here can never fire and keeps the return type ergonomic.
+        // (Kept off the true "public failure path" — it is structurally
+        // impossible, not input-dependent.)
+        self.sheets
+            .last_mut()
+            .expect("just pushed a sheet, so last_mut is Some")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared string table construction.
+// ---------------------------------------------------------------------------
+
+/// The result of scanning all cells for strings: the ordered list of distinct
+/// strings (the SST payload), a map from string → its SST index, and the total
+/// number of string-cell references (`cstTotal`).
+struct SharedStrings {
+    /// Distinct strings in first-seen order. Index into this vec is the `isst`.
+    unique: Vec<String>,
+    /// Total count of string cells across all sheets (`cstTotal`).
+    total_refs: u32,
+}
+
+impl SharedStrings {
+    /// Scan every sheet's cells, deduplicating string values into the SST.
+    ///
+    /// De-dup is by exact string equality (first occurrence wins the index).
+    /// `total_refs` counts every string *cell* (so two cells with the same text
+    /// count twice); `unique.len()` is `cstUnique`.
+    fn collect(sheets: &[Sheet]) -> SharedStrings {
+        // A small linear-probe index. Workbooks here are tiny, so a `Vec` +
+        // linear search is simpler than pulling in a hash map and is plenty
+        // fast; it also keeps ordering trivially deterministic.
+        let mut unique: Vec<String> = Vec::new();
+        let mut total_refs: u32 = 0;
+        for sheet in sheets {
+            for cell in &sheet.cells {
+                if let CellValue::Str(s) = &cell.value {
+                    total_refs = total_refs.saturating_add(1);
+                    if !unique.iter().any(|u| u == s) {
+                        unique.push(s.clone());
+                    }
+                }
+            }
+        }
+        SharedStrings { unique, total_refs }
+    }
+
+    /// Look up the SST index (`isst`) of a string. Returns `None` only if the
+    /// string was never registered (impossible for a string that came from a
+    /// scanned cell, but total by construction).
+    fn index_of(&self, s: &str) -> Option<u32> {
+        self.unique
+            .iter()
+            .position(|u| u == s)
+            .and_then(|p| u32::try_from(p).ok())
+    }
+}
+
+/// Encode the SST record body from the collected shared strings.
+///
+/// Layout (spec §3): `u32 cstTotal`, `u32 cstUnique`, then each unique string as
+/// an `XLUnicodeRichExtendedString` (`u16 cch`, `u8 grbit`, chars).
+///
+/// **Limitation:** we build the whole SST as one record. If the encoded body
+/// would exceed `u16::MAX` bytes it cannot fit the record's size field; rather
+/// than emit a corrupt record we stop adding strings once we would overflow
+/// (the already-written strings remain valid and indexable). Realistic small
+/// workbooks never approach this; `CONTINUE`-splitting is future work.
+fn encode_sst(shared: &SharedStrings) -> Vec<u8> {
+    let mut body = Vec::new();
+    push_u32(&mut body, shared.total_refs);
+    // `cstUnique` = number of distinct strings.
+    let unique_count = u32::try_from(shared.unique.len()).unwrap_or(u32::MAX);
+    push_u32(&mut body, unique_count);
+
+    for s in &shared.unique {
+        let enc = encode_string(s);
+        // A single string with more than u16::MAX code units cannot fit its
+        // `cch` field; skip it rather than write a wrong length. (Its `isst`
+        // still resolves to *a* string for any cell that referenced it — the
+        // preceding valid strings — because we never renumber; but a string this
+        // large is pathological and out of scope.)
+        let cch = match u16::try_from(enc.cch) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        // Would adding this string overflow the record body? Header for this
+        // string is 3 bytes (u16 cch + u8 grbit) plus its char bytes.
+        let addition = 3usize.saturating_add(enc.chars.len());
+        if body.len().saturating_add(addition) > MAX_RECORD_BODY {
+            // Documented limitation: stop before overflowing the size field.
+            break;
+        }
+        push_u16(&mut body, cch);
+        body.push(if enc.high_byte { 0x01 } else { 0x00 });
+        body.extend_from_slice(&enc.chars);
+    }
+    body
+}
+
+// ---------------------------------------------------------------------------
+// Record builders.
+// ---------------------------------------------------------------------------
+
+/// Append a `BOF` record for the given substream kind (`DT_GLOBALS` or
+/// `DT_WORKSHEET`). The 16-byte body is `vers`, `dt`, then four zeroed trailer
+/// fields (`rupBuild`, `rupYear`, `bfh`, `sfo`) for deterministic output.
+fn push_bof(buf: &mut Vec<u8>, dt: u16) {
+    let mut body = Vec::with_capacity(16);
+    push_u16(&mut body, BIFF8_VERSION);
+    push_u16(&mut body, dt);
+    push_u16(&mut body, 0); // rupBuild
+    push_u16(&mut body, 0); // rupYear
+    push_u32(&mut body, 0); // bfh
+    push_u32(&mut body, 0); // sfo
+    push_record(buf, REC_BOF, &body);
+}
+
+/// Append an `EOF` record (empty body).
+fn push_eof(buf: &mut Vec<u8>) {
+    push_record(buf, REC_EOF, &[]);
+}
+
+/// Append the 6-byte cell head (`row`, `col`, `ixfe=0`) to a record body. The
+/// caller has already validated that `row`/`col` fit in `u16`.
+fn push_cell_head(body: &mut Vec<u8>, row: u16, col: u16) {
+    push_u16(body, row);
+    push_u16(body, col);
+    push_u16(body, 0); // ixfe: the default cell format (XF 0)
+}
+
+/// Build the globals substream, returning the bytes **and** the byte offset,
+/// within those bytes, of each sheet's `BOUNDSHEET.lbPlyPos` field (so the
+/// caller can backfill it once worksheet positions are known — spec §4).
+///
+/// The `lbPlyPos` fields are written as placeholder `0` here.
+fn build_globals(sheets: &[Sheet], shared: &SharedStrings) -> (Vec<u8>, Vec<usize>) {
+    let mut buf = Vec::new();
+    push_bof(&mut buf, DT_GLOBALS);
+
+    // One BOUNDSHEET per sheet. Record where each lbPlyPos field lands so we can
+    // patch it later.
+    let mut ply_pos_offsets: Vec<usize> = Vec::with_capacity(sheets.len());
+    for sheet in sheets {
+        // Build the BOUNDSHEET body: u32 lbPlyPos (placeholder), u8 hsState,
+        // u8 dt, then a ShortXLUnicodeString name.
+        let mut body = Vec::new();
+        push_u32(&mut body, 0); // lbPlyPos placeholder — patched in build_workbook_stream
+        body.push(0); // hsState = 0 (visible)
+        body.push(0); // dt = 0 (worksheet)
+
+        // ShortXLUnicodeString: u8 cch, u8 grbit, chars. `cch` is a u8, so a
+        // name longer than 255 code units is clamped (documented) — sheet names
+        // are 31 chars in real Excel anyway.
+        let enc = encode_string(&sheet.name);
+        let cch = enc.cch.min(u8::MAX as usize) as u8;
+        body.push(cch);
+        body.push(if enc.high_byte { 0x01 } else { 0x00 });
+        // Emit exactly `cch` characters' worth of bytes.
+        let char_bytes = if enc.high_byte { cch as usize * 2 } else { cch as usize };
+        body.extend_from_slice(&enc.chars[..char_bytes.min(enc.chars.len())]);
+
+        // The lbPlyPos field is the first 4 bytes of the body, which lands right
+        // after this record's 4-byte header. Record its absolute offset in buf.
+        let record_start = buf.len();
+        let ply_pos_offset = record_start + 4; // skip u16 type + u16 size
+        ply_pos_offsets.push(ply_pos_offset);
+        push_record(&mut buf, REC_BOUNDSHEET, &body);
+    }
+
+    // The shared string table.
+    let sst_body = encode_sst(shared);
+    push_record(&mut buf, REC_SST, &sst_body);
+
+    push_eof(&mut buf);
+    (buf, ply_pos_offsets)
+}
+
+/// Build one worksheet substream: `BOF`, the cell records, `EOF`.
+///
+/// Cells whose row or col exceeds `u16::MAX` are **skipped** (spec §6) rather
+/// than wrapped into a wrong address.
+fn build_worksheet(sheet: &Sheet, shared: &SharedStrings) -> Vec<u8> {
+    let mut buf = Vec::new();
+    push_bof(&mut buf, DT_WORKSHEET);
+
+    for cell in &sheet.cells {
+        // Reject out-of-range addresses cleanly.
+        let (row, col) = match (u16::try_from(cell.row), u16::try_from(cell.col)) {
+            (Ok(r), Ok(c)) => (r, c),
+            _ => continue, // documented: skip cells beyond the 65535 grid limit
+        };
+        match &cell.value {
+            CellValue::Num(n) => {
+                let mut body = Vec::with_capacity(14);
+                push_cell_head(&mut body, row, col);
+                push_f64(&mut body, *n);
+                push_record(&mut buf, REC_NUMBER, &body);
+            }
+            CellValue::Str(s) => {
+                // Resolve the string's SST index. It must exist (we scanned the
+                // same cells to build the SST); if for any reason it does not,
+                // skip the cell rather than emit a dangling reference.
+                let Some(isst) = shared.index_of(s) else {
+                    continue;
+                };
+                let mut body = Vec::with_capacity(10);
+                push_cell_head(&mut body, row, col);
+                push_u32(&mut body, isst);
+                push_record(&mut buf, REC_LABELSST, &body);
+            }
+        }
+    }
+
+    push_eof(&mut buf);
+    buf
+}
+
+/// Assemble the whole `Workbook` byte-stream: globals + every worksheet, with
+/// each `BOUNDSHEET.lbPlyPos` backfilled to point at its worksheet's `BOF`
+/// (the two-pass of spec §4).
+fn build_workbook_stream(wb: &Workbook) -> Vec<u8> {
+    let shared = SharedStrings::collect(&wb.sheets);
+    let (mut globals, ply_pos_offsets) = build_globals(&wb.sheets, &shared);
+
+    // Build each worksheet buffer and remember its length.
+    let worksheets: Vec<Vec<u8>> = wb
+        .sheets
+        .iter()
+        .map(|s| build_worksheet(s, &shared))
+        .collect();
+
+    // Compute each worksheet's absolute start offset in the final stream:
+    //   offset(sheet k) = globals.len() + Σ_{i<k} worksheet[i].len()
+    let globals_len = globals.len();
+    let mut running = globals_len;
+    for (i, offset) in ply_pos_offsets.iter().enumerate() {
+        // Backfill this sheet's lbPlyPos with `running` (its BOF offset).
+        let pos = u32::try_from(running).unwrap_or(u32::MAX);
+        let bytes = pos.to_le_bytes();
+        // `offset` was computed as a valid index into `globals`; patch 4 bytes.
+        if let Some(slot) = globals.get_mut(*offset..*offset + 4) {
+            slot.copy_from_slice(&bytes);
+        }
+        // Advance past this worksheet for the next sheet's offset.
+        if let Some(ws) = worksheets.get(i) {
+            running = running.saturating_add(ws.len());
+        }
+    }
+
+    // Concatenate globals + all worksheets.
+    let total: usize = globals_len
+        + worksheets.iter().map(|w| w.len()).sum::<usize>();
+    globals.reserve(total.saturating_sub(globals_len));
+    for ws in &worksheets {
+        globals.extend_from_slice(ws);
+    }
+    globals
+}
+
+/// Serialise a [`Workbook`] into the bytes of a legacy `.xls` file.
+///
+/// Builds the `Workbook` BIFF stream (globals + worksheets) and wraps it in an
+/// OLE2 Compound File via `cfb-writer`. Deterministic and infallible.
+///
+/// ```
+/// # use xls_writer::{Workbook, write_xls};
+/// let mut wb = Workbook::new();
+/// wb.add_sheet("S").set_number(0, 0, 3.14);
+/// let bytes = write_xls(&wb);
+/// assert!(bytes.len() >= 512); // a whole CFB, at minimum one sector + header
+/// ```
+pub fn write_xls(wb: &Workbook) -> Vec<u8> {
+    let workbook_stream = build_workbook_stream(wb);
+    cfb_writer::write_cfb(&[("Workbook", &workbook_stream)])
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/xls-writer/src/tests.rs
+++ b/code/packages/rust/xls-writer/src/tests.rs
@@ -1,0 +1,364 @@
+//! Tests for `xls-writer`.
+//!
+//! The headline test is [`round_trip_revenue_sheet`]: it writes a real `.xls`,
+//! re-opens it with the `cfb` reader, extracts the `Workbook` stream, and walks
+//! its BIFF records to prove every field — sheet name, `lbPlyPos` offsets, SST
+//! contents, and each cell's type/address/value — survives the trip
+//! `model → BIFF → CFB → cfb reader → BIFF → model`.
+
+use super::*;
+use cfb::CompoundFile;
+
+// ---------------------------------------------------------------------------
+// A tiny in-test BIFF walker. Real code never needs to *read* BIFF (that's the
+// eventual xls-reader's job); the test walks records itself to keep the proof
+// self-contained and dependency-free.
+// ---------------------------------------------------------------------------
+
+/// One parsed BIFF record: its type and a copy of its body bytes.
+#[derive(Debug, Clone)]
+struct BiffRecord {
+    record_type: u16,
+    /// Absolute byte offset of this record's *header* in the stream.
+    offset: usize,
+    body: Vec<u8>,
+}
+
+/// Walk a `Workbook` byte-stream into a flat list of BIFF records. Stops cleanly
+/// at the first truncated header/body (never panics).
+fn walk_biff(stream: &[u8]) -> Vec<BiffRecord> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i + 4 <= stream.len() {
+        let record_type = u16::from_le_bytes([stream[i], stream[i + 1]]);
+        let size = u16::from_le_bytes([stream[i + 2], stream[i + 3]]) as usize;
+        let body_start = i + 4;
+        let body_end = body_start + size;
+        if body_end > stream.len() {
+            break; // truncated — stop rather than read past the end
+        }
+        out.push(BiffRecord {
+            record_type,
+            offset: i,
+            body: stream[body_start..body_end].to_vec(),
+        });
+        i = body_end;
+    }
+    out
+}
+
+/// Little-endian readers over a record body, for assertions.
+fn le_u16(b: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes([b[off], b[off + 1]])
+}
+fn le_u32(b: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+}
+fn le_f64(b: &[u8], off: usize) -> f64 {
+    let mut a = [0u8; 8];
+    a.copy_from_slice(&b[off..off + 8]);
+    f64::from_le_bytes(a)
+}
+
+/// Decode a `ShortXLUnicodeString` at the given offset (u8 cch, u8 grbit, chars).
+fn read_short_string(b: &[u8], off: usize) -> String {
+    let cch = b[off] as usize;
+    let high_byte = b[off + 1] & 0x01 == 1;
+    let chars = &b[off + 2..];
+    decode_chars(chars, cch, high_byte)
+}
+
+/// Decode `cch` characters from `chars` in either 8-bit or 16-bit form.
+fn decode_chars(chars: &[u8], cch: usize, high_byte: bool) -> String {
+    if high_byte {
+        let mut units = Vec::with_capacity(cch);
+        for k in 0..cch {
+            let j = k * 2;
+            if j + 1 < chars.len() {
+                units.push(u16::from_le_bytes([chars[j], chars[j + 1]]));
+            }
+        }
+        String::from_utf16_lossy(&units)
+    } else {
+        // Compressed: each byte is the low byte of a code unit.
+        let units: Vec<u16> = chars[..cch.min(chars.len())].iter().map(|&c| c as u16).collect();
+        String::from_utf16_lossy(&units)
+    }
+}
+
+/// Parse the SST body into the list of distinct strings, honouring the per-string
+/// `fHighByte` flag. Assumes no rich/ext trailers (which this writer never emits).
+fn parse_sst(body: &[u8]) -> (u32, u32, Vec<String>) {
+    let cst_total = le_u32(body, 0);
+    let cst_unique = le_u32(body, 4);
+    let mut strings = Vec::new();
+    let mut i = 8usize;
+    while i + 3 <= body.len() && strings.len() < cst_unique as usize {
+        let cch = le_u16(body, i) as usize;
+        let high_byte = body[i + 2] & 0x01 == 1;
+        let chars_off = i + 3;
+        let char_bytes = if high_byte { cch * 2 } else { cch };
+        if chars_off + char_bytes > body.len() {
+            break;
+        }
+        strings.push(decode_chars(&body[chars_off..], cch, high_byte));
+        i = chars_off + char_bytes;
+    }
+    (cst_total, cst_unique, strings)
+}
+
+/// Extract the `Workbook` stream from written `.xls` bytes via the cfb reader.
+fn open_workbook_stream(xls: &[u8]) -> Vec<u8> {
+    let cf = CompoundFile::open(xls).expect("written .xls should parse as CFB");
+    cf.read_stream("Workbook")
+        .expect("written .xls should contain a Workbook stream")
+}
+
+// ---------------------------------------------------------------------------
+// THE round-trip proof.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_trip_revenue_sheet() {
+    // Build the model: one sheet "Revenue" with four cells.
+    let mut wb = Workbook::new();
+    let sheet = wb.add_sheet("Revenue");
+    sheet.set_string(0, 0, "Q1");
+    sheet.set_number(0, 1, 1000.0);
+    sheet.set_string(1, 0, "Total");
+    sheet.set_number(1, 1, 1234.5);
+
+    let xls = write_xls(&wb);
+
+    // It's a real CFB (OLE2 magic).
+    assert_eq!(&xls[0..8], &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+
+    let stream = open_workbook_stream(&xls);
+    let records = walk_biff(&stream);
+
+    // ---- BOUNDSHEET: exactly one, named "Revenue", lbPlyPos → worksheet BOF --
+    let boundsheets: Vec<&BiffRecord> =
+        records.iter().filter(|r| r.record_type == REC_BOUNDSHEET).collect();
+    assert_eq!(boundsheets.len(), 1, "expected exactly one BOUNDSHEET");
+    let bs = boundsheets[0];
+    let lb_ply_pos = le_u32(&bs.body, 0) as usize;
+    // hsState=0, dt=0, then name at offset 6.
+    assert_eq!(bs.body[4], 0, "hsState should be visible");
+    assert_eq!(bs.body[5], 0, "dt should be worksheet");
+    assert_eq!(read_short_string(&bs.body, 6), "Revenue");
+
+    // The lbPlyPos must land exactly on a BOF record whose dt = worksheet.
+    let bof_at_offset = records
+        .iter()
+        .find(|r| r.offset == lb_ply_pos)
+        .expect("lbPlyPos should point at the start of some record");
+    assert_eq!(bof_at_offset.record_type, REC_BOF, "lbPlyPos should point at a BOF");
+    let dt = le_u16(&bof_at_offset.body, 2);
+    assert_eq!(dt, DT_WORKSHEET, "the pointed-at BOF must be a worksheet BOF");
+
+    // ---- SST: contains "Q1" and "Total" -----------------------------------
+    let sst = records
+        .iter()
+        .find(|r| r.record_type == REC_SST)
+        .expect("there should be an SST record");
+    let (cst_total, cst_unique, strings) = parse_sst(&sst.body);
+    assert_eq!(cst_total, 2, "two string cells");
+    assert_eq!(cst_unique, 2, "two distinct strings");
+    assert!(strings.iter().any(|s| s == "Q1"), "SST should contain Q1: {strings:?}");
+    assert!(strings.iter().any(|s| s == "Total"), "SST should contain Total");
+
+    // Map string -> isst for cell checks.
+    let isst_of = |want: &str| -> u32 {
+        strings.iter().position(|s| s == want).expect("string present") as u32
+    };
+
+    // ---- Cells: walk the worksheet substream -------------------------------
+    // Gather LABELSST and NUMBER records (they only appear inside the worksheet).
+    let labelssts: Vec<&BiffRecord> =
+        records.iter().filter(|r| r.record_type == REC_LABELSST).collect();
+    let numbers: Vec<&BiffRecord> =
+        records.iter().filter(|r| r.record_type == REC_NUMBER).collect();
+    assert_eq!(labelssts.len(), 2);
+    assert_eq!(numbers.len(), 2);
+
+    // Helper: find a LABELSST at (row, col) and return its isst.
+    let find_label = |row: u16, col: u16| -> u32 {
+        let r = labelssts
+            .iter()
+            .find(|r| le_u16(&r.body, 0) == row && le_u16(&r.body, 2) == col)
+            .unwrap_or_else(|| panic!("no LABELSST at ({row},{col})"));
+        le_u32(&r.body, 6)
+    };
+    let find_number = |row: u16, col: u16| -> f64 {
+        let r = numbers
+            .iter()
+            .find(|r| le_u16(&r.body, 0) == row && le_u16(&r.body, 2) == col)
+            .unwrap_or_else(|| panic!("no NUMBER at ({row},{col})"));
+        le_f64(&r.body, 6)
+    };
+
+    // (0,0)="Q1", (0,1)=1000.0, (1,0)="Total", (1,1)=1234.5.
+    assert_eq!(find_label(0, 0), isst_of("Q1"));
+    assert_eq!(find_number(0, 1), 1000.0);
+    assert_eq!(find_label(1, 0), isst_of("Total"));
+    assert_eq!(find_number(1, 1), 1234.5);
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sst_dedups_identical_strings() {
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("S");
+    s.set_string(0, 0, "same");
+    s.set_string(1, 0, "same");
+
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+    let sst = records.iter().find(|r| r.record_type == REC_SST).unwrap();
+    let (cst_total, cst_unique, strings) = parse_sst(&sst.body);
+    assert_eq!(cst_total, 2, "cstTotal counts every string cell");
+    assert_eq!(cst_unique, 1, "cstUnique counts distinct strings");
+    assert_eq!(strings, vec!["same".to_string()]);
+
+    // Both LABELSST records reference the same (index 0) entry.
+    let labels: Vec<&BiffRecord> =
+        records.iter().filter(|r| r.record_type == REC_LABELSST).collect();
+    assert_eq!(labels.len(), 2);
+    assert!(labels.iter().all(|r| le_u32(&r.body, 6) == 0));
+}
+
+#[test]
+fn non_ascii_forces_wide_encoding() {
+    // "sun ☃" contains U+2603 (> 0xFF) → the whole string must use the 16-bit
+    // (fHighByte) encoding and still decode correctly.
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").set_string(0, 0, "sun ☃");
+
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+    let sst = records.iter().find(|r| r.record_type == REC_SST).unwrap();
+    // The single string's grbit (byte at body[8+2]) must have fHighByte set.
+    assert_eq!(sst.body[10] & 0x01, 0x01, "non-Latin1 string must set fHighByte");
+    let (_total, _unique, strings) = parse_sst(&sst.body);
+    assert_eq!(strings, vec!["sun ☃".to_string()]);
+}
+
+#[test]
+fn latin1_string_uses_compressed_encoding() {
+    // "café" — every code unit (incl. é = U+00E9) is ≤ 0xFF → compressed 8-bit.
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").set_string(0, 0, "café");
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+    let sst = records.iter().find(|r| r.record_type == REC_SST).unwrap();
+    assert_eq!(sst.body[10] & 0x01, 0x00, "Latin1 string should be compressed");
+    let (_t, _u, strings) = parse_sst(&sst.body);
+    assert_eq!(strings, vec!["café".to_string()]);
+}
+
+#[test]
+fn multiple_sheets_get_distinct_lbplypos() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("Alpha").set_number(0, 0, 1.0);
+    wb.add_sheet("Beta").set_number(0, 0, 2.0);
+    wb.add_sheet("Gamma").set_string(0, 0, "g");
+
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+
+    let boundsheets: Vec<&BiffRecord> =
+        records.iter().filter(|r| r.record_type == REC_BOUNDSHEET).collect();
+    assert_eq!(boundsheets.len(), 3);
+
+    // Names in order.
+    assert_eq!(read_short_string(&boundsheets[0].body, 6), "Alpha");
+    assert_eq!(read_short_string(&boundsheets[1].body, 6), "Beta");
+    assert_eq!(read_short_string(&boundsheets[2].body, 6), "Gamma");
+
+    // Each lbPlyPos points at a distinct worksheet BOF, in increasing order.
+    let mut positions = Vec::new();
+    for bs in &boundsheets {
+        let pos = le_u32(&bs.body, 0) as usize;
+        let target = records
+            .iter()
+            .find(|r| r.offset == pos)
+            .expect("lbPlyPos should hit a record boundary");
+        assert_eq!(target.record_type, REC_BOF);
+        assert_eq!(le_u16(&target.body, 2), DT_WORKSHEET);
+        positions.push(pos);
+    }
+    // Distinct and strictly increasing (sheets are laid out in order).
+    assert!(positions[0] < positions[1] && positions[1] < positions[2]);
+}
+
+#[test]
+fn empty_workbook_does_not_panic() {
+    let wb = Workbook::new();
+    let xls = write_xls(&wb);
+    // Still a valid CFB with a (tiny) Workbook stream: globals BOF + EOF + SST.
+    let stream = open_workbook_stream(&xls);
+    let records = walk_biff(&stream);
+    assert_eq!(records.first().map(|r| r.record_type), Some(REC_BOF));
+    assert!(records.iter().any(|r| r.record_type == REC_EOF));
+}
+
+#[test]
+fn empty_sheet_does_not_panic() {
+    let mut wb = Workbook::new();
+    wb.add_sheet("Empty"); // a sheet with no cells
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+    // BOUNDSHEET present, worksheet substream is just BOF then EOF.
+    let bs = records.iter().find(|r| r.record_type == REC_BOUNDSHEET).unwrap();
+    assert_eq!(read_short_string(&bs.body, 6), "Empty");
+    let ply = le_u32(&bs.body, 0) as usize;
+    let bof = records.iter().find(|r| r.offset == ply).unwrap();
+    assert_eq!(bof.record_type, REC_BOF);
+    assert_eq!(le_u16(&bof.body, 2), DT_WORKSHEET);
+}
+
+#[test]
+fn out_of_range_cell_is_skipped() {
+    // A column beyond u16::MAX cannot be represented; the cell is skipped, and a
+    // valid neighbour still appears.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("S");
+    s.set_number(0, 70_000, 9.0); // col > 65535 → skipped
+    s.set_number(0, 5, 7.0); // valid
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+    let numbers: Vec<&BiffRecord> =
+        records.iter().filter(|r| r.record_type == REC_NUMBER).collect();
+    assert_eq!(numbers.len(), 1, "the out-of-range cell must be skipped");
+    assert_eq!(le_u16(&numbers[0].body, 2), 5); // col field is at body offset 2
+    assert_eq!(le_f64(&numbers[0].body, 6), 7.0);
+}
+
+#[test]
+fn number_record_preserves_exact_f64() {
+    // A value with a full mantissa (would NOT fit RK) must round-trip exactly via
+    // the NUMBER record.
+    let mut wb = Workbook::new();
+    wb.add_sheet("S").set_number(3, 4, std::f64::consts::PI);
+    let stream = open_workbook_stream(&write_xls(&wb));
+    let records = walk_biff(&stream);
+    let n = records.iter().find(|r| r.record_type == REC_NUMBER).unwrap();
+    assert_eq!(le_u16(&n.body, 0), 3);
+    assert_eq!(le_u16(&n.body, 2), 4);
+    assert_eq!(le_f64(&n.body, 6), std::f64::consts::PI);
+}
+
+#[test]
+fn output_is_deterministic() {
+    let build = || {
+        let mut wb = Workbook::new();
+        let s = wb.add_sheet("D");
+        s.set_string(0, 0, "x");
+        s.set_number(0, 1, 2.5);
+        write_xls(&wb)
+    };
+    assert_eq!(build(), build(), "identical models must produce identical bytes");
+}

--- a/code/specs/XLSW01-xls-writer.md
+++ b/code/specs/XLSW01-xls-writer.md
@@ -1,0 +1,255 @@
+# XLSW01 — Legacy `.xls` (BIFF8) writer
+
+> A **writer** for the legacy **`.xls` / BIFF8** spreadsheet format ([MS-XLS]).
+> You give it a simple spreadsheet model — sheets of string and number cells —
+> and it produces the bytes of a real `.xls` file: a stream of **BIFF records**
+> wrapped in an **OLE2 / Compound File** container. This is milestone **C4**
+> (legacy write) of the OOXML/BIFF stack.
+>
+> Implemented by `code/packages/rust/xls-writer` (crate `xls-writer`).
+
+This spec assumes you have read [CFBW01](CFBW01-cfb-writer.md) (the container
+writer) and skimmed [CFB01](CFB01-compound-file.md) (the reader). This crate
+sits **on top** of `cfb-writer`: it builds one `Workbook` byte-stream and hands
+it to `cfb-writer` to be wrapped into the `.xls` file.
+
+```
+        deflate ── zip ── xml ── opc ── spreadsheetml ── xlsx-eval   (OOXML, .xlsx)
+
+   cfb (reader) ◄──────── round-trip proof ────────► cfb-writer     (OLE2 container)
+                                                          │
+                                                     xls-writer      (this crate — BIFF8)
+```
+
+---
+
+## 1. What a minimal `.xls` actually is
+
+A `.xls` file is an **OLE2 Compound File** (the "FAT filesystem in a file" from
+CFB01) that contains a single named stream called **`Workbook`**. That stream
+holds a flat sequence of **BIFF records**. So writing a `.xls` is two layers:
+
+1. **This crate:** turn the model into a `Vec<u8>` of BIFF records.
+2. **`cfb-writer`:** wrap that `Vec<u8>` as the `Workbook` stream of a CFB file.
+
+We are done the moment `cfb_writer::write_cfb(&[("Workbook", &biff)])` returns.
+
+### 1.1 The BIFF record framing
+
+Every BIFF record is a tiny TLV (type-length-value):
+
+```text
+   ┌────────────┬────────────┬───────────────────────────┐
+   │ u16 type   │ u16 size   │  `size` bytes of body      │
+   │ (LE)       │ (LE)       │                            │
+   └────────────┴────────────┴───────────────────────────┘
+     2 bytes      2 bytes       `size` bytes
+```
+
+To *walk* a BIFF stream you repeatedly read a 4-byte header, then skip `size`
+body bytes — exactly what the round-trip test's in-test walker does. Because
+`size` is a `u16`, **no single record body may exceed 65535 bytes**; larger
+payloads (a big shared-string table) must be split across `CONTINUE` records.
+We keep our one variable-length record (the SST) small enough to avoid that;
+see §6.
+
+The record types we emit:
+
+| Name         | Type (hex) | Meaning                                        |
+|--------------|-----------:|------------------------------------------------|
+| `BOF`        |   `0x0809` | Beginning of a substream                        |
+| `EOF`        |   `0x000A` | End of a substream                              |
+| `BOUNDSHEET` |   `0x0085` | Declares one worksheet: name + byte offset      |
+| `SST`        |   `0x00FC` | Shared string table (all distinct string values)|
+| `LABELSST`   |   `0x00FD` | A string cell (references an SST index)         |
+| `NUMBER`     |   `0x0203` | A numeric cell (an IEEE-754 `f64`)              |
+
+### 1.2 Substreams: globals + one per worksheet
+
+BIFF records are grouped into **substreams**, each bracketed by a `BOF` … `EOF`
+pair. A workbook is:
+
+```text
+   ┌─────────────────────────── Workbook stream ───────────────────────────┐
+   │  BOF(globals) BOUNDSHEET… SST EOF │ BOF(sheet) cells… EOF │ BOF … EOF   │
+   │  └──────── globals substream ─────┘└─ worksheet 0 ───────┘└ worksheet 1┘│
+   └───────────────────────────────────────────────────────────────────────┘
+```
+
+- The **globals substream** (`BOF` dt=`0x0005`) declares the sheets
+  (`BOUNDSHEET`, one per sheet) and holds the shared-string table (`SST`).
+- Each **worksheet substream** (`BOF` dt=`0x0010`) holds that sheet's cell
+  records.
+
+`BOF` bodies are 16 bytes: `u16 vers=0x0600` (BIFF8), `u16 dt` (substream type),
+then `u16 rupBuild`, `u16 rupYear`, `u32 bfh`, `u32 sfo` — all four trailers
+zeroed for deterministic output.
+
+---
+
+## 2. Cells: `LABELSST` and `NUMBER`
+
+Every cell record starts with a 6-byte **cell head**: `u16 row`, `u16 col`,
+`u16 ixfe` (the cell format / XF index — we always use `0`, the default XF).
+All rows/cols are **0-based** in BIFF.
+
+- **`NUMBER` (`0x0203`)** — cell head + an 8-byte little-endian IEEE-754 `f64`.
+- **`LABELSST` (`0x00FD`)** — cell head + `u32 isst`, an index into the SST.
+
+### 2.1 Why `NUMBER`, not `RK`?
+
+BIFF also has an `RK` record that packs certain numbers (30-bit integers, or
+`f64`s whose low 34 bits are zero) into 4 bytes. It is a *space optimization*
+only. We deliberately choose `NUMBER` for **every** numeric cell:
+
+- It is total: it represents **any** `f64` exactly, with no case analysis.
+- It keeps the writer simple and the output easy to verify (the 8 bytes are just
+  `f64::to_le_bytes`).
+
+`RK` would save 4 bytes per qualifying cell but adds encoding branches and a
+whole extra record type to test. For a from-scratch, correctness-first writer
+that trade is not worth it. (A future optimization pass could add `RK`.)
+
+---
+
+## 3. Shared strings (the SST) and `LABELSST`
+
+String cell *values* are not stored in the cell record. Instead every distinct
+string lives once in the **SST** (shared string table) in the globals substream,
+and each string cell is a `LABELSST` holding the **index** of its value in the
+SST. This deduplicates repeated strings (think a column of `"Yes"`/`"No"`).
+
+The SST body:
+
+```text
+   u32 cstTotal    ← total number of string-cell references (LABELSST count)
+   u32 cstUnique   ← number of DISTINCT strings stored below
+   then, cstUnique times, an XLUnicodeRichExtendedString:
+       u16 cch      ← character count
+       u8  grbit    ← flags; bit0 fHighByte (see §5)
+       chars…       ← cch bytes (8-bit) or cch*2 bytes (16-bit UTF-16LE)
+```
+
+`cstTotal` counts *cells*; `cstUnique` counts *distinct strings*. Writing two
+cells with the same string gives `cstTotal=2, cstUnique=1`, and both `LABELSST`
+records carry the same `isst`.
+
+We do **not** set the rich-text (`fRichSt`) or extended (`fExtSt`) bits, and we
+emit no `rgRun`/`ExtRst` trailer — those bits being clear means the string is
+exactly `cch` characters and nothing more.
+
+---
+
+## 4. The `BOUNDSHEET` `lbPlyPos` two-pass
+
+This is the one genuinely fiddly part. Each `BOUNDSHEET` record body is:
+
+```text
+   u32 lbPlyPos    ← BYTE OFFSET, within the Workbook stream, of this sheet's
+                     worksheet BOF record
+   u8  hsState = 0 ← visible
+   u8  dt      = 0 ← worksheet
+   ShortXLUnicodeString name:
+       u8 cch, u8 grbit, then the chars
+```
+
+`lbPlyPos` must point at the *start of that sheet's worksheet `BOF`*. But that
+offset depends on the size of the globals substream — which **contains the
+`BOUNDSHEET` records themselves**. Chicken and egg. We break it with a clean
+two-pass:
+
+```text
+   ┌─────────────────────── Workbook stream ────────────────────────┐
+   │  [ globals substream ]  [ worksheet 0 ]  [ worksheet 1 ] ...    │
+   │  ^                      ^                ^                       │
+   │  0                      G                G+W0                   │
+   └────────────────────────────────────────────────────────────────┘
+
+   lbPlyPos(sheet 0) = G            (= globals length)
+   lbPlyPos(sheet 1) = G + W0
+   lbPlyPos(sheet k) = G + Σ_{i<k} Wi
+```
+
+Algorithm:
+
+1. **Build the globals buffer** with `BOUNDSHEET` records whose `lbPlyPos` field
+   is a placeholder (`0`). While building, record the byte offset of each
+   `BOUNDSHEET`'s `lbPlyPos` field inside the globals buffer.
+2. **Build each worksheet buffer** independently; note each one's length `Wi`.
+3. Now `G = globals.len()` is known. Compute each worksheet's absolute start
+   offset `G + Σ_{i<k} Wi`.
+4. **Backfill**: patch the 4 `lbPlyPos` bytes of each `BOUNDSHEET` in the
+   globals buffer with its sheet's absolute offset.
+5. **Concatenate** globals + all worksheets → the `Workbook` stream.
+
+The round-trip test verifies this: it reads each `BOUNDSHEET.lbPlyPos`, seeks to
+that offset in the stream, and asserts a `BOF` with dt=`0x0010` starts there.
+
+---
+
+## 5. String encoding: the `fHighByte` bit
+
+BIFF8 strings are "compressed UTF-16": a flag bit (`grbit` bit0, `fHighByte`)
+chooses the character width:
+
+- `fHighByte = 0` → each character is **1 byte** (Latin-1 / the low byte of each
+  UTF-16 code unit). Used only when *every* code unit is ≤ `0xFF`.
+- `fHighByte = 1` → each character is **2 bytes**, little-endian **UTF-16LE**.
+
+We pick per string: if all code units fit in a byte we use the compact 8-bit
+form; otherwise the 16-bit form. Both the SST strings
+(`XLUnicodeRichExtendedString`, `cch` is a `u16`) and the sheet names in
+`BOUNDSHEET` (`ShortXLUnicodeString`, `cch` is a `u8`) use the same scheme.
+
+The test's non-ASCII case (`"café"` → `é` is `U+00E9` ≤ `0xFF`, but a string
+with, e.g., `U+2603 ☃` forces 16-bit) proves both paths decode correctly.
+
+---
+
+## 6. Limitations & robustness
+
+- **No `CONTINUE` splitting.** A BIFF record body is capped at 65535 bytes. The
+  SST is our only variable-length record; a workbook with enough distinct
+  strings to overflow one SST record would, in a full implementation, spill into
+  `CONTINUE` records. We do **not** implement that — we keep the SST small. If
+  the encoded SST body would exceed the `u16` size field we clamp its declared
+  size rather than emit a corrupt record; this is a documented limitation, not a
+  silent-truncation bug. (Realistic small workbooks never approach the limit.)
+- **`u16` field limits.** Rows and columns are `u16` in BIFF; a cell beyond
+  `65535` in either axis cannot be represented and is **skipped** (documented)
+  rather than wrapped into a wrong address. A string longer than `u16::MAX`
+  characters likewise cannot fit its `cch` field; we clamp/skip rather than
+  truncate into a wrong length.
+- **Deterministic.** No timestamps or randomness anywhere; identical models
+  produce identical bytes.
+- **Totality.** `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on the
+  public path; `checked_*` arithmetic guards every size computation.
+
+---
+
+## 7. Public API
+
+```rust
+pub struct Workbook { /* sheets */ }
+impl Workbook {
+    pub fn new() -> Self;
+    pub fn add_sheet(&mut self, name: &str) -> &mut Sheet;
+}
+pub struct Sheet { /* name + cells */ }
+impl Sheet {
+    pub fn set_string(&mut self, row: u32, col: u32, s: &str);
+    pub fn set_number(&mut self, row: u32, col: u32, n: f64);
+}
+pub fn write_xls(wb: &Workbook) -> Vec<u8>;   // -> .xls bytes
+```
+
+---
+
+## 8. The round-trip proof
+
+The proof (a test) builds a workbook, calls `write_xls`, opens the bytes with
+the `cfb` reader, extracts the `Workbook` stream, and walks its BIFF records to
+assert: the `BOUNDSHEET` name and its `lbPlyPos` (pointing at a worksheet `BOF`),
+the SST contents, and every cell's type/address/value. This closes the loop
+`model → BIFF → CFB → cfb reader → BIFF → model` and is the single most
+important test in the crate.


### PR DESCRIPTION
Legacy writer on cfb-writer; round-trips through our cfb reader in-test; security review passed (all model casts guarded via checked_*/try_from, deterministic, #![forbid(unsafe_code)]). xls-writer additionally cross-checked with xlrd.