### PR TITLE
feat(adj-ladder): rung-75 audiology corrected-hearing-threshold index (difference-quotient scaled by a factor)

### DIFF
--- a/code/specs/data/adj-ladder/rung75_hearing_threshold/gen_items.py
+++ b/code/specs/data/adj-ladder/rung75_hearing_threshold/gen_items.py
@@ -1,0 +1,247 @@
+"""Generate rung-75 (audiology corrected-hearing-threshold index) items.json for the ADJ-LADDER.
+
+Rung 75 opens the **audiology / hearing-threshold** panel on the quantitative band — the arithmetic of a corrected
+hearing threshold. An audiometry test measures a `raw_threshold`, subtracts a `masking_level`, normalises the remainder
+by a `calibration_factor`, and scales it by a `frequency_gain`. Taking a DIFFERENCE FIRST, then dividing, then scaling
+introduces a genuinely NEW arithmetic shape on the ladder: a **difference-quotient scaled by a factor** — `(a-b)/c*d`,
+i.e. `((a-b)/c)*d`.
+
+This is the deliberate contrast to every neighbour so far: rung-73/74 opened with a bare leading term (`a ∓ b/c*d`);
+rung-75 leads with a PARENTHESISED difference that is then divided and scaled. It is the first ladder rung whose whole
+numerator is a subtraction fed into a divide-then-multiply. The operation order matters: `(a-b)/c*d` is left-to-right
+`((a-b)/c)*d = (a-b)*d/c`, NOT `(a-b)/(c*d)` — the distractor exploits exactly that confusion. Contrast the other
+neighbours: rung-67 was `(a-b)*c/d` (a difference scaled THEN divided) and rung-53 was `(a+b+c)/d` (a bare triple sum
+over a divisor). Here a difference is divided THEN scaled.
+
+The setup: a `raw_threshold`, a `masking_level`, a `calibration_factor`, and a `frequency_gain`. The corrected
+threshold is:
+
+  CORRECTED THRESHOLD    (raw_threshold - masking_level) / calibration_factor * frequency_gain   [ diff, normalised, scaled ]
+  NET THRESHOLD          raw_threshold - masking_level                                            [ the difference ]
+  CALIBRATED THRESHOLD   (raw_threshold - masking_level) / calibration_factor                     [ the difference-quotient ]
+
+The **corrected threshold** is what makes this rung distinctive — it is the ladder's first **difference-quotient scaled
+by a factor** (divide the difference, then multiply). (The net threshold `raw_threshold - masking_level` and the
+calibrated threshold `(raw_threshold - masking_level) / calibration_factor` ride alongside as component readouts, so the
+panel teaches the whole calculation — exactly as rungs 47-74 shipped their component sums/products/differences/ratios
+beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the subtraction of the masking level, the division by the calibration factor, and the
+multiplication by the frequency gain (left-to-right) — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../73/74. This rung exercises the
+engine across **a difference-quotient scaled by a factor** — the fact that `(a-b)/c*d` is NOT `(a-b)/(c*d)` and NOT
+`(a-b)*c/d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `-`, `/`, and `*`
+— **no structural constants** — so no numeric literal appears in any program, and neither the net threshold, the
+calibrated threshold, nor any corrected figure is ever a literal (each is computed from the observed quantities). The
+observed quantities carry **digit-free identifiers** (`raw_threshold`, `masking_level`, `calibration_factor`,
+`frequency_gain`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (raw_threshold - masking_level) / (calibration_factor * frequency_gain)   DIVIDE the difference by the
+                                                                                       PRODUCT of the calibration factor
+                                                                                       and frequency gain, not divide-
+                                                                                       then-multiply (the classic
+                                                                                       `(a-b)/c*d` vs `(a-b)/(c*d)`
+                                                                                       error), and
+  SWAPPED    (raw_threshold - masking_level) * calibration_factor / frequency_gain     MULTIPLY the difference by the
+                                                                                       calibration factor and divide by
+                                                                                       the frequency gain — the
+                                                                                       operations swapped (`(a-b)*c/d`
+                                                                                       instead of `(a-b)/c*d`),
+
+which are exactly the mistakes a student makes (folding both denominators into one product, or swapping which quantity
+divides and which multiplies). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five
+always appear as options.
+
+Distinctness: the raw threshold exceeds the masking level (`raw_threshold > masking_level`) so the difference is
+positive and every family member — a positive difference times/over positive factors — is positive; the calibration
+factor and the frequency gain both exceed one (so the calibrated difference-quotient differs from the net threshold)
+and differ from each other (so the corrected value `(a-b)*d/c` differs from the swapped value `(a-b)*c/d`); the five
+family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (RAW_THRESHOLD, MASKING_LEVEL, CALIBRATION_FACTOR, FREQUENCY_GAIN) — a raw threshold, a masking level to subtract, a
+# calibration factor to divide by, and a frequency gain to scale by, all plain positive numbers with
+# raw_threshold > masking_level (positive difference), calibration_factor > 1, frequency_gain > 1, and
+# calibration_factor != frequency_gain. The five family values are asserted pairwise-distinct below.
+TABLES = [
+    (20, 8, 3, 2),
+    (30, 6, 4, 3),
+    (25, 5, 5, 2),
+    (40, 4, 6, 3),
+    (28, 13, 5, 3),
+    (22, 6, 2, 3),
+    (50, 10, 5, 4),
+]
+
+# The option family (5 members), all built from the four observed quantities via -, /, and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "corrected_threshold",
+        "corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)",
+        "(raw_threshold - masking_level) / calibration_factor * frequency_gain",
+    ),
+    (
+        "net_threshold",
+        "the net threshold (raw threshold minus the masking level)",
+        "raw_threshold - masking_level",
+    ),
+    (
+        "calibrated_threshold",
+        "the calibrated threshold before scaling (net threshold over the calibration factor)",
+        "(raw_threshold - masking_level) / calibration_factor",
+    ),
+    (
+        "crossed",
+        "the net threshold divided by the PRODUCT of the calibration factor and frequency gain, not divide-then-multiply (a wrong scaling)",
+        "(raw_threshold - masking_level) / (calibration_factor * frequency_gain)",
+    ),
+    (
+        "swapped",
+        "the net threshold MULTIPLIED by the calibration factor and DIVIDED by the frequency gain, the operations swapped (a wrong scaling)",
+        "(raw_threshold - masking_level) * calibration_factor / frequency_gain",
+    ),
+]
+QUERIED = ["corrected_threshold", "net_threshold", "calibrated_threshold"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(raw_threshold, masking_level, calibration_factor, frequency_gain):
+    # Operation order mirrors the ADJ programs exactly (the parenthesised difference is normalised by the calibration
+    # factor, then the left-to-right multiply by the frequency gain), so the Python option value and the engine result
+    # are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "corrected_threshold": (raw_threshold - masking_level) / calibration_factor * frequency_gain,
+        "net_threshold": raw_threshold - masking_level,
+        "calibrated_threshold": (raw_threshold - masking_level) / calibration_factor,
+        "crossed": (raw_threshold - masking_level) / (calibration_factor * frequency_gain),
+        "swapped": (raw_threshold - masking_level) * calibration_factor / frequency_gain,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for raw_threshold, masking_level, calibration_factor, frequency_gain in TABLES:
+        assert (
+            raw_threshold > 0
+            and masking_level > 0
+            and calibration_factor > 0
+            and frequency_gain > 0
+        ), (raw_threshold, masking_level, calibration_factor, frequency_gain)
+        # The raw threshold exceeds the masking level so the difference is positive (=> every family member is
+        # positive). The calibration factor and frequency gain exceed one so the calibrated difference-quotient differs
+        # from the net threshold, and they differ from each other so the corrected value ((a-b)*d/c) differs from the
+        # swapped value ((a-b)*c/d).
+        assert raw_threshold > masking_level, (raw_threshold, masking_level, calibration_factor, frequency_gain)
+        assert calibration_factor > 1, (raw_threshold, masking_level, calibration_factor, frequency_gain)
+        assert frequency_gain > 1, (raw_threshold, masking_level, calibration_factor, frequency_gain)
+        assert calibration_factor != frequency_gain, (raw_threshold, masking_level, calibration_factor, frequency_gain)
+        fv = family_values(raw_threshold, masking_level, calibration_factor, frequency_gain)
+        for key, v in fv.items():
+            assert v > 0, (key, raw_threshold, masking_level, calibration_factor, frequency_gain, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    raw_threshold,
+                    masking_level,
+                    calibration_factor,
+                    frequency_gain,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                raw_threshold,
+                masking_level,
+                calibration_factor,
+                frequency_gain,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r75hear-{idx + 1:02d}",
+                "qtype": "hearing_threshold",
+                "stem": (
+                    f"An audiometry test records a raw threshold of {num(raw_threshold)}, a masking level of "
+                    f"{num(masking_level)} to subtract, a calibration factor of {num(calibration_factor)} to divide by "
+                    f"and a frequency gain of {num(frequency_gain)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe raw_threshold({num(raw_threshold)})\n"
+                    f"observe masking_level({num(masking_level)})\n"
+                    f"observe calibration_factor({num(calibration_factor)})\n"
+                    f"observe frequency_gain({num(frequency_gain)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 75 — audiology corrected-hearing-threshold index from four stated quantities (a NEW panel: "
+            "audiology / hearing-threshold). From a raw threshold, a masking level to subtract, a calibration factor to "
+            "divide by, and a frequency gain to scale by, compute the corrected threshold "
+            "((raw_threshold-masking_level)/calibration_factor*frequency_gain), the net threshold "
+            "(raw_threshold-masking_level), or the calibrated threshold "
+            "((raw_threshold-masking_level)/calibration_factor). Each item is a compute_dimensioned program (observe the "
+            "four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, "
+            "DIFFERENCE-QUOTIENT SCALED BY A FACTOR (a-b)/c*d (subtract first, then DIVIDE, then scale — contrast "
+            "rung-67 (a-b)*c/d which scales THEN divides; the left-to-right (a-b)/c*d = (a-b)*d/c, not (a-b)/(c*d)) — "
+            "and the harness matches the scalar to the printed options. Contamination-safe: every index is built only "
+            "from the four observed quantities via -, /, and * — no constant leaks, and neither the net threshold, the "
+            "calibrated threshold, nor any corrected figure ever appears as a literal (each is computed) — and the "
+            "observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five "
+            "options are a family over the same four quantities, so the distractors are exactly the slips students "
+            "make: DIVIDING by the PRODUCT ((a-b)/(c*d), a wrong scaling) and SWAPPING the multiply and divide "
+            "((a-b)*c/d, a wrong scaling). The core confusion tested is that (a-b)/c*d is not (a-b)/(c*d) and not "
+            "(a-b)*c/d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung75_hearing_threshold/items.json
+++ b/code/specs/data/adj-ladder/rung75_hearing_threshold/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 75 \u2014 audiology corrected-hearing-threshold index from four stated quantities (a NEW panel: audiology / hearing-threshold). From a raw threshold, a masking level to subtract, a calibration factor to divide by, and a frequency gain to scale by, compute the corrected threshold ((raw_threshold-masking_level)/calibration_factor*frequency_gain), the net threshold (raw_threshold-masking_level), or the calibrated threshold ((raw_threshold-masking_level)/calibration_factor). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, DIFFERENCE-QUOTIENT SCALED BY A FACTOR (a-b)/c*d (subtract first, then DIVIDE, then scale \u2014 contrast rung-67 (a-b)*c/d which scales THEN divides; the left-to-right (a-b)/c*d = (a-b)*d/c, not (a-b)/(c*d)) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via -, /, and * \u2014 no constant leaks, and neither the net threshold, the calibrated threshold, nor any corrected figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: DIVIDING by the PRODUCT ((a-b)/(c*d), a wrong scaling) and SWAPPING the multiply and divide ((a-b)*c/d, a wrong scaling). The core confusion tested is that (a-b)/c*d is not (a-b)/(c*d) and not (a-b)*c/d.",
+  "items": [
+    {
+      "id": "r75hear-01",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 20, a masking level of 8 to subtract, a calibration factor of 3 to divide by and a frequency gain of 2. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(20)\nobserve masking_level(8)\nobserve calibration_factor(3)\nobserve frequency_gain(2)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r75hear-02",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 20, a masking level of 8 to subtract, a calibration factor of 3 to divide by and a frequency gain of 2. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(20)\nobserve masking_level(8)\nobserve calibration_factor(3)\nobserve frequency_gain(2)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r75hear-03",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 20, a masking level of 8 to subtract, a calibration factor of 3 to divide by and a frequency gain of 2. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(20)\nobserve masking_level(8)\nobserve calibration_factor(3)\nobserve frequency_gain(2)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r75hear-04",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 30, a masking level of 6 to subtract, a calibration factor of 4 to divide by and a frequency gain of 3. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(30)\nobserve masking_level(6)\nobserve calibration_factor(4)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r75hear-05",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 30, a masking level of 6 to subtract, a calibration factor of 4 to divide by and a frequency gain of 3. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(30)\nobserve masking_level(6)\nobserve calibration_factor(4)\nobserve frequency_gain(3)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r75hear-06",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 30, a masking level of 6 to subtract, a calibration factor of 4 to divide by and a frequency gain of 3. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(30)\nobserve masking_level(6)\nobserve calibration_factor(4)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r75hear-07",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 25, a masking level of 5 to subtract, a calibration factor of 5 to divide by and a frequency gain of 2. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(25)\nobserve masking_level(5)\nobserve calibration_factor(5)\nobserve frequency_gain(2)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r75hear-08",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 25, a masking level of 5 to subtract, a calibration factor of 5 to divide by and a frequency gain of 2. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(25)\nobserve masking_level(5)\nobserve calibration_factor(5)\nobserve frequency_gain(2)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r75hear-09",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 25, a masking level of 5 to subtract, a calibration factor of 5 to divide by and a frequency gain of 2. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(25)\nobserve masking_level(5)\nobserve calibration_factor(5)\nobserve frequency_gain(2)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r75hear-10",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 40, a masking level of 4 to subtract, a calibration factor of 6 to divide by and a frequency gain of 3. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(40)\nobserve masking_level(4)\nobserve calibration_factor(6)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 72.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r75hear-11",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 40, a masking level of 4 to subtract, a calibration factor of 6 to divide by and a frequency gain of 3. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(40)\nobserve masking_level(4)\nobserve calibration_factor(6)\nobserve frequency_gain(3)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r75hear-12",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 40, a masking level of 4 to subtract, a calibration factor of 6 to divide by and a frequency gain of 3. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(40)\nobserve masking_level(4)\nobserve calibration_factor(6)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 72.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r75hear-13",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 28, a masking level of 13 to subtract, a calibration factor of 5 to divide by and a frequency gain of 3. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(28)\nobserve masking_level(13)\nobserve calibration_factor(5)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 25.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r75hear-14",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 28, a masking level of 13 to subtract, a calibration factor of 5 to divide by and a frequency gain of 3. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(28)\nobserve masking_level(13)\nobserve calibration_factor(5)\nobserve frequency_gain(3)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 25.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r75hear-15",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 28, a masking level of 13 to subtract, a calibration factor of 5 to divide by and a frequency gain of 3. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(28)\nobserve masking_level(13)\nobserve calibration_factor(5)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 25.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r75hear-16",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 22, a masking level of 6 to subtract, a calibration factor of 2 to divide by and a frequency gain of 3. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(22)\nobserve masking_level(6)\nobserve calibration_factor(2)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10.666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r75hear-17",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 22, a masking level of 6 to subtract, a calibration factor of 2 to divide by and a frequency gain of 3. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(22)\nobserve masking_level(6)\nobserve calibration_factor(2)\nobserve frequency_gain(3)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10.666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r75hear-18",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 22, a masking level of 6 to subtract, a calibration factor of 2 to divide by and a frequency gain of 3. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(22)\nobserve masking_level(6)\nobserve calibration_factor(2)\nobserve frequency_gain(3)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 24.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10.666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r75hear-19",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 50, a masking level of 10 to subtract, a calibration factor of 5 to divide by and a frequency gain of 4. What is the corrected hearing threshold (net threshold normalised by the calibration factor, then gain-scaled)?",
+      "program": "observe raw_threshold(50)\nobserve masking_level(10)\nobserve calibration_factor(5)\nobserve frequency_gain(4)\nlet answer = (raw_threshold - masking_level) / calibration_factor * frequency_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r75hear-20",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 50, a masking level of 10 to subtract, a calibration factor of 5 to divide by and a frequency gain of 4. What is the the net threshold (raw threshold minus the masking level)?",
+      "program": "observe raw_threshold(50)\nobserve masking_level(10)\nobserve calibration_factor(5)\nobserve frequency_gain(4)\nlet answer = raw_threshold - masking_level\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 40,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r75hear-21",
+      "qtype": "hearing_threshold",
+      "stem": "An audiometry test records a raw threshold of 50, a masking level of 10 to subtract, a calibration factor of 5 to divide by and a frequency gain of 4. What is the the calibrated threshold before scaling (net threshold over the calibration factor)?",
+      "program": "observe raw_threshold(50)\nobserve masking_level(10)\nobserve calibration_factor(5)\nobserve frequency_gain(4)\nlet answer = (raw_threshold - masking_level) / calibration_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 32.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -112,6 +112,7 @@ SELF_CONTAINED_RUNGS = (
     "rung72_amniotic_index",
     "rung73_spirometry_flow",
     "rung74_dialysis_clearance",
+    "rung75_hearing_threshold",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-75 — audiology corrected-hearing-threshold index (difference-quotient scaled by a factor)

Adds the next self-contained quantitative rung to the ADJ-LADDER.

### New arithmetic shape
`(a-b)/c*d` — a **difference-quotient scaled by a factor** = `((a-b)/c)*d`. The first rung whose whole numerator
is a subtraction fed into a divide-then-multiply. Operation order matters: `(a-b)/c*d` is left-to-right
`((a-b)/c)*d = (a-b)*d/c`, **not** `(a-b)/(c*d)`. Contrast rung-67 `(a-b)*c/d` (a difference scaled **then**
divided) and rung-53 `(a+b+c)/d` (a bare triple sum over a divisor). Here a difference is divided **then** scaled.

### New clinical panel
**Audiology / hearing-threshold** — an audiometry test's `raw_threshold` has a `masking_level` subtracted, is
normalised by a `calibration_factor`, and scaled by a `frequency_gain`:
`(raw_threshold - masking_level) / calibration_factor * frequency_gain` (the corrected threshold). Distinct from
every used ladder domain.

### Item family (5 mutually-confusable members)
| key | formula | role |
|---|---|---|
| `corrected_threshold` | `(a-b)/c*d` | **gold** — the headline `(a-b)/c*d` |
| `net_threshold` | `a-b` | **gold** — the difference |
| `calibrated_threshold` | `(a-b)/c` | **gold** — the difference-quotient (before scaling) |
| `crossed` | `(a-b)/(c*d)` | distractor — DIVIDE the difference by the PRODUCT `c*d` (`(a-b)/(c*d)`) |
| `swapped` | `(a-b)*c/d` | distractor — SWAP the multiply and divide (`(a-b)*c/d`, rung-67's shape) |

First three QUERIED as gold; all five always appear as options. Gold rotates A–E by index (`idx % 5`).

### Contamination safety
- Every formula built ONLY from the four observed quantities via `-`, `/`, and `*` — **no numeric constants**.
- No net-threshold / calibrated-threshold / corrected figure ever appears as a literal (each is computed).
- **Digit-free identifiers** (`raw_threshold`, `masking_level`, `calibration_factor`, `frequency_gain`).
- 7 tables × 3 queried = **21 items**; `raw_threshold > masking_level` (positive difference → every family member
  positive), `calibration_factor > 1` and `frequency_gain > 1` (so the calibrated difference-quotient differs from
  the net threshold), `calibration_factor ≠ frequency_gain` (so the corrected `(a-b)*d/c` differs from the swapped
  `(a-b)*c/d`); the five family values are asserted pairwise-distinct (`>1e-6`) at build.

### Verification
```
$ mise exec -- python3 -m pytest test_ladder_eval.py -k rung75 -q
3 passed, 336 deselected
```
(the compute test confirms the ADJ engine selects every gold via the CLI, exercising subtract-then-divide-then-scale
with left-to-right `/`-then-`*` precedence). Registered `rung75_hearing_threshold` in `SELF_CONTAINED_RUNGS`.
Data-only change (offline generator + generated `items.json` + one-line harness registration); no engine/harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
