### PR TITLE
feat(twig-aot): E4d-4 runtime (branch-selected) strings on native — all 7 backends

### DIFF
--- a/code/packages/rust/lang-aot/CHANGELOG.md
+++ b/code/packages/rust/lang-aot/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog — `lang-aot`
 
+## 0.174.0 — 2026-07-03 — E4-dyn E4d-4: foothold runtime string now runs on NativeAot (all 7 backends)
+
+The E4-dyn runtime branch-selected-string foothold cell (`INPUT N` picks
+`A$ = "HI"`/`"LO"`) gains the **`NativeAot`** column — completing the E4-dyn
+backend ladder. The runtime string now runs on **all seven backends**
+(NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit), all agreeing on `"HI"`. aarch64 is
+run-verified locally on this Apple Silicon host; x86_64 is verified on the Linux
+CI runner through the same matrix cell.
+
+This is the payoff of `twig-aot` 0.27.0: on native, `str_const` already builds a
+`[i64 len][bytes]` heap buffer and stores its address in the variable's stack
+slot, and `print_str` already has a runtime length-read path (`field_load` the
+header). The E4d-4 fix simply keeps a branch-selected string out of `twig-aot`'s
+compile-time literal map so `print_str` takes that runtime path instead of folding
+one branch's static length — one change covering both the aarch64 and x86_64
+backends. `matrix_every_proven_cell_agrees` + `proven_columns_do_not_silently_skip`
+pass with `NativeAot` added.
+
 ## 0.173.0 — 2026-07-03 — E4-dyn E4d-3: foothold runtime string now runs on Wasm
 
 The E4-dyn runtime branch-selected-string foothold cell (`INPUT N` picks

--- a/code/packages/rust/lang-aot/Cargo.toml
+++ b/code/packages/rust/lang-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lang-aot"
-version = "0.173.0"
+version = "0.174.0"
 edition = "2021"
-description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.173.0 (E4-dyn E4d-3): the runtime branch-selected-string foothold cell now runs on the Wasm column too (in-process wasm-runtime + env.__print_str host) — iir-to-wasm 0.29.0 runtime-string lowering (i32 handle → length-prefixed linear-memory block).  v0.172.0 (E4-dyn E4d-2): the runtime branch-selected-string foothold cell now runs on the Llvm column too (via clang) — iir-to-llvm 0.30.0 runtime-string lowering.  v0.171.0 (E4-dyn foothold): first RUNTIME string cell on the 4 already-dynamic backends.  v0.170.0 (AL-pow): ALGOL 60 exponentiation."
+description = "Multi-language AOT driver — compile Twig, Nib, Brainfuck, Dartmouth BASIC, Oct, and McCarthy Lisp to native executables through the shared IIR pipeline.  v0.174.0 (E4-dyn E4d-4): the runtime branch-selected-string foothold cell now runs on the NativeAot column too (aarch64 run-verified locally, x86_64 on CI) — twig-aot 0.27.0 keeps a branch-selected string out of the compile-time literal map so print_str reads the length from the [i64 len][bytes] buffer header at run time; the E4-dyn foothold is now proven on ALL SEVEN backends.  v0.173.0 (E4-dyn E4d-3): the runtime branch-selected-string foothold cell now runs on the Wasm column too (in-process wasm-runtime + env.__print_str host) — iir-to-wasm 0.29.0 runtime-string lowering (i32 handle → length-prefixed linear-memory block).  v0.172.0 (E4-dyn E4d-2): the runtime branch-selected-string foothold cell now runs on the Llvm column too (via clang) — iir-to-llvm 0.30.0 runtime-string lowering.  v0.171.0 (E4-dyn foothold): first RUNTIME string cell on the 4 already-dynamic backends.  v0.170.0 (AL-pow): ALGOL 60 exponentiation."
 
 [dependencies]
 twig-aot              = { path = "../twig-aot" }

--- a/code/packages/rust/lang-aot/tests/lang_matrix.rs
+++ b/code/packages/rust/lang-aot/tests/lang_matrix.rs
@@ -2290,8 +2290,13 @@ const PROGRAMS: &[Prog] = &[
     // (`java.lang.String` local), CLR (`System.String` local) — which carry a
     // reassigned-across-branches string slot natively, plus the two static
     // backends whose runtime heap-string lowering has landed: Llvm (E4d-2) and
-    // Wasm (E4d-3). The remaining static backend (NativeAot) still folds strings
-    // to compile-time constants and is added by E4d-4. Each E4-dyn backend PR
+    // Wasm (E4d-3), and NativeAot (E4d-4, aarch64 + x86_64). On the native
+    // columns `str_const` already builds a `[i64 len][bytes]` heap buffer and
+    // stores its address in the variable's stack slot (`mov dest = buf`); the
+    // E4d-4 fix keeps a branch-selected string OUT of `twig-aot`'s compile-time
+    // literal map so `print_str` reads the length from the buffer header at run
+    // time (`field_load` + `__twig_print_string`) rather than folding one branch's
+    // constant. Each E4-dyn backend PR
     // (E4d-2 LLVM → E4d-3 WASM → E4d-4 native) extends THIS cell's `backends`
     // list once its runtime string lowering lands. On WASM (E4d-3) a
     // branch-selected string variable carries an i32 **handle** = the offset of
@@ -2304,7 +2309,7 @@ const PROGRAMS: &[Prog] = &[
         ext: "bas",
         src: "10 INPUT N\n20 IF N > 0 THEN 50\n30 LET A$ = \"LO\"\n40 GOTO 60\n50 LET A$ = \"HI\"\n60 PRINT A$\n70 END\n",
         expect: Expect::Stdout("HI"),
-        backends: &[Llvm, Wasm, Jvm, Clr, Vm, Jit],
+        backends: &[NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit],
     },
 ];
 

--- a/code/packages/rust/twig-aot/CHANGELOG.md
+++ b/code/packages/rust/twig-aot/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog — `twig-aot`
 
+## 0.27.0 — 2026-07-03 — E4-dyn E4d-4: runtime (branch-selected) strings on native
+
+Completes the E4-dyn backend ladder: the runtime branch-selected-string foothold
+now runs on the **native aarch64 + x86_64** columns, so the E4-dyn foothold is
+proven on **all seven backends**.
+
+**How native strings already worked.** `lower_string_literals_for_aot` lowers each
+`str_const` to a `push_aot_string_literal` block — an `alloc_bytes` heap buffer with
+the E5/E4d-1 `[i64 len][bytes]` layout (`field_store` len at offset 0, `store_byte`s
+at offset 8+) — followed by `mov dest = buf`, so the variable's stack slot already
+holds the buffer's **address** (a runtime handle). And `print_str`/`str_len` already
+have a runtime branch that reads the length header from the buffer at run time
+(`field_load src[0]`), used today for runtime string *parameters*.
+
+**The bug for a branch-selected local.** `str_const` also registered every `dest`
+in the compile-time `strings` map (last-writer-wins). So for `A$` assigned `"LO"` in
+one block and `"HI"` in another, `print_str A$` took the *static-length* path using
+whichever literal was written last — printing the wrong length whenever the two
+branches' strings differ in length.
+
+**The fix.** Add `collect_runtime_str_vars_for_aot` (same basic-block promotion rule
+as `iir-to-llvm`'s `collect_slot_vars` and `iir-to-wasm`'s `collect_runtime_str_vars`:
+a `str`-typed dest appearing in >1 basic block). In `str_const`, a promoted var is
+**not** registered in `strings`, so every downstream `print_str`/`str_len`/`str_eq`/
+`str_cmp` on it takes its existing runtime path. No backend change is needed — the
+buffer + slot address were already correct — so one change covers both aarch64 and
+x86_64. Single-assignment (and straight-line-reassigned) strings are unchanged.
+
+Two unit tests: `branch_selected_string_reads_length_at_runtime` (differing lengths
+`"LONGER"`/`"HI"` → asserts the emitted `field_load A[0]` runtime length read) and
+`straight_line_reassignment_keeps_static_length` (one block → no `field_load`). The
+`lang-aot` E4-dyn foothold matrix cell adds `NativeAot` and now proves the runtime
+string on all 7 backends (aarch64 run-verified locally; x86_64 on CI).
+
 ## 0.26.0 — 2026-07-03 — E4-dyn E4d-1: runtime string helpers
 
 First step of the **E4-dyn** arc (`code/specs/lang-full-e4-dyn-strings.md`):

--- a/code/packages/rust/twig-aot/Cargo.toml
+++ b/code/packages/rust/twig-aot/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twig-aot"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
-description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
+description = "Twig AOT compiler — produces native Mach-O / ELF executables from Twig source. v0.27.0 (E4-dyn E4d-4): runtime (branch-selected) strings on the native aarch64 + x86_64 columns — a str var assigned by str_const in >1 basic block is kept out of the compile-time literal map so print_str/str_len read the length from the [i64 len][bytes] buffer header at run time (field_load) instead of folding one branch's static length; the var's stack slot already carries the buffer address. v0.26.0 (E4-dyn E4d-1): runtime string helpers __twig_str_concat/_slice/_index/_len/_cmp in twig_runtime.c on the E5 length-prefixed heap block; bounds-trap on slice/index; C-driver unit tests."
 
 [dependencies]
 twig-ir-compiler     = { path = "../twig-ir-compiler" }

--- a/code/packages/rust/twig-aot/src/lib.rs
+++ b/code/packages/rust/twig-aot/src/lib.rs
@@ -51,7 +51,7 @@
 #![warn(rust_2018_idioms)]
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use aarch64_backend::{compile_with_globals, GlobalWordReloc, Reloc};
@@ -1691,7 +1691,56 @@ fn push_aot_string_literal(
     (buf_var, len_var, literal)
 }
 
+/// E4-dyn (E4d-4): compute the set of string variables that are chosen by
+/// control flow — the destination of a `str`-typed instruction in **more than
+/// one basic block**.  For these, the compile-time last-writer-wins literal
+/// tracking (`strings`) cannot resolve a single value, so we must NOT register
+/// them there; `print_str`/`str_len` then fall into their existing **runtime**
+/// paths (`field_load` the length header from the buffer at run time) instead of
+/// the static-length fast path — which would use the wrong branch's length
+/// whenever the two literals differ in length.
+///
+/// This mirrors `iir-to-llvm`'s `collect_slot_vars` and `iir-to-wasm`'s
+/// `collect_runtime_str_vars` exactly (same basic-block rule): a `label` starts
+/// a new block, and a terminator (`jmp`/`jmp_if_false`/`jmp_if_true`/`ret`/
+/// `ret_void`) ends one.  A str reassigned twice *straight-line* stays in one
+/// block and keeps the literal fast path — the linear tracking is right there.
+///
+/// The native buffer built by `push_aot_string_literal` already has the
+/// `[i64 len][bytes]` layout and the var's stack slot already holds the
+/// buffer's address (a runtime handle) via `mov dest = buf`, so no backend
+/// change is needed — dropping the `strings` registration is the whole fix, and
+/// it applies to both the aarch64 and x86_64 backends at once.
+fn collect_runtime_str_vars_for_aot(func: &IIRFunction) -> HashSet<String> {
+    let mut str_blocks: HashMap<&str, HashSet<usize>> = HashMap::new();
+    let mut block: usize = 0;
+    for instr in &func.instructions {
+        let op = instr.op.as_str();
+        if op == "label" {
+            block += 1;
+        }
+        if let Some(dest) = &instr.dest {
+            if instr.type_hint == "str" {
+                str_blocks.entry(dest.as_str()).or_default().insert(block);
+            }
+        }
+        if matches!(op, "jmp" | "jmp_if_false" | "jmp_if_true" | "ret" | "ret_void") {
+            block += 1;
+        }
+    }
+    str_blocks
+        .into_iter()
+        .filter(|(_, blocks)| blocks.len() >= 2)
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
 fn lower_string_literals_for_aot(func: &mut IIRFunction) {
+    // E4-dyn (E4d-4): variables whose string value is chosen by control flow.
+    // These are kept OUT of the compile-time `strings` map so their length is
+    // read at run time from the buffer header, not folded to a (possibly wrong)
+    // branch's constant.
+    let runtime_str_vars = collect_runtime_str_vars_for_aot(func);
     let mut lowered = Vec::with_capacity(func.instructions.len());
     let mut strings: HashMap<String, (String, String, String)> = HashMap::new();
     let mut ints: HashMap<String, i64> = HashMap::new();
@@ -1767,14 +1816,23 @@ fn lower_string_literals_for_aot(func: &mut IIRFunction) {
             // that uses it directly (e.g. `call strlen(dest)`).  The alias is stripped by
             // `strip_dead_aot_string_allocs` when `dest` is not observed outside the
             // already-folded string ops, so this does not inflate the frame for fold-only
-            // strings.
+            // strings.  `dest`'s slot now holds the buffer's address — a runtime handle to
+            // a `[i64 len][bytes]` block, identical to a runtime string parameter.
             lowered.push(IIRInstr::new(
                 "mov",
                 Some(dest.clone()),
                 vec![Operand::Var(buf_var)],
                 "i64",
             ));
-            strings.insert(dest.clone(), (dest, len_var, lit));
+            // E4-dyn (E4d-4): only register a *single-block* (foldable) string in
+            // the compile-time literal map.  A branch-selected string is left out,
+            // so `print_str`/`str_len`/`str_eq`/`str_cmp` on it take their runtime
+            // paths (reading the length header at run time) rather than baking in
+            // one branch's last-written literal — which would print the wrong
+            // length whenever the branches' strings differ in length.
+            if !runtime_str_vars.contains(&dest) {
+                strings.insert(dest.clone(), (dest, len_var, lit));
+            }
             continue;
         }
 
@@ -3290,5 +3348,100 @@ mod tests {
             })
             .collect();
         assert_eq!(store_offsets, vec![8, 9], "byte stores must be at offset 8..9: {:?}", f.instructions);
+    }
+
+    // ── E4-dyn (E4d-4): runtime (branch-selected) strings ────────────────────
+
+    /// A string variable assigned by `str_const` in two different basic blocks
+    /// is chosen by control flow, so `print_str` on it must read the length from
+    /// the buffer header at run time (`field_load` index 0) rather than folding a
+    /// single branch's static length. The two branches here differ in length
+    /// ("LONGER" = 6 vs "HI" = 2), so a static-length fold would be observably
+    /// wrong. This is the native sibling of iir-to-llvm's E4d-2 and iir-to-wasm's
+    /// E4d-3 runtime paths.
+    #[test]
+    fn branch_selected_string_reads_length_at_runtime() {
+        // cond = 1; if !cond goto Lelse
+        // Lthen: A = "LONGER"; goto Ldone
+        // Lelse: A = "HI"
+        // Ldone: print_str A; ret 0
+        let mut f = IIRFunction::new(
+            "main",
+            vec![],
+            "i64",
+            vec![
+                IIRInstr::new("const", Some("cond".into()), vec![Operand::Int(1)], "i64"),
+                IIRInstr::new("jmp_if_false", None,
+                    vec![Operand::Var("cond".into()), Operand::Var("Lelse".into())], "void"),
+                IIRInstr::new("label", None, vec![Operand::Var("Lthen".into())], "void"),
+                IIRInstr::new("str_const", Some("A".into()), vec![Operand::Str("LONGER".into())], "str"),
+                IIRInstr::new("jmp", None, vec![Operand::Var("Ldone".into())], "void"),
+                IIRInstr::new("label", None, vec![Operand::Var("Lelse".into())], "void"),
+                IIRInstr::new("str_const", Some("A".into()), vec![Operand::Str("HI".into())], "str"),
+                IIRInstr::new("label", None, vec![Operand::Var("Ldone".into())], "void"),
+                IIRInstr::new("print_str", None, vec![Operand::Var("A".into())], "void"),
+                IIRInstr::new("const", Some("r".into()), vec![Operand::Int(0)], "i64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            ],
+        );
+
+        lower_string_literals_for_aot(&mut f);
+
+        // Both branches still build their `[i64 len][bytes]` heap buffers.
+        assert_eq!(
+            f.instructions.iter().filter(|i| i.op == "alloc_bytes").count(),
+            2,
+            "each branch's string must still allocate its own buffer: {:?}",
+            f.instructions
+        );
+        // The runtime length read: `field_load` the header (index 0) from `A`.
+        assert!(
+            f.instructions.iter().any(|i| {
+                i.op == "field_load"
+                    && matches!(i.srcs.first(), Some(Operand::Var(v)) if v == "A")
+                    && matches!(i.srcs.get(1), Some(Operand::Int(0)))
+            }),
+            "print_str of a branch-selected string must read the length header at \
+             run time (field_load A[0]), not fold a static length: {:?}",
+            f.instructions
+        );
+        // And it still calls the print runtime.
+        assert!(
+            f.instructions.iter().any(|i| {
+                i.op == "call_builtin"
+                    && matches!(i.srcs.first(), Some(Operand::Var(name)) if name == "print_string")
+            }),
+            "print_str should still lower to call_builtin print_string: {:?}",
+            f.instructions
+        );
+    }
+
+    /// A string reassigned twice *straight-line* (one basic block) is NOT
+    /// promoted: the last-writer-wins literal tracking is exactly right, so
+    /// `print_str` keeps the static-length fast path and emits no runtime
+    /// `field_load`. Mirrors the E4d-2/E4d-3 "straight-line not promoted" rule.
+    #[test]
+    fn straight_line_reassignment_keeps_static_length() {
+        let mut f = IIRFunction::new(
+            "main",
+            vec![],
+            "i64",
+            vec![
+                IIRInstr::new("str_const", Some("s".into()), vec![Operand::Str("OK".into())], "str"),
+                IIRInstr::new("str_const", Some("s".into()), vec![Operand::Str("NO".into())], "str"),
+                IIRInstr::new("print_str", None, vec![Operand::Var("s".into())], "void"),
+                IIRInstr::new("const", Some("r".into()), vec![Operand::Int(0)], "i64"),
+                IIRInstr::new("ret", None, vec![Operand::Var("r".into())], "i64"),
+            ],
+        );
+
+        lower_string_literals_for_aot(&mut f);
+
+        assert!(
+            !f.instructions.iter().any(|i| i.op == "field_load"),
+            "a straight-line reassignment keeps the static-length fast path (no \
+             runtime field_load): {:?}",
+            f.instructions
+        );
     }
 }

--- a/code/specs/lang-full-e4-dyn-strings.md
+++ b/code/specs/lang-full-e4-dyn-strings.md
@@ -84,11 +84,11 @@ handle→ | i64 length (# bytes)     | b0 | b1 | ... | b(len-1) |
 | **CLR** | `ldstr` `String` | `System.String` from `String.Concat`/`Substring` — already dynamic ✅ |
 | **LLVM** | private `{i64,[N×i8]}` global | **`[i64 len][i8…]` block; handle = block address, `inttoptr`+`load` in `print_str`** ✅ (E4d-2) |
 | **WASM** | data segment + side-table | **linear-memory `[i32 len][i8…]` block; handle = i32 offset, `i32.load` in `print_str`** ✅ (E4d-3) |
-| **x86_64** | folded literal | **`__twig_alloc_bytes` heap block** (E5 model) |
-| **aarch64** | folded literal | **`__twig_alloc_bytes` heap block** (E5 model) |
+| **x86_64** | folded literal | **`alloc_bytes` `[i64 len][i8…]` block; slot holds address, `field_load` header in `print_str`** ✅ (E4d-4) |
+| **aarch64** | folded literal | **`alloc_bytes` `[i64 len][i8…]` block; slot holds address, `field_load` header in `print_str`** ✅ (E4d-4) |
 
-The four static backends are the whole job; the other three already run runtime
-strings.
+All four static backends now run runtime strings; the E4-dyn foothold is proven
+on **all seven backends**.
 
 ---
 
@@ -187,10 +187,22 @@ two literals still folds), so nothing regresses; the runtime path is what's new.
    the emitted wasm. Deferred (like E4d-2b): runtime `str_len`/`str_concat`/
    `str_slice`/`str_index`/`str_cmp` over promoted operands (E4d-3b — not needed by
    the foothold, which only *observes* a runtime string via `print_str`). *(needs 1, 1a)*
-4. **E4d-4 — native runtime strings.** `aarch64-backend` + `x86_64-backend` lower
-   the ops to `__twig_alloc_bytes` blocks + `bl/call` helpers + `udf/ud2` bounds
-   traps (mirror E5 arrays). Run-verify aarch64 locally + x86_64 on CI. Extend the
-   foothold cell with `NativeAot` → **all 7 backends**. *(needs 1, 1a)*
+4. **E4d-4 — native runtime strings.** ✅ **Landed** (`twig-aot` 0.27.0 /
+   `lang-aot` 0.174.0). Key finding: the native path *already* had everything —
+   `lower_string_literals_for_aot` builds each `str_const`'s `[i64 len][bytes]`
+   buffer via `alloc_bytes`/`field_store`/`store_byte` and stores its **address**
+   in the var's stack slot (`mov dest = buf`), and `print_str`/`str_len` already
+   read the length header at run time (`field_load src[0]`) for runtime string
+   *parameters*. The only bug was that `str_const` registered every dest in the
+   compile-time `strings` map, so a branch-selected local wrongly took the
+   static-length (last-writer-wins) path. Fix: `collect_runtime_str_vars_for_aot`
+   (same >1-basic-block rule as E4d-2/E4d-3) and skip the `strings` registration
+   for promoted vars → `print_str` reads the runtime length. No backend code
+   changed, so **one change covers both aarch64 and x86_64**. Foothold cell adds
+   `NativeAot` → **all 7 backends** (aarch64 run-verified locally, x86_64 on CI);
+   2 unit tests (differing-length runtime read + straight-line static). Deferred
+   (E4d-4b, like E4d-2b/E4d-3b): runtime `str_concat`/`str_slice`/`str_index` over
+   promoted operands — not needed by the foothold. *(needs 1, 1a)*
 5. **Frontend payoffs** *(each needs 1–4 for the backends it targets)*:
    - **E4d-AL — ALGOL string procedures.** Lift the `string procedures`
      `Unsupported` (algol-iir-compiler:886): a `string procedure` returns a


### PR DESCRIPTION
## E4-dyn E4d-4 — native runtime strings (completes the ladder)

Final rung of the E4-dyn backend ladder (E4d-1 helpers → foothold → E4d-2 LLVM → E4d-3 WASM → **E4d-4 native**). The runtime branch-selected-string foothold now runs on the native **aarch64 + x86_64** columns, so it is proven on **all 7 backends**.

### Key finding — the native path already had everything
`twig-aot`'s `lower_string_literals_for_aot` already:
- Lowers each `str_const` to an `alloc_bytes` heap buffer with the E5/E4d-1 `[i64 len][bytes]` layout (`field_store` len at offset 0, `store_byte`s at offset 8+), then `mov dest = buf` — so the variable's stack slot already holds the buffer's **address** (a runtime handle).
- Gives `print_str`/`str_len` a runtime branch that reads the length header from the buffer at run time (`field_load src[0]`) — used today for runtime string *parameters*.

### The bug
`str_const` also registered **every** `dest` in the compile-time `strings` map (last-writer-wins). So for `A$ = "LO"` in one block and `A$ = "HI"` in another, `print_str A$` took the *static-length* path using whichever literal was written last — printing the wrong length whenever the two branches' strings differ in length.

### The fix
Add `collect_runtime_str_vars_for_aot` — the **same** >1-basic-block promotion rule as iir-to-llvm's `collect_slot_vars` (E4d-2) and iir-to-wasm's `collect_runtime_str_vars` (E4d-3). In `str_const`, a promoted var is **not** registered in `strings`, so `print_str`/`str_len`/`str_eq`/`str_cmp` on it take their existing runtime paths. **No backend code changed** — the buffer + slot address were already correct — so one change covers both aarch64 and x86_64. Single-assignment (and straight-line-reassigned) strings are unchanged.

### Verification
- `twig-aot`: 41 unit tests pass, including 2 new E4d-4 tests — `branch_selected_string_reads_length_at_runtime` (differing lengths `"LONGER"`/`"HI"` → asserts the emitted `field_load A[0]` runtime read, which a static-length bug would fail) and `straight_line_reassignment_keeps_static_length` (one block → no `field_load`).
- `lang-aot`: added `NativeAot` to the E4-dyn foothold matrix cell. Both guard tests (`matrix_every_proven_cell_agrees`, `proven_columns_do_not_silently_skip`) pass — the runtime string now runs **end-to-end on all 7 backends** (NativeAot, Llvm, Wasm, Jvm, Clr, Vm, Jit), all agreeing on `"HI"`. **aarch64 run-verified locally** on this Apple Silicon host; **x86_64 verified on the Linux CI runner** through the same cell.
- Security review passed (no overflow, no new panics, unsupported ops yield a clean `BackendRefused` error, misclassification is at worst a correctness bug over an already-safe runtime buffer mechanism).

### Versions & docs
- `twig-aot` 0.26.0 → 0.27.0; `lang-aot` 0.173.0 → 0.174.0.
- CHANGELOGs updated; spec `lang-full-e4-dyn-strings.md` §step 4 + backend table marked E4d-4 landed (foothold now proven on all 7 backends).

**The E4-dyn foothold — a genuinely runtime, control-flow-selected string — now runs on every backend in the matrix.** Remaining follow-ups: E4d-2b/3b/4b (runtime `str_concat`/`slice`/`index` over promoted operands) and the frontend payoffs (ALGOL string procedures, BASIC string `INPUT`/arrays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)