### PR TITLE
feat(closurec): CLOC12.163 PR2 — bridge generators + yield (closes gap-164)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.28.0] - 2026-07-04
+
+### Added — CLOC12.163 PR2: bridge generator functions and `yield` (closes gap-164)
+
+The bridge now converts `generator_declaration` / `generator_expression`
+(sharing the function converter; a `*` token sets the `generator` flag and is
+skipped during name extraction) and `yield_expression` →
+`Expression::YieldExpression` (delegate = the node carries a `*`; the operand
+is the sole child node), instead of declining these to `UnsupportedSyntax` and
+dragging the whole file to WHITESPACE_ONLY. 5 new bridge unit tests (generator
+declaration with `yield`, delegating `yield*`, binary yield operand, generator
+expression in value position, and a plain-function-is-not-a-generator guard).
+Known grammar limitation: a bare operand-less `yield` (`function*g(){yield;}`)
+does not parse — the grammar's `yield_expression` production requires an
+operand — so the bridge only ever produces `Some(argument)`; tracked as a
+separate grammar gap.
+
 ## [0.27.0] - 2026-07-03
 
 ### Added — CLOC12.162 PR2: bridge spread `...arg` → `SpreadElement` (closes gap-163)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -62,7 +62,7 @@ use coding_adventures_javascript_ast::{
         PropertyKey, PropertyKind, SequenceExpression, SpreadElement, StringLiteral, TaggedTemplateExpression,
         TemplateElement, TemplateLiteral,
         UnaryExpression, UnaryOperator,
-        UndefinedLiteral, UpdateExpression, UpdateOperator,
+        UndefinedLiteral, UpdateExpression, UpdateOperator, YieldExpression,
     },
     statement::{
         BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,
@@ -233,7 +233,10 @@ fn convert_source_element(node: &GrammarASTNode) -> Result<ProgramItem, BridgeEr
     // Alternation → exactly one child Node.
     let child = sole_node(node).ok_or_else(|| internal(node, "expected 1 child"))?;
     match child.rule_name.as_str() {
-        "function_declaration" => {
+        // `function_declaration` and `generator_declaration` share the same
+        // converter — the `*` distinguishes them and sets the `generator` flag
+        // (CLOC12.163 PR2).
+        "function_declaration" | "generator_declaration" => {
             let decl = convert_function_declaration(child)?;
             Ok(ProgramItem::Declaration(Declaration::FunctionDeclaration(decl)))
         }
@@ -903,15 +906,27 @@ fn convert_lexical_declaration(node: &GrammarASTNode) -> Result<VariableDeclarat
 // =========================================================================
 
 fn convert_function_declaration(node: &GrammarASTNode) -> Result<FunctionDeclaration, BridgeError> {
-    // function_declaration = "function" NAME LPAREN [ formal_parameters ] RPAREN
-    //                        LBRACE function_body RBRACE ;
-    // Token children include "function", NAME, "(", ")", "{", "}"
+    // function_declaration  = "function"     NAME LPAREN [ formal_parameters ] RPAREN
+    //                         LBRACE function_body RBRACE ;
+    // generator_declaration = "function" "*" NAME LPAREN [ formal_parameters ] RPAREN
+    //                         LBRACE function_body RBRACE ;
+    // Token children include "function", (optional "*"), NAME, "(", ")", "{", "}"
     // Node children: optional formal_parameters, then function_body
+    //
+    // The two rules share this converter: a `*` token marks a generator
+    // (CLOC12.163 PR2). We skip it during name extraction and record it in the
+    // `generator` flag so the emitter re-prints `function*`.
 
-    // Extract function name from token children (skip "function").
+    // Extract function name from token children (skip "function" and the
+    // generator "*").
     let name = node.children.iter().find_map(|c| match c {
         ASTNodeOrToken::Token(t)
-            if t.value != "function" && t.value != "(" && t.value != ")" && t.value != "{" && t.value != "}" =>
+            if t.value != "function"
+                && t.value != "*"
+                && t.value != "("
+                && t.value != ")"
+                && t.value != "{"
+                && t.value != "}" =>
         {
             Some(t.value.clone())
         }
@@ -945,22 +960,27 @@ fn convert_function_declaration(node: &GrammarASTNode) -> Result<FunctionDeclara
         id: Identifier { cv: None, name },
         params,
         body,
-        generator: false,
+        generator: has_token(node, "*"),
         is_async: false,
     })
 }
 
 fn convert_function_expression(node: &GrammarASTNode) -> Result<FunctionExpression, BridgeError> {
-    // function_expression = "function" [ NAME ] LPAREN [ formal_parameters ] RPAREN
-    //                       LBRACE function_body RBRACE ;
+    // function_expression  = "function"     [ NAME ] LPAREN [ formal_parameters ] RPAREN
+    //                        LBRACE function_body RBRACE ;
+    // generator_expression = "function" "*" [ NAME ] LPAREN [ formal_parameters ] RPAREN
+    //                        LBRACE function_body RBRACE ;
     // Structurally identical to `function_declaration` (see above) with ONE
     // difference: the NAME is OPTIONAL. `function () {}` is anonymous;
     // `function f () {}` in value position binds `f` only inside its own body
     // (a body-local self-reference for recursion), never in the enclosing
     // scope. So a missing name is NOT an error here — it's the common case.
+    // As with declarations, a `*` marks a generator expression (CLOC12.163 PR2):
+    // skip it during name extraction and record it in `generator`.
     let name = node.children.iter().find_map(|c| match c {
         ASTNodeOrToken::Token(t)
             if t.value != "function"
+                && t.value != "*"
                 && t.value != "("
                 && t.value != ")"
                 && t.value != "{"
@@ -997,9 +1017,47 @@ fn convert_function_expression(node: &GrammarASTNode) -> Result<FunctionExpressi
         id: name.map(|name| Identifier { cv: None, name }),
         params,
         body,
-        generator: false,
+        generator: has_token(node, "*"),
         is_async: false,
     })
+}
+
+// ---------------------------------------------------------------------
+// YieldExpression (CLOC12.163 PR2 — bridge enable, gap-164)
+// ---------------------------------------------------------------------
+
+/// Convert a `yield_expression` grammar node into a [`YieldExpression`].
+///
+/// The parse tree has one of two shapes (confirmed by dumping the grammar
+/// parser's output for `function*g(){yield x}` / `function*g(){yield* xs}`):
+///
+/// ```text
+///   yield x     yield_expression = [ Token("yield"),            Node(assignment_expression) ]
+///   yield* xs   yield_expression = [ Token("yield"), Token("*"), Node(assignment_expression) ]
+/// ```
+///
+/// So `delegate` is simply "does the node carry a `*` token", and the operand
+/// is the sole child *node* (`node_children` skips the `yield` / `*` tokens).
+///
+/// **Operand is mandatory in this grammar.** A bare operand-less `yield` does
+/// *not* parse today — the grammar's `yield_expression` production requires an
+/// `assignment_expression` operand (`function*g(){yield;}` is a parse error).
+/// The typed AST models `argument` as `Option` (a bare `yield` is legal ES),
+/// but the bridge only ever produces `Some(_)` until the grammar admits the
+/// operand-less form. If a future grammar change yields an operand-less node,
+/// the `node_children().next()` below returns `None` and we surface an internal
+/// error rather than silently mis-converting.
+fn convert_yield_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> {
+    let delegate = has_token(node, "*");
+    let operand = node_children(node)
+        .into_iter()
+        .next()
+        .ok_or_else(|| internal(node, "yield_expression: missing operand"))?;
+    Ok(Expression::YieldExpression(YieldExpression {
+        cv: None,
+        delegate,
+        argument: Some(Box::new(convert_expression(operand)?)),
+    }))
 }
 
 // ---------------------------------------------------------------------
@@ -1304,6 +1362,21 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
             convert_function_expression(node).map(Expression::FunctionExpression)
         }
 
+        // A generator function in value position (`x = function*(){…}`,
+        // `(function*(){…})()`). Same converter as `function_expression` — the
+        // `*` sets the `generator` flag so the emitter re-prints `function*`
+        // (CLOC12.163 PR2, gap-164).
+        "generator_expression" => {
+            convert_function_expression(node).map(Expression::FunctionExpression)
+        }
+
+        // A `yield` / `yield* x` expression inside a generator body
+        // (CLOC12.163 PR2, gap-164). Now that the typed AST has
+        // `Expression::YieldExpression` (CLOC12.163 PR1) and the bridge
+        // converts the enclosing generator function, convert the yield instead
+        // of declining.
+        "yield_expression" => convert_yield_expression(node),
+
         // Concise-body arrow function (CLOC12.152). `convert_arrow_function`
         // itself declines the ambiguous `() => {}` / object-body case and
         // (until the grammar parses them) never sees a block body.
@@ -1328,9 +1401,7 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
         // no-substitution templates are handled above by
         // `convert_template_literal`.)
         "async_arrow_function"
-        | "yield_expression"
         | "await_expression"
-        | "generator_expression"
         | "async_function_expression"
         | "async_generator_expression"
         | "class_expression"
@@ -4438,5 +4509,103 @@ mod tests {
     #[test]
     fn single_operand_not_a_sequence() {
         assert!(matches!(sole_expr("a;"), Expression::Identifier(i) if i.name == "a"));
+    }
+
+    // ---- Generators + yield (CLOC12.163 PR2, closes gap-164) -----------
+
+    use coding_adventures_javascript_ast::statement::TaggedStatement;
+
+    /// Bridge `src`, expect a single generator/function *declaration*, and
+    /// return `(generator_flag, first_body_expression)`.
+    fn gen_decl(src: &str) -> (bool, Expression) {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Declaration(Declaration::FunctionDeclaration(f)) => {
+                let expr = match &f.body.body[0] {
+                    Statement::Tagged(TaggedStatement::ExpressionStatement(es)) => {
+                        es.expression.clone()
+                    }
+                    other => panic!("expected an expression statement in body, got {other:?}"),
+                };
+                (f.generator, expr)
+            }
+            other => panic!("expected a FunctionDeclaration, got {other:?}"),
+        }
+    }
+
+    /// `function*g(){yield x;}` bridges to a *generator* `FunctionDeclaration`
+    /// (no longer declined) whose body holds a non-delegating `YieldExpression`
+    /// over `x`.
+    #[test]
+    fn generator_declaration_with_yield() {
+        let (is_gen, expr) = gen_decl("function*g(){yield x;}");
+        assert!(is_gen, "function* must set the generator flag");
+        match expr {
+            Expression::YieldExpression(y) => {
+                assert!(!y.delegate, "`yield x` is not delegating");
+                assert!(matches!(y.argument.as_deref(),
+                    Some(Expression::Identifier(i)) if i.name == "x"));
+            }
+            other => panic!("expected YieldExpression, got {other:?}"),
+        }
+    }
+
+    /// `function*g(){yield* xs;}` bridges to a **delegating** `YieldExpression`
+    /// (the `*` sets `delegate`).
+    #[test]
+    fn generator_declaration_with_delegate_yield() {
+        let (is_gen, expr) = gen_decl("function*g(){yield* xs;}");
+        assert!(is_gen);
+        match expr {
+            Expression::YieldExpression(y) => {
+                assert!(y.delegate, "`yield*` is delegating");
+                assert!(matches!(y.argument.as_deref(),
+                    Some(Expression::Identifier(i)) if i.name == "xs"));
+            }
+            other => panic!("expected delegating YieldExpression, got {other:?}"),
+        }
+    }
+
+    /// The yield operand is bridged in full — `yield a + b` carries a
+    /// `BinaryExpression` operand (the bridge does not fold; that is a pass's
+    /// job), so a downstream fold pass can still optimise it.
+    #[test]
+    fn yield_binary_operand_bridged() {
+        let (_, expr) = gen_decl("function*g(){yield a + b;}");
+        match expr {
+            Expression::YieldExpression(y) => {
+                assert!(matches!(y.argument.as_deref(), Some(Expression::BinaryExpression(_))));
+            }
+            other => panic!("expected YieldExpression, got {other:?}"),
+        }
+    }
+
+    /// A **generator expression** in value position (`x = function*(){yield 1;}`)
+    /// bridges to a `FunctionExpression` with `generator == true` — no longer
+    /// declined.
+    #[test]
+    fn generator_expression_in_value_position() {
+        match sole_expr("x = function*(){yield 1;};") {
+            Expression::AssignmentExpression(a) => match &*a.right {
+                Expression::FunctionExpression(f) => {
+                    assert!(f.generator, "function* expression must set the generator flag");
+                }
+                other => panic!("expected a generator FunctionExpression RHS, got {other:?}"),
+            },
+            other => panic!("expected AssignmentExpression, got {other:?}"),
+        }
+    }
+
+    /// A **plain** (non-generator) function declaration keeps `generator ==
+    /// false` — the `*`-detection does not misfire on `function g(){}`.
+    #[test]
+    fn plain_function_is_not_a_generator() {
+        let p = bridge_ok("function g(){return 1;}");
+        match &p.body[0] {
+            ProgramItem::Declaration(Declaration::FunctionDeclaration(f)) => {
+                assert!(!f.generator, "a plain function is not a generator");
+            }
+            other => panic!("expected a FunctionDeclaration, got {other:?}"),
+        }
     }
 }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.3] - 2026-07-04
+
+### Added — CLOC12.163 PR2: generator/`yield` end-to-end fixture
+
+Generator functions and `yield` now flow through the full SIMPLE/ADVANCED
+pipeline (via the javascript-parser 0.28.0 bridge) instead of falling back to
+WHITESPACE_ONLY. New e2e diff fixture `tests/diff/simple-yield/` proving
+`use(function*(){yield 1 + 2;})` → `use(function*(){yield 3})` at SIMPLE: the
+generator prints as `function*`, the `yield` round-trips, and the operand
+`1 + 2` folds to `3` (a WHITESPACE_ONLY fallback would leave `yield 1+2`
+verbatim). Version-sync: `cli.spec.json` and the `--help_markdown` fixture
+bumped to 0.234.3.
+
 ## [0.234.2] - 2026-07-03
 
 ### Added — CLOC12.162 PR2: spread end-to-end fixture

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.2"
+version = "0.234.3"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.2",
+  "version": "0.234.3",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.2
+Version: 0.234.3
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-yield/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-yield/expected.stdout
@@ -1,0 +1,1 @@
+use(function*(){yield 3});

--- a/code/programs/rust/closurec/tests/diff/simple-yield/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-yield/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-yield/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-yield/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-yield/input/a.js
@@ -1,0 +1,1 @@
+use(function*(){yield 1 + 2;});

--- a/code/programs/rust/closurec/tests/diff_simple_yield.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_yield.rs
@@ -1,0 +1,82 @@
+//! Integration test for the `tests/diff/simple-yield/` fixture.
+//!
+//! Exercises CLOC12.163 PR2 — a **generator function** and its **`yield`**
+//! (`YieldExpression`) now flow through the full SIMPLE pipeline (parser →
+//! typed-AST bridge → passes → emitter) instead of declining at the bridge and
+//! dragging the whole file to WHITESPACE_ONLY (gap-164, now closed).
+//!
+//! The fixture is `use(function*(){yield 1 + 2;});` — a retained call (an
+//! unknown `use(...)` has side effects, so DCE keeps it) whose argument is a
+//! generator expression whose body yields the foldable `1 + 2`. Three facts
+//! prove the pipeline ran end-to-end rather than falling back:
+//!   1. the generator prints as `function*` (the bridge set the `generator`
+//!      flag), and
+//!   2. the `yield` round-trips (the bridge produced a real `YieldExpression`
+//!      rather than declining), and
+//!   3. the yield operand `1 + 2` folds to `3`.
+//! A WHITESPACE_ONLY fallback — which a bridge decline would force for the
+//! *whole file* — would instead re-emit the source verbatim, leaving `1 + 2`
+//! unfolded (`yield 1+2`).
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-yield/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_yield_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-yield/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture. Strip spaces so the checks are
+    // insensitive to inter-token whitespace.
+    let a = actual.replace(' ', "");
+    // (1) the generator marker survived — proving the bridge converted the
+    //     generator function rather than declining to WHITESPACE_ONLY.
+    assert!(
+        a.contains("function*"),
+        "generator `function*` did not round-trip: {actual}"
+    );
+    // (2) the yield survived — proving the bridge produced a real
+    //     `YieldExpression`.
+    assert!(
+        a.contains("yield"),
+        "`yield` did not round-trip: {actual}"
+    );
+    // (3) the operand folded — proving the SIMPLE pipeline ran over the
+    //     generator body (`1 + 2` → `3`), not a verbatim WHITESPACE_ONLY pass.
+    assert!(
+        a.contains("yield3"),
+        "yield operand `1 + 2` did not fold to `3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded `1+2` present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2002,22 +2002,52 @@ wrapped), and the whole-node wraps in tighter parents (`(yield a)+1`,
 declines yield (gap-164), so closurec falls back to WHITESPACE_ONLY on generator
 bodies for now. PR2 (bridge-enable) and PR3 (conformance port) follow.
 
-### gap-164 — bridge declines `yield` (`YieldExpression`) — **OPEN**
+### gap-164 — bridge declines `yield` (`YieldExpression`) — **RESOLVED (javascript-parser 0.28.0, CLOC12.163 PR2)**
 
-The `javascript-parser` bridge does not yet convert a `yield` / `yield*`
-expression to `Expression::YieldExpression`; a generator body containing a
-`yield` drops the whole file to WHITESPACE_ONLY. The atomic node PR (CLOC12.163
-PR1) landed the node + emit + pass traversals so the typed AST and every
-downstream pass can already represent and print a yield.
+The `javascript-parser` bridge declined a `yield` / `yield*` expression (and the
+enclosing generator function), returning `UnsupportedSyntax` and dropping the
+whole file to WHITESPACE_ONLY. The atomic node PR (CLOC12.163 PR1) landed the
+node + emit + pass traversals so the typed AST and every downstream pass could
+already represent and print a yield.
 
-**PR2 (bridge-enable) — pending parseability check.** Unlike the preceding
-expression nodes, `yield` is only grammatical inside a generator function body
-(`function* g(){ … }`), so the bridge slice must first confirm the parser
-produces a generator-function parse tree with a reachable `yield`/`yield*`
-sub-node (analogous to the parse-tree dump that unblocked gap-163 for spread).
-If the parser does not yet admit generator bodies, PR2 waits on that grammar
-work and PR1's node remains exercised by hand-constructed AST (emitter unit
-tests) plus the PR3 conformance port — the same staging used for the
-substitution-template slice (gap-157). Note the existing WHITESPACE_ONLY path
-already strips redundant parens around a `yield` operand (gap-105); that is the
-token-level fallback, independent of this structured-AST node.
+**Parseability check (the gate).** Unlike the preceding expression nodes,
+`yield` is only grammatical inside a generator function body
+(`function* g(){ … }`). Dumping the grammar parser's output confirmed:
+`function*g(){}` parses (`generator_declaration`), and `function*g(){yield x;}`
+/ `function*g(){yield* xs;}` parse with a **reachable `yield_expression`
+node** — shape `[ Token("yield"), Node(assignment_expression) ]`, and delegate
+`[ Token("yield"), Token("*"), Node(assignment_expression) ]`. So both operand
+forms are parseable.
+
+**Fix (CLOC12.163 PR2):** two joined bridge changes, because a bare
+`yield_expression` conversion alone would still fall back to WHITESPACE_ONLY —
+the *enclosing* `generator_declaration` / `generator_expression` was itself
+declined. So this slice bridges both:
+1. `convert_source_element` and `convert_expression` route
+   `generator_declaration` / `generator_expression` through the existing
+   function converters; a `*` token sets the `generator` flag (skipped during
+   name extraction). The emitter already re-prints `function*`
+   (`emit_function_declaration` / `emit_function_expression`), so no emit change
+   was needed.
+2. `convert_yield_expression` wraps the node as `Expression::YieldExpression`
+   (`delegate = has_token(node, "*")`, operand = the sole child node via
+   `node_children`).
+
+5 bridge unit tests (generator declaration with `yield`, delegating `yield*`,
+binary yield operand, generator expression in value position, plain-function
+non-generator guard), plus a closurec e2e diff fixture
+(`tests/diff/simple-yield/`) proving `use(function*(){yield 1 + 2;})` →
+`use(function*(){yield 3})` at SIMPLE: the generator prints `function*`, the
+`yield` round-trips, and the operand `1 + 2` folds to `3` — proving the whole
+file ran through the pipeline rather than WHITESPACE_ONLY.
+
+**Known grammar limitation (separate gap).** A bare operand-less `yield`
+(`function*g(){yield;}`) does **not** parse today — the grammar's
+`yield_expression` production requires an `assignment_expression` operand.
+`Expression::YieldExpression` models `argument` as `Option` (a bare `yield` is
+legal ES), but the bridge only ever produces `Some(_)` until the grammar admits
+the operand-less form; `convert_yield_expression` surfaces an internal error
+rather than mis-converting if a future operand-less node ever appears. Tracked
+as a grammar gap, distinct from this structured-AST slice. (The existing
+WHITESPACE_ONLY path also strips redundant parens around a `yield` operand,
+gap-105 — a token-level fallback independent of this node.)


### PR DESCRIPTION
## CLOC12.163 PR2 — bridge generators + `yield` (closes gap-164)

Completes the CLOC12.163 arc: PR1 (#7585, merged) landed the `YieldExpression` node + emitter + 9 passes; this PR makes `yield` **genuinely reachable end-to-end** by teaching the `javascript-parser` bridge to convert generator functions and `yield`. A generator body now flows through the full closurec pipeline instead of declining at the bridge and dragging the whole file to WHITESPACE_ONLY.

### Parseability check (the gate)
Dumping the grammar parser's output confirmed:
- `function*g(){}` parses (`generator_declaration`)
- `function*g(){yield x;}` / `function*g(){yield* xs;}` parse with a **reachable `yield_expression`** node — shape `[Token("yield"), (Token("*")), Node(assignment_expression)]`.

(A bare operand-less `yield;` does *not* parse — the grammar requires an operand — noted as a separate grammar gap.)

### Two joined bridge changes
A bare `yield_expression` conversion alone would still fall back, because the *enclosing* generator function was itself declined. So this slice bridges both:

1. **Generator functions.** `convert_source_element` / `convert_expression` route `generator_declaration` / `generator_expression` through the existing function converters; a `*` token sets the `generator` flag (and is skipped during name extraction). The emitter **already** re-prints `function*` (`emit_function_declaration` / `_expression`) — so no emit change was needed.
2. **Yield.** `convert_yield_expression` wraps the node as `Expression::YieldExpression` (`delegate = has_token(node, "*")`, operand = the sole child node).

### Verification
- **5 bridge unit tests**: generator declaration with `yield`, delegating `yield*`, binary yield operand, generator expression in value position, and a plain-function-is-not-a-generator guard.
- **closurec e2e diff fixture** (`tests/diff/simple-yield/`) proving `use(function*(){yield 1 + 2;})` → `use(function*(){yield 3})` at SIMPLE: the generator prints `function*`, the `yield` round-trips, and the operand `1 + 2` folds to `3` — proving the whole file ran through the pipeline, not a verbatim WHITESPACE_ONLY pass.
- `cargo test` green: `javascript-parser` (139) + `closurec` (all fixtures incl. the new one + version-bumped `--help_markdown`).
- Security review passed (generator-flag `has_token` inspects only direct token children; graceful error on a would-be operand-less yield; no new recursion class).

### Scope / versions
`javascript-parser` 0.27.0 → **0.28.0** (MINOR); `closurec` 0.234.2 → **0.234.3** (PATCH; `cli.spec.json` + `--help_markdown` fixture synced). Spec **gap-164 flipped OPEN → RESOLVED**; the operand-less-`yield` grammar limitation recorded as a distinct gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)