### PR TITLE
test(cloc12): CLOC12.165 PR3 — CodePrinter `this` conformance port

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.29.1] - 2026-07-04
+
+### Added — CLOC12.165 PR3: CodePrinter `this` conformance port
+
+Ported the upstream `CodePrinterTest` **this** printing cases into
+`tests/upstream/code_printer_this_test.rs` (registered as the
+`upstream_code_printer_this` `[[test]]`). 7 active `#[test]`s, 0 `#[ignore]` —
+`emit_this` + the `PREC_PRIMARY` classification conform to every covered shape:
+the bare keyword `this`, `this` as a member object (`this.x`), call callee
+(`this()`), and call argument (`f(this)`), composed in a member chain
+(`this.a.b`) and a method call (`this.m()`), and left bare under a binary parent
+(`this+1`). Test-only; no emitter behaviour change (the emit logic landed in
+CLOC12.165 PR1, closure-emitter 0.29.0).
+
 ## [0.29.0] - 2026-07-04
 
 ### Added — CLOC12.165: `emit_this` (`this`)

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -88,3 +88,7 @@ path = "tests/upstream/code_printer_yield_test.rs"
 [[test]]
 name = "upstream_code_printer_await"
 path = "tests/upstream/code_printer_await_test.rs"
+
+[[test]]
+name = "upstream_code_printer_this"
+path = "tests/upstream/code_printer_this_test.rs"

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -158,6 +158,22 @@ under the Apache License, Version 2.0:
       treats `await` inside an async body as a plain identifier, so it does not
       yet parse (see the spec).
 
+- `code_printer_this_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the `this` keyword printing cases)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_this` + the `PREC_PRIMARY` classification that landed with
+      `Expression::ThisExpression` (CLOC12.165). 7 active `#[test]`s and **0
+      `#[ignore]`** — `this` printed as a bare reserved-word primary that never
+      needs wrapping and never wraps an operand: the surface `this`, as a member
+      object (`this.x`), as a call callee (`this()`), as a call argument
+      (`f(this)`), composed in a member chain (`this.a.b`) and a method call
+      (`this.m()`), and left bare under a binary parent (`this+1`). Inputs are
+      hand-constructed AST; the bridge conversion of `this` (gap-166) is
+      exercised separately in `javascript-parser` (CLOC12.165 PR2) — unlike
+      `await`, `this` was already parseable, so that bridge slice needed no
+      grammar work.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_this_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_this_test.rs
@@ -1,0 +1,172 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **this** printing cases — the `this` keyword
+//! (`ThisExpression`). This is the eighteenth CodePrinter port into
+//! `closure-emitter` (after core / declarations / trailing-comma / numbers /
+//! string-escape / ascii-escape / object-literal / function-expression /
+//! arrow-function / template / update / new / sequence / tagged-template /
+//! spread / yield / await) and isolates `emit_this` + the `PREC_PRIMARY`
+//! classification that landed with `Expression::ThisExpression`
+//! (CLOC12.165).
+//!
+//! # How the emitter prints a `this` (recap)
+//!
+//! `this` is a *reserved-word primary* — a bare keyword that binds at the
+//! tightest level, like an identifier. The emitter prints the four characters
+//! `this` and never wraps it (in any parent) nor forces a paren around an
+//! operand (it carries none).
+//!
+//! ```text
+//!   this        → this        bare keyword
+//!   this.x      → this.x      member object binds at primary → no parens
+//!   this()      → this()      call callee binds at primary → no parens
+//!   f(this)     → f(this)     plain primary argument
+//!   this+1      → this+1      a binary parent leaves the primary bare
+//!   this.a.b    → this.a.b    member chains compose without parens
+//!   this.m()    → this.m()    method call composes without parens
+//! ```
+//!
+//! # Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (the emitter is the unit
+//! under test). The bridge conversion of `this` (gap-166) lands in CLOC12.165
+//! PR2 and is exercised separately in `javascript-parser`; here the emitter is
+//! driven from hand-constructed AST so this port does not depend on the bridge.
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    BinaryExpression, BinaryOperator, CallExpression, Expression, ExpressionStatement, Identifier,
+    MemberExpression, NumericLiteral, Program, ProgramItem, SourceType, Statement, ThisExpression,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn num(value: f64, raw: &str) -> Expression {
+    Expression::NumericLiteral(NumericLiteral { cv: None, value, raw: raw.to_string() })
+}
+
+fn member(object: Expression, property: &str) -> Expression {
+    Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(object),
+        property: Box::new(ident(property)),
+        computed: false,
+    })
+}
+
+fn binary(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+    Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: op,
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn call(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::CallExpression(CallExpression { cv: None, callee: Box::new(callee), arguments })
+}
+
+/// Build a `ThisExpression` — the `this` keyword.
+fn this_expr() -> Expression {
+    Expression::ThisExpression(ThisExpression { cv: None })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "this emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — the surface shape
+// =====================================================================
+
+/// `this` — the bare keyword.
+#[test]
+fn this_value_is_bare_keyword() {
+    assert_emits(this_expr(), "this;");
+}
+
+// =====================================================================
+// Active — `this` as a primary composes without parens
+// =====================================================================
+
+/// `this.x` — a member parent binds at primary strength; the `this` object
+/// needs no parens.
+#[test]
+fn this_member_object_is_bare() {
+    assert_emits(member(this_expr(), "x"), "this.x;");
+}
+
+/// `this()` — a call callee likewise leaves the primary `this` bare.
+#[test]
+fn this_call_callee_is_bare() {
+    assert_emits(call(this_expr(), vec![]), "this();");
+}
+
+/// `f(this)` — `this` as a call argument is a plain primary operand.
+#[test]
+fn this_as_call_argument_is_bare() {
+    assert_emits(call(ident("f"), vec![this_expr()]), "f(this);");
+}
+
+/// `this.a.b` — member chains off `this` compose without any parens.
+#[test]
+fn this_member_chain_is_bare() {
+    assert_emits(member(member(this_expr(), "a"), "b"), "this.a.b;");
+}
+
+/// `this.m()` — a method call `this.m()` composes without parens (member then
+/// call, both at primary strength).
+#[test]
+fn this_method_call_is_bare() {
+    assert_emits(call(member(this_expr(), "m"), vec![]), "this.m();");
+}
+
+// =====================================================================
+// Active — the whole node's precedence (this tags at PREC_PRIMARY)
+// =====================================================================
+
+/// `this+1` — even a binary parent leaves the primary `this` bare on the left.
+#[test]
+fn this_under_binary_parent_is_bare() {
+    assert_emits(binary(BinaryOperator::Add, this_expr(), num(1.0, "1")), "this+1;");
+}


### PR DESCRIPTION
## CLOC12.165 PR3 — CodePrinter `this` conformance port

Third and final PR of the `this` arc. Ports the upstream `CodePrinterTest`
`this`-printing cases into `closure-emitter/tests/upstream/code_printer_this_test.rs`
(registered as the `upstream_code_printer_this` `[[test]]`).

**7 active `#[test]`s, 0 `#[ignore]`** — `emit_this` + the `PREC_PRIMARY`
classification conform to every covered shape:
- bare `this`
- member object `this.x`, call callee `this()`, call argument `f(this)`
- member chain `this.a.b`, method call `this.m()`
- `this+1` (left bare under a binary parent)

Inputs are hand-constructed typed-AST (the emitter is the unit under test). The
bridge conversion of `this` (gap-166) is exercised separately in
`javascript-parser` — CLOC12.165 PR2 (#7616).

### Verification
Full `closure-emitter` suite green (0 failures), including the new
`upstream_code_printer_this` (7 tests). Test-only; `closure-emitter`
0.29.0 → 0.29.1 — no emitter behaviour change (the emit logic landed in
CLOC12.165 PR1, #7613).

Independent of #7616 (no file overlap); both build off `main` which has PR1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)