### PR TITLE
feat(spreadsheet-io): SSIOCSV01 — CSV/TSV load & save on the unified core

### DIFF
--- a/code/packages/rust/csv-parser/CHANGELOG.md
+++ b/code/packages/rust/csv-parser/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — csv-parser (Rust)
 
+## [0.1.1] — 2026-07-03
+
+### Added
+- `parse_records(source, delimiter) -> Result<Vec<Vec<String>>, CsvError>` — the
+  raw grid of records (rows of fields, header row included, no header→value
+  mapping). This exposes the internal `tokenise_rows` primitive that the
+  HashMap-returning `parse_csv` / `parse_csv_with_delimiter` are built on, for
+  callers that need column order and the header preserved (e.g. loading a CSV
+  into a positional spreadsheet grid, added in `spreadsheet-io` SSIO-CSV).
+  Purely additive; existing APIs unchanged.
+
 ## [0.1.0] — 2026-03-25
 
 ### Added

--- a/code/packages/rust/csv-parser/Cargo.toml
+++ b/code/packages/rust/csv-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-csv-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "CSV parser — a hand-rolled state machine parser for RFC 4180-style CSV files"
 

--- a/code/packages/rust/csv-parser/src/lib.rs
+++ b/code/packages/rust/csv-parser/src/lib.rs
@@ -294,6 +294,30 @@ pub fn parse_csv_with_delimiter(
     Ok(result)
 }
 
+/// Parse delimited text into its raw **grid of records** — a `Vec<Vec<String>>`
+/// of rows, each a list of field strings, in file order, with quoting/escaping
+/// resolved but **no header interpretation**.
+///
+/// This is the lower-level primitive that [`parse_csv`] / [`parse_csv_with_delimiter`]
+/// build their header→value maps on top of. Use it when you need column order
+/// and the header row itself preserved — e.g. loading a CSV into a positional
+/// grid (a spreadsheet), or a `DataSource` that reads the header separately.
+/// The first row is the header only by convention; this function does not treat
+/// it specially.
+///
+/// # Examples
+///
+/// ```
+/// use coding_adventures_csv_parser::parse_records;
+///
+/// let rows = parse_records("name,age\nAda,36\nGrace,45\n", ',').unwrap();
+/// assert_eq!(rows[0], vec!["name", "age"]);      // header row preserved
+/// assert_eq!(rows[2], vec!["Grace", "45"]);      // in column order
+/// ```
+pub fn parse_records(source: &str, delimiter: char) -> Result<Vec<Vec<String>>, CsvError> {
+    tokenise_rows(source, delimiter)
+}
+
 // ===========================================================================
 // Internal: tokenise_rows
 // ===========================================================================

--- a/code/packages/rust/spreadsheet-io/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-io/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `spreadsheet-io` are documented here.
 
+## [0.3.0] — SSIO-CSV: delimited text (CSV / TSV) load & save
+
+### Added
+- `load_csv` / `load_tsv` / `load_delimited(bytes, delimiter)` — read delimited
+  text into a one-sheet `Workbook` (field `(r,c)` → cell `(r+1,c+1)`); a numeric
+  field becomes `Number`, else `Text`, blank → empty. Via `csv-parser`'s new
+  `parse_records` (grid-preserving), so column order and the header row are kept.
+- `save_csv` / `save_tsv` / `save_delimited(&wb, delimiter)` — write the **first**
+  sheet's used range as delimited text; cells rendered as text (a formula as its
+  computed value, bool as `TRUE`/`FALSE`, error as its display text), fields
+  quoted per RFC 4180.
+- `IoError::Csv` variant.
+- 9 tests: coercion, number/text round-trip, RFC-4180 quoting round-trip (comma /
+  quote / newline), TSV, formula→value, first-sheet-only, invalid-UTF-8 rejection,
+  empty input, and a **CSV → .xlsx bridge** (any format in, any format out).
+
+### Notes / limitations
+- A CSV is a single positional grid: `save_csv` writes one sheet (others dropped —
+  use `.xlsx` for multi-sheet), has no formulas/booleans/types, and its size is
+  proportional to the used-range **area** (inherent to the dense format; callers
+  exposing it to untrusted workbooks should bound the used range first).
+
 ## [0.2.0] — SSIO02: legacy `.xls` (BIFF8) load & save
 
 ### Added

--- a/code/packages/rust/spreadsheet-io/Cargo.toml
+++ b/code/packages/rust/spreadsheet-io/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spreadsheet-io"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
-description = "The adapter layer that unifies every spreadsheet file format onto a single in-memory model: load/save .xlsx and legacy .xls straight to and from the spreadsheet-core engine VisiCalc computes on (SSIO01-02)"
+description = "The adapter layer that unifies every spreadsheet/tabular file format onto a single in-memory model: load/save .xlsx, legacy .xls, and CSV/TSV straight to and from the spreadsheet-core engine VisiCalc computes on (SSIO01-03)"
 license = "MIT"
 
 [dependencies]
@@ -11,3 +11,4 @@ coding-adventures-xlsx-eval = { path = "../xlsx-eval" }
 coding-adventures-xlsx-writer = { path = "../xlsx-writer" }
 xls = { path = "../xls" }
 xls-writer = { path = "../xls-writer" }
+coding-adventures-csv-parser = { path = "../csv-parser" }

--- a/code/packages/rust/spreadsheet-io/README.md
+++ b/code/packages/rust/spreadsheet-io/README.md
@@ -13,14 +13,17 @@ could talk to another. `spreadsheet-io` makes `spreadsheet-core::Workbook` the
 live workbook:
 
 ```text
-  .xlsx ──load_xlsx──┐                              ┌──save_xlsx──▶ .xlsx
-                     ├─▶  spreadsheet-core::Workbook ─┤
-  .xls  ──load_xls───┘     (THE model)               └──save_xls───▶ .xls
+  .xlsx ──load_xlsx────┐                              ┌────save_xlsx──▶ .xlsx
+  .xls  ──load_xls─────┤─▶  spreadsheet-core::Workbook ─┤────save_xls───▶ .xls
+  .csv/.tsv ─load_csv──┘        (THE model)             └────save_csv───▶ .csv/.tsv
 ```
 
-Both modern `.xlsx` (SSIO01) and legacy `.xls`/BIFF8 (SSIO02) are supported.
-`.xlsx` preserves live formulas; `.xls` is lower-fidelity (values only — see
-below).
+Modern `.xlsx` (SSIO01), legacy `.xls`/BIFF8 (SSIO02), and delimited `.csv`/`.tsv`
+(SSIOCSV01) are supported. `.xlsx` preserves live formulas; `.xls` and CSV are
+lower-fidelity (values only — see below). Because everything lands in the one
+`Workbook`, any format loads and any format saves: `load_csv` then `save_xlsx`
+converts a CSV to Excel, and a loaded sheet is queryable with SQL via
+`sql-spreadsheet-source`.
 
 It is the *only* crate that depends on both the engine and the file-format
 codecs, so the engine never learns what a `.xlsx` is and each codec stays small.

--- a/code/packages/rust/spreadsheet-io/src/lib.rs
+++ b/code/packages/rust/spreadsheet-io/src/lib.rs
@@ -78,6 +78,9 @@ pub enum IoError {
     /// compound file, a missing/short workbook stream, or a malformed record.
     /// Carries the underlying message for diagnostics.
     Xls(String),
+    /// The delimited-text (CSV/TSV) bytes could not be read — not valid UTF-8,
+    /// or malformed CSV structure. Carries the underlying message.
+    Csv(String),
 }
 
 impl std::fmt::Display for IoError {
@@ -85,6 +88,7 @@ impl std::fmt::Display for IoError {
         match self {
             IoError::Xlsx(msg) => write!(f, "failed to load .xlsx: {msg}"),
             IoError::Xls(msg) => write!(f, "failed to load .xls: {msg}"),
+            IoError::Csv(msg) => write!(f, "failed to load CSV/TSV: {msg}"),
         }
     }
 }
@@ -335,6 +339,159 @@ pub fn save_xls(wb: &Workbook) -> Vec<u8> {
     }
 
     xls_writer::write_xls(&out)
+}
+
+// ===========================================================================
+// Delimited text (CSV / TSV) — load & save
+// ===========================================================================
+//
+// A CSV/TSV is a single positional grid, so it maps to a one-sheet workbook:
+// field (r, c) → cell (r+1, c+1). There is no formula, type, or multi-sheet
+// notion in the format, so:
+//   - load coerces each field to a Number (if it parses) or Text; blank → empty.
+//   - save writes the FIRST sheet's used range, cells rendered as text. Other
+//     sheets are dropped (use .xlsx for multi-sheet); formulas save as their
+//     computed value.
+
+/// Decide the cell value for a raw CSV field: an empty field is a blank cell; a
+/// field that parses as a number becomes `Number` (so a spreadsheet import of
+/// `42` is numeric, and `007` becomes `7` just as Excel would); everything else
+/// is `Text`.
+fn coerce_field(field: &str) -> CellValue {
+    if field.is_empty() {
+        CellValue::Empty
+    } else if let Ok(n) = field.parse::<f64>() {
+        CellValue::Number(n)
+    } else {
+        CellValue::Text(field.to_string())
+    }
+}
+
+/// Render one cell's computed value as a CSV field string (before quoting).
+fn cell_to_field(v: CellValue) -> String {
+    match v {
+        CellValue::Empty => String::new(),
+        CellValue::Number(n) => {
+            if n.fract() == 0.0 && n.is_finite() {
+                format!("{}", n as i64)
+            } else {
+                format!("{n}")
+            }
+        }
+        CellValue::Text(s) => s,
+        CellValue::Boolean(b) => if b { "TRUE" } else { "FALSE" }.to_string(),
+        CellValue::Error(e) => e.display().to_string(),
+    }
+}
+
+/// Quote a field per RFC 4180 if it contains the delimiter, a quote, or a
+/// newline: wrap in `"` and double any internal `"`. Otherwise return it as-is.
+fn csv_quote(field: &str, delimiter: char) -> String {
+    let needs = field.contains(delimiter)
+        || field.contains('"')
+        || field.contains('\n')
+        || field.contains('\r');
+    if needs {
+        format!("\"{}\"", field.replace('"', "\"\""))
+    } else {
+        field.to_string()
+    }
+}
+
+/// Load delimited text (`delimiter` = `,` for CSV, `\t` for TSV, …) into a
+/// one-sheet [`Workbook`] named `Sheet1`. Each field lands at its grid position
+/// (row 1 = the first line); a field that looks numeric becomes a `Number`,
+/// otherwise `Text`; a blank field is an empty cell.
+///
+/// # Errors
+///
+/// [`IoError::Csv`] if the bytes are not valid UTF-8 or the CSV is malformed.
+pub fn load_delimited(bytes: &[u8], delimiter: char) -> Result<Workbook, IoError> {
+    let text = std::str::from_utf8(bytes).map_err(|e| IoError::Csv(e.to_string()))?;
+    let rows = coding_adventures_csv_parser::parse_records(text, delimiter)
+        .map_err(|e| IoError::Csv(format!("{e:?}")))?;
+
+    let mut wb = Workbook::new();
+    let sheet = wb.add_sheet("Sheet1");
+    for (r, row) in rows.iter().enumerate() {
+        // 1-based, checked: a field past the u32 address space (a >4-billion-row
+        // or -column CSV) can't be placed and is skipped rather than wrapping to
+        // a wrong, colliding address.
+        let Ok(row_i) = u32::try_from(r + 1) else {
+            continue;
+        };
+        for (c, field) in row.iter().enumerate() {
+            let value = coerce_field(field);
+            if value == CellValue::Empty {
+                continue;
+            }
+            let Ok(col_i) = u32::try_from(c + 1) else {
+                continue;
+            };
+            wb.set_value(sheet, CellAddress::new(row_i, col_i), value);
+        }
+    }
+    wb.recalc_all();
+    Ok(wb)
+}
+
+/// Load a `.csv` (comma-delimited) file. See [`load_delimited`].
+pub fn load_csv(bytes: &[u8]) -> Result<Workbook, IoError> {
+    load_delimited(bytes, ',')
+}
+
+/// Load a `.tsv` (tab-delimited) file. See [`load_delimited`].
+pub fn load_tsv(bytes: &[u8]) -> Result<Workbook, IoError> {
+    load_delimited(bytes, '\t')
+}
+
+/// Serialize the workbook's **first sheet** to delimited text using `delimiter`.
+///
+/// The output is the sheet's used range as a positional grid — line `r` holds
+/// row `r`, each cell rendered as text (a formula as its computed value, a
+/// boolean as `TRUE`/`FALSE`, an error as its display text), fields quoted per
+/// RFC 4180 where needed, rows joined with `\n`.
+///
+/// **Size note:** because a CSV is a *dense* positional grid, its size is
+/// proportional to the used-range **area**. A sheet with a far-flung cell
+/// therefore yields a correspondingly large CSV — inherent to the format, unlike
+/// the sparse `.xlsx` writer. Callers exposing this to untrusted workbooks
+/// should bound the used range first.
+pub fn save_delimited(wb: &Workbook, delimiter: char) -> Vec<u8> {
+    let Some(first) = wb.sheet_names().first().and_then(|n| wb.sheet_id(n)) else {
+        return Vec::new(); // no sheets → empty file
+    };
+    let Some(ur) = wb.used_range(first) else {
+        return Vec::new(); // empty sheet → empty file
+    };
+
+    let delim = delimiter.to_string();
+    let mut out = String::new();
+    for row in ur.min_row..=ur.max_row {
+        if row > ur.min_row {
+            out.push('\n');
+        }
+        for col in ur.min_col..=ur.max_col {
+            if col > ur.min_col {
+                out.push_str(&delim);
+            }
+            let value = wb
+                .get_value(first, CellAddress::new(row, col))
+                .unwrap_or(CellValue::Empty);
+            out.push_str(&csv_quote(&cell_to_field(value), delimiter));
+        }
+    }
+    out.into_bytes()
+}
+
+/// Serialize the first sheet to `.csv` (comma-delimited). See [`save_delimited`].
+pub fn save_csv(wb: &Workbook) -> Vec<u8> {
+    save_delimited(wb, ',')
+}
+
+/// Serialize the first sheet to `.tsv` (tab-delimited). See [`save_delimited`].
+pub fn save_tsv(wb: &Workbook) -> Vec<u8> {
+    save_delimited(wb, '\t')
 }
 
 #[cfg(test)]

--- a/code/packages/rust/spreadsheet-io/src/tests.rs
+++ b/code/packages/rust/spreadsheet-io/src/tests.rs
@@ -5,7 +5,9 @@
 //! formulas*. We also assert the writer is idempotent (re-saving the reopened
 //! workbook is byte-identical) and cover the documented edge cases.
 
-use super::{load_xls, load_xlsx, save_xls, save_xlsx};
+use super::{
+    load_csv, load_tsv, load_xls, load_xlsx, save_csv, save_tsv, save_xls, save_xlsx,
+};
 use spreadsheet_core::{CellAddress, CellValue, SheetId, Workbook};
 
 /// Build the canonical test workbook: two sheets, numbers, text, and a live
@@ -453,4 +455,119 @@ fn biff_error_code_mapping() {
     assert_eq!(super::biff_error_to_core(0x0F), Value);
     assert_eq!(super::biff_error_to_core(0x24), Num);
     assert_eq!(super::biff_error_to_core(0xFF), Value); // unknown → generic
+}
+
+// =========================================================================
+// Delimited text (CSV / TSV) — SSIO-CSV
+// =========================================================================
+
+fn cell(wb: &Workbook, a1: &str) -> CellValue {
+    let s = wb.sheet_id("Sheet1").unwrap();
+    wb.get_value(s, CellAddress::parse(a1).unwrap())
+        .unwrap_or(CellValue::Empty)
+}
+
+#[test]
+fn csv_loads_grid_with_type_coercion() {
+    let wb = load_csv(b"name,age,active\nAda,36,yes\nGrace,45,no\n").unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Text("name".into())); // header stays text
+    assert_eq!(cell(&wb, "A2"), CellValue::Text("Ada".into()));
+    assert_eq!(cell(&wb, "B2"), CellValue::Number(36.0)); // numeric field → Number
+    assert_eq!(cell(&wb, "C2"), CellValue::Text("yes".into()));
+}
+
+#[test]
+fn csv_round_trips_numbers_and_text() {
+    let original = b"region,amount\nWest,100\nEast,80.5\n";
+    let wb = load_csv(original).unwrap();
+    let out = save_csv(&wb);
+    // Numbers render without trailing .0; text unchanged.
+    assert_eq!(out, b"region,amount\nWest,100\nEast,80.5", "{}", String::from_utf8_lossy(&out));
+    // And reloading yields the same values.
+    let wb2 = load_csv(&out).unwrap();
+    assert_eq!(cell(&wb2, "B2"), CellValue::Number(100.0));
+    assert_eq!(cell(&wb2, "B3"), CellValue::Number(80.5));
+}
+
+#[test]
+fn csv_quotes_fields_that_need_it() {
+    // A field with a comma, a quote, and a newline must be RFC-4180 quoted.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("Sheet1");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Text("a,b".into()));
+    wb.set_value(s, CellAddress::new(1, 2), CellValue::Text("he said \"hi\"".into()));
+    wb.set_value(s, CellAddress::new(2, 1), CellValue::Text("line1\nline2".into()));
+    wb.recalc_all();
+
+    let out = String::from_utf8(save_csv(&wb)).unwrap();
+    assert_eq!(out, "\"a,b\",\"he said \"\"hi\"\"\"\n\"line1\nline2\",");
+    // Round-trips: the quoting is understood on the way back in.
+    let wb2 = load_csv(out.as_bytes()).unwrap();
+    assert_eq!(cell(&wb2, "A1"), CellValue::Text("a,b".into()));
+    assert_eq!(cell(&wb2, "B1"), CellValue::Text("he said \"hi\"".into()));
+    assert_eq!(cell(&wb2, "A2"), CellValue::Text("line1\nline2".into()));
+}
+
+#[test]
+fn tsv_uses_tabs() {
+    let wb = load_tsv(b"a\tb\n1\t2\n").unwrap();
+    assert_eq!(cell(&wb, "A2"), CellValue::Number(1.0));
+    assert_eq!(cell(&wb, "B2"), CellValue::Number(2.0));
+    let out = save_tsv(&wb);
+    assert_eq!(out, b"a\tb\n1\t2");
+}
+
+#[test]
+fn csv_formula_saves_as_computed_value() {
+    // A CSV has no formulas: the computed value is written.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("Sheet1");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Number(10.0));
+    wb.set_value(s, CellAddress::new(1, 2), CellValue::Number(20.0));
+    wb.set_formula(s, CellAddress::new(1, 3), "=A1+B1").unwrap();
+    wb.recalc_all();
+    assert_eq!(save_csv(&wb), b"10,20,30");
+}
+
+#[test]
+fn csv_save_writes_only_first_sheet() {
+    let mut wb = Workbook::new();
+    let s1 = wb.add_sheet("Sheet1");
+    wb.set_value(s1, CellAddress::new(1, 1), CellValue::Text("first".into()));
+    let s2 = wb.add_sheet("Sheet2");
+    wb.set_value(s2, CellAddress::new(1, 1), CellValue::Text("second".into()));
+    wb.recalc_all();
+    assert_eq!(save_csv(&wb), b"first");
+}
+
+#[test]
+fn csv_load_rejects_invalid_utf8() {
+    match load_csv(&[0xff, 0xfe, 0x00]) {
+        Ok(_) => panic!("invalid UTF-8 must not load as CSV"),
+        Err(e) => {
+            assert!(matches!(e, super::IoError::Csv(_)));
+            assert!(e.to_string().contains("failed to load CSV/TSV"));
+        }
+    }
+}
+
+#[test]
+fn csv_empty_input_is_empty_workbook() {
+    let wb = load_csv(b"").unwrap();
+    let s = wb.sheet_id("Sheet1").unwrap();
+    assert!(wb.used_range(s).is_none());
+    assert_eq!(save_csv(&wb), b"");
+}
+
+#[test]
+fn csv_to_xlsx_bridge() {
+    // A CSV loaded into the engine can be saved right back out as a real .xlsx —
+    // the whole point of a single hub: any format in, any format out.
+    let wb = load_csv(b"h1,h2\n1,two\n").unwrap();
+    let xlsx = save_xlsx(&wb);
+    assert_eq!(&xlsx[..2], b"PK");
+    let reopened = load_xlsx(&xlsx).unwrap();
+    let s = reopened.sheet_id("Sheet1").unwrap();
+    assert_eq!(reopened.get_value(s, CellAddress::new(2, 1)), Some(CellValue::Number(1.0)));
+    assert_eq!(reopened.get_value(s, CellAddress::new(2, 2)), Some(CellValue::Text("two".into())));
 }

--- a/code/specs/SSIOCSV01-delimited-text.md
+++ b/code/specs/SSIOCSV01-delimited-text.md
@@ -1,0 +1,60 @@
+# SSIOCSV01 — `spreadsheet-io`: delimited text (CSV / TSV) load & save
+
+Extends `spreadsheet-io` (which unified `.xlsx`/`.xls` onto `spreadsheet-core`)
+with **CSV / TSV**, so the same engine reads and writes plain delimited tables —
+the first step of "read and process any tabular format, export any tabular
+format" onto the one core. A CSV loaded this way is editable in VisiCalc,
+queryable with SQL (`sql-spreadsheet-source`), and re-exportable as `.xlsx`.
+
+## API (added)
+
+```rust
+pub fn load_csv(bytes: &[u8]) -> Result<Workbook, IoError>;
+pub fn load_tsv(bytes: &[u8]) -> Result<Workbook, IoError>;
+pub fn load_delimited(bytes: &[u8], delimiter: char) -> Result<Workbook, IoError>;
+
+pub fn save_csv(wb: &Workbook) -> Vec<u8>;
+pub fn save_tsv(wb: &Workbook) -> Vec<u8>;
+pub fn save_delimited(wb: &Workbook, delimiter: char) -> Vec<u8>;
+```
+
+`IoError` gains a `Csv(String)` variant (invalid UTF-8 / malformed CSV).
+
+## Model: a CSV is a one-sheet positional grid
+
+- **Load** parses the bytes with `csv-parser`'s new `parse_records` (the
+  grid-level primitive — rows of fields, in order, header row included), then
+  writes each field to sheet `Sheet1` at `(r+1, c+1)`. A field that parses as a
+  number becomes `Number` (so `42` is numeric and `007` becomes `7`, as a
+  spreadsheet import would); anything else is `Text`; a blank field is an empty
+  cell. There is no header, formula, or type notion — a CSV is just a grid.
+- **Save** writes the **first** sheet's used range as lines of delimited fields.
+  Each cell is rendered as text: a formula as its **computed value**, a number
+  without a trailing `.0`, a boolean as `TRUE`/`FALSE`, an error as its display
+  text. Fields containing the delimiter, a `"`, or a newline are quoted per
+  **RFC 4180** (wrapped in `"`, internal `"` doubled). Rows join with `\n`.
+
+## Round-trip & interop
+
+Numbers and text round-trip exactly (`load_csv(save_csv(wb))` preserves values);
+RFC-4180 quoting round-trips (a field with a comma/quote/newline survives). The
+output is exactly what Python's `csv` module (same RFC 4180) reads, and a
+`csv → .xlsx` bridge test proves any-format-in / any-format-out.
+
+## Limitations (documented + tested)
+
+- **One sheet.** A CSV holds a single table; `save_csv` writes the first sheet
+  and drops the rest — use `.xlsx` for multi-sheet.
+- **No types/formulas/booleans-as-such.** Formulas save as their value; booleans
+  save as `TRUE`/`FALSE` and reload as text; a numeric-looking string loads as a
+  number (leading zeros lost) — the standard spreadsheet-CSV bargain.
+- **Size = used-range area.** A CSV is dense and positional, so a sheet with a
+  far-flung cell yields a correspondingly large CSV (inherent to the format,
+  unlike the sparse `.xlsx` writer). A caller exposing `save_csv` to untrusted
+  workbooks should bound the used range first.
+
+## Non-goals
+
+- Delimiter/encoding sniffing (the caller picks `,`/`\t`/…; UTF-8 only).
+- Header-aware typing of columns (that lives in `sql-spreadsheet-source`, which
+  reads the header row as SQL column names).


### PR DESCRIPTION
Extends `spreadsheet-io` with **CSV / TSV**, so the same `spreadsheet-core` engine reads and writes plain delimited tables too — the first step of your "read/process/export **any** tabular format" ask onto the one hub. A CSV loaded here is editable in VisiCalc, **queryable with SQL** (`sql-spreadsheet-source`), and **re-exportable as `.xlsx`**.

## API
- `load_csv` / `load_tsv` / `load_delimited(bytes, delim)` → `Workbook` (a CSV is a one-sheet positional grid; numeric fields → `Number`, else `Text`).
- `save_csv` / `save_tsv` / `save_delimited(&wb, delim)` → bytes (first sheet's used range; formula → computed value, bool → `TRUE`/`FALSE`; RFC-4180 quoting).
- `IoError::Csv`.

## csv-parser 0.1.0 → 0.1.1 (additive)
Exposes `parse_records(source, delimiter) → Vec<Vec<String>>` — the grid primitive the HashMap API was already built on — for callers needing column order + the header row. Existing consumer (`sql-csv-source`) unaffected.

## Verification
36 tests (9 new): coercion, number/text round-trip, **RFC-4180 quoting round-trip** (comma/quote/newline), TSV, formula→value, first-sheet-only, invalid-UTF-8 rejection, empty, and a **CSV → `.xlsx` bridge** (any format in, any format out). Interop: our output is exactly what Python's `csv` reads (same RFC 4180). Load uses **checked `u32::try_from`** (a >4-billion-row CSV skips un-addressable cells, no wrap). Security review **passed**.

## Limitations (documented + tested)
Single sheet; no types/formulas (formulas save as value); CSV size = used-range **area** (inherent to the dense positional format — bound the range before exporting untrusted workbooks).

Completes the tabular trio landing on one core: **`.xlsx` / `.xls` / CSV in and out, query it with SQL, edit it in VisiCalc.**