### PR TITLE
feat(adj-ladder): rung-68 gait efficiency index (sum times factor over a divisor)

### DIFF
--- a/code/specs/data/adj-ladder/rung68_gait_efficiency_index/gen_items.py
+++ b/code/specs/data/adj-ladder/rung68_gait_efficiency_index/gen_items.py
@@ -1,0 +1,238 @@
+"""Generate rung-68 (gait efficiency index) items.json for the ADJ-LADDER.
+
+Rung 68 opens the **physical therapy / gait analysis** panel on the quantitative band — the arithmetic of a gait
+efficiency index. An instrumented walkway measures the time the foot spends on the ground (the stance phase) and off it
+(the swing phase); their SUM is the stride time. That stride is scaled by the walker's cadence and normalised to the leg
+length, giving a per-leg geared stride. Multiplying a SUM by a FACTOR and then dividing by a normaliser introduces a
+genuinely NEW arithmetic shape on the ladder: a **sum-times-factor over a divisor** — `(a+b)*c/d`, i.e. `((a+b)*c)/d`.
+
+This is the deliberate MIRROR of rung-67's `(a-b)*c/d` (ergometry specific work): rung-67 scaled a DIFFERENCE by a factor
+and divided; rung-68 scales a SUM. So the two rungs sit as a matched pair, and rung-68's `crossed` distractor is exactly
+rung-67's headline shape (`(a-b)*c/d`) — a student who differences the two phases instead of summing them lands on the
+neighbouring rung's formula.
+
+The setup: a `stance_phase`, a `swing_phase`, a `cadence_count`, and a `leg_length`. The gait efficiency index is:
+
+  GAIT INDEX   (stance_phase + swing_phase) * cadence_count / leg_length   [ geared stride per unit leg length ]
+  STRIDE       stance_phase + swing_phase                                  [ the numerator sum (stride time) ]
+  GEARED       (stance_phase + swing_phase) * cadence_count                [ the scaled sum, before dividing ]
+
+The **gait index** is what makes this rung distinctive — it is the ladder's first **sum scaled by a factor, then
+divided**. Contrast the neighbours already on the ladder: rung-67 was `(a-b)*c/d` (a DIFFERENCE scaled then divided),
+rung-49 was `a*(b+c)` (a lone factor leading a parenthesised sum — no division), and rung-53 was `(a+b+c)/d` (a bare
+triple sum over a divisor, no scaling factor). Here a sum is scaled AND normalised. (The stride `stance_phase +
+swing_phase` and the geared stride `(stance_phase + swing_phase) * cadence_count` ride alongside as component readouts,
+so the panel teaches the whole calculation — exactly as rungs 47-67 shipped their component sums/products/differences/
+ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the numerator sum, the multiplication by the cadence, and the division by leg length — and the
+harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs
+8/16/.../66/67. This rung exercises the engine across **a scaled sum over a divisor** — the fact that `(a+b)*c/d` is NOT
+`(a-b)*c/d` and NOT `(a+b)/c*d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, `*`, and
+`/` — **no structural constants** — so no numeric literal appears in any program, and neither the stride, the geared
+stride, nor any gait-index figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`stance_phase`, `swing_phase`, `cadence_count`, `leg_length`) so no numeral
+hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (stance_phase - swing_phase) * cadence_count / leg_length   DIFFERENCE the two phases instead of SUMMING
+                                                                         them (the classic `(a+b)*c/d` vs `(a-b)*c/d`
+                                                                         error — and exactly rung-67's shape), and
+  SWAPPED    (stance_phase + swing_phase) / cadence_count * leg_length    SWAP the multiply and divide — divide by the
+                                                                         cadence and multiply by the leg length
+                                                                         (`(a+b)/c*d` instead of `(a+b)*c/d`),
+
+which are exactly the mistakes a student makes (differencing the two phases, or swapping which quantity multiplies and
+which divides). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness: all four observed quantities are strictly positive; the tables are chosen so the stance phase exceeds the
+swing phase (so the DIFFERENCE distractor `crossed` stays strictly positive), the cadence count and the leg length both
+exceed one and differ from each other (so stride != geared, gait index != geared, and gait index != swapped), and the
+leg length is not the square of the cadence count (so geared != swapped); the five family values are pairwise distinct
+with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (STANCE_PHASE, SWING_PHASE, CADENCE_COUNT, LEG_LENGTH) — a stance and a swing phase (their sum is the stride), a
+# cadence count to scale by, and a leg length to normalise by, all plain positive numbers with stance > swing,
+# cadence_count > 1, leg_length > 1, cadence_count != leg_length, and leg_length != cadence_count**2. The five family
+# values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (60, 40, 6, 50),
+    (70, 30, 8, 50),
+    (80, 40, 5, 60),
+    (90, 30, 6, 40),
+    (100, 20, 8, 60),
+    (110, 50, 7, 40),
+    (75, 45, 6, 90),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, -, *, and /. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "gait_index",
+        "gait efficiency index (stride geared by cadence, per unit leg length)",
+        "(stance_phase + swing_phase) * cadence_count / leg_length",
+    ),
+    (
+        "stride",
+        "the stride time (stance plus swing phase)",
+        "stance_phase + swing_phase",
+    ),
+    (
+        "geared",
+        "the geared stride before normalising to leg length (stride times the cadence count)",
+        "(stance_phase + swing_phase) * cadence_count",
+    ),
+    (
+        "crossed",
+        "the DIFFERENCE of the two phases geared and normalised, not their sum (a wrong stride)",
+        "(stance_phase - swing_phase) * cadence_count / leg_length",
+    ),
+    (
+        "swapped",
+        "the stride DIVIDED by the cadence count and MULTIPLIED by the leg length, the multiply and divide swapped (a wrong scaling)",
+        "(stance_phase + swing_phase) / cadence_count * leg_length",
+    ),
+]
+QUERIED = ["gait_index", "stride", "geared"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(stance_phase, swing_phase, cadence_count, leg_length):
+    # Operation order mirrors the ADJ programs exactly (the parenthesised sum formed first, then the left-to-right
+    # multiply-then-divide), so the Python option value and the engine result are the same IEEE-double (well within the
+    # harness's 1e-9 match tolerance).
+    return {
+        "gait_index": (stance_phase + swing_phase) * cadence_count / leg_length,
+        "stride": stance_phase + swing_phase,
+        "geared": (stance_phase + swing_phase) * cadence_count,
+        "crossed": (stance_phase - swing_phase) * cadence_count / leg_length,
+        "swapped": (stance_phase + swing_phase) / cadence_count * leg_length,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for stance_phase, swing_phase, cadence_count, leg_length in TABLES:
+        assert (
+            stance_phase > 0
+            and swing_phase > 0
+            and cadence_count > 0
+            and leg_length > 0
+        ), (stance_phase, swing_phase, cadence_count, leg_length)
+        # Stance must exceed swing so the DIFFERENCE distractor (crossed) stays positive. The cadence count and leg
+        # length exceed one and differ, and leg length is not the cadence count squared, so no two family members
+        # collide structurally.
+        assert stance_phase > swing_phase, (stance_phase, swing_phase, cadence_count, leg_length)
+        assert cadence_count > 1 and leg_length > 1, (stance_phase, swing_phase, cadence_count, leg_length)
+        assert cadence_count != leg_length, (stance_phase, swing_phase, cadence_count, leg_length)
+        assert leg_length != cadence_count * cadence_count, (stance_phase, swing_phase, cadence_count, leg_length)
+        fv = family_values(stance_phase, swing_phase, cadence_count, leg_length)
+        for key, v in fv.items():
+            assert v > 0, (key, stance_phase, swing_phase, cadence_count, leg_length, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    stance_phase,
+                    swing_phase,
+                    cadence_count,
+                    leg_length,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                stance_phase,
+                swing_phase,
+                cadence_count,
+                leg_length,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r68gait-{idx + 1:02d}",
+                "qtype": "gait_efficiency_index",
+                "stem": (
+                    f"A gait analysis records a stance phase of {num(stance_phase)} and a swing phase of "
+                    f"{num(swing_phase)}, scaled by a cadence count of {num(cadence_count)} and normalised to a leg "
+                    f"length of {num(leg_length)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe stance_phase({num(stance_phase)})\n"
+                    f"observe swing_phase({num(swing_phase)})\n"
+                    f"observe cadence_count({num(cadence_count)})\n"
+                    f"observe leg_length({num(leg_length)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 68 — gait efficiency index from four stated quantities (a NEW panel: physical therapy / "
+            "gait analysis). From a stance and a swing phase (their sum is the stride time), a cadence count to scale "
+            "by, and a leg length to normalise by, compute the gait index "
+            "((stance_phase+swing_phase)*cadence_count/leg_length), the stride (stance_phase+swing_phase), or the "
+            "geared stride ((stance_phase+swing_phase)*cadence_count). Each item is a compute_dimensioned program "
+            "(observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, "
+            "SUM-TIMES-FACTOR OVER A DIVISOR (a+b)*c/d, the first on the ladder to scale a sum by a factor and then "
+            "divide (the mirror of rung-67 (a-b)*c/d, and distinct from rung-49 a*(b+c) with the factor leading and "
+            "rung-53 (a+b+c)/d with no scaling factor) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via +, -, *, and / — no "
+            "constant leaks, and neither the stride, the geared stride, nor any gait-index figure ever appears as a "
+            "literal (each is computed) — and the observed quantities carry digit-free identifiers so no numeral hides "
+            "inside a variable name. The five options are a family over the same four quantities, so the distractors "
+            "are exactly the slips students make: DIFFERENCING the two phases ((a-b)*c/d, a wrong stride — and exactly "
+            "rung-67's shape) and SWAPPING the multiply and divide ((a+b)/c*d, a wrong scaling). The core confusion "
+            "tested is that (a+b)*c/d is not (a-b)*c/d and not (a+b)/c*d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung68_gait_efficiency_index/items.json
+++ b/code/specs/data/adj-ladder/rung68_gait_efficiency_index/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 68 \u2014 gait efficiency index from four stated quantities (a NEW panel: physical therapy / gait analysis). From a stance and a swing phase (their sum is the stride time), a cadence count to scale by, and a leg length to normalise by, compute the gait index ((stance_phase+swing_phase)*cadence_count/leg_length), the stride (stance_phase+swing_phase), or the geared stride ((stance_phase+swing_phase)*cadence_count). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, SUM-TIMES-FACTOR OVER A DIVISOR (a+b)*c/d, the first on the ladder to scale a sum by a factor and then divide (the mirror of rung-67 (a-b)*c/d, and distinct from rung-49 a*(b+c) with the factor leading and rung-53 (a+b+c)/d with no scaling factor) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, -, *, and / \u2014 no constant leaks, and neither the stride, the geared stride, nor any gait-index figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: DIFFERENCING the two phases ((a-b)*c/d, a wrong stride \u2014 and exactly rung-67's shape) and SWAPPING the multiply and divide ((a+b)/c*d, a wrong scaling). The core confusion tested is that (a+b)*c/d is not (a-b)*c/d and not (a+b)/c*d.",
+  "items": [
+    {
+      "id": "r68gait-01",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 60 and a swing phase of 40, scaled by a cadence count of 6 and normalised to a leg length of 50. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(60)\nobserve swing_phase(40)\nobserve cadence_count(6)\nobserve leg_length(50)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 833.3333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r68gait-02",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 60 and a swing phase of 40, scaled by a cadence count of 6 and normalised to a leg length of 50. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(60)\nobserve swing_phase(40)\nobserve cadence_count(6)\nobserve leg_length(50)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 833.3333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r68gait-03",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 60 and a swing phase of 40, scaled by a cadence count of 6 and normalised to a leg length of 50. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(60)\nobserve swing_phase(40)\nobserve cadence_count(6)\nobserve leg_length(50)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 833.3333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r68gait-04",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 70 and a swing phase of 30, scaled by a cadence count of 8 and normalised to a leg length of 50. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(70)\nobserve swing_phase(30)\nobserve cadence_count(8)\nobserve leg_length(50)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 800,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 625.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r68gait-05",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 70 and a swing phase of 30, scaled by a cadence count of 8 and normalised to a leg length of 50. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(70)\nobserve swing_phase(30)\nobserve cadence_count(8)\nobserve leg_length(50)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 800,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 625.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 100,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r68gait-06",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 70 and a swing phase of 30, scaled by a cadence count of 8 and normalised to a leg length of 50. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(70)\nobserve swing_phase(30)\nobserve cadence_count(8)\nobserve leg_length(50)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 800,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 100,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 625.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r68gait-07",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 80 and a swing phase of 40, scaled by a cadence count of 5 and normalised to a leg length of 60. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(80)\nobserve swing_phase(40)\nobserve cadence_count(5)\nobserve leg_length(60)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.3333333333333335,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1440.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r68gait-08",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 80 and a swing phase of 40, scaled by a cadence count of 5 and normalised to a leg length of 60. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(80)\nobserve swing_phase(40)\nobserve cadence_count(5)\nobserve leg_length(60)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.3333333333333335,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1440.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r68gait-09",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 80 and a swing phase of 40, scaled by a cadence count of 5 and normalised to a leg length of 60. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(80)\nobserve swing_phase(40)\nobserve cadence_count(5)\nobserve leg_length(60)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.3333333333333335,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 600,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1440.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r68gait-10",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 90 and a swing phase of 30, scaled by a cadence count of 6 and normalised to a leg length of 40. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(90)\nobserve swing_phase(30)\nobserve cadence_count(6)\nobserve leg_length(40)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 800.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r68gait-11",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 90 and a swing phase of 30, scaled by a cadence count of 6 and normalised to a leg length of 40. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(90)\nobserve swing_phase(30)\nobserve cadence_count(6)\nobserve leg_length(40)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r68gait-12",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 90 and a swing phase of 30, scaled by a cadence count of 6 and normalised to a leg length of 40. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(90)\nobserve swing_phase(30)\nobserve cadence_count(6)\nobserve leg_length(40)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r68gait-13",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 100 and a swing phase of 20, scaled by a cadence count of 8 and normalised to a leg length of 60. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(100)\nobserve swing_phase(20)\nobserve cadence_count(8)\nobserve leg_length(60)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 900.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r68gait-14",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 100 and a swing phase of 20, scaled by a cadence count of 8 and normalised to a leg length of 60. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(100)\nobserve swing_phase(20)\nobserve cadence_count(8)\nobserve leg_length(60)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 960,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 900.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r68gait-15",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 100 and a swing phase of 20, scaled by a cadence count of 8 and normalised to a leg length of 60. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(100)\nobserve swing_phase(20)\nobserve cadence_count(8)\nobserve leg_length(60)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 900.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 960,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r68gait-16",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 110 and a swing phase of 50, scaled by a cadence count of 7 and normalised to a leg length of 40. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(110)\nobserve swing_phase(50)\nobserve cadence_count(7)\nobserve leg_length(40)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 914.2857142857143,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r68gait-17",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 110 and a swing phase of 50, scaled by a cadence count of 7 and normalised to a leg length of 40. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(110)\nobserve swing_phase(50)\nobserve cadence_count(7)\nobserve leg_length(40)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 914.2857142857143,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r68gait-18",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 110 and a swing phase of 50, scaled by a cadence count of 7 and normalised to a leg length of 40. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(110)\nobserve swing_phase(50)\nobserve cadence_count(7)\nobserve leg_length(40)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 160,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 914.2857142857143,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r68gait-19",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 75 and a swing phase of 45, scaled by a cadence count of 6 and normalised to a leg length of 90. What is the gait efficiency index (stride geared by cadence, per unit leg length)?",
+      "program": "observe stance_phase(75)\nobserve swing_phase(45)\nobserve cadence_count(6)\nobserve leg_length(90)\nlet answer = (stance_phase + swing_phase) * cadence_count / leg_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r68gait-20",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 75 and a swing phase of 45, scaled by a cadence count of 6 and normalised to a leg length of 90. What is the the stride time (stance plus swing phase)?",
+      "program": "observe stance_phase(75)\nobserve swing_phase(45)\nobserve cadence_count(6)\nobserve leg_length(90)\nlet answer = stance_phase + swing_phase\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1800.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 120,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r68gait-21",
+      "qtype": "gait_efficiency_index",
+      "stem": "A gait analysis records a stance phase of 75 and a swing phase of 45, scaled by a cadence count of 6 and normalised to a leg length of 90. What is the the geared stride before normalising to leg length (stride times the cadence count)?",
+      "program": "observe stance_phase(75)\nobserve swing_phase(45)\nobserve cadence_count(6)\nobserve leg_length(90)\nlet answer = (stance_phase + swing_phase) * cadence_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 720,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 120,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1800.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -105,6 +105,7 @@ SELF_CONTAINED_RUNGS = (
     "rung65_audiometry_corrected_threshold",
     "rung66_periodontal_attachment_level",
     "rung67_ergometry_specific_work",
+    "rung68_gait_efficiency_index",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-68 — gait efficiency index (sum × factor, over a divisor)

Adds the next self-contained quantitative rung to the ADJ-LADDER.

### New arithmetic shape
`(a+b)*c/d` — a **sum, scaled by a factor, over a divisor** = `((a+b)*c)/d`. The deliberate **mirror**
of rung-67's `(a-b)*c/d` (ergometry specific work): rung-67 scaled a *difference*, rung-68 scales a
*sum*, so the two sit as a matched pair — and rung-68's `crossed` distractor is exactly rung-67's
headline shape. Distinct from rung-49 `a*(b+c)` (factor leads a sum, no division) and rung-53
`(a+b+c)/d` (bare triple sum over a divisor, no scaling factor).

### New clinical panel
**Physical therapy / gait analysis** — an instrumented walkway records the `stance_phase` (foot on the
ground) and `swing_phase` (foot off it); their sum is the stride time. The stride is scaled by the
`cadence_count` and normalised to `leg_length`: `(stance_phase + swing_phase) * cadence_count /
leg_length` (the gait efficiency index). Distinct from every used ladder domain.

### Item family (5 mutually-confusable members)
| key | formula | role |
|---|---|---|
| `gait_index` | `(stance+swing)*cadence/leg_length` | **gold** — the headline `(a+b)*c/d` |
| `stride` | `stance+swing` | **gold** — the numerator sum |
| `geared` | `(stance+swing)*cadence` | **gold** — the scaled sum before dividing |
| `crossed` | `(stance-swing)*cadence/leg_length` | distractor — DIFFERENCE the sum (`(a-b)*c/d`, rung-67's shape) |
| `swapped` | `(stance+swing)/cadence*leg_length` | distractor — SWAP × and ÷ (`(a+b)/c*d`) |

First three QUERIED as gold; all five always appear as options. Gold rotates A–E by index (`idx % 5`).

### Contamination safety
- Every formula built ONLY from the four observed quantities via `+`, `-`, `*`, `/` — **no numeric constants**.
- No stride / geared / gait-index figure ever appears as a literal (each is computed).
- **Digit-free identifiers** (`stance_phase`, `swing_phase`, `cadence_count`, `leg_length`).
- 7 tables × 3 queried = **21 items**; positivity/distinctness guaranteed by `stance > swing`,
  `cadence_count > 1`, `leg_length > 1`, `cadence_count ≠ leg_length`, and `leg_length ≠ cadence_count²`
  (each guards a specific structural collision — e.g. `leg_length ≠ cadence²` keeps `geared ≠ swapped`);
  the five family values asserted pairwise-distinct (`>1e-6`) at build.

### Verification
```
$ mise exec -- python3 -m pytest test_ladder_eval.py -k rung68 -q
3 passed, 315 deselected
```
(the compute test confirms the ADJ engine selects every gold via the CLI). Registered
`rung68_gait_efficiency_index` in `SELF_CONTAINED_RUNGS`. Data-only change (offline generator +
generated `items.json` + one-line harness registration); no engine/harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
