### PR TITLE
test(sir-conformance): capture the division floor-vs-trunc frontier (oracle-judged, §E3)

### DIFF
--- a/code/packages/rust/sir-conformance/CHANGELOG.md
+++ b/code/packages/rust/sir-conformance/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `sir-conformance` crate will be documented in this file.
 
+## [0.10.0] - Division frontier captured (oracle-judged), §E3
+
+### Added — `tests/division.rs`
+
+Probing division through the current pipeline (with the T3b-1 `DivOp` oracle as
+judge) surfaced a **confirmed, multi-way cross-backend divergence** — the exact
+"one overloaded `divide` that does the Ruby thing on Tuesdays" bug §E3 exists to
+kill. Ruby's integer `/` floors (`-7 / 2 == -4`); today:
+
+- **Python** prints `-3` — its runtime `div` truncates toward zero (`int(a/b)`),
+  and is deliberately documented/unit-tested that way ("to match SIR semantics").
+- **JavaScript** prints `-3.5` — true (float) division, not integer at all
+  (even `7 / 2` prints `3.5`).
+- **Go / Rust** — the emitted program **crashes** on the negative path.
+
+So besides bugs, there is a genuine **semantics conflict** to resolve: the Python
+runtime's truncating `div` vs. the SIR21 oracle's (and Ruby's) floor `/`. That is
+exactly why §E3 splits `/` into explicit `div_floor` / `div_trunc`; resolving it
+(flip vs. split, plus `Integer#/` floors while `Float#/` true-divides) is a
+design decision tracked separately, not made here.
+
+This slice **captures** the frontier so it is oracle-judged and tracked (the way
+`arithmetic.rs` captures the 10²⁴ bignum frontier):
+
+- `oracle_floor_matches_ruby_integer_division` — a toolchain-free control
+  pinning the oracle's floor expectations to Ruby (`7/2=3`, `-7/2=-4`, …).
+- `division_matches_ruby_floor_on_every_backend` — the cross-backend frontier,
+  `#[ignore]`d so the suite stays green; verified to genuinely fail today
+  (`javascript computed 7/2 = 3.5, Ruby floor = 3`) and it flips to a passing
+  assertion once division is made floor-faithful everywhere.
+
 ## [0.9.0] - SIR21 T3b (T3b-1) — division reference semantics (floor vs trunc, §E3)
 
 ### Added — `oracle::DivOp` + `Outcome::DivByZero`

--- a/code/packages/rust/sir-conformance/Cargo.toml
+++ b/code/packages/rust/sir-conformance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sir-conformance"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Cross-backend golden conformance harness for the Semantic IR: lowers real Ruby source and runs the emitted program through every backend's real toolchain, asserting identical output."
 

--- a/code/packages/rust/sir-conformance/tests/division.rs
+++ b/code/packages/rust/sir-conformance/tests/division.rs
@@ -1,0 +1,108 @@
+//! # Division conformance — the confirmed floor-vs-trunc frontier (SIR21 §E3)
+//!
+//! Ruby's integer `/` **floors** (rounds toward −∞): `7 / 2 == 3`,
+//! `-7 / 2 == -4`. That is what the reference oracle
+//! ([`sir_conformance::oracle::DivOp::Floor`]) prescribes, and what a faithful
+//! transpile of Ruby must reproduce on every backend.
+//!
+//! It does **not**, today. Probing the current pipeline surfaced a real,
+//! multi-way divergence — the textbook "one overloaded `divide` that does the
+//! Ruby thing on Tuesdays" bug SIR21 §E3 exists to kill:
+//!
+//! | `-7 / 2` (Ruby floor = **−4**) | backend today |
+//! |-------------------------------|---------------|
+//! | Python `-3`                   | truncates toward 0 (its runtime `div` is `int(a/b)`) |
+//! | JavaScript `-3.5`             | true (float) division, not integer at all |
+//! | Go / Rust — **crash**         | native `/` panics / errors on the path |
+//!
+//! Even *positive* division diverges: `7 / 2` prints `3.5` on JavaScript.
+//!
+//! There is also a **deliberate conflict** to resolve, not just bugs to fix: the
+//! Python runtime's `div` is documented and unit-tested as *truncating* ("to
+//! match SIR semantics"), while the SIR21 oracle (and Ruby) say *floor*. The two
+//! disagree on what a bare `/` means — which is precisely why §E3 splits it into
+//! explicit `div_floor` / `div_trunc`. Resolving that (flip vs. split, and the
+//! `Integer#/` floors but `Float#/` true-divides polymorphism) is a design
+//! decision tracked outside this test.
+//!
+//! This file **captures** the frontier so it is tracked and oracle-judged, the
+//! way the `10²⁴` bignum frontier is captured in `arithmetic.rs`. The
+//! cross-backend assertion is `#[ignore]`d so the suite stays green; it flips to
+//! a passing assertion the day division is made floor-faithful everywhere. The
+//! toolchain-free control below always runs.
+
+use sir_conformance::oracle::{DivOp, Outcome};
+use sir_conformance::{run_source, RunOutcome, Target};
+
+/// `(lhs, rhs)` pairs covering every sign combination plus exact division.
+/// Ruby evaluates each with **floor** `/`.
+const CASES: &[(i128, i128)] = &[
+    (7, 2),   // 3
+    (-7, 2),  // -4  (floor; trunc would be -3)
+    (7, -2),  // -4
+    (-7, -2), // 3
+    (6, 3),   // 2   (exact — floor == trunc)
+    (-6, 2),  // -3  (exact)
+];
+
+/// The Ruby-floor expected output for a case, straight from the oracle.
+fn floor_expected(lhs: i128, rhs: i128) -> String {
+    match DivOp::Floor.eval(lhs, rhs) {
+        Outcome::Value(v) => v.to_string(),
+        other => panic!("division case {lhs}/{rhs}: oracle gave {other:?}, expected a Value"),
+    }
+}
+
+/// Toolchain-free control: the oracle's floor expectations really are Ruby's.
+/// This always runs — it is the ground truth the frontier is measured against.
+#[test]
+fn oracle_floor_matches_ruby_integer_division() {
+    assert_eq!(floor_expected(7, 2), "3");
+    assert_eq!(floor_expected(-7, 2), "-4");
+    assert_eq!(floor_expected(7, -2), "-4");
+    assert_eq!(floor_expected(-7, -2), "3");
+    assert_eq!(floor_expected(6, 3), "2");
+    assert_eq!(floor_expected(-6, 2), "-3");
+}
+
+/// The frontier itself: every backend must reproduce Ruby's floor `/`. Ignored
+/// until division is made floor-faithful (Python truncates, JS true-divides,
+/// Go/Rust crash on the negative path) — run with `cargo test -- --ignored` to
+/// watch it, and it becomes a passing assertion once the gap is closed.
+#[test]
+#[ignore = "division frontier (SIR21 §E3): backends don't implement Ruby floor `/` — \
+            Python truncates, JS true-divides, Go/Rust crash on negatives. Flips green \
+            when division is made floor-faithful. Semantics decision tracked separately."]
+fn division_matches_ruby_floor_on_every_backend() {
+    let mut ran = 0usize;
+    for &(lhs, rhs) in CASES {
+        let expected = floor_expected(lhs, rhs);
+        let ruby = format!("puts({} / {})\n", lhs, rhs);
+        for &target in Target::all() {
+            match run_source("division", &ruby, target) {
+                RunOutcome::Ran(out) => {
+                    assert_eq!(
+                        out,
+                        expected,
+                        "\nDIVISION FRONTIER: backend {} computed {}/{} = {out}, Ruby floor = {expected}\n",
+                        target.tag(),
+                        lhs,
+                        rhs,
+                    );
+                    ran += 1;
+                }
+                // A crash (Go/Rust today) is a Failed outcome — surface it as a
+                // frontier failure too when this test is un-ignored.
+                RunOutcome::Failed(msg) => panic!(
+                    "DIVISION FRONTIER: backend {} failed on {}/{}: {}",
+                    target.tag(),
+                    lhs,
+                    rhs,
+                    msg.lines().next().unwrap_or("")
+                ),
+                RunOutcome::Skipped(_) => {}
+            }
+        }
+    }
+    assert!(ran > 0, "no backend toolchain available — the frontier proved nothing");
+}

--- a/lessons.md
+++ b/lessons.md
@@ -1231,3 +1231,27 @@ with a from-scratch zero-dep `code/packages/rust/fsrs`.
   code path you actually use before assuming it's unavoidable.
 
 Discovered: 2026-07-03, Engram zero-dep Phase B (drop `fsrs`).
+
+## The conformance oracle can expose a *deliberate* semantics conflict, not just a bug
+
+Building the SIR21 integer/division reference oracle (`sir-conformance::oracle`)
+and probing division across backends surfaced that Ruby's integer `/` (which
+*floors*: `-7 / 2 == -4`) is implemented **four different wrong ways**: Python's
+runtime `div` truncates (`int(a/b)` → `-3`) and is *deliberately* documented +
+unit-tested that way ("to match SIR semantics"); JavaScript true-divides (`7 / 2`
+→ `3.5`); Go/Rust crash on the negative path. So the oracle didn't just find
+bugs — it found a **genuine design conflict** between a pre-existing, tested,
+documented runtime decision (truncate) and the newer reference authority (Ruby
+floor).
+
+Lesson: when the reference model disagrees with a deliberately-chosen, tested,
+documented behaviour in shared/published code, do **not** unilaterally flip it in
+an autonomous loop — that overrides someone's decision and risks breaking the
+tests that pin it. Capture the divergence as an `#[ignore]`d, oracle-judged
+frontier test (so it's tracked and flips green when resolved), record the
+conflict, and surface the *decision* (here: div_floor/div_trunc split vs. flip,
+plus the `Integer#/` floors / `Float#/` true-divides polymorphism) to the human.
+The split is exactly what SIR21 §E3 prescribes precisely to avoid one overloaded
+`/` that different sources read differently.
+
+Discovered: 2026-07-04, SIR21 division frontier (sir-conformance 0.10.0).


### PR DESCRIPTION
## Division frontier captured — a confirmed cross-backend divergence *and* a semantics conflict (§E3)

When the loop reached backend wiring, I probed division through the current pipeline (judged by the merged T3b-1 `oracle::DivOp`) and found the exact **"one overloaded `divide` that does the Ruby thing on Tuesdays"** bug §E3 exists to kill. Ruby integer `/` **floors** (`-7 / 2 == -4`); today:

| `-7 / 2` (Ruby floor = **−4**) | backend today |
|---|---|
| **Python** `-3` | runtime `div` truncates (`int(a/b)`) — and this is **deliberate** (docstring + `test_truncating_division` assert it "to match SIR semantics") |
| **JavaScript** `-3.5` | true float division, not integer (even `7 / 2` → `3.5`) |
| **Go / Rust** | emitted program **crashes** on the negative path |

So this isn't only bugs — it's a genuine **semantics conflict**: the Python runtime's *deliberate, tested, documented* truncating `div` vs. the SIR21 oracle's (and Ruby's) floor `/`. Resolving it (the §E3 `div_floor`/`div_trunc` split vs. a flip, plus the `Integer#/` floors / `Float#/` true-divides polymorphism) is a **design decision** — surfaced to the human via a task chip + lessons.md, **not** made unilaterally in an autonomous loop.

### What this PR does — *capture*, not fix
`tests/division.rs`, mirroring how `arithmetic.rs` captures the 10²⁴ bignum frontier:
- **`oracle_floor_matches_ruby_integer_division`** — toolchain-free control pinning the oracle's floor expectations to Ruby (`7/2=3`, `-7/2=-4`, …). Always runs.
- **`division_matches_ruby_floor_on_every_backend`** — the cross-backend frontier, **`#[ignore]`d** so the suite stays green. Verified to genuinely fail today (`javascript computed 7/2 = 3.5, Ruby floor = 3`); it flips to a passing assertion once division is made floor-faithful everywhere.

Plus a **lessons.md** entry: when the reference oracle disagrees with a deliberate, tested, documented behaviour in shared/published code, capture + surface the decision — don't unilaterally flip it.

### The fix is queued
A task is filed for **T3b-2** (the actual cross-backend division fix, once the semantics decision is made). No runtime/source code changes here — test + docs only; security review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)