### PR TITLE
feat(adj-ladder): rung-74 nephrology dialysis corrected-clearance index (term plus a scaled quotient)

### DIFF
--- a/code/specs/data/adj-ladder/rung74_dialysis_clearance/gen_items.py
+++ b/code/specs/data/adj-ladder/rung74_dialysis_clearance/gen_items.py
@@ -1,0 +1,237 @@
+"""Generate rung-74 (nephrology dialysis corrected-clearance index) items.json for the ADJ-LADDER.
+
+Rung 74 opens the **nephrology / dialysis-clearance** panel on the quantitative band — the arithmetic of a corrected
+solute clearance. A dialysis machine reads a `blood_flow`, then a `solute_load` is divided by a `membrane_factor` and
+scaled by a `session_gain`, and that scaled quotient is ADDED to the blood flow. A leading term with a scaled quotient
+added introduces a genuinely NEW arithmetic shape on the ladder: a **term plus a scaled quotient** — `a + b/c*d`, i.e.
+`a + ((b/c)*d)`.
+
+This is the deliberate contrast to rung-73's `a - b/c*d` (pulmonology spirometry), which SUBTRACTS the scaled quotient;
+rung-74 ADDS it — the plus-counterpart, sharing the same divide-then-multiply subtrahend structure. The operation order
+inside the added term matters: `b/c*d` is left-to-right `((b/c)*d) = b*d/c`, NOT `b/(c*d)` — the distractor exploits
+exactly that confusion. Contrast the other neighbours: rung-53 was `(a+b+c)/d` (a bare triple sum over a divisor) and
+rung-68 was `(a+b)*c/d` (a sum scaled then divided). Here a whole term has a scaled quotient added to it.
+
+The setup: a `blood_flow`, a `solute_load`, a `membrane_factor`, and a `session_gain`. The corrected clearance is:
+
+  CORRECTED CLEARANCE  blood_flow + solute_load / membrane_factor * session_gain   [ term plus the scaled load ]
+  LOAD RATIO           solute_load / membrane_factor                               [ the quotient ]
+  SCALED LOAD          solute_load / membrane_factor * session_gain                [ the quotient scaled, the addend ]
+
+The **corrected clearance** is what makes this rung distinctive — it is the ladder's first **leading term with a scaled
+quotient added** (the addend is a divide-then-multiply). (The load ratio `solute_load / membrane_factor` and the scaled
+load `solute_load / membrane_factor * session_gain` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 47-73 shipped their component sums/products/differences/ratios beside the headline
+figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the division of the solute load by the membrane factor, the multiplication by the session gain
+(left-to-right), and the addition of that scaled quotient to the blood flow — and the harness reads the scalar via the
+existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../72/73. This rung exercises
+the engine across **a term plus a scaled quotient** — the fact that `a + b/c*d` is NOT `a + b/(c*d)` and NOT `a + b*c/d`
+made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `/`, `*`, and `+`
+— **no structural constants** — so no numeric literal appears in any program, and neither the load ratio, the scaled
+load, nor any corrected figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`blood_flow`, `solute_load`, `membrane_factor`, `session_gain`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    blood_flow + solute_load / (membrane_factor * session_gain)   DIVIDE the solute load by the PRODUCT of the
+                                                                           membrane factor and session gain, not divide-
+                                                                           then-multiply (the classic `a + b/c*d` vs
+                                                                           `a + b/(c*d)` error), and
+  SWAPPED    blood_flow + solute_load * membrane_factor / session_gain     MULTIPLY the solute load by the membrane
+                                                                           factor and divide by the session gain — the
+                                                                           operations swapped (`a + b*c/d` instead of
+                                                                           `a + b/c*d`),
+
+which are exactly the mistakes a student makes (folding both denominators into one product, or swapping which quantity
+divides and which multiplies inside the added term). Gold rotates A-E by index. QUERIED (used as gold) = the three real
+readouts; all five always appear as options.
+
+Distinctness: all four observed quantities are strictly positive, so every family member — a sum of positive terms — is
+automatically positive; the membrane factor and the session gain both exceed one (so the load-ratio quotient differs
+from the scaled load) and differ from each other (so the corrected value `a + b*d/c` differs from the swapped value
+`a + b*c/d`); the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (BLOOD_FLOW, SOLUTE_LOAD, MEMBRANE_FACTOR, SESSION_GAIN) — a blood flow, a solute load to divide, a membrane factor to
+# divide by, and a session gain to scale by, all plain positive numbers with membrane_factor > 1, session_gain > 1, and
+# membrane_factor != session_gain. Because every family value is a sum of positive terms, positivity is automatic; the
+# five family values are asserted pairwise-distinct below.
+TABLES = [
+    (20, 12, 3, 2),
+    (30, 12, 4, 3),
+    (30, 10, 5, 2),
+    (40, 18, 6, 3),
+    (36, 15, 5, 3),
+    (28, 8, 2, 3),
+    (50, 20, 5, 4),
+]
+
+# The option family (5 members), all built from the four observed quantities via /, *, and +. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "corrected_clearance",
+        "corrected solute clearance (blood flow plus the scaled solute load)",
+        "blood_flow + solute_load / membrane_factor * session_gain",
+    ),
+    (
+        "load_ratio",
+        "the load ratio (solute load over the membrane factor)",
+        "solute_load / membrane_factor",
+    ),
+    (
+        "scaled_load",
+        "the scaled load that is added (load ratio times the session gain)",
+        "solute_load / membrane_factor * session_gain",
+    ),
+    (
+        "crossed",
+        "the blood flow plus the solute load divided by the PRODUCT of the membrane factor and session gain, not divide-then-multiply (a wrong scaling)",
+        "blood_flow + solute_load / (membrane_factor * session_gain)",
+    ),
+    (
+        "swapped",
+        "the blood flow plus the solute load MULTIPLIED by the membrane factor and DIVIDED by the session gain, the operations swapped (a wrong scaling)",
+        "blood_flow + solute_load * membrane_factor / session_gain",
+    ),
+]
+QUERIED = ["corrected_clearance", "load_ratio", "scaled_load"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(blood_flow, solute_load, membrane_factor, session_gain):
+    # Operation order mirrors the ADJ programs exactly (the left-to-right divide-then-multiply forms the scaled load,
+    # then it is added to the blood flow), so the Python option value and the engine result are the same IEEE-double
+    # (well within the harness's 1e-9 match tolerance).
+    return {
+        "corrected_clearance": blood_flow + solute_load / membrane_factor * session_gain,
+        "load_ratio": solute_load / membrane_factor,
+        "scaled_load": solute_load / membrane_factor * session_gain,
+        "crossed": blood_flow + solute_load / (membrane_factor * session_gain),
+        "swapped": blood_flow + solute_load * membrane_factor / session_gain,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for blood_flow, solute_load, membrane_factor, session_gain in TABLES:
+        assert (
+            blood_flow > 0
+            and solute_load > 0
+            and membrane_factor > 0
+            and session_gain > 0
+        ), (blood_flow, solute_load, membrane_factor, session_gain)
+        # Membrane factor and session gain exceed one so the load-ratio quotient differs from the scaled load, and they
+        # differ from each other so the corrected value (a + b*d/c) differs from the swapped value (a + b*c/d). Every
+        # family member is a sum of positive terms, so positivity is automatic.
+        assert membrane_factor > 1, (blood_flow, solute_load, membrane_factor, session_gain)
+        assert session_gain > 1, (blood_flow, solute_load, membrane_factor, session_gain)
+        assert membrane_factor != session_gain, (blood_flow, solute_load, membrane_factor, session_gain)
+        fv = family_values(blood_flow, solute_load, membrane_factor, session_gain)
+        for key, v in fv.items():
+            assert v > 0, (key, blood_flow, solute_load, membrane_factor, session_gain, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    blood_flow,
+                    solute_load,
+                    membrane_factor,
+                    session_gain,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                blood_flow,
+                solute_load,
+                membrane_factor,
+                session_gain,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r74dial-{idx + 1:02d}",
+                "qtype": "dialysis_clearance",
+                "stem": (
+                    f"A dialysis session records a blood flow of {num(blood_flow)}, a solute load of "
+                    f"{num(solute_load)} divided by a membrane factor of {num(membrane_factor)} and scaled by a session "
+                    f"gain of {num(session_gain)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe blood_flow({num(blood_flow)})\n"
+                    f"observe solute_load({num(solute_load)})\n"
+                    f"observe membrane_factor({num(membrane_factor)})\n"
+                    f"observe session_gain({num(session_gain)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 74 — nephrology dialysis corrected-clearance index from four stated quantities (a NEW "
+            "panel: nephrology / dialysis-clearance). From a blood flow, a solute load to divide, a membrane factor to "
+            "divide by, and a session gain to scale by, compute the corrected clearance "
+            "(blood_flow+solute_load/membrane_factor*session_gain), the load ratio (solute_load/membrane_factor), or "
+            "the scaled load (solute_load/membrane_factor*session_gain). Each item is a compute_dimensioned program "
+            "(observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, "
+            "TERM PLUS A SCALED QUOTIENT a + b/c*d (a leading term with a divide-then-multiply addend added — contrast "
+            "rung-73 a-b/c*d which subtracts the scaled quotient; the left-to-right b/c*d = b*d/c, not b/(c*d)) — and "
+            "the harness matches the scalar to the printed options. Contamination-safe: every index is built only from "
+            "the four observed quantities via /, *, and + — no constant leaks, and neither the load ratio, the scaled "
+            "load, nor any corrected figure ever appears as a literal (each is computed) — and the observed quantities "
+            "carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family "
+            "over the same four quantities, so the distractors are exactly the slips students make: DIVIDING by the "
+            "PRODUCT (a + b/(c*d), a wrong scaling) and SWAPPING the multiply and divide (a + b*c/d, a wrong scaling). "
+            "The core confusion tested is that a + b/c*d is not a + b/(c*d) and not a + b*c/d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung74_dialysis_clearance/items.json
+++ b/code/specs/data/adj-ladder/rung74_dialysis_clearance/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 74 \u2014 nephrology dialysis corrected-clearance index from four stated quantities (a NEW panel: nephrology / dialysis-clearance). From a blood flow, a solute load to divide, a membrane factor to divide by, and a session gain to scale by, compute the corrected clearance (blood_flow+solute_load/membrane_factor*session_gain), the load ratio (solute_load/membrane_factor), or the scaled load (solute_load/membrane_factor*session_gain). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, TERM PLUS A SCALED QUOTIENT a + b/c*d (a leading term with a divide-then-multiply addend added \u2014 contrast rung-73 a-b/c*d which subtracts the scaled quotient; the left-to-right b/c*d = b*d/c, not b/(c*d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via /, *, and + \u2014 no constant leaks, and neither the load ratio, the scaled load, nor any corrected figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: DIVIDING by the PRODUCT (a + b/(c*d), a wrong scaling) and SWAPPING the multiply and divide (a + b*c/d, a wrong scaling). The core confusion tested is that a + b/c*d is not a + b/(c*d) and not a + b*c/d.",
+  "items": [
+    {
+      "id": "r74dial-01",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 20, a solute load of 12 divided by a membrane factor of 3 and scaled by a session gain of 2. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(20)\nobserve solute_load(12)\nobserve membrane_factor(3)\nobserve session_gain(2)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 38.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r74dial-02",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 20, a solute load of 12 divided by a membrane factor of 3 and scaled by a session gain of 2. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(20)\nobserve solute_load(12)\nobserve membrane_factor(3)\nobserve session_gain(2)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 38.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r74dial-03",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 20, a solute load of 12 divided by a membrane factor of 3 and scaled by a session gain of 2. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(20)\nobserve solute_load(12)\nobserve membrane_factor(3)\nobserve session_gain(2)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 28.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 38.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r74dial-04",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 30, a solute load of 12 divided by a membrane factor of 4 and scaled by a session gain of 3. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(30)\nobserve solute_load(12)\nobserve membrane_factor(4)\nobserve session_gain(3)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 31.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 39.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 46.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r74dial-05",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 30, a solute load of 12 divided by a membrane factor of 4 and scaled by a session gain of 3. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(30)\nobserve solute_load(12)\nobserve membrane_factor(4)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 39.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 31.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 46.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r74dial-06",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 30, a solute load of 12 divided by a membrane factor of 4 and scaled by a session gain of 3. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(30)\nobserve solute_load(12)\nobserve membrane_factor(4)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 39.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 31.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 46.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r74dial-07",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 30, a solute load of 10 divided by a membrane factor of 5 and scaled by a session gain of 2. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(30)\nobserve solute_load(10)\nobserve membrane_factor(5)\nobserve session_gain(2)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 34.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 31.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r74dial-08",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 30, a solute load of 10 divided by a membrane factor of 5 and scaled by a session gain of 2. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(30)\nobserve solute_load(10)\nobserve membrane_factor(5)\nobserve session_gain(2)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 34.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 31.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r74dial-09",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 30, a solute load of 10 divided by a membrane factor of 5 and scaled by a session gain of 2. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(30)\nobserve solute_load(10)\nobserve membrane_factor(5)\nobserve session_gain(2)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 34.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 31.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 55.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r74dial-10",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 40, a solute load of 18 divided by a membrane factor of 6 and scaled by a session gain of 3. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(40)\nobserve solute_load(18)\nobserve membrane_factor(6)\nobserve session_gain(3)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 41.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 76.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 49.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r74dial-11",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 40, a solute load of 18 divided by a membrane factor of 6 and scaled by a session gain of 3. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(40)\nobserve solute_load(18)\nobserve membrane_factor(6)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 49.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 41.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 76.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r74dial-12",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 40, a solute load of 18 divided by a membrane factor of 6 and scaled by a session gain of 3. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(40)\nobserve solute_load(18)\nobserve membrane_factor(6)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 49.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 41.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 76.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r74dial-13",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 36, a solute load of 15 divided by a membrane factor of 5 and scaled by a session gain of 3. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(36)\nobserve solute_load(15)\nobserve membrane_factor(5)\nobserve session_gain(3)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 37.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 61.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r74dial-14",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 36, a solute load of 15 divided by a membrane factor of 5 and scaled by a session gain of 3. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(36)\nobserve solute_load(15)\nobserve membrane_factor(5)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 45.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 37.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 61.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r74dial-15",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 36, a solute load of 15 divided by a membrane factor of 5 and scaled by a session gain of 3. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(36)\nobserve solute_load(15)\nobserve membrane_factor(5)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 45.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 37.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 61.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r74dial-16",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 28, a solute load of 8 divided by a membrane factor of 2 and scaled by a session gain of 3. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(28)\nobserve solute_load(8)\nobserve membrane_factor(2)\nobserve session_gain(3)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 33.333333333333336,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r74dial-17",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 28, a solute load of 8 divided by a membrane factor of 2 and scaled by a session gain of 3. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(28)\nobserve solute_load(8)\nobserve membrane_factor(2)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 33.333333333333336,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r74dial-18",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 28, a solute load of 8 divided by a membrane factor of 2 and scaled by a session gain of 3. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(28)\nobserve solute_load(8)\nobserve membrane_factor(2)\nobserve session_gain(3)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 33.333333333333336,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r74dial-19",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 50, a solute load of 20 divided by a membrane factor of 5 and scaled by a session gain of 4. What is the corrected solute clearance (blood flow plus the scaled solute load)?",
+      "program": "observe blood_flow(50)\nobserve solute_load(20)\nobserve membrane_factor(5)\nobserve session_gain(4)\nlet answer = blood_flow + solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 51.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 66.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 75.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r74dial-20",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 50, a solute load of 20 divided by a membrane factor of 5 and scaled by a session gain of 4. What is the the load ratio (solute load over the membrane factor)?",
+      "program": "observe blood_flow(50)\nobserve solute_load(20)\nobserve membrane_factor(5)\nobserve session_gain(4)\nlet answer = solute_load / membrane_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 66.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 51.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 75.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r74dial-21",
+      "qtype": "dialysis_clearance",
+      "stem": "A dialysis session records a blood flow of 50, a solute load of 20 divided by a membrane factor of 5 and scaled by a session gain of 4. What is the the scaled load that is added (load ratio times the session gain)?",
+      "program": "observe blood_flow(50)\nobserve solute_load(20)\nobserve membrane_factor(5)\nobserve session_gain(4)\nlet answer = solute_load / membrane_factor * session_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 66.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 51.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 75.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -111,6 +111,7 @@ SELF_CONTAINED_RUNGS = (
     "rung71_refraction_acuity",
     "rung72_amniotic_index",
     "rung73_spirometry_flow",
+    "rung74_dialysis_clearance",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-74 — nephrology dialysis corrected-clearance index (term plus a scaled quotient)

Adds the next self-contained quantitative rung to the ADJ-LADDER.

### New arithmetic shape
`a + b/c*d` — a **term plus a scaled quotient** = `a + ((b/c)*d)`. The plus-counterpart of rung-73's
`a - b/c*d`: a leading term with a divide-then-multiply addend. Operation order inside the addend matters:
`b/c*d` is left-to-right `((b/c)*d) = b*d/c`, **not** `b/(c*d)`. Contrast rung-73 `a - b/c*d` (subtracts the
scaled quotient), rung-72 `a/b*c-d`, and rung-69 `a*b/c+d`.

### New clinical panel
**Nephrology / dialysis-clearance** — a dialysis session's `blood_flow` has a `solute_load` divided by a
`membrane_factor`, scaled by a `session_gain`, and that scaled quotient added:
`blood_flow + solute_load / membrane_factor * session_gain` (the corrected clearance). Distinct from every
used ladder domain.

### Item family (5 mutually-confusable members)
| key | formula | role |
|---|---|---|
| `corrected_clearance` | `a + b/c*d` | **gold** — the headline `a + b/c*d` |
| `load_ratio` | `b/c` | **gold** — the quotient |
| `scaled_load` | `b/c*d` | **gold** — the quotient scaled (the addend) |
| `crossed` | `a + b/(c*d)` | distractor — DIVIDE by the PRODUCT `c*d` (`a + b/(c*d)`) |
| `swapped` | `a + b*c/d` | distractor — SWAP the multiply and divide in the addend (`a + b*c/d`) |

First three QUERIED as gold; all five always appear as options. Gold rotates A–E by index (`idx % 5`).

### Contamination safety
- Every formula built ONLY from the four observed quantities via `/`, `*`, and `+` — **no numeric constants**.
- No load-ratio / scaled-load / corrected figure ever appears as a literal (each is computed).
- **Digit-free identifiers** (`blood_flow`, `solute_load`, `membrane_factor`, `session_gain`).
- 7 tables × 3 queried = **21 items**; every family value is a sum of positive terms so positivity is
  automatic; `membrane_factor > 1` and `session_gain > 1` (so the load-ratio quotient differs from the scaled
  load), `membrane_factor ≠ session_gain` (so the corrected `a + b*d/c` differs from the swapped `a + b*c/d`);
  the five family values are asserted pairwise-distinct (`>1e-6`) at build.

### Verification
```
$ mise exec -- python3 -m pytest test_ladder_eval.py -k rung74 -q
3 passed, 333 deselected
```
(the compute test confirms the ADJ engine selects every gold via the CLI, exercising left-to-right `/`-then-`*`
inside an added addend). Registered `rung74_dialysis_clearance` in `SELF_CONTAINED_RUNGS`. Data-only change
(offline generator + generated `items.json` + one-line harness registration); no engine/harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
