### PR TITLE
feat(adj-ladder): rung-69 traction force (product over a divisor, plus a term)

### DIFF
--- a/code/specs/data/adj-ladder/rung69_traction_force/gen_items.py
+++ b/code/specs/data/adj-ladder/rung69_traction_force/gen_items.py
@@ -1,0 +1,229 @@
+"""Generate rung-69 (skeletal traction force) items.json for the ADJ-LADDER.
+
+Rung 69 opens the **orthopedics / skeletal traction** panel on the quantitative band — the arithmetic of a traction
+force. A skeletal traction rig hangs a weight over a pulley to pull a fractured limb straight: the applied weight is
+multiplied by a mechanical `pulley_factor`, normalised to the `limb_length` being pulled, and added to a resting
+`baseline_tension` already in the line. Multiplying two quantities into a PRODUCT, dividing that product by a normaliser,
+and then ADDING a baseline term introduces a genuinely NEW arithmetic shape on the ladder: a **product-over-a-divisor
+plus a term** — `a*b/c+d`, i.e. `((a*b)/c)+d`.
+
+This is the first rung to put a **product** (not a sum or a difference) over the divisor and then add a trailing term.
+Contrast the neighbours already on the ladder: rung-65 was `(a-b)/c+d` (a DIFFERENCE over the divisor, plus a term),
+rung-66 was `(a+b)/c-d` (a SUM over the divisor, minus a term), and rung-68 was `(a+b)*c/d` (a sum scaled by a factor
+then divided, with NO trailing term). Here a product is normalised AND offset.
+
+The setup: an `applied_weight`, a `pulley_factor`, a `limb_length`, and a `baseline_tension`. The traction force is:
+
+  TRACTION FORCE   applied_weight * pulley_factor / limb_length + baseline_tension   [ geared load per unit limb, offset ]
+  LEVERAGE         applied_weight * pulley_factor                                    [ the raw product ]
+  DISTRIBUTED      applied_weight * pulley_factor / limb_length                      [ the product over the limb, before offsetting ]
+
+The **traction force** is what makes this rung distinctive — it is the ladder's first **product over a divisor, then a
+term added**. (The leverage `applied_weight * pulley_factor` and the distributed load `applied_weight * pulley_factor /
+limb_length` ride alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-68
+shipped their component sums/products/differences/ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the product, the division by limb length, and the addition of the baseline tension — and the
+harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs
+8/16/.../67/68. This rung exercises the engine across **a product over a divisor, then offset** — the fact that
+`a*b/c+d` is NOT `(a*b+d)/c` and NOT `a*b/(c+d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `*`, `/`, and `+`
+— **no structural constants** — so no numeric literal appears in any program, and neither the leverage, the distributed
+load, nor any traction figure is ever a literal (each is computed from the observed quantities). The observed quantities
+carry **digit-free identifiers** (`applied_weight`, `pulley_factor`, `limb_length`, `baseline_tension`) so no numeral
+hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (applied_weight * pulley_factor + baseline_tension) / limb_length   ADD the baseline BEFORE dividing instead
+                                                                                 of after (the classic `a*b/c+d` vs
+                                                                                 `(a*b+d)/c` error), and
+  SWAPPED    applied_weight * pulley_factor / (limb_length + baseline_tension)    ADD the baseline into the DENOMINATOR
+                                                                                 instead of after the division
+                                                                                 (`a*b/(c+d)` instead of `a*b/c+d`),
+
+which are exactly the mistakes a student makes (folding the baseline into the numerator before dividing, or into the
+denominator). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness: all four observed quantities are strictly positive (so every family member is positive); the limb length
+exceeds one (so the raw leverage `a*b` differs from the distributed load `a*b/c`); the five family values are pairwise
+distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (APPLIED_WEIGHT, PULLEY_FACTOR, LIMB_LENGTH, BASELINE_TENSION) — a weight and a pulley factor whose product is the
+# leverage, a limb length to normalise by, and a baseline tension to add, all plain positive numbers with limb_length > 1
+# (so leverage != distributed). The five family values are asserted pairwise-distinct (with margin) below.
+TABLES = [
+    (12, 5, 3, 4),
+    (10, 6, 4, 5),
+    (8, 9, 6, 3),
+    (15, 4, 5, 6),
+    (9, 8, 4, 2),
+    (14, 5, 7, 3),
+    (6, 10, 4, 8),
+]
+
+# The option family (5 members), all built from the four observed quantities via *, /, and +. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "traction_force",
+        "traction force (leverage distributed over the limb length, plus the baseline tension)",
+        "applied_weight * pulley_factor / limb_length + baseline_tension",
+    ),
+    (
+        "leverage",
+        "the leverage (applied weight times the pulley factor)",
+        "applied_weight * pulley_factor",
+    ),
+    (
+        "distributed",
+        "the distributed load before adding the baseline tension (leverage over the limb length)",
+        "applied_weight * pulley_factor / limb_length",
+    ),
+    (
+        "crossed",
+        "the baseline tension added to the leverage BEFORE dividing by the limb length, not after (a wrong offset)",
+        "(applied_weight * pulley_factor + baseline_tension) / limb_length",
+    ),
+    (
+        "swapped",
+        "the leverage divided by the limb length PLUS the baseline tension in the denominator, the baseline mis-placed (a wrong divisor)",
+        "applied_weight * pulley_factor / (limb_length + baseline_tension)",
+    ),
+]
+QUERIED = ["traction_force", "leverage", "distributed"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(applied_weight, pulley_factor, limb_length, baseline_tension):
+    # Operation order mirrors the ADJ programs exactly (the product formed first, then the left-to-right divide, then the
+    # trailing add), so the Python option value and the engine result are the same IEEE-double (well within the harness's
+    # 1e-9 match tolerance).
+    return {
+        "traction_force": applied_weight * pulley_factor / limb_length + baseline_tension,
+        "leverage": applied_weight * pulley_factor,
+        "distributed": applied_weight * pulley_factor / limb_length,
+        "crossed": (applied_weight * pulley_factor + baseline_tension) / limb_length,
+        "swapped": applied_weight * pulley_factor / (limb_length + baseline_tension),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for applied_weight, pulley_factor, limb_length, baseline_tension in TABLES:
+        assert (
+            applied_weight > 0
+            and pulley_factor > 0
+            and limb_length > 0
+            and baseline_tension > 0
+        ), (applied_weight, pulley_factor, limb_length, baseline_tension)
+        # Limb length exceeds one so the raw leverage (a*b) differs from the distributed load (a*b/c); all four
+        # quantities are positive so every family member is positive.
+        assert limb_length > 1, (applied_weight, pulley_factor, limb_length, baseline_tension)
+        fv = family_values(applied_weight, pulley_factor, limb_length, baseline_tension)
+        for key, v in fv.items():
+            assert v > 0, (key, applied_weight, pulley_factor, limb_length, baseline_tension, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    applied_weight,
+                    pulley_factor,
+                    limb_length,
+                    baseline_tension,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                applied_weight,
+                pulley_factor,
+                limb_length,
+                baseline_tension,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r69trac-{idx + 1:02d}",
+                "qtype": "traction_force",
+                "stem": (
+                    f"A skeletal traction rig applies a weight of {num(applied_weight)} through a pulley factor of "
+                    f"{num(pulley_factor)}, normalised to a limb length of {num(limb_length)} and added to a baseline "
+                    f"tension of {num(baseline_tension)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe applied_weight({num(applied_weight)})\n"
+                    f"observe pulley_factor({num(pulley_factor)})\n"
+                    f"observe limb_length({num(limb_length)})\n"
+                    f"observe baseline_tension({num(baseline_tension)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 69 — skeletal traction force from four stated quantities (a NEW panel: orthopedics / "
+            "skeletal traction). From an applied weight and a pulley factor (their product is the leverage), a limb "
+            "length to normalise by, and a baseline tension to add, compute the traction force "
+            "(applied_weight*pulley_factor/limb_length+baseline_tension), the leverage (applied_weight*pulley_factor), "
+            "or the distributed load (applied_weight*pulley_factor/limb_length). Each item is a compute_dimensioned "
+            "program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW "
+            "shape, PRODUCT OVER A DIVISOR PLUS A TERM a*b/c+d, the first on the ladder to put a product (not a sum or "
+            "difference) over the divisor and then add a term (distinct from rung-65 (a-b)/c+d, rung-66 (a+b)/c-d, and "
+            "rung-68 (a+b)*c/d with no trailing term) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via *, /, and + — no "
+            "constant leaks, and neither the leverage, the distributed load, nor any traction figure ever appears as a "
+            "literal (each is computed) — and the observed quantities carry digit-free identifiers so no numeral hides "
+            "inside a variable name. The five options are a family over the same four quantities, so the distractors "
+            "are exactly the slips students make: ADDING the baseline BEFORE dividing ((a*b+d)/c, a wrong offset) and "
+            "folding the baseline into the DENOMINATOR (a*b/(c+d), a wrong divisor). The core confusion tested is that "
+            "a*b/c+d is not (a*b+d)/c and not a*b/(c+d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung69_traction_force/items.json
+++ b/code/specs/data/adj-ladder/rung69_traction_force/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 69 \u2014 skeletal traction force from four stated quantities (a NEW panel: orthopedics / skeletal traction). From an applied weight and a pulley factor (their product is the leverage), a limb length to normalise by, and a baseline tension to add, compute the traction force (applied_weight*pulley_factor/limb_length+baseline_tension), the leverage (applied_weight*pulley_factor), or the distributed load (applied_weight*pulley_factor/limb_length). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OVER A DIVISOR PLUS A TERM a*b/c+d, the first on the ladder to put a product (not a sum or difference) over the divisor and then add a term (distinct from rung-65 (a-b)/c+d, rung-66 (a+b)/c-d, and rung-68 (a+b)*c/d with no trailing term) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via *, /, and + \u2014 no constant leaks, and neither the leverage, the distributed load, nor any traction figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: ADDING the baseline BEFORE dividing ((a*b+d)/c, a wrong offset) and folding the baseline into the DENOMINATOR (a*b/(c+d), a wrong divisor). The core confusion tested is that a*b/c+d is not (a*b+d)/c and not a*b/(c+d).",
+  "items": [
+    {
+      "id": "r69trac-01",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 12 through a pulley factor of 5, normalised to a limb length of 3 and added to a baseline tension of 4. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(12)\nobserve pulley_factor(5)\nobserve limb_length(3)\nobserve baseline_tension(4)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 21.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.571428571428571,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r69trac-02",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 12 through a pulley factor of 5, normalised to a limb length of 3 and added to a baseline tension of 4. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(12)\nobserve pulley_factor(5)\nobserve limb_length(3)\nobserve baseline_tension(4)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 21.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.571428571428571,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r69trac-03",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 12 through a pulley factor of 5, normalised to a limb length of 3 and added to a baseline tension of 4. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(12)\nobserve pulley_factor(5)\nobserve limb_length(3)\nobserve baseline_tension(4)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 21.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.571428571428571,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r69trac-04",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 10 through a pulley factor of 6, normalised to a limb length of 4 and added to a baseline tension of 5. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(10)\nobserve pulley_factor(6)\nobserve limb_length(4)\nobserve baseline_tension(5)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r69trac-05",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 10 through a pulley factor of 6, normalised to a limb length of 4 and added to a baseline tension of 5. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(10)\nobserve pulley_factor(6)\nobserve limb_length(4)\nobserve baseline_tension(5)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r69trac-06",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 10 through a pulley factor of 6, normalised to a limb length of 4 and added to a baseline tension of 5. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(10)\nobserve pulley_factor(6)\nobserve limb_length(4)\nobserve baseline_tension(5)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r69trac-07",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 8 through a pulley factor of 9, normalised to a limb length of 6 and added to a baseline tension of 3. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(8)\nobserve pulley_factor(9)\nobserve limb_length(6)\nobserve baseline_tension(3)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r69trac-08",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 8 through a pulley factor of 9, normalised to a limb length of 6 and added to a baseline tension of 3. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(8)\nobserve pulley_factor(9)\nobserve limb_length(6)\nobserve baseline_tension(3)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r69trac-09",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 8 through a pulley factor of 9, normalised to a limb length of 6 and added to a baseline tension of 3. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(8)\nobserve pulley_factor(9)\nobserve limb_length(6)\nobserve baseline_tension(3)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r69trac-10",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 15 through a pulley factor of 4, normalised to a limb length of 5 and added to a baseline tension of 6. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(15)\nobserve pulley_factor(4)\nobserve limb_length(5)\nobserve baseline_tension(6)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.454545454545454,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r69trac-11",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 15 through a pulley factor of 4, normalised to a limb length of 5 and added to a baseline tension of 6. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(15)\nobserve pulley_factor(4)\nobserve limb_length(5)\nobserve baseline_tension(6)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.454545454545454,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r69trac-12",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 15 through a pulley factor of 4, normalised to a limb length of 5 and added to a baseline tension of 6. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(15)\nobserve pulley_factor(4)\nobserve limb_length(5)\nobserve baseline_tension(6)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.454545454545454,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r69trac-13",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 9 through a pulley factor of 8, normalised to a limb length of 4 and added to a baseline tension of 2. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(9)\nobserve pulley_factor(8)\nobserve limb_length(4)\nobserve baseline_tension(2)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r69trac-14",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 9 through a pulley factor of 8, normalised to a limb length of 4 and added to a baseline tension of 2. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(9)\nobserve pulley_factor(8)\nobserve limb_length(4)\nobserve baseline_tension(2)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r69trac-15",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 9 through a pulley factor of 8, normalised to a limb length of 4 and added to a baseline tension of 2. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(9)\nobserve pulley_factor(8)\nobserve limb_length(4)\nobserve baseline_tension(2)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r69trac-16",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 14 through a pulley factor of 5, normalised to a limb length of 7 and added to a baseline tension of 3. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(14)\nobserve pulley_factor(5)\nobserve limb_length(7)\nobserve baseline_tension(3)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r69trac-17",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 14 through a pulley factor of 5, normalised to a limb length of 7 and added to a baseline tension of 3. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(14)\nobserve pulley_factor(5)\nobserve limb_length(7)\nobserve baseline_tension(3)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r69trac-18",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 14 through a pulley factor of 5, normalised to a limb length of 7 and added to a baseline tension of 3. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(14)\nobserve pulley_factor(5)\nobserve limb_length(7)\nobserve baseline_tension(3)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 70,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r69trac-19",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 6 through a pulley factor of 10, normalised to a limb length of 4 and added to a baseline tension of 8. What is the traction force (leverage distributed over the limb length, plus the baseline tension)?",
+      "program": "observe applied_weight(6)\nobserve pulley_factor(10)\nobserve limb_length(4)\nobserve baseline_tension(8)\nlet answer = applied_weight * pulley_factor / limb_length + baseline_tension\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r69trac-20",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 6 through a pulley factor of 10, normalised to a limb length of 4 and added to a baseline tension of 8. What is the the leverage (applied weight times the pulley factor)?",
+      "program": "observe applied_weight(6)\nobserve pulley_factor(10)\nobserve limb_length(4)\nobserve baseline_tension(8)\nlet answer = applied_weight * pulley_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 23.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r69trac-21",
+      "qtype": "traction_force",
+      "stem": "A skeletal traction rig applies a weight of 6 through a pulley factor of 10, normalised to a limb length of 4 and added to a baseline tension of 8. What is the the distributed load before adding the baseline tension (leverage over the limb length)?",
+      "program": "observe applied_weight(6)\nobserve pulley_factor(10)\nobserve limb_length(4)\nobserve baseline_tension(8)\nlet answer = applied_weight * pulley_factor / limb_length\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 23.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 17.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -106,6 +106,7 @@ SELF_CONTAINED_RUNGS = (
     "rung66_periodontal_attachment_level",
     "rung67_ergometry_specific_work",
     "rung68_gait_efficiency_index",
+    "rung69_traction_force",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-69 — skeletal traction force (product over a divisor, plus a term)

Adds the next self-contained quantitative rung to the ADJ-LADDER.

### New arithmetic shape
`a*b/c+d` — a **product, over a divisor, plus a term** = `((a*b)/c)+d`. The first rung to put a
**product** (not a sum or a difference) over the divisor and then add a trailing term. Distinct from
rung-65 `(a-b)/c+d` (a difference over the divisor, plus a term), rung-66 `(a+b)/c-d` (a sum over the
divisor, minus a term), and rung-68 `(a+b)*c/d` (a sum scaled then divided, no trailing term).

### New clinical panel
**Orthopedics / skeletal traction** — a traction rig hangs an `applied_weight` over a pulley
(`pulley_factor`), normalises to the `limb_length` being pulled, and adds a resting `baseline_tension`:
`applied_weight * pulley_factor / limb_length + baseline_tension` (the traction force). Distinct from
every used ladder domain.

### Item family (5 mutually-confusable members)
| key | formula | role |
|---|---|---|
| `traction_force` | `a*b/c+d` | **gold** — the headline `a*b/c+d` |
| `leverage` | `a*b` | **gold** — the raw product |
| `distributed` | `a*b/c` | **gold** — the product over the limb, before offsetting |
| `crossed` | `(a*b+d)/c` | distractor — ADD the baseline BEFORE dividing (`(a*b+d)/c`) |
| `swapped` | `a*b/(c+d)` | distractor — fold the baseline into the DENOMINATOR (`a*b/(c+d)`) |

First three QUERIED as gold; all five always appear as options. Gold rotates A–E by index (`idx % 5`).

### Contamination safety
- Every formula built ONLY from the four observed quantities via `*`, `/`, `+` — **no numeric constants**.
- No leverage / distributed / traction figure ever appears as a literal (each is computed).
- **Digit-free identifiers** (`applied_weight`, `pulley_factor`, `limb_length`, `baseline_tension`).
- 7 tables × 3 queried = **21 items**; positivity guaranteed by all four quantities `> 0`; `limb_length > 1`
  keeps the raw leverage `a*b` distinct from the distributed load `a*b/c`; the five family values asserted
  pairwise-distinct (`>1e-6`) at build.

### Verification
```
$ mise exec -- python3 -m pytest test_ladder_eval.py -k rung69 -q
3 passed, 318 deselected
```
(the compute test confirms the ADJ engine selects every gold via the CLI). Registered
`rung69_traction_force` in `SELF_CONTAINED_RUNGS`. Data-only change (offline generator + generated
`items.json` + one-line harness registration); no engine/harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
