### PR TITLE
feat(cloc12): CLOC12.166 PR1 — Super (`super`) atomic node + emit + 9 passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.30.0] - 2026-07-04
+
+### Added — CLOC12.166: emit `Super` (`super`)
+
+Added `emit_super` (prints the bare keyword `super` after recording its source-map anchor) and classified `Expression::Super` at `PREC_PRIMARY` in `expr_prec` — the sibling of `this`. As a primary leaf it never needs wrapping and never forces a paren around an operand, so `super.m()`, `super[k]`, `super()` compose paren-free. Five unit tests. (CLOC12.166)
+
+
 ## [0.29.1] - 2026-07-04
 
 ### Added — CLOC12.165 PR3: CodePrinter `this` conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.29.1"
+version = "0.30.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -79,6 +79,7 @@ use coding_adventures_javascript_ast::{
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
     TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
+    Super,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1140,6 +1141,7 @@ impl<'a> Emitter<'a> {
             Expression::YieldExpression(y) => self.emit_yield(y),
             Expression::AwaitExpression(a) => self.emit_await(a),
             Expression::ThisExpression(t) => self.emit_this(t),
+            Expression::Super(s) => self.emit_super(s),
         }
         if needs_parens {
             self.write_str(")");
@@ -1637,6 +1639,17 @@ impl<'a> Emitter<'a> {
         self.write_str("this");
     }
 
+    /// `super` — a bare reserved-word keyword, the sibling of `this`. Like
+    /// `this` it carries no operand, so the emit is simply the five
+    /// characters `super` (after recording the source-map anchor). As a
+    /// `PREC_PRIMARY` leaf it is only ever followed by a member/call token
+    /// (`super.x`, `super()`, `super[k]`) or a punctuator, never by another
+    /// word that would fuse, so no trailing separator is needed.
+    fn emit_super(&mut self, s: &Super) {
+        self.maybe_map(&s.cv);
+        self.write_str("super");
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -2013,7 +2026,12 @@ fn expr_prec(e: &Expression) -> u8 {
         // tightest level, like an identifier. It never needs wrapping in any
         // parent (`this.x`, `this()`, `f(this)` are all valid bare), and no
         // operand context ever forces a paren around it.
-        | Expression::ThisExpression(_) => PREC_PRIMARY,
+        | Expression::ThisExpression(_)
+        // `super` is a reserved-word primary, the sibling of `this`: a bare
+        // keyword that binds at the tightest level. It is only ever the object
+        // of a member access or a call callee (`super.m()`, `super[k]`,
+        // `super()`) — all of which compose paren-free at primary strength.
+        | Expression::Super(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
         // Update (`++x` / `x++`) binds a hair tighter than the pure unary
@@ -5103,5 +5121,45 @@ mod tests {
     fn this_under_binary_parent_is_bare() {
         let e = binary(BinaryOperator::Add, this_expr(), num(1.0));
         assert_eq!(emit_expr(e), "this+1;");
+    }
+
+    // =================================================================
+    // Super (`super`) — CLOC12.166
+    // =================================================================
+
+    /// Build a `Super`.
+    fn super_expr() -> Expression {
+        Expression::Super(Super { cv: None })
+    }
+
+    /// `super` — a bare keyword, printed verbatim.
+    #[test]
+    fn super_emits_bare_keyword() {
+        assert_eq!(emit_expr(super_expr()), "super;");
+    }
+
+    /// `super.x` — `super` is a primary, so a member parent needs no parens.
+    #[test]
+    fn super_as_member_object_is_bare() {
+        assert_eq!(emit_expr(member(super_expr(), "x", false)), "super.x;");
+    }
+
+    /// `super()` — as a call callee `super` stays bare (primary strength).
+    #[test]
+    fn super_as_call_callee_is_bare() {
+        assert_eq!(emit_expr(call(super_expr(), vec![])), "super();");
+    }
+
+    /// `super.m()` — a method call off `super` composes without parens.
+    #[test]
+    fn super_method_call_is_bare() {
+        assert_eq!(emit_expr(call(member(super_expr(), "m", false), vec![])), "super.m();");
+    }
+
+    /// `super+1` — even a binary parent leaves the primary `super` bare.
+    #[test]
+    fn super_under_binary_parent_is_bare() {
+        let e = binary(BinaryOperator::Add, super_expr(), num(1.0));
+        assert_eq!(emit_expr(e), "super+1;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.85.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.8"
+version = "0.85.9"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -503,6 +503,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         // `this` is a leaf keyword — nothing inside to fold, and it is never
         // itself a constant, so it passes through unchanged like the literals.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => fold_binary(b, st),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.20.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.8"
+version = "0.20.9"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -1166,6 +1166,7 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         // `this` is a leaf keyword — no sub-expression to walk, never dead on
         // its own, so it clones through like the literals.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.20.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match + `expression_cv` arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.8"
+version = "0.20.9"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -280,6 +280,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         YieldExpression(y) => y.cv.clone(),
         AwaitExpression(a) => a.cv.clone(),
         ThisExpression(t) => t.cv.clone(),
+        Super(s) => s.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1362,6 +1363,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         // `this` is a leaf keyword — nothing inside to fold, so it clones
         // through like the literals.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.11.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.8"
+version = "0.11.9"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -731,6 +731,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         | Expression::BigIntLiteral(_)
         // `this` binds no variable name — nothing to count or propagate into.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             count_uses_expr(&be.left, name, count);
@@ -1033,6 +1034,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         | Expression::BigIntLiteral(_)
         // `this` binds no variable name — nothing to count or propagate into.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= propagate_in_expr(&mut be.left, cand);

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.25.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arms

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.8"
+version = "0.25.9"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -440,6 +440,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         // `this` is a single leaf keyword — it contributes one node like the
         // other leaves (which this arm counts as 0 sub-nodes).
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => 0,
         Expression::BinaryExpression(be) => expr_node_count(&be.left) + expr_node_count(&be.right),
         Expression::LogicalExpression(le) => expr_node_count(&le.left) + expr_node_count(&le.right),
@@ -757,6 +758,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // bound at the call site, so the inliner's triv-/pure-expression
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_binding_idents_expr(&be.left, out);
@@ -1043,6 +1045,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         // bound at the call site, so the inliner's triv-/pure-expression
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             tally_expr(&be.left, cand, t);
@@ -1385,6 +1388,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         // bound at the call site, so the inliner's triv-/pure-expression
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= inline_in_expr(&mut be.left, cand);
@@ -1517,6 +1521,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         // bound at the call site, so the inliner's triv-/pure-expression
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             substitute(&mut be.left, map);
@@ -2037,6 +2042,7 @@ fn expr_collect_mutated_params(
         // bound at the call site, so the inliner's triv-/pure-expression
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
     }
 }
@@ -3387,6 +3393,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // bound at the call site, so the inliner's triv-/pure-expression
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_in_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.10.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.8"
+version = "0.10.9"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -636,6 +636,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BigIntLiteral(_)
         // `this` binds no global name — nothing to collect or rename.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -959,6 +960,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BigIntLiteral(_)
         // `this` binds no global name — nothing to collect or rename.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_apply_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.12.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1147,6 +1147,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         | Expression::BigIntLiteral(_)
         // `this` holds no property name to classify or rewrite.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             classify_expr(&be.left, cls);
@@ -1432,6 +1433,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BigIntLiteral(_)
         // `this` holds no property name to classify or rewrite.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.14.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.8"
+version = "0.14.9"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -914,6 +914,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BigIntLiteral(_)
         // `this` is a reserved-word leaf — never a renameable identifier.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -1223,6 +1224,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BigIntLiteral(_)
         // `this` is a reserved-word leaf — never a renameable identifier.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_uses_expr(&mut be.left, map);

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.9] - 2026-07-04
+
+### Changed — CLOC12.166: `Super` exhaustive-match arm
+
+Added an `Expression::Super` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.166 atomic node PR1). `super` is a leaf keyword with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.12.8] - 2026-07-04
 
 ### Changed — CLOC12.165: `ThisExpression` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.8"
+version = "0.12.9"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -852,6 +852,7 @@ fn walk_expression(
         // `this` binds no lexical name — it is resolved by the runtime, not by
         // scope analysis — so it introduces and references nothing.
         | Expression::ThisExpression(_)
+        | Expression::Super(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             walk_expression(&be.left, ctx, analysis, pending);

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.25.0] - 2026-07-04
+
+### Added — CLOC12.166: `Expression::Super` (`super`)
+
+Added `Expression::Super` variant + `Super { cv }` struct — the `super` keyword, a reserved-word **leaf** primary (same shape as `ThisExpression`, no operand). Like `this`, modelled as its own node rather than `Identifier { name: "super" }` so renaming passes never touch it; `super` is syntactically restricted to member-object / call-callee position inside a method or derived constructor, but that is the parser's concern — the AST treats it as a plain leaf primary. Re-exported from the crate root. Atomic node PR (PR1): the node + `closure-emitter` emit + all nine downstream pass match-arms land together so the workspace never breaks. (CLOC12.166)
+
+
 ## [0.24.0] - 2026-07-04
 
 ### Added — CLOC12.165: `Expression::ThisExpression` (`this`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -121,6 +121,18 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   `f(this)` all print bare) and never forces a paren around an operand. Node +
   `closure-emitter` + all pass traversals land in one atomic PR; the
   bridge-enable + conformance port follow.
+- `Super` (CLOC12.166) — the `super` keyword: the reserved-word **leaf**
+  sibling of `this`, naming the home object's prototype (`super.m()`,
+  `super[k]`) or the superclass constructor (`super(a, b)`). `Super { cv }` —
+  no operand, the same shape as `ThisExpression`. Named `Super` to match
+  ESTree's node type exactly (ESTree uses bare `Super`, asymmetric with
+  `ThisExpression`). Modelled as its own node so the renaming passes never
+  touch it. `super` is syntactically restricted to member-object / call-callee
+  position inside a method or derived constructor, but that is the parser's
+  concern — the AST treats it as a plain leaf primary. It tags at
+  `PREC_PRIMARY` and prints as the bare keyword. Node + `closure-emitter` +
+  all pass traversals land in one atomic PR; the bridge-enable + conformance
+  port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -65,6 +65,7 @@ pub enum Expression {
     YieldExpression(YieldExpression),
     AwaitExpression(AwaitExpression),
     ThisExpression(ThisExpression),
+    Super(Super),
 }
 
 // ---------------------------------------------------------------------
@@ -613,6 +614,41 @@ pub struct ThisExpression {
     pub cv: Option<CvId>,
 }
 
+/// The `super` keyword — a primary that names the *home object's* prototype
+/// (in a method) or the *superclass constructor* (in a derived
+/// constructor):
+///
+/// ```text
+///   super.method()     call an overridden method on the prototype chain
+///   super[key]         computed member access off the home object's proto
+///   super(a, b)        delegate to the superclass constructor (constructor only)
+/// ```
+///
+/// # Shape
+///
+/// `super` is a **leaf** — like [`ThisExpression`], it carries no operand and
+/// no payload beyond its `cv`. ESTree models it as its own `Super` node
+/// rather than an `Identifier { name: "super" }`, because `super` is a
+/// reserved word: it can never be a variable name, so passes that rename
+/// identifiers must never touch it. Note that `super` is *syntactically*
+/// restricted — it may appear only as the object of a member access or as a
+/// call callee, and only inside a method/derived-constructor — but that is
+/// the **parser's** concern: the AST and emitter treat it as a plain leaf
+/// primary and print it wherever it is placed.
+///
+/// # Precedence
+///
+/// `super` binds at **primary** strength — the tightest level, exactly like
+/// `this`. It never needs wrapping in any parent context, and no parent
+/// operand ever forces a paren around it. The emitter tags it `PREC_PRIMARY`
+/// and prints the bare keyword.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Super {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+}
+
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the
 /// `property` is conventionally an [`Expression::Identifier`]);
 /// `computed = true` ↔ `obj[key]` (the `property` is any expression).
@@ -1058,6 +1094,21 @@ mod tests {
         let json = serde_json::to_string(&t).expect("serialize");
         assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
         assert_eq!(t.clone(), roundtrip(t));
+    }
+
+    #[test]
+    fn super_roundtrips_traced() {
+        let s = Expression::Super(Super { cv: Some("super.1".to_string()) });
+        assert_eq!(s.clone(), roundtrip(s.clone()));
+        assert_eq!(type_tag(&s), "Super");
+    }
+
+    #[test]
+    fn super_untraced_omits_cv() {
+        let s = Expression::Super(Super { cv: None });
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(s.clone(), roundtrip(s));
     }
 
     #[test]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
-    AwaitExpression, ThisExpression, YieldExpression,
+    AwaitExpression, Super, ThisExpression, YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC02-javascript-ast.md
+++ b/code/specs/CLOC02-javascript-ast.md
@@ -217,7 +217,7 @@ variant to produce.
 pub enum Expression {
     // Primary
     This(ThisExpression),
-    Super(SuperExpression),              // ES2015+
+    Super(Super),                        // ES2015+ (ESTree node type is bare `Super`; CLOC12.166)
     Identifier(Identifier),
     PrivateName(PrivateName),            // ES2022+ (only valid inside class)
     Literal(Literal),

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2137,6 +2137,53 @@ shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
 
+## CLOC12.166 — `Super` (`super`): atomic node + emit + passes (PR1)
+
+Adds `Expression::Super { cv }` to `javascript-ast` (0.25.0) — the `super`
+keyword, the reserved-word **leaf** sibling of `this`. `super` names the home
+object's prototype (in a method: `super.m()`, `super[k]`) or the superclass
+constructor (in a derived constructor: `super(a, b)`). Like `this`, it is the
+simplest possible node: no operand, no axis, the same shape as `ThisExpression`
+/ `NullLiteral`.
+
+It is modelled as its own variant rather than `Identifier { name: "super" }`
+for the same reason as `this`: `super` is a reserved word, can never be a
+variable name, and the renaming passes must exclude it structurally. `super`
+is *syntactically* restricted — legal only as a member-object or call-callee
+inside a method / derived constructor — but that is the **parser's** concern;
+the AST and emitter treat it as a plain leaf primary and print it wherever it
+is placed.
+
+**Naming — divergence from CLOC02 spec.** CLOC02 §Expression pencilled in
+`Super(SuperExpression)`. The node is named **`Super`** (struct `Super`) to
+match ESTree's node type exactly (ESTree uses bare `"Super"` — note the
+asymmetry with `"ThisExpression"`). The CLOC02 spec line is updated to
+`Super(Super)` to match the implementation.
+
+**Emit (`closure-emitter` 0.30.0).** `emit_super` writes the bare five-character
+keyword. `super` tags at `PREC_PRIMARY` — the tightest level, exactly like
+`this` — so it never needs wrapping in any parent (`super.x`, `super()`,
+`super.m()` all print bare) and never forces a paren around an operand.
+
+**Passes (PATCH bumps).** The three rebuild passes (`constant-fold`, `dce`,
+`fold-control-flow`) clone the leaf through unchanged like the literals;
+`fold-control-flow` also gains a `Super` arm in its `expression_cv` accessor.
+The six traversal passes get a no-op arm (`super` binds/references no ordinary
+identifier and has no sub-expression). Atomic node PR1: node + emit + all nine
+downstream pass arms land together so the workspace never breaks.
+
+### gap-167 — bridge declines `super` (`Super`) — pending (CLOC12.166 PR2)
+
+The `javascript-parser` bridge returns `UnsupportedSyntax { rule: "Super" }`
+(bridge.rs, the `super`-token guard) for the `super` primary, so any file
+containing `super` currently drops to WHITESPACE_ONLY. Like `this` (gap-166,
+resolved) and **unlike `await` (gap-165)**, `super` is already parseable — the
+grammar produces the token the bridge *reaches* and explicitly declines — so
+PR2 is a pure bridge slice with **no grammar work required**: swap the decline
+for `Ok(Expression::Super(Super { cv: … }))`, mirroring the `this` fix. Tracked
+for CLOC12.166 PR2.
+
+
 ## CLOC12.165 — `ThisExpression` (`this`): atomic node + emit + passes (PR1)
 
 Adds `Expression::ThisExpression { cv }` to `javascript-ast` (0.24.0) — the


### PR DESCRIPTION
Adds `Expression::Super { cv }` to `javascript-ast` (0.25.0) — the `super` keyword, the reserved-word **leaf** sibling of `this` (CLOC12.165). Names the home objects prototype (`super.m()`, `super[k]`) or the superclass constructor (`super(a, b)`). Same shape as `ThisExpression`: no operand, no axis. Modelled as its own variant (not `Identifier { name: "super" }`) so the renaming passes exclude it structurally.

## Atomic node PR1

The node + `closure-emitter` emit + all **nine** downstream pass match-arms land in one commit so the workspace never breaks.

**Emit (`closure-emitter` 0.30.0)** — `emit_super` prints the bare keyword; `super` tags at `PREC_PRIMARY` (sibling of `this`), so `super.x`, `super()`, `super.m()` compose paren-free and it never forces a paren around an operand. 5 unit tests.

**Passes (PATCH bumps, all nine)** — the three rebuild passes (`constant-fold`, `dce`, `fold-control-flow`) clone the leaf through unchanged like the literals; `fold-control-flow` also gains a `Super` arm in its `expression_cv` accessor. The six traversal passes (`inline`, `inline-variables`, `rename`, `rename-globals`, `rename-properties`, `scope-analyzer`) get a no-op arm. `super` is deliberately kept OUT of the inliners trivial/pure predicates — it is lexically context-bound (only valid inside a method / derived constructor), so substituting it across call sites would be unsound (same conservative posture as `this`).

## Naming — divergence from CLOC02 spec

The node is named **`Super`** (struct `Super`), not the specs pencilled `SuperExpression`, to match ESTrees node type exactly (ESTree uses bare `Super`, asymmetric with `ThisExpression`). CLOC02 §Expression updated to `Super(Super)`; `CLOC12-gaps.md` gains a CLOC12.166 section + **gap-167** (bridge declines `super`; already parseable like `this`/gap-166, so PR2 needs no grammar work).

## Verification

`javascript-ast` + `closure-emitter` + all nine passes compile and pass (0 failures). Security review passed (no vulnerabilities). Follow-ups: PR2 bridge-enable (closes gap-167) + PR3 CodePrinter conformance port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)