### PR TITLE
feat(sql-spreadsheet-source): SSQL01 — query a spreadsheet with SQL

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -387,6 +387,7 @@ members = [
     "csv-parser",
     "sql-execution-engine",
     "sql-csv-source",
+    "sql-spreadsheet-source",
     "sql-backend",
     "sql-planner",
     "sql-optimizer",

--- a/code/packages/rust/sql-spreadsheet-source/BUILD
+++ b/code/packages/rust/sql-spreadsheet-source/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-sql-spreadsheet-source -- --nocapture

--- a/code/packages/rust/sql-spreadsheet-source/BUILD_windows
+++ b/code/packages/rust/sql-spreadsheet-source/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-sql-spreadsheet-source -- --nocapture

--- a/code/packages/rust/sql-spreadsheet-source/CHANGELOG.md
+++ b/code/packages/rust/sql-spreadsheet-source/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to `coding-adventures-sql-spreadsheet-source` are documented here.
+
+## [0.1.0] — SSQL01: query a spreadsheet with SQL
+
+### Added
+- New crate: a `DataSource` (for `sql-execution-engine`) that exposes each sheet
+  of a `spreadsheet-core::Workbook` as a SQL table — the sheet's first populated
+  row is the column header, the rows below are the data.
+- `SpreadsheetSource<'a>` (borrows a `&Workbook`) + `query(wb, sql) -> QueryResult`.
+- `CellValue → SqlValue` mapping: integral numbers → `Int`, else `Float`; text →
+  `Text`; bool → `Bool`; empty/error → `NULL`. Duplicate headers disambiguated
+  with a `_2` suffix.
+- Sparse iteration (`populated_cells`, never the dense used-range box), so a
+  sheet spanning a huge range but holding few cells scans in O(populated).
+- 13 tests + doctest: SELECT/WHERE(numeric+text)/GROUP BY+SUM/ORDER BY+LIMIT,
+  multi-sheet-as-multi-table, unknown-table error, blank→NULL, duplicate headers,
+  far-corner DoS guard, and an **end-to-end query over a `.xlsx` reopened via
+  spreadsheet-io**. An example (`query_xlsx`) runs SQL over a file on disk.

--- a/code/packages/rust/sql-spreadsheet-source/Cargo.toml
+++ b/code/packages/rust/sql-spreadsheet-source/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "coding-adventures-sql-spreadsheet-source"
+version = "0.1.0"
+edition = "2021"
+description = "Query a spreadsheet with SQL: a DataSource that exposes each sheet of a spreadsheet-core Workbook as a SQL table (header row = columns, data rows = rows) for the sql-execution-engine (SSQL01)"
+license = "MIT"
+
+[dependencies]
+spreadsheet-core = { path = "../spreadsheet-core" }
+coding-adventures-sql-execution-engine = { path = "../sql-execution-engine" }
+
+[dev-dependencies]
+# The end-to-end test loads a real .xlsx and runs SQL over it.
+spreadsheet-io = { path = "../spreadsheet-io" }

--- a/code/packages/rust/sql-spreadsheet-source/README.md
+++ b/code/packages/rust/sql-spreadsheet-source/README.md
@@ -1,0 +1,31 @@
+# sql-spreadsheet-source
+
+**Query a spreadsheet with SQL.** A `DataSource` that exposes each sheet of a
+`spreadsheet-core::Workbook` as a SQL table, so the existing `sql-execution-engine`
+can run `SELECT … FROM 'Sheet1' WHERE …` over a loaded `.xlsx`/`.xls`/CSV — or a
+live VisiCalc document.
+
+```rust
+use coding_adventures_sql_spreadsheet_source::query;
+
+// `wb` is a spreadsheet-core Workbook (e.g. from spreadsheet_io::load_xlsx).
+let result = query(&wb, "SELECT region, SUM(amount) FROM sales GROUP BY region")?;
+for row in &result.rows { /* HashMap<column, SqlValue> */ }
+```
+
+## Convention
+
+- **Sheet = table** (`FROM sales` → the `sales` sheet).
+- **First populated row = header** (column names); rows below are data.
+- `CellValue → SqlValue`: integral numbers → `Int`, else `Float`; text → `Text`;
+  bool → `Bool`; empty/error → `NULL`. Duplicate headers get a `_2` suffix.
+
+## Demo
+
+```
+cargo run -p coding-adventures-sql-spreadsheet-source --example query_xlsx -- \
+    sales.xlsx "SELECT rep, amount FROM sales WHERE amount > 100 ORDER BY amount DESC"
+```
+
+Pure and DoS-safe (iterates populated cells sparsely, never the dense used-range
+rectangle). See `code/specs/SSQL01-sql-spreadsheet-source.md`.

--- a/code/packages/rust/sql-spreadsheet-source/examples/query_xlsx.rs
+++ b/code/packages/rust/sql-spreadsheet-source/examples/query_xlsx.rs
@@ -1,0 +1,41 @@
+//! Run a SQL query over a real `.xlsx` file:
+//!
+//! ```text
+//! cargo run -p coding-adventures-sql-spreadsheet-source --example query_xlsx -- \
+//!     data.xlsx "SELECT region, SUM(amount) FROM sales GROUP BY region"
+//! ```
+//!
+//! Loads the workbook via `spreadsheet-io`, exposes each sheet as a SQL table,
+//! runs the query, and prints the result as a simple table. A demonstration that
+//! a spreadsheet on disk is directly queryable with SQL.
+
+use coding_adventures_sql_execution_engine::SqlPrimitive;
+use coding_adventures_sql_spreadsheet_source::query;
+
+fn cell(v: &Option<SqlPrimitive>) -> String {
+    match v {
+        None => "NULL".to_string(),
+        Some(SqlPrimitive::Int(i)) => i.to_string(),
+        Some(SqlPrimitive::Float(f)) => f.to_string(),
+        Some(SqlPrimitive::Text(s)) => s.clone(),
+        Some(SqlPrimitive::Bool(b)) => b.to_string(),
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let path = args.next().expect("usage: query_xlsx <file.xlsx> <SQL>");
+    let sql = args.next().expect("usage: query_xlsx <file.xlsx> <SQL>");
+
+    let bytes = std::fs::read(&path).expect("read file");
+    let wb = spreadsheet_io::load_xlsx(&bytes).expect("parse .xlsx");
+    let result = query(&wb, &sql).expect("run SQL");
+
+    println!("{}", result.columns.join(" | "));
+    println!("{}", "-".repeat(result.columns.join(" | ").len().max(3)));
+    for row in &result.rows {
+        let line: Vec<String> = result.columns.iter().map(|c| cell(&row[c])).collect();
+        println!("{}", line.join(" | "));
+    }
+    println!("({} row{})", result.rows.len(), if result.rows.len() == 1 { "" } else { "s" });
+}

--- a/code/packages/rust/sql-spreadsheet-source/required_capabilities.json
+++ b/code/packages/rust/sql-spreadsheet-source/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/sql-spreadsheet-source",
+  "capabilities": [],
+  "justification": "Pure computation. Adapts an in-memory spreadsheet-core Workbook to the SQL engine's DataSource trait (schema + scan). No filesystem, network, process, or environment access — the caller supplies the workbook and the SQL string."
+}

--- a/code/packages/rust/sql-spreadsheet-source/src/lib.rs
+++ b/code/packages/rust/sql-spreadsheet-source/src/lib.rs
@@ -1,0 +1,238 @@
+//! # `sql-spreadsheet-source` — query a spreadsheet with SQL
+//!
+//! This crate lets you run SQL over a live [`spreadsheet_core::Workbook`]: each
+//! **sheet becomes a table**, the sheet's **first populated row is the column
+//! header**, and the rows beneath it are the data. It is a thin
+//! [`DataSource`](coding_adventures_sql_execution_engine::DataSource) adapter —
+//! all the actual SQL (SELECT / WHERE / GROUP BY / ORDER BY / JOIN / aggregates)
+//! is the existing [`sql-execution-engine`](coding_adventures_sql_execution_engine).
+//! See `code/specs/SSQL01-sql-spreadsheet-source.md`.
+//!
+//! ```text
+//!   a Workbook (from a .xlsx/.xls/CSV, or edited live in VisiCalc)
+//!        │   each sheet = a table
+//!        ▼
+//!   SpreadsheetSource  ──impl DataSource──▶  sql-execution-engine::execute
+//!        │                                            │
+//!        └── header row → columns; data rows → rows   └── SELECT … FROM 'Sheet1' WHERE …
+//! ```
+//!
+//! ## Example
+//!
+//! ```
+//! use spreadsheet_core::{CellAddress, CellValue, Workbook};
+//! use coding_adventures_sql_spreadsheet_source::query;
+//!
+//! // A sheet laid out as a table: a header row, then data.
+//! let mut wb = Workbook::new();
+//! let s = wb.add_sheet("people");
+//! for (a1, v) in [("A1", "name"), ("B1", "age")] {
+//!     wb.set_value(s, CellAddress::parse(a1).unwrap(), CellValue::Text(v.into()));
+//! }
+//! wb.set_value(s, CellAddress::parse("A2").unwrap(), CellValue::Text("Ada".into()));
+//! wb.set_value(s, CellAddress::parse("B2").unwrap(), CellValue::Number(36.0));
+//! wb.set_value(s, CellAddress::parse("A3").unwrap(), CellValue::Text("Grace".into()));
+//! wb.set_value(s, CellAddress::parse("B3").unwrap(), CellValue::Number(45.0));
+//! wb.recalc_all();
+//!
+//! let result = query(&wb, "SELECT name FROM people WHERE age > 40").unwrap();
+//! assert_eq!(result.columns, vec!["name"]);
+//! assert_eq!(result.rows.len(), 1); // just Grace
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::collections::HashMap;
+
+use coding_adventures_sql_execution_engine::{
+    execute, DataSource, ExecutionError, QueryResult, SqlPrimitive, SqlValue,
+};
+use spreadsheet_core::{CellAddress, CellValue, SheetId, Workbook};
+
+// ===========================================================================
+// Value + header conversion
+// ===========================================================================
+
+/// Convert an engine [`CellValue`] to a nullable SQL value.
+///
+/// - `Empty` and `Error` become SQL `NULL` — a blank or a `#DIV/0!` is "no
+///   value" to a query.
+/// - A `Number` that is integral (and fits `i64`) becomes `Int`, else `Float`.
+///   This mirrors the CSV source's coercion, so `WHERE age = 40` (an integer
+///   literal) matches a spreadsheet `40` naturally.
+/// - `Boolean` and `Text` map straight across.
+fn cell_to_sql(v: CellValue) -> SqlValue {
+    match v {
+        CellValue::Empty | CellValue::Error(_) => None,
+        CellValue::Boolean(b) => Some(SqlPrimitive::Bool(b)),
+        CellValue::Text(s) => Some(SqlPrimitive::Text(s)),
+        CellValue::Number(n) => {
+            if n.fract() == 0.0 && n >= i64::MIN as f64 && n <= i64::MAX as f64 {
+                Some(SqlPrimitive::Int(n as i64))
+            } else {
+                Some(SqlPrimitive::Float(n))
+            }
+        }
+    }
+}
+
+/// The column name a header cell contributes. A header is normally text; a
+/// numeric or boolean header is stringified so it can still name a column. An
+/// empty header (which shouldn't occur, since we only read *populated* header
+/// cells) falls back to `col{n}`.
+fn header_name(v: CellValue, col: u32) -> String {
+    let name = match v {
+        CellValue::Text(s) => s.trim().to_string(),
+        CellValue::Number(n) => {
+            if n.fract() == 0.0 {
+                format!("{}", n as i64)
+            } else {
+                format!("{n}")
+            }
+        }
+        CellValue::Boolean(b) => if b { "TRUE" } else { "FALSE" }.to_string(),
+        CellValue::Empty | CellValue::Error(_) => String::new(),
+    };
+    if name.is_empty() {
+        format!("col{col}")
+    } else {
+        name
+    }
+}
+
+/// Make a header list unique: a repeated name gets a `_2`, `_3`, … suffix. The
+/// SQL row model is keyed by column name, so duplicates would otherwise collide
+/// and silently drop a column's data.
+fn dedupe(names: Vec<String>) -> Vec<String> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    names
+        .into_iter()
+        .map(|name| {
+            let c = counts.entry(name.clone()).or_insert(0);
+            *c += 1;
+            if *c == 1 {
+                name
+            } else {
+                format!("{name}_{c}")
+            }
+        })
+        .collect()
+}
+
+// ===========================================================================
+// The DataSource
+// ===========================================================================
+
+/// Exposes a [`Workbook`] to the SQL engine: each **sheet is a table** named by
+/// the sheet's name.
+///
+/// Layout convention: the sheet's **first populated row is the header** (column
+/// names), and every populated row below it is a data row. Columns are exactly
+/// the populated header cells — a data cell in a column with no header is
+/// ignored (SQL needs named columns); a data row is any row below the header
+/// that has at least one populated cell.
+///
+/// Borrows the workbook, so it is a zero-copy view — build one per query.
+pub struct SpreadsheetSource<'a> {
+    wb: &'a Workbook,
+}
+
+impl<'a> SpreadsheetSource<'a> {
+    /// View `wb`'s sheets as SQL tables.
+    pub fn new(wb: &'a Workbook) -> Self {
+        Self { wb }
+    }
+
+    /// Resolve a table name to a sheet id, or [`ExecutionError::TableNotFound`].
+    fn resolve(&self, table_name: &str) -> Result<SheetId, ExecutionError> {
+        self.wb
+            .sheet_id(table_name)
+            .ok_or_else(|| ExecutionError::TableNotFound(table_name.to_string()))
+    }
+
+    /// The `(column, name)` pairs and the header row index for `sheet`.
+    ///
+    /// Built from the header row's **populated** cells only — iterating the
+    /// sparse populated set, never the dense used-range rectangle, so a sheet
+    /// that spans a huge range but holds few cells costs `O(populated)`, not
+    /// `O(area)`. Returns an empty column list (and header row `1`) for an empty
+    /// sheet.
+    fn columns(&self, sheet: SheetId) -> (Vec<(u32, String)>, u32) {
+        let Some(used) = self.wb.used_range(sheet) else {
+            return (Vec::new(), 1);
+        };
+        let header_row = used.min_row;
+        // populated_cells is sorted by (row, col); the header cells are those in
+        // the header row, already in column order.
+        let raw: Vec<(u32, CellValue)> = self
+            .wb
+            .populated_cells(sheet)
+            .into_iter()
+            .filter(|addr| addr.row == header_row)
+            .map(|addr| {
+                let v = self.wb.get_value(sheet, addr).unwrap_or(CellValue::Empty);
+                (addr.col, v)
+            })
+            .collect();
+        let names = dedupe(raw.iter().map(|(c, v)| header_name(v.clone(), *c)).collect());
+        let cols = raw.into_iter().map(|(c, _)| c).zip(names).collect();
+        (cols, header_row)
+    }
+}
+
+impl DataSource for SpreadsheetSource<'_> {
+    fn schema(&self, table_name: &str) -> Result<Vec<String>, ExecutionError> {
+        let sheet = self.resolve(table_name)?;
+        let (cols, _) = self.columns(sheet);
+        Ok(cols.into_iter().map(|(_, name)| name).collect())
+    }
+
+    fn scan(&self, table_name: &str) -> Result<Vec<HashMap<String, SqlValue>>, ExecutionError> {
+        let sheet = self.resolve(table_name)?;
+        let (cols, header_row) = self.columns(sheet);
+
+        // The data rows are the distinct populated rows *below* the header —
+        // derived sparsely, so empty gaps in the range never materialise.
+        let mut data_rows: Vec<u32> = self
+            .wb
+            .populated_cells(sheet)
+            .into_iter()
+            .map(|addr| addr.row)
+            .filter(|&row| row > header_row)
+            .collect();
+        data_rows.sort_unstable();
+        data_rows.dedup();
+
+        let rows = data_rows
+            .into_iter()
+            .map(|row| {
+                cols.iter()
+                    .map(|(col, name)| {
+                        let v = self
+                            .wb
+                            .get_value(sheet, CellAddress::new(row, *col))
+                            .unwrap_or(CellValue::Empty);
+                        (name.clone(), cell_to_sql(v))
+                    })
+                    .collect::<HashMap<String, SqlValue>>()
+            })
+            .collect();
+        Ok(rows)
+    }
+}
+
+// ===========================================================================
+// Convenience
+// ===========================================================================
+
+/// Run one SQL statement over `wb` and return the result — the common case,
+/// equivalent to `execute(sql, &SpreadsheetSource::new(wb))`.
+///
+/// Table names in the SQL are sheet names (`FROM 'Sheet1'`). See
+/// [`coding_adventures_sql_execution_engine::execute`] for the supported SQL.
+pub fn query(wb: &Workbook, sql: &str) -> Result<QueryResult, ExecutionError> {
+    execute(sql, &SpreadsheetSource::new(wb))
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/sql-spreadsheet-source/src/tests.rs
+++ b/code/packages/rust/sql-spreadsheet-source/src/tests.rs
@@ -1,0 +1,221 @@
+//! Tests for querying a spreadsheet with SQL.
+
+use super::{query, SpreadsheetSource};
+use coding_adventures_sql_execution_engine::{execute, DataSource, ExecutionError, SqlPrimitive};
+use spreadsheet_core::{CellAddress, CellValue, Workbook};
+
+/// Build a `sales` sheet laid out as a table:
+///
+/// | region | rep   | amount |
+/// |--------|-------|--------|
+/// | West   | Ada   | 100    |
+/// | East   | Grace | 80     |
+/// | West   | Lin   | 150    |
+/// | East   | Ada   | 120    |
+fn sales_workbook() -> Workbook {
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("sales");
+    let rows = [
+        ("region", "rep", None),
+        ("West", "Ada", Some(100.0)),
+        ("East", "Grace", Some(80.0)),
+        ("West", "Lin", Some(150.0)),
+        ("East", "Ada", Some(120.0)),
+    ];
+    for (r, (a, b, amount)) in rows.iter().enumerate() {
+        let row = (r + 1) as u32;
+        wb.set_value(s, CellAddress::new(row, 1), CellValue::Text((*a).into()));
+        wb.set_value(s, CellAddress::new(row, 2), CellValue::Text((*b).into()));
+        match amount {
+            Some(n) => wb.set_value(s, CellAddress::new(row, 3), CellValue::Number(*n)),
+            None => wb.set_value(s, CellAddress::new(row, 3), CellValue::Text("amount".into())),
+        }
+    }
+    wb.recalc_all();
+    wb
+}
+
+fn int_of(v: &Option<SqlPrimitive>) -> i64 {
+    match v {
+        Some(SqlPrimitive::Int(i)) => *i,
+        other => panic!("expected Int, got {other:?}"),
+    }
+}
+fn text_of(v: &Option<SqlPrimitive>) -> String {
+    match v {
+        Some(SqlPrimitive::Text(s)) => s.clone(),
+        other => panic!("expected Text, got {other:?}"),
+    }
+}
+
+#[test]
+fn schema_is_the_header_row() {
+    let wb = sales_workbook();
+    let src = SpreadsheetSource::new(&wb);
+    assert_eq!(
+        src.schema("sales").unwrap(),
+        vec!["region".to_string(), "rep".to_string(), "amount".to_string()]
+    );
+}
+
+#[test]
+fn scan_returns_data_rows_only() {
+    let wb = sales_workbook();
+    let src = SpreadsheetSource::new(&wb);
+    let rows = src.scan("sales").unwrap();
+    assert_eq!(rows.len(), 4, "header row is excluded");
+    // Values are typed: amount is an integer, region is text.
+    let west = rows.iter().find(|r| text_of(&r["rep"]) == "Ada" && text_of(&r["region"]) == "West");
+    assert_eq!(int_of(&west.unwrap()["amount"]), 100);
+}
+
+#[test]
+fn select_star() {
+    let result = query(&sales_workbook(), "SELECT * FROM sales").unwrap();
+    assert_eq!(result.rows.len(), 4);
+    assert!(result.columns.contains(&"region".to_string()));
+}
+
+#[test]
+fn where_filters_numeric() {
+    let result = query(&sales_workbook(), "SELECT rep FROM sales WHERE amount > 100").unwrap();
+    // Lin (150) and Ada-East (120).
+    let reps: Vec<String> = result.rows.iter().map(|r| text_of(&r["rep"])).collect();
+    assert_eq!(result.rows.len(), 2);
+    assert!(reps.contains(&"Lin".to_string()));
+    assert!(reps.contains(&"Ada".to_string()));
+}
+
+#[test]
+fn where_filters_text() {
+    let result = query(&sales_workbook(), "SELECT amount FROM sales WHERE region = 'West'").unwrap();
+    let amounts: Vec<i64> = result.rows.iter().map(|r| int_of(&r["amount"])).collect();
+    assert_eq!(amounts.len(), 2);
+    assert!(amounts.contains(&100) && amounts.contains(&150));
+}
+
+#[test]
+fn aggregate_sum_group_by() {
+    let result =
+        query(&sales_workbook(), "SELECT region, SUM(amount) FROM sales GROUP BY region").unwrap();
+    assert_eq!(result.rows.len(), 2); // West, East
+    // Find the SUM column (name may be "SUM(amount)"); grab the aggregate value
+    // by locating the non-region column.
+    let sum_col = result.columns.iter().find(|c| c.as_str() != "region").unwrap().clone();
+    for r in &result.rows {
+        let region = text_of(&r["region"]);
+        let total = match &r[&sum_col] {
+            Some(SqlPrimitive::Int(i)) => *i as f64,
+            Some(SqlPrimitive::Float(f)) => *f,
+            other => panic!("unexpected sum {other:?}"),
+        };
+        match region.as_str() {
+            "West" => assert_eq!(total, 250.0), // 100 + 150
+            "East" => assert_eq!(total, 200.0), // 80 + 120
+            other => panic!("unexpected region {other}"),
+        }
+    }
+}
+
+#[test]
+fn order_by_and_limit() {
+    let result =
+        query(&sales_workbook(), "SELECT amount FROM sales ORDER BY amount DESC LIMIT 1").unwrap();
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(int_of(&result.rows[0]["amount"]), 150);
+}
+
+#[test]
+fn each_sheet_is_a_table() {
+    // Two sheets → two independently queryable tables.
+    let mut wb = sales_workbook();
+    let t = wb.add_sheet("targets");
+    wb.set_value(t, CellAddress::new(1, 1), CellValue::Text("region".into()));
+    wb.set_value(t, CellAddress::new(1, 2), CellValue::Text("goal".into()));
+    wb.set_value(t, CellAddress::new(2, 1), CellValue::Text("West".into()));
+    wb.set_value(t, CellAddress::new(2, 2), CellValue::Number(200.0));
+    wb.recalc_all();
+
+    let src = SpreadsheetSource::new(&wb);
+    assert_eq!(src.schema("targets").unwrap(), vec!["region", "goal"]);
+    assert_eq!(src.scan("targets").unwrap().len(), 1);
+    // The other table still works.
+    assert_eq!(src.scan("sales").unwrap().len(), 4);
+}
+
+#[test]
+fn unknown_sheet_is_table_not_found() {
+    let wb = sales_workbook();
+    let src = SpreadsheetSource::new(&wb);
+    assert!(matches!(src.schema("nope"), Err(ExecutionError::TableNotFound(_))));
+    assert!(matches!(
+        execute("SELECT * FROM nope", &src),
+        Err(ExecutionError::TableNotFound(_))
+    ));
+}
+
+#[test]
+fn empty_and_blank_cells_are_null() {
+    // A data row with a blank cell → that column is SQL NULL.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("t");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Text("a".into()));
+    wb.set_value(s, CellAddress::new(1, 2), CellValue::Text("b".into()));
+    wb.set_value(s, CellAddress::new(2, 1), CellValue::Text("x".into()));
+    // (2,2) left blank
+    wb.recalc_all();
+
+    let rows = SpreadsheetSource::new(&wb).scan("t").unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["a"], Some(SqlPrimitive::Text("x".into())));
+    assert_eq!(rows[0]["b"], None, "blank cell → NULL");
+}
+
+#[test]
+fn duplicate_headers_are_disambiguated() {
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("t");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Text("x".into()));
+    wb.set_value(s, CellAddress::new(1, 2), CellValue::Text("x".into())); // duplicate
+    wb.set_value(s, CellAddress::new(2, 1), CellValue::Number(1.0));
+    wb.set_value(s, CellAddress::new(2, 2), CellValue::Number(2.0));
+    wb.recalc_all();
+
+    let src = SpreadsheetSource::new(&wb);
+    assert_eq!(src.schema("t").unwrap(), vec!["x", "x_2"]);
+    let rows = src.scan("t").unwrap();
+    assert_eq!(int_of(&rows[0]["x"]), 1);
+    assert_eq!(int_of(&rows[0]["x_2"]), 2);
+}
+
+#[test]
+fn sparse_far_corner_does_not_blow_up() {
+    // Header row + one data row, but a stray cell far away (row 1,000,000).
+    // A dense scan would iterate a million rows; the sparse scan must stay fast
+    // and return exactly the real data rows.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("t");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Text("k".into()));
+    wb.set_value(s, CellAddress::new(2, 1), CellValue::Number(1.0));
+    wb.set_value(s, CellAddress::new(1_000_000, 1), CellValue::Number(9.0));
+    wb.recalc_all();
+
+    let rows = SpreadsheetSource::new(&wb).scan("t").unwrap(); // must return promptly
+    // Two data rows: the real one (row 2) and the far stray (row 1_000_000).
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn end_to_end_query_a_real_xlsx_file() {
+    // The headline: build a workbook, save it as a real .xlsx, reopen it via
+    // spreadsheet-io, and run SQL over the reopened file.
+    let bytes = {
+        let wb = sales_workbook();
+        spreadsheet_io::save_xlsx(&wb)
+    };
+    let wb = spreadsheet_io::load_xlsx(&bytes).expect("reopen .xlsx");
+    let result = query(&wb, "SELECT rep, amount FROM sales WHERE amount >= 120 ORDER BY amount")
+        .expect("SQL over the loaded spreadsheet");
+    let reps: Vec<String> = result.rows.iter().map(|r| text_of(&r["rep"])).collect();
+    assert_eq!(reps, vec!["Ada".to_string(), "Lin".to_string()]); // 120 then 150
+}

--- a/code/specs/SSQL01-sql-spreadsheet-source.md
+++ b/code/specs/SSQL01-sql-spreadsheet-source.md
@@ -1,0 +1,75 @@
+# SSQL01 — `sql-spreadsheet-source`: query a spreadsheet with SQL
+
+Lets you run SQL over a live [`spreadsheet_core::Workbook`] — the same model
+VisiCalc computes on and that `spreadsheet-io` loads `.xlsx`/`.xls`/(soon
+CSV/JSON) into. Each **sheet becomes a table**. It is a thin adapter: all the
+SQL is the existing `sql-execution-engine`; this crate only teaches it how to
+read a spreadsheet.
+
+```
+  a Workbook (a loaded .xlsx/.xls/CSV, or a live VisiCalc doc)
+       │  each sheet = a table
+       ▼
+  SpreadsheetSource : impl DataSource  ──▶  sql-execution-engine::execute
+       │                                          │
+       header row → columns; data rows → rows     SELECT … FROM 'Sheet1' WHERE …
+```
+
+## Public API
+
+```rust
+/// Views a workbook's sheets as SQL tables (borrows the workbook).
+pub struct SpreadsheetSource<'a> { /* &Workbook */ }
+impl<'a> SpreadsheetSource<'a> { pub fn new(wb: &'a Workbook) -> Self; }
+impl DataSource for SpreadsheetSource<'_> { /* schema, scan */ }
+
+/// Convenience: run one statement over a workbook.
+pub fn query(wb: &Workbook, sql: &str) -> Result<QueryResult, ExecutionError>;
+```
+
+`DataSource`, `QueryResult`, `SqlValue`, `ExecutionError` are re-used from
+`sql-execution-engine`; the SQL surface (SELECT / WHERE / GROUP BY / HAVING /
+ORDER BY / LIMIT / JOIN / COUNT·SUM·AVG·MIN·MAX) is whatever that engine
+supports.
+
+## The sheet-as-table convention
+
+- **Table name = sheet name.** `FROM sales` queries the sheet named `sales`; an
+  unknown name is `ExecutionError::TableNotFound`.
+- **Header = the first populated row.** Its populated cells define the columns,
+  left to right. A numeric/boolean header is stringified; duplicate headers get a
+  `_2`, `_3`, … suffix (the SQL row model is keyed by column name, so duplicates
+  must be disambiguated).
+- **Rows = the populated rows below the header.** A data cell under a column with
+  no header is ignored (SQL needs named columns).
+
+## Value mapping (`CellValue` → `SqlValue`)
+
+| `CellValue` | `SqlValue` |
+|-------------|-----------|
+| `Empty`     | `NULL` |
+| `Error(_)`  | `NULL` (an error is not a value) |
+| `Number(n)` integral, fits i64 | `Int(n)` |
+| `Number(n)` otherwise | `Float(n)` |
+| `Text(s)`   | `Text(s)` |
+| `Boolean(b)`| `Bool(b)` |
+
+Integral numbers become `Int` (not `Float`) so an integer literal in SQL
+(`WHERE age = 40`) matches a spreadsheet `40` — mirroring the CSV source's
+coercion.
+
+## Resource safety
+
+`schema`/`scan` iterate the sheet's **populated cells sparsely**
+(`populated_cells`), never the dense `used_range` rectangle. A sheet with a
+header, one data row, and a stray cell at row 1,000,000 has a ~1e6-row used
+range but scans in `O(populated + data_rows × columns)`. A test pins this
+(`sparse_far_corner_does_not_blow_up`) — the same DoS lesson as the file writers.
+
+## Non-goals
+
+- Writing query results back into a sheet (a future `dataframe`/range writer).
+- Type inference beyond per-cell mapping (a column of mixed Int/Float is left
+  mixed, exactly as the CSV source leaves it).
+- Cross-workbook joins from SQL text alone (a `DataSource` sees one workbook; the
+  engine's JOIN across that workbook's sheets works today).


### PR DESCRIPTION
**You can now run SQL over a spreadsheet.** New `DataSource` for the existing `sql-execution-engine` that exposes each sheet of a `spreadsheet-core::Workbook` as a SQL table — so a loaded `.xlsx`/`.xls` (via `spreadsheet-io`) or a live VisiCalc document is directly queryable.

```rust
let result = query(&wb, "SELECT region, SUM(amount) FROM sales GROUP BY region")?;
```

Demoed live over an **openpyxl-authored `.xlsx`**:
```
$ query_xlsx sales.xlsx "SELECT region, SUM(amount) FROM sales GROUP BY region ORDER BY region"
region | SUM(amount)
East | 200
West | 340
```

## Design (thin adapter — all SQL is the existing engine)
- **Sheet = table**, **first populated row = header**, rows below = data.
- `CellValue → SqlValue`: integral numbers → `Int` (else `Float`, so integer literals match), text → `Text`, bool → `Bool`, empty/error → `NULL`. Duplicate headers get a `_2` suffix.
- **DoS-safe:** iterates `populated_cells` **sparsely**, never the dense `used_range` rectangle — a sheet spanning a huge range but holding few cells scans in `O(populated)`. Pinned by a far-corner (row 1,000,000) test.
- Reuses `sql-execution-engine`'s full surface: SELECT / WHERE / GROUP BY / HAVING / ORDER BY / LIMIT / JOIN / COUNT·SUM·AVG·MIN·MAX.

## Verification
13 tests + doctest (SELECT/WHERE/GROUP+SUM/ORDER+LIMIT, multi-sheet=multi-table, unknown-table error, blank→NULL, duplicate headers, far-corner DoS guard, **end-to-end query over a `.xlsx` reopened via spreadsheet-io**). Pure computation, `#![forbid(unsafe_code)]`. Security review **passed, no findings**.

Part of turning `spreadsheet-core` into a universal tabular hub (query it with SQL; next: CSV/TSV/JSON I/O into the same core).