### PR TITLE
feat(doc-writer): C4 write legacy .doc binary (FIB+piece table) via cfb-writer

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "doc",
     "cfb-writer",
     "xls-writer",
+    "doc-writer",
     "binary-search-tree",
     "avl-tree",
     "red-black-tree",

--- a/code/packages/rust/doc-writer/BUILD
+++ b/code/packages/rust/doc-writer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p doc-writer -- --nocapture

--- a/code/packages/rust/doc-writer/BUILD_windows
+++ b/code/packages/rust/doc-writer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p doc-writer -- --nocapture

--- a/code/packages/rust/doc-writer/CHANGELOG.md
+++ b/code/packages/rust/doc-writer/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to `doc-writer` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and the project adheres to
+Semantic Versioning.
+
+## [0.1.0] — 2026-07-03
+
+Initial release. Milestone **C4**: write a legacy `.doc` (Word 97-2003 binary,
+[MS-DOC]) from a simple document model.
+
+### Added
+
+- `Document` model with `new()` and `add_paragraph(&str)`; paragraphs are joined
+  by the Word paragraph mark `\r` into a single text run.
+- `write_doc(&Document) -> Vec<u8>` — emits a valid `.doc` byte buffer:
+  - a **`WordDocument`** stream: the FIB (`wIdent`, `nFib`, `fWhichTblStm`,
+    `csw`, `cslw`, `ccpText`, `cbRgFcLcb`, `fcClx`, `lcbClx`) with the document
+    text stored at a fixed offset (2048).
+  - a **`1Table`** stream: a CLX (`Pcdt` → one-piece `PlcPcd`) that maps the
+    whole document to the text via a single PCD.
+  - both wrapped in an OLE2 / Compound File container via `cfb-writer`.
+- **Encoding selection:** 8-bit compressed (Latin-1, one byte/char) when every
+  character is `<= U+00FF`, otherwise a 16-bit UTF-16LE fallback that faithfully
+  round-trips non-Latin-1 and astral (surrogate-pair) characters. The choice is
+  carried by the `FcCompressed` bit-30 (`fCompressed`) flag.
+- **Round-trip test:** re-implements [MS-DOC] piece-table retrieval in-test and
+  opens the output with the independent `cfb` reader to prove the bytes are a
+  genuinely readable `.doc`. Covers `"Hello, DOC!"`, multi-paragraph
+  (`"a\rb\rc"`), non-Latin-1 (`"café 你好"`), Latin-1 supplement (`"café"` stays
+  8-bit), and an astral char (`"hi 😀"`).
+- Unit tests for `FcCompressed` (8-bit and 16-bit) encoding, the exact CLX byte
+  layout, `lcbClx` matching the emitted CLX length, FIB field values, encoding
+  selection at the `U+00FF` boundary, and the empty document.
+
+### Robustness
+
+- `#![forbid(unsafe_code)]`; no `unwrap`/`expect`/`panic!` on the public path;
+  `checked_*` arithmetic on every offset/length a huge document could overflow,
+  degrading to a valid empty document on overflow. Deterministic output.
+
+[MS-DOC]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/

--- a/code/packages/rust/doc-writer/Cargo.toml
+++ b/code/packages/rust/doc-writer/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "doc-writer"
+version = "0.1.0"
+edition = "2021"
+description = "A from-scratch, zero-third-party-dependency writer for legacy .doc (Word 97-2003 binary, [MS-DOC]) files — emits the FIB + a piece table (CLX) + text, wrapped in an OLE2 Compound File via the `cfb-writer` crate."
+license = "MIT"
+
+[dependencies]
+# Only our own zero-dependency CFB container writer.
+cfb-writer = { path = "../cfb-writer" }
+
+[dev-dependencies]
+# The CFB reader, used to prove our output round-trips back to the original text.
+cfb = { path = "../cfb" }

--- a/code/packages/rust/doc-writer/README.md
+++ b/code/packages/rust/doc-writer/README.md
@@ -1,0 +1,85 @@
+# doc-writer
+
+A from-scratch, **zero-third-party-dependency** writer for the legacy **`.doc`**
+format ([MS-DOC]) — the Word 97-2003 binary document. You give it a simple
+document model (paragraphs of text); it produces a valid `.doc` byte buffer by
+emitting the **FIB** (File Information Block), a **piece table** (CLX), and the
+text, all wrapped in an **OLE2 / Compound File Binary** container via the
+sibling [`cfb-writer`](../cfb-writer) crate.
+
+This is milestone **C4** of the legacy-Office stack. The only dependency is our
+own `cfb-writer`; the dev-dependency `cfb` (the reader) is used solely to prove
+the output round-trips.
+
+## Where it fits
+
+```text
+  Document (paragraphs)
+        │  write_doc
+        ▼
+  FIB + text  ┐
+  CLX (pieces)┘── cfb-writer::write_cfb ──▶  .doc bytes (a CFB container)
+```
+
+A `.doc` is a CFB holding two streams:
+
+- **`WordDocument`** — the FIB (a fixed header of offsets/lengths) followed by
+  the document text at a fixed offset.
+- **`1Table`** — the **CLX**, whose **piece table** (`PlcPcd`) maps character
+  positions to byte offsets in `WordDocument` and records the text encoding
+  (8-bit Latin-1 or 16-bit UTF-16LE) via the `FcCompressed` bit-30 trick.
+
+We always emit **one piece** covering the whole document.
+
+## Usage
+
+```rust
+use doc_writer::{Document, write_doc};
+
+let mut doc = Document::new();
+doc.add_paragraph("Hello, DOC!");
+doc.add_paragraph("Second paragraph.");
+
+let bytes = write_doc(&doc);
+std::fs::write("hello.doc", &bytes).unwrap();
+```
+
+Paragraphs are joined by the Word paragraph mark `\r` (`0x0D`) into a single run
+of text. The retrieved text is therefore the paragraphs joined by `\r`.
+
+### Encoding
+
+- If **every** character is `<= U+00FF` (Latin-1), the text is stored **8-bit
+  compressed** — one byte per character (compact).
+- If **any** character is `> U+00FF`, the whole document falls back to **16-bit**
+  UTF-16LE — the faithful choice that never mangles a character. Astral
+  characters (surrogate pairs) round-trip correctly.
+
+## The round-trip proof
+
+The test suite writes a document, opens it with the independent `cfb` reader,
+and then **re-implements** the [MS-DOC] retrieval from first principles (FIB →
+`fcClx`/`lcbClx` → CLX → `PlcPcd` → PCD → `FcCompressed` → text). It asserts the
+reassembled text equals the input. This proves the bytes are a genuinely
+readable `.doc`, not merely something our own encoder can read back.
+
+## Robustness
+
+- `#![forbid(unsafe_code)]`.
+- No `unwrap`/`expect`/`panic!` on the public path.
+- `checked_*` arithmetic guards every offset/length a colossal document could
+  overflow; on overflow the writer degrades to a valid **empty** document rather
+  than emitting corrupt bytes.
+- Output is **deterministic** — the same document always yields the same bytes.
+
+## Limitations (future extensions)
+
+- Always a **single piece**; no in-place edit history.
+- One encoding for the whole document (no mixed 8-bit/16-bit pieces).
+- No formatting (character/paragraph properties, styles).
+
+See `code/specs/DOCW01-doc-writer.md` for the full literate specification,
+including every FIB field offset, the CLX/`Pcdt`/`PlcPcd`/PCD layout, the
+`FcCompressed` bit trick, and a diagram of the retrieval path.
+
+[MS-DOC]: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-doc/

--- a/code/packages/rust/doc-writer/required_capabilities.json
+++ b/code/packages/rust/doc-writer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/doc-writer",
+  "capabilities": [],
+  "justification": "Pure in-memory binary emission. Callers build a Document and receive a byte buffer; the crate does no filesystem, network, process, or environment access."
+}

--- a/code/packages/rust/doc-writer/src/lib.rs
+++ b/code/packages/rust/doc-writer/src/lib.rs
@@ -1,0 +1,359 @@
+//! # doc-writer — Legacy `.doc` (Word 97-2003 binary) writer (DOCW01)
+//!
+//! A from-scratch, zero-third-party-dependency **writer** for the legacy
+//! **`.doc`** format ([MS-DOC]) — the Word 97-2003 document. You give it a
+//! simple [`Document`] (paragraphs of text); it emits a valid `.doc` byte buffer
+//! by writing the **FIB** (File Information Block), a **piece table** (CLX), and
+//! the text, all wrapped in an **OLE2 / Compound File Binary** container via the
+//! sibling [`cfb-writer`] crate. See `code/specs/DOCW01-doc-writer.md` for the
+//! full literate walkthrough.
+//!
+//! ## The one-paragraph mental model
+//!
+//! A `.doc` is a CFB container (see the `cfb`/`cfb-writer` crates — "a FAT
+//! filesystem crammed into a single file") holding two streams:
+//!
+//! - **`WordDocument`** — starts with the **FIB**, a big fixed-layout header of
+//!   offsets and lengths. The document *characters* also live here, but not at a
+//!   fixed place: you follow a pointer to find them.
+//! - **`1Table`** — holds the **CLX**, whose **piece table** (`PlcPcd`) maps
+//!   *character positions* to *byte offsets* in `WordDocument`, and records
+//!   whether each run is stored 8-bit (Latin-1) or 16-bit (UTF-16LE).
+//!
+//! The reader's retrieval path — which our round-trip test re-implements — is:
+//!
+//! ```text
+//!   FIB (in WordDocument)  ── fcClx/lcbClx ──▶  CLX (in 1Table)
+//!                                                   │  PlcPcd (piece table)
+//!                                                   ▼
+//!                                    for each piece: FcCompressed
+//!                          bit 30 set → 8-bit text at (fc & 0x3FFFFFFF)/2
+//!                          bit 30 clear → 16-bit text at fc
+//! ```
+//!
+//! We always emit **one piece** covering the whole document. That is the whole
+//! trick: build the FIB, build a one-piece piece table, wrap in CFB.
+//!
+//! ```
+//! # use doc_writer::{Document, write_doc};
+//! let mut doc = Document::new();
+//! doc.add_paragraph("Hello, DOC!");
+//! let bytes = write_doc(&doc);
+//! // Opens with the CFB signature.
+//! assert_eq!(&bytes[0..8], &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+//! ```
+
+#![forbid(unsafe_code)]
+
+// ---------------------------------------------------------------------------
+// Constants — the FIB field offsets/values and the piece-table encoding. These
+// mirror exactly what a [MS-DOC] reader looks for; a writer and reader must
+// agree byte-for-byte.
+// ---------------------------------------------------------------------------
+
+/// Fixed location, past the FIB, where we store the document text inside the
+/// `WordDocument` stream. Any offset comfortably beyond the FIB fields we set
+/// works; 2048 is a round, spec-safe choice.
+const TEXT_OFFSET: usize = 2048;
+
+/// `wIdent` — the magic that identifies a Word FIB (u16 @ 0).
+const W_IDENT: u16 = 0xA5EC;
+/// `nFib` — FIB version. Word 97 = 193 = `0x00C1` (u16 @ 2).
+const N_FIB_WORD97: u16 = 0x00C1;
+/// FibBase flags (u16 @ 10). Bit 9 (`0x0200`) is `fWhichTblStm`: 1 → the table
+/// stream is named `1Table` (rather than `0Table`).
+const FIB_FLAGS_1TABLE: u16 = 0x0200;
+/// `csw` — count of 16-bit values in `fibRgW` = 14 (u16 @ 32).
+const CSW: u16 = 0x000E;
+/// `cslw` — count of 32-bit values in `fibRgLw` = 22 (u16 @ 62).
+const CSLW: u16 = 0x0016;
+/// `cbRgFcLcb` — count of FC/LCB pairs in the FIB blob = 93 (u16 @ 152).
+const CB_RG_FC_LCB: u16 = 0x005D;
+
+/// Byte offset within `WordDocument` of the `fcClx` field (u32).
+const OFF_FC_CLX: usize = 0x1A2; // 418
+/// Byte offset within `WordDocument` of the `lcbClx` field (u32).
+const OFF_LCB_CLX: usize = 0x1A6; // 422
+/// Byte offset within `WordDocument` of `ccpText` (u32, informational).
+const OFF_CCP_TEXT: usize = 0x4C; // 76
+
+/// `clxt` value marking a CLX component as a `Pcdt` (piece-table container).
+const CLXT_PCDT: u8 = 0x02;
+
+/// The `fCompressed` flag (bit 30) inside an `FcCompressed`. Set → the text is
+/// 8-bit (one Latin-1 byte per char) and the stored offset is doubled.
+const FC_COMPRESSED_FLAG: u32 = 0x4000_0000;
+/// Mask recovering the offset payload from an `FcCompressed` (low 30 bits).
+const FC_OFFSET_MASK: u32 = 0x3FFF_FFFF;
+
+/// The CFB stream name for the FIB + text.
+const STREAM_WORD_DOCUMENT: &str = "WordDocument";
+/// The CFB stream name for the table (CLX). We always emit `1Table` (see
+/// [`FIB_FLAGS_1TABLE`]).
+const STREAM_1TABLE: &str = "1Table";
+
+// ---------------------------------------------------------------------------
+// Little-endian writers. Small helpers that patch a pre-sized buffer. None can
+// panic on the public path because every buffer is sized to a computed length
+// and every offset here is a compile-time constant within that length.
+// ---------------------------------------------------------------------------
+
+/// Write a `u16` little-endian at `off`, if it fits. Returns whether it fit.
+#[inline]
+fn put_u16(buf: &mut [u8], off: usize, v: u16) -> bool {
+    match buf.get_mut(off..off + 2) {
+        Some(slot) => {
+            slot.copy_from_slice(&v.to_le_bytes());
+            true
+        }
+        None => false,
+    }
+}
+
+/// Write a `u32` little-endian at `off`, if it fits. Returns whether it fit.
+#[inline]
+fn put_u32(buf: &mut [u8], off: usize, v: u32) -> bool {
+    match buf.get_mut(off..off + 4) {
+        Some(slot) => {
+            slot.copy_from_slice(&v.to_le_bytes());
+            true
+        }
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The public document model.
+// ---------------------------------------------------------------------------
+
+/// A minimal document model: an ordered list of paragraphs. The emitted `.doc`
+/// stores the paragraphs joined by Word's paragraph mark, the carriage return
+/// `\r` (`0x0D`), as a single run of text.
+#[derive(Debug, Default, Clone)]
+pub struct Document {
+    /// Paragraphs, in order. Empty means an empty document.
+    paragraphs: Vec<String>,
+}
+
+impl Document {
+    /// Create an empty document. [`write_doc`] on it yields a valid, minimal
+    /// `.doc` with zero characters.
+    pub fn new() -> Self {
+        Document {
+            paragraphs: Vec::new(),
+        }
+    }
+
+    /// Append a paragraph of text. Paragraphs are joined by `\r` when written.
+    pub fn add_paragraph(&mut self, text: &str) {
+        self.paragraphs.push(text.to_string());
+    }
+
+    /// The document's logical text: paragraphs joined by the paragraph mark
+    /// `\r`. This is exactly what a reader reassembles from the piece table.
+    fn text(&self) -> String {
+        self.paragraphs.join("\r")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The encoder.
+// ---------------------------------------------------------------------------
+
+/// Which on-disk encoding a single piece of text uses. This is the single most
+/// important bit in the whole format: it selects how a reader turns bytes back
+/// into characters, and it is carried by the `fCompressed` flag of the PCD's
+/// `FcCompressed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Encoding {
+    /// 8-bit: one Latin-1 byte per character. Only usable when every character
+    /// is `<= U+00FF`. Compact, and the flag is *set*.
+    Compressed8,
+    /// 16-bit: two UTF-16LE bytes per character. The faithful fallback for any
+    /// character `> U+00FF`. The flag is *clear*.
+    Uncompressed16,
+}
+
+/// Encode `text` into the WordDocument text-region bytes for the chosen
+/// encoding. Returns `None` if the byte length would overflow `usize` (a
+/// pathologically huge document), so the caller can degrade gracefully.
+fn encode_text_bytes(text: &str, encoding: Encoding) -> Option<Vec<u8>> {
+    match encoding {
+        Encoding::Compressed8 => {
+            // One byte per char. Every char is guaranteed `<= 0xFF` here.
+            let mut out = Vec::with_capacity(text.chars().count());
+            for ch in text.chars() {
+                // Defensive: never truncate silently. Callers only pick this
+                // encoding after `pick_encoding` verified the range, but stay
+                // total regardless.
+                let cp = ch as u32;
+                if cp > 0xFF {
+                    return None;
+                }
+                out.push(cp as u8);
+            }
+            Some(out)
+        }
+        Encoding::Uncompressed16 => {
+            // Two bytes per UTF-16 code unit. `encode_utf16` handles surrogate
+            // pairs for astral chars, so the count can exceed the char count.
+            let units: Vec<u16> = text.encode_utf16().collect();
+            let byte_len = units.len().checked_mul(2)?;
+            let mut out = Vec::with_capacity(byte_len);
+            for u in units {
+                out.extend_from_slice(&u.to_le_bytes());
+            }
+            Some(out)
+        }
+    }
+}
+
+/// Choose the encoding for a document: 8-bit compressed if every character fits
+/// in Latin-1 (`<= U+00FF`), otherwise 16-bit uncompressed — the faithful path
+/// that never mangles a character.
+fn pick_encoding(text: &str) -> Encoding {
+    if text.chars().all(|c| (c as u32) <= 0xFF) {
+        Encoding::Compressed8
+    } else {
+        Encoding::Uncompressed16
+    }
+}
+
+/// Build the `FcCompressed` `u32` for storing text at `text_offset` under the
+/// given encoding. Returns `None` if the offset cannot be represented (would
+/// collide with the flag bit or overflow when doubled).
+///
+/// - **8-bit:** the offset is stored *doubled*, with bit 30 set. A reader
+///   recovers the real offset as `(fc & 0x3FFFFFFF) / 2`. The doubled offset
+///   must fit in the low 30 bits.
+/// - **16-bit:** the offset is stored *as-is*, bit 30 clear. It must fit in the
+///   low 30 bits directly.
+fn build_fc_compressed(text_offset: usize, encoding: Encoding) -> Option<u32> {
+    match encoding {
+        Encoding::Compressed8 => {
+            // Double the offset, checked, then ensure it fits in 30 bits.
+            let doubled = (text_offset as u64).checked_mul(2)?;
+            if doubled > FC_OFFSET_MASK as u64 {
+                return None;
+            }
+            Some((doubled as u32) | FC_COMPRESSED_FLAG)
+        }
+        Encoding::Uncompressed16 => {
+            if text_offset as u64 > FC_OFFSET_MASK as u64 {
+                return None;
+            }
+            Some(text_offset as u32)
+        }
+    }
+}
+
+/// Build the `1Table` stream: a CLX consisting of a single `Pcdt` wrapping a
+/// one-piece `PlcPcd`.
+///
+/// Layout (see DOCW01 §4):
+/// ```text
+///   u8  clxt = 0x02
+///   u32 lcb  = 16                 (length of the PlcPcd)
+///   PlcPcd:
+///     CP array : u32 0, u32 n     (2 CPs → 1 piece)
+///     PCD      : u16 0, u32 fc, u16 0
+/// ```
+fn build_clx(n_chars: u32, fc_compressed: u32) -> Vec<u8> {
+    // PlcPcd = CP array (8 bytes) + one PCD (8 bytes) = 16 bytes.
+    let mut plc_pcd = Vec::with_capacity(16);
+    plc_pcd.extend_from_slice(&0u32.to_le_bytes()); // CP[0] = 0
+    plc_pcd.extend_from_slice(&n_chars.to_le_bytes()); // CP[1] = n
+    plc_pcd.extend_from_slice(&0u16.to_le_bytes()); // PCD flags
+    plc_pcd.extend_from_slice(&fc_compressed.to_le_bytes()); // FcCompressed
+    plc_pcd.extend_from_slice(&0u16.to_le_bytes()); // prm
+
+    let lcb = plc_pcd.len() as u32; // == 16
+
+    let mut clx = Vec::with_capacity(1 + 4 + plc_pcd.len());
+    clx.push(CLXT_PCDT); // clxt = Pcdt
+    clx.extend_from_slice(&lcb.to_le_bytes()); // lcb
+    clx.extend_from_slice(&plc_pcd); // the PlcPcd itself
+    clx
+}
+
+/// Build the `WordDocument` stream: a zeroed buffer of length
+/// `TEXT_OFFSET + text_bytes.len()` with the FIB fields set and the text placed
+/// at [`TEXT_OFFSET`]. Returns `None` if the buffer length would overflow.
+fn build_word_document(text_bytes: &[u8], n_chars: u32, lcb_clx: u32) -> Option<Vec<u8>> {
+    let total = TEXT_OFFSET.checked_add(text_bytes.len())?;
+    let mut wd = vec![0u8; total];
+
+    // --- FIB fields (see DOCW01 §3) --------------------------------------
+    // Each of these offsets is < TEXT_OFFSET, so `put_*` always fits; we still
+    // route through the fallible helpers to stay panic-free.
+    put_u16(&mut wd, 0, W_IDENT);
+    put_u16(&mut wd, 2, N_FIB_WORD97);
+    put_u16(&mut wd, 10, FIB_FLAGS_1TABLE);
+    put_u16(&mut wd, 32, CSW);
+    put_u16(&mut wd, 62, CSLW);
+    put_u32(&mut wd, OFF_CCP_TEXT, n_chars);
+    put_u16(&mut wd, 152, CB_RG_FC_LCB);
+    put_u32(&mut wd, OFF_FC_CLX, 0); // fcClx = 0 (CLX at start of 1Table)
+    put_u32(&mut wd, OFF_LCB_CLX, lcb_clx); // lcbClx = CLX byte length
+
+    // --- The text, at TEXT_OFFSET ----------------------------------------
+    // `total == TEXT_OFFSET + text_bytes.len()`, so this range always fits.
+    if let Some(slot) = wd.get_mut(TEXT_OFFSET..total) {
+        slot.copy_from_slice(text_bytes);
+    }
+
+    Some(wd)
+}
+
+/// Serialise a [`Document`] into a legacy `.doc` byte buffer.
+///
+/// The pipeline (see DOCW01):
+/// 1. Join paragraphs by `\r` to get the logical text.
+/// 2. Pick 8-bit vs 16-bit encoding (16-bit iff any char `> U+00FF`).
+/// 3. Encode the text bytes and compute the `FcCompressed` offset word.
+/// 4. Build the one-piece CLX (`1Table`) and the FIB+text (`WordDocument`).
+/// 5. Wrap both streams in a CFB container.
+///
+/// Totality: any arithmetic that a colossal document could overflow is
+/// `checked_*`; on overflow (or an out-of-range offset) we degrade to emitting a
+/// valid **empty** document rather than corrupt bytes. Output is deterministic.
+pub fn write_doc(doc: &Document) -> Vec<u8> {
+    let text = doc.text();
+    // Character count: for 8-bit this is bytes; for 16-bit the CP array counts
+    // UTF-16 code units (which is what CP positions index in a 16-bit piece).
+    let encoding = pick_encoding(&text);
+
+    let built = build_streams(&text, encoding);
+    let (wd, table) = match built {
+        Some(pair) => pair,
+        // A pathologically huge document overflowed an offset/length. Fall back
+        // to a valid empty document — never emit corrupt bytes.
+        None => build_streams("", Encoding::Compressed8)
+            .unwrap_or_else(|| (Vec::new(), Vec::new())),
+    };
+
+    cfb_writer::write_cfb(&[(STREAM_WORD_DOCUMENT, &wd), (STREAM_1TABLE, &table)])
+}
+
+/// Build the (`WordDocument`, `1Table`) byte pair for `text` under `encoding`,
+/// or `None` if any length/offset overflows.
+fn build_streams(text: &str, encoding: Encoding) -> Option<(Vec<u8>, Vec<u8>)> {
+    let text_bytes = encode_text_bytes(text, encoding)?;
+
+    // The CP array counts characters for 8-bit, UTF-16 code units for 16-bit —
+    // in both cases exactly `text_bytes.len() / bytes_per_unit`.
+    let n_chars_usize = match encoding {
+        Encoding::Compressed8 => text_bytes.len(),
+        Encoding::Uncompressed16 => text_bytes.len() / 2,
+    };
+    let n_chars = u32::try_from(n_chars_usize).ok()?;
+
+    let fc = build_fc_compressed(TEXT_OFFSET, encoding)?;
+    let table = build_clx(n_chars, fc);
+    let lcb_clx = u32::try_from(table.len()).ok()?;
+    let wd = build_word_document(&text_bytes, n_chars, lcb_clx)?;
+    Some((wd, table))
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/doc-writer/src/tests.rs
+++ b/code/packages/rust/doc-writer/src/tests.rs
@@ -1,0 +1,314 @@
+//! Tests for the `.doc` writer.
+//!
+//! The centrepiece is the **round-trip** test: we write a document, open it with
+//! the independent `cfb` reader, and then **re-implement** the [MS-DOC]
+//! piece-table retrieval from first principles (FIB → CLX → PlcPcd → PCD →
+//! FcCompressed → text). If the reassembled text equals the input, we have
+//! proven the emitted bytes are a genuinely readable `.doc`, not just something
+//! that happens to satisfy our own encoder.
+
+use super::*;
+use cfb::CompoundFile;
+
+// ---------------------------------------------------------------------------
+// A standalone, reader-side re-implementation of `.doc` text retrieval. This
+// intentionally shares NO code with the writer beyond the raw byte constants of
+// the format — it is the adversary that keeps the writer honest.
+// ---------------------------------------------------------------------------
+
+/// One decoded piece: how many characters, from which WordDocument byte offset,
+/// in which encoding.
+#[derive(Debug, Clone, Copy)]
+struct Piece {
+    /// Number of characters (8-bit) or UTF-16 code units (16-bit) in the piece.
+    n_chars: u32,
+    /// Real byte offset into the WordDocument stream.
+    offset: usize,
+    /// True → 8-bit compressed (1 byte/char); false → 16-bit (2 bytes/char).
+    compressed: bool,
+}
+
+fn read_u16(buf: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes([buf[off], buf[off + 1]])
+}
+fn read_u32(buf: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]])
+}
+
+/// Given the two `.doc` streams, reassemble the document text exactly as a
+/// [MS-DOC] reader would.
+fn retrieve_text(word_document: &[u8], table: &[u8]) -> String {
+    // 1. Validate the FIB magic and the table-stream selector.
+    assert_eq!(read_u16(word_document, 0), 0xA5EC, "wIdent (FIB magic)");
+    let flags = read_u16(word_document, 10);
+    let f_which_tbl_stm = (flags & 0x0200) != 0;
+    assert!(f_which_tbl_stm, "fWhichTblStm should select 1Table");
+
+    // 2. Locate the CLX in the table stream.
+    let fc_clx = read_u32(word_document, 0x1A2) as usize;
+    let lcb_clx = read_u32(word_document, 0x1A6) as usize;
+    let clx = &table[fc_clx..fc_clx + lcb_clx];
+
+    // 3. Parse the CLX: clxt == 0x02 (Pcdt), then lcb, then the PlcPcd.
+    assert_eq!(clx[0], 0x02, "clxt should be Pcdt");
+    let lcb = read_u32(clx, 1) as usize;
+    let plc_pcd = &clx[5..5 + lcb];
+
+    // 4. A PlcPcd with n pieces is 4*(n+1) CP bytes + 8*n PCD bytes = 12n + 4.
+    assert!(lcb >= 4, "PlcPcd too short");
+    let n = (lcb - 4) / 12;
+    let cp_bytes = 4 * (n + 1);
+
+    // 5. Decode each PCD's FcCompressed and read the piece's characters.
+    let mut pieces = Vec::with_capacity(n);
+    for i in 0..n {
+        let cp_i = read_u32(plc_pcd, i * 4);
+        let cp_next = read_u32(plc_pcd, (i + 1) * 4);
+        let piece_chars = cp_next - cp_i;
+
+        let pcd_off = cp_bytes + i * 8;
+        // PCD = u16 flags, u32 FcCompressed, u16 prm.
+        let fc = read_u32(plc_pcd, pcd_off + 2);
+        let compressed = (fc & 0x4000_0000) != 0;
+        let raw = (fc & 0x3FFF_FFFF) as usize;
+        let offset = if compressed { raw / 2 } else { raw };
+
+        pieces.push(Piece {
+            n_chars: piece_chars,
+            offset,
+            compressed,
+        });
+    }
+
+    // 6. Concatenate the pieces into the reassembled text.
+    let mut out = String::new();
+    for p in pieces {
+        if p.compressed {
+            // 1 byte per char, Latin-1.
+            for k in 0..p.n_chars as usize {
+                let b = word_document[p.offset + k];
+                out.push(b as char);
+            }
+        } else {
+            // 2 bytes per UTF-16LE code unit.
+            let mut units = Vec::with_capacity(p.n_chars as usize);
+            for k in 0..p.n_chars as usize {
+                units.push(read_u16(word_document, p.offset + k * 2));
+            }
+            out.push_str(&String::from_utf16(&units).expect("valid UTF-16"));
+        }
+    }
+    out
+}
+
+/// Open written `.doc` bytes and retrieve the text end-to-end.
+fn round_trip(bytes: &[u8]) -> String {
+    let cf = CompoundFile::open(bytes).expect(".doc should be a valid CFB");
+    let wd = cf.read_stream("WordDocument").expect("WordDocument stream");
+    let table = cf.read_stream("1Table").expect("1Table stream");
+    retrieve_text(&wd, &table)
+}
+
+// ---------------------------------------------------------------------------
+// The required round-trip proofs.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn round_trips_hello_doc() {
+    let mut doc = Document::new();
+    doc.add_paragraph("Hello, DOC!");
+    let bytes = write_doc(&doc);
+    // Opens with the CFB signature.
+    assert_eq!(
+        &bytes[0..8],
+        &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]
+    );
+    assert_eq!(round_trip(&bytes), "Hello, DOC!");
+}
+
+#[test]
+fn round_trips_multiple_paragraphs_joined_by_cr() {
+    let mut doc = Document::new();
+    doc.add_paragraph("a");
+    doc.add_paragraph("b");
+    doc.add_paragraph("c");
+    let bytes = write_doc(&doc);
+    assert_eq!(round_trip(&bytes), "a\rb\rc");
+}
+
+#[test]
+fn round_trips_non_latin1_via_16bit_fallback() {
+    // "café 你好" contains a char (你, 好) beyond U+00FF → forces 16-bit.
+    let mut doc = Document::new();
+    doc.add_paragraph("café 你好");
+    let bytes = write_doc(&doc);
+    assert_eq!(round_trip(&bytes), "café 你好");
+}
+
+#[test]
+fn round_trips_latin1_supplement_still_8bit() {
+    // "café" — all chars <= U+00FF, so this stays 8-bit compressed, and the
+    // é (U+00E9) round-trips as a single Latin-1 byte.
+    let mut doc = Document::new();
+    doc.add_paragraph("café");
+    let bytes = write_doc(&doc);
+    // Confirm it really used the 8-bit path: the WordDocument stream length is
+    // TEXT_OFFSET + 4 (one byte per char), not +8.
+    let cf = CompoundFile::open(&bytes).unwrap();
+    let wd = cf.read_stream("WordDocument").unwrap();
+    assert_eq!(wd.len(), TEXT_OFFSET + 4);
+    assert_eq!(round_trip(&bytes), "café");
+}
+
+#[test]
+fn round_trips_astral_char_16bit_surrogate_pair() {
+    // An astral char (😀 U+1F600) is a surrogate PAIR in UTF-16: two code units.
+    // The CP array must count code units, and retrieval must recombine them.
+    let mut doc = Document::new();
+    doc.add_paragraph("hi 😀");
+    let bytes = write_doc(&doc);
+    assert_eq!(round_trip(&bytes), "hi 😀");
+}
+
+// ---------------------------------------------------------------------------
+// FcCompressed encoding unit tests (the bit-30 trick).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fc_compressed_8bit_encoding() {
+    // TEXT_OFFSET=2048 → (2048*2) | 0x40000000 = 0x40001000.
+    let fc = build_fc_compressed(TEXT_OFFSET, Encoding::Compressed8).unwrap();
+    assert_eq!(fc, 0x4000_1000);
+    // Decode the way a reader does.
+    assert!(fc & 0x4000_0000 != 0, "flag set");
+    assert_eq!((fc & 0x3FFF_FFFF) / 2, TEXT_OFFSET as u32);
+}
+
+#[test]
+fn fc_compressed_16bit_encoding() {
+    // 16-bit: offset stored as-is, flag clear.
+    let fc = build_fc_compressed(TEXT_OFFSET, Encoding::Uncompressed16).unwrap();
+    assert_eq!(fc, TEXT_OFFSET as u32);
+    assert!(fc & 0x4000_0000 == 0, "flag clear");
+    assert_eq!(fc & 0x3FFF_FFFF, TEXT_OFFSET as u32);
+}
+
+#[test]
+fn fc_compressed_rejects_overflowing_offset() {
+    // An 8-bit offset whose doubled value exceeds the 30-bit field is rejected.
+    let too_big = (0x3FFF_FFFF / 2) + 1;
+    assert!(build_fc_compressed(too_big, Encoding::Compressed8).is_none());
+    // And a 16-bit offset beyond the 30-bit field.
+    assert!(build_fc_compressed(0x4000_0000, Encoding::Uncompressed16).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// CLX byte-layout unit tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clx_layout_is_exact() {
+    // n_chars = 11 ("Hello, DOC!"), fc = 0x40001000.
+    let clx = build_clx(11, 0x4000_1000);
+    // clxt(1) + lcb(4) + PlcPcd(16) = 21 bytes.
+    assert_eq!(clx.len(), 21);
+    assert_eq!(clx[0], 0x02); // clxt = Pcdt
+    assert_eq!(read_u32(&clx, 1), 16); // lcb
+    // PlcPcd: CP[0]=0, CP[1]=11, then PCD (u16 0, u32 fc, u16 0).
+    assert_eq!(read_u32(&clx, 5), 0); // CP[0]
+    assert_eq!(read_u32(&clx, 9), 11); // CP[1]
+    assert_eq!(read_u16(&clx, 13), 0); // PCD flags
+    assert_eq!(read_u32(&clx, 15), 0x4000_1000); // FcCompressed
+    assert_eq!(read_u16(&clx, 19), 0); // prm
+}
+
+#[test]
+fn lcb_clx_in_fib_matches_emitted_clx_length() {
+    let mut doc = Document::new();
+    doc.add_paragraph("Hello, DOC!");
+    let bytes = write_doc(&doc);
+    let cf = CompoundFile::open(&bytes).unwrap();
+    let wd = cf.read_stream("WordDocument").unwrap();
+    let table = cf.read_stream("1Table").unwrap();
+    let lcb_clx = read_u32(&wd, 0x1A6) as usize;
+    // The whole 1Table stream IS the CLX (fcClx = 0), and lcbClx should equal
+    // its length exactly.
+    assert_eq!(lcb_clx, table.len());
+    assert_eq!(lcb_clx, 21); // 1 + 4 + 16
+}
+
+// ---------------------------------------------------------------------------
+// FIB field spot-checks.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fib_fields_are_set() {
+    let mut doc = Document::new();
+    doc.add_paragraph("Hello, DOC!");
+    let bytes = write_doc(&doc);
+    let cf = CompoundFile::open(&bytes).unwrap();
+    let wd = cf.read_stream("WordDocument").unwrap();
+    assert_eq!(read_u16(&wd, 0), 0xA5EC); // wIdent
+    assert_eq!(read_u16(&wd, 2), 0x00C1); // nFib (Word 97)
+    assert_eq!(read_u16(&wd, 10), 0x0200); // fWhichTblStm
+    assert_eq!(read_u16(&wd, 32), 0x000E); // csw
+    assert_eq!(read_u16(&wd, 62), 0x0016); // cslw
+    assert_eq!(read_u32(&wd, 0x4C), 11); // ccpText
+    assert_eq!(read_u16(&wd, 152), 0x005D); // cbRgFcLcb
+    assert_eq!(read_u32(&wd, 0x1A2), 0); // fcClx
+}
+
+// ---------------------------------------------------------------------------
+// pick_encoding / edge cases.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pick_encoding_boundary_at_00ff() {
+    // U+00FF is the last Latin-1 char → still 8-bit.
+    assert_eq!(pick_encoding("\u{00FF}"), Encoding::Compressed8);
+    // U+0100 is the first char requiring 16-bit.
+    assert_eq!(pick_encoding("\u{0100}"), Encoding::Uncompressed16);
+}
+
+#[test]
+fn empty_document_does_not_panic_and_round_trips() {
+    let doc = Document::new();
+    let bytes = write_doc(&doc);
+    // Valid CFB.
+    assert_eq!(
+        &bytes[0..8],
+        &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]
+    );
+    // Zero characters reassemble to the empty string.
+    assert_eq!(round_trip(&bytes), "");
+}
+
+#[test]
+fn single_empty_paragraph_round_trips() {
+    let mut doc = Document::new();
+    doc.add_paragraph("");
+    let bytes = write_doc(&doc);
+    assert_eq!(round_trip(&bytes), "");
+}
+
+#[test]
+fn output_is_deterministic() {
+    let mut doc = Document::new();
+    doc.add_paragraph("Deterministic?");
+    let a = write_doc(&doc);
+    let b = write_doc(&doc);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn encode_text_bytes_8bit_is_one_byte_per_char() {
+    let bytes = encode_text_bytes("AZ", Encoding::Compressed8).unwrap();
+    assert_eq!(bytes, vec![0x41, 0x5A]);
+}
+
+#[test]
+fn encode_text_bytes_16bit_is_utf16le() {
+    let bytes = encode_text_bytes("A你", Encoding::Uncompressed16).unwrap();
+    // 'A' = U+0041 → 41 00 ; '你' = U+4F60 → 60 4F.
+    assert_eq!(bytes, vec![0x41, 0x00, 0x60, 0x4F]);
+}

--- a/code/specs/DOCW01-doc-writer.md
+++ b/code/specs/DOCW01-doc-writer.md
@@ -1,0 +1,216 @@
+# DOCW01 — Legacy `.doc` (Word 97-2003) writer
+
+> A **writer** for the legacy **`.doc`** binary format ([MS-DOC]) — the
+> Word 97-2003 document. You give it a simple document model (paragraphs of
+> text); it produces a valid `.doc` byte buffer by emitting the **FIB** (File
+> Information Block), a **piece table** (CLX), and the text, all wrapped in an
+> **OLE2 / Compound File Binary** container via the [CFBW01](CFBW01-cfb-writer.md)
+> writer. This is milestone **C4** of the OOXML/legacy-Office stack.
+
+This spec assumes you have read [CFBW01](CFBW01-cfb-writer.md) and its reader
+sibling [CFB01](CFB01-compound-file.md). Those explain the CFB container ("a FAT
+filesystem crammed into a single file"). Here we focus one level up: what
+*streams* a `.doc` puts inside that container, and how Word finds the document
+text through a **piece table**.
+
+Implemented by `code/packages/rust/doc-writer` (crate `doc-writer`).
+
+---
+
+## 1. The one-paragraph mental model
+
+A `.doc` file is a CFB container holding (among others) two streams:
+
+- **`WordDocument`** — starts with the **FIB**, a big fixed-layout header of
+  offsets and lengths. The document's *characters* also live in this stream, but
+  **not** at a fixed place: you must follow a pointer chain to find them.
+- **`1Table`** (or `0Table`) — holds the **CLX**, which contains the **piece
+  table** (`PlcPcd`). The piece table is the crucial indirection: it maps
+  *character positions* (CPs) in the logical document to *byte offsets* (FCs) in
+  the `WordDocument` stream, and records whether each run of text is stored as
+  **8-bit** (one Latin-1 byte per char) or **16-bit** (UTF-16LE) bytes.
+
+So the retrieval algorithm — the thing every `.doc` reader does, and the thing
+our round-trip test re-implements — is:
+
+```text
+FIB (in WordDocument)  ── fcClx/lcbClx ──▶  CLX (in 1Table)
+                                                │
+                                          PlcPcd (piece table)
+                                                │
+                                   for each piece: FcCompressed
+                                                │
+                        ┌───────────────────────┴───────────────────────┐
+                        │ bit 30 set → 8-bit text at (fc & 0x3FFFFFFF)/2 │
+                        │ bit 30 clear → 16-bit text at fc               │
+                        └───────────────────────┬───────────────────────┘
+                                                ▼
+                                    bytes in WordDocument → characters
+```
+
+Why the indirection? Historically Word edited documents *in place* by keeping
+the original text and appending edits, then rewriting only the piece table to
+splice pieces into the new logical order — an early persistent-rope. We don't
+need that power (we always emit **one** piece covering the whole document), but
+we must still emit a well-formed piece table because that is the only way a
+reader locates the text.
+
+---
+
+## 2. The output we commit to
+
+A **single-piece** `.doc`. The whole document is one run of text stored once,
+either 8-bit compressed (the common, compact case) or 16-bit (the faithful
+fallback when any character is outside Latin-1, i.e. `> U+00FF`).
+
+Two streams go into the CFB:
+
+| Stream         | Contents                                               |
+|----------------|--------------------------------------------------------|
+| `WordDocument` | FIB (fixed header) + the text bytes at a fixed offset  |
+| `1Table`       | the CLX (a `Pcdt` wrapping the `PlcPcd` piece table)   |
+
+The FIB's `fWhichTblStm` flag says whether the table stream is named `0Table` or
+`1Table`. We always set it to **1** → `1Table`.
+
+---
+
+## 3. The `WordDocument` stream — FIB + text
+
+The FIB is a large structure; a reader only needs a handful of its fields to
+find the text. We build a buffer of length `TEXT_OFFSET + text_bytes` where
+`TEXT_OFFSET = 2048` — a fixed location safely past the FIB — and set exactly
+the fields below. Every other byte is zero.
+
+| Offset (dec / hex) | Type  | Value    | Field / meaning                                        |
+|--------------------|-------|----------|--------------------------------------------------------|
+| 0                  | u16   | `0xA5EC` | `wIdent` — the magic that identifies a Word FIB        |
+| 2                  | u16   | `0x00C1` | `nFib` — FIB version (Word 97 = 193 = `0x00C1`)        |
+| 10  / 0x0A         | u16   | `0x0200` | FibBase flags; bit 9 = `fWhichTblStm` = 1 → `1Table`   |
+| 32  / 0x20         | u16   | `0x000E` | `csw` = 14 (count of 16-bit values in `fibRgW`)        |
+| 62  / 0x3E         | u16   | `0x0016` | `cslw` = 22 (count of 32-bit values in `fibRgLw`)      |
+| 76  / 0x4C         | u32   | ccpText  | character count of the main document (informational)   |
+| 152 / 0x98         | u16   | `0x005D` | `cbRgFcLcb` = 93 (count of FC/LCB pairs in `fibRgFcLcbBlob`) |
+| 418 / 0x1A2        | u32   | `0`      | `fcClx` — byte offset of the CLX in the table stream    |
+| 422 / 0x1A6        | u32   | lcbClx   | `lcbClx` — byte length of the CLX                       |
+
+The `fWhichTblStm` bit is bit **9** of the u16 at offset 10, i.e. `0x0200`.
+
+### 3.1 The text bytes
+
+We store the document text **8-bit compressed** when every character is
+`<= U+00FF`: one Latin-1 byte per character, written at byte offset
+`TEXT_OFFSET`. When any character exceeds `U+00FF`, we fall back to **16-bit**:
+two UTF-16LE bytes per character, still at `TEXT_OFFSET`. The piece table's
+`FcCompressed` (below) tells the reader which encoding to expect.
+
+Paragraphs are joined with a single **carriage return** `\r` (`0x0D`), Word's
+paragraph mark, into one text run.
+
+---
+
+## 4. The `1Table` stream — the CLX
+
+The CLX we emit is the simplest legal one: a single **`Pcdt`** (piece table
+container). Its bytes:
+
+```text
+  u8   clxt   = 0x02        ── this CLX component is a Pcdt
+  u32  lcb                  ── byte length of the PlcPcd that follows
+  ── PlcPcd (lcb bytes) ──
+  CP array : u32 0, u32 n   ── (m+1) CPs for m pieces; here 2 CPs, 1 piece
+  PCD array: one 8-byte PCD ── u16 fFlags, u32 FcCompressed, u16 prm
+```
+
+A **`PLC`** (**P**osition-**L**ength-**C**ombined, "plex") is a packed pair of
+parallel arrays: first `m+1` **CP** (character position) `u32`s, then `m`
+fixed-size data records. For the piece table the records are 8-byte **PCD**s and
+`m` is the number of pieces. The CP array is *cumulative*: CP[i] is the first
+character of piece i, and CP[m] is one past the last character — so a single
+piece covering `n` characters has CP array `{0, n}`.
+
+For our single piece:
+
+- CP array = `u32 0`, `u32 n_chars` → 8 bytes.
+- PCD array = one 8-byte PCD: `u16 0` (flags), `u32 FcCompressed`, `u16 0` (prm).
+- So `lcb = 8 (CPs) + 8 (PCD) = 16`, and the whole CLX is `1 + 4 + 16 = 21` bytes.
+
+A reader recovers the piece count as `n = (lcb - 4) / 12` — because a `PlcPcd`
+with `n` pieces is `4*(n+1)` CP bytes + `8*n` PCD bytes = `12*n + 4`.
+
+### 4.1 `FcCompressed` — the bit-30 trick
+
+The middle `u32` of a PCD is an **`FcCompressed`**. Bit 30 (`0x40000000`) is the
+`fCompressed` flag. It overloads one field to carry both a byte offset *and* the
+encoding:
+
+- **8-bit (compressed):** set bit 30, and store the offset **doubled**. The
+  reader computes the real byte offset as `(fc & 0x3FFFFFFF) / 2`. So for
+  `TEXT_OFFSET = 2048`: `fc = (2048 * 2) | 0x40000000 = 4096 | 0x40000000 =`
+  **`0x40001000`**. Text is one byte per char at the real offset.
+- **16-bit (uncompressed):** clear bit 30, and store the offset **as-is** (not
+  doubled). The reader uses `fc & 0x3FFFFFFF` directly. Text is two UTF-16LE
+  bytes per char.
+
+Why doubled in the 8-bit case? The historical intent is that `fc` addresses a
+16-bit code-unit stream; halving it recovers the byte offset, and the low bit
+being consumed by the `/2` is why the offset is stored doubled. We simply mirror
+what every reader does.
+
+---
+
+## 5. Wrapping in CFB
+
+We hand the two streams to the CFB writer in this order:
+
+```rust
+cfb_writer::write_cfb(&[("WordDocument", &wd), ("1Table", &table)])
+```
+
+The result is the finished `.doc` byte buffer, opening with the CFB signature
+`D0 CF 11 E0 A1 B1 1A E1`.
+
+---
+
+## 6. The round-trip proof
+
+The correctness proof (and the required test) does not trust our own reader-side
+helpers — it **re-implements** the retrieval from first principles:
+
+1. Open the bytes with the `cfb` reader; read `WordDocument` and `1Table`.
+2. From `WordDocument`: check `wIdent == 0xA5EC`; read the `fWhichTblStm` bit;
+   read `fcClx` (@418) and `lcbClx` (@422).
+3. Slice the CLX out of `1Table` at `[fcClx .. fcClx + lcbClx]`.
+4. Parse `clxt == 0x02`, then `lcb`, then the `PlcPcd`. Piece count
+   `n = (lcb - 4) / 12`.
+5. For each PCD: decode `FcCompressed` → (real offset, compressed flag);
+   read `CP[i+1] - CP[i]` characters from `WordDocument` at that offset, in the
+   indicated encoding.
+6. Concatenate the pieces → the reassembled document text; assert it equals the
+   input paragraphs joined by `\r`.
+
+---
+
+## 7. Robustness
+
+The writer takes **trusted** input (a `Document` the caller built), but it is
+still **total**: `#![forbid(unsafe_code)]`, no `unwrap`/`expect`/`panic!` on the
+public path, and `checked_*` arithmetic wherever a colossal text could overflow
+an offset or length. If the text is so large that `TEXT_OFFSET + len` (8-bit) or
+`TEXT_OFFSET + 2*len` (16-bit) would overflow `usize`, or the doubled 8-bit
+`FcCompressed` offset would collide with bit 30, we fall back to emitting an
+empty document rather than producing corrupt bytes. Output is **deterministic**.
+
+---
+
+## 8. What we deliberately leave out (future extensions)
+
+- **Multiple pieces.** Real Word splices many pieces; we always emit one. The
+  piece-table code is already general enough to describe more; the writer just
+  never produces them.
+- **Mixed 8-bit/16-bit pieces.** We pick one encoding for the whole document.
+- **Formatting** (character/paragraph properties, `Plcfbte*`, style sheet,
+  `Prm`s): none. A reader that only wants the text sees a clean single run.
+
+These are intentional simplifications for milestone C4; the format leaves room
+for all of them.


### PR DESCRIPTION
Legacy writer on cfb-writer; round-trips through our cfb reader in-test; security review passed (all model casts guarded via checked_*/try_from, deterministic, #![forbid(unsafe_code)]).