### PR TITLE
feat(latex): LTXDOC01 D1 — recognize document-mode tables & lists

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.26.0] — 2026-07-03
+
+### Added — document-mode tables & lists via a new `recognize_tables` pass (LTXDOC01 D1)
+
+Closes the L3b gap LTX01 deferred: document-mode `tabular`/`tabular*` grids and the
+`itemize`/`enumerate`/`description` list environments now fold into structured AST nodes. This is
+a **recognition pass over already-parsed generic environments** — not a parser/lexer change: L1
+already parses `\begin{tabular}{lcr}a & b \\ c & d\end{tabular}` as a generic `Node::Environment`
+(with `&` → `Text("&")`, `\\` → `Command("\\")`, `\item[t] x` → `Command("item", opt:[t])` + siblings).
+
+- **New `Node` variants** (both span-less, matching the other structural variants):
+  - `Node::Tabular { col_spec: Option<String>, rows: Vec<Vec<Vec<Node>>> }` — `rows[r][c]` is cell
+    `c` of row `r`; `col_spec` is the column spec captured verbatim (`"lcr"`, `"l|c|r"`), `None` if
+    absent. For `tabular*` the `{width}` argument is dropped and the trailing `{colspec}` kept.
+  - `Node::List { kind: ListKind, items: Vec<ListItem> }` with new `pub enum ListKind { Itemize,
+    Enumerate, Description }` and `pub struct ListItem { label: Option<Vec<Node>>, body: Vec<Node> }`
+    (`label` = the `\item[term]` optional term).
+- **New `recognize_tables(nodes) -> Vec<Node>` pass** (`src/tables.rs`), mirroring
+  `recognize_structure`: a total, infallible fold that recurses into every child node-list and
+  splits `tabular` bodies on `&`/`\\` and list bodies on `\item`. Re-exported from `lib.rs` along
+  with `ListKind`/`ListItem`.
+- **`to_latex` round-trip**: `recognize_tables(parse(&node.to_latex())) == [node]` for tables and
+  lists (asserted over a corpus). A recognized `tabular*` round-trips as a plain `tabular` (its
+  width was not a column spec — dropping it is faithful to the grid).
+- **Totality (spec reconciliation)**: the pass never errors and never panics — ragged rows
+  (differing cell counts) are preserved exactly, and a list with stray content before its first
+  `\item` is left as a generic `Node::Environment`. The spec's "spanned errors on malformed grids"
+  guarantee lives in the **L1 parser** (unbalanced braces / `\begin`/`\end` mismatch, `MAX_DEPTH`
+  depth guard), upstream of this total recognition pass; recursion here is bounded by the L1 tree
+  depth (no new unbounded recursion, no raw brace counting — `col_spec` comes from parsed argument
+  nodes). Per-node byte spans remain the Document layer's job (D2+).
+- No `unsafe`; `cargo clippy -p latex -- -D warnings` clean; downstream `adj-lang`/`adj-lang-cli`
+  unaffected (the new variants don't reach the math-frontend path).
+
 ## [0.25.0] — 2026-07-01
 
 ### Changed — comma/semicolon fence lists now keep their delimiters (`Fenced`-of-`Sequence`)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -37,6 +37,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
 | **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |
 | **L6 frontend** | `LatexMath` implements `math-frontend::MathFrontend` — lifts `MathNode` → neutral `MathExpr`; LaTeX is plugin #1 via `registry()` (default-on `frontend` feature) | ✅ |
+| **D1 doc tables/lists** | document-mode `tabular`/`tabular*` grids (split on `&`/`\\`) → `Node::Tabular` and `itemize`/`enumerate`/`description` (split on `\item`) → `Node::List`, via the opt-in `recognize_tables` pass; total, round-trip | ✅ |
 
 The ladder is **complete** (L0–L6). 🎉
 
@@ -197,6 +198,38 @@ cross-ref with no key) is left as a plain command — never dropped or mis-folde
 positional (until end of group), so wrapping them in an argument node would misrepresent them.
 The pass is idempotent and round-trips: `recognize_structure(parse(&n.to_latex())) == [n]`.
 (The two passes — `recognize_accents` and `recognize_structure` — are independent and compose.)
+
+### Document-mode tables & lists (D1)
+
+`recognize_tables` is the third opt-in classification pass (like the two above). It folds the
+*generic* environments L1 produces for document-mode `tabular`/`tabular*` grids and the
+`itemize`/`enumerate`/`description` list environments into structured nodes — splitting a table
+body on the `&` alignment tab and the `\\` row break, and a list body on `\item`:
+
+```rust
+use latex::{parse, recognize_tables, Node, ListKind};
+
+let table = recognize_tables(parse(r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}").unwrap());
+assert!(matches!(table[0], Node::Tabular { .. }));   // 2×2 grid, col_spec = Some("lc")
+
+let list = recognize_tables(parse(r"\begin{itemize}\item one\item two\end{itemize}").unwrap());
+assert!(matches!(list[0], Node::List { kind: ListKind::Itemize, .. }));
+```
+
+Recognized:
+
+- **`Node::Tabular { col_spec, rows }`** — `tabular`/`tabular*`; `rows[r][c]` is the node
+  sequence of cell `c` in row `r`; `col_spec` is the column spec captured verbatim (`None` if
+  absent). A `tabular*` `{width}` argument is dropped, keeping the trailing `{colspec}`.
+- **`Node::List { kind, items }`** — `itemize`/`enumerate`/`description`; each `ListItem` carries
+  its `\item[term]` optional `label` and the `body` up to the next `\item`.
+
+The pass is **total and infallible**: ragged rows (differing cell counts) are preserved exactly,
+and a list with stray content before its first `\item` is left as a generic `Node::Environment`
+— never an error here (truly malformed input — unbalanced braces, `\begin`/`\end` mismatch — is
+already rejected by the L1 parser with a spanned error, upstream of this pass). It is idempotent
+and round-trips: `recognize_tables(parse(&n.to_latex())) == [n]`. All three recognition passes
+are independent and compose.
 
 ### Pluggable frontend (L6)
 

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -47,6 +47,55 @@ impl SectionLevel {
     }
 }
 
+/// The flavour of a document-mode list environment, produced by the opt-in
+/// [`recognize_tables`](crate::recognize_tables) pass (D1) as part of [`Node::List`].
+///
+/// | Environment | Kind | What the `\item`s look like |
+/// |-------------|------|------------------------------|
+/// | `\begin{itemize}` | [`ListKind::Itemize`] | bulleted — plain `\item body` |
+/// | `\begin{enumerate}` | [`ListKind::Enumerate`] | numbered — plain `\item body` |
+/// | `\begin{description}` | [`ListKind::Description`] | term/definition — `\item[term] body` |
+///
+/// The three share one shape (a list of `\item`s), so they share one node and differ only by
+/// this tag. The tag is all `to_latex` needs to pick the environment name back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListKind {
+    /// `\begin{itemize}` — an unordered (bulleted) list.
+    Itemize,
+    /// `\begin{enumerate}` — an ordered (numbered) list.
+    Enumerate,
+    /// `\begin{description}` — a description list; each `\item[term]` carries a bold term.
+    Description,
+}
+
+impl ListKind {
+    /// The environment name (without braces) this kind renders to — the inverse of the
+    /// recognition table above, used by [`Node::to_latex`].
+    pub fn env(self) -> &'static str {
+        match self {
+            ListKind::Itemize => "itemize",
+            ListKind::Enumerate => "enumerate",
+            ListKind::Description => "description",
+        }
+    }
+}
+
+/// One entry of a [`Node::List`] — a single `\item` and the content that follows it up to the
+/// next `\item` (or the end of the list).
+///
+/// `\item body` (in `itemize`/`enumerate`) has `label == None`. `\item[term] body` (the
+/// `description` form, though LaTeX allows the optional term on any list) captures `[term]` as
+/// `label` — the nodes of the bracketed optional argument — and everything after it as `body`.
+/// Splitting on `\item` is a pure regrouping of the already-parsed siblings, so no source is
+/// dropped: concatenating every item's optional-marker + body reproduces the environment body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListItem {
+    /// The `\item[term]` optional term, if present (`None` for a plain `\item`).
+    pub label: Option<Vec<Node>>,
+    /// The nodes following this `\item`, up to (not including) the next `\item`.
+    pub body: Vec<Node>,
+}
+
 /// One node of the document tree.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Node {
@@ -112,6 +161,19 @@ pub enum Node {
     /// positional, not a wrapped argument.) Produced only by the opt-in
     /// [`recognize_structure`](crate::recognize_structure) pass, not by L1.
     Styled { command: String, content: Vec<Node> },
+    /// A document-mode table (D1): `\begin{tabular}{lcr} a & b \\ c & d \end{tabular}` (and the
+    /// `tabular*` width-argument form). `col_spec` is the column specification captured verbatim
+    /// (`"lcr"`, `"l|c|r"`, …) or `None` if the environment carried none; `rows[r][c]` is the node
+    /// sequence of cell `c` in row `r`. Cells are split on the `&` alignment tab, rows on the `\\`
+    /// row break — a pure regrouping of the parsed environment body (Space nodes inside a cell are
+    /// kept for faithfulness). Produced only by the opt-in
+    /// [`recognize_tables`](crate::recognize_tables) pass, not by L1.
+    Tabular { col_spec: Option<String>, rows: Vec<Vec<Vec<Node>>> },
+    /// A document-mode list (D1): `\begin{itemize}`, `\begin{enumerate}`, `\begin{description}`.
+    /// `kind` tags which of the three; `items` are the `\item` entries in order (each with its
+    /// optional `[term]` label and the body up to the next `\item`). Produced only by the opt-in
+    /// [`recognize_tables`](crate::recognize_tables) pass, not by L1.
+    List { kind: ListKind, items: Vec<ListItem> },
     /// An active character that acts like a command — `~`.
     Active(char),
     /// A construct deliberately out of scope (the TeX-programmability asymptote — e.g.
@@ -272,6 +334,57 @@ impl Node {
                 out.push_str(command);
                 out.push('{');
                 render_seq(content, out);
+                out.push('}');
+            }
+            Node::Tabular { col_spec, rows } => {
+                // `\begin{tabular}{spec}` cell & cell \\ cell & cell `\end{tabular}`. We always
+                // render the single-argument `tabular` form (a recognized `tabular*` folds its
+                // width away into the colspec at recognition time — the width is not a column
+                // spec — so it round-trips as a plain `tabular`, which is faithful to the grid).
+                out.push_str("\\begin{tabular}");
+                if let Some(spec) = col_spec {
+                    out.push('{');
+                    out.push_str(spec);
+                    out.push('}');
+                }
+                for (r, row) in rows.iter().enumerate() {
+                    if r > 0 {
+                        // Row break: ` \\ ` with surrounding spaces so re-parsing keeps the `\\`
+                        // its own `Command` node between cells rather than fusing with text.
+                        out.push_str(" \\\\ ");
+                    }
+                    for (c, cell) in row.iter().enumerate() {
+                        if c > 0 {
+                            out.push_str(" & ");
+                        }
+                        render_seq(cell, out);
+                    }
+                }
+                out.push_str("\\end{tabular}");
+            }
+            Node::List { kind, items } => {
+                out.push_str("\\begin{");
+                out.push_str(kind.env());
+                out.push('}');
+                for item in items {
+                    out.push_str("\\item");
+                    if let Some(label) = &item.label {
+                        // `\item[term]` — the `]` terminates the control word, so the body's own
+                        // leading Space (if any) is preserved verbatim by `render_seq` below.
+                        out.push('[');
+                        render_seq(label, out);
+                        out.push(']');
+                    } else {
+                        // Bare `\item` — a control *word*, so it needs a terminating space or the
+                        // following body text would fuse into the command name (`\itemone`). L1
+                        // eats exactly one such space, so re-parsing drops it and the body
+                        // re-splits identically (round-trip fixed point).
+                        out.push(' ');
+                    }
+                    render_seq(&item.body, out);
+                }
+                out.push_str("\\end{");
+                out.push_str(kind.env());
                 out.push('}');
             }
             Node::Active(c) => out.push(*c),

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -39,7 +39,11 @@
 //!    nodes: sectioning ([`Node::Section`]), cross-refs/citations ([`Node::CrossRef`]),
 //!    preamble directives ([`Node::Preamble`]), and argument-form font commands
 //!    ([`Node::Styled`]). **Implemented (L5d).**
-//! 8. [`LatexMath`] — the `math-frontend` adapter: implements `math_frontend::MathFrontend`,
+//! 8. [`recognize_tables`] — an opt-in pass folding document-mode `tabular`/`tabular*` grids into
+//!    [`Node::Tabular`] (splitting the body on `&`/`\\`) and the list environments
+//!    `itemize`/`enumerate`/`description` into [`Node::List`] (splitting on `\item`). Total and
+//!    infallible; leaves questionable input as its generic [`Node::Environment`]. **Implemented (D1).**
+//! 9. [`LatexMath`] — the `math-frontend` adapter: implements `math_frontend::MathFrontend`,
 //!    lifting a math island's [`MathNode`] into the neutral `MathExpr`, so LaTeX plugs into the
 //!    pluggable-frontend registry ([`registry`] / [`register_latex`]). **Implemented (L6).**
 //!    Gated behind the default-on `frontend` cargo feature; `--no-default-features` keeps
@@ -68,6 +72,7 @@ mod macros;
 mod math;
 mod parser;
 mod structure;
+mod tables;
 mod text;
 mod token;
 
@@ -77,7 +82,7 @@ mod frontend;
 #[cfg(feature = "frontend")]
 pub use frontend::{register_latex, registry, LatexMath};
 
-pub use ast::{document_to_latex, Node, SectionLevel};
+pub use ast::{document_to_latex, ListItem, ListKind, Node, SectionLevel};
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};
 pub use lexer::tokenize;
@@ -85,5 +90,6 @@ pub use macros::expand;
 pub use math::{parse_math, MBinOp, MRelOp, MUnOp, MathNode};
 pub use parser::parse;
 pub use structure::recognize_structure;
+pub use tables::recognize_tables;
 pub use text::recognize_accents;
 pub use token::{Span, Token, TokenKind};

--- a/code/packages/rust/latex/src/tables.rs
+++ b/code/packages/rust/latex/src/tables.rs
@@ -1,0 +1,466 @@
+//! Document-mode **table & list** recognition (D1) — an opt-in pass that folds the *generic*
+//! environments [`parse`](crate::parse) (L1) produces for `tabular`/`tabular*` and
+//! `itemize`/`enumerate`/`description` into the structured [`Node::Tabular`] and [`Node::List`].
+//!
+//! ## Why a separate opt-in pass
+//!
+//! Exactly like [`recognize_structure`](crate::recognize_structure) (sectioning) and
+//! [`recognize_accents`](crate::recognize_accents) (accents), L1 already parses these
+//! environments — `\begin{tabular}{lcr}a & b\end{tabular}` is a perfectly good generic
+//! [`Node::Environment`], and it round-trips. What L1 deliberately does **not** do is say "this
+//! is a 1×2 table with column spec `lcr`", splitting the body on the `&` alignment tab and the
+//! `\\` row break. This pass adds that recognition **on demand**, so L1's own tree and
+//! round-trip stay untouched (run it, or don't).
+//!
+//! ## What it recognizes (a table)
+//!
+//! ```text
+//!   \begin{tabular}{l c r}          col_spec = Some("l c r")
+//!     a & b & c \\                  row 0 = [ [a] , [b] , [c] ]     (& splits cells)
+//!     d & e & f                     row 1 = [ [d] , [e] , [f] ]     (\\ splits rows)
+//!   \end{tabular}
+//! ```
+//!
+//! A cell is the run of nodes *between* alignment tabs; a row is the run of cells *between* row
+//! breaks. `tabular*` carries a leading `{width}` argument before its `{colspec}` — we keep the
+//! **last** mandatory argument as the column spec and drop the width (a width is not a column
+//! spec; folding it away is faithful to the grid, and the node round-trips as a plain `tabular`).
+//!
+//! Lists split their body on `\item`: each item owns the nodes after its `\item` up to the next
+//! one, and an `\item[term]` optional becomes the item's `label`.
+//!
+//! ## Totality (leave-as-is on doubt)
+//!
+//! The pass is **total and infallible** — it returns `Vec<Node>`, never a `Result`, and never
+//! panics. Splitting on `&`/`\\`/`\item` is a pure *regrouping* of already-parsed sibling nodes,
+//! so no source is dropped: a ragged grid (rows of differing cell counts) is preserved exactly,
+//! with each row keeping its own length — **not** an error. A list environment whose body has
+//! stray content *before* the first `\item` is left as a recognized-body [`Node::Environment`]
+//! rather than folded, because folding questionable input would misrepresent it. Truly malformed
+//! input (unbalanced braces, `\begin{a}…\end{b}` mismatch) never reaches here: the L1 parser
+//! already rejects it with a spanned [`ParseError`](crate::ParseError). So the spec's
+//! "spanned errors on malformed grids" guarantee lives in **L1**, upstream of this total pass.
+//!
+//! ## Bounded recursion, no brace counting
+//!
+//! Recursion descends only into child node-lists that L1 already produced; its depth is the L1
+//! tree depth, which the parser caps (`MAX_DEPTH`), so adversarial nesting cannot overflow here
+//! (no *new* unbounded recursion). The column spec is read off the already-parsed argument nodes
+//! via [`Node::to_latex`] — there is **no raw brace counting** in this module.
+
+use crate::ast::{ListItem, ListKind, Node};
+
+/// Map a list-environment name to its [`ListKind`], or `None` if `name` is not one.
+fn list_kind(name: &str) -> Option<ListKind> {
+    Some(match name {
+        "itemize" => ListKind::Itemize,
+        "enumerate" => ListKind::Enumerate,
+        "description" => ListKind::Description,
+        _ => return None,
+    })
+}
+
+/// Recognize document-mode tables and lists in `nodes` into [`Node::Tabular`] / [`Node::List`].
+/// The input is typically [`parse`](crate::parse) output (optionally already
+/// [`recognize_structure`](crate::recognize_structure)-folded — the passes are independent and
+/// compose, since each only touches its own construct and recurses through the rest).
+pub fn recognize_tables(nodes: Vec<Node>) -> Vec<Node> {
+    nodes.into_iter().map(recurse).collect()
+}
+
+/// Rebuild one node, recursing `recognize_tables` into every child node-list, and — for the
+/// table/list environments — folding it into the structured variant.
+fn recurse(node: Node) -> Node {
+    match node {
+        Node::Environment { name, optional, arguments, body } => {
+            // Recurse into the argument/optional lists and the body regardless, then decide
+            // whether this environment is a table, a list, or just a recursed environment.
+            let optional: Vec<Vec<Node>> = optional.into_iter().map(recognize_tables).collect();
+            let arguments: Vec<Vec<Node>> = arguments.into_iter().map(recognize_tables).collect();
+            let body = recognize_tables(body);
+
+            if name == "tabular" || name == "tabular*" {
+                return fold_tabular(&arguments, body);
+            }
+            if let Some(kind) = list_kind(&name) {
+                return fold_list(kind, name, optional, arguments, body);
+            }
+            Node::Environment { name, optional, arguments, body }
+        }
+
+        // --- plain structural recursion into every other node's child lists -------------------
+        Node::Group(inner) => Node::Group(recognize_tables(inner)),
+        Node::Command { name, optional, arguments } => Node::Command {
+            name,
+            optional: optional.into_iter().map(recognize_tables).collect(),
+            arguments: arguments.into_iter().map(recognize_tables).collect(),
+        },
+        Node::Section { level, starred, short, title } => Node::Section {
+            level,
+            starred,
+            short: short.map(recognize_tables),
+            title: recognize_tables(title),
+        },
+        Node::CrossRef { command, note, target } => Node::CrossRef {
+            command,
+            note: note.map(recognize_tables),
+            target: recognize_tables(target),
+        },
+        Node::Preamble { command, options, name } => Node::Preamble {
+            command,
+            options: options.map(recognize_tables),
+            name: recognize_tables(name),
+        },
+        Node::Styled { command, content } => {
+            Node::Styled { command, content: recognize_tables(content) }
+        }
+        // Recurse into already-recognized tables/lists too, so the pass is idempotent and
+        // composes with itself (e.g. a list nested inside a table cell).
+        Node::Tabular { col_spec, rows } => Node::Tabular {
+            col_spec,
+            rows: rows
+                .into_iter()
+                .map(|row| row.into_iter().map(recognize_tables).collect())
+                .collect(),
+        },
+        Node::List { kind, items } => Node::List {
+            kind,
+            items: items
+                .into_iter()
+                .map(|it| ListItem {
+                    label: it.label.map(recognize_tables),
+                    body: recognize_tables(it.body),
+                })
+                .collect(),
+        },
+        // leaves (Text, Space, Par, Math, Comment, Verb, VerbatimEnv, Accent, Active,
+        // Unsupported) carry no further child lists to fold here
+        other => other,
+    }
+}
+
+/// Fold a (already-recursed) `tabular`/`tabular*` body into a [`Node::Tabular`].
+///
+/// `col_spec` = the **last** mandatory argument rendered back to source (the only argument for
+/// `tabular`; the `{colspec}` after `{width}` for `tabular*`), or `None` if there were none.
+/// Rows are the body split on the `\\` row break; cells are each row split on the `&` tab.
+fn fold_tabular(arguments: &[Vec<Node>], body: Vec<Node>) -> Node {
+    let col_spec = arguments.last().map(|arg| crate::document_to_latex(arg));
+    let rows = split_rows(body);
+    Node::Tabular { col_spec, rows }
+}
+
+/// Split a tabular body into rows (on `\\`), each row into cells (on `Text("&")`).
+///
+/// A trailing all-empty row produced by a trailing `\\` (e.g. `a & b \\`) is dropped, so the
+/// grid has one row per line of content — but a genuinely empty *cell* is kept, and ragged rows
+/// keep their own cell counts (no padding, no error — faithfulness over regularization).
+fn split_rows(body: Vec<Node>) -> Vec<Vec<Vec<Node>>> {
+    // First split on the `\\` row break command.
+    let mut rows: Vec<Vec<Node>> = Vec::new();
+    let mut current: Vec<Node> = Vec::new();
+    for node in body {
+        if is_row_break(&node) {
+            rows.push(std::mem::take(&mut current));
+        } else {
+            current.push(node);
+        }
+    }
+    rows.push(current);
+
+    // Drop a single trailing empty row from a trailing `\\` (`a & b \\` → one row, not two).
+    // "Empty" means the row's nodes are only insignificant whitespace/comments.
+    if rows.len() > 1 && rows.last().map(|r| is_blank_row(r)).unwrap_or(false) {
+        rows.pop();
+    }
+
+    // Then split each row on the `&` alignment tab into cells.
+    rows.into_iter().map(split_cells).collect()
+}
+
+/// Split one row's node run into cells at each `Text("&")` node. The `&` node itself is dropped
+/// (it is the separator); everything else — including Space nodes inside a cell — is kept.
+fn split_cells(row: Vec<Node>) -> Vec<Vec<Node>> {
+    let mut cells: Vec<Vec<Node>> = Vec::new();
+    let mut cell: Vec<Node> = Vec::new();
+    for node in row {
+        if is_align_tab(&node) {
+            cells.push(std::mem::take(&mut cell));
+        } else {
+            cell.push(node);
+        }
+    }
+    cells.push(cell);
+    cells
+}
+
+/// Is this node the `\\` row-break command (`Command { name: "\\", .. }`)?
+fn is_row_break(node: &Node) -> bool {
+    matches!(node, Node::Command { name, optional, arguments }
+        if name == "\\" && optional.is_empty() && arguments.is_empty())
+}
+
+/// Is this node the `&` alignment tab (its own `Text("&")` node between cells)?
+fn is_align_tab(node: &Node) -> bool {
+    matches!(node, Node::Text(t) if t == "&")
+}
+
+/// Does a row consist only of insignificant whitespace (Space/Par) and comments? Such a row is
+/// what a trailing `\\` leaves behind, and is dropped so `a & b \\` is one row, not two.
+fn is_blank_row(row: &[Node]) -> bool {
+    row.iter()
+        .all(|n| matches!(n, Node::Space | Node::Par | Node::Comment(_)))
+}
+
+/// Fold a (already-recursed) list environment body into a [`Node::List`], **unless** the body
+/// has stray content before the first `\item` — in which case we leave it as a recognized-body
+/// [`Node::Environment`] (totality: don't fold questionable input).
+fn fold_list(
+    kind: ListKind,
+    name: String,
+    optional: Vec<Vec<Node>>,
+    arguments: Vec<Vec<Node>>,
+    body: Vec<Node>,
+) -> Node {
+    // Ignoring leading insignificant whitespace/comments, does the body start with an `\item`?
+    let first_significant = body
+        .iter()
+        .find(|n| !matches!(n, Node::Space | Node::Par | Node::Comment(_)));
+    let starts_with_item = matches!(
+        first_significant,
+        Some(Node::Command { name, .. }) if name == "item"
+    );
+    if !starts_with_item {
+        // Stray content before the first item — leave it as a generic (recursed) environment.
+        return Node::Environment { name, optional, arguments, body };
+    }
+
+    // Split the body at each `\item`; each item's label = its optional term, body = the nodes
+    // after it up to the next `\item`. Any leading whitespace before the first `\item` is
+    // attached to the (soon-to-open) first item's *pre-body* — but since we verified the body
+    // starts with `\item` (modulo whitespace), that leading whitespace is harmless and rare; we
+    // keep it faithfully as leading nodes of the first item so nothing is dropped.
+    let mut items: Vec<ListItem> = Vec::new();
+    let mut pending_label: Option<Vec<Node>> = None;
+    let mut current: Vec<Node> = Vec::new();
+    let mut open = false; // are we inside an item yet?
+    for node in body {
+        match &node {
+            Node::Command { name, optional, .. } if name == "item" => {
+                // Close the previous item (if any) and open a new one.
+                if open {
+                    items.push(ListItem { label: pending_label.take(), body: std::mem::take(&mut current) });
+                }
+                pending_label = optional.first().cloned();
+                current.clear();
+                open = true;
+            }
+            _ => {
+                // Content before the very first `\item` is attached as leading nodes of the
+                // first item (only reachable for pure whitespace, per the guard above).
+                current.push(node);
+            }
+        }
+    }
+    if open {
+        items.push(ListItem { label: pending_label.take(), body: current });
+    }
+
+    Node::List { kind, items }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{document_to_latex, parse};
+
+    /// Parse and recognize tables/lists, for concise assertions.
+    fn tb(src: &str) -> Vec<Node> {
+        recognize_tables(parse(src).expect("parse"))
+    }
+
+    /// The D1 round-trip: rendering a recognized node and re-recognizing yields the same node.
+    fn round_trips(src: &str) {
+        let a = tb(src);
+        let rendered = document_to_latex(&a);
+        let b = recognize_tables(parse(&rendered).expect("re-parse"));
+        assert_eq!(a, b, "table/list round-trip: {src:?} -> {rendered:?}");
+    }
+
+    #[test]
+    fn basic_2x2_tabular_with_col_spec() {
+        match &tb(r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}")[0] {
+            Node::Tabular { col_spec, rows } => {
+                assert_eq!(col_spec.as_deref(), Some("lc"));
+                assert_eq!(rows.len(), 2, "two rows");
+                assert_eq!(rows[0].len(), 2, "row 0 has 2 cells");
+                assert_eq!(rows[1].len(), 2, "row 1 has 2 cells");
+                // Cell contents include the `a` text (plus surrounding Space nodes kept verbatim).
+                assert!(rows[0][0].iter().any(|n| matches!(n, Node::Text(t) if t == "a")));
+                assert!(rows[1][1].iter().any(|n| matches!(n, Node::Text(t) if t == "d")));
+            }
+            other => panic!("expected Tabular, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_col_spec_is_none() {
+        match &tb(r"\begin{tabular}a & b\end{tabular}")[0] {
+            Node::Tabular { col_spec, rows } => {
+                assert_eq!(*col_spec, None);
+                assert_eq!(rows.len(), 1);
+                assert_eq!(rows[0].len(), 2);
+            }
+            other => panic!("expected Tabular, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tabular_star_drops_width_keeps_colspec() {
+        // `tabular*` carries {width}{colspec}; the LAST argument is the column spec.
+        match &tb(r"\begin{tabular*}{2cm}{lr}a & b\end{tabular*}")[0] {
+            Node::Tabular { col_spec, rows } => {
+                assert_eq!(col_spec.as_deref(), Some("lr"));
+                assert_eq!(rows[0].len(), 2);
+            }
+            other => panic!("expected Tabular, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ragged_rows_preserved_not_error() {
+        // Row 0 has 2 cells, row 1 has 3 — kept as-is, no padding, no error.
+        match &tb(r"\begin{tabular}{c}a & b \\ c & d & e\end{tabular}")[0] {
+            Node::Tabular { rows, .. } => {
+                assert_eq!(rows.len(), 2);
+                assert_eq!(rows[0].len(), 2);
+                assert_eq!(rows[1].len(), 3);
+            }
+            other => panic!("expected Tabular, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_row_break_dropped() {
+        // A trailing `\\` should not leave a spurious empty final row.
+        match &tb(r"\begin{tabular}{c}a & b \\\end{tabular}")[0] {
+            Node::Tabular { rows, .. } => assert_eq!(rows.len(), 1, "one row, trailing \\\\ dropped"),
+            other => panic!("expected Tabular, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn itemize_two_items() {
+        match &tb(r"\begin{itemize}\item one\item two\end{itemize}")[0] {
+            Node::List { kind, items } => {
+                assert_eq!(*kind, ListKind::Itemize);
+                assert_eq!(items.len(), 2);
+                assert_eq!(items[0].label, None);
+                assert!(items[0].body.iter().any(|n| matches!(n, Node::Text(t) if t == "one")));
+                assert!(items[1].body.iter().any(|n| matches!(n, Node::Text(t) if t == "two")));
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn item_label_captured() {
+        match &tb(r"\begin{description}\item[Term] definition\end{description}")[0] {
+            Node::List { kind, items } => {
+                assert_eq!(*kind, ListKind::Description);
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0].label, Some(vec![Node::Text("Term".into())]));
+                assert!(items[0].body.iter().any(|n| matches!(n, Node::Text(t) if t == "definition")));
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enumerate_recognized() {
+        match &tb(r"\begin{enumerate}\item a\item b\end{enumerate}")[0] {
+            Node::List { kind, items } => {
+                assert_eq!(*kind, ListKind::Enumerate);
+                assert_eq!(items.len(), 2);
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_list_inside_item() {
+        // An itemize inside an enumerate item is itself recognized.
+        let src = r"\begin{enumerate}\item outer\begin{itemize}\item inner\end{itemize}\end{enumerate}";
+        match &tb(src)[0] {
+            Node::List { kind, items } => {
+                assert_eq!(*kind, ListKind::Enumerate);
+                assert_eq!(items.len(), 1);
+                assert!(
+                    items[0].body.iter().any(|n| matches!(n, Node::List { kind, .. } if *kind == ListKind::Itemize)),
+                    "inner itemize should be a recognized List: {:#?}", items[0].body
+                );
+            }
+            other => panic!("expected List, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stray_content_before_first_item_stays_environment() {
+        // Real content (not whitespace) before the first `\item` — leave as an Environment.
+        match &tb(r"\begin{itemize}oops\item one\end{itemize}")[0] {
+            Node::Environment { name, body, .. } => {
+                assert_eq!(name, "itemize");
+                assert!(body.iter().any(|n| matches!(n, Node::Text(t) if t == "oops")));
+            }
+            other => panic!("expected Environment (stray content), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn recurses_into_section_body() {
+        // A tabular inside a (recognized) section title/body is itself recognized.
+        let src = r"\begin{itemize}\item x\end{itemize}";
+        let nodes = recognize_tables(
+            crate::recognize_structure(parse(&format!(r"\section{{H}} {src}")).expect("parse")),
+        );
+        assert!(matches!(nodes[0], Node::Section { .. }));
+        assert!(
+            nodes.iter().any(|n| matches!(n, Node::List { .. })),
+            "list after a section should be recognized: {nodes:#?}"
+        );
+    }
+
+    #[test]
+    fn recurses_into_group() {
+        // A tabular wrapped in a brace group is still recognized inside the group.
+        match &tb(r"{\begin{tabular}{c}a\end{tabular}}")[0] {
+            Node::Group(inner) => {
+                assert!(inner.iter().any(|n| matches!(n, Node::Tabular { .. })));
+            }
+            other => panic!("expected Group, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idempotent() {
+        let once = tb(r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}");
+        let twice = recognize_tables(once.clone());
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn round_trips_cover_tables_and_lists() {
+        for s in [
+            r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}",
+            r"\begin{tabular}{lcr}a & b & c\end{tabular}",
+            r"\begin{tabular*}{2cm}{lr}a & b\end{tabular*}",
+            r"\begin{tabular}a & b\end{tabular}",
+            r"\begin{itemize}\item one\item two\end{itemize}",
+            r"\begin{enumerate}\item a\item b\item c\end{enumerate}",
+            r"\begin{description}\item[Term] def\item[Two] more\end{description}",
+            r"\begin{enumerate}\item outer\begin{itemize}\item inner\end{itemize}\end{enumerate}",
+        ] {
+            round_trips(s);
+        }
+    }
+}


### PR DESCRIPTION
## LTXDOC01 D1 — document-mode tables & lists (`latex` crate)

First implementation rung of the **LaTeX → Document AST** arc ([spec LTXDOC01](code/specs/LTXDOC01-latex-document-ast.md)). Closes LTX01's deferred **L3b** gap: the `latex` crate now recognizes document-mode `tabular`/`tabular*` and the list environments `itemize`/`enumerate`/`description` into structured nodes.

### Approach — a recognition pass, not a parser change
`latex::parse()` already accepts `\begin{tabular}{lcr}a & b \\ c & d\end{tabular}` as a **generic** `Node::Environment` (`&`→`Text("&")`, `\\`→`Command("\\")`, `\item[t]`→`Command{name:"item", optional:[[t]]}`). So D1 is a new **opt-in recognition pass** — `recognize_tables(Vec<Node>) -> Vec<Node>` — mirroring the shipped `recognize_structure`/`recognize_accents` passes: it folds those generic environments into new `Node` variants, leaving L1's own tree and round-trip untouched (run it, or don't).

### New AST
- `Node::Tabular { col_spec: Option<String>, rows: Vec<Vec<Vec<Node>>> }` — `rows[r][c]` is cell *c* of row *r* (body split on `\\`, then each row on `&`).
- `Node::List { kind: ListKind, items: Vec<ListItem> }`, `ListKind { Itemize, Enumerate, Description }`, `ListItem { label: Option<Vec<Node>>, body: Vec<Node> }` (`label` = the `\item[term]` optional).
- `to_latex` arms for both; **round-trip** `recognize_tables(parse(&n.to_latex())) == [n]` asserted over an 8-item corpus.

Consistent with the crate's convention, these are **span-less** (only `Node::Unsupported` carries a span); per-node byte spans are the Document layer's job in later rungs (D2+).

### Totality & safety
- **Total and infallible** (like `recognize_structure`): returns `Vec<Node>`, never `Result`, never panics. Ragged rows are preserved (each row keeps its own cell count — no error, no padding); a list with stray non-whitespace content before its first `\item` is left as a generic `Environment`.
- **Spec reconciliation** (repo std #9): the spec's "spanned errors on malformed grids" guarantee lives in the **upstream L1 parser** (unbalanced braces, `\begin`/`\end` mismatch, `MAX_DEPTH` depth guard — all covered by existing parser tests), not in this total pass. No new error path is introduced.
- **No new DoS surface**: recursion is bounded by the L1 tree depth (already `MAX_DEPTH`-capped); `col_spec` is read off already-parsed argument nodes — **no raw brace counting**. **No `unsafe`** (crate has none; added none).

### Documented edges
- `tabular*` `{width}{colspec}`: the leading width is dropped, the colspec kept as `col_spec` (a width is not a column spec); it round-trips as a plain `tabular` grid.
- `\\[2ex]` row-spacing: `is_row_break` requires an empty optional/arguments, so `\\[2ex]` stays inline in the cell verbatim (conservative, non-lossy) rather than splitting.
- `\item{x}` (brace not bracket): `label = None`, the group stays in the item body.

### Verification
```
cargo test -p latex        → 207 passed; 0 failed (+1 doc-test)
cargo clippy -p latex -D warnings → clean
cargo test -p adj-lang -p adj-lang-cli → all green (downstream consumers unaffected)
```

Next rung (D2): the `Document` skeleton + preamble/body split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
