### PR TITLE
fix(symbolic-vm): add cas_simplify::expand, wire it as Macsyma's Expand handler

### DIFF
--- a/code/packages/rust/cas-simplify/CHANGELOG.md
+++ b/code/packages/rust/cas-simplify/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog — cas-simplify (Rust)
 
+## [0.4.0] — 2026-07-03
+
+### Added
+
+- `expand(node: IRNode) -> IRNode` — full polynomial expansion: distributes
+  `Mul` over `Add`/`Sub` and expands bounded non-negative integer `Pow`s via
+  square-and-multiply, then cleans up the result through the existing
+  `simplify` pipeline. A faithful port of the Python reference's general
+  recursive-distributor path (`symbolic_vm.cas_handlers._sym_expand`),
+  generalized to the n-ary `Add`/`Mul` shape this Rust IR actually produces.
+- `EXPAND_MAX_POW` (32) and `EXPAND_MAX_TERMS` (10,000) — DoS guards.
+  Square-and-multiply on a multi-term base squares the term count at every
+  squaring step (doubly exponential in the number of squarings, not the
+  exponent), so `EXPAND_MAX_TERMS` refuses any single distribution step
+  whose *product* of operand term-counts would exceed the cap, checked
+  before allocating rather than after.
+- **Honest scope note**: `expand` does not collect like terms — repeated
+  monomials produced by distribution are not merged and combined coefficients
+  are not summed (e.g. `expand((x+1)^2)` returns `1 + x + x + x*x`, not the
+  fully-collected `1 + 2*x + x^2`). Mathematically correct, not maximally
+  consolidated. See the module docs for why.
+
+This closes a real, previously-undocumented gap: no consumer had a working
+`Expand`/`expand()` handler at all — `symbolic-vm`'s shared handler table
+never registered one, so Macsyma's `expand(...)` silently returned its input
+unevaluated. See `macsyma-runtime` 0.6.0 and `spice-macsyma-pending-work.md`.
+
 ## [0.2.0] — 2026-05-29
 
 **Track G2 — compound-relation assumption store (Rust port).**

--- a/code/packages/rust/cas-simplify/Cargo.toml
+++ b/code/packages/rust/cas-simplify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-simplify"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Algebraic simplification of symbolic IR trees: canonical form, constant folding, identity rules"
 license = "MIT"

--- a/code/packages/rust/cas-simplify/README.md
+++ b/code/packages/rust/cas-simplify/README.md
@@ -69,6 +69,31 @@ let folded = numeric_fold(apply(sym(ADD), vec![int(2), int(3), sym("x")]));
 | `Sin(0) → 0` | Trig at zero |
 | `Cos(0) → 1` | Trig at zero |
 
+## Polynomial expansion (`expand`)
+
+```rust
+use symbolic_ir::{apply, int, sym, ADD, POW};
+use cas_simplify::expand;
+
+// (x + 1)^2 -> 1 + x + x + x*x  (mathematically x^2 + 2x + 1 — see below)
+let x_plus_1 = apply(sym(ADD), vec![sym("x"), int(1)]);
+let expr = apply(sym(POW), vec![x_plus_1, int(2)]);
+assert_eq!(format!("{}", expand(expr)), "Add(1, x, x, Mul(x, x))");
+```
+
+`expand` distributes `Mul` over `Add`/`Sub` and expands bounded non-negative
+integer `Pow`s via square-and-multiply (`O(log n)` multiplications, not
+`O(n)`), guarded against the doubly-exponential term-count blowup repeated
+squaring can hit on a multi-term base.
+
+**Honestly scoped**: `expand` does **not** collect like terms — the two `x`
+terms above stay separate rather than combining into `2*x`, and `x*x` is not
+folded into `x^2`. The result is always mathematically correct; it is not
+always the most compact form. See the module docs (`src/expand.rs`) for the
+full story, including why this differs from the "clean" example in the
+Python reference's docstring (that example demonstrates a different,
+single-variable-only fast path this port does not include).
+
 ## Stack position
 
 ```

--- a/code/packages/rust/cas-simplify/src/expand.rs
+++ b/code/packages/rust/cas-simplify/src/expand.rs
@@ -1,0 +1,402 @@
+//! Polynomial expansion: distribute `Mul` over `Add`/`Sub`, and expand
+//! non-negative integer powers of a sum via square-and-multiply.
+//!
+//! ## What this is — and, honestly, what it is not
+//!
+//! `expand(x)` is the operation MACSYMA calls `expand()` and Wolfram
+//! calls `Expand[...]`. It **distributes** — `(x+1)*(x+2)` becomes
+//! `2 + x + 2*x + x*x` — but it does **not collect like terms**: the
+//! two `x` terms above stay separate rather than merging into `3*x`,
+//! and `x*x` is never folded into `x^2`. The result is always
+//! mathematically correct (it evaluates identically to the input for
+//! any assignment) but is not always the compact form a human would
+//! write by hand. Full like-term collection is a separate, more
+//! involved pass — tracked as an explicit follow-up, not silently
+//! dropped (see the crate's `spice-macsyma-pending-work.md` entry).
+//!
+//! This is a **faithful recursive-distributor port** of the Python
+//! reference (`symbolic_vm.cas_handlers._sym_expand` /
+//! `_sym_expand_mul` / `_sym_expand_pow`), generalized to the n-ary
+//! `Add`/`Mul` shape this Rust IR actually produces (Python's reference
+//! assumes strictly-binary `Add`/`Sub`/`Mul`, since its frontends never
+//! flatten more than two operands into one node). The Python reference
+//! also has a *second*, faster path for single-variable
+//! rational-coefficient polynomials, built on a `to_rational`/
+//! `from_polynomial` bridge, that *does* collect like terms (that is
+//! what its docstring's "clean" example actually demonstrates — not
+//! the general path this module ports). This port always takes the
+//! general path, so it does not reproduce that fast-path's cleaner
+//! output even for single-variable input.
+//!
+//! ## Truth table (the four expansion rules)
+//!
+//! | Input shape                | Rule                              |
+//! |-----------------------------|------------------------------------|
+//! | `Mul(.., Add(a, b), ..)`   | distribute: `Mul(.., a, ..) + Mul(.., b, ..)` |
+//! | `Mul(.., Sub(a, b), ..)`   | distribute: `Mul(.., a, ..) - Mul(.., b, ..)` |
+//! | `Pow(Add(..), n)` (0≤n≤32) | square-and-multiply: `O(log n)` multiplications, not `O(n)` |
+//! | everything else            | recurse into children, head unchanged |
+//!
+//! ## The DoS this module guards against
+//!
+//! Square-and-multiply on a *k*-term sum roughly **squares the term
+//! count at every squaring step** (a raw, uncombined distribution never
+//! merges like terms), so `m` squarings can reach `k^(2^m)` terms —
+//! doubly exponential in the number of squarings, not the exponent
+//! itself. `(a+b+c+d)^32` (5 squarings from a 4-term base) would reach
+//! `4^32` raw terms without a guard — an instant memory-exhaustion
+//! crash, not a slow computation. [`EXPAND_MAX_TERMS`] bounds this: any
+//! single distribution step whose *product* of operand term-counts
+//! would exceed the cap is refused (the operands are returned as an
+//! unexpanded `Mul` instead of being allocated), so growth stops the
+//! moment it would cross the line rather than after it already has.
+
+use symbolic_ir::{apply, sym, IRApply, IRNode, ADD, MUL, POW, SUB};
+
+use crate::simplifier::simplify;
+
+/// Iteration cap passed to [`simplify`] when cleaning up a raw
+/// distribution result. Matches the cap used elsewhere in this crate
+/// and in every consumer's own `simplify()`/`Simplify[...]` wiring —
+/// the simplifier already fixed-points internally, this is a shared
+/// non-termination guard, not an `expand`-specific tuning choice.
+const EXPAND_SIMPLIFY_MAX_ITERATIONS: usize = 50;
+
+/// Maximum non-negative integer exponent [`expand`] will distribute via
+/// square-and-multiply. Mirrors the Python reference's
+/// `_SYM_EXPAND_MAX_POW` guard. A `Pow` whose exponent is not an
+/// integer in `0..=EXPAND_MAX_POW` is left un-expanded (`Pow(base,
+/// exp)`, recursively expanded but not distributed).
+pub const EXPAND_MAX_POW: i64 = 32;
+
+/// Maximum term-count product a single distribution step may produce.
+/// See the module-level "DoS this module guards against" section for
+/// why this exists and why it must be checked *before* distributing,
+/// not after.
+pub const EXPAND_MAX_TERMS: usize = 10_000;
+
+/// The number of leaf terms `node` contributes to a `Mul` distribution.
+///
+/// This must recurse into `Add`/`Sub` descendants, not just count
+/// `node`'s own direct args: [`expand_mul`] does not flatten/canonicalize
+/// between successive squaring steps inside [`expand_pow`], so an
+/// intermediate result is typically a *nested* `Add(Add(..), Add(..))`
+/// tree, not a single flat `Add` node. Counting only the direct args
+/// (e.g. `2` for `Add(Add(4 terms), Add(4 terms))`) would drastically
+/// undercount the true term count and let the very blowup this guard
+/// exists to prevent slip through uncapped — confirmed by a test that
+/// hung and had to be killed before this fix.
+fn term_count(node: &IRNode) -> usize {
+    match node {
+        IRNode::Apply(app) if is_head(&app.head, ADD) || is_head(&app.head, SUB) => {
+            app.args.iter().map(term_count).sum::<usize>().max(1)
+        }
+        _ => 1,
+    }
+}
+
+/// Whether `node` is the symbol `name` (e.g. `is_head(&app.head, ADD)`
+/// checks whether an application's head is literally `Add`).
+fn is_head(node: &IRNode, name: &str) -> bool {
+    matches!(node, IRNode::Symbol(s) if s == name)
+}
+
+/// Distribute multiplication over addition/subtraction:
+/// `(a+b+c)*d = a*d + b*d + c*d` (generalized to n-ary `Add`/`Sub` —
+/// the true distribution law holds for any number of terms, not just
+/// two). Recurses into *both* operands, so a product of two sums
+/// (`(a+b)*(c+d)`) fully distributes. Returns `Mul(a, b)` unchanged
+/// when neither operand is an `Add`/`Sub`, or when distributing would
+/// exceed [`EXPAND_MAX_TERMS`] (see the module-level DoS note).
+fn expand_mul(a: &IRNode, b: &IRNode) -> IRNode {
+    if term_count(a).saturating_mul(term_count(b)) > EXPAND_MAX_TERMS {
+        return apply(sym(MUL), vec![a.clone(), b.clone()]);
+    }
+    if let IRNode::Apply(app) = a {
+        if is_head(&app.head, ADD) || is_head(&app.head, SUB) {
+            let head = app.head.clone();
+            let terms = app.args.iter().map(|t| expand_mul(t, b)).collect();
+            return apply(head, terms);
+        }
+    }
+    if let IRNode::Apply(app) = b {
+        if is_head(&app.head, ADD) || is_head(&app.head, SUB) {
+            let head = app.head.clone();
+            let terms = app.args.iter().map(|t| expand_mul(a, t)).collect();
+            return apply(head, terms);
+        }
+    }
+    apply(sym(MUL), vec![a.clone(), b.clone()])
+}
+
+/// Expand `base^n` (`n` a non-negative integer, already bounds-checked
+/// against [`EXPAND_MAX_POW`] by the caller) via square-and-multiply:
+/// `O(log n)` distribution steps instead of `O(n)`. Term-count growth
+/// across those `O(log n)` squarings is exactly the doubly-exponential
+/// blowup [`expand_mul`]'s [`EXPAND_MAX_TERMS`] check guards against.
+fn expand_pow(base: &IRNode, n: i64) -> IRNode {
+    if n == 0 {
+        return IRNode::Integer(1);
+    }
+    if n == 1 {
+        return base.clone();
+    }
+    let half = expand_pow(base, n / 2);
+    let squared = expand_mul(&half, &half);
+    if n % 2 == 1 {
+        return expand_mul(&squared, base);
+    }
+    squared
+}
+
+/// Recursively distribute `Mul` over `Add`/`Sub` and expand bounded
+/// non-negative integer `Pow`s throughout `node`, then run the result
+/// through [`simplify`] (canonical form, numeric-literal folding, and
+/// identity rules — `x*1 -> x`, `1*1 -> 1`, etc.) to clean up the raw
+/// distribution.
+///
+/// See the module-level docs for what "does not collect like terms"
+/// means in practice — the output below has two separate `x` terms,
+/// not one `2*x` term, and `x*x` rather than `x^2`.
+///
+/// Non-polynomial subexpressions (trig, transcendentals, symbolic
+/// powers, `Div`) are returned with their children recursively expanded
+/// but their own head unchanged — `expand` is safe to call on any IR
+/// tree, not just pure polynomials.
+///
+/// ```rust
+/// use symbolic_ir::{apply, int, sym, ADD, POW};
+/// use cas_simplify::expand;
+///
+/// // (x + 1)^2 -> 1 + x + x + x*x  (mathematically x^2 + 2x + 1;
+/// // see the module docs for why the two `x` terms and `x*x` are
+/// // not collected/folded further).
+/// let x_plus_1 = apply(sym(ADD), vec![sym("x"), int(1)]);
+/// let expr = apply(sym(POW), vec![x_plus_1, int(2)]);
+/// let expanded = expand(expr);
+/// assert_eq!(format!("{expanded}"), "Add(1, x, x, Mul(x, x))");
+/// ```
+pub fn expand(node: IRNode) -> IRNode {
+    simplify(expand_recursive(node), EXPAND_SIMPLIFY_MAX_ITERATIONS)
+}
+
+fn expand_recursive(node: IRNode) -> IRNode {
+    match node {
+        IRNode::Apply(app) => expand_apply(*app),
+        other => other,
+    }
+}
+
+fn expand_apply(node: IRApply) -> IRNode {
+    let IRApply { head, args } = node;
+    let expanded_args: Vec<IRNode> = args.into_iter().map(expand_recursive).collect();
+
+    if let IRNode::Symbol(name) = &head {
+        if name == ADD {
+            return apply(head.clone(), expanded_args);
+        }
+        if name == MUL {
+            let mut terms = expanded_args.into_iter();
+            let first = terms.next().unwrap_or(IRNode::Integer(1));
+            return terms.fold(first, |acc, next| expand_mul(&acc, &next));
+        }
+        if name == POW && expanded_args.len() == 2 {
+            if let IRNode::Integer(n) = expanded_args[1] {
+                if (0..=EXPAND_MAX_POW).contains(&n) {
+                    return expand_pow(&expanded_args[0], n);
+                }
+            }
+        }
+    }
+    apply(head, expanded_args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbolic_ir::{apply, flt, int, sym, DIV, SIN};
+
+    fn add(args: Vec<IRNode>) -> IRNode {
+        apply(sym(ADD), args)
+    }
+    fn sub(a: IRNode, b: IRNode) -> IRNode {
+        apply(sym(SUB), vec![a, b])
+    }
+    fn mul(args: Vec<IRNode>) -> IRNode {
+        apply(sym(MUL), args)
+    }
+    fn pow(base: IRNode, exp: IRNode) -> IRNode {
+        apply(sym(POW), vec![base, exp])
+    }
+
+    #[test]
+    fn expand_distributes_mul_over_add() {
+        // (x + 1) * (x + 2) -> 2 + x + 2*x + x*x (see module docs:
+        // the `x` term from 1*x and the `2*x` term from 2*x are not
+        // collected into 3*x; x*x is not folded into x^2).
+        let lhs = add(vec![sym("x"), int(1)]);
+        let rhs = add(vec![sym("x"), int(2)]);
+        let result = expand(mul(vec![lhs, rhs]));
+        assert_eq!(
+            result,
+            add(vec![
+                int(2),
+                sym("x"),
+                mul(vec![int(2), sym("x")]),
+                mul(vec![sym("x"), sym("x")]),
+            ])
+        );
+    }
+
+    #[test]
+    fn expand_distributes_mul_over_sub() {
+        // (a + b) * (a - b) -> (a*a - a*b) + (a*b - b*b) — evaluates
+        // to a^2 - b^2 (the two `a*b` terms cancel numerically for any
+        // assignment) but Sub is not flattened into a single Add of
+        // signed terms, so the middle terms are never actually
+        // cancelled structurally. See module docs.
+        let lhs = add(vec![sym("a"), sym("b")]);
+        let rhs = sub(sym("a"), sym("b"));
+        let result = expand(mul(vec![lhs, rhs]));
+        assert_eq!(
+            result,
+            add(vec![
+                sub(mul(vec![sym("a"), sym("a")]), mul(vec![sym("a"), sym("b")]),),
+                sub(mul(vec![sym("a"), sym("b")]), mul(vec![sym("b"), sym("b")]),),
+            ])
+        );
+    }
+
+    #[test]
+    fn expand_pow_of_binomial_distributes_correctly() {
+        // (x + 1)^2 -> 1 + x + x + x*x (mathematically x^2 + 2x + 1;
+        // see module docs for why it isn't collected into that form).
+        let result = expand(pow(add(vec![sym("x"), int(1)]), int(2)));
+        assert_eq!(
+            result,
+            add(vec![
+                int(1),
+                sym("x"),
+                sym("x"),
+                mul(vec![sym("x"), sym("x")])
+            ])
+        );
+    }
+
+    #[test]
+    fn expand_pow_of_trinomial_multivariate() {
+        // (a + b)^3 -> 8 raw monomials (a^3 has only one arrangement;
+        // a^2*b and a*b^2 each have 3 arrangements from square-and-
+        // multiply, matching the binomial coefficients C(3,1)=3, but
+        // emitted as repeated separate terms rather than one term with
+        // coefficient 3 — see module docs).
+        let result = expand(pow(add(vec![sym("a"), sym("b")]), int(3)));
+        let aaa = mul(vec![sym("a"), sym("a"), sym("a")]);
+        let aab = mul(vec![sym("a"), sym("a"), sym("b")]);
+        let abb = mul(vec![sym("a"), sym("b"), sym("b")]);
+        let bbb = mul(vec![sym("b"), sym("b"), sym("b")]);
+        assert_eq!(
+            result,
+            add(vec![
+                aaa,
+                aab.clone(),
+                aab.clone(),
+                aab,
+                abb.clone(),
+                abb.clone(),
+                abb,
+                bbb,
+            ])
+        );
+    }
+
+    #[test]
+    fn expand_pow_zero_and_one() {
+        assert_eq!(expand(pow(sym("x"), int(0))), int(1));
+        assert_eq!(expand(pow(sym("x"), int(1))), sym("x"));
+    }
+
+    #[test]
+    fn expand_pow_above_max_stays_unevaluated() {
+        // exponent above EXPAND_MAX_POW: left as Pow, not expanded
+        // (the base is still recursively processed and canonicalized
+        // by the final `simplify` pass, so `Add(x, 1)` becomes the
+        // canonical `Add(1, x)` even though it was never distributed).
+        let big = int(EXPAND_MAX_POW + 1);
+        let result = expand(pow(add(vec![sym("x"), int(1)]), big.clone()));
+        assert_eq!(result, pow(add(vec![int(1), sym("x")]), big));
+    }
+
+    #[test]
+    fn expand_pow_negative_exponent_stays_unevaluated() {
+        let result = expand(pow(add(vec![sym("x"), int(1)]), int(-1)));
+        assert_eq!(result, pow(add(vec![int(1), sym("x")]), int(-1)));
+    }
+
+    #[test]
+    fn expand_leaves_transcendentals_structurally_unchanged() {
+        // Sin(x + 1) has no Mul-over-Add or integer Pow to distribute;
+        // expand recurses into the argument (which the final
+        // `simplify` pass canonicalizes to `Add(1, x)`) but the Sin
+        // head itself is untouched.
+        let result = expand(apply(sym(SIN), vec![add(vec![sym("x"), int(1)])]));
+        assert_eq!(result, apply(sym(SIN), vec![add(vec![int(1), sym("x")])]));
+    }
+
+    #[test]
+    fn expand_recurses_into_div_operands() {
+        // (x+1)^2 / y -> (1 + x + x + x*x) / y — Div itself is not
+        // distributed, but its numerator is still expanded.
+        let numerator = pow(add(vec![sym("x"), int(1)]), int(2));
+        let result = expand(apply(sym(DIV), vec![numerator, sym("y")]));
+        assert_eq!(
+            result,
+            apply(
+                sym(DIV),
+                vec![
+                    add(vec![
+                        int(1),
+                        sym("x"),
+                        sym("x"),
+                        mul(vec![sym("x"), sym("x")])
+                    ]),
+                    sym("y"),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn expand_atoms_pass_through_unchanged() {
+        assert_eq!(expand(int(5)), int(5));
+        assert_eq!(expand(sym("x")), sym("x"));
+        assert_eq!(expand(flt(2.5)), flt(2.5));
+    }
+
+    #[test]
+    fn expand_mul_term_count_guard_refuses_astronomical_blowup() {
+        // A 4-term base raised to the 32nd power would (without the
+        // guard) reach 4^32 raw terms across 5 squarings — the guard
+        // must stop distribution long before that, leaving a (still
+        // partially expanded, but bounded) Mul/Pow shape rather than
+        // hanging or exhausting memory.
+        let many_terms = add(vec![sym("a"), sym("b"), sym("c"), sym("d")]);
+        let expr = pow(many_terms, int(32));
+        // Must return promptly (no timeout) and must not panic.
+        let result = expand(expr);
+        // The result is some valid IR value — the guard's job is
+        // bounding work, not producing a specific shape.
+        let _ = result;
+    }
+
+    #[test]
+    fn expand_term_count_guard_caps_a_two_large_sums_product() {
+        // Two sums whose term-count product exceeds EXPAND_MAX_TERMS
+        // must not be distributed.
+        let terms_a: Vec<IRNode> = (0..200).map(|i| sym(format!("a{i}"))).collect();
+        let terms_b: Vec<IRNode> = (0..200).map(|i| sym(format!("b{i}"))).collect();
+        // 200 * 200 = 40,000 > EXPAND_MAX_TERMS (10,000).
+        let result = expand_mul(&add(terms_a.clone()), &add(terms_b.clone()));
+        assert_eq!(result, mul(vec![add(terms_a), add(terms_b)]));
+    }
+}

--- a/code/packages/rust/cas-simplify/src/expand.rs
+++ b/code/packages/rust/cas-simplify/src/expand.rs
@@ -50,6 +50,24 @@
 //! would exceed the cap is refused (the operands are returned as an
 //! unexpanded `Mul` instead of being allocated), so growth stops the
 //! moment it would cross the line rather than after it already has.
+//!
+//! **This guard has already had one real bug**, caught in security
+//! review before merge: [`term_count`] originally treated *any*
+//! non-`Add`/`Sub` node — including a refused-and-wrapped `Mul(a, b)`
+//! that [`expand_mul`] itself had just produced — as a single opaque
+//! term of size `1`. That let a capped subtree's true size go dark on
+//! the very next multiplication (the guard saw a stale "1" instead of
+//! the real, possibly-huge count), so a chain of several multi-term
+//! sum factors (`(a1+..)*(b1+..)*(c1+..)*...`, an entirely ordinary-
+//! looking expression, no pathological construction needed) could
+//! still reach hundreds of millions of nodes — confirmed empirically
+//! against the original code before the fix. `term_count` now
+//! recurses into `Mul` descendants *multiplicatively* (mirroring how
+//! it already recurses into `Add`/`Sub` *additively*), so a refused
+//! `Mul`'s true size is always visible to the next check. See
+//! [`term_count`]'s own docs and
+//! `term_count_sees_through_a_refused_mul_instead_of_going_blind` for
+//! the full account and the regression test.
 
 use symbolic_ir::{apply, sym, IRApply, IRNode, ADD, MUL, POW, SUB};
 
@@ -75,22 +93,48 @@ pub const EXPAND_MAX_POW: i64 = 32;
 /// not after.
 pub const EXPAND_MAX_TERMS: usize = 10_000;
 
-/// The number of leaf terms `node` contributes to a `Mul` distribution.
+/// The number of leaf terms `node` *would* have if fully distributed —
+/// not necessarily the number it structurally has right now.
 ///
-/// This must recurse into `Add`/`Sub` descendants, not just count
-/// `node`'s own direct args: [`expand_mul`] does not flatten/canonicalize
-/// between successive squaring steps inside [`expand_pow`], so an
-/// intermediate result is typically a *nested* `Add(Add(..), Add(..))`
-/// tree, not a single flat `Add` node. Counting only the direct args
-/// (e.g. `2` for `Add(Add(4 terms), Add(4 terms))`) would drastically
-/// undercount the true term count and let the very blowup this guard
-/// exists to prevent slip through uncapped — confirmed by a test that
-/// hung and had to be killed before this fix.
+/// This must recurse into **both** `Add`/`Sub` descendants (summed) and
+/// `Mul` descendants (multiplied), not just count `node`'s own direct
+/// args:
+///
+/// - [`expand_mul`] does not flatten/canonicalize between successive
+///   squaring steps inside [`expand_pow`], so an intermediate result is
+///   typically a *nested* `Add(Add(..), Add(..))` tree, not a single
+///   flat `Add` node. Counting only the direct args (e.g. `2` for
+///   `Add(Add(4 terms), Add(4 terms))`) would undercount.
+/// - **Critically**, when [`expand_mul`] *refuses* to distribute
+///   because the product would exceed [`EXPAND_MAX_TERMS`], it returns
+///   the operands wrapped in an ordinary `Mul(a, b)` node — the exact
+///   same shape [`expand_apply`]'s `Mul` branch folds a chain of
+///   factors through. If `term_count` treated every `Mul`-headed node
+///   as a single opaque term (size `1`, the same as any atom), a
+///   refused distribution would make its own true size *invisible* to
+///   the very next fold step: `term_count(refused_mul) == 1` even
+///   though the subtree it wraps may already represent millions of
+///   would-be terms. The next multiplication then sails through the
+///   cap check and distributes anyway, repeating this "cap → go dark →
+///   distribute past the cap → cap again" cycle once per chained
+///   factor — unbounded growth despite the cap, confirmed by an
+///   adversarial-review harness that reached 200M+ nodes from a
+///   perfectly ordinary six-factor expression (six chained parenthesized
+///   sums) before this fix. Recursing multiplicatively into `Mul`
+///   descendants here closes that hole: a refused-and-wrapped `Mul`
+///   reports its true (potentially huge) size on every subsequent
+///   check, so the guard keeps seeing accurate numbers instead of a
+///   stale "1" and correctly keeps refusing to distribute further.
 fn term_count(node: &IRNode) -> usize {
     match node {
         IRNode::Apply(app) if is_head(&app.head, ADD) || is_head(&app.head, SUB) => {
             app.args.iter().map(term_count).sum::<usize>().max(1)
         }
+        IRNode::Apply(app) if is_head(&app.head, MUL) => app
+            .args
+            .iter()
+            .map(term_count)
+            .fold(1usize, |acc, c| acc.saturating_mul(c)),
         _ => 1,
     }
 }
@@ -398,5 +442,62 @@ mod tests {
         // 200 * 200 = 40,000 > EXPAND_MAX_TERMS (10,000).
         let result = expand_mul(&add(terms_a.clone()), &add(terms_b.clone()));
         assert_eq!(result, mul(vec![add(terms_a), add(terms_b)]));
+    }
+
+    /// Recursively counts every node in `node`, regardless of head — a
+    /// literal tree-size measurement, unlike [`term_count`] (which
+    /// counts would-be polynomial terms, not allocated nodes). Used
+    /// only by the regression test below to prove the result actually
+    /// stayed bounded, not just that it returned before a test timeout.
+    fn total_node_count(node: &IRNode) -> usize {
+        match node {
+            IRNode::Apply(app) => 1 + app.args.iter().map(total_node_count).sum::<usize>(),
+            _ => 1,
+        }
+    }
+
+    #[test]
+    fn term_count_sees_through_a_refused_mul_instead_of_going_blind() {
+        // Regression test for a real vulnerability caught in security
+        // review: term_count() originally treated ANY non-Add/Sub node
+        // — including a Mul(a, b) that expand_mul itself had just
+        // *refused* to distribute because it was already too big — as
+        // a single opaque term of size 1. That let a capped subtree's
+        // true size go dark on the very next multiplication: the guard
+        // would see a stale "1" instead of the real (possibly huge)
+        // count, wave the next factor through, and repeat — "cap, go
+        // blind, distribute past the cap, cap again" once per chained
+        // factor. An adversarial-review harness against the original
+        // code reached 200M+ nodes from six chained 20-term sums.
+        //
+        // This constructs the same shape (chained multi-term sum
+        // factors) at a size that would have detonated under the old
+        // logic, and asserts the result stays small — proving
+        // term_count's Mul case (added by this fix) keeps the guard
+        // seeing the real size instead of a fictitious "1".
+        fn sum_of(prefix: &str, n: usize) -> IRNode {
+            add((0..n).map(|i| sym(format!("{prefix}{i}"))).collect())
+        }
+        let factors = vec![
+            sum_of("a", 20),
+            sum_of("b", 20),
+            sum_of("c", 20),
+            sum_of("d", 20),
+            sum_of("e", 20),
+            sum_of("f", 20),
+        ];
+        let expr = mul(factors);
+        let result = expand(expr);
+        // Under the pre-fix logic this reached 200M+ nodes; with the
+        // fix, growth stops the moment any single distribution step
+        // would exceed EXPAND_MAX_TERMS, so the true total stays in
+        // the low tens of thousands at most — nowhere near millions.
+        assert!(
+            total_node_count(&result) < 100_000,
+            "expand() of six chained 20-term sums produced {} nodes -- \
+             the term_count guard is not seeing through a refused Mul \
+             the way it should",
+            total_node_count(&result)
+        );
     }
 }

--- a/code/packages/rust/cas-simplify/src/lib.rs
+++ b/code/packages/rust/cas-simplify/src/lib.rs
@@ -36,6 +36,7 @@
 
 pub mod assumptions;
 pub mod canonical;
+pub mod expand;
 pub mod exponentialize;
 pub mod heads;
 pub mod logcontract;
@@ -46,6 +47,7 @@ pub mod simplifier;
 
 pub use assumptions::AssumptionContext;
 pub use canonical::canonical;
+pub use expand::expand;
 pub use exponentialize::{demoivre, exponentialize};
 pub use logcontract::{logcontract, logexpand};
 pub use numeric_fold::numeric_fold;

--- a/code/packages/rust/macsyma-runtime/CHANGELOG.md
+++ b/code/packages/rust/macsyma-runtime/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.6.0] — 2026-07-03
+
+### Fixed
+
+- **`expand(...)` and `ev(expr, expand)` now actually expand.** Previously
+  `expand((x+1)^2)` returned the input unevaluated — `symbolic-vm`'s shared
+  `build_handler_table` never registered a handler for the `Expand` head
+  the name table already routed `expand`/the `expand` `ev` flag through, so
+  the head silently had nowhere to land. Fixed by registering a new
+  `expand_handler` in `MacsymaBackend` (the same decorator-over-the-shared-
+  table pattern already used for `Simplify`/`RatSimplify`/`Radcan`), backed
+  by the new `cas_simplify::expand` (see that crate's 0.4.0 CHANGELOG entry
+  for the algorithm and its honestly-documented scope: correct distribution,
+  no like-term collection yet). `expand((x+1)^2)` now returns
+  `1 + x + x + x*x`.
+- `ev_routes_supported_flags_and_preserves_unsupported_heads` renamed to
+  `ev_routes_ratsimp_trigsimp_and_expand_flags` and its `expand` case
+  updated to assert the new (correct) output — it previously demonstrated
+  `expand` as an example of an *unsupported* passthrough head, which is no
+  longer true.
+
 ## [0.5.0] — 2026-05-29
 
 - Track M2 — port the MACSYMA `load("name")` runtime package directive

--- a/code/packages/rust/macsyma-runtime/Cargo.toml
+++ b/code/packages/rust/macsyma-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-macsyma-runtime"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "MACSYMA runtime session facade over the Rust symbolic VM"
 license = "MIT"

--- a/code/packages/rust/macsyma-runtime/README.md
+++ b/code/packages/rust/macsyma-runtime/README.md
@@ -42,3 +42,11 @@ results while invalid calls remain unevaluated.
 `TrigReduce(expr)` and `ev(expr, trigreduce)` delegate to the Rust `cas-trig`
 power-reduction walker, so MACSYMA sessions can rewrite supported sine/cosine
 powers and `sin(x)cos(x)` products to multiple-angle forms.
+
+`Expand(expr)` and `ev(expr, expand)` delegate to the Rust `cas-simplify`
+`expand` function, distributing `Mul` over `Add`/`Sub` and expanding bounded
+non-negative integer `Pow`s: `expand((x+1)^2)` returns `1 + x + x + x*x`.
+This distributes correctly but does not yet collect like terms (see
+`cas-simplify`'s own README/module docs for the exact scope) — a real,
+previously-unfixed gap: no handler for `Expand` existed anywhere before this,
+so `expand(...)` silently returned its input unevaluated.

--- a/code/packages/rust/macsyma-runtime/src/lib.rs
+++ b/code/packages/rust/macsyma-runtime/src/lib.rs
@@ -13,7 +13,7 @@ use cas_list_operations::{
     range_ as list_range, rest, reverse, sort_, ListOperationError, ListResult,
 };
 use cas_pretty_printer::{pretty, pretty_2d, MacsymaDialect};
-use cas_simplify::{radcan, simplify, AssumptionContext};
+use cas_simplify::{expand, radcan, simplify, AssumptionContext};
 use cas_solve::{solve_linear_system, try_solve_inequality, try_solve_transcendental, SOLVE};
 use cas_substitution::subst;
 use cas_trig::{expand_trig, trig_reduce, trig_simplify};
@@ -577,6 +577,7 @@ impl MacsymaBackend {
         handlers.insert(FLOAT_FUNC.to_string(), handler_fn(float_handler));
         handlers.insert(SOLVE.to_string(), handler_fn(solve_handler));
         handlers.insert(SIMPLIFY.to_string(), handler_fn(simplify_handler));
+        handlers.insert(EXPAND.to_string(), handler_fn(expand_handler));
         handlers.insert(SUBST.to_string(), handler_fn(subst_handler));
         handlers.insert(RAT_SIMPLIFY.to_string(), handler_fn(simplify_handler));
         let radcan_state = state.clone();
@@ -1569,6 +1570,21 @@ fn simplify_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
         return IRNode::Apply(Box::new(expr));
     }
     simplify(expr.args[0].clone(), 50)
+}
+
+/// `expand(expr)` — full polynomial expansion: distribute `Mul` over
+/// `Add`/`Sub` and expand bounded non-negative integer `Pow`s. Was
+/// previously wired to the `Expand` head via the `EXPAND` name-table
+/// entry, but no handler was ever registered for that head in
+/// `symbolic-vm`'s shared table, so `expand((x+1)^2)` silently returned
+/// the unevaluated input. Fixed by delegating to `cas_simplify::expand`
+/// — see that crate for the full algorithm and its documented scope
+/// (distributes correctly; does not collect like terms).
+fn expand_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return IRNode::Apply(Box::new(expr));
+    }
+    expand(expr.args[0].clone())
 }
 
 fn radcan_handler(state: &Arc<Mutex<MacsymaBackendState>>, expr: IRApply) -> IRNode {

--- a/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
+++ b/code/packages/rust/macsyma-runtime/tests/test_runtime.rs
@@ -820,7 +820,14 @@ fn ev_numer_and_float_coerce_exact_numbers() {
 }
 
 #[test]
-fn ev_routes_supported_flags_and_preserves_unsupported_heads() {
+fn ev_routes_ratsimp_trigsimp_and_expand_flags() {
+    // Previously named `..._and_preserves_unsupported_heads`: the third
+    // case (`ev(x + 1, expand)`) used to demonstrate an unsupported
+    // head passing through unevaluated, because `Expand` had no
+    // registered handler at all (see `expand_distributes_polynomial_
+    // multiplication` for the fix). Now that `Expand` is a real,
+    // supported flag, this asserts its (correct, canonicalized) output
+    // instead of the old no-op passthrough.
     let mut session = MacsymaSession::new();
     let results = session
         .eval_source("ev((x + 0) * 1, ratsimp); ev(sin(0) + cos(0), trigsimp); ev(x + 1, expand);")
@@ -830,7 +837,7 @@ fn ev_routes_supported_flags_and_preserves_unsupported_heads() {
     assert_eq!(results[1].output, int(1));
     assert_eq!(
         results[2].output,
-        apply(sym("Expand"), vec![apply(sym(ADD), vec![sym("x"), int(1)])])
+        apply(sym(ADD), vec![int(1), sym("x")])
     );
 }
 
@@ -1382,5 +1389,36 @@ fn returns_rational_linsolve_results() {
                 apply(sym(RULE), vec![y.clone(), rat(13, 7)]),
             ],
         )
+    );
+}
+
+#[test]
+fn expand_distributes_polynomial_multiplication() {
+    // Regression test: expand((x+1)^2) previously returned unevaluated
+    // -- symbolic-vm's build_handler_table never registered a handler
+    // for "Expand", so the Expand-named head in the shared table was a
+    // silent no-op. Fixed by wiring cas_simplify::expand as the
+    // MacsymaBackend's Expand handler.
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("expand((x+1)^2);").unwrap();
+    assert_eq!(results.len(), 1);
+    let x = sym("x");
+    assert_eq!(
+        results[0].output,
+        apply(
+            sym(ADD),
+            vec![int(1), x.clone(), x.clone(), apply(sym(MUL), vec![x.clone(), x])],
+        )
+    );
+}
+
+#[test]
+fn expand_with_wrong_arity_stays_unevaluated() {
+    let mut session = MacsymaSession::new();
+    let results = session.eval_source("expand(x, y);").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].output,
+        apply(sym("Expand"), vec![sym("x"), sym("y")])
     );
 }

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -2128,20 +2128,23 @@ Simplify[2 + 3]     (* 5 *)
 
 ### §24.2 Remaining (not yet delivered)
 
-`Expand`, `Factor`, `Solve`, `D`, `Integrate`, and the rest of §2's original
-list — each is a separate future item, no grammar change required for any of
-them (all are ordinary `Head[args]` forms the existing grammar already
-parses). **Note on `Expand`:** unlike `Simplify`, Macsyma's own `expand()`
-surface function has no dedicated handler backing its `Expand` head in
-`symbolic-vm`'s `build_handler_table` today (verified: no `"Expand"` handler
-registration exists) — Macsyma's `expand(...)` and `ev(expr, expand)` both
-route through `apply(sym("Expand"), …)`, which currently has no handler to
-land on. Wiring Wolfram's `Expand` is therefore **not** a "call the same
-function Macsyma calls" item the way `Simplify` was; it needs a real
-`Expand` handler (full polynomial distribution over `Add`/`Mul`/`Pow`) built
-first, most naturally in `symbolic-vm` or `cas-simplify` so Macsyma's
-long-standing `expand()` gap closes at the same time. Track as its own item,
-not scope creep into this one.
+`Factor`, `Solve`, `D`, `Integrate`, and the rest of §2's original list —
+each is a separate future item, no grammar change required for any of them
+(all are ordinary `Head[args]` forms the existing grammar already parses).
+
+**`Expand` — the blocker is now cleared, wiring is the remaining step.**
+Macsyma's own `expand()` had no dedicated handler backing its `Expand` head
+in `symbolic-vm`'s `build_handler_table` (verified empirically:
+`expand((x+1)^2)` returned unevaluated) — that gap is now fixed via
+`cas_simplify::expand`, a faithful port of the Python reference's general
+recursive-distributor path (distributes `Mul` over `Add`/`Sub`, expands
+bounded non-negative integer `Pow`, guarded against the doubly-exponential
+term-count blowup square-and-multiply can hit on a multi-term base). Wiring
+Wolfram's `Expand[...]` is now the same thin `call the shared function` shape
+as `Simplify[...]` was. **Honest scope note (inherited from `cas-simplify`,
+not a Wolfram-specific gap):** `expand` does not collect like terms — e.g.
+`Expand[(x+1)^2]` will produce `1 + x + x + x*x`, not the fully-collected
+`1 + 2*x + x^2` — tracked as a separate follow-up.
 
 ### §6 References
 

--- a/code/specs/spice-macsyma-pending-work.md
+++ b/code/specs/spice-macsyma-pending-work.md
@@ -585,21 +585,37 @@ Next ODE work should focus only on the Frobenius power-series case (irregular
 singular points and series solutions around regular singular points) unless a
 parity audit finds a smaller gap.
 
-#### `Expand` has no handler (found 2026-07-03, while wiring Wolfram's `Simplify`)
+#### `Expand` has no handler — ✅ fixed (2026-07-03)
 
 Macsyma's `expand(...)` surface function and `ev(expr, expand)` both route
 through `apply(sym("Expand"), …)` (`macsyma-runtime/src/lib.rs`), but
-`symbolic-vm`'s `build_handler_table` registers no handler under the string
-`"Expand"` — verified by grep, and there is no test anywhere in
-`macsyma-runtime`'s test suite that exercises `expand(...)` end-to-end. So
-today `expand((x+1)^2)` most likely just returns the unevaluated `Expand[...]`
-form (an unresolved head), not the distributed polynomial a user would
-expect — this is a real, previously-undocumented gap, not merely an untested
-path. Needs a real `Expand` handler (full polynomial distribution over
-`Add`/`Mul`/`Pow`), most naturally added to `symbolic-vm` or `cas-simplify`
-so both Macsyma and Wolfram (which hit the identical gap wiring its own
-`Expand`, MA04 §24.2) close at the same time. Not yet scheduled as its own
-track/PR.
+`symbolic-vm`'s `build_handler_table` registered no handler under the string
+`"Expand"` — verified empirically: `expand((x+1)^2)` returned the unevaluated
+input, not the distributed polynomial a user would expect.
+
+**Fix**: added `cas_simplify::expand` — a faithful port of the Python
+reference's general recursive-distributor path (`_sym_expand`/
+`_sym_expand_mul`/`_sym_expand_pow`), generalized to n-ary `Add`/`Mul` and
+guarded against the doubly-exponential term-count blowup square-and-multiply
+can hit on a multi-term base (`EXPAND_MAX_TERMS`, checked *before* every
+distribution step, not after). Registered as the `Expand` handler in
+`MacsymaBackend` (the same decorator-over-`build_handler_table` pattern
+already used for `Simplify`/`RatSimplify`/`Radcan`/etc.) — the shared
+`symbolic-vm` table itself is still unchanged, matching how every other
+Macsyma-specific head is layered on. `expand((x+1)^2)` now correctly returns
+`1 + x + x + x*x`.
+
+**Known remaining gap, honestly scoped out of this fix**: this does **not**
+collect like terms — the two `x` terms above stay separate rather than
+combining into `2*x`, and `x*x` is not folded into `x^2`. Python's reference
+only achieves that clean form via a *second*, single-variable
+rational-polynomial fast path (`to_rational`/`from_polynomial`) that this
+port does not include. A future "collect like terms" pass (grouping
+structurally-repeated monomials and summing their coefficients) is real,
+separate, more involved work — not yet scheduled as its own track/PR.
+
+This also unblocks Wolfram's own `Expand[...]` (MA04 §24.2) via the identical
+thin-wiring pattern used for `Simplify[...]`.
 
 #### Factoring gaps
 


### PR DESCRIPTION
## Summary
- Fixes a real, previously-undocumented bug found while wiring Wolfram's `Simplify[...]`: Macsyma's `expand(...)`/`ev(expr, expand)` route through `apply(sym("Expand"), ...)`, but `symbolic-vm`'s shared `build_handler_table` never registered a handler for `"Expand"` -- verified empirically, `expand((x+1)^2)` returned its input completely unevaluated.
- Adds `cas_simplify::expand` -- a faithful port of the Python reference's general recursive-distributor path (`_sym_expand`/`_sym_expand_mul`/`_sym_expand_pow`), generalized to n-ary `Add`/`Mul`. Registered as `MacsymaBackend`'s `Expand` handler (same decorator pattern already used for `Simplify`/`RatSimplify`/`Radcan`).
- **Honestly scoped**: distributes correctly but does not collect like terms (`expand((x+1)^2)` -> `"1 + x + x + x*x"`, not `"1 + 2*x + x^2"`) -- tracked as a separate follow-up, not silently dropped.
- Also unblocks Wolfram's own `Expand[...]` wiring (tracked separately, since each Wolfram `cas-*` head lands as its own PR).
- `cas-simplify` 0.3.0 -> 0.4.0, `macsyma-runtime` 0.5.0 -> 0.6.0.

## Security review (2 rounds)
- **Round 1** found a CRITICAL DoS guard bypass: `term_count()` treated any `Mul`-headed node (including one `expand_mul` itself had just refused to distribute, due to exceeding `EXPAND_MAX_TERMS`) as size 1, letting a capped subtree's true size go dark on the next multiplication. An adversarial-review harness reached 200M+ nodes from a perfectly ordinary six-factor expression (six chained parenthesized sums) before the fix.
- **Fixed**: `term_count` now recurses into `Mul` descendants multiplicatively (mirroring how it already recurses into `Add`/`Sub` additively), so a refused-and-wrapped `Mul`'s true size is always visible to the next check. New regression test replicates the exact repro shape and asserts the result stays under 100k total nodes.
- **Round 2 re-review**: empirically confirmed the fix works (reverting it reproduces 12.8M+ nodes and fails the new test; the fix passes in <1s). One LOW-severity, pre-existing (not-a-regression) residual gap noted and tracked as a separate follow-up task rather than rushed into this PR.

## Test plan
- [x] `cargo test -p cas-simplify -p coding-adventures-macsyma-runtime` -- 13 + 69 tests passing (including the new DoS regression test).
- [x] `cargo test -p symbolic-vm -p coding-adventures-wolfram-runtime` -- no regressions in downstream consumers of the shared `cas-simplify` crate.
- [x] `cargo fmt --check` -- clean on all touched files.
- [x] `/security-review` -- 2 rounds, CRITICAL finding fixed and re-verified, passed.
- [ ] `/babysit-pr` to green/merge.