### PR TITLE
feat(cloc12): CLOC12.165 ThisExpression (`this`) — atomic node + emit + 9 passes (PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.29.0] - 2026-07-04
+
+### Added — CLOC12.165: `emit_this` (`this`)
+
+Added `emit_this` + the `Expression::ThisExpression` dispatch arm and its `PREC_PRIMARY` classification. `this` prints as the bare four-character keyword — a primary that never needs wrapping in any parent (`this.x`, `this()`, `f(this)`, `this+1` all print bare) and never forces a paren around an operand. Reachable via hand-constructed AST today; the bridge conversion of `this` (gap-166) lands as CLOC12.165 PR2. (CLOC12.165)
+
+
 ## [0.28.1] - 2026-07-04
 
 ### Added — CLOC12.164 PR3: CodePrinter await conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.28.1"
+version = "0.29.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -78,7 +78,7 @@ use coding_adventures_javascript_ast::{
     Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
-    TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression,
+    TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1139,6 +1139,7 @@ impl<'a> Emitter<'a> {
             Expression::SpreadElement(s) => self.emit_spread(s),
             Expression::YieldExpression(y) => self.emit_yield(y),
             Expression::AwaitExpression(a) => self.emit_await(a),
+            Expression::ThisExpression(t) => self.emit_this(t),
         }
         if needs_parens {
             self.write_str(")");
@@ -1626,6 +1627,16 @@ impl<'a> Emitter<'a> {
         self.emit_expression_inner(&a.argument, PREC_UNARY);
     }
 
+    /// `this` — a bare reserved-word keyword. It carries no operand, so the
+    /// emit is simply the four characters `this` (after recording the source
+    /// map anchor). No trailing separator is needed: as a `PREC_PRIMARY`
+    /// leaf `this` is only ever followed by a member/call token (`this.x`,
+    /// `this()`) or a punctuator, never by another word that would fuse.
+    fn emit_this(&mut self, t: &ThisExpression) {
+        self.maybe_map(&t.cv);
+        self.write_str("this");
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -1997,7 +2008,12 @@ fn expr_prec(e: &Expression) -> u8 {
         | Expression::ArrayExpression(_)
         | Expression::ObjectExpression(_)
         | Expression::CallExpression(_)
-        | Expression::MemberExpression(_) => PREC_PRIMARY,
+        | Expression::MemberExpression(_)
+        // `this` is a reserved-word primary — a bare keyword that binds at the
+        // tightest level, like an identifier. It never needs wrapping in any
+        // parent (`this.x`, `this()`, `f(this)` are all valid bare), and no
+        // operand context ever forces a paren around it.
+        | Expression::ThisExpression(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
         // Update (`++x` / `x++`) binds a hair tighter than the pure unary
@@ -5047,5 +5063,45 @@ mod tests {
     #[test]
     fn await_nested_is_bare() {
         assert_eq!(emit_expr(aw(aw(ident("p")))), "await await p;");
+    }
+
+    // =================================================================
+    // ThisExpression (`this`) — CLOC12.165
+    // =================================================================
+
+    /// Build a `ThisExpression`.
+    fn this_expr() -> Expression {
+        Expression::ThisExpression(ThisExpression { cv: None })
+    }
+
+    /// `this` — a bare keyword, printed verbatim.
+    #[test]
+    fn this_emits_bare_keyword() {
+        assert_eq!(emit_expr(this_expr()), "this;");
+    }
+
+    /// `this.x` — `this` is a primary, so a member parent needs no parens.
+    #[test]
+    fn this_as_member_object_is_bare() {
+        assert_eq!(emit_expr(member(this_expr(), "x", false)), "this.x;");
+    }
+
+    /// `this()` — as a call callee `this` stays bare (primary strength).
+    #[test]
+    fn this_as_call_callee_is_bare() {
+        assert_eq!(emit_expr(call(this_expr(), vec![])), "this();");
+    }
+
+    /// `f(this)` — `this` as a call argument is a plain primary operand.
+    #[test]
+    fn this_as_call_argument_is_bare() {
+        assert_eq!(emit_expr(call(ident("f"), vec![this_expr()])), "f(this);");
+    }
+
+    /// `this+1` — even a binary parent leaves the primary `this` bare.
+    #[test]
+    fn this_under_binary_parent_is_bare() {
+        let e = binary(BinaryOperator::Add, this_expr(), num(1.0));
+        assert_eq!(emit_expr(e), "this+1;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.85.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.7"
+version = "0.85.8"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -500,6 +500,9 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — nothing inside to fold, and it is never
+        // itself a constant, so it passes through unchanged like the literals.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => fold_binary(b, st),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.20.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.7"
+version = "0.20.8"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -1163,6 +1163,9 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — no sub-expression to walk, never dead on
+        // its own, so it clones through like the literals.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match + `expression_cv` arm
+
+Added `Expression::ThisExpression` arms to both the rebuild match (clones the leaf through, like the literals) and the `expression_cv` accessor (returns its `cv`), keeping the pass exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). No behaviour change to any existing node.
+
+
 ## [0.20.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.7"
+version = "0.20.8"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -279,6 +279,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         SpreadElement(e) => e.cv.clone(),
         YieldExpression(y) => y.cv.clone(),
         AwaitExpression(a) => a.cv.clone(),
+        ThisExpression(t) => t.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1358,6 +1359,9 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — nothing inside to fold, so it clones
+        // through like the literals.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` no-op arm so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` binds and references no identifier and has no sub-expression, so the traversal does nothing for it. No behaviour change to any existing node.
+
+
 ## [0.11.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` traversal arms

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -729,6 +729,8 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` binds no variable name — nothing to count or propagate into.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             count_uses_expr(&be.left, name, count);
@@ -1029,6 +1031,8 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` binds no variable name — nothing to count or propagate into.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= propagate_in_expr(&mut be.left, cand);

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arms
+
+Added `Expression::ThisExpression` arms to the pass's exhaustive expression matches (node-count → 0 sub-nodes; the collect/tally/substitute/rename traversals → no-op), keeping the pass exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` is deliberately left OUT of the trivial-/pure-expression predicates: `this` is bound at the call site, so treating it as a freely-substitutable primary would be unsound. The inliner therefore handles it conservatively. No behaviour change to any existing node.
+
+
 ## [0.25.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` traversal arms

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.7"
+version = "0.25.8"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -437,6 +437,9 @@ fn expr_node_count(expr: &Expression) -> usize {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a single leaf keyword — it contributes one node like the
+        // other leaves (which this arm counts as 0 sub-nodes).
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => 0,
         Expression::BinaryExpression(be) => expr_node_count(&be.left) + expr_node_count(&be.right),
         Expression::LogicalExpression(le) => expr_node_count(&le.left) + expr_node_count(&le.right),
@@ -748,6 +751,12 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — it binds/references no identifier and has
+        // no sub-expression, so these traversals do nothing for it. (It is
+        // deliberately NOT treated as a freely-substitutable primary: `this` is
+        // bound at the call site, so the inliner's triv-/pure-expression
+        // predicates leave it conservative.)
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_binding_idents_expr(&be.left, out);
@@ -1028,6 +1037,12 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — it binds/references no identifier and has
+        // no sub-expression, so these traversals do nothing for it. (It is
+        // deliberately NOT treated as a freely-substitutable primary: `this` is
+        // bound at the call site, so the inliner's triv-/pure-expression
+        // predicates leave it conservative.)
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             tally_expr(&be.left, cand, t);
@@ -1364,6 +1379,12 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — it binds/references no identifier and has
+        // no sub-expression, so these traversals do nothing for it. (It is
+        // deliberately NOT treated as a freely-substitutable primary: `this` is
+        // bound at the call site, so the inliner's triv-/pure-expression
+        // predicates leave it conservative.)
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= inline_in_expr(&mut be.left, cand);
@@ -1490,6 +1511,12 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — it binds/references no identifier and has
+        // no sub-expression, so these traversals do nothing for it. (It is
+        // deliberately NOT treated as a freely-substitutable primary: `this` is
+        // bound at the call site, so the inliner's triv-/pure-expression
+        // predicates leave it conservative.)
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             substitute(&mut be.left, map);
@@ -2004,6 +2031,12 @@ fn expr_collect_mutated_params(
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — it binds/references no identifier and has
+        // no sub-expression, so these traversals do nothing for it. (It is
+        // deliberately NOT treated as a freely-substitutable primary: `this` is
+        // bound at the call site, so the inliner's triv-/pure-expression
+        // predicates leave it conservative.)
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
     }
 }
@@ -3348,6 +3381,12 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a leaf keyword — it binds/references no identifier and has
+        // no sub-expression, so these traversals do nothing for it. (It is
+        // deliberately NOT treated as a freely-substitutable primary: `this` is
+        // bound at the call site, so the inliner's triv-/pure-expression
+        // predicates leave it conservative.)
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_in_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` no-op arm so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` binds and references no identifier and has no sub-expression, so the traversal does nothing for it. No behaviour change to any existing node.
+
+
 ## [0.10.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` traversal arms

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.7"
+version = "0.10.8"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -634,6 +634,8 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` binds no global name — nothing to collect or rename.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -955,6 +957,8 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` binds no global name — nothing to collect or rename.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_apply_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` no-op arm so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` binds and references no identifier and has no sub-expression, so the traversal does nothing for it. No behaviour change to any existing node.
+
+
 ## [0.12.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` traversal arms

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1145,6 +1145,8 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` holds no property name to classify or rewrite.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             classify_expr(&be.left, cls);
@@ -1428,6 +1430,8 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` holds no property name to classify or rewrite.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` no-op arm so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` binds and references no identifier and has no sub-expression, so the traversal does nothing for it. No behaviour change to any existing node.
+
+
 ## [0.14.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` traversal arms

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.7"
+version = "0.14.8"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -912,6 +912,8 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a reserved-word leaf — never a renameable identifier.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -1219,6 +1221,8 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` is a reserved-word leaf — never a renameable identifier.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_uses_expr(&mut be.left, map);

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.8] - 2026-07-04
+
+### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm
+
+Added an `Expression::ThisExpression` no-op arm so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.165 atomic node PR1). `this` binds and references no identifier and has no sub-expression, so the traversal does nothing for it. No behaviour change to any existing node.
+
+
 ## [0.12.7] - 2026-07-04
 
 ### Changed — CLOC12.164: `AwaitExpression` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -849,6 +849,9 @@ fn walk_expression(
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // `this` binds no lexical name — it is resolved by the runtime, not by
+        // scope analysis — so it introduces and references nothing.
+        | Expression::ThisExpression(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             walk_expression(&be.left, ctx, analysis, pending);

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.24.0] - 2026-07-04
+
+### Added — CLOC12.165: `Expression::ThisExpression` (`this`)
+
+Added `Expression::ThisExpression` variant + `ThisExpression { cv }` struct — the `this` keyword, a reserved-word **leaf** primary (same shape as `NullLiteral` / `UndefinedLiteral`, no operand). Modelled as its own node rather than `Identifier { name: "this" }` so renaming passes never touch it. Re-exported from the crate root. Atomic node PR (PR1): the node + `closure-emitter` emit + all nine downstream pass match-arms land together so the workspace never breaks. (CLOC12.165)
+
+
 ## [0.23.0] - 2026-07-04
 
 ### Added — CLOC12.164: `Expression::AwaitExpression` (`await x`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -111,6 +111,16 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   member/call/new parents wrap the whole await (`(await p).x`, `(await f)()`).
   Node + `closure-emitter` + all pass traversals land in one atomic PR; the
   bridge-enable + conformance port follow.
+- `ThisExpression` (CLOC12.165) — the `this` keyword: a reserved-word **leaf**
+  primary that reads the current execution context's `this` binding.
+  `ThisExpression { cv }` — no operand, the same shape as `NullLiteral` /
+  `UndefinedLiteral`. Modelled as its own node rather than
+  `Identifier { name: "this" }` so the renaming passes never touch it (a
+  reserved word can never be a variable name). It tags at `PREC_PRIMARY` and
+  prints as the bare keyword — it never needs wrapping (`this.x`, `this()`,
+  `f(this)` all print bare) and never forces a paren around an operand. Node +
+  `closure-emitter` + all pass traversals land in one atomic PR; the
+  bridge-enable + conformance port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -64,6 +64,7 @@ pub enum Expression {
     SpreadElement(SpreadElement),
     YieldExpression(YieldExpression),
     AwaitExpression(AwaitExpression),
+    ThisExpression(ThisExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -580,6 +581,38 @@ pub struct AwaitExpression {
     pub argument: Box<Expression>,
 }
 
+/// The `this` keyword — a primary expression that reads the current
+/// execution context's `this` binding:
+///
+/// ```text
+///   this            the receiver of the enclosing method / the global-or-undefined
+///   this.x          member access off the receiver
+///   f(this)         pass the receiver as an argument
+/// ```
+///
+/// # Shape
+///
+/// `this` is a **leaf** — it carries no operand and no payload beyond its
+/// `cv` (the same shape as [`NullLiteral`] / [`UndefinedLiteral`]). ESTree
+/// models it as its own `ThisExpression` node rather than an
+/// `Identifier { name: "this" }`, because `this` is a reserved word: it can
+/// never be a variable name, so passes that rename identifiers must never
+/// touch it. Giving it a dedicated variant lets those passes pattern-match
+/// it out structurally instead of string-comparing every identifier name.
+///
+/// # Precedence
+///
+/// `this` binds at **primary** strength — the tightest level, like an
+/// identifier or a parenthesised group. It never needs wrapping in any
+/// parent context, and no parent operand ever forces a paren around it. The
+/// emitter therefore tags it `PREC_PRIMARY` and prints the bare keyword.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThisExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+}
+
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the
 /// `property` is conventionally an [`Expression::Identifier`]);
 /// `computed = true` ↔ `obj[key]` (the `property` is any expression).
@@ -1010,6 +1043,21 @@ mod tests {
         let json = serde_json::to_string(&u).expect("serialize");
         assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
         assert_eq!(u.clone(), roundtrip(u));
+    }
+
+    #[test]
+    fn this_expression_roundtrips_traced() {
+        let t = Expression::ThisExpression(ThisExpression { cv: Some("this.1".to_string()) });
+        assert_eq!(t.clone(), roundtrip(t.clone()));
+        assert_eq!(type_tag(&t), "ThisExpression");
+    }
+
+    #[test]
+    fn this_expression_untraced_omits_cv() {
+        let t = Expression::ThisExpression(ThisExpression { cv: None });
+        let json = serde_json::to_string(&t).expect("serialize");
+        assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(t.clone(), roundtrip(t));
     }
 
     #[test]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
-    AwaitExpression, YieldExpression,
+    AwaitExpression, ThisExpression, YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2135,3 +2135,48 @@ Until then, PR1's node + the **PR3 conformance port**
 the same staging used for the substitution-template slice (gap-157), which also
 shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
+
+
+## CLOC12.165 — `ThisExpression` (`this`): atomic node + emit + passes (PR1)
+
+Adds `Expression::ThisExpression { cv }` to `javascript-ast` (0.24.0) — the
+`this` keyword, a reserved-word **leaf** primary that reads the current
+execution context's `this` binding. It is the simplest node in the recent
+run: no operand, no axis, the same shape as `NullLiteral` / `UndefinedLiteral`.
+
+It is modelled as its own variant rather than `Identifier { name: "this" }`
+because `this` is a reserved word — it can never be a variable name, so the
+renaming passes (`rename`, `rename-globals`, `rename-properties`) must never
+touch it. A dedicated variant lets those passes exclude it structurally instead
+of string-comparing every identifier name.
+
+**Emit (`closure-emitter` 0.29.0).** `emit_this` writes the bare four-character
+keyword. `this` tags at `PREC_PRIMARY` — the tightest level — so it never needs
+wrapping in any parent (`this.x`, `this()`, `f(this)`, `this+1` all print bare)
+and never forces a paren around an operand.
+
+**Passes (PATCH bumps).** The three rebuild passes (`constant-fold`, `dce`,
+`fold-control-flow`) clone the leaf through unchanged like the literals;
+`fold-control-flow` also gains a `ThisExpression` arm in its `expression_cv`
+accessor. The six traversal passes get a no-op arm (`this` binds/references no
+identifier and has no sub-expression). In `inline`, `this` is deliberately left
+OUT of the trivial-/pure-expression predicates: `this` is bound at the *call
+site*, so treating it as a freely-substitutable primary would be unsound; the
+inliner handles it conservatively.
+
+### gap-166 — bridge declines `this` (`ThisExpression`) — **OPEN (PR2, viable)**
+
+The `javascript-parser` bridge does not yet convert a `this` node to
+`Expression::ThisExpression`; it returns `UnsupportedSyntax { rule:
+"ThisExpression" }`, so any file containing `this` drops to WHITESPACE_ONLY. The
+atomic node PR (CLOC12.165 PR1) landed the node + emit + pass traversals so the
+typed AST and every downstream pass can already represent and print a `this`.
+
+**Unlike `await` (gap-165), `this` is already parseable.** The grammar produces
+a `this` node that the bridge *reaches* and explicitly declines — the bridge
+already matches `"this"` in its decline list, so the parser recognises it as a
+primary expression today. PR2 (bridge-enable) is therefore a straightforward
+bridge slice — convert the `this` grammar node to `Expression::ThisExpression`
+and add a closurec end-to-end diff fixture — with **no grammar work required**.
+The **PR3 conformance port** (`code_printer_this_test.rs`) exercises the emitter
+via hand-constructed AST in the meantime.


### PR DESCRIPTION
## CLOC12.165 — `ThisExpression` (`this`): atomic node PR1

Adds `Expression::ThisExpression { cv }` to `javascript-ast` — the `this`
keyword, a reserved-word **leaf** primary (same shape as `NullLiteral` /
`UndefinedLiteral`, no operand). Modelled as its own node rather than
`Identifier { name: "this" }` so the renaming passes never touch it (a reserved
word can never be a variable name).

This is the next node in the CLOC12 Expression-coverage ladder after
SpreadElement / YieldExpression / AwaitExpression. Unlike `await` (gap-165,
blocked on grammar), **`this` is already parseable** — the bridge reaches and
explicitly declines it — so the full 3-PR arc including the PR2 bridge-enable is
viable with no grammar work (gap-166).

### Atomic PR1 (node + emit + all 9 downstream passes in one commit)
- **`javascript-ast` 0.24.0** — new `ThisExpression` variant + struct + crate re-export + 2 roundtrip tests.
- **`closure-emitter` 0.29.0** — `emit_this` writes the bare keyword; tags at `PREC_PRIMARY` (never wrapped, never wraps an operand) + 5 unit tests (`this;`, `this.x;`, `this();`, `f(this);`, `this+1;`).
- **Rebuild passes** (`constant-fold` 0.85.8, `dce` 0.20.8, `fold-control-flow` 0.20.8) — clone the leaf through like the literals; `fold-control-flow` also adds a `ThisExpression` arm to its `expression_cv` accessor.
- **Traversal passes** (`inline` 0.25.8, `inline-variables` 0.11.8, `rename` 0.14.8, `rename-globals` 0.10.8, `rename-properties` 0.12.8, `scope-analyzer` 0.12.8) — no-op arm.

### Soundness note
In `inline`, `this` is deliberately left **out** of the trivial-/pure-expression
predicates: `this` is bound at the *call site*, so treating it as a
freely-substitutable primary would be unsound. The inliner handles it
conservatively.

### Verification
All 11 affected packages build and test green (0 failures), including the 7 new
`this` tests. Spec: adds the CLOC12.165 section + gap-166 (bridge-enable PR2,
viable). PR2 (bridge) and PR3 (CodePrinter conformance port) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)