### PR TITLE
feat(closurec): CLOC12.164 PR1 — AwaitExpression (await x) atomic node + emit + 9 passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.28.0] - 2026-07-04
+
+### Added — CLOC12.164: emit `AwaitExpression` (`await x`)
+
+Emit `Expression::AwaitExpression` via new `emit_await` — `await ` + operand,
+printed like the word-unaries typeof/void/delete: a mandatory keyword↔operand
+space, operand at `PREC_UNARY` so a looser binary operand wraps (`await (a+b)`)
+while member/call operands print bare (`await a.b`, `await f()`). `expr_prec`
+tags await at `PREC_UNARY` so it binds tighter than binary parents
+(`await a+b`) but member/call/new parents wrap it (`(await p).x`, `(await f)()`).
+8 new unit tests. (CLOC12.164)
+
+
 ## [0.27.1] - 2026-07-04
 
 ### Added — CLOC12.163 PR3: CodePrinter yield conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.27.1"
+version = "0.28.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -78,7 +78,7 @@ use coding_adventures_javascript_ast::{
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
-    TaggedTemplateExpression, SpreadElement, YieldExpression,
+    TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1138,6 +1138,7 @@ impl<'a> Emitter<'a> {
             Expression::TaggedTemplateExpression(t) => self.emit_tagged_template(t),
             Expression::SpreadElement(s) => self.emit_spread(s),
             Expression::YieldExpression(y) => self.emit_yield(y),
+            Expression::AwaitExpression(a) => self.emit_await(a),
         }
         if needs_parens {
             self.write_str(")");
@@ -1606,6 +1607,25 @@ impl<'a> Emitter<'a> {
         }
     }
 
+    /// Emit an `AwaitExpression` — `await x`.
+    ///
+    /// `await` is a *word-shaped* unary operator, so — exactly like
+    /// `typeof` / `void` / `delete` in [`emit_unary`] — it always needs a
+    /// mandatory separator before its operand, or the keyword would fuse into
+    /// one identifier (`awaitx`). We emit `required_ws()` then the operand at
+    /// `PREC_UNARY`, so a looser operand is parenthesised (`await (a+b)` for the
+    /// binary `a+b`), while a member / call / unary operand prints bare
+    /// (`await a.b`, `await f()`, `await -x`). The wrapping of the *whole* await
+    /// in a tighter parent — `(await p).x`, `(await f)()` — is handled by
+    /// `expr_prec` (which tags it at `PREC_UNARY`) plus `emit_expression_inner`,
+    /// the same machinery that wraps a `typeof`/`void` in those positions.
+    fn emit_await(&mut self, a: &AwaitExpression) {
+        self.maybe_map(&a.cv);
+        self.write_str("await");
+        self.required_ws();
+        self.emit_expression_inner(&a.argument, PREC_UNARY);
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -2045,6 +2065,12 @@ fn expr_prec(e: &Expression) -> u8 {
         // emitted at `PREC_ASSIGNMENT` — leave it bare (`x=yield v`,
         // `c?yield a:yield b`). This mirrors the arrow / assignment tags exactly.
         Expression::YieldExpression(_) => PREC_ASSIGNMENT,
+        // `await x` is a unary operator in the grammar (`await UnaryExpression`),
+        // binding exactly like the word unaries `typeof` / `void` / `delete`.
+        // Tag it at `PREC_UNARY` so a member/call/new parent wraps the whole
+        // await (`(await p).x`, `(await f)()`) while a binary/assignment parent
+        // leaves it bare (`await a+b` = `(await a)+b`, `x=await p`).
+        Expression::AwaitExpression(_) => PREC_UNARY,
         // `true`/`false` are emitted as `!0`/`!1` (see `emit_boolean`), which
         // are UnaryExpressions — precedence `PREC_UNARY`, NOT primary. Tagging
         // them here is what makes `emit_expression_inner` parenthesise them in
@@ -4956,5 +4982,70 @@ mod tests {
     fn yield_wrapped_as_member_object() {
         let e = member(yld(false, Some(ident("a"))), "b", false);
         assert_eq!(emit_expr(e), "(yield a).b;");
+    }
+
+    // =================================================================
+    // AwaitExpression (`await x`) — CLOC12.164
+    // =================================================================
+
+    /// Build an `AwaitExpression` (named `aw` — `await` is a Rust keyword).
+    fn aw(argument: Expression) -> Expression {
+        Expression::AwaitExpression(AwaitExpression { cv: None, argument: Box::new(argument) })
+    }
+
+    /// `await p` — the keyword and operand are separated by a mandatory space
+    /// (`awaitp` would be one identifier).
+    #[test]
+    fn await_value_requires_space() {
+        assert_eq!(emit_expr(aw(ident("p"))), "await p;");
+    }
+
+    /// `await a.b` — a member operand binds tighter than unary, so it prints
+    /// bare after `await`.
+    #[test]
+    fn await_member_operand_is_bare() {
+        assert_eq!(emit_expr(aw(member(ident("a"), "b", false))), "await a.b;");
+    }
+
+    /// `await f()` — a call operand also binds tighter than unary → bare.
+    #[test]
+    fn await_call_operand_is_bare() {
+        assert_eq!(emit_expr(aw(call(ident("f"), vec![]))), "await f();");
+    }
+
+    /// `await (a+b)` — a **binary** operand binds looser than unary, so it must
+    /// wrap (a bare `await a+b` would parse as `(await a)+b`).
+    #[test]
+    fn await_binary_operand_is_wrapped() {
+        let e = aw(binary(BinaryOperator::Add, ident("a"), ident("b")));
+        assert_eq!(emit_expr(e), "await (a+b);");
+    }
+
+    /// `await p+1` — the whole await binds *tighter* than `+` (await is unary),
+    /// so a binary parent leaves it bare on the left: `(await p)+1`.
+    #[test]
+    fn await_binds_tighter_than_binary_parent() {
+        let e = binary(BinaryOperator::Add, aw(ident("p")), num(1.0));
+        assert_eq!(emit_expr(e), "await p+1;");
+    }
+
+    /// `(await p).x` — a member parent binds at primary strength and wraps the
+    /// looser await object.
+    #[test]
+    fn await_wrapped_as_member_object() {
+        assert_eq!(emit_expr(member(aw(ident("p")), "x", false)), "(await p).x;");
+    }
+
+    /// `(await f)()` — a call callee likewise wraps the await.
+    #[test]
+    fn await_wrapped_as_call_callee() {
+        assert_eq!(emit_expr(call(aw(ident("f")), vec![])), "(await f)();");
+    }
+
+    /// `await await p` — a nested await operand prints bare (await is exactly at
+    /// the unary operand floor).
+    #[test]
+    fn await_nested_is_bare() {
+        assert_eq!(emit_expr(aw(aw(ident("p")))), "await await p;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm
+
+Added an `Expression::AwaitExpression` arm that rebuilds the node, folding/
+recursing into its `argument`, so the pass stays exhaustive over the new
+`javascript-ast` variant (part of the CLOC12.164 atomic node PR1). No behaviour
+change to any existing node; the await argument is now visited/rewritten exactly
+like any other sub-expression the pass already handles.
+
+
 ## [0.85.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.6"
+version = "0.85.7"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -91,7 +91,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression,
+    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
@@ -572,6 +572,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: y.cv.clone(),
             delegate: y.delegate,
             argument: y.argument.as_ref().map(|a| Box::new(fold_expression(a, st))),
+        }),
+        Expression::AwaitExpression(a) => Expression::AwaitExpression(AwaitExpression {
+            cv: a.cv.clone(),
+            argument: Box::new(fold_expression(&a.argument, st)),
         }),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm
+
+Added an `Expression::AwaitExpression` arm that rebuilds the node, recursing
+into its `argument`, so the pass stays exhaustive over the new `javascript-ast`
+variant (part of the CLOC12.164 atomic node PR1). No behaviour change to any
+existing node; the await argument is now visited/rewritten exactly like any
+other sub-expression the pass already handles.
+
+
 ## [0.20.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.6"
+version = "0.20.7"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
-    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
@@ -1254,6 +1254,10 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
             cv: y.cv.clone(),
             delegate: y.delegate,
             argument: y.argument.as_ref().map(|a| Box::new(dce_expression(a, st))),
+        }),
+        Expression::AwaitExpression(a) => Expression::AwaitExpression(AwaitExpression {
+            cv: a.cv.clone(),
+            argument: Box::new(dce_expression(&a.argument, st)),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm
+
+Added an `Expression::AwaitExpression` arm that rebuilds the node, recursing
+into its `argument`, plus a matching arm in the `expression_cv` accessor, so the
+pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.164 atomic node PR1). No behaviour change to any existing node; the await
+argument is now visited/rewritten exactly like any other sub-expression the pass
+already handles.
+
+
 ## [0.20.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.6"
+version = "0.20.7"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -56,7 +56,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
-    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression,
+    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
@@ -278,6 +278,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         TaggedTemplateExpression(e) => e.cv.clone(),
         SpreadElement(e) => e.cv.clone(),
         YieldExpression(y) => y.cv.clone(),
+        AwaitExpression(a) => a.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1435,6 +1436,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             cv: y.cv.clone(),
             delegate: y.delegate,
             argument: y.argument.as_ref().map(|a| Box::new(fold_expression(a, st))),
+        }),
+        Expression::AwaitExpression(a) => Expression::AwaitExpression(AwaitExpression {
+            cv: a.cv.clone(),
+            argument: Box::new(fold_expression(&a.argument, st)),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` traversal arms
+
+Added `Expression::AwaitExpression` arms that walk into the await's `argument`,
+so the pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.164 atomic node PR1). No behaviour change to any existing node; the await
+argument is now visited exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.11.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` traversal arms

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -828,6 +828,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         // Count uses of `name` inside the spread argument (`...name`).
         Expression::SpreadElement(s) => count_uses_expr(&s.argument, name, count),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { count_uses_expr(a, name, count); } }
+        Expression::AwaitExpression(a) => count_uses_expr(&a.argument, name, count),
     }
 }
 
@@ -1125,6 +1126,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         // Propagate into the spread argument (`...name`).
         Expression::SpreadElement(s) => changed |= propagate_in_expr(&mut s.argument, cand),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { changed |= propagate_in_expr(a, cand); } }
+        Expression::AwaitExpression(a) => changed |= propagate_in_expr(&mut a.argument, cand),
     }
     changed
 }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` traversal arms
+
+Added `Expression::AwaitExpression` arms that walk into the await's `argument`,
+so the pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.164 atomic node PR1). No behaviour change to any existing node; the await
+argument is now visited exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.25.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` traversal arms

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.6"
+version = "0.25.7"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -509,6 +509,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         // `...arg` — the spread weighs exactly its single inner argument.
         Expression::SpreadElement(s) => expr_node_count(&s.argument),
         Expression::YieldExpression(y) => y.argument.as_ref().map_or(0, |a| expr_node_count(a)),
+        Expression::AwaitExpression(a) => expr_node_count(&a.argument),
     }
 }
 
@@ -844,6 +845,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // `...arg` — recurse into the spread argument to collect its bindings.
         Expression::SpreadElement(s) => collect_binding_idents_expr(&s.argument, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_binding_idents_expr(a, out); } }
+        Expression::AwaitExpression(a) => collect_binding_idents_expr(&a.argument, out),
     }
 }
 
@@ -1145,6 +1147,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         // `...arg` — recurse into the spread argument to tally candidate uses.
         Expression::SpreadElement(s) => tally_expr(&s.argument, cand, t),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { tally_expr(a, cand, t); } }
+        Expression::AwaitExpression(a) => tally_expr(&a.argument, cand, t),
     }
 }
 
@@ -1452,6 +1455,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         // `...arg` — recurse into the spread argument to inline candidate calls.
         Expression::SpreadElement(s) => changed |= inline_in_expr(&mut s.argument, cand),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { changed |= inline_in_expr(a, cand); } }
+        Expression::AwaitExpression(a) => changed |= inline_in_expr(&mut a.argument, cand),
     }
     changed
 }
@@ -1610,6 +1614,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         // `...arg` — recurse into the spread argument to substitute through it.
         Expression::SpreadElement(s) => substitute(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { substitute(a, map); } }
+        Expression::AwaitExpression(a) => substitute(&mut a.argument, map),
     }
 }
 
@@ -1992,6 +1997,7 @@ fn expr_collect_mutated_params(
         // `...arg` — recurse into the spread argument to find mutated params.
         Expression::SpreadElement(s) => expr_collect_mutated_params(&s.argument, params, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { expr_collect_mutated_params(a, params, out); } }
+        Expression::AwaitExpression(a) => expr_collect_mutated_params(&a.argument, params, out),
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
@@ -3465,6 +3471,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `...arg` — recurse into the spread argument to alpha-rename through it.
         Expression::SpreadElement(s) => rename_in_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rename_in_expr(a, map); } }
+        Expression::AwaitExpression(a) => rename_in_expr(&mut a.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` traversal arms
+
+Added `Expression::AwaitExpression` arms that walk into the await's `argument`,
+so the pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.164 atomic node PR1). No behaviour change to any existing node; the await
+argument is now visited exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.10.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` traversal arms

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -748,6 +748,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // `...arg` — recurse into the spread argument to collect its idents.
         Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_all_idents_expr(a, out); } }
+        Expression::AwaitExpression(a) => collect_all_idents_expr(&a.argument, out),
     }
 }
 
@@ -1081,6 +1082,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `...arg` — recurse into the spread argument to rename globals through it.
         Expression::SpreadElement(s) => rename_apply_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rename_apply_expr(a, map); } }
+        Expression::AwaitExpression(a) => rename_apply_expr(&mut a.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` traversal arms
+
+Added `Expression::AwaitExpression` arms that walk into the await's `argument`,
+so the pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.164 atomic node PR1). No behaviour change to any existing node; the await
+argument is now visited exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.12.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` traversal arms

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1257,6 +1257,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         // `...arg` — recurse into the spread argument to classify accesses in it.
         Expression::SpreadElement(s) => classify_expr(&s.argument, cls),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { classify_expr(a, cls); } }
+        Expression::AwaitExpression(a) => classify_expr(&a.argument, cls),
     }
 }
 
@@ -1525,6 +1526,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `...arg` — recurse into the spread argument to rewrite accesses in it.
         Expression::SpreadElement(s) => rewrite_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rewrite_expr(a, map); } }
+        Expression::AwaitExpression(a) => rewrite_expr(&mut a.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` traversal arms
+
+Added `Expression::AwaitExpression` arms that walk into the await's `argument`,
+so the pass stays exhaustive over the new `javascript-ast` variant (part of the
+CLOC12.164 atomic node PR1). No behaviour change to any existing node; the await
+argument is now visited exactly like any other sub-expression the pass already
+handles.
+
+
 ## [0.14.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` traversal arms

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -1029,6 +1029,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // `...arg` — recurse into the spread argument to collect its idents.
         Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_all_idents_expr(a, out); } }
+        Expression::AwaitExpression(a) => collect_all_idents_expr(&a.argument, out),
     }
 }
 
@@ -1343,6 +1344,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `...arg` — recurse into the spread argument to rewrite renamed uses in it.
         Expression::SpreadElement(s) => rewrite_uses_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rewrite_uses_expr(a, map); } }
+        Expression::AwaitExpression(a) => rewrite_uses_expr(&mut a.argument, map),
     }
 }
 

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.7] - 2026-07-04
+
+### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm
+
+Added an `Expression::AwaitExpression` arm that walks into the await's
+`argument`, so the analyzer stays exhaustive over the new `javascript-ast`
+variant (part of the CLOC12.164 atomic node PR1). No behaviour change to any
+existing node; the await argument is now visited exactly like any other
+sub-expression the analyzer already handles.
+
+
 ## [0.12.6] - 2026-07-03
 
 ### Changed — CLOC12.163: `YieldExpression` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.6"
+version = "0.12.7"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -944,6 +944,7 @@ fn walk_expression(
         // `...arg` — recurse into the spread argument to resolve references in it.
         Expression::SpreadElement(s) => walk_expression(&s.argument, ctx, analysis, pending),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { walk_expression(a, ctx, analysis, pending); } }
+        Expression::AwaitExpression(a) => walk_expression(&a.argument, ctx, analysis, pending),
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.23.0] - 2026-07-04
+
+### Added — CLOC12.164: `Expression::AwaitExpression` (`await x`)
+
+Added `Expression::AwaitExpression` variant + `AwaitExpression { cv, argument:
+Box<Expression> }` struct — the `await x` async-suspend operator (always has an
+operand; no optional/delegate axis, unlike YieldExpression). Re-exported from
+the crate root. (CLOC12.164)
+
+
 ## [0.22.0] - 2026-07-03
 
 ### Added — CLOC12.163: `Expression::YieldExpression` (`yield` / `yield x` / `yield* xs`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -102,6 +102,15 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   tighter parent wraps the whole yield: `(yield a)+1`). Node + `closure-emitter`
   + all pass traversals land in one atomic PR; the bridge-enable + conformance
   port follow.
+- `AwaitExpression` (CLOC12.164) — an `await x` async-suspend operator: waits on
+  a promise operand and resumes with its settled value.
+  `AwaitExpression { argument: Box<Expression> }` — the `argument` is mandatory
+  (a bare `await` has no meaning), and there is no optional/delegate axis, unlike
+  `YieldExpression`. It tags at `PREC_UNARY`, printed like the word-unaries
+  typeof/void/delete: it binds tighter than binary parents (`await a+b`) but
+  member/call/new parents wrap the whole await (`(await p).x`, `(await f)()`).
+  Node + `closure-emitter` + all pass traversals land in one atomic PR; the
+  bridge-enable + conformance port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -63,6 +63,7 @@ pub enum Expression {
     TaggedTemplateExpression(TaggedTemplateExpression),
     SpreadElement(SpreadElement),
     YieldExpression(YieldExpression),
+    AwaitExpression(AwaitExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -542,6 +543,41 @@ pub struct YieldExpression {
     pub delegate: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub argument: Option<Box<Expression>>,
+}
+
+/// An `await` expression — the async-suspend operator that only appears inside
+/// an async function body:
+///
+/// ```text
+///   await promise      suspend until `promise` settles, then resume with its value
+/// ```
+///
+/// # Shape
+///
+/// Unlike [`YieldExpression`], an `await` **always** has an operand — bare
+/// `await` is a syntax error — so `argument` is a plain (non-optional)
+/// `Box<Expression>`, not an `Option`. There is no delegating form (`await*`
+/// does not exist), so no second axis is needed.
+///
+/// # Precedence
+///
+/// `await` is a **unary** operator in the grammar (`await UnaryExpression`),
+/// binding exactly like the word-prefix unaries `typeof` / `void` / `delete`:
+/// tighter than every binary operator, looser than member/call. So the emitter
+/// tags it at unary precedence — `await a + b` prints bare on the left
+/// (`await a+b`, i.e. `(await a)+b`), while a looser operand wraps
+/// (`await (a+b)`), and a member/call parent wraps the whole await
+/// (`(await p).x`, `(await f)()`). The operand likewise prints at unary
+/// precedence.
+///
+/// Like the other operand-carrying nodes `argument` is a `Box` so the
+/// `Expression` enum stays a fixed size regardless of nesting depth.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AwaitExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub argument: Box<Expression>,
 }
 
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
-    YieldExpression,
+    AwaitExpression, YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2051,3 +2051,72 @@ rather than mis-converting if a future operand-less node ever appears. Tracked
 as a grammar gap, distinct from this structured-AST slice. (The existing
 WHITESPACE_ONLY path also strips redundant parens around a `yield` operand,
 gap-105 — a token-level fallback independent of this node.)
+
+## CLOC12.164 — `AwaitExpression` (`await x`): atomic node + emit + passes (PR1)
+
+Adds `Expression::AwaitExpression { cv, argument: Box<Expression> }` to
+`javascript-ast` (0.23.0) — the **async-suspend** operator `await x`, which
+pauses an async function until its operand promise settles and resumes with the
+settled value. It is the async-side sibling of the generator `yield`
+(CLOC12.163): both are context-restricted suspend operators. Two shape
+differences from yield make the node *simpler*:
+
+- **`argument` is a plain `Box<Expression>`, not `Option`.** A bare `await`
+  (no operand) is a syntax error in every context, so the operand is always
+  present — no `Option` is needed (contrast `yield`, where a bare `yield` is
+  legal).
+- **No `delegate` axis.** There is no `await*` form, so the node needs no
+  second boolean.
+
+`closure-emitter` (0.28.0) `emit_await` prints `await` then a **mandatory**
+separator (`required_ws`) then the operand at `PREC_UNARY` — exactly the
+treatment `emit_unary` gives the word-shaped unaries `typeof` / `void` /
+`delete`. `await` is grammatically a unary operator (`await UnaryExpression`),
+so it binds tighter than every binary operator and looser than member/call:
+
+```text
+  await a.b      → await a.b      member operand binds tighter → bare
+  await f()      → await f()      call operand binds tighter   → bare
+  await (a+b)    → await (a+b)    binary operand binds LOOSER   → wraps
+  await a+b      → await a+b      the whole await binds tighter than + → (await a)+b bare
+  (await p).x    → (await p).x    member parent binds at primary → wraps the await
+  (await f)()    → (await f)()    call callee wraps the await
+```
+
+`expr_prec` tags `AwaitExpression` at `PREC_UNARY` (like the `void`/`typeof`
+unary-word cases), which drives the member/call/new wrapping automatically —
+no emit-site paren surgery. All nine downstream pass/analysis crates get an
+`AwaitExpression` match arm recursing into `argument` (transforms rebuild the
+node; `fold-control-flow`'s exhaustive `expression_cv` accessor gains its arm;
+traversal passes walk into the argument) — structurally identical to the
+`SpreadElement` arms since `argument` is a plain `Box`. All in one atomic commit
+so the workspace never has a broken exhaustive `match`.
+
+8 new emitter unit tests: mandatory space (`await p`), member/call operands
+bare (`await a.b`, `await f()`), binary operand wrapped (`await (a+b)`), await
+binding tighter than a binary parent (`await a+b`), member/call parents wrapping
+the whole await (`(await p).x`, `(await f)()`), and a nested `await await p`. No
+behaviour change for existing inputs — the bridge still declines `await`
+(gap-165), so closurec falls back to WHITESPACE_ONLY on async bodies for now.
+PR2 (bridge-enable) and PR3 (conformance port) follow.
+
+### gap-165 — bridge declines `await` (`AwaitExpression`) — **OPEN**
+
+The `javascript-parser` bridge does not yet convert an `await` expression to
+`Expression::AwaitExpression`; an async function body containing an `await`
+drops the whole file to WHITESPACE_ONLY. The atomic node PR (CLOC12.164 PR1)
+landed the node + emit + pass traversals so the typed AST and every downstream
+pass can already represent and print an await.
+
+**PR2 (bridge-enable) — mirrors the generator/yield slice (CLOC12.163 PR2,
+gap-164).** `await` is only grammatical inside an async function body
+(`async function f(){ … }` / `async () => …`), so the bridge slice must, like
+generators, convert *both* the enclosing async function (setting the `is_async`
+flag — `FunctionDeclaration`/`FunctionExpression` already carry it, and the
+emitter already prints the `async` prefix) *and* the `await_expression` node
+(currently in the `convert_expression` decline list alongside
+`async_function_expression` / `async_arrow_function` / `async_generator_expression`).
+First dump the parse tree to confirm `async function f(){await p}` parses with a
+reachable `await_expression` sub-node (the analogue of the generator parse-tree
+dump that unblocked gap-164). The emit side is already complete, so PR2 is
+bridge-only.


### PR DESCRIPTION
## CLOC12.164 PR1 — `AwaitExpression` atomic node

First PR of the CLOC12.164 arc: adds the async-suspend operator `await x` to the closurec JavaScript-minifier stack as an atomic node — the AST variant, the emitter, and match arms in **all 9 downstream passes** land in one commit so the workspace never has a broken exhaustive `match`.

### The node (`javascript-ast` 0.22.0 → 0.23.0, MINOR)
`Expression::AwaitExpression { cv, argument: Box<Expression> }` — the async-side sibling of the generator `yield` (CLOC12.163). Two shape differences make it *simpler* than yield:
- **`argument` is a plain `Box<Expression>`, not `Option`** — a bare operand-less `await` is a syntax error, so the operand is always present.
- **No `delegate` axis** — there is no `await*` form.

### The emitter (`closure-emitter` 0.27.1 → 0.28.0, MINOR)
`emit_await` prints `await` + a **mandatory** `required_ws()` + the operand at `PREC_UNARY` — exactly the treatment `emit_unary` gives the word unaries `typeof`/`void`/`delete`. `await` is grammatically a unary operator (`await UnaryExpression`):

| source | emits | why |
|--------|-------|-----|
| `await a.b` | `await a.b` | member operand binds tighter → bare |
| `await f()` | `await f()` | call operand binds tighter → bare |
| `await (a+b)` | `await (a+b)` | binary operand binds looser → wraps |
| `await a+b` | `await a+b` | await binds tighter than `+` → `(await a)+b` |
| `(await p).x` | `(await p).x` | member parent wraps the await |
| `(await f)()` | `(await f)()` | call callee wraps the await |

`expr_prec` tags await at `PREC_UNARY`, driving the wrapping automatically (incl. the exponentiation-base case `(await p)**2`). 8 emitter unit tests cover every shape above.

### The 9 downstream passes (PATCH each)
constant-fold, dce, fold-control-flow, inline, inline-variables, rename, rename-globals, rename-properties, scope-analyzer each get an `AwaitExpression` arm recursing into `argument` — rebuild passes reconstruct the node; fold-control-flow also handles it in the exhaustive `expression_cv` accessor; traversal passes walk into the argument. Structurally identical to the `SpreadElement` arms (plain `Box`).

### Behaviour
No change for existing inputs — the bridge still declines `await` (**gap-165**, OPEN; PR2 mirrors the merged generator/yield bridge slice), so closurec falls back to WHITESPACE_ONLY on async bodies for now. Spec `CLOC12-gaps.md` gets the CLOC12.164 section + gap-165.

**PR2** (bridge-enable async + await) and **PR3** (CodePrinter conformance port) follow.

### Verification
- `cargo test` green across `javascript-ast`, `closure-emitter`, and all 9 pass crates (8 new await tests pass by name).
- Whole workspace (incl. closurec + remaining passes) compiles.
- Security review passed (no unsafe/I/O/unwrap; recursion mirrors the already-large-stack-protected SpreadElement arms; `(await p)**2` exponentiation-base parenthesization verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)