### PR TITLE
feat(ppt-writer): C4 write legacy .ppt binary via cfb-writer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "cfb-writer",
     "xls-writer",
     "doc-writer",
+    "ppt-writer",
     "binary-search-tree",
     "avl-tree",
     "red-black-tree",

--- a/code/packages/rust/ppt-writer/BUILD
+++ b/code/packages/rust/ppt-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p ppt-writer -- --nocapture

--- a/code/packages/rust/ppt-writer/BUILD_windows
+++ b/code/packages/rust/ppt-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p ppt-writer -- --nocapture

--- a/code/packages/rust/ppt-writer/CHANGELOG.md
+++ b/code/packages/rust/ppt-writer/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to `ppt-writer` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-03
+
+### Added
+
+- Initial release (**PPTW01**): a from-scratch, zero-third-party-dependency
+  **writer** for the legacy **PowerPoint 97-2003 binary** format (`.ppt`,
+  [MS-PPT]). Milestone **C4**.
+- Public API:
+  - `Presentation::new()`, `Presentation::add_slide() -> &mut Slide`.
+  - `Slide::new()`, `Slide::add_text(&str)` — one paragraph → one text atom.
+  - `write_ppt(&Presentation) -> Vec<u8>`.
+- **Record emission** per [MS-PPT]:
+  - 8-byte **RecordHeader** with bit-packed `recVerAndInstance`
+    (`(recVer & 0xF) | (recInstance << 4)`), `recType`, and a `u32` body
+    `recLen`; `recVer == 0xF` marks a container.
+  - **Slide container** (`recType 0x03EE`, `recVer 0xF`) per slide.
+  - **TextBytesAtom** (`0x0FA8`) for all-Latin-1 paragraphs (one byte per char)
+    and **TextCharsAtom** (`0x0FA0`, UTF-16LE) for anything with a char > 0xFF —
+    chosen per paragraph.
+- **CFB wrapping** via the sibling `cfb-writer` crate: the concatenated Slide
+  containers form the **"PowerPoint Document"** stream, plus a 4-byte stub
+  **"Current User"** stream for authenticity.
+- **Robustness**: `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on
+  the public path; oversize bodies skipped via `u32::try_from` rather than
+  wrapped into a corrupting length; deterministic output.
+- **Round-trip proof**: writes a two-slide deck, reopens it with the `cfb`
+  reader, extracts the "PowerPoint Document" stream, and walks the record tree
+  (recursing into containers, decoding text atoms, stopping on the sector
+  zero-padding sentinel). Asserts two Slide containers and their exact
+  paragraph text. 13 unit tests + 1 doctest, all passing; clippy clean under
+  `-D warnings`.
+
+### Known limitations
+
+- Minimal record profile: no `DocumentContainer`, persist-object directory,
+  master slides, or formatting — just Slide containers with text atoms,
+  sufficient to place and round-trip slide text for milestone C4.
+- Only Slide-level text is modelled; shapes, tables, images, and speaker notes
+  are out of scope for 0.1.0.
+
+[MS-PPT]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/

--- a/code/packages/rust/ppt-writer/Cargo.toml
+++ b/code/packages/rust/ppt-writer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ppt-writer"
+version = "0.1.0"
+edition = "2021"
+description = "A from-scratch, zero-third-party-dependency writer for the legacy PowerPoint 97-2003 binary format (.ppt, [MS-PPT]). Emits records into a 'PowerPoint Document' stream and wraps it in an OLE2 Compound File via the `cfb-writer` crate."
+license = "MIT"
+
+[dependencies]
+# The only dependency is our sibling CFB container writer — no third-party crates.
+cfb-writer = { path = "../cfb-writer" }
+
+[dev-dependencies]
+# The reader, used to prove our .ppt output round-trips: reopen the container,
+# extract the "PowerPoint Document" stream, and walk the record tree.
+cfb = { path = "../cfb" }

--- a/code/packages/rust/ppt-writer/README.md
+++ b/code/packages/rust/ppt-writer/README.md
@@ -1,0 +1,96 @@
+# ppt-writer
+
+A from-scratch, **zero-third-party-dependency** writer for the legacy
+**PowerPoint 97-2003 binary** format (`.ppt`, [MS-PPT]). You build a slide-deck
+model in memory; it produces the bytes of a real `.ppt` file.
+
+This is milestone **C4** of the OOXML/binary-Office effort — the `.ppt` sibling
+to the `.xls` writer path. It sits directly on top of the
+[`cfb-writer`](../cfb-writer) crate, which supplies the OLE2 Compound File
+container.
+
+## Where it fits in the stack
+
+```text
+  Presentation model  (this crate's public API)
+        │  write_ppt
+        ▼
+  "PowerPoint Document" record stream   ← [MS-PPT] Slide containers + text atoms
+        │  cfb-writer::write_cfb
+        ▼
+  OLE2 Compound File bytes  →  a real .ppt file
+```
+
+A `.ppt` file is an OLE2 compound file (the same container as `.xls`/`.doc`)
+whose payload lives in a stream named exactly **"PowerPoint Document"**. That
+stream is a **tree of records**: each opens with an 8-byte header, and its body
+is either child records (a *container*) or opaque data (an *atom*). This crate
+emits, per slide, a **Slide container** whose children are **text atoms** — one
+per paragraph — and hands the concatenated stream to `cfb-writer`.
+
+## Usage
+
+```rust
+use ppt_writer::{Presentation, write_ppt};
+
+let mut deck = Presentation::new();
+
+let s1 = deck.add_slide();
+s1.add_text("Slide One Title");
+s1.add_text("First slide body");
+
+let s2 = deck.add_slide();
+s2.add_text("Slide Two Title");
+s2.add_text("Second slide body");
+
+let bytes = write_ppt(&deck);
+std::fs::write("deck.ppt", &bytes).unwrap();
+```
+
+## API
+
+- `Presentation::new()` — an empty deck.
+- `Presentation::add_slide() -> &mut Slide` — append a slide, get a handle.
+- `Slide::add_text(&str)` — one paragraph → one text atom.
+- `write_ppt(&Presentation) -> Vec<u8>` — serialise to `.ppt` bytes.
+
+## Encoding details
+
+- **RecordHeader** (8 bytes, little-endian): `recVerAndInstance` (low 4 bits =
+  `recVer`, high 12 = `recInstance`), `recType`, then a `u32` `recLen` (body
+  length only). **`recVer == 0xF` marks a container.**
+- **Slide container** — `recType 0x03EE`, `recVer 0xF`.
+- **TextBytesAtom** — `recType 0x0FA8`: one byte per char (Latin-1). Chosen when
+  every char is ≤ U+00FF.
+- **TextCharsAtom** — `recType 0x0FA0`: UTF-16LE. Chosen when any char is
+  > U+00FF (e.g. `"你好"`), so nothing is lost.
+
+The per-paragraph atom choice is a pure size optimisation; a reader decodes each
+atom by its `recType`.
+
+## Robustness
+
+- `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on the public path.
+- Lengths are packed with `u32::try_from`; an atom or container whose body would
+  overflow the `u32` `recLen` is **skipped** rather than wrapped into a
+  corrupting length.
+- Output is **deterministic**: identical models yield identical bytes.
+
+## The proof: round-trip through the `cfb` reader
+
+The test suite writes a two-slide deck, reopens the `.ppt` with the sibling
+[`cfb`](../cfb) reader, extracts the "PowerPoint Document" stream, and walks the
+record tree — asserting two Slide containers and their exact paragraph text.
+Because a CFB stream is zero-padded up to a sector boundary, the walker stops on
+the padding sentinel (`recType == 0 && recLen == 0`) or when fewer than 8 bytes
+remain.
+
+See `code/specs/PPTW01-ppt-writer.md` for the full literate walkthrough.
+
+## Testing
+
+```sh
+cargo test -p ppt-writer -- --nocapture
+```
+
+[MS-PPT]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/

--- a/code/packages/rust/ppt-writer/required_capabilities.json
+++ b/code/packages/rust/ppt-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/ppt-writer",
+  "capabilities": [],
+  "justification": "Pure in-memory binary emission. Callers build a slide-deck model in process and receive a byte buffer; the crate does no filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/ppt-writer/src/lib.rs
+++ b/code/packages/rust/ppt-writer/src/lib.rs
@@ -1,0 +1,254 @@
+//! # ppt-writer — legacy PowerPoint (`.ppt`) writer (PPTW01)
+//!
+//! A from-scratch, zero-third-party-dependency **writer** for the legacy
+//! **PowerPoint 97-2003 binary** format (`.ppt`, [MS-PPT]). You build a
+//! slide-deck model — a [`Presentation`] of [`Slide`]s, each holding paragraphs
+//! of text — and [`write_ppt`] turns it into the bytes of a real `.ppt` file.
+//! See `code/specs/PPTW01-ppt-writer.md` for the full literate walkthrough.
+//!
+//! ## The one-paragraph mental model
+//!
+//! A `.ppt` file is an **OLE2 Compound File** (the same container as `.xls` and
+//! `.doc`). Its payload lives in a stream named exactly **"PowerPoint
+//! Document"**, and that stream is a **tree of records**. Every record opens
+//! with an 8-byte **RecordHeader**; its body is either *more records* (a
+//! *container*) or opaque data (an *atom*). We emit, per slide, a **Slide
+//! container** whose children are **text atoms** — one atom per paragraph. We
+//! then hand the concatenated stream to the sibling [`cfb-writer`] crate, which
+//! wraps it in the OLE2 container.
+//!
+//! ```
+//! # use ppt_writer::{Presentation, write_ppt};
+//! let mut deck = Presentation::new();
+//! let s = deck.add_slide();
+//! s.add_text("Hello slide");
+//! let bytes = write_ppt(&deck);
+//! // It is a Compound File: begins with the OLE2 magic.
+//! assert_eq!(&bytes[0..8], &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+//! ```
+//!
+//! ## The RecordHeader — 8 bytes, bit-packed
+//!
+//! ```text
+//!  offset  size  field       meaning
+//!    0      2    recVerAndI  low 4 bits = recVer, high 12 bits = recInstance
+//!    2      2    recType     which record (0x03EE = Slide, 0x0FA8 = TextBytes…)
+//!    4      4    recLen      length of the BODY that follows, in bytes
+//! ```
+//!
+//! All little-endian. **`recVer == 0xF` marks a container** (body is child
+//! records); any other `recVer` marks an atom (body is opaque data). `recLen`
+//! counts only the body, never the 8 header bytes.
+//!
+//! ## The two text atoms
+//!
+//! Each paragraph becomes exactly one text atom, chosen from the text itself:
+//!
+//! - **TextBytesAtom** (`0x0FA8`): one byte per char (Latin-1). Used when every
+//!   char's scalar value is ≤ `0x00FF`. Half the size of ASCII text.
+//! - **TextCharsAtom** (`0x0FA0`): UTF-16LE, two bytes per code unit. Used when
+//!   any char exceeds `0x00FF`, so nothing is lost (e.g. `"你好"`).
+//!
+//! ## Robustness
+//!
+//! `#![forbid(unsafe_code)]`, and no `unwrap`/`expect`/`panic!` on the public
+//! path. Lengths are packed with `u32::try_from`; an atom or container whose
+//! body would overflow the `u32` `recLen` is **skipped** rather than wrapped
+//! into a corrupting length. Output is deterministic.
+
+#![forbid(unsafe_code)]
+
+// ---------------------------------------------------------------------------
+// Record-type and version constants. These are the [MS-PPT] numbers; a writer
+// and any reader must agree on them exactly.
+// ---------------------------------------------------------------------------
+
+/// `recType` for a **SlideContainer** — one per slide, holds the slide's atoms.
+const REC_TYPE_SLIDE: u16 = 0x03EE;
+/// `recType` for a **TextCharsAtom** — text as UTF-16LE (two bytes per unit).
+const REC_TYPE_TEXT_CHARS: u16 = 0x0FA0;
+/// `recType` for a **TextBytesAtom** — text as Latin-1 (one byte per char).
+const REC_TYPE_TEXT_BYTES: u16 = 0x0FA8;
+
+/// `recVer` value that marks a record as a **container** (its body is children).
+const REC_VER_CONTAINER: u16 = 0xF;
+/// `recVer` value for our text **atoms** (body is opaque data).
+const REC_VER_ATOM: u16 = 0x0;
+
+/// The CFB stream name that carries the record tree. Must be exactly this.
+const STREAM_POWERPOINT_DOCUMENT: &str = "PowerPoint Document";
+/// A tiny stub `CurrentUserAtom` stream, present in real files for authenticity.
+/// Our reader never consults it; it is harmless padding for interoperability.
+const STREAM_CURRENT_USER: &str = "Current User";
+/// The stub "Current User" bytes: a 4-byte little-endian `0x00000014`.
+const CURRENT_USER_STUB: [u8; 4] = [0x14, 0x00, 0x00, 0x00];
+
+// ---------------------------------------------------------------------------
+// The public model: Presentation -> Slide -> paragraphs of text.
+// ---------------------------------------------------------------------------
+
+/// A slide-deck model: an ordered list of [`Slide`]s. Build one with
+/// [`Presentation::new`], append slides with [`Presentation::add_slide`], then
+/// serialise with [`write_ppt`].
+#[derive(Debug, Default, Clone)]
+pub struct Presentation {
+    slides: Vec<Slide>,
+}
+
+impl Presentation {
+    /// Create an empty presentation. Serialising it yields a valid `.ppt` whose
+    /// "PowerPoint Document" stream is logically empty (zero records).
+    pub fn new() -> Self {
+        Presentation { slides: Vec::new() }
+    }
+
+    /// Append a new, empty slide and return a mutable handle to it so the caller
+    /// can add paragraphs. Slides keep insertion order, which becomes the order
+    /// of Slide containers in the output stream.
+    pub fn add_slide(&mut self) -> &mut Slide {
+        self.slides.push(Slide::new());
+        // A `push` guarantees at least one element, so `last_mut` is infallible
+        // here. The `expect` is structural, not an input-driven failure path.
+        self.slides
+            .last_mut()
+            .expect("just pushed a slide, so last_mut is Some")
+    }
+
+    /// The slides, in insertion order (read-only view, mainly for tests).
+    pub fn slides(&self) -> &[Slide] {
+        &self.slides
+    }
+}
+
+/// One slide: an ordered list of paragraphs. Each paragraph becomes exactly one
+/// text atom inside the slide's container.
+#[derive(Debug, Default, Clone)]
+pub struct Slide {
+    paragraphs: Vec<String>,
+}
+
+impl Slide {
+    /// Create an empty slide (no paragraphs). An empty slide is legal: it emits
+    /// a Slide container with a zero-length body.
+    pub fn new() -> Self {
+        Slide {
+            paragraphs: Vec::new(),
+        }
+    }
+
+    /// Add one paragraph of text. It becomes one text atom (TextBytes if the
+    /// text is all-Latin-1, else TextChars).
+    pub fn add_text(&mut self, text: &str) {
+        self.paragraphs.push(text.to_string());
+    }
+
+    /// The paragraphs, in insertion order (read-only view, mainly for tests).
+    pub fn paragraphs(&self) -> &[String] {
+        &self.paragraphs
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Record emission — the heart of the writer.
+// ---------------------------------------------------------------------------
+
+/// Append an 8-byte RecordHeader to `out`.
+///
+/// `recVerAndInstance` (the first `u16`) packs two numbers:
+/// `(recVer & 0xF) | ((recInstance & 0xFFF) << 4)`. We always pass
+/// `recInstance = 0` (the minimal profile has no instance-numbered records).
+///
+/// Returns `false` (and appends nothing) if `body_len` does not fit in the
+/// `u32` `recLen` field — the caller then skips the whole record rather than
+/// emitting a wrong length.
+fn push_record_header(out: &mut Vec<u8>, rec_ver: u16, rec_type: u16, body_len: usize) -> bool {
+    // recLen is a u32; a body larger than u32::MAX cannot be described. Skip.
+    let Ok(rec_len) = u32::try_from(body_len) else {
+        return false;
+    };
+    let rec_instance: u16 = 0;
+    let ver_and_instance = (rec_ver & 0x000F) | ((rec_instance & 0x0FFF) << 4);
+    out.extend_from_slice(&ver_and_instance.to_le_bytes());
+    out.extend_from_slice(&rec_type.to_le_bytes());
+    out.extend_from_slice(&rec_len.to_le_bytes());
+    true
+}
+
+/// Decide whether a string can use the compact TextBytes encoding: true exactly
+/// when every character's Unicode scalar value fits in a single byte (≤ 0xFF).
+fn is_all_latin1(text: &str) -> bool {
+    text.chars().all(|c| (c as u32) <= 0xFF)
+}
+
+/// Encode one paragraph's *body* bytes (no header) and report which atom type to
+/// use. TextBytes → one byte per char; TextChars → UTF-16LE.
+fn encode_text_body(text: &str) -> (u16, Vec<u8>) {
+    if is_all_latin1(text) {
+        // Latin-1: each char's scalar (guaranteed ≤ 0xFF) is one byte.
+        let body: Vec<u8> = text.chars().map(|c| c as u8).collect();
+        (REC_TYPE_TEXT_BYTES, body)
+    } else {
+        // UTF-16LE: two bytes per code unit (surrogate pairs for astral chars).
+        let mut body = Vec::with_capacity(text.len() * 2);
+        for unit in text.encode_utf16() {
+            body.extend_from_slice(&unit.to_le_bytes());
+        }
+        (REC_TYPE_TEXT_CHARS, body)
+    }
+}
+
+/// Emit one text atom (header + body) for `text`, appending to `out`. If the
+/// body would overflow the `u32` `recLen`, the atom is skipped (nothing is
+/// appended) — a shorter valid file beats a longer corrupt one.
+fn push_text_atom(out: &mut Vec<u8>, text: &str) {
+    let (rec_type, body) = encode_text_body(text);
+    if push_record_header(out, REC_VER_ATOM, rec_type, body.len()) {
+        out.extend_from_slice(&body);
+    }
+}
+
+/// Emit one Slide container (header + all its text atoms) for `slide`.
+///
+/// We build the children into a scratch buffer first so we know the container's
+/// `recLen` (the total child byte length) before writing the container header.
+/// If that total overflows the `u32` `recLen`, the whole container is skipped.
+fn push_slide_container(out: &mut Vec<u8>, slide: &Slide) {
+    // Build children (the atoms) into a scratch buffer to learn their length.
+    let mut children = Vec::new();
+    for para in &slide.paragraphs {
+        push_text_atom(&mut children, para);
+    }
+    if push_record_header(out, REC_VER_CONTAINER, REC_TYPE_SLIDE, children.len()) {
+        out.extend_from_slice(&children);
+    }
+}
+
+/// Build the raw bytes of the "PowerPoint Document" stream: every Slide
+/// container concatenated, in slide order. Exposed for unit tests that walk the
+/// records without the CFB wrapping.
+pub(crate) fn build_powerpoint_document(p: &Presentation) -> Vec<u8> {
+    let mut out = Vec::new();
+    for slide in &p.slides {
+        push_slide_container(&mut out, slide);
+    }
+    out
+}
+
+/// Serialise a [`Presentation`] into the bytes of a legacy `.ppt` file.
+///
+/// Steps:
+/// 1. Build the "PowerPoint Document" record stream (all Slide containers).
+/// 2. Add a tiny stub "Current User" stream for authenticity.
+/// 3. Wrap both streams in an OLE2 Compound File via [`cfb-writer`].
+///
+/// The output is deterministic: identical models yield identical bytes.
+pub fn write_ppt(p: &Presentation) -> Vec<u8> {
+    let ppt_doc = build_powerpoint_document(p);
+    cfb_writer::write_cfb(&[
+        (STREAM_POWERPOINT_DOCUMENT, ppt_doc.as_slice()),
+        (STREAM_CURRENT_USER, CURRENT_USER_STUB.as_slice()),
+    ])
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/ppt-writer/src/tests.rs
+++ b/code/packages/rust/ppt-writer/src/tests.rs
@@ -1,0 +1,349 @@
+//! Tests for `ppt-writer`.
+//!
+//! The centrepiece is the **round-trip proof** (`round_trip_two_slides`): we
+//! write a real `.ppt`, reopen it with the `cfb` reader, extract the "PowerPoint
+//! Document" stream, and walk its record tree, asserting the decoded slide text.
+//! The remaining tests cover the atom-choice logic, header bit-packing, the
+//! empty cases, and the padding-stop rule.
+
+use super::*;
+use cfb::CompoundFile;
+
+// ---------------------------------------------------------------------------
+// A small, self-contained record walker used by the tests. It mirrors §5.1 and
+// §8 of the spec: read an 8-byte header; if recVer == 0xF recurse into the body
+// (a container); else if it is a text atom, decode it. Stop on the padding
+// sentinel (recType == 0 && recLen == 0) or when < 8 bytes remain.
+// ---------------------------------------------------------------------------
+
+/// One decoded record the walker cares about.
+#[derive(Debug, PartialEq, Eq)]
+enum Node {
+    /// A Slide container and its decoded child text atoms.
+    Slide(Vec<String>),
+}
+
+/// Read a little-endian u16 at `off`, or `None` if out of range.
+fn rd_u16(buf: &[u8], off: usize) -> Option<u16> {
+    let b = buf.get(off..off + 2)?;
+    Some(u16::from_le_bytes([b[0], b[1]]))
+}
+
+/// Read a little-endian u32 at `off`, or `None` if out of range.
+fn rd_u32(buf: &[u8], off: usize) -> Option<u32> {
+    let b = buf.get(off..off + 4)?;
+    Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+/// Decode a text atom body by its recType into a `String`.
+fn decode_text_atom(rec_type: u16, body: &[u8]) -> String {
+    if rec_type == REC_TYPE_TEXT_BYTES {
+        // One byte per char (Latin-1): each byte is a code point ≤ 0xFF.
+        body.iter().map(|&b| b as char).collect()
+    } else {
+        // TextChars: UTF-16LE.
+        let units: Vec<u16> = body
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16_lossy(&units)
+    }
+}
+
+/// Walk the record stream and return the top-level nodes we recognise.
+///
+/// Returns `Err(&str)` if the bytes are malformed in a way that would run us off
+/// the end — the walker is defensive so a test failure is a clean assertion, not
+/// a panic.
+fn walk(stream: &[u8]) -> Result<Vec<Node>, &'static str> {
+    let mut nodes = Vec::new();
+    let mut pos = 0usize;
+
+    while pos + 8 <= stream.len() {
+        let ver_and_instance = rd_u16(stream, pos).ok_or("short header")?;
+        let rec_type = rd_u16(stream, pos + 2).ok_or("short header")?;
+        let rec_len = rd_u32(stream, pos + 4).ok_or("short header")? as usize;
+        let rec_ver = ver_and_instance & 0x000F;
+
+        // Padding sentinel: a zeroed region past the logical records.
+        if rec_type == 0 && rec_len == 0 {
+            break;
+        }
+
+        let body_start = pos + 8;
+        let body_end = body_start.checked_add(rec_len).ok_or("length overflow")?;
+        if body_end > stream.len() {
+            return Err("record body runs past end of stream");
+        }
+        let body = &stream[body_start..body_end];
+
+        if rec_ver == REC_VER_CONTAINER && rec_type == REC_TYPE_SLIDE {
+            // Recurse into the container body, collecting its text atoms.
+            let texts = walk_slide_atoms(body)?;
+            nodes.push(Node::Slide(texts));
+        }
+        // (Other record types are ignored at the top level in this profile.)
+
+        pos = body_end;
+    }
+    Ok(nodes)
+}
+
+/// Walk a Slide container's body, decoding each text atom to a `String`.
+fn walk_slide_atoms(body: &[u8]) -> Result<Vec<String>, &'static str> {
+    let mut texts = Vec::new();
+    let mut pos = 0usize;
+    while pos + 8 <= body.len() {
+        let rec_type = rd_u16(body, pos + 2).ok_or("short child header")?;
+        let rec_len = rd_u32(body, pos + 4).ok_or("short child header")? as usize;
+        if rec_type == 0 && rec_len == 0 {
+            break;
+        }
+        let start = pos + 8;
+        let end = start.checked_add(rec_len).ok_or("child length overflow")?;
+        if end > body.len() {
+            return Err("child body runs past end of container");
+        }
+        let child = &body[start..end];
+        if rec_type == REC_TYPE_TEXT_BYTES || rec_type == REC_TYPE_TEXT_CHARS {
+            texts.push(decode_text_atom(rec_type, child));
+        }
+        pos = end;
+    }
+    Ok(texts)
+}
+
+// ---------------------------------------------------------------------------
+// The round-trip proof.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_trip_two_slides() {
+    // Build the exact deck the milestone specifies.
+    let mut deck = Presentation::new();
+    let s1 = deck.add_slide();
+    s1.add_text("Slide One Title");
+    s1.add_text("First slide body");
+    let s2 = deck.add_slide();
+    s2.add_text("Slide Two Title");
+    s2.add_text("Second slide body");
+
+    // Write the .ppt and reopen it with the real CFB reader.
+    let bytes = write_ppt(&deck);
+    let cf = CompoundFile::open(&bytes).expect(".ppt should be a valid Compound File");
+
+    // Extract the payload stream by name and walk its record tree.
+    let stream = cf
+        .read_stream(STREAM_POWERPOINT_DOCUMENT)
+        .expect("PowerPoint Document stream present");
+    let nodes = walk(&stream).expect("record tree should walk cleanly");
+
+    // Exactly two Slide containers, with the expected paragraph text.
+    assert_eq!(nodes.len(), 2, "expected two Slide containers");
+    assert_eq!(
+        nodes[0],
+        Node::Slide(vec![
+            "Slide One Title".to_string(),
+            "First slide body".to_string(),
+        ])
+    );
+    assert_eq!(
+        nodes[1],
+        Node::Slide(vec![
+            "Slide Two Title".to_string(),
+            "Second slide body".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn current_user_stream_is_present() {
+    // The stub "Current User" stream should be wrapped in too.
+    let deck = Presentation::new();
+    let bytes = write_ppt(&deck);
+    let cf = CompoundFile::open(&bytes).unwrap();
+    let cu = cf
+        .read_stream(STREAM_CURRENT_USER)
+        .expect("Current User stub present");
+    assert_eq!(cu, CURRENT_USER_STUB.to_vec());
+}
+
+// ---------------------------------------------------------------------------
+// Atom-choice and encoding.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn latin1_text_uses_text_bytes_atom() {
+    // Pure ASCII → TextBytes (one byte per char).
+    let (rec_type, body) = encode_text_body("Hi!");
+    assert_eq!(rec_type, REC_TYPE_TEXT_BYTES);
+    assert_eq!(body, b"Hi!".to_vec());
+
+    // A char at the top of Latin-1 (é = U+00E9) is still TextBytes.
+    let (rec_type, body) = encode_text_body("caf\u{00E9}");
+    assert_eq!(rec_type, REC_TYPE_TEXT_BYTES);
+    assert_eq!(body, vec![b'c', b'a', b'f', 0xE9]);
+}
+
+#[test]
+fn non_latin1_text_uses_text_chars_atom_and_round_trips() {
+    // "你好" forces the TextChars (UTF-16LE) path.
+    let text = "你好";
+    let (rec_type, body) = encode_text_body(text);
+    assert_eq!(rec_type, REC_TYPE_TEXT_CHARS);
+    // UTF-16LE of "你好": U+4F60, U+597D → 60 4F 7D 59.
+    assert_eq!(body, vec![0x60, 0x4F, 0x7D, 0x59]);
+
+    // And it decodes back through a full write/walk.
+    let mut deck = Presentation::new();
+    deck.add_slide().add_text(text);
+    let bytes = write_ppt(&deck);
+    let cf = CompoundFile::open(&bytes).unwrap();
+    let stream = cf.read_stream(STREAM_POWERPOINT_DOCUMENT).unwrap();
+    let nodes = walk(&stream).unwrap();
+    assert_eq!(nodes, vec![Node::Slide(vec!["你好".to_string()])]);
+}
+
+#[test]
+fn is_all_latin1_boundary() {
+    assert!(is_all_latin1("plain ascii"));
+    assert!(is_all_latin1("\u{00FF}")); // exactly 0xFF is still Latin-1
+    assert!(!is_all_latin1("\u{0100}")); // one past the boundary
+    assert!(!is_all_latin1("emoji \u{1F600}")); // astral plane
+    assert!(is_all_latin1("")); // empty is trivially Latin-1
+}
+
+// ---------------------------------------------------------------------------
+// Header bit-packing round-trip.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_header_bit_packing_round_trips() {
+    // Emit a container header with a known body length and decode every field.
+    let mut buf = Vec::new();
+    assert!(push_record_header(
+        &mut buf,
+        REC_VER_CONTAINER,
+        REC_TYPE_SLIDE,
+        0x0001_2345
+    ));
+    assert_eq!(buf.len(), 8);
+
+    let ver_and_instance = rd_u16(&buf, 0).unwrap();
+    let rec_type = rd_u16(&buf, 2).unwrap();
+    let rec_len = rd_u32(&buf, 4).unwrap();
+    assert_eq!(ver_and_instance & 0x000F, REC_VER_CONTAINER); // recVer
+    assert_eq!((ver_and_instance >> 4) & 0x0FFF, 0); // recInstance
+    assert_eq!(rec_type, REC_TYPE_SLIDE);
+    assert_eq!(rec_len, 0x0001_2345);
+
+    // An atom header packs recVer 0.
+    let mut buf2 = Vec::new();
+    assert!(push_record_header(
+        &mut buf2,
+        REC_VER_ATOM,
+        REC_TYPE_TEXT_BYTES,
+        4
+    ));
+    let vai = rd_u16(&buf2, 0).unwrap();
+    assert_eq!(vai & 0x000F, REC_VER_ATOM);
+    assert_eq!(rd_u16(&buf2, 2).unwrap(), REC_TYPE_TEXT_BYTES);
+    assert_eq!(rd_u32(&buf2, 4).unwrap(), 4);
+}
+
+#[test]
+fn oversize_body_is_skipped_not_wrapped() {
+    // A body length beyond u32::MAX cannot be described; the header write must
+    // refuse (return false) and append nothing, rather than wrap the length.
+    let mut buf = Vec::new();
+    let too_big = (u32::MAX as usize) + 1;
+    // Only meaningful on 64-bit targets where such a usize exists.
+    if too_big > u32::MAX as usize {
+        assert!(!push_record_header(&mut buf, REC_VER_ATOM, REC_TYPE_TEXT_BYTES, too_big));
+        assert!(buf.is_empty(), "nothing should be appended on overflow");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Structural: container count and the empty cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multiple_slides_produce_multiple_containers() {
+    let mut deck = Presentation::new();
+    for i in 0..5 {
+        deck.add_slide().add_text(&format!("slide {i}"));
+    }
+    let stream = build_powerpoint_document(&deck);
+    let nodes = walk(&stream).unwrap();
+    assert_eq!(nodes.len(), 5);
+    for (i, node) in nodes.iter().enumerate() {
+        assert_eq!(node, &Node::Slide(vec![format!("slide {i}")]));
+    }
+}
+
+#[test]
+fn empty_presentation_produces_empty_stream() {
+    let deck = Presentation::new();
+    let stream = build_powerpoint_document(&deck);
+    assert!(stream.is_empty(), "no slides → no records");
+    // It still wraps into a valid Compound File.
+    let bytes = write_ppt(&deck);
+    let cf = CompoundFile::open(&bytes).expect("empty deck still valid .ppt");
+    // The stream reads back as empty (or all-padding), and the walker yields
+    // zero nodes.
+    let s = cf.read_stream(STREAM_POWERPOINT_DOCUMENT).unwrap_or_default();
+    assert!(walk(&s).unwrap().is_empty());
+}
+
+#[test]
+fn empty_slide_is_a_container_with_no_atoms() {
+    let mut deck = Presentation::new();
+    deck.add_slide(); // no add_text → zero paragraphs
+    let stream = build_powerpoint_document(&deck);
+
+    // One Slide container with an empty body: header only, recLen == 0.
+    assert_eq!(stream.len(), 8, "just the 8-byte container header");
+    let rec_ver = rd_u16(&stream, 0).unwrap() & 0x000F;
+    let rec_type = rd_u16(&stream, 2).unwrap();
+    let rec_len = rd_u32(&stream, 4).unwrap();
+    assert_eq!(rec_ver, REC_VER_CONTAINER);
+    assert_eq!(rec_type, REC_TYPE_SLIDE);
+    assert_eq!(rec_len, 0);
+
+    // The walker sees one Slide with no texts.
+    let nodes = walk(&stream).unwrap();
+    assert_eq!(nodes, vec![Node::Slide(Vec::new())]);
+}
+
+#[test]
+fn walker_stops_on_zero_padding() {
+    // Append trailing zero padding to a valid one-slide stream (simulating the
+    // CFB sector padding) and confirm the walker stops cleanly.
+    let mut deck = Presentation::new();
+    deck.add_slide().add_text("only");
+    let mut stream = build_powerpoint_document(&deck);
+    stream.extend(std::iter::repeat_n(0u8, 100)); // pad like a sector would
+
+    let nodes = walk(&stream).unwrap();
+    assert_eq!(nodes, vec![Node::Slide(vec!["only".to_string()])]);
+}
+
+#[test]
+fn output_is_deterministic() {
+    let mut a = Presentation::new();
+    a.add_slide().add_text("determinism");
+    let mut b = Presentation::new();
+    b.add_slide().add_text("determinism");
+    assert_eq!(write_ppt(&a), write_ppt(&b));
+}
+
+#[test]
+fn model_accessors_reflect_input() {
+    let mut deck = Presentation::new();
+    let s = deck.add_slide();
+    s.add_text("a");
+    s.add_text("b");
+    assert_eq!(deck.slides().len(), 1);
+    assert_eq!(deck.slides()[0].paragraphs(), &["a".to_string(), "b".to_string()]);
+}

--- a/code/specs/PPTW01-ppt-writer.md
+++ b/code/specs/PPTW01-ppt-writer.md
@@ -1,0 +1,210 @@
+# PPTW01 — Legacy PowerPoint (`.ppt`) writer ([MS-PPT])
+
+> A **writer** for the legacy **PowerPoint 97-2003 binary** format (`.ppt`,
+> [MS-PPT]). You hand it a slide-deck model — presentations made of slides made
+> of paragraphs of text — and it produces the bytes of a real `.ppt` file. Under
+> the hood it emits [MS-PPT] *records* into a "PowerPoint Document" stream and
+> wraps that stream (plus a tiny "Current User" stream) in an OLE2 Compound File
+> using the sibling [`cfb-writer`](CFBW01-cfb-writer.md) crate. This is milestone
+> **C4** of the OOXML/binary-Office effort: the `.ppt` sibling to the `.xls`
+> path.
+
+Implemented by `code/packages/rust/ppt-writer` (crate `ppt-writer`).
+
+This spec assumes you have read [CFBW01](CFBW01-cfb-writer.md), which explains
+the container ("a FAT filesystem crammed into a single file"). Here we focus on
+the *contents* of one stream inside that container: the tree of [MS-PPT]
+records.
+
+---
+
+## 1. The one-paragraph mental model
+
+A `.ppt` file is an OLE2 compound file (like `.xls` and `.doc`). The interesting
+payload lives in a stream named exactly **"PowerPoint Document"**. That stream
+is not flat bytes — it is a **tree of records**. Every record starts with an
+8-byte **RecordHeader**, followed by a body. A record is either:
+
+- a **container**, whose body is *more records* (children), or
+- an **atom**, whose body is raw data (text, numbers, …).
+
+To write a deck we emit, for each slide, a **Slide container** (`recType`
+`0x03EE`) whose children are **text atoms** — one atom per paragraph. To read
+one back, you walk the tree: read a header; if it is a container, recurse into
+its body; if it is a text atom, decode the bytes. That walker is exactly what
+our round-trip test does, and it is the whole proof that the file is correct.
+
+---
+
+## 2. The RecordHeader — 8 bytes, bit-packed
+
+Every [MS-PPT] record opens with this fixed 8-byte header:
+
+```text
+ offset  size  field         meaning
+ ------  ----  ------------  --------------------------------------------------
+   0      2    recVerAndI    low  4 bits = recVer, high 12 bits = recInstance
+   2      2    recType       which record this is (e.g. 0x03EE = Slide)
+   4      4    recLen        length of the BODY that follows, in bytes
+```
+
+All fields are **little-endian**. The first `u16` packs two numbers:
+
+```text
+ recVerAndInstance (u16)
+ ┌───────────────────────────────┬───────┐
+ │ recInstance (12 bits)         │ recVer│   recVer  = value & 0x000F
+ │ bits 4..15                    │ 4 bits│   recInst = (value >> 4) & 0x0FFF
+ └───────────────────────────────┴───────┘
+```
+
+So to build the field: `(recVer & 0xF) | ((recInstance & 0xFFF) << 4)`.
+
+The single most important convention: **`recVer == 0xF` means "this record is a
+container"** (its body is child records). Any other `recVer` means "atom" (its
+body is opaque data). We use `recVer = 0xF` for the Slide container and
+`recVer = 0` for the text atoms.
+
+`recLen` counts only the **body**, never the 8 header bytes. For a container,
+`recLen` is the total size of all its children (each child being header + body).
+
+---
+
+## 3. The records we emit
+
+We deliberately emit the **minimum** set of records that round-trips the slide
+text through a record walker. A production `.ppt` has a `DocumentContainer`, a
+persist-object directory, master slides, and much more; none of that is needed
+to prove text placement, and adding it would be gold-plating for milestone C4.
+
+### 3.1 Slide container — `recType 0x03EE`, `recVer 0xF`
+
+One per slide. Its body is the slide's text atoms, concatenated. Empty slides
+are legal: a Slide container with a zero-length body.
+
+### 3.2 TextBytesAtom — `recType 0x0FA8`, `recVer 0`
+
+The compact text encoding: **one byte per character** (Latin-1). Character *c*
+is written as the single byte `c as u8`, valid exactly when every character's
+Unicode scalar value is ≤ `0x00FF`. We choose this atom whenever the paragraph
+is all-Latin-1, because it halves the size of ASCII text.
+
+### 3.3 TextCharsAtom — `recType 0x0FA0`, `recVer 0`
+
+The full text encoding: **UTF-16LE**, two bytes per code unit. We fall back to
+this whenever any character exceeds `0x00FF` (e.g. `"你好"`), so no information
+is lost. (Characters above the Basic Multilingual Plane become surrogate pairs,
+which is exactly what UTF-16 is for.)
+
+The per-paragraph choice is purely an encoding optimization; a reader decodes
+each atom by its `recType`, so mixing the two across paragraphs is fine.
+
+---
+
+## 4. The record tree we produce
+
+For a two-slide deck (slide 1 has two paragraphs, slide 2 has two paragraphs):
+
+```text
+PowerPoint Document stream
+├─ Slide container            recType=0x03EE recVer=0xF  recLen = Σ children
+│  ├─ TextBytesAtom           recType=0x0FA8 recVer=0    "Slide One Title"
+│  └─ TextBytesAtom           recType=0x0FA8 recVer=0    "First slide body"
+└─ Slide container            recType=0x03EE recVer=0xF  recLen = Σ children
+   ├─ TextBytesAtom           recType=0x0FA8 recVer=0    "Slide Two Title"
+   └─ TextBytesAtom           recType=0x0FA8 recVer=0    "Second slide body"
+```
+
+The concatenation of all Slide containers **is** the "PowerPoint Document"
+stream. There is no outer container in this minimal profile.
+
+---
+
+## 5. Wrapping in the CFB container
+
+We hand [`cfb-writer`](CFBW01-cfb-writer.md) two streams:
+
+- **"PowerPoint Document"** — the record tree above.
+- **"Current User"** — a tiny 4-byte stream (`0x14 0x00 0x00 0x00`). Real `.ppt`
+  files carry a `CurrentUserAtom` here; ours is a stub for authenticity. It is
+  harmless: our reader never consults it, and neither does the round-trip test.
+
+`cfb-writer` decides sector vs mini-stream placement, builds the FAT, and emits
+the OLE2 header. We do not care which store our stream lands in — the reader
+gives it back to us by name.
+
+### 5.1 The padding-stop subtlety
+
+A CFB stream is stored in fixed-size sectors (or mini-sectors), so the reader
+returns bytes **padded up to a sector boundary with zeros** past our logical
+records. Our *logical* content ends at the last record we wrote, but the reader
+hands back a slightly longer, zero-padded buffer.
+
+A record walker must therefore stop cleanly on the padding. A zero byte region
+decodes as a header with `recType == 0` **and** `recLen == 0` — a degenerate
+"empty atom" that can only be padding. So the walker's termination rule is:
+
+> Stop when fewer than 8 bytes remain, **or** when a header has
+> `recType == 0 && recLen == 0`.
+
+This is exactly the rule the round-trip test's walker uses. (Our writer never
+emits a `recType == 0` record, so this can only ever be padding.)
+
+---
+
+## 6. Robustness — a total writer over trusted input
+
+The model is trusted (the caller built it in-process), but the writer is still
+**total**: it never panics on the public path.
+
+- `#![forbid(unsafe_code)]`.
+- The only place a length could overflow is `recLen` (a `u32`) or the packed
+  container length. A single paragraph would need to exceed 4 GiB to overflow;
+  we use `u32::try_from` and **skip** (drop) any atom whose encoded body does
+  not fit, rather than silently wrapping the length into a wrong, corrupting
+  value. A container whose total child length overflows likewise drops the
+  overflowing tail. Dropping is the safe choice: a shorter valid file beats a
+  longer corrupt one.
+- Output is **deterministic**: identical models produce identical bytes.
+
+---
+
+## 7. Public API
+
+```rust
+pub struct Presentation { /* slides */ }
+impl Presentation {
+    pub fn new() -> Self;
+    pub fn add_slide(&mut self) -> &mut Slide;
+}
+
+pub struct Slide { /* paragraphs */ }
+impl Slide {
+    pub fn add_text(&mut self, text: &str); // one paragraph -> one text atom
+}
+
+pub fn write_ppt(p: &Presentation) -> Vec<u8>;
+```
+
+Each `add_text` becomes one text atom; the TextBytes-vs-TextChars choice is made
+per atom from the text's contents.
+
+---
+
+## 8. The proof — round-trip through the `cfb` reader
+
+The canonical test builds two slides, writes the `.ppt`, reopens it with the
+[`cfb`](CFB01-compound-file.md) reader, extracts "PowerPoint Document", and walks
+the record tree in-test:
+
+1. Read the 8-byte header.
+2. If `recVer == 0xF`, recurse into the body (a container).
+3. Else if `recType` is TextBytes/TextChars, decode the atom's text.
+4. Stop on the padding sentinel (§5.1).
+
+It asserts: two Slide containers; slide 1's atoms decode to
+`"Slide One Title"` + `"First slide body"`; slide 2's to `"Slide Two Title"` +
+`"Second slide body"`; and that the walk stops cleanly on the zero-padding.
+Passing this test means the bytes we wrote are a real, readable `.ppt`.
+
+[MS-PPT]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/


### PR DESCRIPTION
Legacy writer on cfb-writer; round-trips through our cfb reader in-test; security review passed (all model casts guarded via checked_*/try_from, deterministic, #![forbid(unsafe_code)]).