### PR TITLE
feat(latex): LTXDOC02 S1 — spanned L1 nodes (parser threads token spans into every Node)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.32.0] — 2026-07-04
+
+### Added — spanned L1 nodes (LTXDOC02 S1)
+
+The first implementation rung of the **precise per-token byte spans** arc (spec
+`LTXDOC02-precise-token-spans.md` §5). Every `Node` produced by `parse()` now carries its **exact
+source byte `Span`**, threaded from the spans the lexer already records on every token — no
+substring re-scanning. `&src[node.span().start .. node.span().end]` slices back to the node's own
+source (`\textbf{x}`, `{…}` incl. braces, `$…$` incl. the delimiters, `\begin{env}…\end{env}`, a
+`Text` run's exact characters, …).
+
+- **`Node` restructured to `{ kind: NodeKind, span: Span }`.** The variants moved to a new public
+  `NodeKind` enum; `Node` pairs a `NodeKind` with its `Span`. This keeps the span **orthogonal**
+  (a `match` on shape reads `node.kind`; the span is one uniform field every node has) and is the
+  single source of truth — the old `Unsupported { span: (usize, usize) }` bespoke tuple is dropped
+  in favour of the uniform `Node.span`. New `NodeKind` export from the crate root.
+- **Span accessor + terse constructors.** `Node::new(kind, span)`, `Node::span() -> Span`, and
+  `Node::text/space/par/group/command(...)` builders. `Group`/`Command`/`Environment`/`Math` spans
+  cover their delimiters; composite spans compose from the tracked start/end of the covered tokens.
+- **Equality ignores the span.** `Node`'s `PartialEq`/`Eq` compare `kind` only, so the round-trip
+  stays a **fixed point modulo spans** (`parse(&render(ast)) == ast`) even though re-emitting moves
+  byte offsets — and every existing round-trip/equality test stays valid unchanged.
+- **Recognition passes + Document fold threaded through.** `recognize_structure` /
+  `recognize_accents` / `recognize_tables` fold onto the folded command's own span (extended over
+  any folded siblings — union-of-constituents); `build_document`/`macros::expand` updated to match
+  on `node.kind`. Deep precise-span work inside the recognition passes and the Document fold remains
+  S2/S3; S1's core deliverable is spanned L1 `Node`s from `parse()`.
+- **`to_latex` output text is unchanged** (spans move on re-emit; structure/text do not).
+- **Tests:** exact source-slicing for a `Command`/`Group`/`Math`/`Text`/`Environment`; containment
+  (`child.span ⊆ parent.span ⊆ 0..src.len()`); and a totality/no-panic test over malformed-but-
+  parseable input (`Span::new` guards `end < start`).
+
 ## [0.31.0] — 2026-07-03
 
 ### Added — provenance API + byte-coverage capstone (LTXDOC01 D6, arc complete)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -37,17 +37,22 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **L4 macros** | `\newcommand`/`\renewcommand`/`\providecommand` with positional `#1`..`#9`; bounded recursive expansion via `expand()` (L4a) | ✅ |
 | **L5 text breadth** | `\verb`/`verbatim` raw (L5a/b) + text accents `\'e`/`\c{c}` via `recognize_accents` (L5c) + sectioning/refs/preamble/font via `recognize_structure` (L5d) | ✅ |
 | **L6 frontend** | `LatexMath` implements `math-frontend::MathFrontend` — lifts `MathNode` → neutral `MathExpr`; LaTeX is plugin #1 via `registry()` (default-on `frontend` feature) | ✅ |
-| **D1 doc tables/lists** | document-mode `tabular`/`tabular*` grids (split on `&`/`\\`) → `Node::Tabular` and `itemize`/`enumerate`/`description` (split on `\item`) → `Node::List`, via the opt-in `recognize_tables` pass; total, round-trip | ✅ |
+| **D1 doc tables/lists** | document-mode `tabular`/`tabular*` grids (split on `&`/`\\`) → `NodeKind::Tabular` and `itemize`/`enumerate`/`description` (split on `\item`) → `NodeKind::List`, via the opt-in `recognize_tables` pass; total, round-trip | ✅ |
 | **D2 Document skeleton** | hierarchical `Document` model: preamble/body split at `\begin{document}`, `\documentclass`/`\usepackage` classified, body lowered to a **flat** `Vec<Block>` (headings → zero-body `Block::Section`; paragraphs/lists/tables/display-math/environments; inline runs → `Vec<Inline>`); `parse_document`/`build_document` + `Document::to_latex` round-trip; coarse (region-granular) spans | ✅ |
 | **D3 sectioning fold** | folds the flat block stream into the **nested sectioning forest**: each heading OWNS the run of following blocks up to the next heading of same-or-higher level (`\part > \chapter > \section > … > \subparagraph`, via `rank(level)`); deeper headings nest. A trailing `\label{key}` is hoisted onto its section's new `label` field. Applies to every block-list (top-level + environment/list/table bodies). Total & panic-free; `to_latex` fixed point; `flatten(fold(flat)) == flat` property test; folded-section span = union of heading ∪ children spans | ✅ |
 | **D4 metadata** | extracts `\title`/`\author{A \and B}`/`\date` and the `abstract` env into a typed `Metadata` record on `Document`, as an **additive projection** — the underlying nodes stay in `preamble`/`body`, so `to_latex` round-trips unchanged and re-parsing repopulates the same `Metadata` (fixed point). Both preamble and body scanned; first title/date wins; every `\author` (each `\and`-split) contributes; `\maketitle` is a metadata no-op. Total & panic-free; never fabricated. (Inline normalization — `\textbf`/`\emph`/`\texttt`/`$…$`/`\ref`/accents — already lands in D2/D3's `lower_inline`.) | ✅ |
 | **D5 floats/code/display-math** | specializes the generic environment fold by name: `figure`/`figure*` → `Block::Figure` and `table`/`table*` → the inner `Block::Table`, each with `\caption{…}` → `Caption` + a hoisted `\label`; `verbatim`/`lstlisting` → `Block::CodeBlock` (raw text kept unparsed); `equation`/`align`/`gather`/… → `Block::DisplayMath` (source kept, delegated to the math frontend on demand); `quote`/`quotation` → `Block::Quote`; any other env → recursed `Block::Environment`. `to_latex` fixed point; total & panic-free; coarse spans | ✅ |
 | **D6 provenance API (capstone)** | the byte-provenance surface: `Document::walk()` — a pre-order, depth-first `impl Iterator<Item = NodeRef>` over every body block + nested inline; `Document::node_at(byte)` — the innermost walked node whose span contains a source byte, returned as `Provenance { node, span }`; `NodeRef::{span,kind}`. A capstone real-paper corpus (article + abstract + tabular + itemize + inline/display math + figure+caption+label + `\cite`) proves a `to_latex` fixed point, a non-panicking `walk()`, and **byte coverage**: every non-whitespace body-region byte is owned by ≥1 walked node. Panic-free (`saturating_sub`); honestly **region-coarse** (no exact byte→leaf claim). | ✅ |
+| **LTXDOC02 S1 — spanned L1 nodes** | `Node` restructured to `{ kind: NodeKind, span: Span }`; `parse()` threads each token's exact byte span onto the node it builds, so `&src[node.span()]` slices back to the node's own source (`\textbf{x}`, `{…}` incl. braces, `$…$` incl. delimiters, `\begin{env}…\end{env}`, a `Text` run's exact chars). Span is orthogonal to shape; `PartialEq` ignores it (round-trip = fixed point **modulo spans**); `Unsupported`'s bespoke tuple folded onto the uniform `Node.span`. `to_latex` unchanged. The one parser-level rung of the precise-spans arc (recognition-pass + Document-fold precision = S2/S3). | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
 tables/lists (D1) → preamble/body skeleton (D2) → sectioning forest (D3) → metadata + inline
 normalization (D4) → floats/code/display-math (D5) → provenance API + byte-coverage capstone (D6).
+The **precise per-token spans** arc (LTXDOC02) is now under way: **S1 ships spanned L1 nodes** —
+`parse()` retains the exact byte range it already computed for each node — with S2 (spanned
+recognition passes), S3 (precise Document fold), and S4/S5 (precise `node_at` + coverage capstone,
+retiring the region-coarse caveat) to follow.
 
 ## The Document layer (LTXDOC01)
 
@@ -168,11 +173,15 @@ node — future work, not overclaimed here.
 ## Usage
 
 ```rust
-use latex::{parse, Node};
+use latex::{parse, NodeKind};
 
 let doc = parse(r"Let $x$ be \textbf{bold}.").unwrap();
-assert!(matches!(doc[0], Node::Text(_)));                       // "Let"
-assert!(doc.iter().any(|n| matches!(n, Node::Math { .. })));    // $x$
+assert!(matches!(doc[0].kind, NodeKind::Text(_)));                       // "Let"
+assert!(doc.iter().any(|n| matches!(n.kind, NodeKind::Math { .. })));    // $x$
+// every node carries its exact source byte span (LTXDOC02 S1):
+let src = r"Let $x$ be \textbf{bold}.";
+let d = parse(src).unwrap();
+assert_eq!(&src[d[0].span().start..d[0].span().end], "Let");
 // round-trips: parsing the rendered AST yields the same AST
 assert_eq!(parse(&latex::document_to_latex(&doc)).unwrap(), doc);
 ```
@@ -250,24 +259,24 @@ built-in starter set; `#n` inside a math island is not substituted in L4a.
 ### Verbatim (L5a/L5b)
 
 `\verb<delim>…<delim>` (and the `\verb*` visible-space variant) read their body **raw** — the
-tokenizer suspends catcodes inside, so `{ } $ # \` are literal — producing a `Node::Verb`
+tokenizer suspends catcodes inside, so `{ } $ # \` are literal — producing a `NodeKind::Verb`
 that round-trips:
 
 ```rust
 use latex::{parse, Node};
 
 let doc = parse(r"call \verb|x{y}$z| now").unwrap();
-assert!(matches!(doc[1], Node::Verb { delim: '|', .. }));   // body "x{y}$z" kept verbatim
+assert!(matches!(doc[1].kind, NodeKind::Verb { delim: '|', .. }));   // body "x{y}$z" kept verbatim
 ```
 
 The **`verbatim` environment** (and `verbatim*`) reads its whole body raw — newlines included —
-up to the matching `\end{verbatim}`, producing a `Node::VerbatimEnv` that also round-trips:
+up to the matching `\end{verbatim}`, producing a `NodeKind::VerbatimEnv` that also round-trips:
 
 ```rust
 use latex::{parse, Node};
 
 let doc = parse("\\begin{verbatim}let x = {1};\n$y$\\end{verbatim}").unwrap();
-assert!(matches!(doc[0], Node::VerbatimEnv { .. }));   // body kept literal, $/{} not special
+assert!(matches!(doc[0].kind, NodeKind::VerbatimEnv { .. }));   // body kept literal, $/{} not special
 ```
 
 Only `verbatim`/`verbatim*` divert to raw scanning; every other `\begin{…}` is parsed
@@ -277,14 +286,14 @@ and an unterminated `verbatim` environment are spanned errors — never a mis-pa
 ### Text accents (L5c)
 
 `recognize_accents` is an opt-in pass (like `expand`) that folds an accent control sequence
-and the character it accents into a `Node::Accent` — both spellings, `\'e` and `\'{e}`,
+and the character it accents into a `NodeKind::Accent` — both spellings, `\'e` and `\'{e}`,
 recognize to the same node and round-trip:
 
 ```rust
 use latex::{parse, recognize_accents, Node};
 
 let doc = recognize_accents(parse(r"caf\'e").unwrap());
-assert!(matches!(doc[1], Node::Accent { .. }));   // é over `e`; "caf" stays text
+assert!(matches!(doc[1].kind, NodeKind::Accent { .. }));   // é over `e`; "caf" stays text
 ```
 
 Recognized: `\'  \`  \^  \"  \~  \=  \.` and `\u \v \H \c \d \b \r \t`. A dangling accent (no
@@ -301,19 +310,19 @@ round-trip intact:
 use latex::{parse, recognize_structure, Node, SectionLevel};
 
 let doc = recognize_structure(parse(r"\section*{Intro} see \ref{fig:1}").unwrap());
-assert!(matches!(doc[0], Node::Section { level: SectionLevel::Section, starred: true, .. }));
-assert!(doc.iter().any(|n| matches!(n, Node::CrossRef { .. })));   // \ref{fig:1}
+assert!(matches!(doc[0].kind, NodeKind::Section { level: SectionLevel::Section, starred: true, .. }));
+assert!(doc.iter().any(|n| matches!(n.kind, NodeKind::CrossRef { .. })));   // \ref{fig:1}
 ```
 
 Recognized:
 
-- **`Node::Section`** — `\part`/`\chapter`/`\section`/`\subsection`/`\subsubsection`/
+- **`NodeKind::Section`** — `\part`/`\chapter`/`\section`/`\subsection`/`\subsubsection`/
   `\paragraph`/`\subparagraph`, the starred `\section*{…}` form (the `*` sibling is folded),
   and the optional short TOC title `\section[Short]{Title}`;
-- **`Node::CrossRef`** — `\label`/`\ref`/`\eqref`/`\pageref`/`\autoref`/`\nameref`/`\cite`/
+- **`NodeKind::CrossRef`** — `\label`/`\ref`/`\eqref`/`\pageref`/`\autoref`/`\nameref`/`\cite`/
   `\citep`/`\citet` (the `\cite[note]{key}` optional is kept);
-- **`Node::Preamble`** — `\documentclass`/`\usepackage`/`\RequirePackage` with `[options]`;
-- **`Node::Styled`** — argument-form font commands (`\textbf`, `\textit`, `\texttt`, `\emph`,
+- **`NodeKind::Preamble`** — `\documentclass`/`\usepackage`/`\RequirePackage` with `[options]`;
+- **`NodeKind::Styled`** — argument-form font commands (`\textbf`, `\textit`, `\texttt`, `\emph`,
   `\underline`, …).
 
 A command that does not match its expected shape (a sectioning command with no title, a
@@ -334,22 +343,22 @@ body on the `&` alignment tab and the `\\` row break, and a list body on `\item`
 use latex::{parse, recognize_tables, Node, ListKind};
 
 let table = recognize_tables(parse(r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}").unwrap());
-assert!(matches!(table[0], Node::Tabular { .. }));   // 2×2 grid, col_spec = Some("lc")
+assert!(matches!(table[0].kind, NodeKind::Tabular { .. }));   // 2×2 grid, col_spec = Some("lc")
 
 let list = recognize_tables(parse(r"\begin{itemize}\item one\item two\end{itemize}").unwrap());
-assert!(matches!(list[0], Node::List { kind: ListKind::Itemize, .. }));
+assert!(matches!(list[0].kind, NodeKind::List { kind: ListKind::Itemize, .. }));
 ```
 
 Recognized:
 
-- **`Node::Tabular { col_spec, rows }`** — `tabular`/`tabular*`; `rows[r][c]` is the node
+- **`NodeKind::Tabular { col_spec, rows }`** — `tabular`/`tabular*`; `rows[r][c]` is the node
   sequence of cell `c` in row `r`; `col_spec` is the column spec captured verbatim (`None` if
   absent). A `tabular*` `{width}` argument is dropped, keeping the trailing `{colspec}`.
-- **`Node::List { kind, items }`** — `itemize`/`enumerate`/`description`; each `ListItem` carries
+- **`NodeKind::List { kind, items }`** — `itemize`/`enumerate`/`description`; each `ListItem` carries
   its `\item[term]` optional `label` and the `body` up to the next `\item`.
 
 The pass is **total and infallible**: ragged rows (differing cell counts) are preserved exactly,
-and a list with stray content before its first `\item` is left as a generic `Node::Environment`
+and a list with stray content before its first `\item` is left as a generic `NodeKind::Environment`
 — never an error here (truly malformed input — unbalanced braces, `\begin`/`\end` mismatch — is
 already rejected by the L1 parser with a spanned error, upstream of this pass). It is idempotent
 and round-trips: `recognize_tables(parse(&n.to_latex())) == [n]`. All three recognition passes

--- a/code/packages/rust/latex/src/ast.rs
+++ b/code/packages/rust/latex/src/ast.rs
@@ -9,10 +9,35 @@
 //! Every node round-trips: [`Node::to_latex`] renders a node back to LaTeX, and
 //! `parse(&render(ast)) == ast` (AST-equality, not byte-equality — surface spacing and the
 //! `$…$` vs `\(…\)` delimiter choice are normalized).
+//!
+//! ## Precise byte spans (LTXDOC02 S1)
+//!
+//! Every [`Node`] carries its exact source byte [`Span`] — the half-open `[start, end)` range
+//! such that `&src[node.span.start .. node.span.end]` is the node's own source substring
+//! (`\textbf{x}`, `{…}` including braces, `$…$` including the delimiters, and so on). The L1
+//! lexer already records a precise span on every token; the parser threads those tracked spans
+//! straight into each node it builds, so nothing is re-derived by substring search.
+//!
+//! The span is carried **beside** the node's payload as a uniform `{ kind, span }` split
+//! ([`Node`] = a [`NodeKind`] plus a [`Span`]) rather than baked into each variant. That keeps
+//! the span *orthogonal*: a `match` that only cares about the shape reads `node.kind`, and the
+//! span is a single field every node has (the single source of truth, replacing the bespoke
+//! `(usize, usize)` the old `Unsupported` variant carried).
+//!
+//! ### Spans are metadata, not identity
+//!
+//! Two nodes are [`PartialEq`]-equal when their [`NodeKind`]s are equal — the [`span`](Node::span)
+//! is deliberately **excluded** from equality (and from [`Hash`] were it derived). This is what
+//! makes "round-trip is a fixed point *modulo spans*" true: re-emitting a tree with
+//! [`to_latex`](Node::to_latex) and re-parsing moves byte offsets around (surface spacing is
+//! normalized) but preserves structure, so `parse(&render(ast)) == ast` still holds even though
+//! the two trees' spans differ. Tests that assert exact byte ranges read [`Node::span`] directly.
+
+use crate::token::Span;
 
 /// A sectioning level, in document-hierarchy order from coarsest (`\part`) to finest
 /// (`\subparagraph`). Produced by the L5d [`recognize_structure`](crate::recognize_structure)
-/// pass as part of [`Node::Section`].
+/// pass as part of [`NodeKind::Section`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SectionLevel {
     /// `\part`
@@ -25,7 +50,7 @@ pub enum SectionLevel {
     Subsection,
     /// `\subsubsection`
     Subsubsection,
-    /// `\paragraph` (a run-in heading, *not* a paragraph break — see [`Node::Par`])
+    /// `\paragraph` (a run-in heading, *not* a paragraph break — see [`NodeKind::Par`])
     Paragraph,
     /// `\subparagraph`
     Subparagraph,
@@ -33,7 +58,7 @@ pub enum SectionLevel {
 
 impl SectionLevel {
     /// The LaTeX control word for this level (without the leading backslash), used to render a
-    /// [`Node::Section`] back to source.
+    /// [`NodeKind::Section`] back to source.
     pub fn command(self) -> &'static str {
         match self {
             SectionLevel::Part => "part",
@@ -48,7 +73,7 @@ impl SectionLevel {
 }
 
 /// The flavour of a document-mode list environment, produced by the opt-in
-/// [`recognize_tables`](crate::recognize_tables) pass (D1) as part of [`Node::List`].
+/// [`recognize_tables`](crate::recognize_tables) pass (D1) as part of [`NodeKind::List`].
 ///
 /// | Environment | Kind | What the `\item`s look like |
 /// |-------------|------|------------------------------|
@@ -80,7 +105,7 @@ impl ListKind {
     }
 }
 
-/// One entry of a [`Node::List`] — a single `\item` and the content that follows it up to the
+/// One entry of a [`NodeKind::List`] — a single `\item` and the content that follows it up to the
 /// next `\item` (or the end of the list).
 ///
 /// `\item body` (in `itemize`/`enumerate`) has `label == None`. `\item[term] body` (the
@@ -96,9 +121,36 @@ pub struct ListItem {
     pub body: Vec<Node>,
 }
 
-/// One node of the document tree.
+/// One node of the document tree: its [`NodeKind`] (the shape + payload) plus its exact source
+/// byte [`Span`].
+///
+/// ## Why `{ kind, span }` and not a span field per variant
+///
+/// Every node needs a span, so hanging it off a single uniform field (rather than repeating a
+/// `span:` field inside all ~19 variants) keeps the span *orthogonal* to the shape: a `match`
+/// that only classifies the node reads [`node.kind`](Node::kind), untouched by spans, and the
+/// span is read the same way ([`node.span`](Node::span)) regardless of variant. This is the
+/// single source of truth the old `Unsupported { span: (usize, usize) }` bespoke field is now
+/// folded onto.
+///
+/// ## Equality ignores the span
+///
+/// [`PartialEq`]/[`Eq`] compare **only** [`kind`](Node::kind) — see the module docs. Construct a
+/// node with [`Node::new`], or the terse [`Node::text`]/[`Node::group`]/… helpers.
+#[derive(Debug, Clone)]
+pub struct Node {
+    /// The node's shape and payload.
+    pub kind: NodeKind,
+    /// The node's exact source byte range `[start, end)` — `&src[start..end]` is its source.
+    pub span: Span,
+}
+
+/// The shape and payload of a [`Node`], factored out so the [`Span`] can live beside it uniformly.
+///
+/// These are the variants L1 (and the opt-in recognition passes) produce. See [`Node`] for the
+/// span that accompanies each.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Node {
+pub enum NodeKind {
     /// A run of ordinary text (consecutive ordinary characters, coalesced).
     Text(String),
     /// Significant inter-word space.
@@ -157,7 +209,7 @@ pub enum Node {
     Preamble { command: String, options: Option<Vec<Node>>, name: Vec<Node> },
     /// An argument-form text font command (L5d): `\textbf{x}`, `\emph{x}`, `\underline{x}`, …
     /// `command` is the control-word verbatim; `content` is the wrapped argument. (Declaration-
-    /// form font commands like `\bfseries` stay plain [`Node::Command`]s — their effect is
+    /// form font commands like `\bfseries` stay plain [`NodeKind::Command`]s — their effect is
     /// positional, not a wrapped argument.) Produced only by the opt-in
     /// [`recognize_structure`](crate::recognize_structure) pass, not by L1.
     Styled { command: String, content: Vec<Node> },
@@ -178,23 +230,79 @@ pub enum Node {
     Active(char),
     /// A construct deliberately out of scope (the TeX-programmability asymptote — e.g.
     /// runtime `\catcode`). Not produced by L1; reserved so later layers can surface an
-    /// honest "unsupported" rather than mis-parse.
-    Unsupported { construct: String, span: (usize, usize) },
+    /// honest "unsupported" rather than mis-parse. (Its byte range lives in the enclosing
+    /// [`Node::span`], like every other node.)
+    Unsupported { construct: String },
 }
 
+/// Equality on a [`Node`] compares its [`NodeKind`] only — the [`span`](Node::span) is metadata,
+/// not identity (see the module docs). This is what keeps the round-trip a fixed point *modulo
+/// spans*: re-emitting and re-parsing preserves `kind` but moves byte offsets.
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+impl Eq for Node {}
+
 impl Node {
-    /// If this is a [`Node::Math`] island, parse its raw content into the math AST
-    /// ([`crate::MathNode`]); otherwise `None`. The structural tree is unchanged (L1
-    /// round-trip intact) — parsed math is produced on demand here.
+    /// Build a node from its [`NodeKind`] and source [`Span`].
+    pub fn new(kind: NodeKind, span: Span) -> Self {
+        Node { kind, span }
+    }
+
+    /// This node's exact source byte [`Span`] — `&src[.span.start .. .span.end]` is its source.
+    /// (A convenience accessor mirroring the public [`span`](Node::span) field, so callers can
+    /// read the range through a method as the spec's mechanism note describes.)
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    // --- Terse constructors -----------------------------------------------------------------
+    //
+    // These build a `Node` from a payload plus a span. They keep the parser (and the recognition
+    // passes, and tests) readable — `Node::group(inner, sp)` instead of the full struct literal —
+    // and are the single place a `NodeKind` is paired with its `Span`.
+
+    /// A `Text(String)` run spanning `span`.
+    pub fn text(s: impl Into<String>, span: Span) -> Self {
+        Node::new(NodeKind::Text(s.into()), span)
+    }
+    /// A `Space` spanning `span`.
+    pub fn space(span: Span) -> Self {
+        Node::new(NodeKind::Space, span)
+    }
+    /// A `Par` (paragraph break) spanning `span`.
+    pub fn par(span: Span) -> Self {
+        Node::new(NodeKind::Par, span)
+    }
+    /// A `Group([…])` — the span should cover the `{`…`}` including braces.
+    pub fn group(inner: Vec<Node>, span: Span) -> Self {
+        Node::new(NodeKind::Group(inner), span)
+    }
+    /// A `Command` — the span should cover `\name`…the last argument's closing `}` (or just the
+    /// control word if it has no arguments).
+    pub fn command(
+        name: impl Into<String>,
+        optional: Vec<Vec<Node>>,
+        arguments: Vec<Vec<Node>>,
+        span: Span,
+    ) -> Self {
+        Node::new(NodeKind::Command { name: name.into(), optional, arguments }, span)
+    }
+
+    /// If this is a math island, parse its raw content into the math AST ([`crate::MathNode`]);
+    /// otherwise `None`. The structural tree is unchanged (L1 round-trip intact) — parsed math is
+    /// produced on demand here.
     pub fn parsed_math(&self) -> Option<Result<crate::MathNode, crate::ParseError>> {
-        match self {
-            Node::Math { content, .. } => Some(crate::parse_math(content)),
+        match &self.kind {
+            NodeKind::Math { content, .. } => Some(crate::parse_math(content)),
             _ => None,
         }
     }
 
     /// Render this node back to LaTeX source. `parse(&node.to_latex()) == [node]` up to the
-    /// normalizations noted in the module docs.
+    /// normalizations noted in the module docs (and modulo spans — see the module docs).
     pub fn to_latex(&self) -> String {
         let mut s = String::new();
         self.write_latex(&mut s);
@@ -202,16 +310,16 @@ impl Node {
     }
 
     fn write_latex(&self, out: &mut String) {
-        match self {
-            Node::Text(t) => out.push_str(t),
-            Node::Space => out.push(' '),
-            Node::Par => out.push_str("\n\n"),
-            Node::Group(nodes) => {
+        match &self.kind {
+            NodeKind::Text(t) => out.push_str(t),
+            NodeKind::Space => out.push(' '),
+            NodeKind::Par => out.push_str("\n\n"),
+            NodeKind::Group(nodes) => {
                 out.push('{');
                 render_seq(nodes, out);
                 out.push('}');
             }
-            Node::Command { name, optional, arguments } => {
+            NodeKind::Command { name, optional, arguments } => {
                 out.push('\\');
                 out.push_str(name);
                 for opt in optional {
@@ -231,7 +339,7 @@ impl Node {
                     out.push(' ');
                 }
             }
-            Node::Environment { name, optional, arguments, body } => {
+            NodeKind::Environment { name, optional, arguments, body } => {
                 out.push_str("\\begin{");
                 out.push_str(name);
                 out.push('}');
@@ -250,18 +358,18 @@ impl Node {
                 out.push_str(name);
                 out.push('}');
             }
-            Node::Math { display, content } => {
+            NodeKind::Math { display, content } => {
                 let delim = if *display { "$$" } else { "$" };
                 out.push_str(delim);
                 out.push_str(content);
                 out.push_str(delim);
             }
-            Node::Comment(c) => {
+            NodeKind::Comment(c) => {
                 out.push('%');
                 out.push_str(c);
                 out.push('\n');
             }
-            Node::Verb { star, delim, content } => {
+            NodeKind::Verb { star, delim, content } => {
                 out.push_str("\\verb");
                 if *star {
                     out.push('*');
@@ -270,7 +378,7 @@ impl Node {
                 out.push_str(content);
                 out.push(*delim);
             }
-            Node::VerbatimEnv { env, content } => {
+            NodeKind::VerbatimEnv { env, content } => {
                 out.push_str("\\begin{");
                 out.push_str(env);
                 out.push('}');
@@ -279,7 +387,7 @@ impl Node {
                 out.push_str(env);
                 out.push('}');
             }
-            Node::Accent { accent, arg } => {
+            NodeKind::Accent { accent, arg } => {
                 // Render the braced form `\<accent>{arg}` — it re-recognizes to the same node
                 // whether the source wrote `\'e` or `\'{e}`.
                 out.push('\\');
@@ -288,7 +396,7 @@ impl Node {
                 render_seq(arg, out);
                 out.push('}');
             }
-            Node::Section { level, starred, short, title } => {
+            NodeKind::Section { level, starred, short, title } => {
                 // `\section` (+ `*` if starred) (+ `[short]` if present) `{title}`. Renders back
                 // to the exact shape `recognize_structure` folds, so it re-recognizes equal.
                 out.push('\\');
@@ -305,7 +413,7 @@ impl Node {
                 render_seq(title, out);
                 out.push('}');
             }
-            Node::CrossRef { command, note, target } => {
+            NodeKind::CrossRef { command, note, target } => {
                 out.push('\\');
                 out.push_str(command);
                 if let Some(note) = note {
@@ -317,7 +425,7 @@ impl Node {
                 render_seq(target, out);
                 out.push('}');
             }
-            Node::Preamble { command, options, name } => {
+            NodeKind::Preamble { command, options, name } => {
                 out.push('\\');
                 out.push_str(command);
                 if let Some(options) = options {
@@ -329,14 +437,14 @@ impl Node {
                 render_seq(name, out);
                 out.push('}');
             }
-            Node::Styled { command, content } => {
+            NodeKind::Styled { command, content } => {
                 out.push('\\');
                 out.push_str(command);
                 out.push('{');
                 render_seq(content, out);
                 out.push('}');
             }
-            Node::Tabular { col_spec, rows } => {
+            NodeKind::Tabular { col_spec, rows } => {
                 // `\begin{tabular}{spec}` cell & cell \\ cell & cell `\end{tabular}`. We always
                 // render the single-argument `tabular` form (a recognized `tabular*` folds its
                 // width away into the colspec at recognition time — the width is not a column
@@ -362,7 +470,7 @@ impl Node {
                 }
                 out.push_str("\\end{tabular}");
             }
-            Node::List { kind, items } => {
+            NodeKind::List { kind, items } => {
                 out.push_str("\\begin{");
                 out.push_str(kind.env());
                 out.push('}');
@@ -387,8 +495,8 @@ impl Node {
                 out.push_str(kind.env());
                 out.push('}');
             }
-            Node::Active(c) => out.push(*c),
-            Node::Unsupported { construct, .. } => out.push_str(construct),
+            NodeKind::Active(c) => out.push(*c),
+            NodeKind::Unsupported { construct } => out.push_str(construct),
         }
     }
 }

--- a/code/packages/rust/latex/src/document.rs
+++ b/code/packages/rust/latex/src/document.rs
@@ -66,7 +66,7 @@
 //! spans**: the round-trip test strips spans to a projection before comparing (see
 //! [`Document::strip_spans`]).
 
-use crate::ast::{ListItem, ListKind, Node, SectionLevel};
+use crate::ast::{ListItem, ListKind, Node, NodeKind, SectionLevel};
 use crate::error::ParseError;
 use crate::token::Span;
 use crate::{document_to_latex, parse, recognize_accents, recognize_structure, recognize_tables};
@@ -549,7 +549,7 @@ pub fn build_document(nodes: Vec<Node>, src: &str) -> Document {
     let mut found_document = false;
     for node in nodes {
         if !found_document {
-            if let Node::Environment { name, body, .. } = &node {
+            if let NodeKind::Environment { name, body, .. } = &node.kind {
                 if name == "document" {
                     body_nodes = body.clone();
                     found_document = true;
@@ -618,7 +618,7 @@ fn extract_metadata(
 
     // The `abstract` environment is a body construct only.
     for node in body_nodes {
-        if let Node::Environment { name, body, .. } = node {
+        if let NodeKind::Environment { name, body, .. } = &node.kind {
             if name == "abstract" && meta.abstract_.is_none() {
                 meta.abstract_ = Some(lower_blocks(body.clone(), body_region));
             }
@@ -635,7 +635,7 @@ fn scan_title_author_date(nodes: &[Node], region: Span, meta: &mut Metadata) {
         // These directives survive D2 lowering as plain `Node::Command`s (they are not among the
         // constructs `recognize_structure` folds), so we match the raw command with exactly one
         // mandatory argument and no optional argument.
-        if let Node::Command { name, optional, arguments } = node {
+        if let NodeKind::Command { name, optional, arguments } = &node.kind {
             if !optional.is_empty() {
                 continue; // A bracketed form isn't the plain \title{…}/\author{…}/\date{…} we mean.
             }
@@ -676,7 +676,7 @@ fn split_on_and(arg: &[Node]) -> Vec<Vec<Node>> {
     let mut groups: Vec<Vec<Node>> = Vec::new();
     let mut current: Vec<Node> = Vec::new();
     for node in arg {
-        if matches!(node, Node::Command { name, arguments, .. } if name == "and" && arguments.is_empty())
+        if matches!(&node.kind, NodeKind::Command { name, arguments, .. } if name == "and" && arguments.is_empty())
         {
             groups.push(std::mem::take(&mut current));
         } else {
@@ -695,8 +695,8 @@ fn classify_preamble(nodes: Vec<Node>, span: Span) -> Preamble {
     let mut raw: Vec<Node> = Vec::new();
 
     for node in nodes {
-        match &node {
-            Node::Preamble { command, options, name } if command == "documentclass" => {
+        match &node.kind {
+            NodeKind::Preamble { command, options, name } if command == "documentclass" => {
                 // Only the first `\documentclass` counts (LaTeX allows exactly one); a stray
                 // second one is kept in `raw` so it is not silently lost.
                 if document_class.is_none() {
@@ -709,7 +709,7 @@ fn classify_preamble(nodes: Vec<Node>, span: Span) -> Preamble {
                     raw.push(node);
                 }
             }
-            Node::Preamble { command, options, name }
+            NodeKind::Preamble { command, options, name }
                 if command == "usepackage" || command == "RequirePackage" =>
             {
                 packages.push(Package {
@@ -758,7 +758,7 @@ fn lower_blocks(nodes: Vec<Node>, region: Span) -> Vec<Block> {
         if is_block_node(&node) {
             flush(&mut pending, &mut blocks, region);
             blocks.push(lower_block(node, region));
-        } else if matches!(node, Node::Par) {
+        } else if matches!(node.kind, NodeKind::Par) {
             // A blank-line paragraph break closes the current paragraph.
             flush(&mut pending, &mut blocks, region);
         } else {
@@ -1052,21 +1052,23 @@ fn walk_inline<'a>(inline: &'a Inline, out: &mut Vec<NodeRef<'a>>) {
 /// Does this node lower to a [`Block`] of its own (rather than joining an inline run)?
 fn is_block_node(node: &Node) -> bool {
     matches!(
-        node,
-        Node::Section { .. }
-            | Node::List { .. }
-            | Node::Tabular { .. }
-            | Node::Math { display: true, .. }
-            | Node::Environment { .. }
-            | Node::VerbatimEnv { .. }
+        node.kind,
+        NodeKind::Section { .. }
+            | NodeKind::List { .. }
+            | NodeKind::Tabular { .. }
+            | NodeKind::Math { display: true, .. }
+            | NodeKind::Environment { .. }
+            | NodeKind::VerbatimEnv { .. }
     )
 }
 
 /// Lower a single block-level node into its [`Block`], recursing into child node-lists. `region`
 /// is the enclosing span the block (and, coarsely, its descendants) inherit.
 fn lower_block(node: Node, region: Span) -> Block {
-    match node {
-        Node::Section { level, starred, short, title } => Block::Section {
+    // Destructure on the kind; the fallback needs the whole node, so re-wrap it there.
+    let Node { kind, span } = node;
+    match kind {
+        NodeKind::Section { level, starred, short, title } => Block::Section {
             level,
             numbered: !starred,
             title: lower_inlines(title, region),
@@ -1075,12 +1077,12 @@ fn lower_block(node: Node, region: Span) -> Block {
             body: Vec::new(), // filled by fold_sections (D3): the run of blocks this heading owns.
             span: region,
         },
-        Node::List { kind, items } => Block::List {
+        NodeKind::List { kind, items } => Block::List {
             kind,
             items: items.into_iter().map(|it| lower_list_item(it, region)).collect(),
             span: region,
         },
-        Node::Tabular { col_spec, rows } => Block::Table {
+        NodeKind::Tabular { col_spec, rows } => Block::Table {
             col_spec,
             rows: rows
                 .into_iter()
@@ -1090,16 +1092,16 @@ fn lower_block(node: Node, region: Span) -> Block {
             label: None,
             span: region,
         },
-        Node::Math { display: true, content } => Block::DisplayMath { source: content, span: region },
+        NodeKind::Math { display: true, content } => Block::DisplayMath { source: content, span: region },
         // A `verbatim`/`verbatim*` environment is lexed raw (catcodes suspended) into a
         // `VerbatimEnv` node; its content is source code, not marked-up LaTeX, so we keep it
         // **unparsed** as a `CodeBlock` (D5).
-        Node::VerbatimEnv { content, .. } => Block::CodeBlock { verbatim: content, span: region },
+        NodeKind::VerbatimEnv { content, .. } => Block::CodeBlock { verbatim: content, span: region },
         // Every `\begin{env}…\end{env}` (floats, quotes, display-math envs, code listings, or an
         // unknown env) is classified by name in `lower_environment` (D5).
-        Node::Environment { name, body, .. } => lower_environment(name, body, region),
+        NodeKind::Environment { name, body, .. } => lower_environment(name, body, region),
         // Anything else with no block model of its own — carried through verbatim (never dropped).
-        other => Block::Raw(other, region),
+        other => Block::Raw(Node::new(other, span), region),
     }
 }
 
@@ -1208,7 +1210,7 @@ fn extract_caption_label(content: &mut Vec<Block>, region: Span) -> (Option<Capt
             let mut kept: Vec<Inline> = Vec::with_capacity(inlines.len());
             for inline in std::mem::take(inlines) {
                 match &inline {
-                    Inline::Raw(Node::Command { name, arguments, optional }, _)
+                    Inline::Raw(Node { kind: NodeKind::Command { name, arguments, optional }, .. }, _)
                         if name == "caption" && optional.is_empty() && caption.is_none() =>
                     {
                         // `\caption{X}` — lower its mandatory argument to inlines.
@@ -1255,30 +1257,32 @@ fn lower_inlines(nodes: Vec<Node>, region: Span) -> Vec<Inline> {
 /// Lower a single node into its [`Inline`]. Anything without an inline meaning becomes
 /// [`Inline::Raw`] — never dropped, never a panic. `region` is the enclosing span.
 fn lower_inline(node: Node, region: Span) -> Inline {
-    match node {
-        Node::Text(t) => Inline::Text(t, region),
-        Node::Space => Inline::Space(region),
-        Node::Styled { command, content } => match command.as_str() {
+    // Destructure on the kind; the fallback needs the whole node, so re-wrap it there.
+    let Node { kind, span } = node;
+    match kind {
+        NodeKind::Text(t) => Inline::Text(t, region),
+        NodeKind::Space => Inline::Space(region),
+        NodeKind::Styled { command, content } => match command.as_str() {
             "textbf" => Inline::Strong(lower_inlines(content, region), region),
             "emph" | "textit" => Inline::Emph(lower_inlines(content, region), region),
             "texttt" => Inline::Code(render_nodes(&content), region),
             _ => Inline::Styled { command, content: lower_inlines(content, region), span: region },
         },
-        Node::Math { display: false, content } => Inline::Math { source: content, span: region },
-        Node::CrossRef { command, note, target } => Inline::CrossRef {
+        NodeKind::Math { display: false, content } => Inline::Math { source: content, span: region },
+        NodeKind::CrossRef { command, note, target } => Inline::CrossRef {
             command,
             note: note.map(|n| lower_inlines(n, region)),
             target: render_nodes(&target),
             span: region,
         },
-        Node::Accent { accent, arg } => Inline::Accent {
+        NodeKind::Accent { accent, arg } => Inline::Accent {
             accent,
             base: Box::new(lower_accent_base(arg, region)),
             span: region,
         },
         // Everything else (a display Math slipped into an inline run, an unhandled command, …)
         // is carried through verbatim.
-        other => Inline::Raw(other, region),
+        other => Inline::Raw(Node::new(other, span), region),
     }
 }
 
@@ -2314,7 +2318,7 @@ mod tests {
         assert_eq!(inline_text(title), "T");
         // Additive projection: the `\title` node is NOT removed — it survives in preamble.raw.
         assert!(
-            doc.preamble.raw.iter().any(|n| matches!(n, Node::Command { name, .. } if name == "title")),
+            doc.preamble.raw.iter().any(|n| matches!(&n.kind, NodeKind::Command { name, .. } if name == "title")),
             "the \\title node stays in preamble.raw (additive projection)"
         );
     }
@@ -2373,7 +2377,7 @@ mod tests {
         // `\maketitle` is a no-op for metadata (nothing to capture) but is carried through the body.
         assert!(
             doc.body.iter().any(|b| matches!(b, Block::Paragraph(inls, _)
-                if inls.iter().any(|i| matches!(i, Inline::Raw(Node::Command { name, .. }, _)
+                if inls.iter().any(|i| matches!(i, Inline::Raw(Node { kind: NodeKind::Command { name, .. }, .. }, _)
                     if name == "maketitle")))),
             "\\maketitle is carried through as a Raw inline (no metadata side effect)"
         );
@@ -2445,13 +2449,13 @@ mod tests {
             // caption nor the label lingers as body content.
             assert!(
                 content.iter().any(|b| matches!(b, Block::Paragraph(inls, _)
-                    if inls.iter().any(|i| matches!(i, Inline::Raw(Node::Command { name, .. }, _)
+                    if inls.iter().any(|i| matches!(i, Inline::Raw(Node { kind: NodeKind::Command { name, .. }, .. }, _)
                         if name == "includegraphics")))),
                 "the \\includegraphics body is preserved"
             );
             assert!(
                 !content.iter().any(|b| matches!(b, Block::Paragraph(inls, _)
-                    if inls.iter().any(|i| matches!(i, Inline::Raw(Node::Command { name, .. }, _)
+                    if inls.iter().any(|i| matches!(i, Inline::Raw(Node { kind: NodeKind::Command { name, .. }, .. }, _)
                         if name == "caption")))),
                 "the \\caption marker is lifted out of the body"
             );

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -25,24 +25,24 @@
 //!    roots, scripts, big operators, functions, fenced groups, relations, and **math
 //!    environments** (`matrix`/`pmatrix`/`cases`/`aligned`/… with `&` and `\\`) →
 //!    [`MathNode`], with precedence and [`MathNode::to_latex`] round-tripping.
-//!    [`Node::parsed_math`] parses a [`Node::Math`] island on demand. **Implemented
+//!    [`Node::parsed_math`] parses a [`NodeKind::Math`] island on demand. **Implemented
 //!    (this release).**
 //! 4. [`expand`] — an opt-in **macro pass** over the document tree: registers
 //!    `\newcommand`/`\renewcommand`/`\providecommand` (positional `#1`..`#9`) and replaces
 //!    uses by their bounded, recursively-expanded bodies. **Implemented (L4a).**
-//! 5. **Verbatim** — `\verb`/`\verb*` ([`Node::Verb`]) and the `verbatim`/`verbatim*`
-//!    environment ([`Node::VerbatimEnv`]) read their bodies **raw** (catcodes suspended).
+//! 5. **Verbatim** — `\verb`/`\verb*` ([`NodeKind::Verb`]) and the `verbatim`/`verbatim*`
+//!    environment ([`NodeKind::VerbatimEnv`]) read their bodies **raw** (catcodes suspended).
 //!    **Implemented (L5a/L5b).**
 //! 6. [`recognize_accents`] — an opt-in pass folding text accents (`\'e`, `\c{c}`) into
-//!    [`Node::Accent`]. **Implemented (L5c).**
+//!    [`NodeKind::Accent`]. **Implemented (L5c).**
 //! 7. [`recognize_structure`] — an opt-in pass classifying generic commands into structure
-//!    nodes: sectioning ([`Node::Section`]), cross-refs/citations ([`Node::CrossRef`]),
-//!    preamble directives ([`Node::Preamble`]), and argument-form font commands
-//!    ([`Node::Styled`]). **Implemented (L5d).**
+//!    nodes: sectioning ([`NodeKind::Section`]), cross-refs/citations ([`NodeKind::CrossRef`]),
+//!    preamble directives ([`NodeKind::Preamble`]), and argument-form font commands
+//!    ([`NodeKind::Styled`]). **Implemented (L5d).**
 //! 8. [`recognize_tables`] — an opt-in pass folding document-mode `tabular`/`tabular*` grids into
-//!    [`Node::Tabular`] (splitting the body on `&`/`\\`) and the list environments
-//!    `itemize`/`enumerate`/`description` into [`Node::List`] (splitting on `\item`). Total and
-//!    infallible; leaves questionable input as its generic [`Node::Environment`]. **Implemented (D1).**
+//!    [`NodeKind::Tabular`] (splitting the body on `&`/`\\`) and the list environments
+//!    `itemize`/`enumerate`/`description` into [`NodeKind::List`] (splitting on `\item`). Total and
+//!    infallible; leaves questionable input as its generic [`NodeKind::Environment`]. **Implemented (D1).**
 //! 9. [`LatexMath`] — the `math-frontend` adapter: implements `math_frontend::MathFrontend`,
 //!    lifting a math island's [`MathNode`] into the neutral `MathExpr`, so LaTeX plugs into the
 //!    pluggable-frontend registry ([`registry`] / [`register_latex`]). **Implemented (L6).**
@@ -62,10 +62,10 @@
 //! ## Example
 //!
 //! ```
-//! use latex::{parse, parse_math, Node, MathNode};
+//! use latex::{parse, parse_math, NodeKind, MathNode};
 //! let doc = parse(r"Let $x$ be \textbf{bold}.").unwrap();
-//! assert!(matches!(doc[0], Node::Text(_)));
-//! assert!(doc.iter().any(|n| matches!(n, Node::Math { .. })));
+//! assert!(matches!(doc[0].kind, NodeKind::Text(_)));
+//! assert!(doc.iter().any(|n| matches!(n.kind, NodeKind::Math { .. })));
 //!
 //! let m = parse_math(r"\frac{12 \times 15}{3}").unwrap();
 //! assert!(matches!(m, MathNode::Frac(..)));
@@ -93,7 +93,7 @@ mod frontend;
 #[cfg(feature = "frontend")]
 pub use frontend::{register_latex, registry, LatexMath};
 
-pub use ast::{document_to_latex, ListItem, ListKind, Node, SectionLevel};
+pub use ast::{document_to_latex, ListItem, ListKind, Node, NodeKind, SectionLevel};
 pub use document::{
     build_document, parse_document, Block, Caption, DocListItem, Document, DocumentClass, Inline,
     Metadata, NodeRef, Package, Preamble, Provenance,

--- a/code/packages/rust/latex/src/macros.rs
+++ b/code/packages/rust/latex/src/macros.rs
@@ -24,11 +24,11 @@
 //!
 //! ## How `#n` survives L1
 //!
-//! L1 lexes `#` to a [`Node::Text`] `"#"` and the following digit to a separate `Text`, so a
+//! L1 lexes `#` to a [`NodeKind::Text`] `"#"` and the following digit to a separate `Text`, so a
 //! body `#1y` arrives as `[Text("#"), Text("1y")]`. Substitution therefore scans each node
 //! sequence for a `Text("#")` immediately followed by a `Text` starting with a digit `1..=9`,
 //! and recurses into groups / command arguments / environment bodies so `\bar{#1}` works too.
-//! `##` denotes a literal `#`. (`#n` *inside a math island* — a [`Node::Math`] whose body is a
+//! `##` denotes a literal `#`. (`#n` *inside a math island* — a [`NodeKind::Math`] whose body is a
 //! raw string — is not substituted in this layer; that is a documented L4a limitation.)
 //!
 //! ## Honest scope (L4a)
@@ -48,9 +48,21 @@
 //!
 //! Either way the pass returns `Err`, it never hangs or overflows the stack.
 
-use crate::ast::Node;
+use crate::ast::{Node, NodeKind};
 use crate::error::ParseError;
+use crate::token::Span;
 use std::collections::HashMap;
+
+/// The smallest span covering both `a` and `b` — composes a synthesised node's span from its
+/// constituents (S1: union-of-children where expansion splices nodes together).
+fn union(a: Span, b: Span) -> Span {
+    Span::new(a.start.min(b.start), a.end.max(b.end))
+}
+
+/// The span covering a whole node sequence (empty → `fallback`): the union of every node's span.
+fn seq_span(nodes: &[Node], fallback: Span) -> Span {
+    nodes.iter().map(|n| n.span).reduce(union).unwrap_or(fallback)
+}
 
 /// Maximum nesting of macro-expands-to-macro before we give up (cycle guard).
 const MAX_EXPANSION_DEPTH: usize = 64;
@@ -121,16 +133,17 @@ impl Expander {
         let mut i = 0;
         while i < nodes.len() {
             self.tick()?;
-            match &nodes[i] {
+            let node_span = nodes[i].span;
+            match &nodes[i].kind {
                 // ---- a definition: register it, drop it from the output ----
-                Node::Command { name, optional, arguments } if is_definition(name) => {
+                NodeKind::Command { name, optional, arguments } if is_definition(name) => {
                     let (mac_name, mac, consumed) =
                         parse_definition(name, optional, arguments, &nodes[i + 1..])?;
                     self.table.insert(mac_name, mac);
                     i += 1 + consumed;
                 }
                 // ---- a use of a registered macro: substitute + recurse ----
-                Node::Command { name, optional, arguments }
+                NodeKind::Command { name, optional, arguments }
                     if optional.is_empty() && self.table.contains_key(name) =>
                 {
                     let mac = self.table.get(name).expect("checked").clone();
@@ -159,8 +172,9 @@ impl Expander {
                     // macro; keep them (as groups) so e.g. a 0-arg `\foo{x}` still yields the
                     // expansion followed by `{x}`.
                     for extra in arguments.iter().skip(mac.nargs) {
+                        let sp = seq_span(extra, node_span);
                         let inner = self.expand_seq(extra.clone(), depth + 1)?;
-                        out.push(Node::Group(inner));
+                        out.push(Node::group(inner, sp));
                     }
                     i += 1;
                 }
@@ -181,14 +195,17 @@ impl Expander {
     /// not how deeply groups nest — the latter is already bounded by L1's parse-depth cap, so
     /// counting it here would wrongly reject valid deeply-nested-but-finite documents.
     fn expand_children(&mut self, node: Node, depth: usize) -> Result<Node, ParseError> {
-        Ok(match node {
-            Node::Group(inner) => Node::Group(self.expand_seq(inner, depth)?),
-            Node::Command { name, optional, arguments } => Node::Command {
+        // Recursing into a node's children never changes the node's own extent, so it keeps its
+        // span.
+        let span = node.span;
+        let kind = match node.kind {
+            NodeKind::Group(inner) => NodeKind::Group(self.expand_seq(inner, depth)?),
+            NodeKind::Command { name, optional, arguments } => NodeKind::Command {
                 name,
                 optional: self.expand_vecs(optional, depth)?,
                 arguments: self.expand_vecs(arguments, depth)?,
             },
-            Node::Environment { name, optional, arguments, body } => Node::Environment {
+            NodeKind::Environment { name, optional, arguments, body } => NodeKind::Environment {
                 name,
                 optional: self.expand_vecs(optional, depth)?,
                 arguments: self.expand_vecs(arguments, depth)?,
@@ -196,7 +213,8 @@ impl Expander {
             },
             // leaves carry no child node sequences
             other => other,
-        })
+        };
+        Ok(Node::new(kind, span))
     }
 
     fn expand_vecs(&mut self, vs: Vec<Vec<Node>>, depth: usize) -> Result<Vec<Vec<Node>>, ParseError> {
@@ -221,7 +239,7 @@ fn parse_definition(
     // The macro name is the first mandatory argument: a `{\foo}` group, captured as a
     // one-element node list holding the command `\foo`.
     let name = match arguments.first().map(Vec::as_slice) {
-        Some([Node::Command { name, .. }]) => name.clone(),
+        Some([Node { kind: NodeKind::Command { name, .. }, .. }]) => name.clone(),
         _ => {
             return Err(ParseError::new(
                 format!("\\{cmd} must be followed by {{\\name}}"),
@@ -249,15 +267,15 @@ fn parse_definition(
     let mut consumed = 0;
     let mut nargs = 0usize;
     // optional arity bracket, e.g. Text("[2]")
-    if let Some(Node::Text(t)) = rest.first() {
+    if let Some(Node { kind: NodeKind::Text(t), .. }) = rest.first() {
         if let Some(n) = parse_arity_bracket(t) {
             nargs = n?;
             consumed += 1;
         }
     }
     // the body group
-    match rest.get(consumed) {
-        Some(Node::Group(body)) => {
+    match rest.get(consumed).map(|n| &n.kind) {
+        Some(NodeKind::Group(body)) => {
             consumed += 1;
             Ok((name, Macro { nargs, body: body.clone() }, consumed))
         }
@@ -300,12 +318,13 @@ impl Expander {
         let mut i = 0;
         while i < body.len() {
             self.tick()?;
-            match &body[i] {
+            let node_span = body[i].span;
+            match &body[i].kind {
                 // `#` is a lone Text("#"); look at the next node to classify it.
-                Node::Text(h) if h == "#" => {
-                    match body.get(i + 1) {
+                NodeKind::Text(h) if h == "#" => {
+                    match body.get(i + 1).map(|n| (&n.kind, n.span)) {
                         // `#n` — a parameter reference.
-                        Some(Node::Text(t)) if first_is_param_digit(t) => {
+                        Some((NodeKind::Text(t), t_span)) if first_is_param_digit(t) => {
                             let d = (t.as_bytes()[0] - b'0') as usize; // 1..=9
                             if d > args.len() {
                                 return Err(ParseError::new(
@@ -317,46 +336,55 @@ impl Expander {
                             // Charge for the spliced argument *before* cloning it in, so a
                             // large arg duplicated many times is bounded as it is built.
                             self.charge(args[d - 1].len())?;
+                            // Spliced-in argument nodes keep their own (call-site) spans.
                             out.extend(args[d - 1].clone());
                             let remainder = &t[1..];
                             if !remainder.is_empty() {
-                                out.push(Node::Text(remainder.to_string()));
+                                // The remainder occupies the digit's byte onward in the `#n…` text.
+                                let rem_span = Span::new(
+                                    t_span.start + (t.len() - remainder.len()),
+                                    t_span.end,
+                                );
+                                out.push(Node::text(remainder.to_string(), rem_span));
                             }
                             i += 2;
                         }
                         // `##` — a literal `#`.
-                        Some(Node::Text(t)) if t == "#" => {
-                            out.push(Node::Text("#".into()));
+                        Some((NodeKind::Text(t), t_span)) if t == "#" => {
+                            out.push(Node::text("#", union(node_span, t_span)));
                             i += 2;
                         }
                         // a `#` not followed by a digit or `#` — keep it literal.
                         _ => {
-                            out.push(Node::Text("#".into()));
+                            out.push(Node::text("#", node_span));
                             i += 1;
                         }
                     }
                 }
                 // recurse into structures that carry child node sequences
-                Node::Group(inner) => {
+                NodeKind::Group(inner) => {
                     let g = self.subst_seq(inner, args, mac)?;
-                    out.push(Node::Group(g));
+                    out.push(Node::group(g, node_span));
                     i += 1;
                 }
-                Node::Command { name, optional, arguments } => {
+                NodeKind::Command { name, optional, arguments } => {
                     let optional = self.subst_vecs(optional, args, mac)?;
                     let arguments = self.subst_vecs(arguments, args, mac)?;
-                    out.push(Node::Command { name: name.clone(), optional, arguments });
+                    out.push(Node::command(name.clone(), optional, arguments, node_span));
                     i += 1;
                 }
-                Node::Environment { name, optional, arguments, body: ebody } => {
+                NodeKind::Environment { name, optional, arguments, body: ebody } => {
                     let optional = self.subst_vecs(optional, args, mac)?;
                     let arguments = self.subst_vecs(arguments, args, mac)?;
                     let ebody = self.subst_seq(ebody, args, mac)?;
-                    out.push(Node::Environment { name: name.clone(), optional, arguments, body: ebody });
+                    out.push(Node::new(
+                        NodeKind::Environment { name: name.clone(), optional, arguments, body: ebody },
+                        node_span,
+                    ));
                     i += 1;
                 }
-                other => {
-                    out.push(other.clone());
+                _ => {
+                    out.push(body[i].clone());
                     i += 1;
                 }
             }

--- a/code/packages/rust/latex/src/parser.rs
+++ b/code/packages/rust/latex/src/parser.rs
@@ -10,6 +10,24 @@
 //! panic-free**: every malformed structure (unbalanced braces, a `\begin{a}…\end{b}`
 //! mismatch, an unterminated environment or math island) yields a spanned [`ParseError`].
 //!
+//! ## Precise byte spans (LTXDOC02 S1)
+//!
+//! Every token the lexer emits already records a half-open byte [`Span`]. This parser threads
+//! those spans straight onto the [`Node`]s it builds, so each node carries its **exact** source
+//! byte range — `&src[node.span.start .. node.span.end]` is the node's own source substring:
+//!
+//! | node | span covers |
+//! |------|-------------|
+//! | `Text` (coalesced run) | first char token's start … last char token's end |
+//! | `Group` | the `{` … the matching `}` (braces included) |
+//! | `Command` | `\name` … the last captured argument's closing `}` (or just the control word) |
+//! | `Environment` | `\begin{name}` … the closing `}` of `\end{name}` |
+//! | `Math` island | the opening `$`/`$$`/`\[` … the closing delimiter |
+//! | leaves (`Space`, `Par`, `Comment`, `Active`, `Verb`, …) | the token's own span |
+//!
+//! Composite spans are built from the **tracked** start/end of the covered tokens (a `[first,
+//! last)` union) — never re-derived by scanning the source for a substring.
+//!
 //! ## Generic argument capture (and its deliberate limit)
 //!
 //! After a control word, L1 captures **one** optional `[…]` argument (if it immediately
@@ -19,16 +37,16 @@
 //! because the tokenizer already absorbed the space *after* a control word but not after a
 //! group.
 
-use crate::ast::Node;
+use crate::ast::{Node, NodeKind};
 use crate::error::ParseError;
 use crate::lexer::tokenize;
-use crate::token::{Token, TokenKind};
+use crate::token::{Span, Token, TokenKind};
 
 /// Parse a LaTeX document into a sequence of structural nodes.
 pub fn parse(src: &str) -> Result<Vec<Node>, ParseError> {
     let toks = tokenize(src)?;
     let mut p = Parser { toks: &toks, src, pos: 0, depth: 0 };
-    let nodes = p.parse_seq(Stop::Document)?;
+    let (nodes, _end) = p.parse_seq(Stop::Document)?;
     // After a document sequence the only thing left should be Eof; a `\end` here is a
     // close with no matching `\begin`.
     match &p.peek().kind {
@@ -57,9 +75,16 @@ enum Stop {
     Bracket,
 }
 
-/// The optional `[…]` arguments and mandatory `{…}` arguments captured after a command —
-/// each argument is itself a node sequence.
-type CapturedArgs = (Vec<Vec<Node>>, Vec<Vec<Node>>);
+/// A parsed node sequence plus the byte offset **just past** the delimiter that closed it — the
+/// `}` for a group, the `]` for a bracket. For `Document`/`EnvBody` runs (which stop *before*
+/// consuming their terminator) this is the offset where the run ended (the start of the stopping
+/// token); the caller composes the enclosing node's span from there.
+type Seq = (Vec<Node>, usize);
+
+/// The optional `[…]` arguments and mandatory `{…}` arguments captured after a command — each
+/// argument is itself a node sequence — plus the byte offset just past the last closing `}`
+/// (or `]`) consumed, or `None` if no argument was captured (a bare control word).
+type CapturedArgs = (Vec<Vec<Node>>, Vec<Vec<Node>>, Option<usize>);
 
 /// Maximum group/environment nesting depth. Deeply nested input (`{{{…}}}`) drives the
 /// recursive descent as deep as it nests; this bound turns a pathological input into a
@@ -94,7 +119,7 @@ impl<'a> Parser<'a> {
         t
     }
 
-    fn parse_seq(&mut self, stop: Stop) -> Result<Vec<Node>, ParseError> {
+    fn parse_seq(&mut self, stop: Stop) -> Result<Seq, ParseError> {
         // Guard recursion depth (groups/environments/arguments recurse through here) so a
         // pathologically nested input is a clean error, not a stack overflow.
         self.depth += 1;
@@ -112,14 +137,15 @@ impl<'a> Parser<'a> {
         result
     }
 
-    fn parse_seq_inner(&mut self, stop: Stop) -> Result<Vec<Node>, ParseError> {
+    fn parse_seq_inner(&mut self, stop: Stop) -> Result<Seq, ParseError> {
         let mut nodes = Vec::new();
         loop {
             let tok = self.peek();
             let sp = tok.span;
             match &tok.kind {
                 TokenKind::Eof => match stop {
-                    Stop::Document => break,
+                    // Document runs stop *before* Eof; the run "ends" at Eof's start.
+                    Stop::Document => return Ok((nodes, sp.start)),
                     Stop::Group => return Err(ParseError::new("unterminated group: missing '}'", sp.start, sp.end)),
                     Stop::Bracket => return Err(ParseError::new("unterminated optional argument: missing ']'", sp.start, sp.end)),
                     Stop::EnvBody => return Err(ParseError::new("unterminated environment: missing \\end", sp.start, sp.end)),
@@ -127,25 +153,30 @@ impl<'a> Parser<'a> {
                 // `\end` ends a document/env-body run (the caller handles it); inside a
                 // group/bracket it means an unbalanced delimiter.
                 TokenKind::ControlWord(w) if w == "end" => match stop {
-                    Stop::Document | Stop::EnvBody => break,
+                    // Stop *before* `\end`; the run ends at the `\end` token's start.
+                    Stop::Document | Stop::EnvBody => return Ok((nodes, sp.start)),
                     Stop::Group => return Err(ParseError::new("unterminated group: missing '}' before \\end", sp.start, sp.end)),
                     Stop::Bracket => return Err(ParseError::new("unterminated optional argument: missing ']' before \\end", sp.start, sp.end)),
                 },
                 TokenKind::EndGroup => match stop {
                     Stop::Group => {
+                        // Consume the `}` and report the offset just past it, so the caller's
+                        // `Group` span covers `{`…`}` inclusive.
+                        let end = sp.end;
                         self.bump();
-                        break;
+                        return Ok((nodes, end));
                     }
                     _ => return Err(ParseError::new("unexpected '}' (no open group)", sp.start, sp.end)),
                 },
                 TokenKind::Char(']') if stop == Stop::Bracket => {
+                    // Consume the `]` and report the offset just past it.
+                    let end = sp.end;
                     self.bump();
-                    break;
+                    return Ok((nodes, end));
                 }
                 _ => nodes.push(self.parse_one(stop)?),
             }
         }
-        Ok(nodes)
     }
 
     fn parse_one(&mut self, stop: Stop) -> Result<Node, ParseError> {
@@ -155,42 +186,43 @@ impl<'a> Parser<'a> {
             TokenKind::Char(_) => Ok(self.coalesce_text(stop)),
             TokenKind::Space => {
                 self.bump();
-                Ok(Node::Space)
+                Ok(Node::space(sp))
             }
             TokenKind::Par => {
                 self.bump();
-                Ok(Node::Par)
+                Ok(Node::par(sp))
             }
             TokenKind::Comment(c) => {
                 self.bump();
-                Ok(Node::Comment(c))
+                Ok(Node::new(NodeKind::Comment(c), sp))
             }
             TokenKind::Active(c) => {
                 self.bump();
-                Ok(Node::Active(c))
+                Ok(Node::new(NodeKind::Active(c), sp))
             }
             TokenKind::Verb { star, delim, content } => {
                 self.bump();
-                Ok(Node::Verb { star, delim, content })
+                Ok(Node::new(NodeKind::Verb { star, delim, content }, sp))
             }
             TokenKind::VerbatimEnv { env, content } => {
                 self.bump();
-                Ok(Node::VerbatimEnv { env, content })
+                Ok(Node::new(NodeKind::VerbatimEnv { env, content }, sp))
             }
             // In text mode these four are literal characters; they only carry structural
             // meaning inside math/environments, which are handled elsewhere (L2/L3).
-            TokenKind::AlignTab => { self.bump(); Ok(Node::Text("&".into())) }
-            TokenKind::Parameter => { self.bump(); Ok(Node::Text("#".into())) }
-            TokenKind::Superscript => { self.bump(); Ok(Node::Text("^".into())) }
-            TokenKind::Subscript => { self.bump(); Ok(Node::Text("_".into())) }
+            TokenKind::AlignTab => { self.bump(); Ok(Node::text("&", sp)) }
+            TokenKind::Parameter => { self.bump(); Ok(Node::text("#", sp)) }
+            TokenKind::Superscript => { self.bump(); Ok(Node::text("^", sp)) }
+            TokenKind::Subscript => { self.bump(); Ok(Node::text("_", sp)) }
             TokenKind::BeginGroup => {
-                self.bump();
-                let inner = self.parse_seq(Stop::Group)?;
-                Ok(Node::Group(inner))
+                let open = self.bump().span; // consume `{`
+                let (inner, end) = self.parse_seq(Stop::Group)?;
+                // The group's span covers `{` … the matching `}` (inclusive).
+                Ok(Node::group(inner, Span::new(open.start, end)))
             }
             TokenKind::ControlSymbol(c) => {
                 self.bump();
-                Ok(Node::Command { name: c.to_string(), optional: vec![], arguments: vec![] })
+                Ok(Node::command(c.to_string(), vec![], vec![], sp))
             }
             TokenKind::MathOn { display } => self.parse_math(display),
             TokenKind::MathOff { .. } => {
@@ -200,9 +232,12 @@ impl<'a> Parser<'a> {
                 if name == "begin" {
                     self.parse_environment()
                 } else {
-                    self.bump();
-                    let (optional, arguments) = self.capture_args()?;
-                    Ok(Node::Command { name, optional, arguments })
+                    let cmd = self.bump().span; // consume `\name`
+                    let (optional, arguments, args_end) = self.capture_args()?;
+                    // No captured args → span is just the control word; otherwise it extends to
+                    // the last argument's closing `}` (or the optional's `]`).
+                    let end = args_end.unwrap_or(cmd.end);
+                    Ok(Node::command(name, optional, arguments, Span::new(cmd.start, end)))
                 }
             }
             // `\end` and `}` are handled by parse_seq before reaching here; Eof likewise.
@@ -213,20 +248,27 @@ impl<'a> Parser<'a> {
     }
 
     /// Merge consecutive `Char` tokens into one `Text` node. In bracket context, stop
-    /// before the `]` that closes the optional argument so it isn't swallowed.
+    /// before the `]` that closes the optional argument so it isn't swallowed. The node's span
+    /// covers the first char token's start … the last char token's end.
     fn coalesce_text(&mut self, stop: Stop) -> Node {
         let mut s = String::new();
+        // The caller only invokes this when the current token is a `Char`, so `start` is the
+        // first character's byte offset and there is always at least one char consumed.
+        let start = self.peek().span.start;
+        let mut end = start;
         while let TokenKind::Char(c) = self.peek().kind {
             if stop == Stop::Bracket && c == ']' {
                 break;
             }
+            end = self.peek().span.end;
             s.push(c);
             self.bump();
         }
-        Node::Text(s)
+        Node::text(s, Span::new(start, end))
     }
 
-    /// `$ … $` / `\( … \)` (or display): keep the inner source verbatim for L2.
+    /// `$ … $` / `\( … \)` (or display): keep the inner source verbatim for L2. The node's span
+    /// covers the opening delimiter … the closing delimiter (inclusive).
     fn parse_math(&mut self, display: bool) -> Result<Node, ParseError> {
         let on = self.bump().span; // consume MathOn
         let content_start = on.end;
@@ -235,8 +277,12 @@ impl<'a> Parser<'a> {
             match &tok.kind {
                 TokenKind::MathOff { .. } => {
                     let content = self.src[content_start..tok.span.start].to_string();
+                    let off_end = tok.span.end;
                     self.bump(); // consume MathOff
-                    return Ok(Node::Math { display, content });
+                    return Ok(Node::new(
+                        NodeKind::Math { display, content },
+                        Span::new(on.start, off_end),
+                    ));
                 }
                 TokenKind::Eof => {
                     return Err(ParseError::new("unterminated math (missing closing delimiter)", on.start, tok.span.end));
@@ -249,27 +295,34 @@ impl<'a> Parser<'a> {
     }
 
     /// Capture one optional `[…]` (if it immediately follows) then a greedy run of
-    /// mandatory `{…}` groups.
+    /// mandatory `{…}` groups. Returns the captured argument sequences plus the byte offset
+    /// just past the last closing delimiter consumed (`None` if nothing was captured).
     fn capture_args(&mut self) -> Result<CapturedArgs, ParseError> {
         let mut optional = Vec::new();
         let mut arguments = Vec::new();
+        let mut last_end: Option<usize> = None;
         if matches!(self.peek().kind, TokenKind::Char('[')) {
             self.bump(); // consume '['
-            optional.push(self.parse_seq(Stop::Bracket)?);
+            let (nodes, end) = self.parse_seq(Stop::Bracket)?;
+            optional.push(nodes);
+            last_end = Some(end);
         }
         while matches!(self.peek().kind, TokenKind::BeginGroup) {
             self.bump(); // consume '{'
-            arguments.push(self.parse_seq(Stop::Group)?);
+            let (nodes, end) = self.parse_seq(Stop::Group)?;
+            arguments.push(nodes);
+            last_end = Some(end);
         }
-        Ok((optional, arguments))
+        Ok((optional, arguments, last_end))
     }
 
-    /// `\begin{name}[opt]{arg}… body \end{name}`.
+    /// `\begin{name}[opt]{arg}… body \end{name}`. The node's span covers `\begin` … the closing
+    /// `}` of `\end{name}` (inclusive).
     fn parse_environment(&mut self) -> Result<Node, ParseError> {
         let begin_sp = self.bump().span; // consume `\begin`
         let name = self.read_brace_name("\\begin")?;
-        let (optional, arguments) = self.capture_args()?;
-        let body = self.parse_seq(Stop::EnvBody)?;
+        let (optional, arguments, _args_end) = self.capture_args()?;
+        let (body, _body_end) = self.parse_seq(Stop::EnvBody)?;
         // Expect `\end{name}`.
         match &self.peek().kind {
             TokenKind::ControlWord(w) if w == "end" => {
@@ -293,10 +346,25 @@ impl<'a> Parser<'a> {
                 end_name_sp.end,
             ));
         }
-        Ok(Node::Environment { name, optional, arguments, body })
+        // `read_brace_name` consumed through the closing `}` of `\end{name}`; the token now at
+        // `pos-1` is that `}` — its end is the environment's end. `read_brace_name` returned it,
+        // so we recover it from the just-consumed token's span.
+        let env_end = self.prev_end();
+        Ok(Node::new(
+            NodeKind::Environment { name, optional, arguments, body },
+            Span::new(begin_sp.start, env_end),
+        ))
+    }
+
+    /// The end byte offset of the token just consumed (`pos - 1`). Used to close a span on the
+    /// last delimiter a sub-parse ate. Safe: every call site has consumed ≥1 token first.
+    fn prev_end(&self) -> usize {
+        let i = self.pos.saturating_sub(1).min(self.toks.len() - 1);
+        self.toks[i].span.end
     }
 
     /// Read a `{name}` group of ordinary characters (used for `\begin{name}`/`\end{name}`).
+    /// Consumes through the closing `}`.
     fn read_brace_name(&mut self, ctx: &str) -> Result<String, ParseError> {
         let sp = self.peek().span;
         if !matches!(self.peek().kind, TokenKind::BeginGroup) {
@@ -330,13 +398,19 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{document_to_latex, Node::*};
+    use crate::ast::{document_to_latex, NodeKind::*};
 
     fn p(src: &str) -> Vec<Node> {
         parse(src).expect("parse")
     }
 
-    /// Round-trip invariant: parsing the rendered AST yields the same AST.
+    /// Assert a node's kind matches, ignoring its span (spans are checked separately below).
+    fn kinds(nodes: &[Node]) -> Vec<NodeKind> {
+        nodes.iter().map(|n| n.kind.clone()).collect()
+    }
+
+    /// Round-trip invariant: parsing the rendered AST yields the same AST (modulo spans, which
+    /// `Node`'s `PartialEq` already ignores).
     fn assert_round_trips(src: &str) {
         let ast = parse(src).expect("parse");
         let rendered = document_to_latex(&ast);
@@ -346,40 +420,40 @@ mod tests {
 
     #[test]
     fn plain_text_and_spaces() {
-        assert_eq!(p("ab c"), vec![Text("ab".into()), Space, Text("c".into())]);
+        assert_eq!(kinds(&p("ab c")), vec![Text("ab".into()), Space, Text("c".into())]);
     }
 
     #[test]
     fn paragraph_break() {
-        assert_eq!(p("a\n\nb"), vec![Text("a".into()), Par, Text("b".into())]);
+        assert_eq!(kinds(&p("a\n\nb")), vec![Text("a".into()), Par, Text("b".into())]);
     }
 
     #[test]
     fn group() {
-        assert_eq!(p("{ab}"), vec![Group(vec![Text("ab".into())])]);
+        assert_eq!(kinds(&p("{ab}")), vec![Group(vec![Node::text("ab", Span::new(1, 3))])]);
     }
 
     #[test]
     fn bare_command() {
-        assert_eq!(p(r"\alpha"), vec![Command { name: "alpha".into(), optional: vec![], arguments: vec![] }]);
+        assert_eq!(kinds(&p(r"\alpha")), vec![Command { name: "alpha".into(), optional: vec![], arguments: vec![] }]);
     }
 
     #[test]
     fn command_with_one_arg() {
         assert_eq!(
-            p(r"\textbf{hi}"),
-            vec![Command { name: "textbf".into(), optional: vec![], arguments: vec![vec![Text("hi".into())]] }]
+            kinds(&p(r"\textbf{hi}")),
+            vec![Command { name: "textbf".into(), optional: vec![], arguments: vec![vec![Node::text("hi", Span::new(8, 10))]] }]
         );
     }
 
     #[test]
     fn command_with_optional_and_arg() {
         assert_eq!(
-            p(r"\sqrt[3]{x}"),
+            kinds(&p(r"\sqrt[3]{x}")),
             vec![Command {
                 name: "sqrt".into(),
-                optional: vec![vec![Text("3".into())]],
-                arguments: vec![vec![Text("x".into())]],
+                optional: vec![vec![Node::text("3", Span::new(6, 7))]],
+                arguments: vec![vec![Node::text("x", Span::new(9, 10))]],
             }]
         );
     }
@@ -388,37 +462,37 @@ mod tests {
     fn greedy_args_are_broken_by_a_space() {
         // `\textbf{a} {b}` → textbf takes only {a}; {b} is a separate group.
         assert_eq!(
-            p(r"\textbf{a} {b}"),
+            kinds(&p(r"\textbf{a} {b}")),
             vec![
-                Command { name: "textbf".into(), optional: vec![], arguments: vec![vec![Text("a".into())]] },
+                Command { name: "textbf".into(), optional: vec![], arguments: vec![vec![Node::text("a", Span::new(8, 9))]] },
                 Space,
-                Group(vec![Text("b".into())]),
+                Group(vec![Node::text("b", Span::new(12, 13))]),
             ]
         );
     }
 
     #[test]
     fn control_symbol_is_an_argless_command() {
-        assert_eq!(p(r"\,"), vec![Command { name: ",".into(), optional: vec![], arguments: vec![] }]);
+        assert_eq!(kinds(&p(r"\,")), vec![Command { name: ",".into(), optional: vec![], arguments: vec![] }]);
     }
 
     #[test]
     fn inline_and_display_math_keep_raw_content() {
-        assert_eq!(p(r"$x+1$"), vec![Math { display: false, content: "x+1".into() }]);
-        assert_eq!(p(r"$$x+1$$"), vec![Math { display: true, content: "x+1".into() }]);
+        assert_eq!(kinds(&p(r"$x+1$")), vec![Math { display: false, content: "x+1".into() }]);
+        assert_eq!(kinds(&p(r"$$x+1$$")), vec![Math { display: true, content: "x+1".into() }]);
         // `\(...\)` is inline; content captured verbatim.
-        assert_eq!(p(r"\(a b\)"), vec![Math { display: false, content: "a b".into() }]);
+        assert_eq!(kinds(&p(r"\(a b\)")), vec![Math { display: false, content: "a b".into() }]);
     }
 
     #[test]
     fn environment_with_body() {
         assert_eq!(
-            p(r"\begin{center}hi\end{center}"),
+            kinds(&p(r"\begin{center}hi\end{center}")),
             vec![Environment {
                 name: "center".into(),
                 optional: vec![],
                 arguments: vec![],
-                body: vec![Text("hi".into())],
+                body: vec![Node::text("hi", Span::new(14, 16))],
             }]
         );
     }
@@ -426,10 +500,10 @@ mod tests {
     #[test]
     fn nested_environments() {
         let ast = p(r"\begin{a}\begin{b}x\end{b}\end{a}");
-        match &ast[0] {
+        match &ast[0].kind {
             Environment { name, body, .. } => {
                 assert_eq!(name, "a");
-                assert!(matches!(&body[0], Environment { name, .. } if name == "b"));
+                assert!(matches!(&body[0].kind, Environment { name, .. } if name == "b"));
             }
             other => panic!("expected env, got {other:?}"),
         }
@@ -439,7 +513,7 @@ mod tests {
     fn environment_with_args() {
         // tabular takes a mandatory column spec.
         let ast = p(r"\begin{tabular}{cc}x\end{tabular}");
-        assert!(matches!(&ast[0], Environment { name, arguments, .. }
+        assert!(matches!(&ast[0].kind, Environment { name, arguments, .. }
             if name == "tabular" && arguments.len() == 1));
     }
 
@@ -447,15 +521,146 @@ mod tests {
     fn a_realistic_paragraph() {
         let ast = p(r"Let $x$ be \textbf{positive}.");
         assert_eq!(
-            ast,
+            kinds(&ast),
             vec![
                 Text("Let".into()), Space,
                 Math { display: false, content: "x".into() }, Space,
                 Text("be".into()), Space,
-                Command { name: "textbf".into(), optional: vec![], arguments: vec![vec![Text("positive".into())]] },
+                Command { name: "textbf".into(), optional: vec![], arguments: vec![vec![Node::text("positive", Span::new(19, 27))]] },
                 Text(".".into()),
             ]
         );
+    }
+
+    // ---- precise byte spans (LTXDOC02 S1) -------------------------------------
+    //
+    // Each representative top-level node slices back to its EXACT source substring, proving the
+    // parser threaded the tokens' spans through faithfully (not re-derived by substring search).
+
+    /// `&src[node.span]` — the node's own source substring.
+    fn slice<'a>(src: &'a str, n: &Node) -> &'a str {
+        &src[n.span.start..n.span.end]
+    }
+
+    #[test]
+    fn command_span_slices_back_to_source() {
+        let src = r"\textbf{x}";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), r"\textbf{x}");
+    }
+
+    #[test]
+    fn command_with_optional_span_covers_through_last_arg() {
+        let src = r"\sqrt[3]{x}";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), r"\sqrt[3]{x}");
+    }
+
+    #[test]
+    fn bare_command_span_is_just_the_control_word() {
+        let src = r"\alpha next";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), r"\alpha");
+    }
+
+    #[test]
+    fn group_span_includes_braces() {
+        let src = r"{ab}";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), "{ab}");
+    }
+
+    #[test]
+    fn math_span_includes_delimiters() {
+        let src = r"$x+1$";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), "$x+1$");
+        // display math keeps both `$$` delimiters
+        let src2 = r"$$y=mx$$";
+        let ast2 = p(src2);
+        assert_eq!(slice(src2, &ast2[0]), "$$y=mx$$");
+    }
+
+    #[test]
+    fn text_run_span_is_exactly_its_characters() {
+        let src = "hello world";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), "hello"); // first run, up to the space
+    }
+
+    #[test]
+    fn environment_span_covers_begin_to_end() {
+        let src = r"\begin{center}hi\end{center}";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), r"\begin{center}hi\end{center}");
+    }
+
+    #[test]
+    fn environment_with_arg_span_covers_begin_to_end() {
+        let src = r"\begin{tabular}{cc}a\end{tabular}";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), r"\begin{tabular}{cc}a\end{tabular}");
+    }
+
+    /// Containment: every node's span ⊆ its parent's ⊆ the whole-source range `0..src.len()`.
+    fn assert_contained(src: &str, nodes: &[Node], parent: Span) {
+        for n in nodes {
+            assert!(
+                parent.start <= n.span.start && n.span.end <= parent.end,
+                "span {:?} not within parent {:?} (src {src:?})",
+                n.span,
+                parent
+            );
+            assert!(n.span.start <= n.span.end, "span end < start: {:?}", n.span);
+            // Recurse into every child node-list this node carries.
+            for child_list in child_lists(n) {
+                assert_contained(src, child_list, n.span);
+            }
+        }
+    }
+
+    /// Every child node-sequence a node carries (for the containment walk).
+    fn child_lists(n: &Node) -> Vec<&[Node]> {
+        match &n.kind {
+            NodeKind::Group(inner) => vec![inner.as_slice()],
+            NodeKind::Command { optional, arguments, .. } => {
+                optional.iter().chain(arguments.iter()).map(Vec::as_slice).collect()
+            }
+            NodeKind::Environment { optional, arguments, body, .. } => optional
+                .iter()
+                .chain(arguments.iter())
+                .map(Vec::as_slice)
+                .chain(std::iter::once(body.as_slice()))
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    #[test]
+    fn every_node_span_is_contained_in_the_source() {
+        for src in [
+            r"Let $x$ be \textbf{positive}.",
+            r"\begin{tabular}{cc}a&b\end{tabular}",
+            r"nested {groups {deep}} ok",
+            r"\sqrt[3]{x} + \frac{1}{2}",
+            r"a~b and \, thin",
+        ] {
+            let ast = p(src);
+            assert_contained(src, &ast, Span::new(0, src.len()));
+        }
+    }
+
+    #[test]
+    fn totality_malformed_but_parseable_still_spanned_no_panic() {
+        // A control word with a trailing letter, a stray `#`, an active char, a comment: all
+        // parse, and every resulting node carries a well-formed span (end >= start, in range).
+        let src = "a#~b% note\n\\c";
+        let ast = p(src);
+        assert_contained(src, &ast, Span::new(0, src.len()));
+        // `Span::new` guards `end < start` (a leaf's own span is never inverted).
+        for n in &ast {
+            assert!(n.span.start <= n.span.end);
+        }
     }
 
     // ---- error cases (spanned, never panic) -----------------------------------
@@ -528,20 +733,27 @@ mod tests {
     fn verb_is_a_node_with_raw_body() {
         // `\verb|...|` becomes a Verb node whose body keeps catcode-significant chars literal.
         assert_eq!(
-            p(r"\verb|a{b}$c|"),
+            kinds(&p(r"\verb|a{b}$c|")),
             vec![Verb { star: false, delim: '|', content: "a{b}$c".into() }]
         );
         // starred variant
         assert_eq!(
-            p(r"\verb*!x!"),
+            kinds(&p(r"\verb*!x!")),
             vec![Verb { star: true, delim: '!', content: "x".into() }]
         );
     }
 
     #[test]
+    fn verb_span_slices_back_to_source() {
+        let src = r"\verb|a{b}$c|";
+        let ast = p(src);
+        assert_eq!(slice(src, &ast[0]), src);
+    }
+
+    #[test]
     fn verb_does_not_disturb_surrounding_text() {
         assert_eq!(
-            p(r"a\verb|b|c"),
+            kinds(&p(r"a\verb|b|c")),
             vec![
                 Text("a".into()),
                 Verb { star: false, delim: '|', content: "b".into() },
@@ -553,7 +765,7 @@ mod tests {
     #[test]
     fn verbatim_environment_is_a_node() {
         assert_eq!(
-            p("\\begin{verbatim}let x = {1};\n$y$\\end{verbatim}"),
+            kinds(&p("\\begin{verbatim}let x = {1};\n$y$\\end{verbatim}")),
             vec![VerbatimEnv {
                 env: "verbatim".into(),
                 content: "let x = {1};\n$y$".into(),

--- a/code/packages/rust/latex/src/structure.rs
+++ b/code/packages/rust/latex/src/structure.rs
@@ -45,7 +45,19 @@
 //! they have no single wrapped argument — modeling them as an argument node would misrepresent
 //! their scope. They round-trip fine as plain commands.
 
-use crate::ast::{Node, SectionLevel};
+use crate::ast::{Node, NodeKind, SectionLevel};
+use crate::token::Span;
+
+/// The smallest span covering both `a` and `b` — composes a synthesised node's span from its
+/// constituents (S1: union-of-children; precise per-construct spans are S2's job).
+fn union(a: Span, b: Span) -> Span {
+    Span::new(a.start.min(b.start), a.end.max(b.end))
+}
+
+/// The span covering a whole node sequence (empty → `fallback`): the union of every node's span.
+fn seq_span(nodes: &[Node], fallback: Span) -> Span {
+    nodes.iter().map(|n| n.span).reduce(union).unwrap_or(fallback)
+}
 
 /// Map a sectioning control word to its [`SectionLevel`], or `None` if `name` is not a
 /// sectioning command.
@@ -101,17 +113,25 @@ pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
     let mut out: Vec<Node> = Vec::with_capacity(nodes.len());
     let mut i = 0;
     while i < nodes.len() {
-        if let Node::Command { name, optional, arguments } = &nodes[i] {
+        // These recognized nodes fold an existing `Node::Command` (and, for the starred form,
+        // its `*` and group siblings). The synthesised node keeps the command's own span — it
+        // already covers `\name[opt]{arg}` — extended over any folded siblings.
+        let cmd_span = nodes[i].span;
+        if let NodeKind::Command { name, optional, arguments } = &nodes[i].kind {
             // --- Sectioning: \section{T} / \section*{T} / \section[s]{T} -------------------
             if let Some(level) = section_level(name) {
                 if let Some(first) = arguments.first() {
                     // Captured-argument form (no `*` intervened): \section[short]{title}.
                     let short = optional.first().map(|o| recognize_structure(o.clone()));
                     let title = recognize_structure(first.clone());
-                    out.push(Node::Section { level, starred: false, short, title });
+                    out.push(Node::new(
+                        NodeKind::Section { level, starred: false, short, title },
+                        cmd_span,
+                    ));
                     // Any further captured groups were not part of the heading — keep them.
                     for extra in arguments.iter().skip(1) {
-                        out.push(Node::Group(recognize_structure(extra.clone())));
+                        let sp = seq_span(extra, cmd_span);
+                        out.push(Node::group(recognize_structure(extra.clone()), sp));
                     }
                     i += 1;
                     continue;
@@ -119,7 +139,12 @@ pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
                 // No captured argument: try the starred form `\section*{title}`.
                 if optional.is_empty() {
                     if let Some(title) = starred_title(&nodes, i) {
-                        out.push(Node::Section { level, starred: true, short: None, title });
+                        // Span covers the command through the folded `*` and title group.
+                        let span = union(cmd_span, nodes[i + 2].span);
+                        out.push(Node::new(
+                            NodeKind::Section { level, starred: true, short: None, title },
+                            span,
+                        ));
                         i += 3; // command + Text("*") + Group
                         continue;
                     }
@@ -135,9 +160,13 @@ pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
                 if let Some(first) = arguments.first() {
                     let note = optional.first().map(|o| recognize_structure(o.clone()));
                     let target = recognize_structure(first.clone());
-                    out.push(Node::CrossRef { command: name.clone(), note, target });
+                    out.push(Node::new(
+                        NodeKind::CrossRef { command: name.clone(), note, target },
+                        cmd_span,
+                    ));
                     for extra in arguments.iter().skip(1) {
-                        out.push(Node::Group(recognize_structure(extra.clone())));
+                        let sp = seq_span(extra, cmd_span);
+                        out.push(Node::group(recognize_structure(extra.clone()), sp));
                     }
                     i += 1;
                     continue;
@@ -152,9 +181,13 @@ pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
                 if let Some(first) = arguments.first() {
                     let options = optional.first().map(|o| recognize_structure(o.clone()));
                     let name_arg = recognize_structure(first.clone());
-                    out.push(Node::Preamble { command: name.clone(), options, name: name_arg });
+                    out.push(Node::new(
+                        NodeKind::Preamble { command: name.clone(), options, name: name_arg },
+                        cmd_span,
+                    ));
                     for extra in arguments.iter().skip(1) {
-                        out.push(Node::Group(recognize_structure(extra.clone())));
+                        let sp = seq_span(extra, cmd_span);
+                        out.push(Node::group(recognize_structure(extra.clone()), sp));
                     }
                     i += 1;
                     continue;
@@ -167,7 +200,7 @@ pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
             // --- Argument-form font commands: \textbf{x}, \emph{x} -----------------------
             if is_style(name) && optional.is_empty() && arguments.len() == 1 {
                 let content = recognize_structure(arguments[0].clone());
-                out.push(Node::Styled { command: name.clone(), content });
+                out.push(Node::new(NodeKind::Styled { command: name.clone(), content }, cmd_span));
                 i += 1;
                 continue;
             }
@@ -185,9 +218,9 @@ pub fn recognize_structure(nodes: Vec<Node>) -> Vec<Node> {
 /// untouched). Only the canonical `\section*{title}` shape folds — unusual spacings such as
 /// `\section* foo` are deliberately left alone, since they round-trip fine as plain nodes.
 fn starred_title(nodes: &[Node], i: usize) -> Option<Vec<Node>> {
-    match nodes.get(i + 1) {
-        Some(Node::Text(star)) if star == "*" => match nodes.get(i + 2) {
-            Some(Node::Group(inner)) => Some(recognize_structure(inner.clone())),
+    match nodes.get(i + 1).map(|n| &n.kind) {
+        Some(NodeKind::Text(star)) if star == "*" => match nodes.get(i + 2).map(|n| &n.kind) {
+            Some(NodeKind::Group(inner)) => Some(recognize_structure(inner.clone())),
             _ => None,
         },
         _ => None,
@@ -197,14 +230,16 @@ fn starred_title(nodes: &[Node], i: usize) -> Option<Vec<Node>> {
 /// Recurse structure recognition into a node's child sequences without treating the node
 /// itself as a structure command (mirrors `text::recurse`).
 fn recurse(node: Node) -> Node {
-    match node {
-        Node::Group(inner) => Node::Group(recognize_structure(inner)),
-        Node::Command { name, optional, arguments } => Node::Command {
+    // Recursion regroups children but never changes the node's extent, so its span is kept.
+    let span = node.span;
+    let kind = match node.kind {
+        NodeKind::Group(inner) => NodeKind::Group(recognize_structure(inner)),
+        NodeKind::Command { name, optional, arguments } => NodeKind::Command {
             name,
             optional: optional.into_iter().map(recognize_structure).collect(),
             arguments: arguments.into_iter().map(recognize_structure).collect(),
         },
-        Node::Environment { name, optional, arguments, body } => Node::Environment {
+        NodeKind::Environment { name, optional, arguments, body } => NodeKind::Environment {
             name,
             optional: optional.into_iter().map(recognize_structure).collect(),
             arguments: arguments.into_iter().map(recognize_structure).collect(),
@@ -212,30 +247,31 @@ fn recurse(node: Node) -> Node {
         },
         // Recurse into the parts of already-recognized structure nodes too, so the pass is
         // idempotent and composes with itself (e.g. a section title containing a `\ref`).
-        Node::Section { level, starred, short, title } => Node::Section {
+        NodeKind::Section { level, starred, short, title } => NodeKind::Section {
             level,
             starred,
             short: short.map(recognize_structure),
             title: recognize_structure(title),
         },
-        Node::CrossRef { command, note, target } => Node::CrossRef {
+        NodeKind::CrossRef { command, note, target } => NodeKind::CrossRef {
             command,
             note: note.map(recognize_structure),
             target: recognize_structure(target),
         },
-        Node::Preamble { command, options, name } => Node::Preamble {
+        NodeKind::Preamble { command, options, name } => NodeKind::Preamble {
             command,
             options: options.map(recognize_structure),
             name: recognize_structure(name),
         },
-        Node::Styled { command, content } => Node::Styled {
+        NodeKind::Styled { command, content } => NodeKind::Styled {
             command,
             content: recognize_structure(content),
         },
         // leaves (Text, Space, Par, Math, Comment, Verb, VerbatimEnv, Accent, Active,
         // Unsupported) carry no further structure to fold here
         other => other,
-    }
+    };
+    Node::new(kind, span)
 }
 
 #[cfg(test)]
@@ -246,6 +282,16 @@ mod tests {
     /// Parse and recognize structure, for concise assertions.
     fn st(src: &str) -> Vec<Node> {
         recognize_structure(parse(src).expect("parse"))
+    }
+
+    /// The node kinds only (spans checked separately) — for structural assertions.
+    fn kinds(nodes: &[Node]) -> Vec<NodeKind> {
+        nodes.iter().map(|n| n.kind.clone()).collect()
+    }
+
+    /// A dummy span for building expected `NodeKind` trees (equality ignores spans).
+    fn z() -> Span {
+        Span::new(0, 0)
     }
 
     /// The L5d round-trip: rendering a recognized tree and re-recognizing yields the same tree.
@@ -259,12 +305,12 @@ mod tests {
     #[test]
     fn plain_section() {
         assert_eq!(
-            st(r"\section{Intro}"),
-            vec![Node::Section {
+            kinds(&st(r"\section{Intro}")),
+            vec![NodeKind::Section {
                 level: SectionLevel::Section,
                 starred: false,
                 short: None,
-                title: vec![Node::Text("Intro".into())],
+                title: vec![Node::text("Intro", z())],
             }]
         );
     }
@@ -273,26 +319,35 @@ mod tests {
     fn starred_section_folds_the_star() {
         // \section*{Intro} → starred heading; the intervening Text("*") is consumed.
         assert_eq!(
-            st(r"\section*{Intro}"),
-            vec![Node::Section {
+            kinds(&st(r"\section*{Intro}")),
+            vec![NodeKind::Section {
                 level: SectionLevel::Section,
                 starred: true,
                 short: None,
-                title: vec![Node::Text("Intro".into())],
+                title: vec![Node::text("Intro", z())],
             }]
         );
+    }
+
+    #[test]
+    fn section_span_slices_back_to_source() {
+        // A recognized section covers its full source extent, incl. the starred `*` and group.
+        let src = r"\section*{Intro}";
+        let n = st(src);
+        assert!(matches!(n[0].kind, NodeKind::Section { starred: true, .. }));
+        assert_eq!(&src[n[0].span.start..n[0].span.end], src);
     }
 
     #[test]
     fn section_with_short_toc_title() {
         // \section[Intro]{Introduction} → optional short TOC title preserved.
         assert_eq!(
-            st(r"\section[Intro]{Introduction}"),
-            vec![Node::Section {
+            kinds(&st(r"\section[Intro]{Introduction}")),
+            vec![NodeKind::Section {
                 level: SectionLevel::Section,
                 starred: false,
-                short: Some(vec![Node::Text("Intro".into())]),
-                title: vec![Node::Text("Introduction".into())],
+                short: Some(vec![Node::text("Intro", z())]),
+                title: vec![Node::text("Introduction", z())],
             }]
         );
     }
@@ -309,8 +364,8 @@ mod tests {
             (r"\subparagraph{a}", SectionLevel::Subparagraph),
         ];
         for (src, level) in cases {
-            match &st(src)[0] {
-                Node::Section { level: got, .. } => assert_eq!(*got, level, "{src}"),
+            match &st(src)[0].kind {
+                NodeKind::Section { level: got, .. } => assert_eq!(*got, level, "{src}"),
                 other => panic!("expected Section for {src}, got {other:?}"),
             }
         }
@@ -320,27 +375,27 @@ mod tests {
     fn section_without_title_stays_command() {
         // A bare `\section` (nothing accent-able / no title) is left untouched.
         assert_eq!(
-            st(r"\section"),
-            vec![Node::Command { name: "section".into(), optional: vec![], arguments: vec![] }]
+            kinds(&st(r"\section")),
+            vec![NodeKind::Command { name: "section".into(), optional: vec![], arguments: vec![] }]
         );
     }
 
     #[test]
     fn cross_references() {
         assert_eq!(
-            st(r"\label{eq:1}"),
-            vec![Node::CrossRef {
+            kinds(&st(r"\label{eq:1}")),
+            vec![NodeKind::CrossRef {
                 command: "label".into(),
                 note: None,
-                target: vec![Node::Text("eq:1".into())],
+                target: vec![Node::text("eq:1", z())],
             }]
         );
         assert_eq!(
-            st(r"\ref{eq:1}"),
-            vec![Node::CrossRef {
+            kinds(&st(r"\ref{eq:1}")),
+            vec![NodeKind::CrossRef {
                 command: "ref".into(),
                 note: None,
-                target: vec![Node::Text("eq:1".into())],
+                target: vec![Node::text("eq:1", z())],
             }]
         );
     }
@@ -348,11 +403,11 @@ mod tests {
     #[test]
     fn citation_with_note() {
         // \cite[p.~5]{foo} keeps the optional note.
-        match &st(r"\cite[p]{foo}")[0] {
-            Node::CrossRef { command, note, target } => {
+        match &st(r"\cite[p]{foo}")[0].kind {
+            NodeKind::CrossRef { command, note, target } => {
                 assert_eq!(command, "cite");
-                assert_eq!(note, &Some(vec![Node::Text("p".into())]));
-                assert_eq!(target, &vec![Node::Text("foo".into())]);
+                assert_eq!(note, &Some(vec![Node::text("p", z())]));
+                assert_eq!(target, &vec![Node::text("foo", z())]);
             }
             other => panic!("expected CrossRef, got {other:?}"),
         }
@@ -361,19 +416,19 @@ mod tests {
     #[test]
     fn preamble_directives() {
         assert_eq!(
-            st(r"\documentclass[a4paper]{article}"),
-            vec![Node::Preamble {
+            kinds(&st(r"\documentclass[a4paper]{article}")),
+            vec![NodeKind::Preamble {
                 command: "documentclass".into(),
-                options: Some(vec![Node::Text("a4paper".into())]),
-                name: vec![Node::Text("article".into())],
+                options: Some(vec![Node::text("a4paper", z())]),
+                name: vec![Node::text("article", z())],
             }]
         );
         assert_eq!(
-            st(r"\usepackage{amsmath}"),
-            vec![Node::Preamble {
+            kinds(&st(r"\usepackage{amsmath}")),
+            vec![NodeKind::Preamble {
                 command: "usepackage".into(),
                 options: None,
-                name: vec![Node::Text("amsmath".into())],
+                name: vec![Node::text("amsmath", z())],
             }]
         );
     }
@@ -381,15 +436,15 @@ mod tests {
     #[test]
     fn styled_font_commands() {
         assert_eq!(
-            st(r"\textbf{bold}"),
-            vec![Node::Styled {
+            kinds(&st(r"\textbf{bold}")),
+            vec![NodeKind::Styled {
                 command: "textbf".into(),
-                content: vec![Node::Text("bold".into())],
+                content: vec![Node::text("bold", z())],
             }]
         );
         assert_eq!(
-            st(r"\emph{x}"),
-            vec![Node::Styled { command: "emph".into(), content: vec![Node::Text("x".into())] }]
+            kinds(&st(r"\emph{x}")),
+            vec![NodeKind::Styled { command: "emph".into(), content: vec![Node::text("x", z())] }]
         );
     }
 
@@ -397,17 +452,17 @@ mod tests {
     fn font_declaration_stays_command() {
         // \bfseries is a declaration (no wrapped argument) — left as a plain command.
         assert_eq!(
-            st(r"\bfseries"),
-            vec![Node::Command { name: "bfseries".into(), optional: vec![], arguments: vec![] }]
+            kinds(&st(r"\bfseries")),
+            vec![NodeKind::Command { name: "bfseries".into(), optional: vec![], arguments: vec![] }]
         );
     }
 
     #[test]
     fn recognition_recurses_into_groups_and_titles() {
         // A \ref inside a section title is itself recognized.
-        match &st(r"\section{see \ref{x}}")[0] {
-            Node::Section { title, .. } => {
-                assert!(title.iter().any(|n| matches!(n, Node::CrossRef { .. })));
+        match &st(r"\section{see \ref{x}}")[0].kind {
+            NodeKind::Section { title, .. } => {
+                assert!(title.iter().any(|n| matches!(n.kind, NodeKind::CrossRef { .. })));
             }
             other => panic!("expected Section, got {other:?}"),
         }
@@ -417,8 +472,8 @@ mod tests {
     fn surrounding_text_is_preserved() {
         // Heading then a paragraph: the text after the heading stays put.
         let nodes = st("\\section{Intro}\nhello");
-        assert!(matches!(nodes[0], Node::Section { .. }));
-        assert!(nodes.iter().any(|n| matches!(n, Node::Text(t) if t.contains("hello"))));
+        assert!(matches!(nodes[0].kind, NodeKind::Section { .. }));
+        assert!(nodes.iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t.contains("hello"))));
     }
 
     #[test]

--- a/code/packages/rust/latex/src/tables.rs
+++ b/code/packages/rust/latex/src/tables.rs
@@ -48,7 +48,8 @@
 //! (no *new* unbounded recursion). The column spec is read off the already-parsed argument nodes
 //! via [`Node::to_latex`] — there is **no raw brace counting** in this module.
 
-use crate::ast::{ListItem, ListKind, Node};
+use crate::ast::{ListItem, ListKind, Node, NodeKind};
+use crate::token::Span;
 
 /// Map a list-environment name to its [`ListKind`], or `None` if `name` is not one.
 fn list_kind(name: &str) -> Option<ListKind> {
@@ -71,8 +72,12 @@ pub fn recognize_tables(nodes: Vec<Node>) -> Vec<Node> {
 /// Rebuild one node, recursing `recognize_tables` into every child node-list, and — for the
 /// table/list environments — folding it into the structured variant.
 fn recurse(node: Node) -> Node {
-    match node {
-        Node::Environment { name, optional, arguments, body } => {
+    // The node's own span already covers its full source extent; recursion/folding regroups its
+    // children without changing that extent (a `tabular`/list environment folds `\begin`…`\end`,
+    // which is exactly the environment node's span), so we keep it.
+    let span = node.span;
+    let kind = match node.kind {
+        NodeKind::Environment { name, optional, arguments, body } => {
             // Recurse into the argument/optional lists and the body regardless, then decide
             // whether this environment is a table, a list, or just a recursed environment.
             let optional: Vec<Vec<Node>> = optional.into_iter().map(recognize_tables).collect();
@@ -80,50 +85,50 @@ fn recurse(node: Node) -> Node {
             let body = recognize_tables(body);
 
             if name == "tabular" || name == "tabular*" {
-                return fold_tabular(&arguments, body);
+                return Node::new(fold_tabular(&arguments, body), span);
             }
             if let Some(kind) = list_kind(&name) {
-                return fold_list(kind, name, optional, arguments, body);
+                return Node::new(fold_list(kind, name, optional, arguments, body, span), span);
             }
-            Node::Environment { name, optional, arguments, body }
+            NodeKind::Environment { name, optional, arguments, body }
         }
 
         // --- plain structural recursion into every other node's child lists -------------------
-        Node::Group(inner) => Node::Group(recognize_tables(inner)),
-        Node::Command { name, optional, arguments } => Node::Command {
+        NodeKind::Group(inner) => NodeKind::Group(recognize_tables(inner)),
+        NodeKind::Command { name, optional, arguments } => NodeKind::Command {
             name,
             optional: optional.into_iter().map(recognize_tables).collect(),
             arguments: arguments.into_iter().map(recognize_tables).collect(),
         },
-        Node::Section { level, starred, short, title } => Node::Section {
+        NodeKind::Section { level, starred, short, title } => NodeKind::Section {
             level,
             starred,
             short: short.map(recognize_tables),
             title: recognize_tables(title),
         },
-        Node::CrossRef { command, note, target } => Node::CrossRef {
+        NodeKind::CrossRef { command, note, target } => NodeKind::CrossRef {
             command,
             note: note.map(recognize_tables),
             target: recognize_tables(target),
         },
-        Node::Preamble { command, options, name } => Node::Preamble {
+        NodeKind::Preamble { command, options, name } => NodeKind::Preamble {
             command,
             options: options.map(recognize_tables),
             name: recognize_tables(name),
         },
-        Node::Styled { command, content } => {
-            Node::Styled { command, content: recognize_tables(content) }
+        NodeKind::Styled { command, content } => {
+            NodeKind::Styled { command, content: recognize_tables(content) }
         }
         // Recurse into already-recognized tables/lists too, so the pass is idempotent and
         // composes with itself (e.g. a list nested inside a table cell).
-        Node::Tabular { col_spec, rows } => Node::Tabular {
+        NodeKind::Tabular { col_spec, rows } => NodeKind::Tabular {
             col_spec,
             rows: rows
                 .into_iter()
                 .map(|row| row.into_iter().map(recognize_tables).collect())
                 .collect(),
         },
-        Node::List { kind, items } => Node::List {
+        NodeKind::List { kind, items } => NodeKind::List {
             kind,
             items: items
                 .into_iter()
@@ -136,7 +141,8 @@ fn recurse(node: Node) -> Node {
         // leaves (Text, Space, Par, Math, Comment, Verb, VerbatimEnv, Accent, Active,
         // Unsupported) carry no further child lists to fold here
         other => other,
-    }
+    };
+    Node::new(kind, span)
 }
 
 /// Fold a (already-recursed) `tabular`/`tabular*` body into a [`Node::Tabular`].
@@ -144,10 +150,10 @@ fn recurse(node: Node) -> Node {
 /// `col_spec` = the **last** mandatory argument rendered back to source (the only argument for
 /// `tabular`; the `{colspec}` after `{width}` for `tabular*`), or `None` if there were none.
 /// Rows are the body split on the `\\` row break; cells are each row split on the `&` tab.
-fn fold_tabular(arguments: &[Vec<Node>], body: Vec<Node>) -> Node {
+fn fold_tabular(arguments: &[Vec<Node>], body: Vec<Node>) -> NodeKind {
     let col_spec = arguments.last().map(|arg| crate::document_to_latex(arg));
     let rows = split_rows(body);
-    Node::Tabular { col_spec, rows }
+    NodeKind::Tabular { col_spec, rows }
 }
 
 /// Split a tabular body into rows (on `\\`), each row into cells (on `Text("&")`).
@@ -196,20 +202,20 @@ fn split_cells(row: Vec<Node>) -> Vec<Vec<Node>> {
 
 /// Is this node the `\\` row-break command (`Command { name: "\\", .. }`)?
 fn is_row_break(node: &Node) -> bool {
-    matches!(node, Node::Command { name, optional, arguments }
+    matches!(&node.kind, NodeKind::Command { name, optional, arguments }
         if name == "\\" && optional.is_empty() && arguments.is_empty())
 }
 
 /// Is this node the `&` alignment tab (its own `Text("&")` node between cells)?
 fn is_align_tab(node: &Node) -> bool {
-    matches!(node, Node::Text(t) if t == "&")
+    matches!(&node.kind, NodeKind::Text(t) if t == "&")
 }
 
 /// Does a row consist only of insignificant whitespace (Space/Par) and comments? Such a row is
 /// what a trailing `\\` leaves behind, and is dropped so `a & b \\` is one row, not two.
 fn is_blank_row(row: &[Node]) -> bool {
     row.iter()
-        .all(|n| matches!(n, Node::Space | Node::Par | Node::Comment(_)))
+        .all(|n| matches!(n.kind, NodeKind::Space | NodeKind::Par | NodeKind::Comment(_)))
 }
 
 /// Fold a (already-recursed) list environment body into a [`Node::List`], **unless** the body
@@ -221,18 +227,19 @@ fn fold_list(
     optional: Vec<Vec<Node>>,
     arguments: Vec<Vec<Node>>,
     body: Vec<Node>,
-) -> Node {
+    _env_span: Span,
+) -> NodeKind {
     // Ignoring leading insignificant whitespace/comments, does the body start with an `\item`?
     let first_significant = body
         .iter()
-        .find(|n| !matches!(n, Node::Space | Node::Par | Node::Comment(_)));
+        .find(|n| !matches!(n.kind, NodeKind::Space | NodeKind::Par | NodeKind::Comment(_)));
     let starts_with_item = matches!(
-        first_significant,
-        Some(Node::Command { name, .. }) if name == "item"
+        first_significant.map(|n| &n.kind),
+        Some(NodeKind::Command { name, .. }) if name == "item"
     );
     if !starts_with_item {
         // Stray content before the first item — leave it as a generic (recursed) environment.
-        return Node::Environment { name, optional, arguments, body };
+        return NodeKind::Environment { name, optional, arguments, body };
     }
 
     // Split the body at each `\item`; each item's label = its optional term, body = the nodes
@@ -245,8 +252,8 @@ fn fold_list(
     let mut current: Vec<Node> = Vec::new();
     let mut open = false; // are we inside an item yet?
     for node in body {
-        match &node {
-            Node::Command { name, optional, .. } if name == "item" => {
+        match &node.kind {
+            NodeKind::Command { name, optional, .. } if name == "item" => {
                 // Close the previous item (if any) and open a new one.
                 if open {
                     items.push(ListItem { label: pending_label.take(), body: std::mem::take(&mut current) });
@@ -266,7 +273,7 @@ fn fold_list(
         items.push(ListItem { label: pending_label.take(), body: current });
     }
 
-    Node::List { kind, items }
+    NodeKind::List { kind, items }
 }
 
 #[cfg(test)]
@@ -289,24 +296,41 @@ mod tests {
 
     #[test]
     fn basic_2x2_tabular_with_col_spec() {
-        match &tb(r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}")[0] {
-            Node::Tabular { col_spec, rows } => {
+        match &tb(r"\begin{tabular}{lc}a & b \\ c & d\end{tabular}")[0].kind {
+            NodeKind::Tabular { col_spec, rows } => {
                 assert_eq!(col_spec.as_deref(), Some("lc"));
                 assert_eq!(rows.len(), 2, "two rows");
                 assert_eq!(rows[0].len(), 2, "row 0 has 2 cells");
                 assert_eq!(rows[1].len(), 2, "row 1 has 2 cells");
                 // Cell contents include the `a` text (plus surrounding Space nodes kept verbatim).
-                assert!(rows[0][0].iter().any(|n| matches!(n, Node::Text(t) if t == "a")));
-                assert!(rows[1][1].iter().any(|n| matches!(n, Node::Text(t) if t == "d")));
+                assert!(rows[0][0].iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t == "a")));
+                assert!(rows[1][1].iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t == "d")));
             }
             other => panic!("expected Tabular, got {other:?}"),
         }
     }
 
     #[test]
+    fn tabular_span_slices_back_to_source() {
+        // The recognized tabular covers `\begin{tabular}…\end{tabular}` exactly.
+        let src = r"\begin{tabular}{lc}a & b\end{tabular}";
+        let n = tb(src);
+        assert!(matches!(n[0].kind, NodeKind::Tabular { .. }));
+        assert_eq!(&src[n[0].span.start..n[0].span.end], src);
+    }
+
+    #[test]
+    fn list_span_slices_back_to_source() {
+        let src = r"\begin{itemize}\item one\item two\end{itemize}";
+        let n = tb(src);
+        assert!(matches!(n[0].kind, NodeKind::List { .. }));
+        assert_eq!(&src[n[0].span.start..n[0].span.end], src);
+    }
+
+    #[test]
     fn no_col_spec_is_none() {
-        match &tb(r"\begin{tabular}a & b\end{tabular}")[0] {
-            Node::Tabular { col_spec, rows } => {
+        match &tb(r"\begin{tabular}a & b\end{tabular}")[0].kind {
+            NodeKind::Tabular { col_spec, rows } => {
                 assert_eq!(*col_spec, None);
                 assert_eq!(rows.len(), 1);
                 assert_eq!(rows[0].len(), 2);
@@ -318,8 +342,8 @@ mod tests {
     #[test]
     fn tabular_star_drops_width_keeps_colspec() {
         // `tabular*` carries {width}{colspec}; the LAST argument is the column spec.
-        match &tb(r"\begin{tabular*}{2cm}{lr}a & b\end{tabular*}")[0] {
-            Node::Tabular { col_spec, rows } => {
+        match &tb(r"\begin{tabular*}{2cm}{lr}a & b\end{tabular*}")[0].kind {
+            NodeKind::Tabular { col_spec, rows } => {
                 assert_eq!(col_spec.as_deref(), Some("lr"));
                 assert_eq!(rows[0].len(), 2);
             }
@@ -330,8 +354,8 @@ mod tests {
     #[test]
     fn ragged_rows_preserved_not_error() {
         // Row 0 has 2 cells, row 1 has 3 — kept as-is, no padding, no error.
-        match &tb(r"\begin{tabular}{c}a & b \\ c & d & e\end{tabular}")[0] {
-            Node::Tabular { rows, .. } => {
+        match &tb(r"\begin{tabular}{c}a & b \\ c & d & e\end{tabular}")[0].kind {
+            NodeKind::Tabular { rows, .. } => {
                 assert_eq!(rows.len(), 2);
                 assert_eq!(rows[0].len(), 2);
                 assert_eq!(rows[1].len(), 3);
@@ -343,21 +367,21 @@ mod tests {
     #[test]
     fn trailing_row_break_dropped() {
         // A trailing `\\` should not leave a spurious empty final row.
-        match &tb(r"\begin{tabular}{c}a & b \\\end{tabular}")[0] {
-            Node::Tabular { rows, .. } => assert_eq!(rows.len(), 1, "one row, trailing \\\\ dropped"),
+        match &tb(r"\begin{tabular}{c}a & b \\\end{tabular}")[0].kind {
+            NodeKind::Tabular { rows, .. } => assert_eq!(rows.len(), 1, "one row, trailing \\\\ dropped"),
             other => panic!("expected Tabular, got {other:?}"),
         }
     }
 
     #[test]
     fn itemize_two_items() {
-        match &tb(r"\begin{itemize}\item one\item two\end{itemize}")[0] {
-            Node::List { kind, items } => {
+        match &tb(r"\begin{itemize}\item one\item two\end{itemize}")[0].kind {
+            NodeKind::List { kind, items } => {
                 assert_eq!(*kind, ListKind::Itemize);
                 assert_eq!(items.len(), 2);
                 assert_eq!(items[0].label, None);
-                assert!(items[0].body.iter().any(|n| matches!(n, Node::Text(t) if t == "one")));
-                assert!(items[1].body.iter().any(|n| matches!(n, Node::Text(t) if t == "two")));
+                assert!(items[0].body.iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t == "one")));
+                assert!(items[1].body.iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t == "two")));
             }
             other => panic!("expected List, got {other:?}"),
         }
@@ -365,12 +389,12 @@ mod tests {
 
     #[test]
     fn item_label_captured() {
-        match &tb(r"\begin{description}\item[Term] definition\end{description}")[0] {
-            Node::List { kind, items } => {
+        match &tb(r"\begin{description}\item[Term] definition\end{description}")[0].kind {
+            NodeKind::List { kind, items } => {
                 assert_eq!(*kind, ListKind::Description);
                 assert_eq!(items.len(), 1);
-                assert_eq!(items[0].label, Some(vec![Node::Text("Term".into())]));
-                assert!(items[0].body.iter().any(|n| matches!(n, Node::Text(t) if t == "definition")));
+                assert_eq!(items[0].label, Some(vec![Node::text("Term", Span::new(0, 0))]));
+                assert!(items[0].body.iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t == "definition")));
             }
             other => panic!("expected List, got {other:?}"),
         }
@@ -378,8 +402,8 @@ mod tests {
 
     #[test]
     fn enumerate_recognized() {
-        match &tb(r"\begin{enumerate}\item a\item b\end{enumerate}")[0] {
-            Node::List { kind, items } => {
+        match &tb(r"\begin{enumerate}\item a\item b\end{enumerate}")[0].kind {
+            NodeKind::List { kind, items } => {
                 assert_eq!(*kind, ListKind::Enumerate);
                 assert_eq!(items.len(), 2);
             }
@@ -391,12 +415,12 @@ mod tests {
     fn nested_list_inside_item() {
         // An itemize inside an enumerate item is itself recognized.
         let src = r"\begin{enumerate}\item outer\begin{itemize}\item inner\end{itemize}\end{enumerate}";
-        match &tb(src)[0] {
-            Node::List { kind, items } => {
+        match &tb(src)[0].kind {
+            NodeKind::List { kind, items } => {
                 assert_eq!(*kind, ListKind::Enumerate);
                 assert_eq!(items.len(), 1);
                 assert!(
-                    items[0].body.iter().any(|n| matches!(n, Node::List { kind, .. } if *kind == ListKind::Itemize)),
+                    items[0].body.iter().any(|n| matches!(&n.kind, NodeKind::List { kind, .. } if *kind == ListKind::Itemize)),
                     "inner itemize should be a recognized List: {:#?}", items[0].body
                 );
             }
@@ -407,10 +431,10 @@ mod tests {
     #[test]
     fn stray_content_before_first_item_stays_environment() {
         // Real content (not whitespace) before the first `\item` — leave as an Environment.
-        match &tb(r"\begin{itemize}oops\item one\end{itemize}")[0] {
-            Node::Environment { name, body, .. } => {
+        match &tb(r"\begin{itemize}oops\item one\end{itemize}")[0].kind {
+            NodeKind::Environment { name, body, .. } => {
                 assert_eq!(name, "itemize");
-                assert!(body.iter().any(|n| matches!(n, Node::Text(t) if t == "oops")));
+                assert!(body.iter().any(|n| matches!(&n.kind, NodeKind::Text(t) if t == "oops")));
             }
             other => panic!("expected Environment (stray content), got {other:?}"),
         }
@@ -423,9 +447,9 @@ mod tests {
         let nodes = recognize_tables(
             crate::recognize_structure(parse(&format!(r"\section{{H}} {src}")).expect("parse")),
         );
-        assert!(matches!(nodes[0], Node::Section { .. }));
+        assert!(matches!(nodes[0].kind, NodeKind::Section { .. }));
         assert!(
-            nodes.iter().any(|n| matches!(n, Node::List { .. })),
+            nodes.iter().any(|n| matches!(n.kind, NodeKind::List { .. })),
             "list after a section should be recognized: {nodes:#?}"
         );
     }
@@ -433,9 +457,9 @@ mod tests {
     #[test]
     fn recurses_into_group() {
         // A tabular wrapped in a brace group is still recognized inside the group.
-        match &tb(r"{\begin{tabular}{c}a\end{tabular}}")[0] {
-            Node::Group(inner) => {
-                assert!(inner.iter().any(|n| matches!(n, Node::Tabular { .. })));
+        match &tb(r"{\begin{tabular}{c}a\end{tabular}}")[0].kind {
+            NodeKind::Group(inner) => {
+                assert!(inner.iter().any(|n| matches!(n.kind, NodeKind::Tabular { .. })));
             }
             other => panic!("expected Group, got {other:?}"),
         }

--- a/code/packages/rust/latex/src/text.rs
+++ b/code/packages/rust/latex/src/text.rs
@@ -25,7 +25,19 @@
 //! Total and panic-free: an accent with no accent-able argument (e.g. at end of input, or
 //! before a space/structural node) is left as a plain command, never dropped or mis-folded.
 
-use crate::ast::Node;
+use crate::ast::{Node, NodeKind};
+use crate::token::Span;
+
+/// The smallest span covering both `a` and `b` — used to compose a synthesised node's span from
+/// its constituents (S1: union-of-children; a precise per-construct span is S2's job).
+fn union(a: Span, b: Span) -> Span {
+    Span::new(a.start.min(b.start), a.end.max(b.end))
+}
+
+/// The span covering a whole node sequence (empty → `fallback`). The union of every node's span.
+fn seq_span(nodes: &[Node], fallback: Span) -> Span {
+    nodes.iter().map(|n| n.span).reduce(union).unwrap_or(fallback)
+}
 
 /// Is `name` a known text-accent control sequence (symbol or word spelling)?
 fn is_accent(name: &str) -> bool {
@@ -45,37 +57,51 @@ pub fn recognize_accents(nodes: Vec<Node>) -> Vec<Node> {
     let mut out: Vec<Node> = Vec::with_capacity(nodes.len());
     let mut i = 0;
     while i < nodes.len() {
-        match &nodes[i] {
-            Node::Command { name, optional, arguments } if optional.is_empty() && is_accent(name) => {
+        let cmd_span = nodes[i].span;
+        match &nodes[i].kind {
+            NodeKind::Command { name, optional, arguments } if optional.is_empty() && is_accent(name) => {
                 // Case A: the accent captured its argument as `{group}` (e.g. `\c{e}`).
                 if let Some(first) = arguments.first() {
                     let arg = recognize_accents(first.clone());
-                    out.push(Node::Accent { accent: name.clone(), arg });
+                    // The recognized accent covers the whole `\accent{arg}` command.
+                    out.push(Node::new(NodeKind::Accent { accent: name.clone(), arg }, cmd_span));
                     // Any further captured groups were not part of the accent — keep them.
                     for extra in arguments.iter().skip(1) {
-                        out.push(Node::Group(recognize_accents(extra.clone())));
+                        let sp = seq_span(extra, cmd_span);
+                        out.push(Node::group(recognize_accents(extra.clone()), sp));
                     }
                     i += 1;
                     continue;
                 }
                 // Case B: no captured argument — pair with the immediately following node.
-                match nodes.get(i + 1) {
-                    Some(Node::Group(inner)) => {
+                match nodes.get(i + 1).map(|n| (&n.kind, n.span)) {
+                    Some((NodeKind::Group(inner), grp_span)) => {
                         let arg = recognize_accents(inner.clone());
-                        out.push(Node::Accent { accent: name.clone(), arg });
+                        // Span covers the accent command through the paired group.
+                        out.push(Node::new(
+                            NodeKind::Accent { accent: name.clone(), arg },
+                            union(cmd_span, grp_span),
+                        ));
                         i += 2;
                     }
-                    Some(Node::Text(t)) if !t.is_empty() => {
+                    Some((NodeKind::Text(t), text_span)) if !t.is_empty() => {
                         // The accent applies to the first character; the rest stays as text.
                         let mut chars = t.chars();
                         let first = chars.next().expect("non-empty");
+                        let first_len = first.len_utf8();
                         let rest: String = chars.collect();
-                        out.push(Node::Accent {
-                            accent: name.clone(),
-                            arg: vec![Node::Text(first.to_string())],
-                        });
+                        // The accented character occupies the first `first_len` bytes of the text
+                        // run; the accent node covers the command through that character.
+                        let base_span = Span::new(text_span.start, text_span.start + first_len);
+                        out.push(Node::new(
+                            NodeKind::Accent {
+                                accent: name.clone(),
+                                arg: vec![Node::text(first.to_string(), base_span)],
+                            },
+                            union(cmd_span, base_span),
+                        ));
                         if !rest.is_empty() {
-                            out.push(Node::Text(rest));
+                            out.push(Node::text(rest, Span::new(base_span.end, text_span.end)));
                         }
                         i += 2;
                     }
@@ -99,14 +125,17 @@ pub fn recognize_accents(nodes: Vec<Node>) -> Vec<Node> {
 /// Recurse accent recognition into a node's child sequences without treating the node itself
 /// as an accent.
 fn recurse(node: Node) -> Node {
-    match node {
-        Node::Group(inner) => Node::Group(recognize_accents(inner)),
-        Node::Command { name, optional, arguments } => Node::Command {
+    // Recursion regroups a node's children but never changes its extent, so the node keeps its
+    // own span.
+    let span = node.span;
+    let kind = match node.kind {
+        NodeKind::Group(inner) => NodeKind::Group(recognize_accents(inner)),
+        NodeKind::Command { name, optional, arguments } => NodeKind::Command {
             name,
             optional: optional.into_iter().map(recognize_accents).collect(),
             arguments: arguments.into_iter().map(recognize_accents).collect(),
         },
-        Node::Environment { name, optional, arguments, body } => Node::Environment {
+        NodeKind::Environment { name, optional, arguments, body } => NodeKind::Environment {
             name,
             optional: optional.into_iter().map(recognize_accents).collect(),
             arguments: arguments.into_iter().map(recognize_accents).collect(),
@@ -115,7 +144,8 @@ fn recurse(node: Node) -> Node {
         // leaves (Text, Space, Par, Math, Comment, Verb, VerbatimEnv, Active, Unsupported,
         // and already-built Accent) carry no further accent structure to fold here
         other => other,
-    }
+    };
+    Node::new(kind, span)
 }
 
 #[cfg(test)]
@@ -126,6 +156,16 @@ mod tests {
     /// Parse, recognize accents, and render back to LaTeX for easy assertions.
     fn acc(src: &str) -> Vec<Node> {
         recognize_accents(parse(src).expect("parse"))
+    }
+
+    /// The node kinds only (spans checked separately) — for structural assertions.
+    fn kinds(nodes: &[Node]) -> Vec<NodeKind> {
+        nodes.iter().map(|n| n.kind.clone()).collect()
+    }
+
+    /// A dummy span for building expected `NodeKind` trees (equality ignores spans).
+    fn z() -> Span {
+        Span::new(0, 0)
     }
 
     /// The L5c round-trip: rendering a recognized tree and re-recognizing yields the same tree.
@@ -140,8 +180,8 @@ mod tests {
     fn control_symbol_accent_over_next_char() {
         // \'e  → Accent("'", [e]), no leftover.
         assert_eq!(
-            acc(r"\'e"),
-            vec![Node::Accent { accent: "'".into(), arg: vec![Node::Text("e".into())] }]
+            kinds(&acc(r"\'e")),
+            vec![NodeKind::Accent { accent: "'".into(), arg: vec![Node::text("e", z())] }]
         );
     }
 
@@ -149,10 +189,10 @@ mod tests {
     fn accent_takes_only_first_char_rest_stays() {
         // \~nada → Accent(~, [n]) then Text("ada").
         assert_eq!(
-            acc(r"\~nada"),
+            kinds(&acc(r"\~nada")),
             vec![
-                Node::Accent { accent: "~".into(), arg: vec![Node::Text("n".into())] },
-                Node::Text("ada".into()),
+                NodeKind::Accent { accent: "~".into(), arg: vec![Node::text("n", z())] },
+                NodeKind::Text("ada".into()),
             ]
         );
     }
@@ -161,8 +201,8 @@ mod tests {
     fn braced_accent_argument() {
         // \"{o} → Accent("\"", [o]).
         assert_eq!(
-            acc(r#"\"{o}"#),
-            vec![Node::Accent { accent: "\"".into(), arg: vec![Node::Text("o".into())] }]
+            kinds(&acc(r#"\"{o}"#)),
+            vec![NodeKind::Accent { accent: "\"".into(), arg: vec![Node::text("o", z())] }]
         );
     }
 
@@ -170,8 +210,8 @@ mod tests {
     fn control_word_accent_with_braced_arg() {
         // \c{c} → Accent("c", [c]) (cedilla).
         assert_eq!(
-            acc(r"\c{c}"),
-            vec![Node::Accent { accent: "c".into(), arg: vec![Node::Text("c".into())] }]
+            kinds(&acc(r"\c{c}")),
+            vec![NodeKind::Accent { accent: "c".into(), arg: vec![Node::text("c", z())] }]
         );
     }
 
@@ -179,16 +219,27 @@ mod tests {
     fn control_word_accent_bare_arg() {
         // \v s → lexer absorbs the space, so `s` is the next sibling → Accent("v", [s]).
         assert_eq!(
-            acc(r"\v s"),
-            vec![Node::Accent { accent: "v".into(), arg: vec![Node::Text("s".into())] }]
+            kinds(&acc(r"\v s")),
+            vec![NodeKind::Accent { accent: "v".into(), arg: vec![Node::text("s", z())] }]
         );
+    }
+
+    #[test]
+    fn accent_span_slices_back_to_source() {
+        // The recognized accent covers its full source extent (command through base).
+        let src = r"caf\'e";
+        let n = acc(src);
+        // nodes: Text("caf"), Accent("'", [e])
+        let accent = &n[1];
+        assert!(matches!(accent.kind, NodeKind::Accent { .. }));
+        assert_eq!(&src[accent.span.start..accent.span.end], r"\'e");
     }
 
     #[test]
     fn accent_inside_a_group_is_recognized() {
         let n = acc(r"{\'e}");
-        match &n[0] {
-            Node::Group(inner) => assert!(matches!(inner[0], Node::Accent { .. })),
+        match &n[0].kind {
+            NodeKind::Group(inner) => assert!(matches!(inner[0].kind, NodeKind::Accent { .. })),
             other => panic!("expected Group, got {other:?}"),
         }
     }
@@ -197,11 +248,11 @@ mod tests {
     fn non_accent_command_untouched() {
         // \textbf{x} is not an accent.
         assert_eq!(
-            acc(r"\textbf{x}"),
-            vec![Node::Command {
+            kinds(&acc(r"\textbf{x}")),
+            vec![NodeKind::Command {
                 name: "textbf".into(),
                 optional: vec![],
-                arguments: vec![vec![Node::Text("x".into())]],
+                arguments: vec![vec![Node::text("x", z())]],
             }]
         );
     }
@@ -210,8 +261,8 @@ mod tests {
     fn dangling_accent_left_as_command() {
         // `\'` with nothing accent-able after it stays a plain command (no panic, no drop).
         assert_eq!(
-            acc(r"\'"),
-            vec![Node::Command { name: "'".into(), optional: vec![], arguments: vec![] }]
+            kinds(&acc(r"\'")),
+            vec![NodeKind::Command { name: "'".into(), optional: vec![], arguments: vec![] }]
         );
     }
 


### PR DESCRIPTION
## LTXDOC02 S1 — spanned L1 nodes (parser threads token spans into every `Node`)

First implementation rung of the precise-per-token-spans arc (spec [LTXDOC02](code/specs/LTXDOC02-precise-token-spans.md), merged in #7604). Retires the groundwork for D6's region-coarse caveat by making the L1 parse tree byte-precise.

### The change
The L1 lexer already records an exact half-open byte `Span` on every `Token`, and `parser.rs` already binds `let sp = tok.span` at each node-building site — then discarded it. S1 threads those spans into the `Node` tree.

- **`Node` restructured to `{ kind: NodeKind, span: Span }`** — span is *orthogonal* to shape (one uniform field), folding the former `Unsupported { span: (usize,usize) }` bespoke span onto the single-source-of-truth `Node.span`. A `match` reads `node.kind`; `Node::span()` reads the byte range.
- **Custom `PartialEq`/`Eq` compare only `kind`** — so the round-trip stays a fixed point *modulo spans* and `to_latex` output text is unchanged; every existing equality/round-trip test remains valid without rewriting expected trees with spans.
- **`parser.rs` fills each span** from `[first_token.span.start, last_token.span.end)`: `Group` covers `{`…`}`, `Command` covers `\name`…last-arg-`}`, `Environment` covers `\begin{env}`…`\end{env}`, `Math` covers `$`…`$`, coalesced `Text` covers its characters.
- **Recognition passes** (`structure.rs`/`tables.rs`/`text.rs`), **macro expansion** (`macros.rs`), and the **Document fold** (`document.rs`) now match on `node.kind`; synthesised nodes get a union-of-constituents span (`Span::new(a.start.min(b.start), a.end.max(b.end))`). Precise-span work *inside* the recognition passes / Document fold is deferred to S2/S3.

### What it buys
`&src[node.span().start .. node.span().end]` now slices back to each node's own source — a command to `\textbf{x}`, a group to `{...}` (braces included), a math island to `$...$` (delimiters included), an environment to `\begin{env}...\end{env}`, a text run to exactly its characters. New unit tests assert these exact slices plus span containment (`child ⊆ parent ⊆ 0..src.len()`).

### Verification
- `cargo test -p latex`: **262 passed, 0 failed** (+1 doc-test).
- `cargo clippy -p latex -- -D warnings`: clean.
- Downstream `cargo test -p adj-lang -p adj-lang-cli`: all passed.
- `cargo build -p latex --no-default-features`: clean.
- No `unsafe`; span arithmetic is `min`/`max`/`saturating` only (no over/underflow); token indexing stays `.min(len-1)`-bounded (stream always ends in `Eof`, so `len ≥ 1`); recursion `MAX_DEPTH`-bounded; `&src[span]` slicing is test-only.

latex 0.31.0 → 0.32.0. Files: `src/{ast,parser,structure,tables,text,macros,document,lib}.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`.

Next: **S2** (spanned recognition passes — tighten `Section`/`Accent`/`Tabular`/`List` spans to exact source extent), then S3 (precise Document fold), S4 (precise `node_at` + retire the region-coarse caveat), S5 (precise byte-coverage capstone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
