### PR TITLE
feat(adj-ladder): rung-67 ergometry specific work rate (difference times factor, over a divisor)

### DIFF
--- a/code/specs/data/adj-ladder/rung67_ergometry_specific_work/gen_items.py
+++ b/code/specs/data/adj-ladder/rung67_ergometry_specific_work/gen_items.py
@@ -1,0 +1,230 @@
+"""Generate rung-67 (ergometry specific work rate) items.json for the ADJ-LADDER.
+
+Rung 67 opens the **sports medicine / ergometry** panel on the quantitative band — the arithmetic of a specific work
+rate. A cycle-ergometer test measures the power an athlete adds above a resting baseline (the net power = peak minus
+baseline), scales it by the gear ratio, and normalises to the athlete's body mass. Multiplying a DIFFERENCE by a FACTOR
+and then dividing by a normaliser introduces a genuinely NEW arithmetic shape on the ladder: a **difference-times-factor
+over a divisor** — `(a-b)*c/d`, i.e. `((a-b)*c)/d`.
+
+The setup: a `peak_power`, a `baseline_power`, a `gear_ratio`, and a `body_mass`. The specific work rate is:
+
+  SPECIFIC WORK   (peak_power - baseline_power) * gear_ratio / body_mass   [ geared net power per unit mass ]
+  NET POWER       peak_power - baseline_power                              [ the numerator difference ]
+  GEARED POWER    (peak_power - baseline_power) * gear_ratio               [ the scaled difference, before dividing ]
+
+The **specific work** is what makes this rung distinctive — it is the ladder's first **difference scaled by a factor,
+then divided**. Contrast the neighbours already on the ladder: rung-50 was `a*(b-c)` (a lone factor leading a
+parenthesised difference — no division), rung-33 was `(a-b)*(c-d)` (a product of two differences), and rung-51 was
+`a*b*c` (a bare triple product). Here a difference is scaled AND normalised. (The net power
+`peak_power-baseline_power` and the geared power `(peak_power-baseline_power)*gear_ratio` ride alongside as component
+readouts, so the panel teaches the whole calculation — exactly as rungs 47-66 shipped their component
+sums/products/differences/ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the numerator difference, the multiplication by the gear ratio, and the division by body mass —
+and the harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as
+rungs 8/16/.../65/66. This rung exercises the engine across **a scaled difference over a divisor** — the fact that
+`(a-b)*c/d` is NOT `(a+b)*c/d` and NOT `(a-b)/c*d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `-`, `*`, and `/`
+— **no structural constants** — so no numeric literal appears in any program, and neither the net power, the geared
+power, nor any specific-work figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`peak_power`, `baseline_power`, `gear_ratio`, `body_mass`) so no numeral
+hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (peak_power + baseline_power) * gear_ratio / body_mass   SUM the two powers instead of DIFFERENCING them
+                                                                      (the classic `(a-b)*c/d` vs `(a+b)*c/d` error), and
+  SWAPPED    (peak_power - baseline_power) / gear_ratio * body_mass    SWAP the multiply and divide — divide by the gear
+                                                                      and multiply by the mass (`(a-b)/c*d` instead of
+                                                                      `(a-b)*c/d`),
+
+which are exactly the mistakes a student makes (adding the two powers, or swapping which quantity multiplies and which
+divides). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness: all four observed quantities are strictly positive; the tables are chosen so the peak power exceeds the
+baseline power (the net power — and therefore the geared power and the specific work — is positive), the gear ratio and
+the body mass both exceed one and differ from each other (so net power != geared power, specific work != geared power,
+and specific work != swapped), and the body mass is not the square of the gear ratio (so geared power != swapped); the
+five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (PEAK_POWER, BASELINE_POWER, GEAR_RATIO, BODY_MASS) — a peak and a baseline power, a gear ratio to scale by, and a body
+# mass to normalise by, all plain positive numbers with peak > baseline, gear_ratio > 1, body_mass > 1, gear_ratio !=
+# body_mass, and body_mass != gear_ratio**2. The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (200, 80, 6, 60),
+    (180, 60, 8, 80),
+    (150, 50, 5, 80),
+    (240, 120, 6, 90),
+    (200, 40, 8, 80),
+    (220, 100, 7, 60),
+    (160, 40, 6, 90),
+]
+
+# The option family (5 members), all built from the four observed quantities via -, *, and /. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "specific_work",
+        "specific work rate (net power geared, per unit body mass)",
+        "(peak_power - baseline_power) * gear_ratio / body_mass",
+    ),
+    (
+        "net_power",
+        "the net power (peak minus baseline power)",
+        "peak_power - baseline_power",
+    ),
+    (
+        "geared_power",
+        "the geared power before normalising to body mass (net power times the gear ratio)",
+        "(peak_power - baseline_power) * gear_ratio",
+    ),
+    (
+        "crossed",
+        "the SUM of the two powers geared and normalised, not their difference (a wrong net power)",
+        "(peak_power + baseline_power) * gear_ratio / body_mass",
+    ),
+    (
+        "swapped",
+        "the net power DIVIDED by the gear ratio and MULTIPLIED by the body mass, the multiply and divide swapped (a wrong scaling)",
+        "(peak_power - baseline_power) / gear_ratio * body_mass",
+    ),
+]
+QUERIED = ["specific_work", "net_power", "geared_power"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(peak_power, baseline_power, gear_ratio, body_mass):
+    # Operation order mirrors the ADJ programs exactly (the parenthesised difference formed first, then the left-to-right
+    # multiply-then-divide), so the Python option value and the engine result are the same IEEE-double (well within the
+    # harness's 1e-9 match tolerance).
+    return {
+        "specific_work": (peak_power - baseline_power) * gear_ratio / body_mass,
+        "net_power": peak_power - baseline_power,
+        "geared_power": (peak_power - baseline_power) * gear_ratio,
+        "crossed": (peak_power + baseline_power) * gear_ratio / body_mass,
+        "swapped": (peak_power - baseline_power) / gear_ratio * body_mass,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for peak_power, baseline_power, gear_ratio, body_mass in TABLES:
+        assert (
+            peak_power > 0
+            and baseline_power > 0
+            and gear_ratio > 0
+            and body_mass > 0
+        ), (peak_power, baseline_power, gear_ratio, body_mass)
+        # Net power must be positive (numerator). The gear ratio and body mass exceed one and differ,
+        # and body mass is not the gear ratio squared, so no two family members collide structurally.
+        assert peak_power > baseline_power, (peak_power, baseline_power, gear_ratio, body_mass)
+        assert gear_ratio > 1 and body_mass > 1, (peak_power, baseline_power, gear_ratio, body_mass)
+        assert gear_ratio != body_mass, (peak_power, baseline_power, gear_ratio, body_mass)
+        assert body_mass != gear_ratio * gear_ratio, (peak_power, baseline_power, gear_ratio, body_mass)
+        fv = family_values(peak_power, baseline_power, gear_ratio, body_mass)
+        for key, v in fv.items():
+            assert v > 0, (key, peak_power, baseline_power, gear_ratio, body_mass, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    peak_power,
+                    baseline_power,
+                    gear_ratio,
+                    body_mass,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                peak_power,
+                baseline_power,
+                gear_ratio,
+                body_mass,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r67ergo-{idx + 1:02d}",
+                "qtype": "ergometry_specific_work",
+                "stem": (
+                    f"An ergometer test records a peak power of {num(peak_power)} and a baseline of "
+                    f"{num(baseline_power)}, scaled by a gear ratio of {num(gear_ratio)} and normalised to a body mass "
+                    f"of {num(body_mass)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe peak_power({num(peak_power)})\n"
+                    f"observe baseline_power({num(baseline_power)})\n"
+                    f"observe gear_ratio({num(gear_ratio)})\n"
+                    f"observe body_mass({num(body_mass)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 67 — specific work rate from four stated quantities (a NEW panel: sports medicine / "
+            "ergometry). From a peak and a baseline power (their difference is the net power), a gear ratio to scale by, "
+            "and a body mass to normalise by, compute the specific work "
+            "((peak_power-baseline_power)*gear_ratio/body_mass), the net power (peak_power-baseline_power), or the "
+            "geared power ((peak_power-baseline_power)*gear_ratio). Each item is a compute_dimensioned program (observe "
+            "the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, "
+            "DIFFERENCE-TIMES-FACTOR OVER A DIVISOR (a-b)*c/d, the first on the ladder to scale a difference by a factor "
+            "and then divide (distinct from rung-50 a*(b-c) with the factor leading, rung-33 (a-b)*(c-d), and rung-51 "
+            "a*b*c) — and the harness matches the scalar to the printed options. Contamination-safe: every index is "
+            "built only from the four observed quantities via -, *, and / — no constant leaks, and neither the net "
+            "power, the geared power, nor any specific-work figure ever appears as a literal (each is computed) — and "
+            "the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five "
+            "options are a family over the same four quantities, so the distractors are exactly the slips students "
+            "make: SUMMING the two powers ((a+b)*c/d, a wrong net power) and SWAPPING the multiply and divide "
+            "((a-b)/c*d, a wrong scaling). The core confusion tested is that (a-b)*c/d is not (a+b)*c/d and not "
+            "(a-b)/c*d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung67_ergometry_specific_work/items.json
+++ b/code/specs/data/adj-ladder/rung67_ergometry_specific_work/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 67 \u2014 specific work rate from four stated quantities (a NEW panel: sports medicine / ergometry). From a peak and a baseline power (their difference is the net power), a gear ratio to scale by, and a body mass to normalise by, compute the specific work ((peak_power-baseline_power)*gear_ratio/body_mass), the net power (peak_power-baseline_power), or the geared power ((peak_power-baseline_power)*gear_ratio). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, DIFFERENCE-TIMES-FACTOR OVER A DIVISOR (a-b)*c/d, the first on the ladder to scale a difference by a factor and then divide (distinct from rung-50 a*(b-c) with the factor leading, rung-33 (a-b)*(c-d), and rung-51 a*b*c) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via -, *, and / \u2014 no constant leaks, and neither the net power, the geared power, nor any specific-work figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: SUMMING the two powers ((a+b)*c/d, a wrong net power) and SWAPPING the multiply and divide ((a-b)/c*d, a wrong scaling). The core confusion tested is that (a-b)*c/d is not (a+b)*c/d and not (a-b)/c*d.",
+  "items": [
+    {
+      "id": "r67ergo-01",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 200 and a baseline of 80, scaled by a gear ratio of 6 and normalised to a body mass of 60. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(200)\nobserve baseline_power(80)\nobserve gear_ratio(6)\nobserve body_mass(60)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r67ergo-02",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 200 and a baseline of 80, scaled by a gear ratio of 6 and normalised to a body mass of 60. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(200)\nobserve baseline_power(80)\nobserve gear_ratio(6)\nobserve body_mass(60)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r67ergo-03",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 200 and a baseline of 80, scaled by a gear ratio of 6 and normalised to a body mass of 60. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(200)\nobserve baseline_power(80)\nobserve gear_ratio(6)\nobserve body_mass(60)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r67ergo-04",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 180 and a baseline of 60, scaled by a gear ratio of 8 and normalised to a body mass of 80. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(180)\nobserve baseline_power(60)\nobserve gear_ratio(8)\nobserve body_mass(80)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r67ergo-05",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 180 and a baseline of 60, scaled by a gear ratio of 8 and normalised to a body mass of 80. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(180)\nobserve baseline_power(60)\nobserve gear_ratio(8)\nobserve body_mass(80)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1200.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r67ergo-06",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 180 and a baseline of 60, scaled by a gear ratio of 8 and normalised to a body mass of 80. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(180)\nobserve baseline_power(60)\nobserve gear_ratio(8)\nobserve body_mass(80)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1200.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r67ergo-07",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 150 and a baseline of 50, scaled by a gear ratio of 5 and normalised to a body mass of 80. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(150)\nobserve baseline_power(50)\nobserve gear_ratio(5)\nobserve body_mass(80)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 500,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1600.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r67ergo-08",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 150 and a baseline of 50, scaled by a gear ratio of 5 and normalised to a body mass of 80. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(150)\nobserve baseline_power(50)\nobserve gear_ratio(5)\nobserve body_mass(80)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 500,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1600.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r67ergo-09",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 150 and a baseline of 50, scaled by a gear ratio of 5 and normalised to a body mass of 80. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(150)\nobserve baseline_power(50)\nobserve gear_ratio(5)\nobserve body_mass(80)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 500,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1600.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r67ergo-10",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 240 and a baseline of 120, scaled by a gear ratio of 6 and normalised to a body mass of 90. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(240)\nobserve baseline_power(120)\nobserve gear_ratio(6)\nobserve body_mass(90)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1800.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r67ergo-11",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 240 and a baseline of 120, scaled by a gear ratio of 6 and normalised to a body mass of 90. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(240)\nobserve baseline_power(120)\nobserve gear_ratio(6)\nobserve body_mass(90)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r67ergo-12",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 240 and a baseline of 120, scaled by a gear ratio of 6 and normalised to a body mass of 90. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(240)\nobserve baseline_power(120)\nobserve gear_ratio(6)\nobserve body_mass(90)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r67ergo-13",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 200 and a baseline of 40, scaled by a gear ratio of 8 and normalised to a body mass of 80. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(200)\nobserve baseline_power(40)\nobserve gear_ratio(8)\nobserve body_mass(80)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1280,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1600.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r67ergo-14",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 200 and a baseline of 40, scaled by a gear ratio of 8 and normalised to a body mass of 80. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(200)\nobserve baseline_power(40)\nobserve gear_ratio(8)\nobserve body_mass(80)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1280,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1600.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r67ergo-15",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 200 and a baseline of 40, scaled by a gear ratio of 8 and normalised to a body mass of 80. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(200)\nobserve baseline_power(40)\nobserve gear_ratio(8)\nobserve body_mass(80)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1600.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1280,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r67ergo-16",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 220 and a baseline of 100, scaled by a gear ratio of 7 and normalised to a body mass of 60. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(220)\nobserve baseline_power(100)\nobserve gear_ratio(7)\nobserve body_mass(60)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 840,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 37.333333333333336,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1028.5714285714284,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r67ergo-17",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 220 and a baseline of 100, scaled by a gear ratio of 7 and normalised to a body mass of 60. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(220)\nobserve baseline_power(100)\nobserve gear_ratio(7)\nobserve body_mass(60)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 840,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 37.333333333333336,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1028.5714285714284,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r67ergo-18",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 220 and a baseline of 100, scaled by a gear ratio of 7 and normalised to a body mass of 60. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(220)\nobserve baseline_power(100)\nobserve gear_ratio(7)\nobserve body_mass(60)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 840,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 37.333333333333336,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1028.5714285714284,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r67ergo-19",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 160 and a baseline of 40, scaled by a gear ratio of 6 and normalised to a body mass of 90. What is the specific work rate (net power geared, per unit body mass)?",
+      "program": "observe peak_power(160)\nobserve baseline_power(40)\nobserve gear_ratio(6)\nobserve body_mass(90)\nlet answer = (peak_power - baseline_power) * gear_ratio / body_mass\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.333333333333334,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r67ergo-20",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 160 and a baseline of 40, scaled by a gear ratio of 6 and normalised to a body mass of 90. What is the the net power (peak minus baseline power)?",
+      "program": "observe peak_power(160)\nobserve baseline_power(40)\nobserve gear_ratio(6)\nobserve body_mass(90)\nlet answer = peak_power - baseline_power\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.333333333333334,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1800.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r67ergo-21",
+      "qtype": "ergometry_specific_work",
+      "stem": "An ergometer test records a peak power of 160 and a baseline of 40, scaled by a gear ratio of 6 and normalised to a body mass of 90. What is the the geared power before normalising to body mass (net power times the gear ratio)?",
+      "program": "observe peak_power(160)\nobserve baseline_power(40)\nobserve gear_ratio(6)\nobserve body_mass(90)\nlet answer = (peak_power - baseline_power) * gear_ratio\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.333333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -104,6 +104,7 @@ SELF_CONTAINED_RUNGS = (
     "rung64_gastric_acid_buffer",
     "rung65_audiometry_corrected_threshold",
     "rung66_periodontal_attachment_level",
+    "rung67_ergometry_specific_work",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-67 — ergometry specific work rate (difference × factor, over a divisor)

Adds the next self-contained quantitative rung to the ADJ-LADDER.

### New arithmetic shape
`(a-b)*c/d` — a **difference, scaled by a factor, over a divisor** = `((a-b)*c)/d`. First rung to
scale a difference by a factor and then divide. Distinct from rung-50 `a*(b-c)` (factor leads a
difference, no division), rung-33 `(a-b)*(c-d)` (product of two differences), rung-51 `a*b*c` (bare
triple product).

### New clinical panel
**Sports medicine / ergometry** — a cycle-ergometer test's net power (`peak_power - baseline_power`)
is scaled by the `gear_ratio` and normalised to `body_mass`: `(peak_power - baseline_power) *
gear_ratio / body_mass` (the specific work rate). Distinct from every used ladder domain.

### Item family (5 mutually-confusable members)
| key | formula | role |
|---|---|---|
| `specific_work` | `(peak-baseline)*gear/body_mass` | **gold** — the headline `(a-b)*c/d` |
| `net_power` | `peak-baseline` | **gold** — the numerator difference |
| `geared_power` | `(peak-baseline)*gear` | **gold** — the scaled difference before dividing |
| `crossed` | `(peak+baseline)*gear/body_mass` | distractor — SUM the difference (`(a+b)*c/d`) |
| `swapped` | `(peak-baseline)/gear*body_mass` | distractor — SWAP × and ÷ (`(a-b)/c*d`) |

First three QUERIED as gold; all five always appear as options. Gold rotates A–E by index (`idx % 5`).

### Contamination safety
- Every formula built ONLY from the four observed quantities via `-`, `*`, `/` — **no numeric constants**.
- No power / geared / specific figure ever appears as a literal (each computed).
- **Digit-free identifiers** (`peak_power`, `baseline_power`, `gear_ratio`, `body_mass`).
- 7 tables × 3 queried = **21 items**; positivity/distinctness guaranteed by `peak > baseline`,
  `gear_ratio > 1`, `body_mass > 1`, `gear_ratio ≠ body_mass`, and `body_mass ≠ gear_ratio²` (each
  guards a specific structural collision — e.g. `body_mass ≠ gear²` keeps `geared_power ≠ swapped`);
  the five family values asserted pairwise-distinct (`>1e-6`) at build.

### Verification
```
$ mise exec -- python3 -m pytest test_ladder_eval.py -k rung67 -q
3 passed, 312 deselected
```
(the compute test confirms the ADJ engine selects every gold via the CLI). Registered
`rung67_ergometry_specific_work` in `SELF_CONTAINED_RUNGS`. Data-only change (offline generator +
generated `items.json` + one-line harness registration); no engine/harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
