### PR TITLE
feat(closurec): CLOC12.163 PR1 — YieldExpression (yield/yield*) atomic node + emit + 9 passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.27.0] - 2026-07-03
+
+### Added — CLOC12.163: emit `YieldExpression` (`yield` / `yield x` / `yield* xs`)
+
+New `emit_yield` prints `Expression::YieldExpression`: a bare `yield`, a value
+yield `yield x` (mandatory keyword↔argument space), and a delegating
+`yield*xs` (no space after `*`). The argument is printed at `PREC_ASSIGNMENT`,
+so a sequence argument wraps (`yield (a,b)`) while a conditional or assignment
+argument prints bare. `expr_prec` tags a yield at `PREC_ASSIGNMENT`, so a
+tighter parent wraps the whole yield (`(yield a)+1`, `(yield a).b`). 9 new unit
+tests.
+
+
 ## [0.26.1] - 2026-07-03
 
 ### Added — CLOC12.162 PR3: CodePrinter spread conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -78,7 +78,7 @@ use coding_adventures_javascript_ast::{
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
-    TaggedTemplateExpression, SpreadElement,
+    TaggedTemplateExpression, SpreadElement, YieldExpression,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1137,6 +1137,7 @@ impl<'a> Emitter<'a> {
             Expression::TemplateLiteral(t) => self.emit_template_literal(t),
             Expression::TaggedTemplateExpression(t) => self.emit_tagged_template(t),
             Expression::SpreadElement(s) => self.emit_spread(s),
+            Expression::YieldExpression(y) => self.emit_yield(y),
         }
         if needs_parens {
             self.write_str(")");
@@ -1558,6 +1559,51 @@ impl<'a> Emitter<'a> {
         self.maybe_map(&s.cv);
         self.write_str("...");
         self.emit_expression_inner(&s.argument, PREC_ASSIGNMENT);
+    }
+
+    /// Emit a `YieldExpression` — `yield`, `yield x`, or `yield* xs`.
+    ///
+    /// Three shapes, driven by the two independent fields `delegate` and
+    /// `argument`:
+    ///
+    /// ```text
+    ///   yield             delegate=false, argument=None    → "yield"
+    ///   yield x           delegate=false, argument=Some    → "yield x"
+    ///   yield* xs         delegate=true,  argument=Some    → "yield*xs"
+    /// ```
+    ///
+    /// **Token separation.** `yield` is a *word* keyword, so a non-delegating
+    /// `yield` followed by an argument needs a mandatory separator or the two
+    /// would fuse into one identifier (`yieldx`): we emit `required_ws()`
+    /// between them (`yield x`). A delegating `yield*` needs no separator — the
+    /// `*` is punctuation that already terminates the keyword token, and no
+    /// valid `AssignmentExpression` argument begins with `*`, so `yield*xs`
+    /// tokenises unambiguously. (A delegating yield without an argument would be
+    /// a syntax error upstream; if a malformed AST presents `delegate=true,
+    /// argument=None` we still emit a bare `yield*`, leaving the invalidity
+    /// visible rather than silently rewriting it.)
+    ///
+    /// **Precedence.** The argument prints at `PREC_ASSIGNMENT` — the yield
+    /// operand grammar is an `AssignmentExpression`, so a conditional or
+    /// assignment argument prints bare (`yield a?b:c`, `yield a=b`) while a
+    /// looser sequence wraps (`yield (a,b)`). The wrapping of the *whole* yield
+    /// in a tighter parent is handled by `expr_prec` (which tags it at
+    /// `PREC_ASSIGNMENT`) plus `emit_expression_inner`, exactly as for arrows
+    /// and assignments — no local paren logic is needed here.
+    fn emit_yield(&mut self, y: &YieldExpression) {
+        self.maybe_map(&y.cv);
+        self.write_str("yield");
+        if y.delegate {
+            self.write_str("*");
+        }
+        if let Some(arg) = &y.argument {
+            // A non-delegating `yield` must be separated from its argument;
+            // after a delegating `yield*` the `*` already separates the tokens.
+            if !y.delegate {
+                self.required_ws();
+            }
+            self.emit_expression_inner(arg, PREC_ASSIGNMENT);
+        }
     }
 
     fn emit_member(&mut self, m: &MemberExpression) {
@@ -1991,6 +2037,14 @@ fn expr_prec(e: &Expression) -> u8 {
         // never emitted as a sub-operand of another operator (that would be
         // invalid JS), so no other context can observe this precedence.
         Expression::SpreadElement(_) => PREC_ASSIGNMENT,
+        // `yield` / `yield* x` is an `AssignmentExpression` alternative in the
+        // grammar — it binds looser than every operator except the comma. Tag it
+        // at `PREC_ASSIGNMENT` so a tighter parent wraps it (`(yield x)+1`,
+        // `f((yield x))` when the call slot is not itself assignment-position,
+        // `(yield x).y`), while an assignment RHS or conditional branch — both
+        // emitted at `PREC_ASSIGNMENT` — leave it bare (`x=yield v`,
+        // `c?yield a:yield b`). This mirrors the arrow / assignment tags exactly.
+        Expression::YieldExpression(_) => PREC_ASSIGNMENT,
         // `true`/`false` are emitted as `!0`/`!1` (see `emit_boolean`), which
         // are UnaryExpressions — precedence `PREC_UNARY`, NOT primary. Tagging
         // them here is what makes `emit_expression_inner` parenthesise them in
@@ -4815,5 +4869,92 @@ mod tests {
         });
         let e = call(ident("f"), vec![spread(cond)]);
         assert_eq!(emit_expr(e), "f(...a?b:c);");
+    }
+
+    // =================================================================
+    // YieldExpression (`yield` / `yield x` / `yield* xs`) — CLOC12.163
+    // =================================================================
+
+    /// Build a `YieldExpression` from its two axes.
+    fn yld(delegate: bool, argument: Option<Expression>) -> Expression {
+        Expression::YieldExpression(YieldExpression {
+            cv: None,
+            delegate,
+            argument: argument.map(Box::new),
+        })
+    }
+
+    /// `yield` — a bare yield with no operand prints just the keyword.
+    #[test]
+    fn yield_bare_prints_keyword_only() {
+        assert_eq!(emit_expr(yld(false, None)), "yield;");
+    }
+
+    /// `yield a` — a non-delegating yield separates the keyword from its
+    /// argument with a mandatory space (`yielda` would be one identifier).
+    #[test]
+    fn yield_value_has_required_space() {
+        assert_eq!(emit_expr(yld(false, Some(ident("a")))), "yield a;");
+    }
+
+    /// `yield*xs` — a delegating yield needs no separator: the `*` already
+    /// terminates the keyword token, so the argument abuts it.
+    #[test]
+    fn yield_delegate_needs_no_space() {
+        assert_eq!(emit_expr(yld(true, Some(ident("xs")))), "yield*xs;");
+    }
+
+    /// `yield*a.b` — a delegating yield's argument may be a member chain; it
+    /// binds tighter than assignment so it prints bare after `yield*`.
+    #[test]
+    fn yield_delegate_member_argument() {
+        let e = yld(true, Some(member(ident("a"), "b", false)));
+        assert_eq!(emit_expr(e), "yield*a.b;");
+    }
+
+    /// `yield a?b:c` — a conditional argument binds tighter than the sequence
+    /// floor (yield's operand grammar is an `AssignmentExpression`), so it
+    /// prints bare — no over-wrap.
+    #[test]
+    fn yield_conditional_argument_is_bare() {
+        let cond = Expression::ConditionalExpression(ConditionalExpression {
+            cv: None,
+            test: Box::new(ident("a")),
+            consequent: Box::new(ident("b")),
+            alternate: Box::new(ident("c")),
+        });
+        assert_eq!(emit_expr(yld(false, Some(cond))), "yield a?b:c;");
+    }
+
+    /// `yield a=b` — an assignment argument also prints bare (it is exactly at
+    /// the operand's assignment precedence).
+    #[test]
+    fn yield_assignment_argument_is_bare() {
+        let e = yld(false, Some(assign("a", AssignmentOperator::Eq, ident("b"))));
+        assert_eq!(emit_expr(e), "yield a=b;");
+    }
+
+    /// `yield (a,b)` — a **sequence** argument is the one form that must wrap:
+    /// it binds looser than the assignment-precedence operand floor.
+    #[test]
+    fn yield_sequence_argument_is_wrapped() {
+        let e = yld(false, Some(seq(vec![ident("a"), ident("b")])));
+        assert_eq!(emit_expr(e), "yield (a,b);");
+    }
+
+    /// `(yield a)+1` — the whole yield binds looser than `+`, so a binary parent
+    /// wraps it (`expr_prec` tags yield at `PREC_ASSIGNMENT`).
+    #[test]
+    fn yield_wrapped_as_binary_operand() {
+        let e = binary(BinaryOperator::Add, yld(false, Some(ident("a"))), num(1.0));
+        assert_eq!(emit_expr(e), "(yield a)+1;");
+    }
+
+    /// `(yield a).b` — a member parent binds at primary strength and wraps the
+    /// looser yield object.
+    #[test]
+    fn yield_wrapped_as_member_object() {
+        let e = member(yld(false, Some(ident("a"))), "b", false);
+        assert_eq!(emit_expr(e), "(yield a).b;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm
+
+Added an `Expression::YieldExpression` arm that rebuilds the node, preserving
+`delegate` and folding/recursing into the optional `argument` when present, so
+the pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.163 atomic node PR1). No behaviour change to any existing node; the
+yield argument is now visited/rewritten exactly like any other sub-expression
+the pass already handles.
+
+
 ## [0.85.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.5"
+version = "0.85.6"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -91,7 +91,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement,
+    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
@@ -567,6 +567,11 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
             cv: s.cv.clone(),
             argument: Box::new(fold_expression(&s.argument, st)),
+        }),
+        Expression::YieldExpression(y) => Expression::YieldExpression(YieldExpression {
+            cv: y.cv.clone(),
+            delegate: y.delegate,
+            argument: y.argument.as_ref().map(|a| Box::new(fold_expression(a, st))),
         }),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm
+
+Added an `Expression::YieldExpression` arm that rebuilds the node, preserving
+`delegate` and recursing into the optional `argument` when present, so the pass
+stays exhaustive over the new `javascript-ast` variant (part of the CLOC12.163
+atomic node PR1). No behaviour change to any existing node; the yield argument
+is now visited/rewritten exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.20.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.5"
+version = "0.20.6"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
-    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
@@ -1249,6 +1249,11 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         Expression::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
             cv: s.cv.clone(),
             argument: Box::new(dce_expression(&s.argument, st)),
+        }),
+        Expression::YieldExpression(y) => Expression::YieldExpression(YieldExpression {
+            cv: y.cv.clone(),
+            delegate: y.delegate,
+            argument: y.argument.as_ref().map(|a| Box::new(dce_expression(a, st))),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm
+
+Added an `Expression::YieldExpression` arm that rebuilds the node, preserving
+`delegate` and recursing into the optional `argument` when present, plus a
+matching arm in the `expression_cv` accessor, so the pass stays exhaustive over
+the new `javascript-ast` variant (part of the CLOC12.163 atomic node PR1). No
+behaviour change to any existing node; the yield argument is now
+visited/rewritten exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.20.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.5"
+version = "0.20.6"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -56,7 +56,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
-    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement,
+    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
@@ -277,6 +277,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         SequenceExpression(e) => e.cv.clone(),
         TaggedTemplateExpression(e) => e.cv.clone(),
         SpreadElement(e) => e.cv.clone(),
+        YieldExpression(y) => y.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1429,6 +1430,11 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
             cv: s.cv.clone(),
             argument: Box::new(fold_expression(&s.argument, st)),
+        }),
+        Expression::YieldExpression(y) => Expression::YieldExpression(YieldExpression {
+            cv: y.cv.clone(),
+            delegate: y.delegate,
+            argument: y.argument.as_ref().map(|a| Box::new(fold_expression(a, st))),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` traversal arms
+
+Added `Expression::YieldExpression` arms (2 across the pass's traversal
+routines) that walk into the yield's optional `argument` when present, so the
+pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.163 atomic node PR1). No behaviour change to any existing node; the
+yield argument is now visited exactly like any other sub-expression the pass
+already handles.
+
+
 ## [0.11.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -827,6 +827,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         }
         // Count uses of `name` inside the spread argument (`...name`).
         Expression::SpreadElement(s) => count_uses_expr(&s.argument, name, count),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { count_uses_expr(a, name, count); } }
     }
 }
 
@@ -1123,6 +1124,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         }
         // Propagate into the spread argument (`...name`).
         Expression::SpreadElement(s) => changed |= propagate_in_expr(&mut s.argument, cand),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { changed |= propagate_in_expr(a, cand); } }
     }
     changed
 }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` traversal arms
+
+Added `Expression::YieldExpression` arms (7 across the pass's traversal
+routines) that walk into the yield's optional `argument` when present, so the
+pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.163 atomic node PR1). No behaviour change to any existing node; the
+yield argument is now visited exactly like any other sub-expression the pass
+already handles.
+
+
 ## [0.25.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.5"
+version = "0.25.6"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -508,6 +508,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         }
         // `...arg` — the spread weighs exactly its single inner argument.
         Expression::SpreadElement(s) => expr_node_count(&s.argument),
+        Expression::YieldExpression(y) => y.argument.as_ref().map_or(0, |a| expr_node_count(a)),
     }
 }
 
@@ -842,6 +843,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         Expression::TaggedTemplateExpression(_) => {}
         // `...arg` — recurse into the spread argument to collect its bindings.
         Expression::SpreadElement(s) => collect_binding_idents_expr(&s.argument, out),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_binding_idents_expr(a, out); } }
     }
 }
 
@@ -1142,6 +1144,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         }
         // `...arg` — recurse into the spread argument to tally candidate uses.
         Expression::SpreadElement(s) => tally_expr(&s.argument, cand, t),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { tally_expr(a, cand, t); } }
     }
 }
 
@@ -1448,6 +1451,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         }
         // `...arg` — recurse into the spread argument to inline candidate calls.
         Expression::SpreadElement(s) => changed |= inline_in_expr(&mut s.argument, cand),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { changed |= inline_in_expr(a, cand); } }
     }
     changed
 }
@@ -1605,6 +1609,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         }
         // `...arg` — recurse into the spread argument to substitute through it.
         Expression::SpreadElement(s) => substitute(&mut s.argument, map),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { substitute(a, map); } }
     }
 }
 
@@ -1986,6 +1991,7 @@ fn expr_collect_mutated_params(
         }
         // `...arg` — recurse into the spread argument to find mutated params.
         Expression::SpreadElement(s) => expr_collect_mutated_params(&s.argument, params, out),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { expr_collect_mutated_params(a, params, out); } }
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
@@ -3458,6 +3464,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         }
         // `...arg` — recurse into the spread argument to alpha-rename through it.
         Expression::SpreadElement(s) => rename_in_expr(&mut s.argument, map),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rename_in_expr(a, map); } }
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` traversal arms
+
+Added `Expression::YieldExpression` arms (2 across the pass's traversal
+routines) that walk into the yield's optional `argument` when present, so the
+pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.163 atomic node PR1). No behaviour change to any existing node; the
+yield argument is now visited exactly like any other sub-expression the pass
+already handles.
+
+
 ## [0.10.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -747,6 +747,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         }
         // `...arg` — recurse into the spread argument to collect its idents.
         Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_all_idents_expr(a, out); } }
     }
 }
 
@@ -1079,6 +1080,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         }
         // `...arg` — recurse into the spread argument to rename globals through it.
         Expression::SpreadElement(s) => rename_apply_expr(&mut s.argument, map),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rename_apply_expr(a, map); } }
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` traversal arms
+
+Added `Expression::YieldExpression` arms (2 across the pass's traversal
+routines) that walk into the yield's optional `argument` when present, so the
+pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.163 atomic node PR1). No behaviour change to any existing node; the
+yield argument is now visited exactly like any other sub-expression the pass
+already handles.
+
+
 ## [0.12.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1256,6 +1256,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         }
         // `...arg` — recurse into the spread argument to classify accesses in it.
         Expression::SpreadElement(s) => classify_expr(&s.argument, cls),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { classify_expr(a, cls); } }
     }
 }
 
@@ -1523,6 +1524,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         }
         // `...arg` — recurse into the spread argument to rewrite accesses in it.
         Expression::SpreadElement(s) => rewrite_expr(&mut s.argument, map),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rewrite_expr(a, map); } }
     }
 }
 

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` traversal arms
+
+Added `Expression::YieldExpression` arms (2 across the pass's traversal
+routines) that walk into the yield's optional `argument` when present, so the
+pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.163 atomic node PR1). No behaviour change to any existing node; the
+yield argument is now visited exactly like any other sub-expression the pass
+already handles.
+
+
 ## [0.14.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -1028,6 +1028,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         }
         // `...arg` — recurse into the spread argument to collect its idents.
         Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_all_idents_expr(a, out); } }
     }
 }
 
@@ -1341,6 +1342,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         }
         // `...arg` — recurse into the spread argument to rewrite renamed uses in it.
         Expression::SpreadElement(s) => rewrite_uses_expr(&mut s.argument, map),
+        Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rewrite_uses_expr(a, map); } }
     }
 }
 

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.6] - 2026-07-03
+
+### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm
+
+Added an `Expression::YieldExpression` arm that walks into the yield's optional
+`argument` when present, so the analyzer stays exhaustive over the new
+`javascript-ast` variant (part of the CLOC12.163 atomic node PR1). No behaviour
+change to any existing node; the yield argument is now visited exactly like any
+other sub-expression the analyzer already handles.
+
+
 ## [0.12.5] - 2026-07-03
 
 ### Changed — CLOC12.162: `SpreadElement` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -943,6 +943,7 @@ fn walk_expression(
         }
         // `...arg` — recurse into the spread argument to resolve references in it.
         Expression::SpreadElement(s) => walk_expression(&s.argument, ctx, analysis, pending),
+        Expression::YieldExpression(y) => { if let Some(a) = &y.argument { walk_expression(a, ctx, analysis, pending); } }
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.22.0] - 2026-07-03
+
+### Added — CLOC12.163: `Expression::YieldExpression` (`yield` / `yield x` / `yield* xs`)
+
+New `YieldExpression { cv, delegate: bool, argument: Option<Box<Expression>> }`
+variant of `Expression` modelling a generator `yield` — a bare `yield`
+(`argument: None`, yields `undefined`), a value yield `yield x`
+(`argument: Some(x)`), and a delegating `yield* xs` (`delegate: true`). The
+argument is optional because a bare `yield` has no operand, and `delegate`
+distinguishes `yield` from `yield*`. Re-exported from the crate root. Atomic
+node PR (PR1): the node + `closure-emitter` emit + all nine downstream pass
+match-arms land in one commit so the workspace never breaks.
+
+
 ## [0.21.0] - 2026-07-03
 
 ### Added — CLOC12.162: `Expression::SpreadElement` (`...arg`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -94,6 +94,14 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   matching the assignment-position list slots it lives in. Node +
   `closure-emitter` + all pass traversals land in one atomic PR; the
   bridge-enable + conformance port follow (gap-163).
+- `YieldExpression` (CLOC12.163) — a generator `yield`: a bare `yield`, a value
+  `yield x`, or a delegating `yield* xs`.
+  `YieldExpression { delegate: bool, argument: Option<Box<Expression>> }` — the
+  `argument` is optional (a bare `yield` has no operand) and `delegate` splits
+  `yield` from `yield*`. It tags at `PREC_ASSIGNMENT` (a yield is loose, so a
+  tighter parent wraps the whole yield: `(yield a)+1`). Node + `closure-emitter`
+  + all pass traversals land in one atomic PR; the bridge-enable + conformance
+  port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -62,6 +62,7 @@ pub enum Expression {
     SequenceExpression(SequenceExpression),
     TaggedTemplateExpression(TaggedTemplateExpression),
     SpreadElement(SpreadElement),
+    YieldExpression(YieldExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -490,6 +491,57 @@ pub struct SpreadElement {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
     pub argument: Box<Expression>,
+}
+
+/// A `yield` expression — the pause/resume operator that only appears inside a
+/// generator function body:
+///
+/// ```text
+///   yield              a bare yield, no operand      (delegate = false, argument = None)
+///   yield value        yield a single value          (delegate = false, argument = Some)
+///   yield* iterable    delegate to another iterable  (delegate = true,  argument = Some)
+/// ```
+///
+/// # Two independent axes
+///
+/// A yield carries two bits of shape, kept as separate fields so the emitter
+/// and every AST walker can reason about them independently:
+///
+/// - **`delegate`** — `false` for `yield` / `yield x`, `true` for `yield* x`.
+///   The `*` turns a yield into a *delegating* yield that forwards every value
+///   its `argument` iterable produces. A delegating yield **must** have an
+///   argument (bare `yield*` is a syntax error); a non-delegating yield may or
+///   may not.
+/// - **`argument`** — `None` for a bare `yield`, `Some(expr)` otherwise. When
+///   present it is an `AssignmentExpression` in the grammar (the loosest
+///   operand), so the emitter prints it at assignment precedence.
+///
+/// | source        | delegate | argument      |
+/// |---------------|----------|---------------|
+/// | `yield`       | `false`  | `None`        |
+/// | `yield x`     | `false`  | `Some(x)`     |
+/// | `yield* xs`   | `true`   | `Some(xs)`    |
+///
+/// # Precedence
+///
+/// `yield` is an `AssignmentExpression` alternative in the grammar — it binds
+/// looser than every operator except the comma. The emitter therefore tags it
+/// at assignment precedence: as an assignment RHS or a conditional branch it
+/// prints bare (`x = yield v`, `c ? yield a : yield b`), but any tighter parent
+/// — a binary operand, a call argument that is *not* already an
+/// assignment-position slot, a member object — wraps it into `(yield v)`.
+///
+/// Like the other operand-carrying nodes we model `argument` as a `Box` to keep
+/// the `Expression` enum a fixed size regardless of how deep the yielded
+/// expression nests.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct YieldExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub delegate: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub argument: Option<Box<Expression>>,
 }
 
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,6 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
+    YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1953,3 +1953,71 @@ WHITESPACE_ONLY.
 **Scope:** object-spread `{...o}` in an object literal (`convert_property_definition`,
 gap tracked as `SpreadProperty`) remains declined — it is a *property*, a
 separate later slice; this PR is the call/array/`new` spread only.
+
+## CLOC12.163 — `YieldExpression` (`yield` / `yield*`): atomic node + emit + passes (PR1)
+
+Adds `Expression::YieldExpression { cv, delegate: bool, argument: Option<Box<Expression>> }`
+to `javascript-ast` (0.22.0) — the generator **yield** operator that pauses a
+generator and surrenders a value to its caller. Two independent axes are kept
+as separate fields so the emitter and every AST walker reason about them
+independently:
+
+| source        | `delegate` | `argument` |
+|---------------|------------|------------|
+| `yield`       | `false`    | `None`     |
+| `yield x`     | `false`    | `Some(x)`  |
+| `yield* xs`   | `true`     | `Some(xs)` |
+
+`delegate` is the `*` of a *delegating* yield (which forwards every value its
+argument iterable produces); `argument` is `None` only for a bare `yield`. The
+argument is boxed so the `Expression` enum stays a fixed size. The variant is
+re-exported from the crate root alongside the other expression nodes.
+
+`closure-emitter` (0.27.0) `emit_yield` prints the `yield` keyword, then the `*`
+for a delegate, then — if an argument is present — the argument at
+`PREC_ASSIGNMENT`. **Token separation:** a non-delegating `yield` needs a
+mandatory `required_ws()` before its argument (`yield x`; `yieldx` would be one
+identifier), while after a delegating `yield*` the `*` already terminates the
+keyword token so the argument abuts it (`yield*xs`). **Precedence:** `yield` is
+an `AssignmentExpression` alternative — the loosest-binding expression bar the
+comma — so a conditional or assignment argument prints bare
+(`yield a?b:c`, `yield a=b`) while the one looser form, a **sequence**, wraps
+(`yield (a,b)`). `expr_prec` tags the whole node at `PREC_ASSIGNMENT` (exactly
+like arrow / assignment), so a tighter parent wraps it — `(yield a)+1`,
+`(yield a).b` — with no local paren logic in `emit_yield`.
+
+All nine downstream pass/analysis crates get a `YieldExpression` match arm that
+recurses into the optional `argument` (the transforms — constant-fold, dce,
+fold-control-flow — rebuild the node preserving `delegate` and mapping over the
+`Option`; `fold-control-flow`'s exhaustive `expression_cv` accessor gains its
+arm; the traversal passes — inline, inline-variables, rename, rename-globals,
+rename-properties, scope-analyzer — walk into the argument when present) — all
+in one atomic commit so the workspace never has a broken exhaustive `match`.
+
+9 new emitter unit tests: bare `yield`, `yield x` (required space), `yield*xs`
+(no space), `yield*a.b` (delegate member arg), the assignment-precedence
+argument cases (`yield a?b:c` and `yield a=b` bare, `yield (a,b)` sequence
+wrapped), and the whole-node wraps in tighter parents (`(yield a)+1`,
+`(yield a).b`). No behaviour change for existing inputs — the bridge still
+declines yield (gap-164), so closurec falls back to WHITESPACE_ONLY on generator
+bodies for now. PR2 (bridge-enable) and PR3 (conformance port) follow.
+
+### gap-164 — bridge declines `yield` (`YieldExpression`) — **OPEN**
+
+The `javascript-parser` bridge does not yet convert a `yield` / `yield*`
+expression to `Expression::YieldExpression`; a generator body containing a
+`yield` drops the whole file to WHITESPACE_ONLY. The atomic node PR (CLOC12.163
+PR1) landed the node + emit + pass traversals so the typed AST and every
+downstream pass can already represent and print a yield.
+
+**PR2 (bridge-enable) — pending parseability check.** Unlike the preceding
+expression nodes, `yield` is only grammatical inside a generator function body
+(`function* g(){ … }`), so the bridge slice must first confirm the parser
+produces a generator-function parse tree with a reachable `yield`/`yield*`
+sub-node (analogous to the parse-tree dump that unblocked gap-163 for spread).
+If the parser does not yet admit generator bodies, PR2 waits on that grammar
+work and PR1's node remains exercised by hand-constructed AST (emitter unit
+tests) plus the PR3 conformance port — the same staging used for the
+substitution-template slice (gap-157). Note the existing WHITESPACE_ONLY path
+already strips redundant parens around a `yield` operand (gap-105); that is the
+token-level fallback, independent of this structured-AST node.


### PR DESCRIPTION
## CLOC12.163 PR1 — `YieldExpression` atomic node

First PR of the CLOC12.163 arc: adds the generator **yield** expression to the closurec JavaScript-minifier stack as an atomic node — the AST variant, the emitter, and match arms in **all 9 downstream passes** land in one commit so the workspace never has a broken exhaustive `match`.

### The node (`javascript-ast` 0.21.0 → 0.22.0, MINOR)
`Expression::YieldExpression { cv, delegate: bool, argument: Option<Box<Expression>> }` — the generator `yield` / `yield x` / `yield* xs`. Two independent axes:

| source      | `delegate` | `argument` |
|-------------|------------|------------|
| `yield`     | `false`    | `None`     |
| `yield x`   | `false`    | `Some(x)`  |
| `yield* xs` | `true`     | `Some(xs)` |

### The emitter (`closure-emitter` 0.26.1 → 0.27.0, MINOR)
`emit_yield` prints `yield`, then `*` for a delegate, then the argument at `PREC_ASSIGNMENT`:
- non-delegating `yield` emits a **mandatory** `required_ws()` before the argument (else `yieldx` fuses) → `yield x`
- after `yield*` the `*` self-terminates the keyword, so the argument abuts → `yield*xs`
- assignment-precedence argument: conditional/assignment print bare (`yield a?b:c`, `yield a=b`); a looser **sequence** wraps (`yield (a,b)`)
- `expr_prec` tags the whole node at `PREC_ASSIGNMENT` (like arrow/assignment), so tighter parents wrap it: `(yield a)+1`, `(yield a).b`

9 emitter unit tests cover every shape above.

### The 9 downstream passes (PATCH each)
constant-fold, dce, fold-control-flow, inline, inline-variables, rename, rename-globals, rename-properties, scope-analyzer each get a `YieldExpression` arm recursing into the optional `argument`. Rebuild passes reconstruct the node (preserving `delegate`, mapping over the `Option`); fold-control-flow also handles it in the exhaustive `expression_cv` accessor; traversal passes walk into the argument when present.

### Behaviour
No change for existing inputs — the bridge still declines `yield` (**gap-164**, OPEN, pending a generator-body parseability check), so closurec falls back to WHITESPACE_ONLY on generator bodies for now. Spec `CLOC12-gaps.md` gets the CLOC12.163 section + gap-164.

**PR2** (bridge-enable, contingent on the parseability check) and **PR3** (CodePrinter conformance port) follow.

### Verification
- `cargo test` green across `javascript-ast`, `closure-emitter`, and all 9 pass crates (9 new yield tests pass by name).
- Whole workspace (incl. closurec + remaining passes) compiles.
- Security review passed (no `unsafe`/I/O/unwrap; recursion mirrors the already-large-stack-protected `SpreadElement` arms; malformed AST handled gracefully).

🤖 Generated with [Claude Code](https://claude.com/claude-code)