### PR TITLE
feat(semantic-ir): SIR22 array/matrix Expr/SirType/Feature variants

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -340,7 +340,7 @@ use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
     Block, Capture, CaptureValue, Effect, EffectSet, ExportName, Expr, Feature, FeatureManifest,
-    Function, Metadata, Module, Param, ParamKind, Scope, Span, Stmt, CURRENT_SIR_VERSION,
+    Function, IndexArg, Metadata, Module, Param, ParamKind, Scope, Span, Stmt, CURRENT_SIR_VERSION,
 };
 use std::collections::HashSet;
 
@@ -623,8 +623,10 @@ impl Lowerer {
             self.file_name.clone(),
             node.start_line.unwrap_or(0),
             node.start_column.unwrap_or(0),
-            node.end_line.unwrap_or_else(|| node.start_line.unwrap_or(0)),
-            node.end_column.unwrap_or_else(|| node.start_column.unwrap_or(0)),
+            node.end_line
+                .unwrap_or_else(|| node.start_line.unwrap_or(0)),
+            node.end_column
+                .unwrap_or_else(|| node.start_column.unwrap_or(0)),
         )
     }
 
@@ -997,8 +999,12 @@ impl Lowerer {
         // or [cond_expr, then_stmt, else_stmt].  The `if`/`else` keywords,
         // parens, etc. are tokens we skip.
         let nodes = child_nodes(node);
-        let cond_node = nodes.first().ok_or_else(|| self.unsupported(node, "if (no condition)"))?;
-        let then_node = nodes.get(1).ok_or_else(|| self.unsupported(node, "if (no then branch)"))?;
+        let cond_node = nodes
+            .first()
+            .ok_or_else(|| self.unsupported(node, "if (no condition)"))?;
+        let then_node = nodes
+            .get(1)
+            .ok_or_else(|| self.unsupported(node, "if (no then branch)"))?;
 
         let cond = self.lower_expression(cond_node, 0)?;
         let then_branch = self.lower_body(then_node, depth)?;
@@ -1027,8 +1033,12 @@ impl Lowerer {
         self.check_stmt_depth(node, depth)?;
         let span = self.span_of(node);
         let nodes = child_nodes(node);
-        let cond_node = nodes.first().ok_or_else(|| self.unsupported(node, "while (no condition)"))?;
-        let body_node = nodes.get(1).ok_or_else(|| self.unsupported(node, "while (no body)"))?;
+        let cond_node = nodes
+            .first()
+            .ok_or_else(|| self.unsupported(node, "while (no condition)"))?;
+        let body_node = nodes
+            .get(1)
+            .ok_or_else(|| self.unsupported(node, "while (no body)"))?;
 
         let cond = self.lower_expression(cond_node, 0)?;
         let body = self.lower_body(body_node, depth)?;
@@ -1071,7 +1081,12 @@ impl Lowerer {
 
         let body = self.lower_loop_body_scoped(&var, node, depth)?;
         self.features_used.add(Feature::Loops);
-        Ok(Stmt::ForEach { var, iter, body, span })
+        Ok(Stmt::ForEach {
+            var,
+            iter,
+            body,
+            span,
+        })
     }
 
     /// Lower a canonical C-style `for_statement` to a [`Stmt::ForRange`].
@@ -1107,9 +1122,9 @@ impl Lowerer {
         // wrapped in a `lexical_declaration` here — the `let` keyword and
         // `binding_list` are direct children).  `var` would surface a
         // `variable_declaration_list` instead; we accept either.
-        let (loop_var, start) = self.extract_for_init(node).ok_or_else(|| {
-            reject("init is not a single `let i = <start>` binding")
-        })?;
+        let (loop_var, start) = self
+            .extract_for_init(node)
+            .ok_or_else(|| reject("init is not a single `let i = <start>` binding"))?;
 
         // ── cond: `i < <stop>` / `i <= <stop>` ──────────────────────────
         // The condition is the first `expression` child after the init's
@@ -1125,9 +1140,11 @@ impl Lowerer {
         let update_expr = self
             .for_clause_expr(node, 1)
             .ok_or_else(|| reject("missing update clause"))?;
-        let step = self.extract_for_step(update_expr, &loop_var).ok_or_else(|| {
-            reject("update is not an increment of the loop variable by a constant step")
-        })?;
+        let step = self
+            .extract_for_step(update_expr, &loop_var)
+            .ok_or_else(|| {
+                reject("update is not an increment of the loop variable by a constant step")
+            })?;
 
         // ── body (loop variable scoped into it) ─────────────────────────
         let body = self.lower_loop_body_scoped(&loop_var, node, depth)?;
@@ -1148,12 +1165,11 @@ impl Lowerer {
     fn extract_for_init(&mut self, for_node: &GrammarASTNode) -> Option<(String, Expr)> {
         // `let`/`const` → `binding_list[ lexical_binding[ Name, =, init ] ]`.
         // `var`         → `variable_declaration_list[ variable_declaration ]`.
-        let (list_name, binding_name) =
-            if child_node_named(for_node, "binding_list").is_some() {
-                ("binding_list", "lexical_binding")
-            } else {
-                ("variable_declaration_list", "variable_declaration")
-            };
+        let (list_name, binding_name) = if child_node_named(for_node, "binding_list").is_some() {
+            ("binding_list", "lexical_binding")
+        } else {
+            ("variable_declaration_list", "variable_declaration")
+        };
         let list = child_node_named(for_node, list_name)?;
         let bindings = children_nodes_named(list, binding_name);
         if bindings.len() != 1 {
@@ -1195,11 +1211,7 @@ impl Lowerer {
     /// Accepts `i < S` (→ `S`) and `i <= S` (→ half-open `S + 1`), where the
     /// left operand is exactly the loop variable `var`.  Returns `None` for
     /// any other comparison (wrong variable, `>`/`>=`, RHS-anchored, …).
-    fn extract_for_cond(
-        &mut self,
-        cond_node: &GrammarASTNode,
-        var: &str,
-    ) -> Option<Expr> {
+    fn extract_for_cond(&mut self, cond_node: &GrammarASTNode, var: &str) -> Option<Expr> {
         // Peel to the branching `relational_expression`: `[lhs, op, rhs]`.
         let branch = peel_to_branch(cond_node);
         if branch.rule_name != "relational_expression" || branch.children.len() != 3 {
@@ -1231,7 +1243,13 @@ impl Lowerer {
                 let span = stop.span().clone();
                 Some(Expr::BuiltinCall {
                     name: "+".to_string(),
-                    args: vec![stop, Expr::IntLit { value: 1, span: span.clone() }],
+                    args: vec![
+                        stop,
+                        Expr::IntLit {
+                            value: 1,
+                            span: span.clone(),
+                        },
+                    ],
                     effects: EffectSet::PURE,
                     span,
                 })
@@ -1249,11 +1267,7 @@ impl Lowerer {
     ///   * `i = i + <step>`→ `<step>`.
     ///
     /// Returns `None` for decrements, `*=`, a different variable, etc.
-    fn extract_for_step(
-        &mut self,
-        update_node: &GrammarASTNode,
-        var: &str,
-    ) -> Option<Expr> {
+    fn extract_for_step(&mut self, update_node: &GrammarASTNode, var: &str) -> Option<Expr> {
         let branch = peel_to_branch(update_node);
         match branch.rule_name.as_str() {
             // ── `i++` : postfix_expression[ lhs, Name("++") ] ───────────
@@ -1265,13 +1279,17 @@ impl Lowerer {
                     return None;
                 }
                 // The operator token must be `++` (reject `i--`).
-                let op_ok = branch.children.iter().any(|c| {
-                    matches!(c, ASTNodeOrToken::Token(tok) if tok.value == "++")
-                });
+                let op_ok = branch
+                    .children
+                    .iter()
+                    .any(|c| matches!(c, ASTNodeOrToken::Token(tok) if tok.value == "++"));
                 if !op_ok {
                     return None;
                 }
-                Some(Expr::IntLit { value: 1, span: self.span_of(branch) })
+                Some(Expr::IntLit {
+                    value: 1,
+                    span: self.span_of(branch),
+                })
             }
             // ── `i += s` or `i = i + s` :
             //    assignment_expression[ lhs, op, rhs ] ─────────────────
@@ -1487,10 +1505,20 @@ impl Lowerer {
             // call it.  First sighting binds; a redeclare re-assigns.
             let stmt = if self.is_current_local(&name) {
                 self.features_used.add(Feature::MutableBindings);
-                Stmt::Assign { name, scope: Scope::Local, value: make, span }
+                Stmt::Assign {
+                    name,
+                    scope: Scope::Local,
+                    value: make,
+                    span,
+                }
             } else {
                 self.declare_local(&name);
-                Stmt::LetStarBinding { name, sir_type: None, value: make, span }
+                Stmt::LetStarBinding {
+                    name,
+                    sir_type: None,
+                    value: make,
+                    span,
+                }
             };
             Ok(Lowered::Stmt(Box::new(stmt)))
         } else {
@@ -1500,7 +1528,9 @@ impl Lowerer {
             // discards (a pure literal is superseded by any real value, and
             // dropped at the end of the block otherwise).
             self.user_functions.push(lowered_fn);
-            Ok(Lowered::Expr(Expr::NilLit { span: self.span_of(node) }))
+            Ok(Lowered::Expr(Expr::NilLit {
+                span: self.span_of(node),
+            }))
         }
     }
 
@@ -1634,8 +1664,7 @@ impl Lowerer {
         let mut i = first_args_idx + 1;
         while i < children.len() {
             // Expect `Dot`, `Name`, `arguments`.
-            let is_dot =
-                matches!(&children[i], ASTNodeOrToken::Token(t) if t.value == ".");
+            let is_dot = matches!(&children[i], ASTNodeOrToken::Token(t) if t.value == ".");
             if !is_dot {
                 // A computed step (`…[expr](…)`) or other trailing access is
                 // not a named method → deferred.
@@ -1655,7 +1684,13 @@ impl Lowerer {
             };
             let step_args = self.lower_arguments(args_node, depth)?;
             let name_span = self.span_of_token(method_tok);
-            acc = self.make_method_dispatch(acc, method_tok.value.clone(), name_span, step_args, span.clone())?;
+            acc = self.make_method_dispatch(
+                acc,
+                method_tok.value.clone(),
+                name_span,
+                step_args,
+                span.clone(),
+            )?;
             i += 3;
         }
 
@@ -1725,8 +1760,7 @@ impl Lowerer {
                 }
                 // Otherwise it must resolve to a *value* (a closure handle
                 // bound to a local / param / capture) → IndirectCall.
-                let target =
-                    self.resolve_name(&fname, span.clone(), tok.line, tok.column)?;
+                let target = self.resolve_name(&fname, span.clone(), tok.line, tok.column)?;
                 self.features_used.add(Feature::Closures);
                 return Ok(Expr::IndirectCall {
                     target: Box::new(target),
@@ -1794,7 +1828,10 @@ impl Lowerer {
         self.features_used.add(Feature::Strings);
         let mut full_args = Vec::with_capacity(args.len() + 2);
         full_args.push(receiver);
-        full_args.push(Expr::StrLit { value: method, span: name_span });
+        full_args.push(Expr::StrLit {
+            value: method,
+            span: name_span,
+        });
         full_args.extend(args);
         Ok(Expr::BuiltinCall {
             name: "__method__".to_string(),
@@ -1869,7 +1906,10 @@ impl Lowerer {
             captures: frame
                 .captures
                 .iter()
-                .map(|n| Capture { name: n.clone(), sir_type: None })
+                .map(|n| Capture {
+                    name: n.clone(),
+                    sir_type: None,
+                })
                 .collect(),
             body,
             // A closure body may allocate; a plain top-level function is
@@ -1928,7 +1968,11 @@ impl Lowerer {
                     })
                     .ok_or_else(|| self.unsupported(concise, "arrow concise body"))?;
                 let value = self.lower_expression(expr_node, depth + 1)?;
-                Ok(Block { stmts: Vec::new(), value, span: span.clone() })
+                Ok(Block {
+                    stmts: Vec::new(),
+                    value,
+                    span: span.clone(),
+                })
             }
         })();
 
@@ -1943,7 +1987,10 @@ impl Lowerer {
             captures: frame
                 .captures
                 .iter()
-                .map(|n| Capture { name: n.clone(), sir_type: None })
+                .map(|n| Capture {
+                    name: n.clone(),
+                    sir_type: None,
+                })
                 .collect(),
             body,
             effects: EffectSet::PURE.with(Effect::MayAllocate),
@@ -2082,8 +2129,7 @@ impl Lowerer {
                     self.check_stmt_depth(concrete, depth)?;
                     let span = self.span_of(concrete);
                     let saved = self.cur().locals.clone();
-                    let nested =
-                        self.lower_function_body(&concrete.children, span, depth + 1);
+                    let nested = self.lower_function_body(&concrete.children, span, depth + 1);
                     self.cur().locals = saved;
                     tail = Some(Expr::Block(Box::new(nested?)));
                 }
@@ -2094,18 +2140,20 @@ impl Lowerer {
             }
         }
 
-        let value = tail.unwrap_or(Expr::NilLit { span: block_span.clone() });
-        Ok(Block { stmts, value, span: block_span })
+        let value = tail.unwrap_or(Expr::NilLit {
+            span: block_span.clone(),
+        });
+        Ok(Block {
+            stmts,
+            value,
+            span: block_span,
+        })
     }
 
     /// Lower a *tail-position* `if_statement` to an [`Expr::If`] whose
     /// branch values come from recursively tail-lowering each branch.  A
     /// missing `else` yields a nil-valued else block.
-    fn lower_tail_if(
-        &mut self,
-        node: &GrammarASTNode,
-        depth: usize,
-    ) -> Result<Expr, JsLowerError> {
+    fn lower_tail_if(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, JsLowerError> {
         self.check_stmt_depth(node, depth)?;
         let span = self.span_of(node);
         let nodes = child_nodes(node);
@@ -2181,7 +2229,10 @@ impl Lowerer {
         if node.rule_name == "return_statement" {
             return Err(self.early_return_error(node));
         }
-        if matches!(node.rule_name.as_str(), "function_declaration" | "arrow_function") {
+        if matches!(
+            node.rule_name.as_str(),
+            "function_declaration" | "arrow_function"
+        ) {
             return Ok(());
         }
         for child in &node.children {
@@ -2198,9 +2249,7 @@ impl Lowerer {
     /// [`check_stmt_depth`](Self::check_stmt_depth) emits.
     fn too_deep_error(&self, node: &GrammarASTNode) -> JsLowerError {
         JsLowerError {
-            message: format!(
-                "input nests deeper than the supported limit ({MAX_STMT_DEPTH})"
-            ),
+            message: format!("input nests deeper than the supported limit ({MAX_STMT_DEPTH})"),
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
         }
@@ -2211,7 +2260,9 @@ impl Lowerer {
     fn lower_return_value(&mut self, ret: &GrammarASTNode) -> Result<Expr, JsLowerError> {
         match child_node_named(ret, "expression") {
             Some(e) => self.lower_expression(e, 0),
-            None => Ok(Expr::NilLit { span: self.span_of(ret) }),
+            None => Ok(Expr::NilLit {
+                span: self.span_of(ret),
+            }),
         }
     }
 
@@ -2240,7 +2291,10 @@ impl Lowerer {
         // Bare single-identifier form: `a => …` (no parens, no default).
         if let Some(tok) = ap.token() {
             if matches!(tok.type_, TokenType::Name) {
-                return Ok(vec![FormalParamSpec { name: tok.value.clone(), default: None }]);
+                return Ok(vec![FormalParamSpec {
+                    name: tok.value.clone(),
+                    default: None,
+                }]);
             }
         }
         match child_node_named(ap, "formal_parameters") {
@@ -2286,9 +2340,7 @@ impl Lowerer {
             //   - anything else             → deferred
             let default = match &param.children[1..] {
                 [] => None,
-                [ASTNodeOrToken::Token(eq), ASTNodeOrToken::Node(expr)]
-                    if eq.value == "=" =>
-                {
+                [ASTNodeOrToken::Token(eq), ASTNodeOrToken::Node(expr)] if eq.value == "=" => {
                     Some(expr)
                 }
                 _ => return Err(self.deferred_param(ctx_node)),
@@ -2336,10 +2388,7 @@ impl Lowerer {
     /// M2 supports the common single-binding case; a comma-separated
     /// multi-binding list (`let a = 1, b = 2;`) is rejected (deferred) so
     /// the lossy behaviour is explicit rather than silent.
-    fn lower_lexical_declaration(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Stmt, JsLowerError> {
+    fn lower_lexical_declaration(&mut self, node: &GrammarASTNode) -> Result<Stmt, JsLowerError> {
         let list = child_node_named(node, "binding_list")
             .ok_or_else(|| self.unsupported(node, "lexical_declaration (no binding_list)"))?;
         let bindings = children_nodes_named(list, "lexical_binding");
@@ -2353,10 +2402,7 @@ impl Lowerer {
     /// `[ Name, Equals, assignment_expression ]`.  `var` hoisting is NOT
     /// modelled (SIR19 spec "`var` hoisting"): we emit the binding at its
     /// source position, exactly like `let`.
-    fn lower_variable_statement(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Stmt, JsLowerError> {
+    fn lower_variable_statement(&mut self, node: &GrammarASTNode) -> Result<Stmt, JsLowerError> {
         let list = child_node_named(node, "variable_declaration_list")
             .ok_or_else(|| self.unsupported(node, "variable_statement (no declaration list)"))?;
         let decls = children_nodes_named(list, "variable_declaration");
@@ -2390,9 +2436,7 @@ impl Lowerer {
                 ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
                 _ => None,
             })
-            .ok_or_else(|| {
-                self.unsupported(binding, &format!("{what} (destructuring/no name)"))
-            })?;
+            .ok_or_else(|| self.unsupported(binding, &format!("{what} (destructuring/no name)")))?;
         let name = name_tok.value.clone();
         let span = self.span_of(decl_node);
 
@@ -2475,7 +2519,9 @@ impl Lowerer {
         // it's a statement-level assignment.
         let branch = peel_to_branch(expr_node);
         if branch.rule_name == "assignment_expression" && branch.children.len() == 3 {
-            return self.lower_assignment(branch).map(|s| Lowered::Stmt(Box::new(s)));
+            return self
+                .lower_assignment(branch)
+                .map(|s| Lowered::Stmt(Box::new(s)));
         }
         self.lower_expression(expr_node, 0).map(Lowered::Expr)
     }
@@ -2608,7 +2654,9 @@ impl Lowerer {
         let last_access = member
             .children
             .iter()
-            .rposition(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "." || t.value == "["))
+            .rposition(
+                |c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "." || t.value == "["),
+            )
             .ok_or_else(|| self.unsupported(member, "assignment target (no access)"))?;
 
         // The receiver is the member_expression truncated to everything
@@ -2638,7 +2686,10 @@ impl Lowerer {
                 self.features_used.add(Feature::Strings);
                 Ok(Stmt::MapSet {
                     map: recv,
-                    key: Expr::StrLit { value: prop, span: span.clone() },
+                    key: Expr::StrLit {
+                        value: prop,
+                        span: span.clone(),
+                    },
                     value,
                     span,
                 })
@@ -2652,10 +2703,20 @@ impl Lowerer {
                 let index = self.lower_expression(index_node, 0)?;
                 if matches!(index, Expr::StrLit { .. }) {
                     self.features_used.add(Feature::Maps);
-                    Ok(Stmt::MapSet { map: recv, key: index, value, span })
+                    Ok(Stmt::MapSet {
+                        map: recv,
+                        key: index,
+                        value,
+                        span,
+                    })
                 } else {
                     self.features_used.add(Feature::Sequences);
-                    Ok(Stmt::SeqSet { seq: recv, index, value, span })
+                    Ok(Stmt::SeqSet {
+                        seq: recv,
+                        index,
+                        value,
+                        span,
+                    })
                 }
             }
             _ => Err(self.unsupported(member, "assignment target (unsupported access form)")),
@@ -2768,11 +2829,7 @@ impl Lowerer {
     }
 
     /// Dispatch a *branching* precedence node to its operator handler.
-    fn lower_branch(
-        &mut self,
-        node: &GrammarASTNode,
-        depth: usize,
-    ) -> Result<Expr, JsLowerError> {
+    fn lower_branch(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, JsLowerError> {
         match node.rule_name.as_str() {
             // ── flat left-associative binary chains ─────────────────
             // children = [lhs, op, rhs, op, rhs, …]
@@ -2848,8 +2905,7 @@ impl Lowerer {
                         // we cannot model as a plain item; reject it.
                         if peel_to_branch(n).rule_name == "spread_element" {
                             return Err(JsLowerError {
-                                message: "array spread (`[...xs]`) is deferred past M5"
-                                    .to_string(),
+                                message: "array spread (`[...xs]`) is deferred past M5".to_string(),
                                 line: span.start_line,
                                 column: span.start_col,
                             });
@@ -2917,11 +2973,7 @@ impl Lowerer {
 
     /// Extract the string key of a `property_definition`, rejecting the
     /// deferred key forms (computed `[e]`, shorthand, method, numeric).
-    fn object_key(
-        &mut self,
-        prop: &GrammarASTNode,
-        span: &Span,
-    ) -> Result<Expr, JsLowerError> {
+    fn object_key(&mut self, prop: &GrammarASTNode, span: &Span) -> Result<Expr, JsLowerError> {
         let name_node = child_node_named(prop, "property_name").ok_or_else(|| JsLowerError {
             message: "object property key form (computed / shorthand / method) \
                       is deferred past M5"
@@ -3027,7 +3079,10 @@ impl Lowerer {
                     acc = if prop == "length" {
                         // The one dotted property that is a sequence op.
                         self.features_used.add(Feature::Sequences);
-                        Expr::SeqLen { seq: Box::new(acc), span: span.clone() }
+                        Expr::SeqLen {
+                            seq: Box::new(acc),
+                            span: span.clone(),
+                        }
                     } else {
                         self.features_used.add(Feature::Maps);
                         self.features_used.add(Feature::Strings);
@@ -3052,8 +3107,8 @@ impl Lowerer {
                     };
                     let index = self.lower_expression(index_node, depth + 1)?;
                     i += 3; // skip `[`, index, `]`.
-                    // A *string-literal* key reads like object access → MapGet
-                    // (mirrors `obj.prop`); any other index → sequence index.
+                            // A *string-literal* key reads like object access → MapGet
+                            // (mirrors `obj.prop`); any other index → sequence index.
                     acc = if matches!(index, Expr::StrLit { .. }) {
                         self.features_used.add(Feature::Maps);
                         Expr::MapGet {
@@ -3117,12 +3172,7 @@ impl Lowerer {
 
     /// Build one binary `BuiltinCall` from an operator token and its two
     /// already-lowered operands, applying equality normalisation.
-    fn build_binary_op(
-        &mut self,
-        op: &Token,
-        lhs: Expr,
-        rhs: Expr,
-    ) -> Result<Expr, JsLowerError> {
+    fn build_binary_op(&mut self, op: &Token, lhs: Expr, rhs: Expr) -> Result<Expr, JsLowerError> {
         // Normalise the operator spelling to the IR builtin name.  Both
         // loose and strict equality collapse to the strict-shaped IR
         // comparison — a deliberate semantic change (see module docs).
@@ -3200,11 +3250,7 @@ impl Lowerer {
     /// constant-folded into a negative literal (see module docs).  Other
     /// prefix operators (`+`, `~`, `typeof`, `void`, `delete`) are
     /// deferred.
-    fn lower_unary(
-        &mut self,
-        node: &GrammarASTNode,
-        depth: usize,
-    ) -> Result<Expr, JsLowerError> {
+    fn lower_unary(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, JsLowerError> {
         // The operator is the leading token; the operand is the node.
         let op = node
             .children
@@ -3240,7 +3286,8 @@ impl Lowerer {
                 // IntLit` row exact).
                 if let Some(tok) = single_leaf_token(peel_to_branch(operand_node)) {
                     if matches!(tok.type_, TokenType::Number) {
-                        return self.lower_number(&format!("-{}", tok.value), self.span_of_token(op));
+                        return self
+                            .lower_number(&format!("-{}", tok.value), self.span_of_token(op));
                     }
                 }
                 let operand = self.lower_expression(operand_node, depth + 1)?;
@@ -3277,9 +3324,7 @@ impl Lowerer {
                 "false" => Ok(Expr::BoolLit { value: false, span }),
                 "null" => Ok(Expr::NilLit { span }),
                 other => Err(JsLowerError {
-                    message: format!(
-                        "keyword `{other}` is not a value expression supported in M2"
-                    ),
+                    message: format!("keyword `{other}` is not a value expression supported in M2"),
                     line: tok.line,
                     column: tok.column,
                 }),
@@ -3330,7 +3375,10 @@ impl Lowerer {
         let digits = text.strip_prefix('-').unwrap_or(text);
         let non_decimal = digits.len() > 1
             && digits.starts_with('0')
-            && matches!(digits.as_bytes()[1], b'x' | b'X' | b'o' | b'O' | b'b' | b'B');
+            && matches!(
+                digits.as_bytes()[1],
+                b'x' | b'X' | b'o' | b'O' | b'b' | b'B'
+            );
         if non_decimal || text.ends_with('n') {
             return Err(JsLowerError {
                 message: format!(
@@ -3431,16 +3479,19 @@ fn expr_may_have_effects(expr: &Expr) -> bool {
         Expr::SeqIndex { seq, index, .. } => {
             expr_may_have_effects(seq) || expr_may_have_effects(index)
         }
-        Expr::MapGet { map, key, .. } => {
-            expr_may_have_effects(map) || expr_may_have_effects(key)
-        }
+        Expr::MapGet { map, key, .. } => expr_may_have_effects(map) || expr_may_have_effects(key),
         Expr::MapLit { entries, .. } => entries
             .iter()
             .any(|e| expr_may_have_effects(&e.key) || expr_may_have_effects(&e.value)),
         Expr::LogicalAnd { lhs, rhs, .. } | Expr::LogicalOr { lhs, rhs, .. } => {
             expr_may_have_effects(lhs) || expr_may_have_effects(rhs)
         }
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             expr_may_have_effects(cond)
                 || block_may_have_effects(then_branch)
                 || block_may_have_effects(else_branch)
@@ -3452,6 +3503,32 @@ fn expr_may_have_effects(expr: &Expr) -> bool {
         // faithfully so effect inference stays conservative-correct.  Real
         // support pending KW2–KW8.
         Expr::KeywordArg { value, .. } => expr_may_have_effects(value),
+
+        // SIR22 array/matrix nodes: the spec's "Effects" section marks every
+        // one of these `Pure`, so — like `SeqLit`/`MapLit`/etc. above — they
+        // are pure iff every operand is pure.
+        Expr::ArrayLit { rows, .. } => rows.iter().any(|row| row.iter().any(expr_may_have_effects)),
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            expr_may_have_effects(start)
+                || step.as_deref().is_some_and(expr_may_have_effects)
+                || expr_may_have_effects(stop)
+        }
+        Expr::MatMul { lhs, rhs, .. } => expr_may_have_effects(lhs) || expr_may_have_effects(rhs),
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            expr_may_have_effects(lhs) || expr_may_have_effects(rhs)
+        }
+        Expr::Transpose { target, .. } => expr_may_have_effects(target),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            expr_may_have_effects(target)
+                || indices.iter().any(|idx| match idx {
+                    IndexArg::Scalar(e) | IndexArg::Range(e) => expr_may_have_effects(e),
+                    IndexArg::Whole => false,
+                })
+        }
 
         // Calls, closures, and intrinsics may do anything → keep.
         Expr::DirectCall { .. }
@@ -3602,9 +3679,7 @@ fn collect_function_names(
 ) -> Result<(), JsLowerError> {
     if depth > MAX_STMT_DEPTH {
         return Err(JsLowerError {
-            message: format!(
-                "input nests deeper than the supported limit ({MAX_STMT_DEPTH})"
-            ),
+            message: format!("input nests deeper than the supported limit ({MAX_STMT_DEPTH})"),
             line: node.start_line.unwrap_or(0),
             column: node.start_column.unwrap_or(0),
         });
@@ -3808,14 +3883,18 @@ fn collect_stmt_callees(
         Stmt::LetBinding { value, .. }
         | Stmt::LetStarBinding { value, .. }
         | Stmt::Assign { value, .. }
-        | Stmt::ExprStmt { expr: value, .. } => {
-            collect_expr_callees(value, names, self_name, out)
-        }
+        | Stmt::ExprStmt { expr: value, .. } => collect_expr_callees(value, names, self_name, out),
         Stmt::While { cond, body, .. } => {
             collect_expr_callees(cond, names, self_name, out);
             collect_direct_callees(body, names, self_name, out);
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             collect_expr_callees(start, names, self_name, out);
             collect_expr_callees(stop, names, self_name, out);
             collect_expr_callees(step, names, self_name, out);
@@ -3861,7 +3940,12 @@ fn collect_expr_callees(
                 collect_expr_callees(&c.value, names, self_name, out);
             }
         }
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             collect_expr_callees(cond, names, self_name, out);
             collect_direct_callees(then_branch, names, self_name, out);
             collect_direct_callees(else_branch, names, self_name, out);

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -190,8 +190,8 @@ use std::collections::HashSet;
 
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
-    Block, Capture, CaptureValue, EffectSet, Expr, Feature, FeatureManifest, Function, MapEntry,
-    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+    Block, Capture, CaptureValue, EffectSet, Expr, Feature, FeatureManifest, Function, IndexArg,
+    MapEntry, Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
 };
 
 /// Maximum expression-nesting depth the lowerer will descend before
@@ -957,7 +957,9 @@ impl Lowerer {
         };
         match inner.rule_name.as_str() {
             "if_stmt" => Ok(Lowered::Expr(self.lower_if(inner, ctx, depth)?)),
-            "while_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_while(inner, ctx, depth)?))),
+            "while_stmt" => Ok(Lowered::Stmt(Box::new(
+                self.lower_while(inner, ctx, depth)?,
+            ))),
             "for_stmt" => Ok(Lowered::Stmt(Box::new(self.lower_for(inner, ctx, depth)?))),
             "def_stmt" => {
                 // A nested `def` reaching the general statement lowerer:
@@ -1550,8 +1552,7 @@ impl Lowerer {
         let mut seen = HashSet::new();
         self.collect_free_names(body_expr, &bound, &mut free, &mut seen, 0)?;
 
-        let (captures, capture_values) =
-            self.resolve_captures(&free, enclosing, &span)?;
+        let (captures, capture_values) = self.resolve_captures(&free, enclosing, &span)?;
 
         // Lower the body in the synthesised function's own context.
         let mut inner = FunctionCtx::new(bound.clone(), captures.iter().cloned().collect());
@@ -1672,8 +1673,7 @@ impl Lowerer {
             // Record the capture list so a *bare reference* to this
             // function name re-threads the captures (a nested closure
             // returned/passed by name).
-            self.fn_captures
-                .insert(name.to_string(), captures.to_vec());
+            self.fn_captures.insert(name.to_string(), captures.to_vec());
         }
         let f = Function {
             name: name.to_string(),
@@ -1858,9 +1858,8 @@ impl Lowerer {
                     .any(|n| n.rule_name == "assign_suffix");
                 if has_suffix {
                     if let Some(list) = self.first_child_named(node, "expression_list") {
-                        if let Ok(Some(name)) = self
-                            .single_expr(list)
-                            .and_then(|e| self.target_name(e))
+                        if let Ok(Some(name)) =
+                            self.single_expr(list).and_then(|e| self.target_name(e))
                         {
                             out.push(name);
                         }
@@ -2507,9 +2506,7 @@ impl Lowerer {
                     span: span.clone(),
                 })
             }
-            SuffixKind::Subscript => {
-                self.lower_subscript_suffix(base, suffix, ctx, depth, span)
-            }
+            SuffixKind::Subscript => self.lower_subscript_suffix(base, suffix, ctx, depth, span),
             // Attribute suffixes are consumed by the fold's look-ahead
             // (`.method (args)` → method dispatch) before reaching here.
             SuffixKind::Attr(_) => Err(self.err_at(
@@ -2624,9 +2621,7 @@ impl Lowerer {
             .children
             .iter()
             .filter_map(|c| match c {
-                ASTNodeOrToken::Token(t)
-                    if matches!(t.type_, lexer::token::TokenType::Name) =>
-                {
+                ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Name) => {
                     Some(t.value.clone())
                 }
                 _ => None,
@@ -2796,9 +2791,7 @@ impl Lowerer {
                 {
                     name = Some(t.value.clone());
                 }
-                ASTNodeOrToken::Token(t)
-                    if matches!(t.type_, lexer::token::TokenType::Equals) =>
-                {
+                ASTNodeOrToken::Token(t) if matches!(t.type_, lexer::token::TokenType::Equals) => {
                     has_equals = true;
                 }
                 _ => {}
@@ -2875,7 +2868,10 @@ impl Lowerer {
             }
         };
         self.first_child_named(item, "expression").ok_or_else(|| {
-            self.err_at(item, "unsupported: non-expression subscript (deferred)".to_string())
+            self.err_at(
+                item,
+                "unsupported: non-expression subscript (deferred)".to_string(),
+            )
         })
     }
 
@@ -3064,7 +3060,10 @@ impl Lowerer {
             return Ok(None);
         }
         let operand_node = child_nodes(node).into_iter().next().ok_or_else(|| {
-            self.err_at(node, "malformed `not` expression (missing operand)".to_string())
+            self.err_at(
+                node,
+                "malformed `not` expression (missing operand)".to_string(),
+            )
         })?;
         let operand = self.lower_expr_d(operand_node, ctx, depth + 1)?;
         let span = self.span_of(node);
@@ -3508,9 +3507,9 @@ fn is_str_lit(expr: &Expr) -> bool {
 /// detect a slice subscript (`xs[a:b]`), which surfaces as a `Colon` token
 /// inside the `subscript` node and is rejected (deferred) in M5.
 fn has_colon_token(node: &GrammarASTNode) -> bool {
-    node.children.iter().any(|c| {
-        matches!(c, ASTNodeOrToken::Token(t) if t.type_ == lexer::token::TokenType::Colon)
-    })
+    node.children
+        .iter()
+        .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.type_ == lexer::token::TokenType::Colon))
 }
 
 /// An empty `Block` whose value is `NilLit`.
@@ -3553,7 +3552,11 @@ fn collect_callees_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
             collect_direct_callees(body, out);
         }
         Stmt::ForRange {
-            start, stop, step, body, ..
+            start,
+            stop,
+            step,
+            body,
+            ..
         } => {
             collect_callees_expr(start, out);
             collect_callees_expr(stop, out);
@@ -3564,14 +3567,33 @@ fn collect_callees_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
             collect_callees_expr(iter, out);
             collect_direct_callees(body, out);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             collect_callees_expr(seq, out);
             collect_callees_expr(index, out);
             collect_callees_expr(value, out);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             collect_callees_expr(map, out);
             collect_callees_expr(key, out);
+            collect_callees_expr(value, out);
+        }
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            collect_callees_expr(target, out);
+            for idx in indices {
+                match idx {
+                    IndexArg::Scalar(e) | IndexArg::Range(e) => collect_callees_expr(e, out),
+                    IndexArg::Whole => {}
+                }
+            }
             collect_callees_expr(value, out);
         }
         Stmt::ClassDef { body, .. }
@@ -3677,6 +3699,47 @@ fn collect_callees_expr(expr: &Expr, out: &mut HashSet<String>) {
         // `value` (its runtime meaning) so callees nested in a keyword
         // argument are still collected.  Real support pending KW2–KW8.
         Expr::KeywordArg { value, .. } => collect_callees_expr(value, out),
+        // SIR22 array/matrix nodes: the Python frontend never emits these
+        // (no lowering path constructs them today), but a `DirectCall` could
+        // in principle appear nested inside one (e.g. as a row element or a
+        // range bound), so recurse into every child `Expr` slot, matching
+        // the treatment of every other compound node above.
+        Expr::ArrayLit { rows, .. } => {
+            for row in rows {
+                for cell in row {
+                    collect_callees_expr(cell, out);
+                }
+            }
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            collect_callees_expr(start, out);
+            if let Some(step) = step {
+                collect_callees_expr(step, out);
+            }
+            collect_callees_expr(stop, out);
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            collect_callees_expr(lhs, out);
+            collect_callees_expr(rhs, out);
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            collect_callees_expr(lhs, out);
+            collect_callees_expr(rhs, out);
+        }
+        Expr::Transpose { target, .. } => collect_callees_expr(target, out),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            collect_callees_expr(target, out);
+            for idx in indices {
+                match idx {
+                    IndexArg::Scalar(e) | IndexArg::Range(e) => collect_callees_expr(e, out),
+                    IndexArg::Whole => {}
+                }
+            }
+        }
         // Atoms and references bind nothing.
         Expr::IntLit { .. }
         | Expr::BoolLit { .. }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -14,7 +14,7 @@ use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use semantic_ir::{
     Block, Capture, CaptureValue, Effect, EffectSet, ExportName, Expr, Feature, FeatureManifest,
-    Function, Metadata, Module, Param, ParamKind, RescueClause, Scope, Span, Stmt,
+    Function, IndexArg, Metadata, Module, Param, ParamKind, RescueClause, Scope, Span, Stmt,
 };
 
 /// A failure encountered during Ruby → SIR lowering.
@@ -54,10 +54,7 @@ impl std::error::Error for RubyLowerError {}
 pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, RubyLowerError> {
     if program.rule_name != "program" {
         return Err(RubyLowerError {
-            message: format!(
-                "expected root rule `program`, got `{}`",
-                program.rule_name
-            ),
+            message: format!("expected root rule `program`, got `{}`", program.rule_name),
             line: program.start_line.unwrap_or(0),
             column: program.start_column.unwrap_or(0),
         });
@@ -119,8 +116,7 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
             // not a parenless call, so it must be excluded from the
             // call-rewrite below (a local can legitimately shadow a
             // method name).
-            let mut bound: HashSet<String> =
-                f.params.iter().map(|p| p.name.clone()).collect();
+            let mut bound: HashSet<String> = f.params.iter().map(|p| p.name.clone()).collect();
             Lowerer::collect_bound_names_block(&f.body, &mut bound);
             let ctx = BlockNormCtx {
                 methods: &lw.block_param_methods,
@@ -236,7 +232,12 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
         | Expr::StrLit { .. }
         | Expr::FloatLit { .. } => false,
 
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             expr_references_any_name(cond, names)
                 || block_references_any_name(then_branch, names)
                 || block_references_any_name(else_branch, names)
@@ -246,9 +247,7 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
 
         Expr::DirectCall { args, .. }
         | Expr::BuiltinCall { args, .. }
-        | Expr::Intrinsic { args, .. } => {
-            args.iter().any(|a| expr_references_any_name(a, names))
-        }
+        | Expr::Intrinsic { args, .. } => args.iter().any(|a| expr_references_any_name(a, names)),
 
         Expr::IndirectCall { target, args, .. } => {
             expr_references_any_name(target, names)
@@ -259,17 +258,14 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
             .iter()
             .any(|c| expr_references_any_name(&c.value, names)),
 
-        Expr::SeqLit { items, .. } => {
-            items.iter().any(|i| expr_references_any_name(i, names))
-        }
+        Expr::SeqLit { items, .. } => items.iter().any(|i| expr_references_any_name(i, names)),
         Expr::SeqIndex { seq, index, .. } => {
             expr_references_any_name(seq, names) || expr_references_any_name(index, names)
         }
         Expr::SeqLen { seq, .. } => expr_references_any_name(seq, names),
 
         Expr::MapLit { entries, .. } => entries.iter().any(|e| {
-            expr_references_any_name(&e.key, names)
-                || expr_references_any_name(&e.value, names)
+            expr_references_any_name(&e.key, names) || expr_references_any_name(&e.value, names)
         }),
         Expr::MapGet { map, key, .. } => {
             expr_references_any_name(map, names) || expr_references_any_name(key, names)
@@ -279,15 +275,59 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
             expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
         }
 
-        Expr::StrConcat { parts, .. } => {
-            parts.iter().any(|p| expr_references_any_name(p, names))
-        }
+        Expr::StrConcat { parts, .. } => parts.iter().any(|p| expr_references_any_name(p, names)),
 
         // KW1 compile-compat stub: a `KeywordArg` is a single-child wrapper
         // whose runtime meaning is its inner `value` (the `name` is a static
         // label carrying no `VarRef`).  Recurse into `value` so the swap-safety
         // reference check stays faithful.  Real support pending KW2–KW8.
         Expr::KeywordArg { value, .. } => expr_references_any_name(value, names),
+
+        // SIR22 compile-compat stubs: the Ruby frontend never *produces* any
+        // of these array/matrix nodes today (no lowering path emits them), so
+        // these arms are unreachable in practice.  They are still walked
+        // structurally — like every other arm above — so that if a future
+        // lowering path does start emitting them, the swap-safety check
+        // keeps scanning every child `Expr` for `VarRef`s instead of silently
+        // going blind on a subtree.
+        Expr::ArrayLit { rows, .. } => rows
+            .iter()
+            .any(|row| row.iter().any(|e| expr_references_any_name(e, names))),
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            expr_references_any_name(start, names)
+                || step
+                    .as_ref()
+                    .is_some_and(|s| expr_references_any_name(s, names))
+                || expr_references_any_name(stop, names)
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+        Expr::Transpose { target, .. } => expr_references_any_name(target, names),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            expr_references_any_name(target, names)
+                || indices
+                    .iter()
+                    .any(|idx| index_arg_references_any_name(idx, names))
+        }
+    }
+}
+
+// SIR22 helper: `IndexArg` (used by `Expr::IndexGet` / `Stmt::IndexSet`) is
+// not an `Expr` itself but a small wrapper enum around one — mirroring how
+// this file already unwraps other non-`Expr` wrapper shapes (e.g. `MapLit`'s
+// entries) before recursing into their contained expressions.
+fn index_arg_references_any_name(idx: &IndexArg, names: &HashSet<String>) -> bool {
+    match idx {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => expr_references_any_name(e, names),
+        IndexArg::Whole => false,
     }
 }
 
@@ -312,13 +352,17 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                 }
             }
             Stmt::While { cond, body, .. } => {
-                if expr_references_any_name(cond, names)
-                    || block_references_any_name(body, names)
-                {
+                if expr_references_any_name(cond, names) || block_references_any_name(body, names) {
                     return true;
                 }
             }
-            Stmt::ForRange { start, stop, step, body, .. } => {
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
                 if expr_references_any_name(start, names)
                     || expr_references_any_name(stop, names)
                     || expr_references_any_name(step, names)
@@ -328,13 +372,13 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                 }
             }
             Stmt::ForEach { iter, body, .. } => {
-                if expr_references_any_name(iter, names)
-                    || block_references_any_name(body, names)
-                {
+                if expr_references_any_name(iter, names) || block_references_any_name(body, names) {
                     return true;
                 }
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 if expr_references_any_name(seq, names)
                     || expr_references_any_name(index, names)
                     || expr_references_any_name(value, names)
@@ -342,9 +386,31 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                     return true;
                 }
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 if expr_references_any_name(map, names)
                     || expr_references_any_name(key, names)
+                    || expr_references_any_name(value, names)
+                {
+                    return true;
+                }
+            }
+            Stmt::IndexSet {
+                target,
+                indices,
+                value,
+                ..
+            } => {
+                // SIR22 compile-compat stub (never emitted by this frontend
+                // today — see the `Expr::ArrayLit`/etc. arms above for the
+                // same rationale): mirrors the `SeqSet`/`MapSet` arms by
+                // recursing into every child `Expr`, including each
+                // `IndexArg`'s embedded expression.
+                if expr_references_any_name(target, names)
+                    || indices
+                        .iter()
+                        .any(|idx| index_arg_references_any_name(idx, names))
                     || expr_references_any_name(value, names)
                 {
                     return true;
@@ -360,7 +426,9 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                 for inner in body {
                     let synthetic = Block {
                         stmts: vec![inner.clone()],
-                        value: Expr::NilLit { span: inner.span().clone() },
+                        value: Expr::NilLit {
+                            span: inner.span().clone(),
+                        },
                         span: inner.span().clone(),
                     };
                     if block_references_any_name(&synthetic, names) {
@@ -368,7 +436,12 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                     }
                 }
             }
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 // Exception handling (Phase 16a): the try body, each
                 // rescue body, and the optional ensure body are all
                 // `Vec<Stmt>`.  Recurse over every contained statement via
@@ -377,7 +450,9 @@ fn block_references_any_name(block: &Block, names: &HashSet<String>) -> bool {
                     stmts.iter().any(|inner| {
                         let synthetic = Block {
                             stmts: vec![inner.clone()],
-                            value: Expr::NilLit { span: inner.span().clone() },
+                            value: Expr::NilLit {
+                                span: inner.span().clone(),
+                            },
                             span: inner.span().clone(),
                         };
                         block_references_any_name(&synthetic, names)
@@ -433,12 +508,25 @@ fn sequentialize_let_bindings(stmts: &mut [Stmt]) {
             let taken = std::mem::replace(
                 s,
                 Stmt::ExprStmt {
-                    expr: Expr::NilLit { span: Span::synthetic() },
+                    expr: Expr::NilLit {
+                        span: Span::synthetic(),
+                    },
                     span: Span::synthetic(),
                 },
             );
-            if let Stmt::LetBinding { name, sir_type, value, span } = taken {
-                *s = Stmt::LetStarBinding { name, sir_type, value, span };
+            if let Stmt::LetBinding {
+                name,
+                sir_type,
+                value,
+                span,
+            } = taken
+            {
+                *s = Stmt::LetStarBinding {
+                    name,
+                    sir_type,
+                    value,
+                    span,
+                };
             }
         }
         // Record the name this statement binds, so later statements see it.
@@ -811,7 +899,9 @@ impl Lowerer {
         if stmts_in.is_empty() {
             return Ok(Block {
                 stmts: Vec::new(),
-                value: Expr::NilLit { span: self.span_of(program) },
+                value: Expr::NilLit {
+                    span: self.span_of(program),
+                },
                 span: self.span_of(program),
             });
         }
@@ -838,17 +928,21 @@ impl Lowerer {
 
             let is_tail = i == last_idx;
             let tail_kind = inner.rule_name.as_str();
-            if is_tail && matches!(tail_kind, "expression_stmt" | "method_call" | "method_call_no_paren") {
+            if is_tail
+                && matches!(
+                    tail_kind,
+                    "expression_stmt" | "method_call" | "method_call_no_paren"
+                )
+            {
                 // Promote the tail expression to the block's value.
                 let v = match tail_kind {
                     "expression_stmt" => {
-                        let expr_node = self.first_node_child(inner).ok_or_else(|| {
-                            RubyLowerError {
+                        let expr_node =
+                            self.first_node_child(inner).ok_or_else(|| RubyLowerError {
                                 message: "expression_stmt had no expression child".to_string(),
                                 line: inner.start_line.unwrap_or(0),
                                 column: inner.start_column.unwrap_or(0),
-                            }
-                        })?;
+                            })?;
                         self.lower_expression(expr_node)?
                     }
                     "method_call" | "method_call_no_paren" => self.lower_method_call(inner)?,
@@ -863,7 +957,9 @@ impl Lowerer {
             }
         }
 
-        let value = value.unwrap_or(Expr::NilLit { span: self.span_of(program) });
+        let value = value.unwrap_or(Expr::NilLit {
+            span: self.span_of(program),
+        });
         // Ruby assignments are sequential: rewrite any `LetBinding` whose RHS
         // reads an earlier local to a `LetStarBinding` (see the fn's doc).
         sequentialize_let_bindings(&mut stmts_out);
@@ -924,10 +1020,7 @@ impl Lowerer {
     /// Lower the inner rule node of a `statement` (one of
     /// `assignment` / `method_call` / `expression_stmt`) into a
     /// `Stmt`.
-    fn lower_statement_inner(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Stmt, RubyLowerError> {
+    fn lower_statement_inner(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
         match node.rule_name.as_str() {
             "assignment" => self.lower_assignment(node),
             "rightward_assignment" => self.lower_rightward_assignment(node),
@@ -1089,8 +1182,7 @@ impl Lowerer {
                 // effect set when the block is constructed.  Modelling
                 // `yield` itself as PURE keeps the effect lattice from
                 // double-counting block effects.
-                let yield_args_node = self
-                    .find_node_child(node, "yield_args");
+                let yield_args_node = self.find_node_child(node, "yield_args");
                 let call_arg_nodes: Vec<&GrammarASTNode> = if let Some(ya) = yield_args_node {
                     ya.children
                         .iter()
@@ -1145,7 +1237,9 @@ impl Lowerer {
                 let arg_node = self.find_node_child(node, "expression");
                 let arg = match arg_node {
                     Some(n) => self.lower_expression(n)?,
-                    None => Expr::NilLit { span: self.span_of(node) },
+                    None => Expr::NilLit {
+                        span: self.span_of(node),
+                    },
                 };
                 let expr = Expr::BuiltinCall {
                     name: name.to_string(),
@@ -1307,10 +1401,7 @@ impl Lowerer {
     /// condition is negated.  `elsif` chains nest right — the
     /// `else_branch` of the outermost `If` is itself an `If` for
     /// the first elsif, etc.
-    fn lower_if_or_unless(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_if_or_unless(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         let is_unless = node.rule_name == "unless_statement";
         // The first `expression` child is the condition.
         let cond_node = self
@@ -1359,7 +1450,9 @@ impl Lowerer {
         } else {
             Block {
                 stmts: Vec::new(),
-                value: Expr::NilLit { span: self.span_of(node) },
+                value: Expr::NilLit {
+                    span: self.span_of(node),
+                },
                 span: self.span_of(node),
             }
         };
@@ -1367,13 +1460,13 @@ impl Lowerer {
         // Unwind elsif clauses in reverse order, each wrapping the
         // accumulated tail as its own else-branch.
         for ec in elsifs.iter().rev() {
-            let ec_cond = self.find_node_child(ec, "expression").ok_or_else(|| {
-                RubyLowerError {
+            let ec_cond = self
+                .find_node_child(ec, "expression")
+                .ok_or_else(|| RubyLowerError {
                     message: "elsif_clause missing condition expression".to_string(),
                     line: ec.start_line.unwrap_or(0),
                     column: ec.start_column.unwrap_or(0),
-                }
-            })?;
+                })?;
             let ec_cond_expr = self.lower_expression(ec_cond)?;
             let ec_body = self.lower_clause_statements(ec)?;
             tail = Block {
@@ -1401,10 +1494,7 @@ impl Lowerer {
     /// `Block`.  Tail-expression promotion follows the same rule as
     /// `lower_program` — last bare `expression_stmt` / `method_call`
     /// becomes `value`, otherwise `value = NilLit`.
-    fn lower_clause_statements(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Block, RubyLowerError> {
+    fn lower_clause_statements(&mut self, node: &GrammarASTNode) -> Result<Block, RubyLowerError> {
         // Phase 6b: each branch is an independent SIR `Block`.
         // Lock the declared-locals set to the outer-scope's snapshot
         // before lowering the body, then restore on exit.  Without
@@ -1423,7 +1513,9 @@ impl Lowerer {
         if stmts_in.is_empty() {
             return Ok(Block {
                 stmts: Vec::new(),
-                value: Expr::NilLit { span: self.span_of(node) },
+                value: Expr::NilLit {
+                    span: self.span_of(node),
+                },
                 span: self.span_of(node),
             });
         }
@@ -1450,7 +1542,9 @@ impl Lowerer {
             // Phase 6r — multi-stmt fan-out for `multi_assignment`.
             stmts_out.extend(self.lower_statement_inner_multi(inner)?);
         }
-        let value = value.unwrap_or(Expr::NilLit { span: self.span_of(node) });
+        let value = value.unwrap_or(Expr::NilLit {
+            span: self.span_of(node),
+        });
         // Restore the outer scope's declared locals.
         self.declared_locals = saved_locals;
         // Sequential-assignment fix-up (see `sequentialize_let_bindings`).
@@ -1501,10 +1595,7 @@ impl Lowerer {
     /// implicit return is observable.  A *script's* top-level value is not
     /// language-visible, so [`Self::lower_program`] keeps a bare trailing
     /// `if` as a `Stmt` (see its own promotion list).
-    fn lower_tail_value(
-        &mut self,
-        inner: &GrammarASTNode,
-    ) -> Result<Option<Expr>, RubyLowerError> {
+    fn lower_tail_value(&mut self, inner: &GrammarASTNode) -> Result<Option<Expr>, RubyLowerError> {
         let value = match inner.rule_name.as_str() {
             "expression_stmt" => {
                 let expr_node = self.first_node_child(inner).ok_or_else(|| RubyLowerError {
@@ -1534,10 +1625,7 @@ impl Lowerer {
     /// Lower a `while_statement` or `until_statement` into a
     /// `Stmt::While`.  `until cond` lowers to `while !cond`
     /// (condition wrapped in `BuiltinCall("not", ...)`).
-    fn lower_while_or_until(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Stmt, RubyLowerError> {
+    fn lower_while_or_until(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
         let is_until = node.rule_name == "until_statement";
         let cond_node = self
             .find_node_child(node, "expression")
@@ -1610,21 +1698,18 @@ impl Lowerer {
     /// - Range/Regex/Class values in `when` lists work syntactically
     ///   (they parse as expressions) but the `==` comparison won't
     ///   match Ruby's case-equality semantics.
-    fn lower_case_statement(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_case_statement(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // 1. Scrutinee — the first `expression` direct child of the
         //    case_statement.  (subsequent `expression` children belong
         //    to when_clause descendants, but they're inside subnodes,
         //    not direct children.)
-        let scrutinee_node = self
-            .find_node_child(node, "expression")
-            .ok_or_else(|| RubyLowerError {
-                message: "case_statement missing scrutinee expression".to_string(),
-                line: node.start_line.unwrap_or(0),
-                column: node.start_column.unwrap_or(0),
-            })?;
+        let scrutinee_node =
+            self.find_node_child(node, "expression")
+                .ok_or_else(|| RubyLowerError {
+                    message: "case_statement missing scrutinee expression".to_string(),
+                    line: node.start_line.unwrap_or(0),
+                    column: node.start_column.unwrap_or(0),
+                })?;
         let scrutinee = self.lower_expression(scrutinee_node)?;
 
         // 2. Collect every when_clause / in_clause subnode in source order.
@@ -1657,7 +1742,9 @@ impl Lowerer {
         } else {
             Block {
                 stmts: Vec::new(),
-                value: Expr::NilLit { span: self.span_of(node) },
+                value: Expr::NilLit {
+                    span: self.span_of(node),
+                },
                 span: self.span_of(node),
             }
         };
@@ -1758,7 +1845,13 @@ impl Lowerer {
             //     which dispatches Range→membership, Regexp→match, else `==`.
             // The `case_eq` floor is `==`, so plain literals keep their old
             // behaviour.
-            let cmp = if matches!(val, Expr::VarRef { scope: Scope::Const, .. }) {
+            let cmp = if matches!(
+                val,
+                Expr::VarRef {
+                    scope: Scope::Const,
+                    ..
+                }
+            ) {
                 self.features_used.insert(Feature::Classes);
                 // The synthetic `"is_a?"` method-name is a string literal.
                 self.features_used.insert(Feature::Strings);
@@ -1766,7 +1859,10 @@ impl Lowerer {
                     name: "__method__".to_string(),
                     args: vec![
                         scrutinee.clone(),
-                        Expr::StrLit { value: "is_a?".to_string(), span: span.clone() },
+                        Expr::StrLit {
+                            value: "is_a?".to_string(),
+                            span: span.clone(),
+                        },
                         val,
                     ],
                     effects: EffectSet::PURE,
@@ -1836,13 +1932,13 @@ impl Lowerer {
         pattern_node: &GrammarASTNode,
         scrutinee: &Expr,
     ) -> Result<(Expr, Vec<Stmt>), RubyLowerError> {
-        let inner = self.first_node_child(pattern_node).ok_or_else(|| {
-            RubyLowerError {
+        let inner = self
+            .first_node_child(pattern_node)
+            .ok_or_else(|| RubyLowerError {
                 message: "pattern node had no inner rule child".to_string(),
                 line: pattern_node.start_line.unwrap_or(0),
                 column: pattern_node.start_column.unwrap_or(0),
-            }
-        })?;
+            })?;
         let span = self.span_of(pattern_node);
         match inner.rule_name.as_str() {
             "literal_pattern" => {
@@ -2245,9 +2341,7 @@ impl Lowerer {
                         .children
                         .iter()
                         .find_map(|c| match c {
-                            ASTNodeOrToken::Token(t)
-                                if matches!(t.type_, TokenType::Name) =>
-                            {
+                            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => {
                                 Some(t)
                             }
                             _ => None,
@@ -2627,12 +2721,8 @@ impl Lowerer {
                             // Reuse the Phase-6z numeric dispatch so
                             // every shape (float/hex/bin/oct/dec) is
                             // handled identically here.
-                            return self.lower_numeric_literal(
-                                &tok.value,
-                                span,
-                                tok.line,
-                                tok.column,
-                            );
+                            return self
+                                .lower_numeric_literal(&tok.value, span, tok.line, tok.column);
                         }
                         TokenType::String => {
                             return Ok(Expr::StrLit {
@@ -2739,10 +2829,7 @@ impl Lowerer {
     /// The LHS body is wrapped in a single-statement `Block` (with
     /// `value: NilLit` — the modifier form is statement-position only,
     /// never tail-promoted to expression).
-    fn lower_modifier_statement(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Stmt, RubyLowerError> {
+    fn lower_modifier_statement(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
         // 1. Find the LHS inner-rule node.  It's the first child that's
         //    one of the four LHS-eligible rules.
         let lhs_node = node
@@ -2752,10 +2839,7 @@ impl Lowerer {
                 ASTNodeOrToken::Node(n)
                     if matches!(
                         n.rule_name.as_str(),
-                        "assignment"
-                            | "method_call"
-                            | "method_call_no_paren"
-                            | "expression_stmt"
+                        "assignment" | "method_call" | "method_call_no_paren" | "expression_stmt"
                     ) =>
                 {
                     Some(n)
@@ -2778,10 +2862,7 @@ impl Lowerer {
                 ASTNodeOrToken::Token(t)
                     if matches!(
                         t.value.as_str(),
-                        "if_modifier"
-                            | "unless_modifier"
-                            | "while_modifier"
-                            | "until_modifier"
+                        "if_modifier" | "unless_modifier" | "while_modifier" | "until_modifier"
                     ) =>
                 {
                     Some(t.value.as_str())
@@ -2830,8 +2911,7 @@ impl Lowerer {
         //    wrap it in `not` — identical to the leading-keyword
         //    `unless_statement` / `until_statement` lowerings.
         let mut cond = self.lower_expression(cond_node)?;
-        let negate =
-            matches!(modifier_kw, "unless_modifier" | "until_modifier");
+        let negate = matches!(modifier_kw, "unless_modifier" | "until_modifier");
         if negate {
             cond = Expr::BuiltinCall {
                 name: "not".to_string(),
@@ -2889,10 +2969,7 @@ impl Lowerer {
     /// `self.user_functions`.  Method bodies are recursively
     /// lowered using a *fresh* declared-locals set so the outer
     /// program's let-bindings don't leak in.
-    fn collect_def_statements(
-        &mut self,
-        program: &GrammarASTNode,
-    ) -> Result<(), RubyLowerError> {
+    fn collect_def_statements(&mut self, program: &GrammarASTNode) -> Result<(), RubyLowerError> {
         for child in &program.children {
             let stmt = match child {
                 ASTNodeOrToken::Node(n) if n.rule_name == "statement" => n,
@@ -3243,7 +3320,10 @@ impl Lowerer {
     /// `def m` and `def self.m` to coexist).  The runtime class-method table is
     /// keyed on the bare method name, so dispatch is unaffected by the suffix.
     fn qualified_class_method_fn_name(&self, class_name: &str, method_name: &str) -> String {
-        format!("{}_cm", self.qualified_method_fn_name(class_name, method_name))
+        format!(
+            "{}_cm",
+            self.qualified_method_fn_name(class_name, method_name)
+        )
     }
 
     /// Issue #59 — does this `def_statement` / `endless_def_statement` carry a
@@ -3299,8 +3379,14 @@ impl Lowerer {
             expr: Expr::BuiltinCall {
                 name: builtin.to_string(),
                 args: vec![
-                    Expr::StrLit { value: class_name.to_string(), span: span.clone() },
-                    Expr::StrLit { value: method_name.to_string(), span: span.clone() },
+                    Expr::StrLit {
+                        value: class_name.to_string(),
+                        span: span.clone(),
+                    },
+                    Expr::StrLit {
+                        value: method_name.to_string(),
+                        span: span.clone(),
+                    },
                     Expr::MakeClosure {
                         fn_name: fn_name.to_string(),
                         captures: Vec::new(),
@@ -3334,7 +3420,9 @@ impl Lowerer {
     ) -> Result<Option<Vec<Stmt>>, RubyLowerError> {
         // The callee is the first Name token directly under the call node.
         let callee = call_node.children.iter().find_map(|c| match c {
-            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t.value.as_str()),
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => {
+                Some(t.value.as_str())
+            }
             _ => None,
         });
         let (want_reader, want_writer) = match callee {
@@ -3478,7 +3566,9 @@ impl Lowerer {
     ) -> Result<Option<Stmt>, RubyLowerError> {
         // The callee is the first Name token directly under the call node.
         let callee = call_node.children.iter().find_map(|c| match c {
-            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t.value.as_str()),
+            ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => {
+                Some(t.value.as_str())
+            }
             _ => None,
         });
         let builtin = match callee {
@@ -3501,7 +3591,11 @@ impl Lowerer {
         };
         let lowered = self.lower_expression(arg_node)?;
         let module_name = match lowered {
-            Expr::VarRef { name, scope: Scope::Const, .. } => name,
+            Expr::VarRef {
+                name,
+                scope: Scope::Const,
+                ..
+            } => name,
             // Not a bare constant — fall through to the ordinary-call path.
             _ => return Ok(None),
         };
@@ -3517,8 +3611,14 @@ impl Lowerer {
             expr: Expr::BuiltinCall {
                 name: builtin.to_string(),
                 args: vec![
-                    Expr::StrLit { value: owner.to_string(), span: span.clone() },
-                    Expr::StrLit { value: module_name, span: span.clone() },
+                    Expr::StrLit {
+                        value: owner.to_string(),
+                        span: span.clone(),
+                    },
+                    Expr::StrLit {
+                        value: module_name,
+                        span: span.clone(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: span.clone(),
@@ -3535,7 +3635,10 @@ impl Lowerer {
         if node.rule_name == "symbol_literal" {
             return node.children.iter().find_map(|c| match c {
                 ASTNodeOrToken::Token(t)
-                    if matches!(t.type_, TokenType::Name | TokenType::Keyword | TokenType::String) =>
+                    if matches!(
+                        t.type_,
+                        TokenType::Name | TokenType::Keyword | TokenType::String
+                    ) =>
                 {
                     Some(t.value.clone())
                 }
@@ -3562,10 +3665,7 @@ impl Lowerer {
     /// explicit Name-type filter for symmetry with the analogous
     /// helper inside `lower_def_statement` that extracts the method
     /// name).
-    fn extract_class_name(
-        &self,
-        node: &GrammarASTNode,
-    ) -> Result<String, RubyLowerError> {
+    fn extract_class_name(&self, node: &GrammarASTNode) -> Result<String, RubyLowerError> {
         let name_token = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
             _ => None,
@@ -3584,10 +3684,7 @@ impl Lowerer {
     /// Shape: `KEYWORD("module") NAME { !"end" statement } "end"`.  The
     /// name is the first `TokenType::Name` token — symmetric with
     /// `extract_class_name`, but with a module-specific error message.
-    fn extract_module_name(
-        &self,
-        node: &GrammarASTNode,
-    ) -> Result<String, RubyLowerError> {
+    fn extract_module_name(&self, node: &GrammarASTNode) -> Result<String, RubyLowerError> {
         let name_token = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Name) => Some(t),
             _ => None,
@@ -3721,7 +3818,6 @@ impl Lowerer {
         func
     }
 
-
     /// Rewrite every direct-in-body `yield` within a [`Block`], returning
     /// whether at least one was found.  Recurses through the block's
     /// statements and its trailing value expression.
@@ -3755,13 +3851,21 @@ impl Lowerer {
             Stmt::LetBinding { value, .. }
             | Stmt::LetStarBinding { value, .. }
             | Stmt::Assign { value, .. }
-            | Stmt::ExprStmt { expr: value, .. } => Self::rewrite_yields_in_expr(value, block_scope),
+            | Stmt::ExprStmt { expr: value, .. } => {
+                Self::rewrite_yields_in_expr(value, block_scope)
+            }
             Stmt::While { cond, body, .. } => {
                 let mut found = Self::rewrite_yields_in_expr(cond, block_scope);
                 found |= Self::rewrite_yields_in_block(body, block_scope);
                 found
             }
-            Stmt::ForRange { start, stop, step, body, .. } => {
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
                 let mut found = Self::rewrite_yields_in_expr(start, block_scope);
                 found |= Self::rewrite_yields_in_expr(stop, block_scope);
                 found |= Self::rewrite_yields_in_expr(step, block_scope);
@@ -3773,19 +3877,48 @@ impl Lowerer {
                 found |= Self::rewrite_yields_in_block(body, block_scope);
                 found
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 let mut found = Self::rewrite_yields_in_expr(seq, block_scope);
                 found |= Self::rewrite_yields_in_expr(index, block_scope);
                 found |= Self::rewrite_yields_in_expr(value, block_scope);
                 found
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 let mut found = Self::rewrite_yields_in_expr(map, block_scope);
                 found |= Self::rewrite_yields_in_expr(key, block_scope);
                 found |= Self::rewrite_yields_in_expr(value, block_scope);
                 found
             }
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            // SIR22 compile-compat stub: this frontend never emits
+            // `IndexSet` today, so this arm is unreachable in practice.
+            // It still recurses into every child `Expr` (including each
+            // `IndexArg`'s embedded expression), mirroring the `SeqSet` /
+            // `MapSet` arms above, so a nested `yield` would still be
+            // found and rewritten if a future lowering path ever produced
+            // this node inside a `yield`-bearing method body.
+            Stmt::IndexSet {
+                target,
+                indices,
+                value,
+                ..
+            } => {
+                let mut found = Self::rewrite_yields_in_expr(target, block_scope);
+                for idx in indices.iter_mut() {
+                    found |= Self::rewrite_yields_in_index_arg(idx, block_scope);
+                }
+                found |= Self::rewrite_yields_in_expr(value, block_scope);
+                found
+            }
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 let mut found = Self::rewrite_yields_in_stmts(body, block_scope);
                 for r in rescues {
                     found |= Self::rewrite_yields_in_stmts(&mut r.body, block_scope);
@@ -3798,9 +3931,21 @@ impl Lowerer {
             // Class/module/singleton declaration bodies are NOT descended:
             // their method `def`s are hoisted to their own top-level
             // Functions, where any `yield` is rewritten in its own right.
-            Stmt::ClassDef { .. }
-            | Stmt::ModuleDef { .. }
-            | Stmt::SingletonClassDef { .. } => false,
+            Stmt::ClassDef { .. } | Stmt::ModuleDef { .. } | Stmt::SingletonClassDef { .. } => {
+                false
+            }
+        }
+    }
+
+    /// SIR22 helper for the `yield`-rewrite pass: `IndexArg` wraps an
+    /// optional inner `Expr` (see `Expr::IndexGet`/`Stmt::IndexSet`);
+    /// recurse into it exactly like any other single-child wrapper above.
+    fn rewrite_yields_in_index_arg(idx: &mut IndexArg, block_scope: Scope) -> bool {
+        match idx {
+            IndexArg::Scalar(e) | IndexArg::Range(e) => {
+                Self::rewrite_yields_in_expr(e, block_scope)
+            }
+            IndexArg::Whole => false,
         }
     }
 
@@ -3813,7 +3958,12 @@ impl Lowerer {
     /// `yield` inside a block literal belongs to the enclosing method).
     fn rewrite_yields_in_expr(expr: &mut Expr, block_scope: Scope) -> bool {
         match expr {
-            Expr::BuiltinCall { name, args, effects, span } if name == "yield" => {
+            Expr::BuiltinCall {
+                name,
+                args,
+                effects,
+                span,
+            } if name == "yield" => {
                 // Rewrite any yields nested within this yield's own
                 // arguments first (e.g. `yield(yield x)`), then replace
                 // the whole node with the indirect call.
@@ -3852,7 +4002,12 @@ impl Lowerer {
                 }
                 found
             }
-            Expr::If { cond, then_branch, else_branch, .. } => {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 let mut found = Self::rewrite_yields_in_expr(cond, block_scope);
                 found |= Self::rewrite_yields_in_block(then_branch, block_scope);
                 found |= Self::rewrite_yields_in_block(else_branch, block_scope);
@@ -3901,9 +4056,7 @@ impl Lowerer {
             // `value` (its runtime meaning) so a `yield` nested inside a
             // keyword argument is still rewritten.  Real support pending
             // KW2–KW8.
-            Expr::KeywordArg { value, .. } => {
-                Self::rewrite_yields_in_expr(value, block_scope)
-            }
+            Expr::KeywordArg { value, .. } => Self::rewrite_yields_in_expr(value, block_scope),
             // Phase Q10b — `block_given?` reaches the lowerer as a bare
             // `VarRef` named "block_given?" (it is parenless, so the
             // method-call parser treats it as a name).  Inside a method
@@ -3947,6 +4100,51 @@ impl Lowerer {
             | Expr::StrLit { .. }
             | Expr::FloatLit { .. }
             | Expr::VarRef { .. } => false,
+
+            // SIR22 compile-compat stubs: unreachable in practice (this
+            // frontend never emits these array/matrix nodes), but they
+            // recurse into every child `Expr` — same convention as
+            // `SeqLit`/`MapLit`/etc. above — so a nested `yield` inside one
+            // would still be found if such a node were ever produced.
+            Expr::ArrayLit { rows, .. } => {
+                let mut found = false;
+                for row in rows.iter_mut() {
+                    for e in row.iter_mut() {
+                        found |= Self::rewrite_yields_in_expr(e, block_scope);
+                    }
+                }
+                found
+            }
+            Expr::Range {
+                start, step, stop, ..
+            } => {
+                let mut found = Self::rewrite_yields_in_expr(start, block_scope);
+                if let Some(s) = step {
+                    found |= Self::rewrite_yields_in_expr(s, block_scope);
+                }
+                found |= Self::rewrite_yields_in_expr(stop, block_scope);
+                found
+            }
+            Expr::MatMul { lhs, rhs, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(lhs, block_scope);
+                found |= Self::rewrite_yields_in_expr(rhs, block_scope);
+                found
+            }
+            Expr::ElementwiseOp { lhs, rhs, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(lhs, block_scope);
+                found |= Self::rewrite_yields_in_expr(rhs, block_scope);
+                found
+            }
+            Expr::Transpose { target, .. } => Self::rewrite_yields_in_expr(target, block_scope),
+            Expr::IndexGet {
+                target, indices, ..
+            } => {
+                let mut found = Self::rewrite_yields_in_expr(target, block_scope);
+                for idx in indices.iter_mut() {
+                    found |= Self::rewrite_yields_in_index_arg(idx, block_scope);
+                }
+                found
+            }
         }
     }
 
@@ -4003,29 +4201,64 @@ impl Lowerer {
                 Self::collect_bound_names_in_expr(cond, out);
                 Self::collect_bound_names_in_block(body, out);
             }
-            Stmt::ForRange { var, start, stop, step, body, .. } => {
+            Stmt::ForRange {
+                var,
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
                 out.insert(var.clone());
                 Self::collect_bound_names_in_expr(start, out);
                 Self::collect_bound_names_in_expr(stop, out);
                 Self::collect_bound_names_in_expr(step, out);
                 Self::collect_bound_names_in_block(body, out);
             }
-            Stmt::ForEach { var, iter, body, .. } => {
+            Stmt::ForEach {
+                var, iter, body, ..
+            } => {
                 out.insert(var.clone());
                 Self::collect_bound_names_in_expr(iter, out);
                 Self::collect_bound_names_in_block(body, out);
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 Self::collect_bound_names_in_expr(seq, out);
                 Self::collect_bound_names_in_expr(index, out);
                 Self::collect_bound_names_in_expr(value, out);
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 Self::collect_bound_names_in_expr(map, out);
                 Self::collect_bound_names_in_expr(key, out);
                 Self::collect_bound_names_in_expr(value, out);
             }
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            // SIR22 compile-compat stub (never emitted by this frontend):
+            // an index-assignment binds no new name, but its operand
+            // expressions can still contain a `MakeClosure` whose captures
+            // read outer locals, so recurse into all of them exactly like
+            // the `SeqSet`/`MapSet` arms above.
+            Stmt::IndexSet {
+                target,
+                indices,
+                value,
+                ..
+            } => {
+                Self::collect_bound_names_in_expr(target, out);
+                for idx in indices {
+                    Self::collect_bound_names_in_index_arg(idx, out);
+                }
+                Self::collect_bound_names_in_expr(value, out);
+            }
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 for s in body {
                     Self::collect_bound_names_in_stmt(s, out);
                 }
@@ -4044,15 +4277,18 @@ impl Lowerer {
                 }
             }
             // Declaration bodies hoist their own methods; not descended.
-            Stmt::ClassDef { .. }
-            | Stmt::ModuleDef { .. }
-            | Stmt::SingletonClassDef { .. } => {}
+            Stmt::ClassDef { .. } | Stmt::ModuleDef { .. } | Stmt::SingletonClassDef { .. } => {}
         }
     }
 
     fn collect_bound_names_in_expr(expr: &Expr, out: &mut HashSet<String>) {
         match expr {
-            Expr::If { cond, then_branch, else_branch, .. } => {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 Self::collect_bound_names_in_expr(cond, out);
                 Self::collect_bound_names_in_block(then_branch, out);
                 Self::collect_bound_names_in_block(else_branch, out);
@@ -4105,6 +4341,16 @@ impl Lowerer {
         }
     }
 
+    /// SIR22 helper for `collect_bound_names_in_stmt`: recurse into an
+    /// `IndexArg`'s embedded expression (if any), mirroring the treatment
+    /// above of other single-child wrapper shapes.
+    fn collect_bound_names_in_index_arg(idx: &IndexArg, out: &mut HashSet<String>) {
+        match idx {
+            IndexArg::Scalar(e) | IndexArg::Range(e) => Self::collect_bound_names_in_expr(e, out),
+            IndexArg::Whole => {}
+        }
+    }
+
     /// Rewrite every free *read* (`VarRef{scope:Local}`) of a name for which
     /// `is_free(name)` holds to `Scope::Capture`, recording each captured
     /// name once in first-occurrence order.  Nested `MakeClosure` bodies are
@@ -4136,7 +4382,13 @@ impl Lowerer {
                 Self::recapture_reads_in_expr(cond, is_free, found);
                 Self::recapture_reads_in_block(body, is_free, found);
             }
-            Stmt::ForRange { start, stop, step, body, .. } => {
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
                 Self::recapture_reads_in_expr(start, is_free, found);
                 Self::recapture_reads_in_expr(stop, is_free, found);
                 Self::recapture_reads_in_expr(step, is_free, found);
@@ -4146,17 +4398,42 @@ impl Lowerer {
                 Self::recapture_reads_in_expr(iter, is_free, found);
                 Self::recapture_reads_in_block(body, is_free, found);
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 Self::recapture_reads_in_expr(seq, is_free, found);
                 Self::recapture_reads_in_expr(index, is_free, found);
                 Self::recapture_reads_in_expr(value, is_free, found);
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 Self::recapture_reads_in_expr(map, is_free, found);
                 Self::recapture_reads_in_expr(key, is_free, found);
                 Self::recapture_reads_in_expr(value, is_free, found);
             }
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            // SIR22 compile-compat stub (never emitted by this frontend):
+            // recurse into every child `Expr`, including each `IndexArg`'s
+            // embedded expression, mirroring `SeqSet`/`MapSet` above, so a
+            // free outer-local read nested inside one is still recaptured.
+            Stmt::IndexSet {
+                target,
+                indices,
+                value,
+                ..
+            } => {
+                Self::recapture_reads_in_expr(target, is_free, found);
+                for idx in indices.iter_mut() {
+                    Self::recapture_reads_in_index_arg(idx, is_free, found);
+                }
+                Self::recapture_reads_in_expr(value, is_free, found);
+            }
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 for s in body {
                     Self::recapture_reads_in_stmt(s, is_free, found);
                 }
@@ -4171,9 +4448,22 @@ impl Lowerer {
                     }
                 }
             }
-            Stmt::ClassDef { .. }
-            | Stmt::ModuleDef { .. }
-            | Stmt::SingletonClassDef { .. } => {}
+            Stmt::ClassDef { .. } | Stmt::ModuleDef { .. } | Stmt::SingletonClassDef { .. } => {}
+        }
+    }
+
+    /// SIR22 helper for `recapture_reads_in_stmt`: recurse into an
+    /// `IndexArg`'s embedded expression (if any).
+    fn recapture_reads_in_index_arg(
+        idx: &mut IndexArg,
+        is_free: &impl Fn(&str) -> bool,
+        found: &mut Vec<String>,
+    ) {
+        match idx {
+            IndexArg::Scalar(e) | IndexArg::Range(e) => {
+                Self::recapture_reads_in_expr(e, is_free, found)
+            }
+            IndexArg::Whole => {}
         }
     }
 
@@ -4189,7 +4479,12 @@ impl Lowerer {
                 }
                 *scope = Scope::Capture;
             }
-            Expr::If { cond, then_branch, else_branch, .. } => {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 Self::recapture_reads_in_expr(cond, is_free, found);
                 Self::recapture_reads_in_block(then_branch, is_free, found);
                 Self::recapture_reads_in_block(else_branch, is_free, found);
@@ -4290,7 +4585,13 @@ impl Lowerer {
                 Self::normalize_calls_in_expr(cond, ctx);
                 Self::normalize_block_call_args(body, ctx);
             }
-            Stmt::ForRange { start, stop, step, body, .. } => {
+            Stmt::ForRange {
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
                 Self::normalize_calls_in_expr(start, ctx);
                 Self::normalize_calls_in_expr(stop, ctx);
                 Self::normalize_calls_in_expr(step, ctx);
@@ -4300,14 +4601,35 @@ impl Lowerer {
                 Self::normalize_calls_in_expr(iter, ctx);
                 Self::normalize_block_call_args(body, ctx);
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 Self::normalize_calls_in_expr(seq, ctx);
                 Self::normalize_calls_in_expr(index, ctx);
                 Self::normalize_calls_in_expr(value, ctx);
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 Self::normalize_calls_in_expr(map, ctx);
                 Self::normalize_calls_in_expr(key, ctx);
+                Self::normalize_calls_in_expr(value, ctx);
+            }
+            // SIR22 compile-compat stub (never emitted by this frontend):
+            // recurse into every child `Expr`, including each `IndexArg`'s
+            // embedded expression, mirroring `SeqSet`/`MapSet` above, so a
+            // parenless block-method call nested inside one is still
+            // threaded/normalized.
+            Stmt::IndexSet {
+                target,
+                indices,
+                value,
+                ..
+            } => {
+                Self::normalize_calls_in_expr(target, ctx);
+                for idx in indices.iter_mut() {
+                    Self::normalize_calls_in_index_arg(idx, ctx);
+                }
                 Self::normalize_calls_in_expr(value, ctx);
             }
             // Class/module/singleton bodies carry non-`def` statements
@@ -4317,7 +4639,12 @@ impl Lowerer {
             Stmt::ClassDef { body, .. }
             | Stmt::ModuleDef { body, .. }
             | Stmt::SingletonClassDef { body, .. } => Self::normalize_calls_in_stmts(body, ctx),
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 Self::normalize_calls_in_stmts(body, ctx);
                 for r in rescues {
                     Self::normalize_calls_in_stmts(&mut r.body, ctx);
@@ -4341,9 +4668,11 @@ impl Lowerer {
             // matches the def's trailing `__sir_block__` parameter.  The
             // synthesized call already carries its block slot, so it is
             // not re-walked (no double-padding).
-            Expr::VarRef { name, scope: Scope::Local, span }
-                if ctx.methods.contains(name) && !ctx.bound.contains(name) =>
-            {
+            Expr::VarRef {
+                name,
+                scope: Scope::Local,
+                span,
+            } if ctx.methods.contains(name) && !ctx.bound.contains(name) => {
                 let span = span.clone();
                 *expr = Expr::DirectCall {
                     fn_name: name.clone(),
@@ -4352,7 +4681,12 @@ impl Lowerer {
                     span,
                 };
             }
-            Expr::DirectCall { fn_name, args, span, .. } => {
+            Expr::DirectCall {
+                fn_name,
+                args,
+                span,
+                ..
+            } => {
                 // Normalize nested calls in the arguments first (so an
                 // unwrapped `block_pass` inner / a closure capture value
                 // is itself threaded), then fix this call's trailing slot.
@@ -4393,7 +4727,12 @@ impl Lowerer {
                     Self::normalize_calls_in_expr(a, ctx);
                 }
             }
-            Expr::If { cond, then_branch, else_branch, .. } => {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 Self::normalize_calls_in_expr(cond, ctx);
                 Self::normalize_block_call_args(then_branch, ctx);
                 Self::normalize_block_call_args(else_branch, ctx);
@@ -4439,6 +4778,43 @@ impl Lowerer {
             Expr::KeywordArg { value, .. } => {
                 Self::normalize_calls_in_expr(value, ctx);
             }
+            // SIR22 compile-compat stubs (never emitted by this frontend):
+            // recurse into every child `Expr`, matching the treatment of
+            // `SeqLit`/`MapLit`/etc. above, so a parenless block-method call
+            // nested inside one of these would still be normalized.
+            Expr::ArrayLit { rows, .. } => {
+                for row in rows.iter_mut() {
+                    for e in row.iter_mut() {
+                        Self::normalize_calls_in_expr(e, ctx);
+                    }
+                }
+            }
+            Expr::Range {
+                start, step, stop, ..
+            } => {
+                Self::normalize_calls_in_expr(start, ctx);
+                if let Some(s) = step {
+                    Self::normalize_calls_in_expr(s, ctx);
+                }
+                Self::normalize_calls_in_expr(stop, ctx);
+            }
+            Expr::MatMul { lhs, rhs, .. } => {
+                Self::normalize_calls_in_expr(lhs, ctx);
+                Self::normalize_calls_in_expr(rhs, ctx);
+            }
+            Expr::ElementwiseOp { lhs, rhs, .. } => {
+                Self::normalize_calls_in_expr(lhs, ctx);
+                Self::normalize_calls_in_expr(rhs, ctx);
+            }
+            Expr::Transpose { target, .. } => Self::normalize_calls_in_expr(target, ctx),
+            Expr::IndexGet {
+                target, indices, ..
+            } => {
+                Self::normalize_calls_in_expr(target, ctx);
+                for idx in indices.iter_mut() {
+                    Self::normalize_calls_in_index_arg(idx, ctx);
+                }
+            }
             // Atomic literals and a non-rewritten VarRef carry no
             // sub-expressions.
             Expr::IntLit { .. }
@@ -4448,6 +4824,15 @@ impl Lowerer {
             | Expr::StrLit { .. }
             | Expr::FloatLit { .. }
             | Expr::VarRef { .. } => {}
+        }
+    }
+
+    /// SIR22 helper for `normalize_calls_in_stmt`/`normalize_calls_in_expr`:
+    /// recurse into an `IndexArg`'s embedded expression (if any).
+    fn normalize_calls_in_index_arg(idx: &mut IndexArg, ctx: &BlockNormCtx) {
+        match idx {
+            IndexArg::Scalar(e) | IndexArg::Range(e) => Self::normalize_calls_in_expr(e, ctx),
+            IndexArg::Whole => {}
         }
     }
 
@@ -4473,8 +4858,7 @@ impl Lowerer {
 
     fn collect_bound_names_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
         match stmt {
-            Stmt::LetBinding { name, value, .. }
-            | Stmt::LetStarBinding { name, value, .. } => {
+            Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
                 out.insert(name.clone());
                 Self::collect_bound_names_expr(value, out);
             }
@@ -4487,32 +4871,67 @@ impl Lowerer {
                 Self::collect_bound_names_expr(cond, out);
                 Self::collect_bound_names_block(body, out);
             }
-            Stmt::ForRange { var, start, stop, step, body, .. } => {
+            Stmt::ForRange {
+                var,
+                start,
+                stop,
+                step,
+                body,
+                ..
+            } => {
                 out.insert(var.clone());
                 Self::collect_bound_names_expr(start, out);
                 Self::collect_bound_names_expr(stop, out);
                 Self::collect_bound_names_expr(step, out);
                 Self::collect_bound_names_block(body, out);
             }
-            Stmt::ForEach { var, iter, body, .. } => {
+            Stmt::ForEach {
+                var, iter, body, ..
+            } => {
                 out.insert(var.clone());
                 Self::collect_bound_names_expr(iter, out);
                 Self::collect_bound_names_block(body, out);
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 Self::collect_bound_names_expr(seq, out);
                 Self::collect_bound_names_expr(index, out);
                 Self::collect_bound_names_expr(value, out);
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 Self::collect_bound_names_expr(map, out);
                 Self::collect_bound_names_expr(key, out);
+                Self::collect_bound_names_expr(value, out);
+            }
+            // SIR22 compile-compat stub (never emitted by this frontend):
+            // an index-assignment binds no new name itself, but recurse
+            // into every child `Expr` — including each `IndexArg`'s
+            // embedded expression — matching `SeqSet`/`MapSet` above, in
+            // case a nested closure or let-binding is ever produced there.
+            Stmt::IndexSet {
+                target,
+                indices,
+                value,
+                ..
+            } => {
+                Self::collect_bound_names_expr(target, out);
+                for idx in indices {
+                    Self::collect_bound_names_expr_in_index_arg(idx, out);
+                }
                 Self::collect_bound_names_expr(value, out);
             }
             Stmt::ClassDef { body, .. }
             | Stmt::ModuleDef { body, .. }
             | Stmt::SingletonClassDef { body, .. } => Self::collect_bound_names_stmts(body, out),
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 Self::collect_bound_names_stmts(body, out);
                 for r in rescues {
                     if let Some(b) = &r.binding {
@@ -4529,7 +4948,12 @@ impl Lowerer {
 
     fn collect_bound_names_expr(expr: &Expr, out: &mut HashSet<String>) {
         match expr {
-            Expr::If { cond, then_branch, else_branch, .. } => {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 Self::collect_bound_names_expr(cond, out);
                 Self::collect_bound_names_block(then_branch, out);
                 Self::collect_bound_names_block(else_branch, out);
@@ -4586,6 +5010,43 @@ impl Lowerer {
             // `value` so a name bound inside a keyword argument is still
             // collected.  Real support pending KW2–KW8.
             Expr::KeywordArg { value, .. } => Self::collect_bound_names_expr(value, out),
+            // SIR22 compile-compat stubs (never emitted by this frontend):
+            // recurse into every child `Expr`, matching the treatment of
+            // `SeqLit`/`MapLit`/etc. above, so a name bound inside a nested
+            // closure would still be collected.
+            Expr::ArrayLit { rows, .. } => {
+                for row in rows {
+                    for e in row {
+                        Self::collect_bound_names_expr(e, out);
+                    }
+                }
+            }
+            Expr::Range {
+                start, step, stop, ..
+            } => {
+                Self::collect_bound_names_expr(start, out);
+                if let Some(s) = step {
+                    Self::collect_bound_names_expr(s, out);
+                }
+                Self::collect_bound_names_expr(stop, out);
+            }
+            Expr::MatMul { lhs, rhs, .. } => {
+                Self::collect_bound_names_expr(lhs, out);
+                Self::collect_bound_names_expr(rhs, out);
+            }
+            Expr::ElementwiseOp { lhs, rhs, .. } => {
+                Self::collect_bound_names_expr(lhs, out);
+                Self::collect_bound_names_expr(rhs, out);
+            }
+            Expr::Transpose { target, .. } => Self::collect_bound_names_expr(target, out),
+            Expr::IndexGet {
+                target, indices, ..
+            } => {
+                Self::collect_bound_names_expr(target, out);
+                for idx in indices {
+                    Self::collect_bound_names_expr_in_index_arg(idx, out);
+                }
+            }
             Expr::IntLit { .. }
             | Expr::BoolLit { .. }
             | Expr::NilLit { .. }
@@ -4593,6 +5054,16 @@ impl Lowerer {
             | Expr::StrLit { .. }
             | Expr::FloatLit { .. }
             | Expr::VarRef { .. } => {}
+        }
+    }
+
+    /// SIR22 helper for `collect_bound_names_stmt`/`collect_bound_names_expr`
+    /// (Q10c section): recurse into an `IndexArg`'s embedded expression (if
+    /// any).
+    fn collect_bound_names_expr_in_index_arg(idx: &IndexArg, out: &mut HashSet<String>) {
+        match idx {
+            IndexArg::Scalar(e) | IndexArg::Range(e) => Self::collect_bound_names_expr(e, out),
+            IndexArg::Whole => {}
         }
     }
 
@@ -4712,10 +5183,7 @@ impl Lowerer {
         Ok(threaded)
     }
 
-    fn lower_def_statement(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Function, RubyLowerError> {
+    fn lower_def_statement(&mut self, node: &GrammarASTNode) -> Result<Function, RubyLowerError> {
         // Shape:
         //   KEYWORD("def") NAME [ LPAREN [ params ] RPAREN ]
         //                  { !"end" statement } KEYWORD("end")
@@ -4820,7 +5288,9 @@ impl Lowerer {
                     ensure_body,
                     span: self.span_of(node),
                 }],
-                Expr::NilLit { span: self.span_of(node) },
+                Expr::NilLit {
+                    span: self.span_of(node),
+                },
             )
         } else {
             let mut stmts_out: Vec<Stmt> = Vec::new();
@@ -4832,12 +5302,10 @@ impl Lowerer {
             } else {
                 let last_idx = body_stmts.len() - 1;
                 for (i, s) in body_stmts.iter().enumerate() {
-                    let inner = self.first_node_child(s).ok_or_else(|| {
-                        RubyLowerError {
-                            message: "statement node had no child rule".to_string(),
-                            line: s.start_line.unwrap_or(0),
-                            column: s.start_column.unwrap_or(0),
-                        }
+                    let inner = self.first_node_child(s).ok_or_else(|| RubyLowerError {
+                        message: "statement node had no child rule".to_string(),
+                        line: s.start_line.unwrap_or(0),
+                        column: s.start_column.unwrap_or(0),
                     })?;
                     let is_tail = i == last_idx;
                     // Phase FC — Ruby methods have no explicit `return`: the
@@ -4859,7 +5327,9 @@ impl Lowerer {
             }
             (
                 stmts_out,
-                value.unwrap_or(Expr::NilLit { span: self.span_of(node) }),
+                value.unwrap_or(Expr::NilLit {
+                    span: self.span_of(node),
+                }),
             )
         };
 
@@ -4907,13 +5377,13 @@ impl Lowerer {
     fn lower_assignment(&mut self, node: &GrammarASTNode) -> Result<Stmt, RubyLowerError> {
         // Shape (post-6p): NAME ( EQUALS | "+=" | "-=" | "*=" | "/=" | "||=" | "&&=" ) expression
         let (name, name_span) = self.expect_first_name_token(node)?;
-        let expr_node = self.find_node_child(node, "expression").ok_or_else(|| {
-            RubyLowerError {
+        let expr_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
                 message: "assignment missing RHS expression".to_string(),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
-            }
-        })?;
+            })?;
         let rhs = self.lower_expression(expr_node)?;
 
         // Phase 6p — detect compound-assign operator.  The lexer
@@ -5224,13 +5694,13 @@ impl Lowerer {
     ) -> Result<Stmt, RubyLowerError> {
         // Step 1: the LHS-as-source (Ruby left side) is the value
         // expression — the `expression` Node child.
-        let expr_node = self.find_node_child(node, "expression").ok_or_else(|| {
-            RubyLowerError {
+        let expr_node = self
+            .find_node_child(node, "expression")
+            .ok_or_else(|| RubyLowerError {
                 message: "rightward_assignment missing LHS expression".to_string(),
                 line: node.start_line.unwrap_or(0),
                 column: node.start_column.unwrap_or(0),
-            }
-        })?;
+            })?;
         let value = self.lower_expression(expr_node)?;
 
         // Step 2: the binding name is the trailing `NAME` token.  Walk
@@ -5359,10 +5829,7 @@ impl Lowerer {
                                 {
                                     is_splat = true;
                                 } else if t.type_ == TokenType::Name {
-                                    name_and_span = Some((
-                                        t.value.clone(),
-                                        self.span_of_token(t),
-                                    ));
+                                    name_and_span = Some((t.value.clone(), self.span_of_token(t)));
                                 }
                             }
                         }
@@ -5427,8 +5894,7 @@ impl Lowerer {
         // `Expr::SeqIndex`.  The check below permits that shape; the
         // dispatch a few lines down routes it to the dedicated helper.
         if splat_idx.is_none() {
-            let is_single_rhs_unpack =
-                rhs_exprs.len() == 1 && lhs_targets.len() > 1;
+            let is_single_rhs_unpack = rhs_exprs.len() == 1 && lhs_targets.len() > 1;
             if lhs_targets.len() != rhs_exprs.len() && !is_single_rhs_unpack {
                 return Err(RubyLowerError {
                     message: format!(
@@ -5538,8 +6004,7 @@ impl Lowerer {
         // so nested or repeated multi-assignments don't collide.  Names
         // are double-underscore-prefixed so they can't collide with
         // user-typeable Ruby locals.
-        let lhs_name_set: HashSet<String> =
-            lhs_names.iter().map(|(n, _)| n.clone()).collect();
+        let lhs_name_set: HashSet<String> = lhs_names.iter().map(|(n, _)| n.clone()).collect();
         let needs_temps = lowered_rhs
             .iter()
             .any(|e| expr_references_any_name(e, &lhs_name_set));
@@ -5577,9 +6042,7 @@ impl Lowerer {
             }
 
             // Pass 2: assign each LHS from its temp.
-            for ((name, name_span), tmp_ref) in
-                lhs_names.into_iter().zip(temp_refs.into_iter())
-            {
+            for ((name, name_span), tmp_ref) in lhs_names.into_iter().zip(temp_refs.into_iter()) {
                 let span = name_span.clone();
                 let stmt = if self.declared_locals.contains(&name) {
                     self.features_used.insert(Feature::MutableBindings);
@@ -5604,9 +6067,7 @@ impl Lowerer {
             // Fast path: no LHS appears in any RHS, so the sequential
             // lowering Phase 6r used is observably equivalent to the
             // truly-parallel form.  Emit one Stmt per pair.
-            for ((name, name_span), value) in
-                lhs_names.into_iter().zip(lowered_rhs.into_iter())
-            {
+            for ((name, name_span), value) in lhs_names.into_iter().zip(lowered_rhs.into_iter()) {
                 let span = name_span.clone();
                 let stmt = if self.declared_locals.contains(&name) {
                     self.features_used.insert(Feature::MutableBindings);
@@ -5980,9 +6441,7 @@ impl Lowerer {
                         .children
                         .iter()
                         .find_map(|c| match c {
-                            ASTNodeOrToken::Node(en)
-                                if en.rule_name == "exception_list" =>
-                            {
+                            ASTNodeOrToken::Node(en) if en.rule_name == "exception_list" => {
                                 Some(en)
                             }
                             _ => None,
@@ -5991,9 +6450,7 @@ impl Lowerer {
                             en.children
                                 .iter()
                                 .filter_map(|cc| match cc {
-                                    ASTNodeOrToken::Token(t)
-                                        if t.type_ == TokenType::Name =>
-                                    {
+                                    ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => {
                                         Some(t.value.clone())
                                     }
                                     _ => None,
@@ -6126,10 +6583,7 @@ impl Lowerer {
     /// (so splat/double-splat prefixes have a slot).  Callers route
     /// each returned `call_arg` through [`lower_call_arg`] to unwrap
     /// the `*` / `**` envelope.
-    fn head_call_args<'a>(
-        &self,
-        node: &'a GrammarASTNode,
-    ) -> Vec<&'a GrammarASTNode> {
+    fn head_call_args<'a>(&self, node: &'a GrammarASTNode) -> Vec<&'a GrammarASTNode> {
         let mut out = Vec::new();
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
@@ -6166,10 +6620,7 @@ impl Lowerer {
     /// (where the lossy v0 Param shape can't represent variadic
     /// parameters directly).  Callers downstream can pattern-match the
     /// builtin name to convert back to splat syntax in target source.
-    fn lower_call_arg(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_call_arg(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // KW7 — keyword argument `name: value` (`f(a: 1)`).  The grammar's
         // FIRST `call_arg` alternative is `NAME COLON expression`, so a
         // keyword arg node carries a COLON token child (the single `:`).
@@ -6232,9 +6683,7 @@ impl Lowerer {
         // Op token — the `&.` safe-nav fusion does not fire because no
         // `.` follows a block-pass `&`).
         let prefix = node.children.iter().find_map(|c| match c {
-            ASTNodeOrToken::Token(t)
-                if matches!(t.value.as_str(), "*" | "**" | "&") =>
-            {
+            ASTNodeOrToken::Token(t) if matches!(t.value.as_str(), "*" | "**" | "&") => {
                 Some(t.value.clone())
             }
             _ => None,
@@ -6314,10 +6763,7 @@ impl Lowerer {
     /// (no captures from the outer scope).  Bodies that reference
     /// outer locals will fail the SIR validator at the `VarRef` stage.
     /// Documented in the crate CHANGELOG as a known limitation.
-    fn lower_method_with_block(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_method_with_block(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // Shape:
         //   (NAME | KEYWORD) [LPAREN [expression (COMMA expression)*] RPAREN] block
         // The leading callee name comes first.
@@ -6391,11 +6837,13 @@ impl Lowerer {
         block_node: &GrammarASTNode,
     ) -> Result<(String, Vec<CaptureValue>), RubyLowerError> {
         // Drill into the do_block / brace_block child.
-        let inner = self.first_node_child(block_node).ok_or_else(|| RubyLowerError {
-            message: "block missing do_block/brace_block child".to_string(),
-            line: block_node.start_line.unwrap_or(0),
-            column: block_node.start_column.unwrap_or(0),
-        })?;
+        let inner = self
+            .first_node_child(block_node)
+            .ok_or_else(|| RubyLowerError {
+                message: "block missing do_block/brace_block child".to_string(),
+                line: block_node.start_line.unwrap_or(0),
+                column: block_node.start_column.unwrap_or(0),
+            })?;
 
         // Extract block parameters (the `|x, y|` pipe form).  Each
         // Name token *that isn't a `|`* is a parameter.  The lexer
@@ -6417,9 +6865,7 @@ impl Lowerer {
             let mut seen_semicolon = false;
             for c in &pn.children {
                 match c {
-                    ASTNodeOrToken::Token(t)
-                        if matches!(t.type_, TokenType::Semicolon) =>
-                    {
+                    ASTNodeOrToken::Token(t) if matches!(t.type_, TokenType::Semicolon) => {
                         seen_semicolon = true;
                     }
                     ASTNodeOrToken::Token(t)
@@ -6751,10 +7197,7 @@ impl Lowerer {
     ///   `method_with_block` — they're regular keyword-led calls.
     ///   The SIR builtin table tags both as `BuiltinCall("lambda", …)`
     ///   so downstream emitters see a single closure-construction shape.
-    fn lower_lambda_literal(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_lambda_literal(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         // 1. Find the `block` subnode (mandatory).
         let block_node = self
             .find_node_child(node, "block")
@@ -6810,11 +7253,13 @@ impl Lowerer {
         block_node: &GrammarASTNode,
         params: Vec<Param>,
     ) -> Result<String, RubyLowerError> {
-        let inner = self.first_node_child(block_node).ok_or_else(|| RubyLowerError {
-            message: "block missing do_block/brace_block child".to_string(),
-            line: block_node.start_line.unwrap_or(0),
-            column: block_node.start_column.unwrap_or(0),
-        })?;
+        let inner = self
+            .first_node_child(block_node)
+            .ok_or_else(|| RubyLowerError {
+                message: "block missing do_block/brace_block child".to_string(),
+                line: block_node.start_line.unwrap_or(0),
+                column: block_node.start_column.unwrap_or(0),
+            })?;
 
         // Lower body with fresh scope (params pre-declared as locals
         // + tracked in current_params so VarRefs get Scope::Param).
@@ -6856,8 +7301,7 @@ impl Lowerer {
                         "expression_stmt" => {
                             let en = self.first_node_child(inner_stmt).ok_or_else(|| {
                                 RubyLowerError {
-                                    message: "expression_stmt had no expression child"
-                                        .to_string(),
+                                    message: "expression_stmt had no expression child".to_string(),
                                     line: inner_stmt.start_line.unwrap_or(0),
                                     column: inner_stmt.start_column.unwrap_or(0),
                                 }
@@ -6999,9 +7443,7 @@ impl Lowerer {
             // `::` as Colon-typed tokens, but a param suffix only ever holds
             // the single `:`.)
             let is_keyword = param_node.children.iter().any(|cc| match cc {
-                ASTNodeOrToken::Token(t) => {
-                    matches!(t.type_, TokenType::Colon) && t.value == ":"
-                }
+                ASTNodeOrToken::Token(t) => matches!(t.type_, TokenType::Colon) && t.value == ":",
                 _ => false,
             });
 
@@ -7009,9 +7451,7 @@ impl Lowerer {
             // `*`/`**` prefix.
             let name_tok = param_node.children.iter().find_map(|cc| match cc {
                 ASTNodeOrToken::Token(t)
-                    if matches!(t.type_, TokenType::Name)
-                        && t.value != "*"
-                        && t.value != "**" =>
+                    if matches!(t.type_, TokenType::Name) && t.value != "*" && t.value != "**" =>
                 {
                     Some(t)
                 }
@@ -7341,10 +7781,7 @@ impl Lowerer {
     /// comparison operators by *value*, not by token type — the same
     /// trick used for `=>` in `hash_entry`.  This means the helper is
     /// resilient to the lexer's classifier changing in the future.
-    fn lower_comparison_chain(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_comparison_chain(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         const COMPARISON_OPS: &[&str] = &["==", "!=", "<", ">", "<=", ">="];
         let mut acc: Option<Expr> = None;
         let mut pending_op: Option<(String, Span)> = None;
@@ -7453,17 +7890,16 @@ impl Lowerer {
     /// Lower a `logical_not` node.  Shape: `{ "!" | "not" } comparison`.
     /// Each leading `!` or `not` wraps the inner expression in another
     /// `BuiltinCall("not", …)` layer — so `!!x` produces `not(not(x))`.
-    fn lower_logical_not(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_logical_not(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         let not_count = node
             .children
             .iter()
-            .filter(|c| matches!(
-                c,
-                ASTNodeOrToken::Token(t) if t.value == "!" || t.value == "not"
-            ))
+            .filter(|c| {
+                matches!(
+                    c,
+                    ASTNodeOrToken::Token(t) if t.value == "!" || t.value == "not"
+                )
+            })
             .count();
         // The single Node child is the inner `comparison` expression.
         let inner = self.first_node_child(node).ok_or_else(|| RubyLowerError {
@@ -7689,10 +8125,7 @@ impl Lowerer {
     /// Name/Keyword/String token that follows.  For quoted forms
     /// (`:"hello world"`) the String token's value already strips
     /// the surrounding quotes, so we use it verbatim.
-    fn lower_symbol_literal(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_symbol_literal(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         let name_tok = node.children.iter().find_map(|c| match c {
             ASTNodeOrToken::Token(t)
                 if matches!(
@@ -7717,10 +8150,7 @@ impl Lowerer {
     }
 
     /// Phase 6d — `[a, b, c]` → `Expr::SeqLit`.
-    fn lower_array_literal(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_array_literal(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         let items: Vec<Expr> = node
             .children
             .iter()
@@ -7745,10 +8175,7 @@ impl Lowerer {
     /// `SymLit` for the shorthand (since `a:` is sugar for `:a =>`)
     /// or whatever the LHS expression evaluates to for the rocket
     /// form.
-    fn lower_hash_literal(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_hash_literal(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         let entry_nodes: Vec<&GrammarASTNode> = node
             .children
             .iter()
@@ -7970,10 +8397,7 @@ impl Lowerer {
         // Defensive fallback: if either delimiter is missing (which
         // would be a lexer bug), treat the whole value as the body so
         // we don't panic on a malformed input.
-        let body = if raw.len() >= 2
-            && raw.starts_with('`')
-            && raw.ends_with('`')
-        {
+        let body = if raw.len() >= 2 && raw.starts_with('`') && raw.ends_with('`') {
             &raw[1..raw.len() - 1]
         } else {
             raw
@@ -8054,7 +8478,10 @@ impl Lowerer {
             name: "regex".to_string(),
             args: vec![
                 pattern_expr,
-                Expr::StrLit { value: flags.to_string(), span: span.clone() },
+                Expr::StrLit {
+                    value: flags.to_string(),
+                    span: span.clone(),
+                },
             ],
             effects: EffectSet::PURE,
             span,
@@ -8480,10 +8907,7 @@ impl Lowerer {
     /// will reject as an unknown name — `defined?` on a never-bound bare
     /// local is not representable yet.  In practice the operand is a
     /// bound name, a method call, or a literal.
-    fn lower_defined_expression(
-        &mut self,
-        node: &GrammarASTNode,
-    ) -> Result<Expr, RubyLowerError> {
+    fn lower_defined_expression(&mut self, node: &GrammarASTNode) -> Result<Expr, RubyLowerError> {
         let operand_node = self.first_node_child(node).ok_or_else(|| RubyLowerError {
             message: "defined_expression missing operand".to_string(),
             line: node.start_line.unwrap_or(0),
@@ -8529,12 +8953,8 @@ impl Lowerer {
                             // value carries the verbatim source text.  The
                             // parser sees them all uniformly at the factor
                             // atom position — no grammar changes needed.
-                            return self.lower_numeric_literal(
-                                &tok.value,
-                                span,
-                                tok.line,
-                                tok.column,
-                            );
+                            return self
+                                .lower_numeric_literal(&tok.value, span, tok.line, tok.column);
                         }
                         TokenType::String => {
                             // Phase 7a — backtick command literal dispatch.
@@ -8545,10 +8965,7 @@ impl Lowerer {
                             // percent literals and heredocs use.  Detect by
                             // checking the leading byte.
                             if tok.value.starts_with('`') {
-                                return Ok(self.lower_backtick_command_literal(
-                                    &tok.value,
-                                    span,
-                                ));
+                                return Ok(self.lower_backtick_command_literal(&tok.value, span));
                             }
                             // Phase 7b — heredoc dispatch.  The lexer (Phase
                             // 3c / 4o) finalises every heredoc into a single
@@ -8558,10 +8975,7 @@ impl Lowerer {
                             // tag.  We detect by the `<<` prefix.
                             if tok.value.starts_with("<<") {
                                 return Ok(self.lower_heredoc_literal(
-                                    &tok.value,
-                                    span,
-                                    tok.line,
-                                    tok.column,
+                                    &tok.value, span, tok.line, tok.column,
                                 ));
                             }
                             // Phase 19d (FC) — `%r{...}` regex literal
@@ -8572,8 +8986,7 @@ impl Lowerer {
                             // so interpolation inside `%r{...}` is handled
                             // for free by the shared pattern splitter.
                             if let Some((pattern, flags)) = percent_r_pattern_flags(&tok.value) {
-                                let (pattern, flags) =
-                                    (pattern.to_string(), flags.to_string());
+                                let (pattern, flags) = (pattern.to_string(), flags.to_string());
                                 return self.lower_regex_literal(
                                     &pattern, &flags, span, tok.line, tok.column,
                                 );
@@ -8586,8 +8999,7 @@ impl Lowerer {
                             // strings like `/usr/bin` via the flag-letter
                             // check), splitting it into pattern + flags.
                             if let Some((pattern, flags)) = regex_pattern_flags(&tok.value) {
-                                let (pattern, flags) =
-                                    (pattern.to_string(), flags.to_string());
+                                let (pattern, flags) = (pattern.to_string(), flags.to_string());
                                 return self.lower_regex_literal(
                                     &pattern, &flags, span, tok.line, tok.column,
                                 );
@@ -8602,10 +9014,7 @@ impl Lowerer {
                             // when absent we fall through to a plain
                             // `StrLit` (zero-cost fast path).
                             return self.lower_string_literal_with_interp(
-                                &tok.value,
-                                span,
-                                tok.line,
-                                tok.column,
+                                &tok.value, span, tok.line, tok.column,
                             );
                         }
                         TokenType::Name => {
@@ -8617,9 +9026,7 @@ impl Lowerer {
                             // requests `Feature::Exceptions`.  A `raise`
                             // shadowed by a local binding (`raise = 1`)
                             // keeps the local.
-                            if tok.value == "raise"
-                                && !self.declared_locals.contains("raise")
-                            {
+                            if tok.value == "raise" && !self.declared_locals.contains("raise") {
                                 self.features_used.insert(Feature::Exceptions);
                                 return Ok(Expr::BuiltinCall {
                                     name: "raise".to_string(),
@@ -8652,8 +9059,7 @@ impl Lowerer {
                             // A `__FILE__` shadowed by a local binding
                             // (`__FILE__ = 1`) keeps the local, mirroring
                             // the `raise` shadow guard.
-                            if tok.value == "__FILE__"
-                                && !self.declared_locals.contains("__FILE__")
+                            if tok.value == "__FILE__" && !self.declared_locals.contains("__FILE__")
                             {
                                 self.features_used.insert(Feature::Strings);
                                 return Ok(Expr::StrLit {
@@ -8681,8 +9087,7 @@ impl Lowerer {
                             // A `__LINE__` shadowed by a local binding
                             // (`__LINE__ = 1`) keeps the local, mirroring
                             // the `__FILE__` / `raise` shadow guards.
-                            if tok.value == "__LINE__"
-                                && !self.declared_locals.contains("__LINE__")
+                            if tok.value == "__LINE__" && !self.declared_locals.contains("__LINE__")
                             {
                                 return Ok(Expr::IntLit {
                                     value: tok.line as i64,
@@ -8716,13 +9121,8 @@ impl Lowerer {
                             // sibling shadow guards.  Scope: the bare form;
                             // the explicit-call form `__dir__()` is a
                             // deliberate follow-up slice.
-                            if tok.value == "__dir__"
-                                && !self.declared_locals.contains("__dir__")
-                            {
-                                let dir = match self
-                                    .file_name
-                                    .rfind(|c| c == '/' || c == '\\')
-                                {
+                            if tok.value == "__dir__" && !self.declared_locals.contains("__dir__") {
+                                let dir = match self.file_name.rfind(|c| c == '/' || c == '\\') {
                                     Some(i) => self.file_name[..i].to_string(),
                                     None => ".".to_string(),
                                 };
@@ -8917,7 +9317,11 @@ impl Lowerer {
         let (rhs_name, rhs_span) = self.expect_first_name_token(sr_node)?;
         self.features_used.insert(Feature::Constants);
         match base {
-            Expr::VarRef { name, scope: Scope::Const, span } => Ok(Expr::VarRef {
+            Expr::VarRef {
+                name,
+                scope: Scope::Const,
+                span,
+            } => Ok(Expr::VarRef {
                 name: format!("{name}::{rhs_name}"),
                 scope: Scope::Const,
                 span,
@@ -8985,7 +9389,12 @@ impl Lowerer {
         // exactly as required, and a longer chain (`c.inc.inc`) nests the same
         // way.
         if method_name == "new" {
-            if let Expr::VarRef { name: class_name, scope: Scope::Const, .. } = &receiver {
+            if let Expr::VarRef {
+                name: class_name,
+                scope: Scope::Const,
+                ..
+            } = &receiver
+            {
                 self.features_used.insert(Feature::Classes);
                 self.features_used.insert(Feature::Strings);
                 let mut new_args: Vec<Expr> = Vec::with_capacity(args.len() + 1);
@@ -9017,7 +9426,12 @@ impl Lowerer {
         // `Foo.bar.baz`, this folds `.bar` into a `__class_method__` call and
         // `apply_dot_chain` then folds `.baz` with that call as the receiver of
         // an outer `__method__` — exactly the nesting `.new(...).meth` uses.
-        if let Expr::VarRef { name: class_name, scope: Scope::Const, .. } = &receiver {
+        if let Expr::VarRef {
+            name: class_name,
+            scope: Scope::Const,
+            ..
+        } = &receiver
+        {
             self.features_used.insert(Feature::Classes);
             self.features_used.insert(Feature::Strings);
             let mut cm_args: Vec<Expr> = Vec::with_capacity(args.len() + 2);
@@ -9164,9 +9578,7 @@ fn token_lexeme_for_op(t: TokenType) -> &'static str {
 /// will grow this as the lowering matures.
 fn ruby_builtin_effects(name: &str) -> Option<EffectSet> {
     match name {
-        "puts" | "print" | "p" => {
-            Some(EffectSet::PURE.with(Effect::MayPrint))
-        }
+        "puts" | "print" | "p" => Some(EffectSet::PURE.with(Effect::MayPrint)),
         "gets" => {
             // Reads from stdin — modelled as a blocking effect.  Not
             // strictly pure, but `MayBlock` is the closest tag we
@@ -9178,7 +9590,11 @@ fn ruby_builtin_effects(name: &str) -> Option<EffectSet> {
             // also throws — backends use both tags to suppress
             // unreachable-code warnings and to emit `throw`/`return`
             // shapes correctly.
-            Some(EffectSet::PURE.with(Effect::MayThrow).with(Effect::Divergent))
+            Some(
+                EffectSet::PURE
+                    .with(Effect::MayThrow)
+                    .with(Effect::Divergent),
+            )
         }
         // Phase 6g: block-taking iterators.  These all accept a
         // trailing block (closure) as their last argument and invoke
@@ -9194,15 +9610,11 @@ fn ruby_builtin_effects(name: &str) -> Option<EffectSet> {
         // builtins (PURE) gives downstream emitters a single
         // closure-construction shape — same as Phase 6w's arrow-lambda.
         "lambda" | "proc" => Some(EffectSet::PURE),
-        "each" | "map" | "select" | "reject" | "filter"
-        | "each_with_index" | "each_with_object" | "times"
-        | "tap" | "then" | "yield_self" | "loop"
-        | "collect" | "find" | "detect" | "any?" | "all?"
-        | "none?" | "count" | "reduce" | "inject" | "sort_by"
-        | "group_by" | "min_by" | "max_by" | "flat_map"
-        | "partition" | "each_slice" | "each_cons" => {
-            Some(EffectSet::PURE)
-        }
+        "each" | "map" | "select" | "reject" | "filter" | "each_with_index"
+        | "each_with_object" | "times" | "tap" | "then" | "yield_self" | "loop" | "collect"
+        | "find" | "detect" | "any?" | "all?" | "none?" | "count" | "reduce" | "inject"
+        | "sort_by" | "group_by" | "min_by" | "max_by" | "flat_map" | "partition"
+        | "each_slice" | "each_cons" => Some(EffectSet::PURE),
         // Phase 26a (FC) — `using Mod` activates a refinement module in
         // the current lexical scope.  It is an ordinary method call
         // (`using` is a `Kernel`/`Module` method, not a keyword), so it
@@ -9247,4 +9659,3 @@ impl RubyLowerError {
         self
     }
 }
-

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -18,9 +18,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use semantic_ir::{
-    Block, Expr, Function, Global, Module, ParamKind, Scope, Stmt,
-};
+use semantic_ir::{Block, Expr, Function, Global, Module, ParamKind, Scope, Stmt};
 // `RescueClause` is referenced by name in `emit_try_catch`'s signature.
 use semantic_ir::RescueClause;
 
@@ -63,7 +61,9 @@ pub fn emit_module(m: &Module) -> String {
     let mut out = String::new();
     emit_banner(&mut out, m);
     out.push_str("package main\n\n");
-    out.push_str("import (\n\t\"fmt\"\n\t\"math\"\n\t\"sort\"\n\t\"strconv\"\n\t\"strings\"\n)\n\n");
+    out.push_str(
+        "import (\n\t\"fmt\"\n\t\"math\"\n\t\"sort\"\n\t\"strconv\"\n\t\"strings\"\n)\n\n",
+    );
     // Suppress unused-import linter complaints if a tiny module
     // happens not to reference them (the runtime always does, so
     // we're fine — but blank-import the packages defensively in
@@ -149,7 +149,12 @@ fn emit_ancestry_init(out: &mut String, m: &Module) {
     edges.dedup();
     out.push_str("\t_sir_register_ancestry(map[string]string{\n");
     for (sub, sup) in &edges {
-        let _ = writeln!(out, "\t\t{}: {},", quote_go_string(sub), quote_go_string(sup));
+        let _ = writeln!(
+            out,
+            "\t\t{}: {},",
+            quote_go_string(sub),
+            quote_go_string(sup)
+        );
     }
     out.push_str("\t})\n");
 }
@@ -162,7 +167,12 @@ fn collect_ancestry_edges_in_block(b: &Block, edges: &mut Vec<(String, String)>)
 
 fn collect_ancestry_edges_in_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
     match s {
-        Stmt::ClassDef { name, superclass, body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
             if let Some(sup) = superclass {
                 edges.push((name.clone(), sup.clone()));
             }
@@ -175,7 +185,12 @@ fn collect_ancestry_edges_in_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
                 collect_ancestry_edges_in_stmt(st, edges);
             }
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             for st in body {
                 collect_ancestry_edges_in_stmt(st, edges);
             }
@@ -202,7 +217,11 @@ fn collect_ancestry_edges_in_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
 // ---------------------------------------------------------------------------
 
 fn emit_function(out: &mut String, f: &Function) {
-    let _ = writeln!(out, "// SIR span: {}", sanitize_comment(&f.span.to_string()));
+    let _ = writeln!(
+        out,
+        "// SIR span: {}",
+        sanitize_comment(&f.span.to_string())
+    );
     let _ = write!(out, "func {}(", function_emit_name(&f.name));
 
     let mut first = true;
@@ -338,7 +357,12 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push('\n');
         }
-        Stmt::Assign { name, scope: Scope::Global, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Global,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}_sir_globals[{}] = ", pad, quote_go_string(name));
             emit_expr(out, value, indent);
             out.push('\n');
@@ -348,28 +372,45 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // class variable.  The full sigil name is the runtime key.  The
         // helper returns the value; we discard it (`_ = …`) in statement
         // position.
-        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Instance,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}_ = _sir_ivar_set({}, ", pad, quote_go_string(name));
             emit_expr(out, value, indent);
             out.push_str(")\n");
         }
-        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::ClassVar,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}_ = _sir_cvar_set({}, ", pad, quote_go_string(name));
             emit_expr(out, value, indent);
             out.push_str(")\n");
         }
         // ── SIR16 loops (Loops) ─────────────────────────────────────
         Stmt::While { cond, body, .. } => emit_while(out, cond, body, indent),
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
-            emit_for_range(out, var, start, stop, step, body, indent)
-        }
-        Stmt::ForEach { var, iter, body, .. } => {
-            emit_for_each(out, var, iter, body, indent)
-        }
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => emit_for_range(out, var, start, stop, step, body, indent),
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => emit_for_each(out, var, iter, body, indent),
         // ── SIR16 indexed assignment (Sequences/Maps) ───────────────
         // `seq[index] = value` mutates the shared backing slice in place
         // via `_sir_seq_set`; the returned value is discarded (`_ = …`).
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             let _ = write!(out, "{}_ = _sir_seq_set(", pad);
             emit_expr(out, seq, indent);
             out.push_str(", ");
@@ -379,7 +420,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             out.push_str(")\n");
         }
         // `map[key] = value` inserts/overwrites via `_sir_map_set`.
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             let _ = write!(out, "{}_ = _sir_map_set(", pad);
             emit_expr(out, map, indent);
             out.push_str(", ");
@@ -462,8 +505,21 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // that re-panic still unwinds through the already-registered ensure
         // defer, so `ensure` runs on the propagating path too.  On the normal
         // (no-raise) path recover returns nil and only ensure's body runs.
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             emit_try_catch(out, body, rescues, ensure_body.as_deref(), indent);
+        }
+        // ── SIR22 (array/matrix IR) ──────────────────────────────────
+        // `IndexSet` observes `Feature::NDArrays`/`Feature::MatrixOps`,
+        // neither of which `ACCEPTED_FEATURES` declares, so the capability
+        // gate rejects any module using it before emit is ever reached.
+        // Mirrors the `Stmt::Assign` unsupported-scope panic above.
+        Stmt::IndexSet { span, .. } => {
+            panic!("go backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet", span);
         }
     }
 }
@@ -509,13 +565,22 @@ fn emit_try_catch(
             if i == 0 {
                 let _ = writeln!(out, "{}if _sir_rescue_matches(r, {}) {{", cpad, types);
             } else {
-                let _ = writeln!(out, "{}}} else if _sir_rescue_matches(r, {}) {{", cpad, types);
+                let _ = writeln!(
+                    out,
+                    "{}}} else if _sir_rescue_matches(r, {}) {{",
+                    cpad, types
+                );
             }
             // `rescue Foo => e` binds the caught value; only emit the
             // binding when the clause names one (avoids an unused `e`).
             if let Some(bind) = &r.binding {
                 let safe = sanitize_ident(bind);
-                let _ = writeln!(out, "{}{} := _sir_exc_value(r)", indent_str(inner + 3), safe);
+                let _ = writeln!(
+                    out,
+                    "{}{} := _sir_exc_value(r)",
+                    indent_str(inner + 3),
+                    safe
+                );
                 let _ = writeln!(out, "{}_ = {}", indent_str(inner + 3), safe);
             }
             emit_stmt_list(out, &r.body, inner + 3);
@@ -581,7 +646,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             let _ = write!(out, "Value({})", quote_go_string(value));
         }
         Expr::VarRef { name, scope, .. } => emit_var_ref(out, name, *scope),
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             // Go has no expression-position `if`; lift to an IIFE.
             out.push_str("func() Value {\n");
             let pad = indent_str(indent + 1);
@@ -610,7 +680,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str("})");
         }
         Expr::BuiltinCall { name, args, .. } => emit_builtin_call(out, name, args, indent),
-        Expr::MakeClosure { fn_name, captures, .. } => {
+        Expr::MakeClosure {
+            fn_name, captures, ..
+        } => {
             // _sir_make_closure is `(fn func([]Value) Value,
             // captures []Value) Value`.  The runtime helper builds
             // a Closure whose `Fn` prepends `captures` to the
@@ -751,6 +823,26 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // on the deferred indirect path, with a message that says so.
         Expr::KeywordArg { span, .. } => {
             panic!("go backend reached a keyword argument outside a DirectCall at {} — indirect/closure keyword calls are deferred for the Go backend (KW6, spec §Out of scope); frontends do not emit them", span);
+        }
+        // ── SIR22 (array/matrix IR) ──────────────────────────────────
+        // `ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`
+        // all observe `Feature::NDArrays` and/or `Feature::MatrixOps`,
+        // neither of which `ACCEPTED_FEATURES` declares, so the SIR10
+        // capability gate (`Backend::check_module`) rejects any module
+        // using one of these nodes before it ever reaches emit.  Mirrors
+        // the `Expr::StrConcat`/`Expr::KeywordArg` deferred-node panics
+        // above.
+        Expr::ArrayLit { .. }
+        | Expr::Range { .. }
+        | Expr::MatMul { .. }
+        | Expr::ElementwiseOp { .. }
+        | Expr::Transpose { .. }
+        | Expr::IndexGet { .. } => {
+            panic!(
+                "go backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                e.span()
+            );
         }
     }
 }
@@ -893,8 +985,9 @@ fn emit_direct_call(out: &mut String, fn_name: &str, args: &[Expr], indent: usiz
         if slot < positionals.len() {
             // A leading positional argument fills this slot.
             emit_expr(out, positionals[slot], indent);
-        } else if let Some((_, value)) =
-            keyword_args.iter().find(|(kw_name, _)| *kw_name == shape.name)
+        } else if let Some((_, value)) = keyword_args
+            .iter()
+            .find(|(kw_name, _)| *kw_name == shape.name)
         {
             // A `KeywordArg` names this param — resolved by name, not position.
             emit_expr(out, value, indent);
@@ -981,16 +1074,17 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             // `Integer`); there is no runtime binding for a built-in class
             // name, so pass it as its name STRING — matching how the
             // Python/TS backends feed the predicate.
-            let is_class_pred =
-                matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
+            let is_class_pred = matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
             for (i, a) in args[2..].iter().enumerate() {
                 if i > 0 {
                     out.push_str(", ");
                 }
                 match a {
-                    Expr::VarRef { name: cn, scope: Scope::Const, .. }
-                        if is_class_pred && i == 0 =>
-                    {
+                    Expr::VarRef {
+                        name: cn,
+                        scope: Scope::Const,
+                        ..
+                    } if is_class_pred && i == 0 => {
                         let _ = write!(out, "Value({})", quote_go_string(cn));
                     }
                     // A `&:sym` / `&proc` block argument on the dispatched
@@ -1049,9 +1143,18 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         if let (Expr::StrLit { value: cls, .. }, Expr::StrLit { value: meth, .. }) =
             (&args[0], &args[1])
         {
-            let helper =
-                if name == "__def_method__" { "_sir_def_method" } else { "_sir_def_class_method" };
-            let _ = write!(out, "{}({}, {}, ", helper, quote_go_string(cls), quote_go_string(meth));
+            let helper = if name == "__def_method__" {
+                "_sir_def_method"
+            } else {
+                "_sir_def_class_method"
+            };
+            let _ = write!(
+                out,
+                "{}({}, {}, ",
+                helper,
+                quote_go_string(cls),
+                quote_go_string(meth)
+            );
             emit_expr(out, &args[2], indent);
             out.push(')');
             return;
@@ -1077,7 +1180,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         if let (Expr::StrLit { value: owner, .. }, Expr::StrLit { value: module, .. }) =
             (&args[0], &args[1])
         {
-            let helper = if name == "__include__" { "_sir_include" } else { "_sir_extend" };
+            let helper = if name == "__include__" {
+                "_sir_include"
+            } else {
+                "_sir_extend"
+            };
             let _ = write!(
                 out,
                 "{}({}, {})",
@@ -1128,8 +1235,16 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             None => {
                 out.push_str("func() Value { panic(_sir_new_error(\"RuntimeError\", nil)) }()");
             }
-            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
-                let _ = write!(out, "func() Value {{ panic(_sir_new_error({}, ", quote_go_string(cn));
+            Some(Expr::VarRef {
+                name: cn,
+                scope: Scope::Const,
+                ..
+            }) => {
+                let _ = write!(
+                    out,
+                    "func() Value {{ panic(_sir_new_error({}, ",
+                    quote_go_string(cn)
+                );
                 match args.get(1) {
                     Some(msg) => emit_expr(out, msg, indent),
                     None => out.push_str("nil"),
@@ -1213,7 +1328,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             return;
         }
         _ => {
-            let _ = write!(out, "_sir_call_builtin_by_name({}, []Value{{", quote_go_string(name));
+            let _ = write!(
+                out,
+                "_sir_call_builtin_by_name({}, []Value{{",
+                quote_go_string(name)
+            );
             emit_args(out, args, indent);
             out.push_str("})");
             return;
@@ -1493,11 +1612,31 @@ fn is_valid_go_ident(s: &str) -> bool {
 fn is_go_keyword(s: &str) -> bool {
     matches!(
         s,
-        "break" | "case" | "chan" | "const" | "continue" | "default"
-            | "defer" | "else" | "fallthrough" | "for" | "func"
-            | "go" | "goto" | "if" | "import" | "interface"
-            | "map" | "package" | "range" | "return" | "select"
-            | "struct" | "switch" | "type" | "var"
+        "break"
+            | "case"
+            | "chan"
+            | "const"
+            | "continue"
+            | "default"
+            | "defer"
+            | "else"
+            | "fallthrough"
+            | "for"
+            | "func"
+            | "go"
+            | "goto"
+            | "if"
+            | "import"
+            | "interface"
+            | "map"
+            | "package"
+            | "range"
+            | "return"
+            | "select"
+            | "struct"
+            | "switch"
+            | "type"
+            | "var"
     )
 }
 
@@ -1506,14 +1645,45 @@ fn is_go_keyword(s: &str) -> bool {
 fn is_go_builtin(s: &str) -> bool {
     matches!(
         s,
-        "bool" | "byte" | "complex64" | "complex128" | "error"
-            | "float32" | "float64" | "int" | "int8" | "int16"
-            | "int32" | "int64" | "rune" | "string" | "uint"
-            | "uint8" | "uint16" | "uint32" | "uint64" | "uintptr"
-            | "true" | "false" | "iota" | "nil"
-            | "append" | "cap" | "close" | "complex" | "copy"
-            | "delete" | "imag" | "len" | "make" | "new" | "panic"
-            | "print" | "println" | "real" | "recover"
+        "bool"
+            | "byte"
+            | "complex64"
+            | "complex128"
+            | "error"
+            | "float32"
+            | "float64"
+            | "int"
+            | "int8"
+            | "int16"
+            | "int32"
+            | "int64"
+            | "rune"
+            | "string"
+            | "uint"
+            | "uint8"
+            | "uint16"
+            | "uint32"
+            | "uint64"
+            | "uintptr"
+            | "true"
+            | "false"
+            | "iota"
+            | "nil"
+            | "append"
+            | "cap"
+            | "close"
+            | "complex"
+            | "copy"
+            | "delete"
+            | "imag"
+            | "len"
+            | "make"
+            | "new"
+            | "panic"
+            | "print"
+            | "println"
+            | "real"
+            | "recover"
     )
 }
 
@@ -1551,9 +1721,7 @@ fn quote_go_string(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{
-        EffectSet, Feature, FeatureManifest, Metadata, Param, ParamKind, Span,
-    };
+    use semantic_ir::{EffectSet, Feature, FeatureManifest, Metadata, Param, ParamKind, Span};
 
     fn s() -> Span {
         Span::synthetic()
@@ -1599,7 +1767,14 @@ mod tests {
     #[test]
     fn emit_int_literal() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::IntLit { value: 42, span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::IntLit {
+                value: 42,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "Value(int64(42))");
     }
 
@@ -1608,8 +1783,22 @@ mod tests {
         let mut a = String::new();
         let mut b = String::new();
         let mut c = String::new();
-        emit_expr(&mut a, &Expr::BoolLit { value: true, span: s() }, 0);
-        emit_expr(&mut b, &Expr::BoolLit { value: false, span: s() }, 0);
+        emit_expr(
+            &mut a,
+            &Expr::BoolLit {
+                value: true,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut b,
+            &Expr::BoolLit {
+                value: false,
+                span: s(),
+            },
+            0,
+        );
         emit_expr(&mut c, &Expr::NilLit { span: s() }, 0);
         assert_eq!(a, "Value(true)");
         assert_eq!(b, "Value(false)");
@@ -1621,7 +1810,14 @@ mod tests {
         // Integral floats must render with `.0` so the Go literal is a
         // float64, never an int.
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::FloatLit { value: 3.0, span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::FloatLit {
+                value: 3.0,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "Value(float64(3.0))");
     }
 
@@ -1629,8 +1825,22 @@ mod tests {
     fn emit_float_literal_fractional_and_negative() {
         let mut a = String::new();
         let mut b = String::new();
-        emit_expr(&mut a, &Expr::FloatLit { value: 3.25, span: s() }, 0);
-        emit_expr(&mut b, &Expr::FloatLit { value: -7.5, span: s() }, 0);
+        emit_expr(
+            &mut a,
+            &Expr::FloatLit {
+                value: 3.25,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut b,
+            &Expr::FloatLit {
+                value: -7.5,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(a, "Value(float64(3.25))");
         assert_eq!(b, "Value(float64(-7.5))");
     }
@@ -1640,9 +1850,30 @@ mod tests {
         let mut nan = String::new();
         let mut inf = String::new();
         let mut ninf = String::new();
-        emit_expr(&mut nan, &Expr::FloatLit { value: f64::NAN, span: s() }, 0);
-        emit_expr(&mut inf, &Expr::FloatLit { value: f64::INFINITY, span: s() }, 0);
-        emit_expr(&mut ninf, &Expr::FloatLit { value: f64::NEG_INFINITY, span: s() }, 0);
+        emit_expr(
+            &mut nan,
+            &Expr::FloatLit {
+                value: f64::NAN,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut inf,
+            &Expr::FloatLit {
+                value: f64::INFINITY,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut ninf,
+            &Expr::FloatLit {
+                value: f64::NEG_INFINITY,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(nan, "Value(math.NaN())");
         assert_eq!(inf, "Value(math.Inf(1))");
         assert_eq!(ninf, "Value(math.Inf(-1))");
@@ -1654,8 +1885,14 @@ mod tests {
         emit_expr(
             &mut out,
             &Expr::LogicalAnd {
-                lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
-                rhs: Box::new(Expr::IntLit { value: 5, span: s() }),
+                lhs: Box::new(Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -1679,8 +1916,14 @@ mod tests {
             &Expr::BuiltinCall {
                 name: "and".into(),
                 args: vec![
-                    Expr::BoolLit { value: true, span: s() },
-                    Expr::IntLit { value: 5, span: s() },
+                    Expr::BoolLit {
+                        value: true,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 5,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -1697,8 +1940,14 @@ mod tests {
             &Expr::BuiltinCall {
                 name: "or".into(),
                 args: vec![
-                    Expr::BoolLit { value: false, span: s() },
-                    Expr::IntLit { value: 7, span: s() },
+                    Expr::BoolLit {
+                        value: false,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 7,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -1718,8 +1967,14 @@ mod tests {
         emit_expr(
             &mut out,
             &Expr::LogicalOr {
-                lhs: Box::new(Expr::BoolLit { value: false, span: s() }),
-                rhs: Box::new(Expr::IntLit { value: 7, span: s() }),
+                lhs: Box::new(Expr::BoolLit {
+                    value: false,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 7,
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -1739,11 +1994,20 @@ mod tests {
             &mut out,
             &Expr::LogicalOr {
                 lhs: Box::new(Expr::LogicalAnd {
-                    lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
-                    rhs: Box::new(Expr::IntLit { value: 1, span: s() }),
+                    lhs: Box::new(Expr::BoolLit {
+                        value: true,
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    }),
                     span: s(),
                 }),
-                rhs: Box::new(Expr::IntLit { value: 2, span: s() }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -1755,11 +2019,18 @@ mod tests {
     // ── SIR16 MutableBindings + Loops ──────────────────────────────
 
     fn ilit(v: i64) -> Expr {
-        Expr::IntLit { value: v, span: s() }
+        Expr::IntLit {
+            value: v,
+            span: s(),
+        }
     }
 
     fn nil_block() -> Block {
-        Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() }
+        Block {
+            stmts: vec![],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        }
     }
 
     #[test]
@@ -1802,13 +2073,19 @@ mod tests {
         emit_stmt(
             &mut out,
             &Stmt::While {
-                cond: Expr::BoolLit { value: true, span: s() },
+                cond: Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                },
                 body: nil_block(),
                 span: s(),
             },
             1,
         );
-        assert!(out.starts_with("\tfor _sir_truthy(Value(true)) {\n"), "got: {out}");
+        assert!(
+            out.starts_with("\tfor _sir_truthy(Value(true)) {\n"),
+            "got: {out}"
+        );
         // A nil block value emits no dangling `_ = nil`.
         assert!(!out.contains("_ = Value(nil)"), "got: {out}");
         assert!(out.trim_end().ends_with('}'));
@@ -1832,8 +2109,14 @@ mod tests {
             1,
         );
         // Bounds cached into temps once.
-        assert!(out.contains("__sir_stop_0 := _sir_as_int(Value(int64(5)))"), "got: {out}");
-        assert!(out.contains("__sir_step_0 := _sir_as_int(Value(int64(1)))"), "got: {out}");
+        assert!(
+            out.contains("__sir_stop_0 := _sir_as_int(Value(int64(5)))"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("__sir_step_0 := _sir_as_int(Value(int64(1)))"),
+            "got: {out}"
+        );
         // Native three-clause for with direction-aware continue test.
         assert!(
             out.contains("for __sir_i_0 := _sir_as_int(Value(int64(0))); _sir_range_cont(__sir_i_0, __sir_stop_0, __sir_step_0); __sir_i_0 += __sir_step_0 {"),
@@ -1875,7 +2158,10 @@ mod tests {
             },
             1,
         );
-        assert!(out.contains("for _, x := range _sir_seq_iter(Value(nil)) {"), "got: {out}");
+        assert!(
+            out.contains("for _, x := range _sir_seq_iter(Value(nil)) {"),
+            "got: {out}"
+        );
         assert!(out.contains("_ = x"), "got: {out}");
     }
 
@@ -1887,8 +2173,15 @@ mod tests {
         emit_stmt(
             &mut out,
             &Stmt::While {
-                cond: Expr::BoolLit { value: false, span: s() },
-                body: Block { stmts: vec![], value: ilit(9), span: s() },
+                cond: Expr::BoolLit {
+                    value: false,
+                    span: s(),
+                },
+                body: Block {
+                    stmts: vec![],
+                    value: ilit(9),
+                    span: s(),
+                },
                 span: s(),
             },
             1,
@@ -1903,7 +2196,10 @@ mod tests {
         let mut out = String::new();
         emit_expr(
             &mut out,
-            &Expr::SeqLit { items: vec![ilit(1), ilit(2), ilit(3)], span: s() },
+            &Expr::SeqLit {
+                items: vec![ilit(1), ilit(2), ilit(3)],
+                span: s(),
+            },
             0,
         );
         assert_eq!(
@@ -1915,7 +2211,14 @@ mod tests {
     #[test]
     fn emit_empty_seq_lit() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::SeqLit { items: vec![], span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::SeqLit {
+                items: vec![],
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "_sir_seq_lit([]Value{})");
     }
 
@@ -1939,7 +2242,10 @@ mod tests {
         let mut out = String::new();
         emit_expr(
             &mut out,
-            &Expr::SeqLen { seq: Box::new(var_local("xs")), span: s() },
+            &Expr::SeqLen {
+                seq: Box::new(var_local("xs")),
+                span: s(),
+            },
             0,
         );
         assert_eq!(out, "_sir_seq_len(xs)");
@@ -1955,11 +2261,17 @@ mod tests {
             &Expr::MapLit {
                 entries: vec![
                     semantic_ir::nodes::MapEntry {
-                        key: Expr::StrLit { value: "a".into(), span: s() },
+                        key: Expr::StrLit {
+                            value: "a".into(),
+                            span: s(),
+                        },
                         value: ilit(1),
                     },
                     semantic_ir::nodes::MapEntry {
-                        key: Expr::StrLit { value: "b".into(), span: s() },
+                        key: Expr::StrLit {
+                            value: "b".into(),
+                            span: s(),
+                        },
                         value: ilit(2),
                     },
                 ],
@@ -1976,7 +2288,14 @@ mod tests {
     #[test]
     fn emit_empty_map_lit() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::MapLit { entries: vec![], span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::MapLit {
+                entries: vec![],
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "_sir_map_lit([]Value{}, []Value{})");
     }
 
@@ -1987,7 +2306,10 @@ mod tests {
             &mut out,
             &Expr::MapGet {
                 map: Box::new(var_local("d")),
-                key: Box::new(Expr::StrLit { value: "k".into(), span: s() }),
+                key: Box::new(Expr::StrLit {
+                    value: "k".into(),
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -2008,7 +2330,10 @@ mod tests {
             },
             1,
         );
-        assert_eq!(out, "\t_ = _sir_seq_set(xs, Value(int64(0)), Value(int64(9)))\n");
+        assert_eq!(
+            out,
+            "\t_ = _sir_seq_set(xs, Value(int64(0)), Value(int64(9)))\n"
+        );
     }
 
     #[test]
@@ -2018,17 +2343,27 @@ mod tests {
             &mut out,
             &Stmt::MapSet {
                 map: var_local("d"),
-                key: Expr::StrLit { value: "k".into(), span: s() },
+                key: Expr::StrLit {
+                    value: "k".into(),
+                    span: s(),
+                },
                 value: ilit(1),
                 span: s(),
             },
             1,
         );
-        assert_eq!(out, "\t_ = _sir_map_set(d, Value(\"k\"), Value(int64(1)))\n");
+        assert_eq!(
+            out,
+            "\t_ = _sir_map_set(d, Value(\"k\"), Value(int64(1)))\n"
+        );
     }
 
     fn var_local(name: &str) -> Expr {
-        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+        Expr::VarRef {
+            name: name.into(),
+            scope: Scope::Local,
+            span: s(),
+        }
     }
 
     #[test]
@@ -2044,7 +2379,13 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() }],
+            params: vec![Param {
+                name: "x".into(),
+                kind: ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            }],
             return_type: None,
             captures: vec![],
             body,
@@ -2066,8 +2407,15 @@ mod tests {
         let plus = Expr::BuiltinCall {
             name: "+".into(),
             args: vec![
-                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                Expr::IntLit { value: 1, span: s() },
+                Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2075,8 +2423,20 @@ mod tests {
         Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
-                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: Some(Box::new(plus)), span: s() },
+                Param {
+                    name: "a".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "b".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: Some(Box::new(plus)),
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
@@ -2085,8 +2445,16 @@ mod tests {
                 value: Expr::BuiltinCall {
                     name: "+".into(),
                     args: vec![
-                        Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                        Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                        Expr::VarRef {
+                            name: "a".into(),
+                            scope: Scope::Param,
+                            span: s(),
+                        },
+                        Expr::VarRef {
+                            name: "b".into(),
+                            scope: Scope::Param,
+                            span: s(),
+                        },
                     ],
                     effects: EffectSet::PURE,
                     span: s(),
@@ -2108,7 +2476,10 @@ mod tests {
         emit_function(&mut out, &defaulted_fn());
         assert!(out.contains("func f(a Value, b Value) Value"), "got: {out}");
         assert!(out.contains("if _sir_is_missing(b) {"), "got: {out}");
-        assert!(out.contains("b = _sir_plus([]Value{a, Value(int64(1))})"), "got: {out}");
+        assert!(
+            out.contains("b = _sir_plus([]Value{a, Value(int64(1))})"),
+            "got: {out}"
+        );
         // `a` is required — no guard for it.
         assert!(!out.contains("_sir_is_missing(a)"), "got: {out}");
     }
@@ -2153,9 +2524,7 @@ mod tests {
         };
         let m = Module {
             name: "demo".into(),
-            manifest: FeatureManifest::from_features(&[
-                semantic_ir::Feature::DefaultParams,
-            ]),
+            manifest: FeatureManifest::from_features(&[semantic_ir::Feature::DefaultParams]),
             imports: vec![],
             exports: vec![],
             functions: vec![defaulted_fn(), main],
@@ -2167,9 +2536,15 @@ mod tests {
         };
         let out = emit_module(&m);
         // `f(5)` pads the one omitted trailing arg with the sentinel.
-        assert!(out.contains("f(Value(int64(5)), _sir_missing)"), "got: {out}");
+        assert!(
+            out.contains("f(Value(int64(5)), _sir_missing)"),
+            "got: {out}"
+        );
         // `f(5, 10)` is full-arity — no padding.
-        assert!(out.contains("f(Value(int64(5)), Value(int64(10)))"), "got: {out}");
+        assert!(
+            out.contains("f(Value(int64(5)), Value(int64(10)))"),
+            "got: {out}"
+        );
     }
 
     // ── KW6 keyword parameters & arguments ─────────────────────────
@@ -2181,11 +2556,18 @@ mod tests {
     // (`compile_and_run_keyword_params.rs`) exercises both params.
 
     fn strlit(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     fn kwarg(name: &str, value: Expr) -> Expr {
-        Expr::KeywordArg { name: name.into(), value: Box::new(value), span: s() }
+        Expr::KeywordArg {
+            name: name.into(),
+            value: Box::new(value),
+            span: s(),
+        }
     }
 
     fn greet_fn() -> Function {
@@ -2211,7 +2593,11 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "name".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "name".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -2302,14 +2688,23 @@ mod tests {
         // confirm the emitted positional call restores declared order.
         let m = greet_module(
             // greet(name: "ada", greeting: "hi")  — reversed source order
-            vec![kwarg("name", strlit("ada")), kwarg("greeting", strlit("hi"))],
+            vec![
+                kwarg("name", strlit("ada")),
+                kwarg("greeting", strlit("hi")),
+            ],
             // greet(greeting: "hi", name: "ada")  — declared source order
-            vec![kwarg("greeting", strlit("hi")), kwarg("name", strlit("ada"))],
+            vec![
+                kwarg("greeting", strlit("hi")),
+                kwarg("name", strlit("ada")),
+            ],
         );
         let out = emit_module(&m);
         // Both calls must emit `greet("hi", "ada")` — greeting first, then name.
         let occurrences = out.matches("greet(Value(\"hi\"), Value(\"ada\"))").count();
-        assert_eq!(occurrences, 2, "expected both calls reordered to declared order; got: {out}");
+        assert_eq!(
+            occurrences, 2,
+            "expected both calls reordered to declared order; got: {out}"
+        );
     }
 
     #[test]
@@ -2321,7 +2716,10 @@ mod tests {
             // greet(greeting: "hi")               — name omitted
             vec![kwarg("greeting", strlit("hi"))],
             // greet(greeting: "hi", name: "ada")  — name supplied
-            vec![kwarg("greeting", strlit("hi")), kwarg("name", strlit("ada"))],
+            vec![
+                kwarg("greeting", strlit("hi")),
+                kwarg("name", strlit("ada")),
+            ],
         );
         let out = emit_module(&m);
         // Omitted optional → sentinel in the name slot.
@@ -2371,7 +2769,10 @@ mod tests {
                 captures: vec![],
                 body: Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
                 effects: EffectSet::PURE,
@@ -2398,9 +2799,20 @@ mod tests {
     // ── C5: collection-method dispatch emission ────────────────────
 
     fn method_call(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
-        let mut args = vec![recv, Expr::StrLit { value: name.into(), span: s() }];
+        let mut args = vec![
+            recv,
+            Expr::StrLit {
+                value: name.into(),
+                span: s(),
+            },
+        ];
         args.extend(extra);
-        Expr::BuiltinCall { name: "__method__".into(), args, effects: EffectSet::PURE, span: s() }
+        Expr::BuiltinCall {
+            name: "__method__".into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
     }
 
     #[test]
@@ -2408,9 +2820,18 @@ mod tests {
         // `[1,2,3].length` → `_sir_call_method(<seq>, "length", []Value{})`.
         let recv = Expr::SeqLit {
             items: vec![
-                Expr::IntLit { value: 1, span: s() },
-                Expr::IntLit { value: 2, span: s() },
-                Expr::IntLit { value: 3, span: s() },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 3,
+                    span: s(),
+                },
             ],
             span: s(),
         };
@@ -2420,20 +2841,37 @@ mod tests {
             out.starts_with("_sir_call_method(_sir_seq_lit("),
             "unexpected emit: {out}"
         );
-        assert!(out.contains(r#", "length", []Value{}"#), "unexpected emit: {out}");
+        assert!(
+            out.contains(r#", "length", []Value{}"#),
+            "unexpected emit: {out}"
+        );
     }
 
     #[test]
     fn method_dispatch_with_arg_emits_arg_in_slice() {
         // `xs.push(4)` → the arg rides inside the []Value slice.
-        let recv = Expr::VarRef { name: "xs".into(), scope: Scope::Local, span: s() };
+        let recv = Expr::VarRef {
+            name: "xs".into(),
+            scope: Scope::Local,
+            span: s(),
+        };
         let mut out = String::new();
         emit_expr(
             &mut out,
-            &method_call(recv, "push", vec![Expr::IntLit { value: 4, span: s() }]),
+            &method_call(
+                recv,
+                "push",
+                vec![Expr::IntLit {
+                    value: 4,
+                    span: s(),
+                }],
+            ),
             0,
         );
-        assert_eq!(out, r#"_sir_call_method(xs, "push", []Value{Value(int64(4))})"#);
+        assert_eq!(
+            out,
+            r#"_sir_call_method(xs, "push", []Value{Value(int64(4))})"#
+        );
     }
 
     #[test]
@@ -2441,8 +2879,16 @@ mod tests {
         // `xs.map { |x| x }` — the block is a MakeClosure; it must land as
         // the trailing element of the []Value args so the runtime peels it.
         FN_ARITY.with(|t| t.borrow_mut().insert("__lam".into(), 1));
-        let recv = Expr::VarRef { name: "xs".into(), scope: Scope::Local, span: s() };
-        let block = Expr::MakeClosure { fn_name: "__lam".into(), captures: vec![], span: s() };
+        let recv = Expr::VarRef {
+            name: "xs".into(),
+            scope: Scope::Local,
+            span: s(),
+        };
+        let block = Expr::MakeClosure {
+            fn_name: "__lam".into(),
+            captures: vec![],
+            span: s(),
+        };
         let mut out = String::new();
         emit_expr(&mut out, &method_call(recv, "map", vec![block]), 0);
         FN_ARITY.with(|t| t.borrow_mut().clear());
@@ -2453,10 +2899,17 @@ mod tests {
     fn method_dispatch_sym_block_pass_emits_sym_to_proc() {
         // `xs.map(&:to_s)` — block_pass(SymLit) survives to the dispatch and
         // must convert via `_sir_sym_to_proc`.
-        let recv = Expr::VarRef { name: "xs".into(), scope: Scope::Local, span: s() };
+        let recv = Expr::VarRef {
+            name: "xs".into(),
+            scope: Scope::Local,
+            span: s(),
+        };
         let bp = Expr::BuiltinCall {
             name: "block_pass".into(),
-            args: vec![Expr::SymLit { name: "to_s".into(), span: s() }],
+            args: vec![Expr::SymLit {
+                name: "to_s".into(),
+                span: s(),
+            }],
             effects: EffectSet::PURE,
             span: s(),
         };
@@ -2471,18 +2924,31 @@ mod tests {
     #[test]
     fn method_dispatch_class_predicate_passes_const_as_name_string() {
         // `x.is_a?(Integer)` — the Const class operand becomes a name string.
-        let recv = Expr::VarRef { name: "x".into(), scope: Scope::Local, span: s() };
-        let cls = Expr::VarRef { name: "Integer".into(), scope: Scope::Const, span: s() };
+        let recv = Expr::VarRef {
+            name: "x".into(),
+            scope: Scope::Local,
+            span: s(),
+        };
+        let cls = Expr::VarRef {
+            name: "Integer".into(),
+            scope: Scope::Const,
+            span: s(),
+        };
         let mut out = String::new();
         emit_expr(&mut out, &method_call(recv, "is_a?", vec![cls]), 0);
-        assert_eq!(out, r#"_sir_call_method(x, "is_a?", []Value{Value("Integer")})"#);
+        assert_eq!(
+            out,
+            r#"_sir_call_method(x, "is_a?", []Value{Value("Integer")})"#
+        );
     }
 
     #[test]
     fn runtime_preamble_carries_catalog() {
         // The dispatch helper + catalog entry points must be present in the
         // inlined runtime of every emitted program.
-        assert!(RUNTIME.contains("func _sir_call_method(recv Value, name string, args []Value) Value"));
+        assert!(
+            RUNTIME.contains("func _sir_call_method(recv Value, name string, args []Value) Value")
+        );
         assert!(RUNTIME.contains("func _sir_sym_to_proc(sym Value) Value"));
         assert!(RUNTIME.contains("func _sir_array_method("));
         assert!(RUNTIME.contains("func _sir_hash_method("));
@@ -2500,8 +2966,15 @@ mod tests {
         let raise = Expr::BuiltinCall {
             name: "raise".into(),
             args: vec![
-                Expr::VarRef { name: "ArgumentError".into(), scope: Scope::Const, span: s() },
-                Expr::StrLit { value: "bad".into(), span: s() },
+                Expr::VarRef {
+                    name: "ArgumentError".into(),
+                    scope: Scope::Const,
+                    span: s(),
+                },
+                Expr::StrLit {
+                    value: "bad".into(),
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2529,7 +3002,10 @@ mod tests {
         };
         let mut out = String::new();
         emit_expr(&mut out, &raise, 0);
-        assert_eq!(out, r#"func() Value { panic(_sir_new_error("MyErr", nil)) }()"#);
+        assert_eq!(
+            out,
+            r#"func() Value { panic(_sir_new_error("MyErr", nil)) }()"#
+        );
     }
 
     /// `raise "boom"` (non-const first arg) → implicit `RuntimeError`.
@@ -2537,13 +3013,19 @@ mod tests {
     fn emit_raise_bare_string_is_runtime_error() {
         let raise = Expr::BuiltinCall {
             name: "raise".into(),
-            args: vec![Expr::StrLit { value: "boom".into(), span: s() }],
+            args: vec![Expr::StrLit {
+                value: "boom".into(),
+                span: s(),
+            }],
             effects: EffectSet::PURE,
             span: s(),
         };
         let mut out = String::new();
         emit_expr(&mut out, &raise, 0);
-        assert_eq!(out, r#"func() Value { panic(_sir_new_error("RuntimeError", Value("boom"))) }()"#);
+        assert_eq!(
+            out,
+            r#"func() Value { panic(_sir_new_error("RuntimeError", Value("boom"))) }()"#
+        );
     }
 
     /// Bare `raise` (no args) → a generic `RuntimeError`.
@@ -2557,7 +3039,10 @@ mod tests {
         };
         let mut out = String::new();
         emit_expr(&mut out, &raise, 0);
-        assert_eq!(out, r#"func() Value { panic(_sir_new_error("RuntimeError", nil)) }()"#);
+        assert_eq!(
+            out,
+            r#"func() Value { panic(_sir_new_error("RuntimeError", nil)) }()"#
+        );
     }
 
     /// `puts` routes to the variadic `_sir_puts` runtime helper (same
@@ -2568,7 +3053,10 @@ mod tests {
         // Single arg.
         let puts1 = Expr::BuiltinCall {
             name: "puts".into(),
-            args: vec![Expr::StrLit { value: "hi".into(), span: s() }],
+            args: vec![Expr::StrLit {
+                value: "hi".into(),
+                span: s(),
+            }],
             effects: EffectSet::PURE,
             span: s(),
         };
@@ -2580,8 +3068,14 @@ mod tests {
         let puts2 = Expr::BuiltinCall {
             name: "puts".into(),
             args: vec![
-                Expr::StrLit { value: "a".into(), span: s() },
-                Expr::StrLit { value: "b".into(), span: s() },
+                Expr::StrLit {
+                    value: "a".into(),
+                    span: s(),
+                },
+                Expr::StrLit {
+                    value: "b".into(),
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2620,11 +3114,17 @@ mod tests {
     #[test]
     fn emit_try_catch_shape() {
         let tc = Stmt::TryCatch {
-            body: vec![print_stmt(Expr::StrLit { value: "try".into(), span: s() })],
+            body: vec![print_stmt(Expr::StrLit {
+                value: "try".into(),
+                span: s(),
+            })],
             rescues: vec![RescueClause {
                 exception_types: vec!["StandardError".into()],
                 binding: Some("e".into()),
-                body: vec![print_stmt(Expr::StrLit { value: "caught".into(), span: s() })],
+                body: vec![print_stmt(Expr::StrLit {
+                    value: "caught".into(),
+                    span: s(),
+                })],
                 span: s(),
             }],
             ensure_body: None,
@@ -2633,15 +3133,27 @@ mod tests {
         let mut out = String::new();
         emit_stmt(&mut out, &tc, 0);
         // Structural checks: IIFE, deferred recover, matcher, binding, re-raise.
-        assert!(out.starts_with("func() {\n"), "must open an IIFE; got:\n{out}");
-        assert!(out.contains("defer func() {"), "must register a deferred recover");
-        assert!(out.contains("if r := recover(); r != nil {"), "must recover the panic");
+        assert!(
+            out.starts_with("func() {\n"),
+            "must open an IIFE; got:\n{out}"
+        );
+        assert!(
+            out.contains("defer func() {"),
+            "must register a deferred recover"
+        );
+        assert!(
+            out.contains("if r := recover(); r != nil {"),
+            "must recover the panic"
+        );
         assert!(
             out.contains(r#"if _sir_rescue_matches(r, []string{"StandardError"}) {"#),
             "must ask the ancestry matcher; got:\n{out}"
         );
         assert!(out.contains("e := _sir_exc_value(r)"), "must bind `=> e`");
-        assert!(out.contains("} else {\n") && out.contains("panic(r)"), "must re-raise unmatched");
+        assert!(
+            out.contains("} else {\n") && out.contains("panic(r)"),
+            "must re-raise unmatched"
+        );
         assert!(out.trim_end().ends_with("}()"), "must invoke the IIFE");
     }
 
@@ -2661,9 +3173,15 @@ mod tests {
         };
         let mut out = String::new();
         emit_stmt(&mut out, &tc, 0);
-        assert!(out.contains("_sir_rescue_matches(r, []string{})"), "empty list = catch-all");
+        assert!(
+            out.contains("_sir_rescue_matches(r, []string{})"),
+            "empty list = catch-all"
+        );
         // No binding was named → no `_sir_exc_value` call.
-        assert!(!out.contains("_sir_exc_value"), "no binding ⇒ no exc-value bind");
+        assert!(
+            !out.contains("_sir_exc_value"),
+            "no binding ⇒ no exc-value bind"
+        );
     }
 
     /// ENSURE ORDERING: the ensure defer must be registered BEFORE the
@@ -2675,10 +3193,16 @@ mod tests {
             rescues: vec![RescueClause {
                 exception_types: vec![],
                 binding: None,
-                body: vec![print_stmt(Expr::StrLit { value: "r".into(), span: s() })],
+                body: vec![print_stmt(Expr::StrLit {
+                    value: "r".into(),
+                    span: s(),
+                })],
                 span: s(),
             }],
-            ensure_body: Some(vec![print_stmt(Expr::StrLit { value: "ens".into(), span: s() })]),
+            ensure_body: Some(vec![print_stmt(Expr::StrLit {
+                value: "ens".into(),
+                span: s(),
+            })]),
             span: s(),
         };
         let mut out = String::new();
@@ -2741,11 +3265,19 @@ mod tests {
     // ── O4: user-defined-class OOP emission shapes ────────────────────────
 
     fn builtin(name: &str, args: Vec<Expr>) -> Expr {
-        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+        Expr::BuiltinCall {
+            name: name.into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
     }
 
     fn str_lit(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     /// `__new__("Dog", arg)` → `_sir_call_new("Dog", <arg>)`.
@@ -2771,20 +3303,36 @@ mod tests {
     fn super_emits_call_super_with_method_and_class() {
         let e = builtin(
             "__super__",
-            vec![str_lit("describe"), str_lit("Cat"), Expr::IntLit { value: 4, span: s() }],
+            vec![
+                str_lit("describe"),
+                str_lit("Cat"),
+                Expr::IntLit {
+                    value: 4,
+                    span: s(),
+                },
+            ],
         );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
-        assert_eq!(out, r#"_sir_call_super("describe", "Cat", Value(int64(4)))"#);
+        assert_eq!(
+            out,
+            r#"_sir_call_super("describe", "Cat", Value(int64(4)))"#
+        );
     }
 
     /// `__def_method__("Dog", "speak", <closure>)` → `_sir_def_method("Dog", "speak", <closure>)`.
     #[test]
     fn def_method_emits_registration() {
         FN_ARITY.with(|t| t.borrow_mut().insert("speak_impl".into(), 0));
-        let closure =
-            Expr::MakeClosure { fn_name: "speak_impl".into(), captures: vec![], span: s() };
-        let e = builtin("__def_method__", vec![str_lit("Dog"), str_lit("speak"), closure]);
+        let closure = Expr::MakeClosure {
+            fn_name: "speak_impl".into(),
+            captures: vec![],
+            span: s(),
+        };
+        let e = builtin(
+            "__def_method__",
+            vec![str_lit("Dog"), str_lit("speak"), closure],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         FN_ARITY.with(|t| t.borrow_mut().clear());
@@ -2798,9 +3346,15 @@ mod tests {
     #[test]
     fn def_class_method_emits_class_registration() {
         FN_ARITY.with(|t| t.borrow_mut().insert("zero_impl".into(), 0));
-        let closure =
-            Expr::MakeClosure { fn_name: "zero_impl".into(), captures: vec![], span: s() };
-        let e = builtin("__def_class_method__", vec![str_lit("Counter"), str_lit("zero"), closure]);
+        let closure = Expr::MakeClosure {
+            fn_name: "zero_impl".into(),
+            captures: vec![],
+            span: s(),
+        };
+        let e = builtin(
+            "__def_class_method__",
+            vec![str_lit("Counter"), str_lit("zero"), closure],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         FN_ARITY.with(|t| t.borrow_mut().clear());
@@ -2835,11 +3389,21 @@ mod tests {
     fn class_method_call_emits_dispatch() {
         let e = builtin(
             "__class_method__",
-            vec![str_lit("Registry"), str_lit("total"), Expr::IntLit { value: 5, span: s() }],
+            vec![
+                str_lit("Registry"),
+                str_lit("total"),
+                Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                },
+            ],
         );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
-        assert_eq!(out, r#"_sir_call_class_method("Registry", "total", Value(int64(5)))"#);
+        assert_eq!(
+            out,
+            r#"_sir_call_class_method("Registry", "total", Value(int64(5)))"#
+        );
     }
 
     /// `__self__()` → `_sir_current_self()`.
@@ -2854,7 +3418,11 @@ mod tests {
     /// A `@ivar` read (`VarRef{Instance}`) → `_sir_ivar_get("@name")`.
     #[test]
     fn ivar_ref_emits_ivar_get() {
-        let e = Expr::VarRef { name: "@name".into(), scope: Scope::Instance, span: s() };
+        let e = Expr::VarRef {
+            name: "@name".into(),
+            scope: Scope::Instance,
+            span: s(),
+        };
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(out, r#"_sir_ivar_get("@name")"#);
@@ -2863,7 +3431,11 @@ mod tests {
     /// A `@@cvar` read (`VarRef{ClassVar}`) → `_sir_cvar_get("@@count")`.
     #[test]
     fn cvar_ref_emits_cvar_get() {
-        let e = Expr::VarRef { name: "@@count".into(), scope: Scope::ClassVar, span: s() };
+        let e = Expr::VarRef {
+            name: "@@count".into(),
+            scope: Scope::ClassVar,
+            span: s(),
+        };
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(out, r#"_sir_cvar_get("@@count")"#);
@@ -2875,7 +3447,10 @@ mod tests {
         let s0 = Stmt::Assign {
             name: "@x".into(),
             scope: Scope::Instance,
-            value: Expr::IntLit { value: 7, span: s() },
+            value: Expr::IntLit {
+                value: 7,
+                span: s(),
+            },
             span: s(),
         };
         let mut out = String::new();
@@ -2889,7 +3464,10 @@ mod tests {
         let s0 = Stmt::Assign {
             name: "@@n".into(),
             scope: Scope::ClassVar,
-            value: Expr::IntLit { value: 0, span: s() },
+            value: Expr::IntLit {
+                value: 0,
+                span: s(),
+            },
             span: s(),
         };
         let mut out = String::new();

--- a/code/packages/rust/semantic-ir-to-go/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/lib.rs
@@ -343,7 +343,12 @@ fn unsupported(msg: &str, span: semantic_ir::Span) -> BackendError {
 fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
     use semantic_ir::Stmt;
     match s {
-        Stmt::Assign { scope: Scope::Const, name, span, .. } => {
+        Stmt::Assign {
+            scope: Scope::Const,
+            name,
+            span,
+            ..
+        } => {
             errs.push(unsupported(
                 &format!(
                     "go backend cannot emit a constant assignment `{}` — \
@@ -374,7 +379,13 @@ fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
             }
             check_soundness_expr(&body.value, errs);
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             check_soundness_expr(start, errs);
             check_soundness_expr(stop, errs);
             check_soundness_expr(step, errs);
@@ -390,12 +401,16 @@ fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
             }
             check_soundness_expr(&body.value, errs);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             check_soundness_expr(seq, errs);
             check_soundness_expr(index, errs);
             check_soundness_expr(value, errs);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             check_soundness_expr(map, errs);
             check_soundness_expr(key, errs);
             check_soundness_expr(value, errs);
@@ -405,7 +420,12 @@ fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
                 check_soundness_stmt(st, errs);
             }
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             for st in body {
                 check_soundness_stmt(st, errs);
             }
@@ -420,13 +440,32 @@ fn check_soundness_stmt(s: &semantic_ir::Stmt, errs: &mut Vec<BackendError>) {
                 }
             }
         }
+        // ── SIR22 (array/matrix IR) ──────────────────────────────────
+        // `IndexSet` (`A(i, j) = v`) observes `Feature::NDArrays` /
+        // `Feature::MatrixOps`, neither of which this backend accepts (see
+        // `ACCEPTED_FEATURES`), so the SIR10 capability gate
+        // (`Backend::check_module`) rejects any module containing it before
+        // `check_soundness_stmt` (called only on already-gated modules) ever
+        // sees one.  Reaching this arm would be an internal bug, not a user
+        // error — mirror the `Stmt::Assign` unsupported-scope arm above.
+        Stmt::IndexSet { span, .. } => {
+            panic!(
+                "go backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet",
+                span
+            );
+        }
     }
 }
 
 fn check_soundness_expr(e: &semantic_ir::Expr, errs: &mut Vec<BackendError>) {
     use semantic_ir::Expr;
     match e {
-        Expr::VarRef { scope: Scope::Const, name, span, .. } => {
+        Expr::VarRef {
+            scope: Scope::Const,
+            name,
+            span,
+            ..
+        } => {
             errs.push(unsupported(
                 &format!(
                     "go backend cannot emit a constant reference `{}` outside a \
@@ -441,7 +480,15 @@ fn check_soundness_expr(e: &semantic_ir::Expr, errs: &mut Vec<BackendError>) {
             // The FIRST arg of `raise` may be a `Const` class name — that is
             // the whitelisted position, so skip it and check only the rest.
             for (i, a) in args.iter().enumerate() {
-                if i == 0 && matches!(a, Expr::VarRef { scope: Scope::Const, .. }) {
+                if i == 0
+                    && matches!(
+                        a,
+                        Expr::VarRef {
+                            scope: Scope::Const,
+                            ..
+                        }
+                    )
+                {
                     continue;
                 }
                 check_soundness_expr(a, errs);
@@ -458,7 +505,12 @@ fn check_soundness_expr(e: &semantic_ir::Expr, errs: &mut Vec<BackendError>) {
                 check_soundness_expr(a, errs);
             }
         }
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             check_soundness_expr(cond, errs);
             check_soundness_block(then_branch, errs);
             check_soundness_block(else_branch, errs);
@@ -542,8 +594,11 @@ mod tests {
         )
         .expect("lower");
         let a = compile(&m).expect("compile");
-        assert!(a.source.contains("func _0x5flambda_5f0_(n Value, x Value) Value")
-            || a.source.contains("func __lambda_0(n Value, x Value) Value"));
+        assert!(
+            a.source
+                .contains("func _0x5flambda_5f0_(n Value, x Value) Value")
+                || a.source.contains("func __lambda_0(n Value, x Value) Value")
+        );
         assert!(a.source.contains("_sir_make_closure"));
     }
 
@@ -602,7 +657,10 @@ mod tests {
                     name: "x".into(),
                     kind: ParamKind::Keyword,
                     sir_type: None,
-                    default: Some(Box::new(Expr::IntLit { value: 1, span: sp() })),
+                    default: Some(Box::new(Expr::IntLit {
+                        value: 1,
+                        span: sp(),
+                    })),
                     span: sp(),
                 },
             ],
@@ -618,7 +676,10 @@ mod tests {
                     name: "x".into(),
                     kind: ParamKind::Keyword,
                     sir_type: None,
-                    default: Some(Box::new(Expr::IntLit { value: 1, span: sp() })),
+                    default: Some(Box::new(Expr::IntLit {
+                        value: 1,
+                        span: sp(),
+                    })),
                     span: sp(),
                 },
                 Param {
@@ -638,7 +699,11 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "a".into(), scope: Scope::Param, span: sp() },
+                value: Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: sp(),
+                },
                 span: sp(),
             },
             effects: EffectSet::PURE,
@@ -656,10 +721,16 @@ mod tests {
                     expr: Expr::DirectCall {
                         fn_name: "f".into(),
                         args: vec![
-                            Expr::IntLit { value: 10, span: sp() },
+                            Expr::IntLit {
+                                value: 10,
+                                span: sp(),
+                            },
                             Expr::KeywordArg {
                                 name: "x".into(),
-                                value: Box::new(Expr::IntLit { value: 5, span: sp() }),
+                                value: Box::new(Expr::IntLit {
+                                    value: 5,
+                                    span: sp(),
+                                }),
                                 span: sp(),
                             },
                         ],
@@ -703,8 +774,7 @@ mod tests {
         let err = compile(&m).expect_err("keyword+*rest mix must be rejected");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
         assert!(
-            err.message.contains("keyword parameters")
-                && err.message.contains("*rest/**kwrest"),
+            err.message.contains("keyword parameters") && err.message.contains("*rest/**kwrest"),
             "unexpected message: {}",
             err.message
         );
@@ -764,13 +834,25 @@ mod tests {
             args: vec![
                 Expr::SeqLit {
                     items: vec![
-                        Expr::IntLit { value: 1, span: sp() },
-                        Expr::IntLit { value: 2, span: sp() },
-                        Expr::IntLit { value: 3, span: sp() },
+                        Expr::IntLit {
+                            value: 1,
+                            span: sp(),
+                        },
+                        Expr::IntLit {
+                            value: 2,
+                            span: sp(),
+                        },
+                        Expr::IntLit {
+                            value: 3,
+                            span: sp(),
+                        },
                     ],
                     span: sp(),
                 },
-                Expr::StrLit { value: "length".into(), span: sp() },
+                Expr::StrLit {
+                    value: "length".into(),
+                    span: sp(),
+                },
             ],
             effects: EffectSet::PURE,
             span: sp(),
@@ -781,7 +863,10 @@ mod tests {
             return_type: None,
             captures: vec![],
             body: Block {
-                stmts: vec![Stmt::ExprStmt { expr: dispatch, span: sp() }],
+                stmts: vec![Stmt::ExprStmt {
+                    expr: dispatch,
+                    span: sp(),
+                }],
                 value: Expr::NilLit { span: sp() },
                 span: sp(),
             },
@@ -831,7 +916,10 @@ mod tests {
             body: vec![Stmt::Assign {
                 name: "@count".into(),
                 scope: Scope::Instance,
-                value: Expr::IntLit { value: 0, span: sp() },
+                value: Expr::IntLit {
+                    value: 0,
+                    span: sp(),
+                },
                 span: sp(),
             }],
             span: sp(),
@@ -889,7 +977,10 @@ mod tests {
                 stmts: vec![Stmt::Assign {
                     name: "FOO".into(),
                     scope: Scope::Const,
-                    value: Expr::IntLit { value: 4, span: sp() },
+                    value: Expr::IntLit {
+                        value: 4,
+                        span: sp(),
+                    },
                     span: sp(),
                 }],
                 value: Expr::NilLit { span: sp() },

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -187,7 +187,12 @@ fn emit_ancestry_registration(out: &mut String, m: &Module) {
 fn collect_ancestry<'a>(stmts: &'a [Stmt], pairs: &mut Vec<(&'a str, &'a str)>) {
     for s in stmts {
         match s {
-            Stmt::ClassDef { name, superclass, body, .. } => {
+            Stmt::ClassDef {
+                name,
+                superclass,
+                body,
+                ..
+            } => {
                 if let Some(sup) = superclass {
                     pairs.push((name.as_str(), sup.as_str()));
                 }
@@ -196,7 +201,12 @@ fn collect_ancestry<'a>(stmts: &'a [Stmt], pairs: &mut Vec<(&'a str, &'a str)>) 
             Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
                 collect_ancestry(body, pairs);
             }
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 collect_ancestry(body, pairs);
                 for r in rescues {
                     collect_ancestry(&r.body, pairs);
@@ -205,9 +215,9 @@ fn collect_ancestry<'a>(stmts: &'a [Stmt], pairs: &mut Vec<(&'a str, &'a str)>) 
                     collect_ancestry(ens, pairs);
                 }
             }
-            Stmt::While { body, .. }
-            | Stmt::ForRange { body, .. }
-            | Stmt::ForEach { body, .. } => collect_ancestry(&body.stmts, pairs),
+            Stmt::While { body, .. } | Stmt::ForRange { body, .. } | Stmt::ForEach { body, .. } => {
+                collect_ancestry(&body.stmts, pairs)
+            }
             _ => {}
         }
     }
@@ -218,7 +228,11 @@ fn collect_ancestry<'a>(stmts: &'a [Stmt], pairs: &mut Vec<(&'a str, &'a str)>) 
 // ---------------------------------------------------------------------------
 
 fn emit_function(out: &mut String, f: &Function) {
-    let _ = writeln!(out, "// SIR span: {}", sanitize_comment(&f.span.to_string()));
+    let _ = writeln!(
+        out,
+        "// SIR span: {}",
+        sanitize_comment(&f.span.to_string())
+    );
     let _ = write!(out, "function {}(", sanitize_ident(&f.name));
     // Captures are positional and come BEFORE params, matching the
     // lowerer's MakeClosure convention (`fn(cap0, cap1, …args)`).
@@ -417,12 +431,22 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // `@x = v` / `@@x = v` store onto the current `self`'s (or its
         // class's) prototype-less bag via the OOP runtime.  The `@`/`@@`
         // sigil is preserved in `name` and used verbatim as the bag key.
-        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Instance,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}__Sir.ivarSet({}, ", pad, quote_js_string(name));
             emit_expr(out, value, indent);
             out.push_str(");\n");
         }
-        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::ClassVar,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}__Sir.cvarSet({}, ", pad, quote_js_string(name));
             emit_expr(out, value, indent);
             out.push_str(");\n");
@@ -450,7 +474,14 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // loop condition is direction-aware so a negative `step` counts
         // down correctly.  JS has one numeric type, so no casts are
         // needed (unlike the TypeScript backend's `as number`).
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             let id = fresh_loop_id();
             let v = sanitize_ident(var);
             let inner = indent + 2;
@@ -477,7 +508,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         }
         // `for (const var of iter) { body }` — iterate a Seq.  `let` is
         // used so a body that reassigns the loop variable still works.
-        Stmt::ForEach { var, iter, body, .. } => {
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => {
             let _ = write!(out, "{}for (let {} of ", pad, sanitize_ident(var));
             emit_expr(out, iter, indent);
             out.push_str(") {\n");
@@ -486,7 +519,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         }
         // ── SIR16: indexed assignment (Sequences / Maps) ────────────
         // `seq[index] = value;` — native array element write.
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             out.push_str(&pad);
             out.push('(');
             emit_expr(out, seq, indent);
@@ -497,7 +532,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             out.push_str(";\n");
         }
         // `map.set(key, value);` — native `Map.set`.
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             out.push_str(&pad);
             out.push('(');
             emit_expr(out, map, indent);
@@ -532,7 +569,12 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // if none match (matching Ruby's "propagate when unrescued").
         // Mirrors the TypeScript backend's `TryCatch` arm exactly, minus
         // the type annotation on the `=> e` binding.
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             let _ = writeln!(out, "{pad}try {{");
             for st in body {
                 emit_stmt(out, st, indent + 2);
@@ -578,6 +620,17 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             }
             out.push('\n');
         }
+        // ── SIR22: array/matrix indexed assignment (deferred) ───────
+        // `Feature::NDArrays` is not in `ACCEPTED_FEATURES` (see lib.rs),
+        // so `check_module` rejects any module using `IndexSet` before
+        // lowering reaches this emitter. Panic here only guards against
+        // that capability check ever drifting — mirrors the `StrConcat`/
+        // `Intrinsic` deferred-kind panics in `emit_expr` below.  Real
+        // codegen (`__SirArray.indexSet(...)`, per the SIR22 spec's
+        // "Backend impact") lands in a follow-up PR.
+        Stmt::IndexSet { span, .. } => {
+            panic!("javascript backend reached a deferred `IndexSet` at {span} — not accepted yet");
+        }
     }
 }
 
@@ -588,7 +641,10 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
 fn pick_global_set(e: &Expr) -> Option<(&str, &Expr)> {
     if let Expr::BuiltinCall { name, args, .. } = e {
         if name == "global_set" && args.len() == 2 {
-            if let Expr::SymLit { name: global_name, .. } = &args[0] {
+            if let Expr::SymLit {
+                name: global_name, ..
+            } = &args[0]
+            {
                 return Some((global_name.as_str(), &args[1]));
             }
         }
@@ -621,7 +677,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         Expr::VarRef { name, scope, .. } => emit_var_ref(out, name, *scope),
         // `(__Sir.truthy(cond) ? then : else)` — the test routes through
         // SIR truthiness (only `false`/`nil` are falsy), never JS's.
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             out.push_str("(__Sir.truthy(");
             emit_expr(out, cond, indent);
             out.push_str(") ? (");
@@ -653,7 +714,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         }
         Expr::BuiltinCall { name, args, .. } => emit_builtin_call(out, name, args, indent),
         // `new __Sir.Closure((..._a) => fn(cap0, cap1, ..._a))`.
-        Expr::MakeClosure { fn_name, captures, .. } => {
+        Expr::MakeClosure {
+            fn_name, captures, ..
+        } => {
             out.push_str("new __Sir.Closure((..._a) => ");
             let _ = write!(out, "{}(", sanitize_ident(fn_name));
             for c in captures {
@@ -726,7 +789,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // ── Deferred expression kinds (rejected at capability check) ──
         // `StrConcat` (SIR18 string interpolation) is not accepted yet.
         Expr::StrConcat { span, .. } => {
-            panic!("javascript backend reached a deferred `StrConcat` at {span} — not accepted yet");
+            panic!(
+                "javascript backend reached a deferred `StrConcat` at {span} — not accepted yet"
+            );
         }
         Expr::Intrinsic { name, span, .. } => {
             // The v0 backend accepts no intrinsics; `check_module`
@@ -744,6 +809,26 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // never meant to be), so we panic with the offending span.
         Expr::KeywordArg { span, .. } => {
             panic!("javascript backend reached a `KeywordArg` outside call-argument position at {span} — this is a backend bug (keyword args are collapsed by emit_call_args)");
+        }
+        // ── SIR22: array/matrix nodes (deferred) ──────────────────────
+        // Neither `Feature::NDArrays` nor `Feature::MatrixOps` is in
+        // `ACCEPTED_FEATURES` (see lib.rs), so `check_module` rejects any
+        // module using these nodes before lowering reaches this emitter —
+        // per the SIR22 spec's "Backend impact": real codegen (calls into
+        // `sir-runtime-array`'s `__SirArray.matmul`/`elementwise`/`range`/
+        // `indexGet`) is a first-wave-JS follow-up PR, not required for
+        // this spec to land safely.  These panics only guard against the
+        // capability check ever drifting, exactly like `StrConcat` above.
+        Expr::ArrayLit { span, .. }
+        | Expr::Range { span, .. }
+        | Expr::MatMul { span, .. }
+        | Expr::ElementwiseOp { span, .. }
+        | Expr::Transpose { span, .. }
+        | Expr::IndexGet { span, .. } => {
+            panic!(
+                "javascript backend reached a deferred SIR22 array/matrix expression ({}) at {span} — not accepted yet",
+                e.kind_name()
+            );
         }
     }
 }
@@ -819,7 +904,9 @@ fn emit_call_args(out: &mut String, args: &[Expr], indent: usize) {
     // Positionals are every arg that is not a keyword.  Because the
     // validator forbids a positional after a keyword, this is exactly the
     // leading run of the vec; a `filter` is equivalent and order-preserving.
-    let positionals = args.iter().filter(|a| !matches!(a, Expr::KeywordArg { .. }));
+    let positionals = args
+        .iter()
+        .filter(|a| !matches!(a, Expr::KeywordArg { .. }));
     let mut wrote_any = false;
     for a in positionals {
         if wrote_any {
@@ -902,9 +989,11 @@ fn emit_call_args(out: &mut String, args: &[Expr], indent: usize) {
 fn emit_oop_name_arg(out: &mut String, e: &Expr) {
     match e {
         Expr::StrLit { value, .. } => out.push_str(&quote_js_string(value)),
-        Expr::VarRef { name, scope: Scope::Const, .. } => {
-            out.push_str(&quote_js_string(name))
-        }
+        Expr::VarRef {
+            name,
+            scope: Scope::Const,
+            ..
+        } => out.push_str(&quote_js_string(name)),
         other => emit_expr(out, other, 0),
     }
 }
@@ -1049,7 +1138,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push_str("__Sir.raiseError(");
         match args.first() {
             None => {}
-            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+            Some(Expr::VarRef {
+                name: cn,
+                scope: Scope::Const,
+                ..
+            }) => {
                 out.push_str(&quote_js_string(cn));
                 if let Some(msg) = args.get(1) {
                     out.push_str(", ");
@@ -1403,7 +1496,11 @@ fn format_float(v: f64) -> String {
         return "NaN".to_string();
     }
     if v.is_infinite() {
-        return if v < 0.0 { "-Infinity".to_string() } else { "Infinity".to_string() };
+        return if v < 0.0 {
+            "-Infinity".to_string()
+        } else {
+            "Infinity".to_string()
+        };
     }
     // `{:?}` on an f64 yields the shortest round-tripping decimal and
     // always includes a decimal point for integer-valued floats
@@ -1504,21 +1601,51 @@ mod tests {
 
     #[test]
     fn emit_int_float_bool_nil() {
-        assert_eq!(emit_e(&Expr::IntLit { value: 42, span: s() }), "42");
-        assert_eq!(emit_e(&Expr::FloatLit { value: 2.5, span: s() }), "2.5");
-        assert_eq!(emit_e(&Expr::BoolLit { value: true, span: s() }), "true");
-        assert_eq!(emit_e(&Expr::BoolLit { value: false, span: s() }), "false");
+        assert_eq!(
+            emit_e(&Expr::IntLit {
+                value: 42,
+                span: s()
+            }),
+            "42"
+        );
+        assert_eq!(
+            emit_e(&Expr::FloatLit {
+                value: 2.5,
+                span: s()
+            }),
+            "2.5"
+        );
+        assert_eq!(
+            emit_e(&Expr::BoolLit {
+                value: true,
+                span: s()
+            }),
+            "true"
+        );
+        assert_eq!(
+            emit_e(&Expr::BoolLit {
+                value: false,
+                span: s()
+            }),
+            "false"
+        );
         assert_eq!(emit_e(&Expr::NilLit { span: s() }), "null");
     }
 
     #[test]
     fn emit_symbol_and_string() {
         assert_eq!(
-            emit_e(&Expr::SymLit { name: "foo".into(), span: s() }),
+            emit_e(&Expr::SymLit {
+                name: "foo".into(),
+                span: s()
+            }),
             r#"__Sir.intern("foo")"#
         );
         assert_eq!(
-            emit_e(&Expr::StrLit { value: "hi".into(), span: s() }),
+            emit_e(&Expr::StrLit {
+                value: "hi".into(),
+                span: s()
+            }),
             r#""hi""#
         );
     }
@@ -1527,7 +1654,11 @@ mod tests {
     fn emit_var_ref_local_param_capture_global_are_bare() {
         for scope in [Scope::Local, Scope::Param, Scope::Capture, Scope::Global] {
             assert_eq!(
-                emit_e(&Expr::VarRef { name: "x".into(), scope, span: s() }),
+                emit_e(&Expr::VarRef {
+                    name: "x".into(),
+                    scope,
+                    span: s()
+                }),
                 "x"
             );
         }
@@ -1536,18 +1667,38 @@ mod tests {
     #[test]
     fn emit_var_ref_builtin_uses_closure() {
         assert_eq!(
-            emit_e(&Expr::VarRef { name: "+".into(), scope: Scope::Builtin, span: s() }),
+            emit_e(&Expr::VarRef {
+                name: "+".into(),
+                scope: Scope::Builtin,
+                span: s()
+            }),
             r#"__Sir.builtinClosure("+")"#
         );
     }
 
     fn bc(name: &str, args: Vec<Expr>) -> Expr {
-        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+        Expr::BuiltinCall {
+            name: name.into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
     }
 
     #[test]
     fn emit_builtin_arithmetic_is_native_infix() {
-        let two = || vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }];
+        let two = || {
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+            ]
+        };
         // `-`/`%` stay native infix (numeric-only in the SIR contract).
         assert_eq!(emit_e(&bc("-", two())), "(1 - 2)");
         assert_eq!(emit_e(&bc("%", two())), "(1 % 2)");
@@ -1558,7 +1709,18 @@ mod tests {
         // `/` routes through `__Sir.divide`, which adds the Ruby
         // zero-divisor check (native JS `/` yields `Infinity`, not a
         // `ZeroDivisionError`).  The numeric result is otherwise identical.
-        let two = || vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }];
+        let two = || {
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+            ]
+        };
         assert_eq!(emit_e(&bc("/", two())), "__Sir.divide(1, 2)");
     }
 
@@ -1569,14 +1731,36 @@ mod tests {
         // runtime dispatch helpers rather than native infix.  Native `[1] +
         // [2]` would be the wrong string `"1,2"`, and `"ab" * 3` would be
         // `NaN` — the helpers fix both while preserving the numeric path.
-        let two = || vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }];
+        let two = || {
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+            ]
+        };
         assert_eq!(emit_e(&bc("+", two())), "__Sir.plus(1, 2)");
         assert_eq!(emit_e(&bc("*", two())), "__Sir.times(1, 2)");
     }
 
     #[test]
     fn emit_builtin_comparison_is_native_infix() {
-        let two = || vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }];
+        let two = || {
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+            ]
+        };
         assert_eq!(emit_e(&bc("=", two())), "(1 === 2)");
         assert_eq!(emit_e(&bc("!=", two())), "(1 !== 2)");
         assert_eq!(emit_e(&bc("<", two())), "(1 < 2)");
@@ -1588,15 +1772,34 @@ mod tests {
     #[test]
     fn emit_builtin_unary_not_neg_len() {
         assert_eq!(
-            emit_e(&bc("not", vec![Expr::BoolLit { value: true, span: s() }])),
+            emit_e(&bc(
+                "not",
+                vec![Expr::BoolLit {
+                    value: true,
+                    span: s()
+                }]
+            )),
             "(!__Sir.truthy(true))"
         );
         assert_eq!(
-            emit_e(&bc("neg", vec![Expr::IntLit { value: 5, span: s() }])),
+            emit_e(&bc(
+                "neg",
+                vec![Expr::IntLit {
+                    value: 5,
+                    span: s()
+                }]
+            )),
             "(-(5))"
         );
         assert_eq!(
-            emit_e(&bc("len", vec![Expr::VarRef { name: "a".into(), scope: Scope::Local, span: s() }])),
+            emit_e(&bc(
+                "len",
+                vec![Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Local,
+                    span: s()
+                }]
+            )),
             "(a).length"
         );
     }
@@ -1604,7 +1807,13 @@ mod tests {
     #[test]
     fn emit_builtin_print_routes_to_runtime() {
         assert_eq!(
-            emit_e(&bc("print", vec![Expr::IntLit { value: 7, span: s() }])),
+            emit_e(&bc(
+                "print",
+                vec![Expr::IntLit {
+                    value: 7,
+                    span: s()
+                }]
+            )),
             "__Sir.print(7)"
         );
     }
@@ -1615,15 +1824,27 @@ mod tests {
     #[test]
     fn emit_builtin_puts_routes_to_runtime() {
         assert_eq!(
-            emit_e(&bc("puts", vec![Expr::IntLit { value: 7, span: s() }])),
+            emit_e(&bc(
+                "puts",
+                vec![Expr::IntLit {
+                    value: 7,
+                    span: s()
+                }]
+            )),
             "__Sir.puts(7)"
         );
         assert_eq!(
             emit_e(&bc(
                 "puts",
                 vec![
-                    Expr::IntLit { value: 1, span: s() },
-                    Expr::IntLit { value: 2, span: s() },
+                    Expr::IntLit {
+                        value: 1,
+                        span: s()
+                    },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s()
+                    },
                 ],
             )),
             "__Sir.puts(1, 2)"
@@ -1639,9 +1860,19 @@ mod tests {
         let e = bc(
             "__method__",
             vec![
-                Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
-                Expr::StrLit { value: "push".into(), span: s() },
-                Expr::IntLit { value: 1, span: s() },
+                Expr::VarRef {
+                    name: "arr".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                },
+                Expr::StrLit {
+                    value: "push".into(),
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
             ],
         );
         assert_eq!(emit_e(&e), r#"__Sir.callMethod(arr, "push", 1)"#);
@@ -1653,8 +1884,15 @@ mod tests {
         let e = bc(
             "__method__",
             vec![
-                Expr::VarRef { name: "s".into(), scope: Scope::Local, span: s() },
-                Expr::StrLit { value: "toUpperCase".into(), span: s() },
+                Expr::VarRef {
+                    name: "s".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                },
+                Expr::StrLit {
+                    value: "toUpperCase".into(),
+                    span: s(),
+                },
             ],
         );
         assert_eq!(emit_e(&e), r#"__Sir.callMethod(s, "toUpperCase")"#);
@@ -1663,7 +1901,10 @@ mod tests {
     // ── OOP builtin emit shape (O3) ───────────────────────────────
 
     fn strlit(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     #[test]
@@ -1672,7 +1913,10 @@ mod tests {
         let e = bc("__new__", vec![strlit("Dog"), strlit("Rex")]);
         assert_eq!(emit_e(&e), r#"__Sir.callNew("Dog", "Rex")"#);
         // Zero-arg construction: just the class name.
-        assert_eq!(emit_e(&bc("__new__", vec![strlit("Dog")])), r#"__Sir.callNew("Dog")"#);
+        assert_eq!(
+            emit_e(&bc("__new__", vec![strlit("Dog")])),
+            r#"__Sir.callNew("Dog")"#
+        );
     }
 
     #[test]
@@ -1681,7 +1925,11 @@ mod tests {
         // *name string*, never a live binding.
         let e = bc(
             "__new__",
-            vec![Expr::VarRef { name: "Dog".into(), scope: Scope::Const, span: s() }],
+            vec![Expr::VarRef {
+                name: "Dog".into(),
+                scope: Scope::Const,
+                span: s(),
+            }],
         );
         assert_eq!(emit_e(&e), r#"__Sir.callNew("Dog")"#);
     }
@@ -1689,7 +1937,10 @@ mod tests {
     #[test]
     fn emit_super_routes_to_call_super() {
         // super("x") inside Cat#describe → __super__("describe","Cat","x").
-        let e = bc("__super__", vec![strlit("describe"), strlit("Cat"), strlit("x")]);
+        let e = bc(
+            "__super__",
+            vec![strlit("describe"), strlit("Cat"), strlit("x")],
+        );
         assert_eq!(emit_e(&e), r#"__Sir.callSuper("describe", "Cat", "x")"#);
     }
 
@@ -1701,7 +1952,10 @@ mod tests {
             captures: vec![],
             span: s(),
         };
-        let e = bc("__def_method__", vec![strlit("Dog"), strlit("speak"), closure]);
+        let e = bc(
+            "__def_method__",
+            vec![strlit("Dog"), strlit("speak"), closure],
+        );
         assert_eq!(
             emit_e(&e),
             r#"__Sir.defMethod("Dog", "speak", new __Sir.Closure((..._a) => Dog__speak(..._a)))"#
@@ -1715,7 +1969,10 @@ mod tests {
             captures: vec![],
             span: s(),
         };
-        let e = bc("__def_class_method__", vec![strlit("Dog"), strlit("count"), closure]);
+        let e = bc(
+            "__def_class_method__",
+            vec![strlit("Dog"), strlit("count"), closure],
+        );
         assert_eq!(
             emit_e(&e),
             r#"__Sir.defClassMethod("Dog", "count", new __Sir.Closure((..._a) => Dog__count(..._a)))"#
@@ -1751,7 +2008,14 @@ mod tests {
         //                    → __Sir.callClassMethod("Widget", "tally", 1).
         let e = bc(
             "__class_method__",
-            vec![strlit("Widget"), strlit("tally"), Expr::IntLit { value: 1, span: s() }],
+            vec![
+                strlit("Widget"),
+                strlit("tally"),
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+            ],
         );
         assert_eq!(emit_e(&e), r#"__Sir.callClassMethod("Widget", "tally", 1)"#);
     }
@@ -1767,7 +2031,11 @@ mod tests {
     fn emit_ivar_read_routes_to_ivar_get() {
         // `@name` (Scope::Instance, sigil preserved) → __Sir.ivarGet("@name").
         assert_eq!(
-            emit_e(&Expr::VarRef { name: "@name".into(), scope: Scope::Instance, span: s() }),
+            emit_e(&Expr::VarRef {
+                name: "@name".into(),
+                scope: Scope::Instance,
+                span: s()
+            }),
             r#"__Sir.ivarGet("@name")"#
         );
     }
@@ -1775,7 +2043,11 @@ mod tests {
     #[test]
     fn emit_cvar_read_routes_to_cvar_get() {
         assert_eq!(
-            emit_e(&Expr::VarRef { name: "@@count".into(), scope: Scope::ClassVar, span: s() }),
+            emit_e(&Expr::VarRef {
+                name: "@@count".into(),
+                scope: Scope::ClassVar,
+                span: s()
+            }),
             r#"__Sir.cvarGet("@@count")"#
         );
     }
@@ -1797,7 +2069,10 @@ mod tests {
         let st = Stmt::Assign {
             name: "@@count".into(),
             scope: Scope::ClassVar,
-            value: Expr::IntLit { value: 0, span: s() },
+            value: Expr::IntLit {
+                value: 0,
+                span: s(),
+            },
             span: s(),
         };
         assert_eq!(emit_s(&st), "__Sir.cvarSet(\"@@count\", 0);\n");
@@ -1808,9 +2083,18 @@ mod tests {
         let three = bc(
             "+",
             vec![
-                Expr::IntLit { value: 1, span: s() },
-                Expr::IntLit { value: 2, span: s() },
-                Expr::IntLit { value: 3, span: s() },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 3,
+                    span: s(),
+                },
             ],
         );
         assert_eq!(emit_e(&three), r#"__Sir.callBuiltin("+", [1, 2, 3])"#);
@@ -1819,7 +2103,13 @@ mod tests {
     #[test]
     fn emit_unknown_builtin_falls_back_to_dispatch() {
         assert_eq!(
-            emit_e(&bc("frobnicate", vec![Expr::IntLit { value: 1, span: s() }])),
+            emit_e(&bc(
+                "frobnicate",
+                vec![Expr::IntLit {
+                    value: 1,
+                    span: s()
+                }]
+            )),
             r#"__Sir.callBuiltin("frobnicate", [1])"#
         );
     }
@@ -1828,7 +2118,16 @@ mod tests {
     fn emit_pairs_route_through_runtime_table() {
         let cons = bc(
             "cons",
-            vec![Expr::IntLit { value: 1, span: s() }, Expr::IntLit { value: 2, span: s() }],
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+            ],
         );
         assert_eq!(emit_e(&cons), r#"__Sir.builtins["cons"](1, 2)"#);
         assert_eq!(
@@ -1841,14 +2140,24 @@ mod tests {
     fn emit_direct_and_indirect_calls() {
         let dc = Expr::DirectCall {
             fn_name: "id".into(),
-            args: vec![Expr::IntLit { value: 7, span: s() }],
+            args: vec![Expr::IntLit {
+                value: 7,
+                span: s(),
+            }],
             effects: EffectSet::PURE,
             span: s(),
         };
         assert_eq!(emit_e(&dc), "id(7)");
         let ic = Expr::IndirectCall {
-            target: Box::new(Expr::VarRef { name: "f".into(), scope: Scope::Local, span: s() }),
-            args: vec![Expr::IntLit { value: 5, span: s() }],
+            target: Box::new(Expr::VarRef {
+                name: "f".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            args: vec![Expr::IntLit {
+                value: 5,
+                span: s(),
+            }],
             effects: EffectSet::PURE,
             span: s(),
         };
@@ -1858,15 +2167,24 @@ mod tests {
     #[test]
     fn emit_if_uses_truthy_ternary() {
         let if_e = Expr::If {
-            cond: Box::new(Expr::BoolLit { value: true, span: s() }),
+            cond: Box::new(Expr::BoolLit {
+                value: true,
+                span: s(),
+            }),
             then_branch: Box::new(Block {
                 stmts: vec![],
-                value: Expr::IntLit { value: 1, span: s() },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             }),
             else_branch: Box::new(Block {
                 stmts: vec![],
-                value: Expr::IntLit { value: 2, span: s() },
+                value: Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
                 span: s(),
             }),
             span: s(),
@@ -1880,11 +2198,17 @@ mod tests {
             fn_name: "__lambda_0".into(),
             captures: vec![CaptureValue {
                 name: "n".into(),
-                value: Expr::IntLit { value: 5, span: s() },
+                value: Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                },
             }],
             span: s(),
         };
-        assert_eq!(emit_e(&mc), "new __Sir.Closure((..._a) => __lambda_0(5, ..._a))");
+        assert_eq!(
+            emit_e(&mc),
+            "new __Sir.Closure((..._a) => __lambda_0(5, ..._a))"
+        );
     }
 
     #[test]
@@ -1893,10 +2217,17 @@ mod tests {
             stmts: vec![Stmt::LetBinding {
                 name: "x".into(),
                 sir_type: None,
-                value: Expr::IntLit { value: 1, span: s() },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             }],
-            value: Expr::VarRef { name: "x".into(), scope: Scope::Local, span: s() },
+            value: Expr::VarRef {
+                name: "x".into(),
+                scope: Scope::Local,
+                span: s(),
+            },
             span: s(),
         };
         let out = emit_e(&Expr::Block(Box::new(b)));
@@ -1909,30 +2240,70 @@ mod tests {
     // ── SIR16 expressions ─────────────────────────────────────────
 
     fn var(name: &str) -> Expr {
-        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+        Expr::VarRef {
+            name: name.into(),
+            scope: Scope::Local,
+            span: s(),
+        }
     }
 
     fn int(v: i64) -> Expr {
-        Expr::IntLit { value: v, span: s() }
+        Expr::IntLit {
+            value: v,
+            span: s(),
+        }
     }
 
     #[test]
     fn emit_float_lit_decimal_and_specials() {
-        assert_eq!(emit_e(&Expr::FloatLit { value: 3.0, span: s() }), "3.0");
-        assert_eq!(emit_e(&Expr::FloatLit { value: 2.5, span: s() }), "2.5");
-        assert_eq!(emit_e(&Expr::FloatLit { value: f64::INFINITY, span: s() }), "Infinity");
         assert_eq!(
-            emit_e(&Expr::FloatLit { value: f64::NEG_INFINITY, span: s() }),
+            emit_e(&Expr::FloatLit {
+                value: 3.0,
+                span: s()
+            }),
+            "3.0"
+        );
+        assert_eq!(
+            emit_e(&Expr::FloatLit {
+                value: 2.5,
+                span: s()
+            }),
+            "2.5"
+        );
+        assert_eq!(
+            emit_e(&Expr::FloatLit {
+                value: f64::INFINITY,
+                span: s()
+            }),
+            "Infinity"
+        );
+        assert_eq!(
+            emit_e(&Expr::FloatLit {
+                value: f64::NEG_INFINITY,
+                span: s()
+            }),
             "-Infinity"
         );
-        assert_eq!(emit_e(&Expr::FloatLit { value: f64::NAN, span: s() }), "NaN");
+        assert_eq!(
+            emit_e(&Expr::FloatLit {
+                value: f64::NAN,
+                span: s()
+            }),
+            "NaN"
+        );
     }
 
     #[test]
     fn emit_seq_lit_is_native_array() {
-        let seq = Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: s() };
+        let seq = Expr::SeqLit {
+            items: vec![int(1), int(2), int(3)],
+            span: s(),
+        };
         assert_eq!(emit_e(&seq), "[1, 2, 3]");
-        let empty = Expr::SeqLit { items: vec![], span: s() };
+        let empty = Expr::SeqLit {
+            items: vec![],
+            span: s(),
+        };
         assert_eq!(emit_e(&empty), "[]");
     }
 
@@ -1948,7 +2319,10 @@ mod tests {
 
     #[test]
     fn emit_seq_len_is_native_length() {
-        let e = Expr::SeqLen { seq: Box::new(var("xs")), span: s() };
+        let e = Expr::SeqLen {
+            seq: Box::new(var("xs")),
+            span: s(),
+        };
         assert_eq!(emit_e(&e), "(xs).length");
     }
 
@@ -1957,18 +2331,27 @@ mod tests {
         let e = Expr::MapLit {
             entries: vec![
                 semantic_ir::nodes::MapEntry {
-                    key: Expr::StrLit { value: "a".into(), span: s() },
+                    key: Expr::StrLit {
+                        value: "a".into(),
+                        span: s(),
+                    },
                     value: int(1),
                 },
                 semantic_ir::nodes::MapEntry {
-                    key: Expr::StrLit { value: "b".into(), span: s() },
+                    key: Expr::StrLit {
+                        value: "b".into(),
+                        span: s(),
+                    },
                     value: int(2),
                 },
             ],
             span: s(),
         };
         assert_eq!(emit_e(&e), r#"new Map([["a", 1], ["b", 2]])"#);
-        let empty = Expr::MapLit { entries: vec![], span: s() };
+        let empty = Expr::MapLit {
+            entries: vec![],
+            span: s(),
+        };
         assert_eq!(emit_e(&empty), "new Map([])");
     }
 
@@ -1976,7 +2359,10 @@ mod tests {
     fn emit_map_get_uses_get_with_nil_default() {
         let e = Expr::MapGet {
             map: Box::new(var("d")),
-            key: Box::new(Expr::StrLit { value: "k".into(), span: s() }),
+            key: Box::new(Expr::StrLit {
+                value: "k".into(),
+                span: s(),
+            }),
             span: s(),
         };
         assert_eq!(emit_e(&e), r#"((d).get("k") ?? null)"#);
@@ -1989,15 +2375,24 @@ mod tests {
         // `Expr::LogicalOr`/`LogicalAnd` — NOT the eager `__Sir.callBuiltin`
         // fallback (which has no `or`/`and` entry and would evaluate both
         // operands, throwing `unknown builtin` at runtime).
-        let a = Expr::StrLit { value: "a".into(), span: s() };
-        let b = Expr::StrLit { value: "b".into(), span: s() };
+        let a = Expr::StrLit {
+            value: "a".into(),
+            span: s(),
+        };
+        let b = Expr::StrLit {
+            value: "b".into(),
+            span: s(),
+        };
         let or = Expr::BuiltinCall {
             name: "or".into(),
             args: vec![a.clone(), b.clone()],
             effects: EffectSet::PURE,
             span: s(),
         };
-        assert_eq!(emit_e(&or), r#"((__l) => __Sir.truthy(__l) ? __l : ("b"))("a")"#);
+        assert_eq!(
+            emit_e(&or),
+            r#"((__l) => __Sir.truthy(__l) ? __l : ("b"))("a")"#
+        );
         assert!(!emit_e(&or).contains("callBuiltin"));
         let and = Expr::BuiltinCall {
             name: "and".into(),
@@ -2005,7 +2400,10 @@ mod tests {
             effects: EffectSet::PURE,
             span: s(),
         };
-        assert_eq!(emit_e(&and), r#"((__l) => __Sir.truthy(__l) ? ("b") : __l)("a")"#);
+        assert_eq!(
+            emit_e(&and),
+            r#"((__l) => __Sir.truthy(__l) ? ("b") : __l)("a")"#
+        );
     }
 
     #[test]
@@ -2064,7 +2462,10 @@ mod tests {
     fn emit_map_set_is_native_map_set() {
         let st = Stmt::MapSet {
             map: var("d"),
-            key: Expr::StrLit { value: "k".into(), span: s() },
+            key: Expr::StrLit {
+                value: "k".into(),
+                span: s(),
+            },
             value: int(1),
             span: s(),
         };
@@ -2098,7 +2499,10 @@ mod tests {
             span: s(),
         };
         let out = emit_s(&st);
-        assert!(out.starts_with("while (__Sir.truthy((i < 3))) {\n"), "got {out}");
+        assert!(
+            out.starts_with("while (__Sir.truthy((i < 3))) {\n"),
+            "got {out}"
+        );
         assert!(out.contains("i = __Sir.plus(i, 1);"));
         // The trailing nil body value is dropped.
         assert!(!out.contains("null;"), "got {out}");
@@ -2166,7 +2570,11 @@ mod tests {
             start: int(0),
             stop: int(2),
             step: int(1),
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             span: s(),
         };
         let a = emit_s(&mk());
@@ -2182,7 +2590,10 @@ mod tests {
         let st = Stmt::LetBinding {
             name: "x".into(),
             sir_type: None,
-            value: Expr::IntLit { value: 9, span: s() },
+            value: Expr::IntLit {
+                value: 9,
+                span: s(),
+            },
             span: s(),
         };
         let mut out = String::new();
@@ -2195,8 +2606,14 @@ mod tests {
         let e = Expr::BuiltinCall {
             name: "global_set".into(),
             args: vec![
-                Expr::SymLit { name: "counter".into(), span: s() },
-                Expr::IntLit { value: 0, span: s() },
+                Expr::SymLit {
+                    name: "counter".into(),
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2211,7 +2628,13 @@ mod tests {
     #[test]
     fn emit_expr_stmt_terminates_with_semicolon() {
         let st = Stmt::ExprStmt {
-            expr: bc("print", vec![Expr::IntLit { value: 1, span: s() }]),
+            expr: bc(
+                "print",
+                vec![Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }],
+            ),
             span: s(),
         };
         let mut out = String::new();
@@ -2238,10 +2661,20 @@ mod tests {
     fn emit_simple_function_flat_body() {
         let f = fun(
             "id",
-            vec![Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() }],
+            vec![Param {
+                name: "x".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
             Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "x".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
         );
@@ -2257,8 +2690,18 @@ mod tests {
     fn emit_rest_param_is_native_spread() {
         let f = fun(
             "f",
-            vec![Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, default: None, span: s() }],
-            Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            vec![Param {
+                name: "rest".into(),
+                sir_type: None,
+                kind: ParamKind::Rest,
+                default: None,
+                span: s(),
+            }],
+            Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
         );
         let mut out = String::new();
         emit_function(&mut out, &f);
@@ -2274,14 +2717,24 @@ mod tests {
         let default = bc(
             "+",
             vec![
-                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 int(1),
             ],
         );
         let f = fun(
             "f",
             vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
                 Param {
                     name: "b".into(),
                     sir_type: None,
@@ -2292,13 +2745,20 @@ mod tests {
             ],
             Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "b".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
         );
         let mut out = String::new();
         emit_function(&mut out, &f);
-        assert!(out.contains("function f(a, b = __Sir.plus(a, 1)) {"), "got {out}");
+        assert!(
+            out.contains("function f(a, b = __Sir.plus(a, 1)) {"),
+            "got {out}"
+        );
     }
 
     #[test]
@@ -2327,7 +2787,13 @@ mod tests {
     }
 
     fn req_param(name: &str) -> Param {
-        Param { name: name.into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() }
+        Param {
+            name: name.into(),
+            sir_type: None,
+            kind: ParamKind::Required,
+            default: None,
+            span: s(),
+        }
     }
 
     #[test]
@@ -2338,17 +2804,28 @@ mod tests {
         // destructuring default; both fold into the single trailing `__kw`.
         let f = fun(
             "f",
-            vec![req_param("a"), kw_param("b", None), kw_param("c", Some(int(1)))],
+            vec![
+                req_param("a"),
+                kw_param("b", None),
+                kw_param("c", Some(int(1))),
+            ],
             Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "b".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
         );
         let mut out = String::new();
         emit_function(&mut out, &f);
         assert!(out.contains("function f(a, __kw) {"), "signature: {out}");
-        assert!(out.contains("const { b, c = 1 } = __kw ?? {};"), "prologue: {out}");
+        assert!(
+            out.contains("const { b, c = 1 } = __kw ?? {};"),
+            "prologue: {out}"
+        );
     }
 
     #[test]
@@ -2361,7 +2838,11 @@ mod tests {
             vec![kw_param("x", None)],
             Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "x".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
         );
@@ -2378,7 +2859,11 @@ mod tests {
         let f = fun(
             "g",
             vec![req_param("a")],
-            Block { stmts: vec![], value: int(0), span: s() },
+            Block {
+                stmts: vec![],
+                value: int(0),
+                span: s(),
+            },
         );
         let mut out = String::new();
         emit_function(&mut out, &f);
@@ -2388,7 +2873,11 @@ mod tests {
 
     /// Build a `KeywordArg` call-argument.
     fn kw_arg(name: &str, value: Expr) -> Expr {
-        Expr::KeywordArg { name: name.into(), value: Box::new(value), span: s() }
+        Expr::KeywordArg {
+            name: name.into(),
+            value: Box::new(value),
+            span: s(),
+        }
     }
 
     #[test]
@@ -2432,7 +2921,11 @@ mod tests {
         // Closure application routes args through `[…]`; the keyword object
         // is the last element of that array: applyClosure(t, [1, { b: 2 }]).
         let ic = Expr::IndirectCall {
-            target: Box::new(Expr::VarRef { name: "t".into(), scope: Scope::Local, span: s() }),
+            target: Box::new(Expr::VarRef {
+                name: "t".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
             args: vec![int(1), kw_arg("b", int(2))],
             effects: EffectSet::PURE,
             span: s(),
@@ -2452,7 +2945,10 @@ mod tests {
                 vec![],
                 Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
             )],
@@ -2481,8 +2977,15 @@ mod tests {
         let e = bc(
             "raise",
             vec![
-                Expr::VarRef { name: "ArgumentError".into(), scope: Scope::Const, span: s() },
-                Expr::StrLit { value: "boom".into(), span: s() },
+                Expr::VarRef {
+                    name: "ArgumentError".into(),
+                    scope: Scope::Const,
+                    span: s(),
+                },
+                Expr::StrLit {
+                    value: "boom".into(),
+                    span: s(),
+                },
             ],
         );
         assert_eq!(emit_e(&e), r#"__Sir.raiseError("ArgumentError", "boom")"#);
@@ -2493,7 +2996,11 @@ mod tests {
     fn emit_raise_const_class_no_message() {
         let e = bc(
             "raise",
-            vec![Expr::VarRef { name: "RuntimeError".into(), scope: Scope::Const, span: s() }],
+            vec![Expr::VarRef {
+                name: "RuntimeError".into(),
+                scope: Scope::Const,
+                span: s(),
+            }],
         );
         assert_eq!(emit_e(&e), r#"__Sir.raiseError("RuntimeError")"#);
     }
@@ -2509,7 +3016,13 @@ mod tests {
     /// carrying the value as the message, matching Ruby and the TS backend.
     #[test]
     fn emit_raise_non_const_is_runtime_error_with_message() {
-        let e = bc("raise", vec![Expr::StrLit { value: "oops".into(), span: s() }]);
+        let e = bc(
+            "raise",
+            vec![Expr::StrLit {
+                value: "oops".into(),
+                span: s(),
+            }],
+        );
         assert_eq!(emit_e(&e), r#"__Sir.raiseError("RuntimeError", "oops")"#);
     }
 
@@ -2520,14 +3033,26 @@ mod tests {
     fn emit_try_catch_emits_rescue_matches_else_chain() {
         let st = Stmt::TryCatch {
             body: vec![Stmt::ExprStmt {
-                expr: bc("print", vec![Expr::StrLit { value: "try".into(), span: s() }]),
+                expr: bc(
+                    "print",
+                    vec![Expr::StrLit {
+                        value: "try".into(),
+                        span: s(),
+                    }],
+                ),
                 span: s(),
             }],
             rescues: vec![RescueClause {
                 exception_types: vec!["StandardError".into()],
                 binding: Some("e".into()),
                 body: vec![Stmt::ExprStmt {
-                    expr: bc("print", vec![Expr::StrLit { value: "caught".into(), span: s() }]),
+                    expr: bc(
+                        "print",
+                        vec![Expr::StrLit {
+                            value: "caught".into(),
+                            span: s(),
+                        }],
+                    ),
                     span: s(),
                 }],
                 span: s(),
@@ -2572,8 +3097,14 @@ mod tests {
             span: s(),
         };
         let out = emit_s(&st);
-        assert!(out.contains(r#"if (__Sir.rescueMatches(__exc, ["TypeError"])) {"#), "got:\n{out}");
-        assert!(out.contains("} else if (__Sir.rescueMatches(__exc, [])) {"), "got:\n{out}");
+        assert!(
+            out.contains(r#"if (__Sir.rescueMatches(__exc, ["TypeError"])) {"#),
+            "got:\n{out}"
+        );
+        assert!(
+            out.contains("} else if (__Sir.rescueMatches(__exc, [])) {"),
+            "got:\n{out}"
+        );
         assert!(out.contains("finally {"), "got:\n{out}");
     }
 
@@ -2598,7 +3129,11 @@ mod tests {
             functions: vec![fun(
                 "main",
                 vec![],
-                Block { stmts: vec![class_def], value: Expr::NilLit { span: s() }, span: s() },
+                Block {
+                    stmts: vec![class_def],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
             )],
             globals: vec![],
             metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
@@ -2613,7 +3148,10 @@ mod tests {
         // before any `rescueMatches` runs.
         let reg = out.find("__Sir.registerAncestry({").unwrap();
         let main = out.find("function main(").unwrap();
-        assert!(reg < main, "registerAncestry call must precede user functions");
+        assert!(
+            reg < main,
+            "registerAncestry call must precede user functions"
+        );
     }
 
     /// A base class (`class Foo`, no superclass) carries no ancestry edge,
@@ -2634,7 +3172,11 @@ mod tests {
             functions: vec![fun(
                 "main",
                 vec![],
-                Block { stmts: vec![class_def], value: Expr::NilLit { span: s() }, span: s() },
+                Block {
+                    stmts: vec![class_def],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
             )],
             globals: vec![],
             metadata: Metadata::new().with_sir_version(semantic_ir::CURRENT_SIR_VERSION),

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -240,9 +240,7 @@ impl Backend for JavaScriptBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{
-        Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Span, Stmt,
-    };
+    use semantic_ir::{Block, EffectSet, Expr, FeatureManifest, Function, Metadata, Span, Stmt};
 
     fn s() -> Span {
         Span::synthetic()
@@ -262,7 +260,10 @@ mod tests {
                 captures: vec![],
                 body: Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
                 effects: EffectSet::PURE,
@@ -378,6 +379,66 @@ mod tests {
         );
     }
 
+    // ── SIR22: array/matrix capability-rejection tests ────────────────
+    //
+    // Per the SIR22 spec's "Backend impact": "Rust/Go/Python backends: not
+    // required to support this in the first wave; they reject modules
+    // declaring NDArrays/MatrixOps per the existing capability-rejection
+    // path."  This JavaScript backend is likewise not updated for real
+    // SIR22 codegen in this PR, so it must reject the same way, via the
+    // same SIR10 capability-check mechanism `rejects_tail_calls_feature`
+    // above already exercises for `Feature::TailCalls`.
+
+    #[test]
+    fn rejects_nd_arrays_feature() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::NDArrays]);
+        let err = compile(&m).expect_err("nd-arrays rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+    }
+
+    #[test]
+    fn rejects_matrix_ops_feature() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::MatrixOps]);
+        let err = compile(&m).expect_err("matrix-ops rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+    }
+
+    /// End-to-end version: a real module body using `Expr::ArrayLit` and
+    /// `Expr::MatMul` (the concrete SIR22 nodes the spec names), not just a
+    /// hand-set manifest flag — proving the rejection path works from
+    /// actual node usage.
+    #[test]
+    fn rejects_module_body_using_array_lit_and_matmul() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::MatrixOps,
+            Feature::ArrayColumnMajor,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::MatMul {
+            lhs: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }]],
+                span: s(),
+            }),
+            rhs: Box::new(Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }]],
+                span: s(),
+            }),
+            span: s(),
+        };
+        let err = compile(&m).expect_err("array/matmul body rejected");
+        assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+    }
+
     #[test]
     fn end_to_end_from_twig_source() {
         let module = twig_to_semantic_ir::compile_source(
@@ -386,13 +447,25 @@ mod tests {
         )
         .expect("lower");
         let a = compile(&module).expect("compile");
-        assert!(a.source.contains("function add(a, b) {"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("function add(a, b) {"),
+            "got:\n{}",
+            a.source
+        );
         // `+` is Ruby-polymorphic, so it routes through the runtime
         // dispatch helper (numeric add, String/Array concat) rather than
         // native infix.
-        assert!(a.source.contains("return __Sir.plus(a, b);"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("return __Sir.plus(a, b);"),
+            "got:\n{}",
+            a.source
+        );
         // Top-level print of a direct call.
-        assert!(a.source.contains("__Sir.print(add(1, 2))"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("__Sir.print(add(1, 2))"),
+            "got:\n{}",
+            a.source
+        );
     }
 
     #[test]
@@ -404,14 +477,22 @@ mod tests {
         .expect("lower");
         let a = compile(&module).expect("compile");
         // A synthesised lambda function is emitted.
-        assert!(a.source.contains("function __lambda_0("), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("function __lambda_0("),
+            "got:\n{}",
+            a.source
+        );
         // MakeClosure → a `new __Sir.Closure`.
         assert!(a.source.contains("new __Sir.Closure"), "got:\n{}", a.source);
         // `add5` is a module global, initialised in `_init`.
         assert!(a.source.contains("let add5 = null;"), "got:\n{}", a.source);
         assert!(a.source.contains("_init();"), "got:\n{}", a.source);
         // The indirect call to the closure routes through applyClosure.
-        assert!(a.source.contains("__Sir.applyClosure"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("__Sir.applyClosure"),
+            "got:\n{}",
+            a.source
+        );
     }
 
     #[test]
@@ -428,8 +509,8 @@ mod tests {
 
     #[test]
     fn output_is_deterministic() {
-        let module =
-            twig_to_semantic_ir::compile_source("(define (id x) x)\n(id 7)", "demo").expect("lower");
+        let module = twig_to_semantic_ir::compile_source("(define (id x) x)\n(id 7)", "demo")
+            .expect("lower");
         let a = compile(&module).expect("compile");
         let b = compile(&module).expect("compile again");
         assert_eq!(a.source, b.source);

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Feature, Function, Global, Module, ParamKind, Scope, Stmt,
+    Block, Expr, Feature, Function, Global, IndexArg, Module, ParamKind, Scope, Stmt,
 };
 
 use crate::runtime::RUNTIME;
@@ -115,7 +115,12 @@ fn collect_ancestry_in_stmt(
     seen: &mut BTreeSet<String>,
 ) {
     match s {
-        Stmt::ClassDef { name, superclass, body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
             if let Some(sup) = superclass {
                 if seen.insert(name.clone()) {
                     pairs.push((name.clone(), sup.clone()));
@@ -126,12 +131,15 @@ fn collect_ancestry_in_stmt(
         Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
             collect_ancestry_in_stmts(body, pairs, seen);
         }
-        Stmt::While { body, .. }
-        | Stmt::ForRange { body, .. }
-        | Stmt::ForEach { body, .. } => {
+        Stmt::While { body, .. } | Stmt::ForRange { body, .. } | Stmt::ForEach { body, .. } => {
             collect_ancestry_in_block(body, pairs, seen);
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             collect_ancestry_in_stmts(body, pairs, seen);
             for r in rescues {
                 collect_ancestry_in_stmts(&r.body, pairs, seen);
@@ -150,16 +158,48 @@ fn collect_ancestry_in_stmt(
         | Stmt::ExprStmt { expr: value, .. } => {
             collect_ancestry_in_expr(value, pairs, seen);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             collect_ancestry_in_expr(seq, pairs, seen);
             collect_ancestry_in_expr(index, pairs, seen);
             collect_ancestry_in_expr(value, pairs, seen);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             collect_ancestry_in_expr(map, pairs, seen);
             collect_ancestry_in_expr(key, pairs, seen);
             collect_ancestry_in_expr(value, pairs, seen);
         }
+        // SIR22 `target[indices...] = value` — same shape as `SeqSet`/
+        // `MapSet` above (an indexed mutation), so recurse into its
+        // sub-expressions the same way: a class def cannot itself be one
+        // of these, but a nested `if`-with-block (etc.) inside `target`,
+        // an index, or `value` could still carry one.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            collect_ancestry_in_expr(target, pairs, seen);
+            for ix in indices {
+                collect_ancestry_in_index_arg(ix, pairs, seen);
+            }
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+    }
+}
+
+fn collect_ancestry_in_index_arg(
+    ix: &IndexArg,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut BTreeSet<String>,
+) {
+    match ix {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => collect_ancestry_in_expr(e, pairs, seen),
+        IndexArg::Whole => {}
     }
 }
 
@@ -169,7 +209,11 @@ fn collect_ancestry_in_expr(
     seen: &mut BTreeSet<String>,
 ) {
     match e {
-        Expr::If { then_branch, else_branch, .. } => {
+        Expr::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
             collect_ancestry_in_block(then_branch, pairs, seen);
             collect_ancestry_in_block(else_branch, pairs, seen);
         }
@@ -216,7 +260,9 @@ fn uses_range(m: &Module) -> bool {
 /// (e.g. `regex`).  Exhaustive over `Stmt`/`Expr` so a new node can't silently
 /// hide a use (the compiler forces every arm to be handled).
 fn module_uses_builtin(m: &Module, name: &str) -> bool {
-    m.functions.iter().any(|f| block_uses_builtin(&f.body, name))
+    m.functions
+        .iter()
+        .any(|f| block_uses_builtin(&f.body, name))
 }
 
 fn block_uses_builtin(b: &Block, name: &str) -> bool {
@@ -236,7 +282,13 @@ fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
         Stmt::While { cond, body, .. } => {
             expr_uses_builtin(cond, name) || block_uses_builtin(body, name)
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             expr_uses_builtin(start, name)
                 || expr_uses_builtin(stop, name)
                 || expr_uses_builtin(step, name)
@@ -245,23 +297,48 @@ fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
         Stmt::ForEach { iter, body, .. } => {
             expr_uses_builtin(iter, name) || block_uses_builtin(body, name)
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             expr_uses_builtin(seq, name)
                 || expr_uses_builtin(index, name)
                 || expr_uses_builtin(value, name)
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             expr_uses_builtin(map, name)
                 || expr_uses_builtin(key, name)
+                || expr_uses_builtin(value, name)
+        }
+        // SIR22 `target[indices...] = value` — same recursion shape as
+        // `SeqSet`/`MapSet`: walk into `target`, each index argument, and
+        // `value` so a nested builtin call (e.g. inside an index
+        // expression) is still detected.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            expr_uses_builtin(target, name)
+                || indices.iter().any(|ix| index_arg_uses_builtin(ix, name))
                 || expr_uses_builtin(value, name)
         }
         Stmt::ClassDef { body, .. }
         | Stmt::ModuleDef { body, .. }
         | Stmt::SingletonClassDef { body, .. } => stmts_use_builtin(body, name),
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             stmts_use_builtin(body, name)
                 || rescues.iter().any(|r| stmts_use_builtin(&r.body, name))
-                || ensure_body.as_deref().is_some_and(|e| stmts_use_builtin(e, name))
+                || ensure_body
+                    .as_deref()
+                    .is_some_and(|e| stmts_use_builtin(e, name))
         }
     }
 }
@@ -275,7 +352,12 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         Expr::IndirectCall { target, args, .. } => {
             expr_uses_builtin(target, name) || args.iter().any(|a| expr_uses_builtin(a, name))
         }
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             expr_uses_builtin(cond, name)
                 || block_uses_builtin(then_branch, name)
                 || block_uses_builtin(else_branch, name)
@@ -304,6 +386,35 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         // whose runtime meaning is its inner `value`; recurse into it so this
         // builtin-usage scan stays faithful.  Real support pending KW2–KW6.
         Expr::KeywordArg { value, .. } => expr_uses_builtin(value, name),
+        // SIR22 array/matrix expressions are not accepted by this backend
+        // yet (see `ACCEPTED_FEATURES` in `lib.rs`), so a validated module
+        // never contains them in practice. Still, this scan is exhaustive
+        // by design so a new node can't silently hide a builtin use — recurse
+        // into every sub-expression the same way the other compound-expr
+        // arms above do.
+        Expr::ArrayLit { rows, .. } => rows
+            .iter()
+            .any(|row| row.iter().any(|c| expr_uses_builtin(c, name))),
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            expr_uses_builtin(start, name)
+                || step.as_deref().is_some_and(|s| expr_uses_builtin(s, name))
+                || expr_uses_builtin(stop, name)
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::Transpose { target, .. } => expr_uses_builtin(target, name),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            expr_uses_builtin(target, name)
+                || indices.iter().any(|ix| index_arg_uses_builtin(ix, name))
+        }
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -311,6 +422,16 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         | Expr::SymLit { .. }
         | Expr::StrLit { .. }
         | Expr::VarRef { .. } => false,
+    }
+}
+
+/// Same walk as `expr_uses_builtin`, specialised to a single SIR22
+/// [`IndexArg`] subscript: `Scalar`/`Range` each wrap one expression to
+/// recurse into, and `Whole` (`:`) carries no expression at all.
+fn index_arg_uses_builtin(ix: &IndexArg, name: &str) -> bool {
+    match ix {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => expr_uses_builtin(e, name),
+        IndexArg::Whole => false,
     }
 }
 
@@ -651,13 +772,20 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push('\n');
         }
-        Stmt::Assign { name, scope: Scope::Global, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Global,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}_globals[{}] = ", pad, quote_py_string(name));
             emit_expr(out, value, indent);
             out.push('\n');
         }
         // `seq[index] = value`
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             out.push_str(&pad);
             emit_expr(out, seq, indent);
             out.push('[');
@@ -667,7 +795,9 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
             out.push('\n');
         }
         // `map[key] = value`
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             out.push_str(&pad);
             emit_expr(out, map, indent);
             out.push('[');
@@ -689,7 +819,14 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
         // `for var in range(start, stop, step):` — Python's `range` is
         // already half-open (`stop` exclusive) and direction-aware (a
         // negative `step` counts down), matching SIR `ForRange`.
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             let _ = write!(out, "{}for {} in range(", pad, sanitize_ident(var));
             emit_expr(out, start, indent);
             out.push_str(", ");
@@ -700,7 +837,9 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
             emit_block_as_stmts(out, body, indent + 1);
         }
         // `for var in iter:` — iterate a Seq.
-        Stmt::ForEach { var, iter, body, .. } => {
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => {
             let _ = write!(out, "{}for {} in ", pad, sanitize_ident(var));
             emit_expr(out, iter, indent);
             out.push_str(":\n");
@@ -709,28 +848,50 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
         // ── SIR17 scopes (assignment) ───────────────────────────────
         // `@x = v` → current-self instance-variable write via the OOP
         // runtime (no native `self` — methods are receiver-less).
-        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Instance,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}_sir_oop_ivar_set({}, ", pad, quote_py_string(name));
             emit_expr(out, value, indent);
             out.push_str(")\n");
         }
         // `@@x = v` → class-variable store write.
-        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::ClassVar,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}_sir_oop_cvar_set({}, ", pad, quote_py_string(name));
             emit_expr(out, value, indent);
             out.push_str(")\n");
         }
         // `CONST = v` → an ordinary module-level binding; reads elsewhere
         // emit the bare identifier (see `emit_var_ref`).
-        Stmt::Assign { name, scope: Scope::Const, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Const,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}{} = ", pad, sanitize_ident(name));
             emit_expr(out, value, indent);
             out.push('\n');
         }
         // `Assign` to a builtin is never produced by any frontend (you
         // cannot rebind `+`); a validated module never reaches here.
-        Stmt::Assign { scope: Scope::Builtin, span, .. } => {
-            panic!("python backend reached an assign to a Builtin-scoped name at {} — invalid SIR", span);
+        Stmt::Assign {
+            scope: Scope::Builtin,
+            span,
+            ..
+        } => {
+            panic!(
+                "python backend reached an assign to a Builtin-scoped name at {} — invalid SIR",
+                span
+            );
         }
         // ── SIR17 class / module / singleton declarations ───────────
         // The Ruby→SIR frontend hoists method `def`s to top-level
@@ -738,8 +899,18 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
         // statements (constant / class-variable assigns).  We register
         // the class in the OOP runtime (for ancestry-aware `is_a?`) and
         // emit the body statements in source order.
-        Stmt::ClassDef { name, superclass, body, .. } => {
-            let _ = write!(out, "{}_sir_oop_define_class({}, ", pad, quote_py_string(name));
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "{}_sir_oop_define_class({}, ",
+                pad,
+                quote_py_string(name)
+            );
             match superclass {
                 Some(sup) => out.push_str(&quote_py_string(sup)),
                 None => out.push_str("None"),
@@ -752,7 +923,12 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
         // A module is a namespace with no superclass; register it so it
         // can participate in `is_a?`/ancestry, then emit its body.
         Stmt::ModuleDef { name, body, .. } => {
-            let _ = write!(out, "{}_sir_oop_define_class({}, None)\n", pad, quote_py_string(name));
+            let _ = write!(
+                out,
+                "{}_sir_oop_define_class({}, None)\n",
+                pad,
+                quote_py_string(name)
+            );
             for st in body {
                 emit_stmt(out, st, indent);
             }
@@ -772,7 +948,12 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
         // clause in source order; a `rescue Foo => e` binds `e = __exc`; if no
         // clause matches the original exception is re-`raise`d (Ruby's
         // "propagate when unrescued").  `ensure_body` → a `finally:` block.
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             let _ = write!(out, "{}try:\n", pad);
             emit_stmt_list(out, body, indent + 1);
             if !rescues.is_empty() {
@@ -814,6 +995,17 @@ fn emit_stmt_inner(out: &mut String, s: &Stmt, indent: usize) {
                 let _ = write!(out, "{}finally:\n", pad);
                 emit_stmt_list(out, ens, indent + 1);
             }
+        }
+        // SIR22 `target[indices...] = value`. This backend does not declare
+        // `Feature::NDArrays`/`Feature::MatrixOps` in `ACCEPTED_FEATURES`
+        // (see `lib.rs`), so `Backend::check_module` rejects any module
+        // using this node before it ever reaches emission — a validated
+        // module never reaches this arm.
+        Stmt::IndexSet { span, .. } => {
+            panic!(
+                "python backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet",
+                span
+            );
         }
     }
 }
@@ -883,7 +1075,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str(&quote_py_string(value));
         }
         Expr::VarRef { name, scope, .. } => emit_var_ref(out, name, *scope),
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             // Python ternary: (then if cond else else)
             out.push('(');
             emit_block_as_expr(out, then_branch, indent);
@@ -907,7 +1104,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str("])");
         }
         Expr::BuiltinCall { name, args, .. } => emit_builtin_call(out, name, args, indent),
-        Expr::MakeClosure { fn_name, captures, .. } => {
+        Expr::MakeClosure {
+            fn_name, captures, ..
+        } => {
             let _ = write!(out, "_sir_make_closure({}, [", function_emit_name(fn_name));
             for (i, c) in captures.iter().enumerate() {
                 if i > 0 {
@@ -1010,6 +1209,24 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str(&sanitize_ident(name));
             out.push('=');
             emit_expr(out, value, indent);
+        }
+        // SIR22 array/matrix expressions. This backend does not declare
+        // `Feature::NDArrays`/`Feature::MatrixOps` in `ACCEPTED_FEATURES`
+        // (see `lib.rs`), so `Backend::check_module` rejects any module
+        // using these nodes before emission is ever reached — matching the
+        // `Expr::Intrinsic` guard above, a validated module never reaches
+        // this arm.
+        Expr::ArrayLit { .. }
+        | Expr::Range { .. }
+        | Expr::MatMul { .. }
+        | Expr::ElementwiseOp { .. }
+        | Expr::Transpose { .. }
+        | Expr::IndexGet { .. } => {
+            panic!(
+                "python backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                e.span()
+            );
         }
     }
 }
@@ -1131,12 +1348,15 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             out.push_str("_sir_oop_call_method(");
             emit_expr(out, &args[0], indent);
             let _ = write!(out, ", {}", quote_py_string(meth));
-            let is_class_pred =
-                matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
+            let is_class_pred = matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
             for (i, a) in args[2..].iter().enumerate() {
                 out.push_str(", ");
                 match a {
-                    Expr::VarRef { name: cn, scope: Scope::Const, .. } if is_class_pred && i == 0 => {
+                    Expr::VarRef {
+                        name: cn,
+                        scope: Scope::Const,
+                        ..
+                    } if is_class_pred && i == 0 => {
                         out.push_str(&quote_py_string(cn));
                     }
                     // A `&:sym` / `&proc` block argument on a dispatched call
@@ -1247,7 +1467,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push_str("_sir_exc_raise_error(");
         match args.first() {
             None => {}
-            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+            Some(Expr::VarRef {
+                name: cn,
+                scope: Scope::Const,
+                ..
+            }) => {
                 out.push_str(&quote_py_string(cn));
                 if let Some(msg) = args.get(1) {
                     out.push_str(", ");
@@ -1446,12 +1670,22 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
         match s {
             Stmt::LetBinding { name, value, .. }
             | Stmt::LetStarBinding { name, value, .. }
-            | Stmt::Assign { name, scope: Scope::Local | Scope::Param | Scope::Capture, value, .. } => {
+            | Stmt::Assign {
+                name,
+                scope: Scope::Local | Scope::Param | Scope::Capture,
+                value,
+                ..
+            } => {
                 let _ = write!(out, "({} := ", sanitize_ident(name));
                 emit_expr(out, value, indent);
                 out.push_str("), ");
             }
-            Stmt::Assign { name, scope: Scope::Global, value, .. } => {
+            Stmt::Assign {
+                name,
+                scope: Scope::Global,
+                value,
+                ..
+            } => {
                 let _ = write!(out, "(_globals.__setitem__({}, ", quote_py_string(name));
                 emit_expr(out, value, indent);
                 out.push_str(")), ");
@@ -1461,7 +1695,9 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
                 emit_expr(out, expr, indent);
                 out.push_str("), ");
             }
-            Stmt::SeqSet { seq, index, value, .. } => {
+            Stmt::SeqSet {
+                seq, index, value, ..
+            } => {
                 out.push('(');
                 emit_expr(out, seq, indent);
                 out.push_str(".__setitem__(");
@@ -1470,7 +1706,9 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
                 emit_expr(out, value, indent);
                 out.push_str(")), ");
             }
-            Stmt::MapSet { map, key, value, .. } => {
+            Stmt::MapSet {
+                map, key, value, ..
+            } => {
                 out.push('(');
                 emit_expr(out, map, indent);
                 out.push_str(".__setitem__(");
@@ -1481,28 +1719,44 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
             }
             // `@x = v` / `@@x = v` → OOP-store writes (return the value,
             // so they compose in the walrus tuple).
-            Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+            Stmt::Assign {
+                name,
+                scope: Scope::Instance,
+                value,
+                ..
+            } => {
                 let _ = write!(out, "(_sir_oop_ivar_set({}, ", quote_py_string(name));
                 emit_expr(out, value, indent);
                 out.push_str(")), ");
             }
-            Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+            Stmt::Assign {
+                name,
+                scope: Scope::ClassVar,
+                value,
+                ..
+            } => {
                 let _ = write!(out, "(_sir_oop_cvar_set({}, ", quote_py_string(name));
                 emit_expr(out, value, indent);
                 out.push_str(")), ");
             }
             // `CONST = v` → walrus binding (the const name is a plain
             // identifier, so `(NAME := v)` both binds and yields it).
-            Stmt::Assign { name, scope: Scope::Const, value, .. } => {
+            Stmt::Assign {
+                name,
+                scope: Scope::Const,
+                value,
+                ..
+            } => {
                 let _ = write!(out, "({} := ", sanitize_ident(name));
                 emit_expr(out, value, indent);
                 out.push_str("), ");
             }
             // Loops were diverted to the lifted-def path above.
-            Stmt::While { span, .. }
-            | Stmt::ForRange { span, .. }
-            | Stmt::ForEach { span, .. } => {
-                panic!("python backend (walrus path) reached a loop at {} — should have been lifted", span);
+            Stmt::While { span, .. } | Stmt::ForRange { span, .. } | Stmt::ForEach { span, .. } => {
+                panic!(
+                    "python backend (walrus path) reached a loop at {} — should have been lifted",
+                    span
+                );
             }
             // `Assign` to a builtin, and class/module/singleton/try
             // declarations, have no walrus-expression form; the former is
@@ -1513,7 +1767,21 @@ fn emit_block_as_expr(out: &mut String, b: &Block, indent: usize) {
             | Stmt::ModuleDef { span, .. }
             | Stmt::SingletonClassDef { span, .. }
             | Stmt::TryCatch { span, .. } => {
-                panic!("python backend (walrus path) reached an unwalrusable statement at {}", span);
+                panic!(
+                    "python backend (walrus path) reached an unwalrusable statement at {}",
+                    span
+                );
+            }
+            // SIR22 `target[indices...] = value`. This backend does not
+            // declare `Feature::NDArrays`/`Feature::MatrixOps` in
+            // `ACCEPTED_FEATURES` (see `lib.rs`), so `Backend::check_module`
+            // rejects any module using this node before emission is ever
+            // reached — a validated module never reaches this arm.
+            Stmt::IndexSet { span, .. } => {
+                panic!(
+                    "python backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet",
+                    span
+                );
             }
         }
     }
@@ -1617,13 +1885,21 @@ fn collect_nonlocals(b: &Block) -> BTreeSet<String> {
     assigned.difference(&bound).cloned().collect()
 }
 
-fn collect_nonlocals_block(b: &Block, assigned: &mut BTreeSet<String>, bound: &mut BTreeSet<String>) {
+fn collect_nonlocals_block(
+    b: &Block,
+    assigned: &mut BTreeSet<String>,
+    bound: &mut BTreeSet<String>,
+) {
     for s in &b.stmts {
         match s {
             Stmt::LetBinding { name, .. } | Stmt::LetStarBinding { name, .. } => {
                 bound.insert(name.clone());
             }
-            Stmt::Assign { name, scope: Scope::Local | Scope::Param | Scope::Capture, .. } => {
+            Stmt::Assign {
+                name,
+                scope: Scope::Local | Scope::Param | Scope::Capture,
+                ..
+            } => {
                 assigned.insert(name.clone());
             }
             Stmt::While { body, .. } => collect_nonlocals_block(body, assigned, bound),
@@ -1635,10 +1911,17 @@ fn collect_nonlocals_block(b: &Block, assigned: &mut BTreeSet<String>, bound: &m
             // each so an outer local reassigned inside the `begin` is declared
             // `nonlocal` in the lifted def.  A rescue binding (`=> e`) is a
             // freshly-introduced local, so it counts as `bound`.
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 let synthetic = Block {
                     stmts: body.clone(),
-                    value: Expr::NilLit { span: s.span().clone() },
+                    value: Expr::NilLit {
+                        span: s.span().clone(),
+                    },
                     span: s.span().clone(),
                 };
                 collect_nonlocals_block(&synthetic, assigned, bound);
@@ -1648,7 +1931,9 @@ fn collect_nonlocals_block(b: &Block, assigned: &mut BTreeSet<String>, bound: &m
                     }
                     let rb = Block {
                         stmts: r.body.clone(),
-                        value: Expr::NilLit { span: s.span().clone() },
+                        value: Expr::NilLit {
+                            span: s.span().clone(),
+                        },
                         span: s.span().clone(),
                     };
                     collect_nonlocals_block(&rb, assigned, bound);
@@ -1656,7 +1941,9 @@ fn collect_nonlocals_block(b: &Block, assigned: &mut BTreeSet<String>, bound: &m
                 if let Some(ens) = ensure_body {
                     let eb = Block {
                         stmts: ens.clone(),
-                        value: Expr::NilLit { span: s.span().clone() },
+                        value: Expr::NilLit {
+                            span: s.span().clone(),
+                        },
                         span: s.span().clone(),
                     };
                     collect_nonlocals_block(&eb, assigned, bound);
@@ -1744,12 +2031,43 @@ fn is_valid_py_ident(s: &str) -> bool {
 fn is_python_keyword(s: &str) -> bool {
     matches!(
         s,
-        "False" | "None" | "True" | "and" | "as" | "assert" | "async"
-            | "await" | "break" | "class" | "continue" | "def" | "del"
-            | "elif" | "else" | "except" | "finally" | "for" | "from"
-            | "global" | "if" | "import" | "in" | "is" | "lambda"
-            | "nonlocal" | "not" | "or" | "pass" | "raise" | "return"
-            | "try" | "while" | "with" | "yield" | "match" | "case"
+        "False"
+            | "None"
+            | "True"
+            | "and"
+            | "as"
+            | "assert"
+            | "async"
+            | "await"
+            | "break"
+            | "class"
+            | "continue"
+            | "def"
+            | "del"
+            | "elif"
+            | "else"
+            | "except"
+            | "finally"
+            | "for"
+            | "from"
+            | "global"
+            | "if"
+            | "import"
+            | "in"
+            | "is"
+            | "lambda"
+            | "nonlocal"
+            | "not"
+            | "or"
+            | "pass"
+            | "raise"
+            | "return"
+            | "try"
+            | "while"
+            | "with"
+            | "yield"
+            | "match"
+            | "case"
     )
 }
 
@@ -1787,9 +2105,7 @@ fn quote_py_string(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{
-        EffectSet, FeatureManifest, Metadata, Param, Span,
-    };
+    use semantic_ir::{EffectSet, FeatureManifest, Metadata, Param, Span};
 
     fn s() -> Span {
         Span::synthetic()
@@ -1846,7 +2162,13 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() }],
+            params: vec![Param {
+                name: "x".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
             return_type: None,
             captures: vec![],
             body,
@@ -1867,13 +2189,35 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
-                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, default: None, span: s() },
-                Param { name: "opts".into(), sir_type: None, kind: ParamKind::KwRest, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "rest".into(),
+                    sir_type: None,
+                    kind: ParamKind::Rest,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "opts".into(),
+                    sir_type: None,
+                    kind: ParamKind::KwRest,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1893,8 +2237,15 @@ mod tests {
         let default_b = Expr::BuiltinCall {
             name: "+".into(),
             args: vec![
-                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                Expr::IntLit { value: 1, span: s() },
+                Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -1904,8 +2255,16 @@ mod tests {
             value: Expr::BuiltinCall {
                 name: "+".into(),
                 args: vec![
-                    Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                    Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                    Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    },
+                    Expr::VarRef {
+                        name: "b".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -1915,7 +2274,13 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
                 Param {
                     name: "b".into(),
                     sir_type: None,
@@ -1941,7 +2306,10 @@ mod tests {
         // The prologue precedes the body's `return`.
         let prologue_at = out.find("if b is _SIR_MISSING:").unwrap();
         let return_at = out.find("return ").unwrap();
-        assert!(prologue_at < return_at, "prologue must precede return; got:\n{out}");
+        assert!(
+            prologue_at < return_at,
+            "prologue must precede return; got:\n{out}"
+        );
         // A param with no default must NOT gain a sentinel default.
         assert!(!out.contains("a=_SIR_MISSING"), "got:\n{out}");
     }
@@ -1960,7 +2328,10 @@ mod tests {
                 captures: vec![],
                 body: Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
                 effects: EffectSet::PURE,
@@ -1988,7 +2359,10 @@ mod tests {
             stmts: vec![Stmt::LetBinding {
                 name: "x".into(),
                 sir_type: None,
-                value: Expr::IntLit { value: 1, span: s() },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             }],
             value: Expr::BuiltinCall {
@@ -1999,7 +2373,10 @@ mod tests {
                         scope: Scope::Local,
                         span: s(),
                     },
-                    Expr::IntLit { value: 2, span: s() },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -2017,7 +2394,13 @@ mod tests {
     // M2 — `&:sym` symbol-to-proc on a method-dispatch call.
 
     fn method_call(recv: Expr, meth: &str, extra: Vec<Expr>) -> Expr {
-        let mut args = vec![recv, Expr::StrLit { value: meth.into(), span: s() }];
+        let mut args = vec![
+            recv,
+            Expr::StrLit {
+                value: meth.into(),
+                span: s(),
+            },
+        ];
         args.extend(extra);
         Expr::BuiltinCall {
             name: "__method__".into(),
@@ -2039,11 +2422,19 @@ mod tests {
     // ── O1: OOP object-model builtin emit arms ───────────────────────────────
 
     fn str_lit(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     fn builtin(name: &str, args: Vec<Expr>) -> Expr {
-        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+        Expr::BuiltinCall {
+            name: name.into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
     }
 
     #[test]
@@ -2073,7 +2464,10 @@ mod tests {
             captures: vec![],
             span: s(),
         };
-        let e = builtin("__def_method__", vec![str_lit("Dog"), str_lit("speak"), closure]);
+        let e = builtin(
+            "__def_method__",
+            vec![str_lit("Dog"), str_lit("speak"), closure],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(
@@ -2133,9 +2527,16 @@ mod tests {
     fn sym_block_pass_on_dispatch_emits_sym_to_proc() {
         // arr.map(&:to_s) → callMethod(arr, "map", sym_to_proc(intern("to_s")))
         let e = method_call(
-            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            Expr::VarRef {
+                name: "arr".into(),
+                scope: Scope::Local,
+                span: s(),
+            },
             "map",
-            vec![block_pass(Expr::SymLit { name: "to_s".into(), span: s() })],
+            vec![block_pass(Expr::SymLit {
+                name: "to_s".into(),
+                span: s(),
+            })],
         );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
@@ -2149,7 +2550,11 @@ mod tests {
     fn proc_block_pass_on_dispatch_unwraps_to_value() {
         // arr.each(&p) → callMethod(arr, "each", p) — the proc IS the block.
         let e = method_call(
-            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            Expr::VarRef {
+                name: "arr".into(),
+                scope: Scope::Local,
+                span: s(),
+            },
             "each",
             vec![block_pass(Expr::VarRef {
                 name: "p".into(),
@@ -2166,7 +2571,14 @@ mod tests {
     fn sym_block_pass_as_plain_arg_emits_sym_to_proc() {
         // The general emit_arg path also handles a surviving block_pass.
         let mut out = String::new();
-        emit_arg(&mut out, &block_pass(Expr::SymLit { name: "upcase".into(), span: s() }), 0);
+        emit_arg(
+            &mut out,
+            &block_pass(Expr::SymLit {
+                name: "upcase".into(),
+                span: s(),
+            }),
+            0,
+        );
         assert_eq!(out, r#"_sir_oop_sym_to_proc(_sir_intern("upcase"))"#);
     }
 }

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -20,9 +20,7 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fmt::Write;
 
-use semantic_ir::{
-    Block, Expr, Function, Global, Module, Param, ParamKind, Scope, Stmt,
-};
+use semantic_ir::{Block, Expr, Function, Global, Module, Param, ParamKind, Scope, Stmt};
 
 use crate::runtime::RUNTIME;
 
@@ -154,9 +152,7 @@ fn emit_main(out: &mut String, m: &Module) {
     };
 
     if uses_exceptions {
-        out.push_str(
-            "    let __r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {\n",
-        );
+        out.push_str("    let __r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {\n");
         run_body(out, "        ");
         out.push_str("    }));\n");
         out.push_str("    if let Err(__payload) = __r {\n");
@@ -207,7 +203,12 @@ fn collect_ancestry_block(b: &Block, edges: &mut Vec<(String, String)>) {
 /// `begin`/`class` still registers.
 fn collect_ancestry_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
     match s {
-        Stmt::ClassDef { name, superclass: Some(sup), body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass: Some(sup),
+            body,
+            ..
+        } => {
             edges.push((name.clone(), sup.clone()));
             for st in body {
                 collect_ancestry_stmt(st, edges);
@@ -220,7 +221,12 @@ fn collect_ancestry_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
                 collect_ancestry_stmt(st, edges);
             }
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             for st in body {
                 collect_ancestry_stmt(st, edges);
             }
@@ -244,7 +250,11 @@ fn collect_ancestry_stmt(s: &Stmt, edges: &mut Vec<(String, String)>) {
 // ---------------------------------------------------------------------------
 
 fn emit_function(out: &mut String, f: &Function) {
-    let _ = writeln!(out, "// SIR span: {}", sanitize_comment(&f.span.to_string()));
+    let _ = writeln!(
+        out,
+        "// SIR span: {}",
+        sanitize_comment(&f.span.to_string())
+    );
     let _ = write!(out, "fn {}(", function_emit_name(&f.name));
 
     let mut first = true;
@@ -324,7 +334,11 @@ fn emit_default_param_prologue(out: &mut String, f: &Function, indent: usize) {
     for p in &f.params {
         let Some(default) = &p.default else { continue };
         let name = sanitize_ident(&p.name);
-        let _ = write!(out, "{}let {} = if __sir::is_missing(&{}) {{ ", pad, name, name);
+        let _ = write!(
+            out,
+            "{}let {} = if __sir::is_missing(&{}) {{ ",
+            pad, name, name
+        );
         emit_expr(out, default, indent);
         let _ = writeln!(out, " }} else {{ {} }};", name);
     }
@@ -344,7 +358,12 @@ fn collect_assigned_locals(b: &Block, out: &mut HashSet<String>) {
 
 fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
     match s {
-        Stmt::Assign { name, scope: Scope::Local, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Local,
+            value,
+            ..
+        } => {
             out.insert(name.clone());
             collect_expr_assigned(value, out);
         }
@@ -357,7 +376,13 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
             collect_expr_assigned(cond, out);
             collect_assigned_locals(body, out);
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             collect_expr_assigned(start, out);
             collect_expr_assigned(stop, out);
             collect_expr_assigned(step, out);
@@ -370,12 +395,16 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
         // SIR16 Seq/Map indexed assignment: the target, index/key, and
         // value sub-expressions can each hold a nested `Assign` (e.g.
         // `xs[i] = (foo := 1)`), so recurse into all three.
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             collect_expr_assigned(seq, out);
             collect_expr_assigned(index, out);
             collect_expr_assigned(value, out);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             collect_expr_assigned(map, out);
             collect_expr_assigned(key, out);
             collect_expr_assigned(value, out);
@@ -386,12 +415,23 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
         | Stmt::ModuleDef { .. }
         | Stmt::SingletonClassDef { .. }
         | Stmt::TryCatch { .. } => {}
+        // SIR22 array/matrix indexed assignment: `Feature::NDArrays` /
+        // `Feature::MatrixOps` are not in this backend's accepted-features
+        // list, so `check_module` rejects any module using `IndexSet`
+        // before it ever reaches this pure collection helper. Nothing
+        // reachable to collect.
+        Stmt::IndexSet { .. } => {}
     }
 }
 
 fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
     match e {
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             collect_expr_assigned(cond, out);
             collect_assigned_locals(then_branch, out);
             collect_assigned_locals(else_branch, out);
@@ -457,6 +497,16 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         | Expr::VarRef { .. }
         | Expr::Intrinsic { .. }
         | Expr::StrConcat { .. } => {}
+        // SIR22 array/matrix nodes (rejected before emit — see
+        // `collect_stmt_assigned`'s `IndexSet` arm): none of these carry a
+        // reachable `Assign` for THIS backend, since a validated module can
+        // never contain them in the first place.
+        Expr::ArrayLit { .. }
+        | Expr::Range { .. }
+        | Expr::MatMul { .. }
+        | Expr::ElementwiseOp { .. }
+        | Expr::Transpose { .. }
+        | Expr::IndexGet { .. } => {}
     }
 }
 
@@ -497,7 +547,13 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             // let emission.  A name later re-bound by an `Assign`
             // (SIR16 MutableBindings) must be declared `let mut` so
             // the reassignment compiles; immutable bindings stay `let`.
-            let _ = write!(out, "{}{} {}: __sir::Value = ", pad, let_keyword(name), sanitize_ident(name));
+            let _ = write!(
+                out,
+                "{}{} {}: __sir::Value = ",
+                pad,
+                let_keyword(name),
+                sanitize_ident(name)
+            );
             emit_expr(out, value, indent);
             out.push_str(";\n");
         }
@@ -526,8 +582,18 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push_str(";\n");
         }
-        Stmt::Assign { name, scope: Scope::Global, value, .. } => {
-            let _ = write!(out, "{}let _ = __sir::global_set(&__sir::intern({}), ", pad, quote_rs_string(name));
+        Stmt::Assign {
+            name,
+            scope: Scope::Global,
+            value,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "{}let _ = __sir::global_set(&__sir::intern({}), ",
+                pad,
+                quote_rs_string(name)
+            );
             emit_expr(out, value, indent);
             out.push_str(");\n");
         }
@@ -536,28 +602,55 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // acting on the current self (a no-op returning `v` outside any
         // method).  The sigil-bearing name is the map key.  The returned
         // value is discarded here (`let _ = …`).
-        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
-            let _ = write!(out, "{}let _ = __sir::ivar_set({}, ", pad, quote_rs_string(name));
+        Stmt::Assign {
+            name,
+            scope: Scope::Instance,
+            value,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "{}let _ = __sir::ivar_set({}, ",
+                pad,
+                quote_rs_string(name)
+            );
             emit_expr(out, value, indent);
             out.push_str(");\n");
         }
-        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
-            let _ = write!(out, "{}let _ = __sir::cvar_set({}, ", pad, quote_rs_string(name));
+        Stmt::Assign {
+            name,
+            scope: Scope::ClassVar,
+            value,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "{}let _ = __sir::cvar_set({}, ",
+                pad,
+                quote_rs_string(name)
+            );
             emit_expr(out, value, indent);
             out.push_str(");\n");
         }
         // ── SIR16 loops ─────────────────────────────────────────────
         Stmt::While { cond, body, .. } => emit_while(out, cond, body, indent),
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
-            emit_for_range(out, var, start, stop, step, body, indent)
-        }
-        Stmt::ForEach { var, iter, body, .. } => {
-            emit_for_each(out, var, iter, body, indent)
-        }
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => emit_for_range(out, var, start, stop, step, body, indent),
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => emit_for_each(out, var, iter, body, indent),
         // ── SIR16 indexed assignment (Sequences/Maps) ───────────────
         // `seq[index] = value` mutates the shared backing vector in place
         // via `seq_set`; the returned value is discarded (`let _ = …`).
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             let _ = write!(out, "{}let _ = __sir::seq_set(&(", pad);
             emit_expr(out, seq, indent);
             out.push_str("), &(");
@@ -567,7 +660,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             out.push_str(");\n");
         }
         // `map[key] = value` inserts/overwrites via `map_set`.
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             let _ = write!(out, "{}let _ = __sir::map_set(&(", pad);
             emit_expr(out, map, indent);
             out.push_str("), ");
@@ -593,13 +688,29 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // `emit_ancestry_registration`); the declaration itself emits no
         // runtime code here — it exists purely as ancestry metadata.  We
         // emit a comment marker so the output is self-documenting.
-        Stmt::ClassDef { name, superclass, body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
             match superclass {
                 Some(sup) => {
-                    let _ = writeln!(out, "{}// class {} < {} (exception ancestry registered at init)", pad, sanitize_comment(name), sanitize_comment(sup));
+                    let _ = writeln!(
+                        out,
+                        "{}// class {} < {} (exception ancestry registered at init)",
+                        pad,
+                        sanitize_comment(name),
+                        sanitize_comment(sup)
+                    );
                 }
                 None => {
-                    let _ = writeln!(out, "{}// class {} (no ancestry edge)", pad, sanitize_comment(name));
+                    let _ = writeln!(
+                        out,
+                        "{}// class {} (no ancestry edge)",
+                        pad,
+                        sanitize_comment(name)
+                    );
                 }
             }
             // Body is empty for accepted (exception-subclass) classes, but
@@ -617,7 +728,12 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // so the defensive body loop below only ever runs for backend-
         // supported statements.
         Stmt::ModuleDef { name, body, .. } => {
-            let _ = writeln!(out, "{}// module {} (methods hoisted to top-level fns)", pad, sanitize_comment(name));
+            let _ = writeln!(
+                out,
+                "{}// module {} (methods hoisted to top-level fns)",
+                pad,
+                sanitize_comment(name)
+            );
             for st in body {
                 emit_stmt(out, st, indent);
             }
@@ -628,8 +744,21 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // `begin … rescue … ensure … end` → a `catch_unwind` region.  See
         // `emit_try_catch` for the full mapping and its ensure-ordering
         // guarantees.
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             emit_try_catch(out, body, rescues, ensure_body, indent);
+        }
+        // SIR22 array/matrix indexed assignment — `Feature::NDArrays` /
+        // `Feature::MatrixOps` are not in this backend's accepted-features
+        // list, so `check_module` rejects any module using `IndexSet`
+        // before it ever reaches emit.  Defensive panic covers internal
+        // bugs only (matches the `SingletonClassDef` arm above).
+        Stmt::IndexSet { span, .. } => {
+            panic!("rust backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet", span);
         }
     }
 }
@@ -724,15 +853,15 @@ fn emit_try_catch(
     // ── Err: an unwind occurred ──────────────────────────────────────
     let _ = writeln!(out, "{}Err(__payload) => {{", arm_pad);
     let dpad = indent_str(arm + 1);
-    let _ = writeln!(out, "{}let __exc = __sir::exc_from_payload(__payload);", dpad);
+    let _ = writeln!(
+        out,
+        "{}let __exc = __sir::exc_from_payload(__payload);",
+        dpad
+    );
     if rescues.is_empty() {
         // No rescue clauses: run ensure, then re-raise the exception.
         emit_ensure(out, arm + 1);
-        let _ = writeln!(
-            out,
-            "{}std::panic::resume_unwind(Box::new(__exc));",
-            dpad
-        );
+        let _ = writeln!(out, "{}std::panic::resume_unwind(Box::new(__exc));", dpad);
     } else {
         for (i, r) in rescues.iter().enumerate() {
             let kw = if i == 0 { "if" } else { "}} else if" };
@@ -804,10 +933,19 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             let _ = write!(out, "__sir::intern({})", quote_rs_string(name));
         }
         Expr::StrLit { value, .. } => {
-            let _ = write!(out, "__sir::Value::Str(::std::rc::Rc::from({}))", quote_rs_string(value));
+            let _ = write!(
+                out,
+                "__sir::Value::Str(::std::rc::Rc::from({}))",
+                quote_rs_string(value)
+            );
         }
         Expr::VarRef { name, scope, .. } => emit_var_ref(out, name, *scope),
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             out.push_str("(if __sir::truthy(&(");
             emit_expr(out, cond, indent);
             out.push_str(")) { ");
@@ -828,7 +966,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str("])");
         }
         Expr::BuiltinCall { name, args, .. } => emit_builtin_call(out, name, args, indent),
-        Expr::MakeClosure { fn_name, captures, .. } => {
+        Expr::MakeClosure {
+            fn_name, captures, ..
+        } => {
             emit_make_closure(out, fn_name, captures, indent);
         }
         Expr::Intrinsic { name, span, .. } => {
@@ -937,6 +1077,24 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         // (matching `StrConcat`/`Intrinsic` above).
         Expr::KeywordArg { span, .. } => {
             panic!("rust backend reached a stand-alone keyword-arg expression at {} — indirect/closure keyword calls are out of scope for v0 (see sir-keyword-params.md)", span);
+        }
+        // SIR22 array/matrix expressions (`ArrayLit`/`Range`/`MatMul`/
+        // `ElementwiseOp`/`Transpose`/`IndexGet`) — `Feature::NDArrays` /
+        // `Feature::MatrixOps` are not in this backend's accepted-features
+        // list, so `check_module` rejects any module using them before it
+        // ever reaches emit.  Defensive panic covers internal bugs only
+        // (matches the `StrConcat`/`Intrinsic` arms above).
+        Expr::ArrayLit { span, .. }
+        | Expr::Range { span, .. }
+        | Expr::MatMul { span, .. }
+        | Expr::ElementwiseOp { span, .. }
+        | Expr::Transpose { span, .. }
+        | Expr::IndexGet { span, .. } => {
+            panic!(
+                "rust backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                span
+            );
         }
     }
 }
@@ -1173,9 +1331,11 @@ fn emit_direct_call(out: &mut String, fn_name: &str, args: &[Expr], indent: usiz
 fn emit_oop_name_arg(out: &mut String, e: &Expr) {
     match e {
         Expr::StrLit { value, .. } => out.push_str(&quote_rs_string(value)),
-        Expr::VarRef { name, scope: Scope::Const, .. } => {
-            out.push_str(&quote_rs_string(name))
-        }
+        Expr::VarRef {
+            name,
+            scope: Scope::Const,
+            ..
+        } => out.push_str(&quote_rs_string(name)),
         other => {
             // Defensive fallback: coerce a non-literal name to a `&str` at
             // runtime.  The frontends never emit this; the runtime helpers
@@ -1209,7 +1369,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             None => {
                 out.push_str("__sir::reraise()");
             }
-            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+            Some(Expr::VarRef {
+                name: cn,
+                scope: Scope::Const,
+                ..
+            }) => {
                 let _ = write!(out, "__sir::raise({}, ", quote_rs_string(cn));
                 match args.get(1) {
                     Some(msg) => emit_expr(out, msg, indent),
@@ -1451,7 +1615,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         }
         _ => {
             // Unknown name → dispatch by name (forward-compat).
-            let _ = write!(out, "__sir::call_builtin_by_name({}, vec![", quote_rs_string(name));
+            let _ = write!(
+                out,
+                "__sir::call_builtin_by_name({}, vec![",
+                quote_rs_string(name)
+            );
             emit_args(out, args, indent);
             out.push_str("])");
             return;
@@ -1806,13 +1974,25 @@ fn emit_for_range(
     // Open a block so the loop temporaries don't leak.
     let _ = writeln!(out, "{}{{", pad);
 
-    let _ = write!(out, "{}let mut __sir_i_{}: i64 = __sir::as_int(&(", inner_pad, id);
+    let _ = write!(
+        out,
+        "{}let mut __sir_i_{}: i64 = __sir::as_int(&(",
+        inner_pad, id
+    );
     emit_expr(out, start, inner);
     out.push_str("));\n");
-    let _ = write!(out, "{}let __sir_stop_{}: i64 = __sir::as_int(&(", inner_pad, id);
+    let _ = write!(
+        out,
+        "{}let __sir_stop_{}: i64 = __sir::as_int(&(",
+        inner_pad, id
+    );
     emit_expr(out, stop, inner);
     out.push_str("));\n");
-    let _ = write!(out, "{}let __sir_step_{}: i64 = __sir::as_int(&(", inner_pad, id);
+    let _ = write!(
+        out,
+        "{}let __sir_step_{}: i64 = __sir::as_int(&(",
+        inner_pad, id
+    );
     emit_expr(out, step, inner);
     out.push_str("));\n");
 
@@ -1855,7 +2035,12 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
     // Compact rendering for block-as-expression contexts.
     match s {
         Stmt::LetBinding { name, value, .. } | Stmt::LetStarBinding { name, value, .. } => {
-            let _ = write!(out, "{} {}: __sir::Value = ", let_keyword(name), sanitize_ident(name));
+            let _ = write!(
+                out,
+                "{} {}: __sir::Value = ",
+                let_keyword(name),
+                sanitize_ident(name)
+            );
             emit_expr(out, value, indent);
             out.push_str("; ");
         }
@@ -1875,18 +2060,37 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push_str("; ");
         }
-        Stmt::Assign { name, scope: Scope::Global, value, .. } => {
-            let _ = write!(out, "let _ = __sir::global_set(&__sir::intern({}), ", quote_rs_string(name));
+        Stmt::Assign {
+            name,
+            scope: Scope::Global,
+            value,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "let _ = __sir::global_set(&__sir::intern({}), ",
+                quote_rs_string(name)
+            );
             emit_expr(out, value, indent);
             out.push_str("); ");
         }
         // ── SIR17 O5 instance / class variable writes (inline) ──────
-        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Instance,
+            value,
+            ..
+        } => {
             let _ = write!(out, "let _ = __sir::ivar_set({}, ", quote_rs_string(name));
             emit_expr(out, value, indent);
             out.push_str("); ");
         }
-        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::ClassVar,
+            value,
+            ..
+        } => {
             let _ = write!(out, "let _ = __sir::cvar_set({}, ", quote_rs_string(name));
             emit_expr(out, value, indent);
             out.push_str("); ");
@@ -1897,17 +2101,24 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         // a Rust block-as-expression too (`{ <loop>; <value> }`), so the
         // inline path reuses them rather than maintaining a second shape.
         Stmt::While { cond, body, .. } => emit_while(out, cond, body, indent),
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
-            emit_for_range(out, var, start, stop, step, body, indent)
-        }
-        Stmt::ForEach { var, iter, body, .. } => {
-            emit_for_each(out, var, iter, body, indent)
-        }
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => emit_for_range(out, var, start, stop, step, body, indent),
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => emit_for_each(out, var, iter, body, indent),
         // SIR16 Seq/Map indexed assignment — compact (inline) rendering
         // for a block-as-expression context.  Same `seq_set`/`map_set`
         // helpers as the statement path, with a trailing space instead of
         // a newline.
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             out.push_str("let _ = __sir::seq_set(&(");
             emit_expr(out, seq, indent);
             out.push_str("), &(");
@@ -1916,7 +2127,9 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
             emit_expr(out, value, indent);
             out.push_str("); ");
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             out.push_str("let _ = __sir::map_set(&(");
             emit_expr(out, map, indent);
             out.push_str("), ");
@@ -1933,10 +2146,20 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         // registered at init.  In a block-as-expression context we emit
         // just the self-documenting comment (multi-line is faithful in a
         // Rust `{ … }`), reusing the same helpers as the loop arms.
-        Stmt::ClassDef { name, superclass, body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
             match superclass {
                 Some(sup) => {
-                    let _ = write!(out, "/* class {} < {} */ ", sanitize_comment(name), sanitize_comment(sup));
+                    let _ = write!(
+                        out,
+                        "/* class {} < {} */ ",
+                        sanitize_comment(name),
+                        sanitize_comment(sup)
+                    );
                 }
                 None => {
                     let _ = write!(out, "/* class {} */ ", sanitize_comment(name));
@@ -1963,8 +2186,19 @@ fn emit_stmt_inline(out: &mut String, s: &Stmt, indent: usize) {
         // `emit_try_catch` helper renders is faithful inside a Rust
         // `{ … }`, so the inline path reuses it rather than maintaining a
         // second shape (same strategy as the loop arms above).
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             emit_try_catch(out, body, rescues, ensure_body, indent);
+        }
+        // SIR22 array/matrix indexed assignment (inline) — see the
+        // `IndexSet` arm in `emit_stmt` above; same reasoning applies here
+        // (matches the `SingletonClassDef` (inline) arm above).
+        Stmt::IndexSet { span, .. } => {
+            panic!("rust backend (inline) reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet", span);
         }
     }
 }
@@ -2064,15 +2298,52 @@ fn is_rust_keyword(s: &str) -> bool {
     // keywords; the few un-raw-able ones get encoded.
     matches!(
         s,
-        "as" | "break" | "const" | "continue" | "else" | "enum"
-            | "false" | "fn" | "for" | "if" | "impl" | "in"
-            | "let" | "loop" | "match" | "mod" | "move" | "mut"
-            | "pub" | "ref" | "return" | "static" | "struct"
-            | "trait" | "true" | "type" | "unsafe" | "use"
-            | "where" | "while" | "async" | "await" | "dyn"
-            | "abstract" | "become" | "box" | "do" | "final"
-            | "macro" | "override" | "priv" | "typeof" | "unsized"
-            | "virtual" | "yield" | "try" | "union"
+        "as" | "break"
+            | "const"
+            | "continue"
+            | "else"
+            | "enum"
+            | "false"
+            | "fn"
+            | "for"
+            | "if"
+            | "impl"
+            | "in"
+            | "let"
+            | "loop"
+            | "match"
+            | "mod"
+            | "move"
+            | "mut"
+            | "pub"
+            | "ref"
+            | "return"
+            | "static"
+            | "struct"
+            | "trait"
+            | "true"
+            | "type"
+            | "unsafe"
+            | "use"
+            | "where"
+            | "while"
+            | "async"
+            | "await"
+            | "dyn"
+            | "abstract"
+            | "become"
+            | "box"
+            | "do"
+            | "final"
+            | "macro"
+            | "override"
+            | "priv"
+            | "typeof"
+            | "unsized"
+            | "virtual"
+            | "yield"
+            | "try"
+            | "union"
     )
 }
 
@@ -2112,9 +2383,7 @@ fn quote_rs_string(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semantic_ir::{
-        EffectSet, FeatureManifest, Metadata, Param, ParamKind, Span,
-    };
+    use semantic_ir::{EffectSet, FeatureManifest, Metadata, Param, ParamKind, Span};
 
     fn s() -> Span {
         Span::synthetic()
@@ -2177,14 +2446,28 @@ mod tests {
     #[test]
     fn emit_int_literal() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::IntLit { value: 42, span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::IntLit {
+                value: 42,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "__sir::Value::Int(42i64)");
     }
 
     #[test]
     fn emit_negative_int() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::IntLit { value: -7, span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::IntLit {
+                value: -7,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "__sir::Value::Int(-7i64)");
     }
 
@@ -2193,8 +2476,22 @@ mod tests {
         let mut a = String::new();
         let mut b = String::new();
         let mut c = String::new();
-        emit_expr(&mut a, &Expr::BoolLit { value: true, span: s() }, 0);
-        emit_expr(&mut b, &Expr::BoolLit { value: false, span: s() }, 0);
+        emit_expr(
+            &mut a,
+            &Expr::BoolLit {
+                value: true,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut b,
+            &Expr::BoolLit {
+                value: false,
+                span: s(),
+            },
+            0,
+        );
         emit_expr(&mut c, &Expr::NilLit { span: s() }, 0);
         assert_eq!(a, "__sir::Value::Bool(true)");
         assert_eq!(b, "__sir::Value::Bool(false)");
@@ -2204,7 +2501,14 @@ mod tests {
     #[test]
     fn emit_symbol_interns() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::SymLit { name: "foo".into(), span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::SymLit {
+                name: "foo".into(),
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, r#"__sir::intern("foo")"#);
     }
 
@@ -2261,15 +2565,24 @@ mod tests {
             &Expr::BuiltinCall {
                 name: "+".into(),
                 args: vec![
-                    Expr::IntLit { value: 1, span: s() },
-                    Expr::IntLit { value: 2, span: s() },
+                    Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
             },
             0,
         );
-        assert_eq!(out, "__sir::plus(vec![__sir::Value::Int(1i64), __sir::Value::Int(2i64)])");
+        assert_eq!(
+            out,
+            "__sir::plus(vec![__sir::Value::Int(1i64), __sir::Value::Int(2i64)])"
+        );
     }
 
     #[test]
@@ -2280,8 +2593,14 @@ mod tests {
             &Expr::BuiltinCall {
                 name: "global_set".into(),
                 args: vec![
-                    Expr::SymLit { name: "x".into(), span: s() },
-                    Expr::IntLit { value: 5, span: s() },
+                    Expr::SymLit {
+                        name: "x".into(),
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 5,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -2305,10 +2624,16 @@ mod tests {
                 name: "__method__".into(),
                 args: vec![
                     Expr::SeqLit {
-                        items: vec![Expr::IntLit { value: 1, span: s() }],
+                        items: vec![Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        }],
                         span: s(),
                     },
-                    Expr::StrLit { value: "length".into(), span: s() },
+                    Expr::StrLit {
+                        value: "length".into(),
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -2331,9 +2656,19 @@ mod tests {
             &Expr::BuiltinCall {
                 name: "__method__".into(),
                 args: vec![
-                    Expr::VarRef { name: "xs".into(), scope: Scope::Local, span: s() },
-                    Expr::StrLit { value: "reduce".into(), span: s() },
-                    Expr::IntLit { value: 0, span: s() },
+                    Expr::VarRef {
+                        name: "xs".into(),
+                        scope: Scope::Local,
+                        span: s(),
+                    },
+                    Expr::StrLit {
+                        value: "reduce".into(),
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    },
                     Expr::MakeClosure {
                         fn_name: "__blk".into(),
                         captures: vec![],
@@ -2359,7 +2694,10 @@ mod tests {
             &mut out,
             &Expr::BuiltinCall {
                 name: "block_pass".into(),
-                args: vec![Expr::SymLit { name: "to_s".into(), span: s() }],
+                args: vec![Expr::SymLit {
+                    name: "to_s".into(),
+                    span: s(),
+                }],
                 effects: EffectSet::PURE,
                 span: s(),
             },
@@ -2375,7 +2713,10 @@ mod tests {
             &mut out,
             &Expr::DirectCall {
                 fn_name: "id".into(),
-                args: vec![Expr::IntLit { value: 7, span: s() }],
+                args: vec![Expr::IntLit {
+                    value: 7,
+                    span: s(),
+                }],
                 effects: EffectSet::PURE,
                 span: s(),
             },
@@ -2411,13 +2752,19 @@ mod tests {
                     scope: Scope::Local,
                     span: s(),
                 }),
-                args: vec![Expr::IntLit { value: 5, span: s() }],
+                args: vec![Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }],
                 effects: EffectSet::PURE,
                 span: s(),
             },
             0,
         );
-        assert_eq!(out, "__sir::apply_closure(&(f.clone()), vec![__sir::Value::Int(5i64)])");
+        assert_eq!(
+            out,
+            "__sir::apply_closure(&(f.clone()), vec![__sir::Value::Int(5i64)])"
+        );
     }
 
     #[test]
@@ -2425,7 +2772,14 @@ mod tests {
         // Integral floats must render with `.0` so the literal is an
         // f64, never an i64.
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::FloatLit { value: 3.0, span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::FloatLit {
+                value: 3.0,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "__sir::Value::Float(3.0f64)");
     }
 
@@ -2433,8 +2787,22 @@ mod tests {
     fn emit_float_literal_fractional_and_negative() {
         let mut a = String::new();
         let mut b = String::new();
-        emit_expr(&mut a, &Expr::FloatLit { value: 3.25, span: s() }, 0);
-        emit_expr(&mut b, &Expr::FloatLit { value: -7.5, span: s() }, 0);
+        emit_expr(
+            &mut a,
+            &Expr::FloatLit {
+                value: 3.25,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut b,
+            &Expr::FloatLit {
+                value: -7.5,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(a, "__sir::Value::Float(3.25f64)");
         assert_eq!(b, "__sir::Value::Float(-7.5f64)");
     }
@@ -2444,9 +2812,30 @@ mod tests {
         let mut nan = String::new();
         let mut inf = String::new();
         let mut ninf = String::new();
-        emit_expr(&mut nan, &Expr::FloatLit { value: f64::NAN, span: s() }, 0);
-        emit_expr(&mut inf, &Expr::FloatLit { value: f64::INFINITY, span: s() }, 0);
-        emit_expr(&mut ninf, &Expr::FloatLit { value: f64::NEG_INFINITY, span: s() }, 0);
+        emit_expr(
+            &mut nan,
+            &Expr::FloatLit {
+                value: f64::NAN,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut inf,
+            &Expr::FloatLit {
+                value: f64::INFINITY,
+                span: s(),
+            },
+            0,
+        );
+        emit_expr(
+            &mut ninf,
+            &Expr::FloatLit {
+                value: f64::NEG_INFINITY,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(nan, "__sir::Value::Float(f64::NAN)");
         assert_eq!(inf, "__sir::Value::Float(f64::INFINITY)");
         assert_eq!(ninf, "__sir::Value::Float(f64::NEG_INFINITY)");
@@ -2458,8 +2847,14 @@ mod tests {
         emit_expr(
             &mut out,
             &Expr::LogicalAnd {
-                lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
-                rhs: Box::new(Expr::IntLit { value: 5, span: s() }),
+                lhs: Box::new(Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -2477,8 +2872,14 @@ mod tests {
         emit_expr(
             &mut out,
             &Expr::LogicalOr {
-                lhs: Box::new(Expr::BoolLit { value: false, span: s() }),
-                rhs: Box::new(Expr::IntLit { value: 7, span: s() }),
+                lhs: Box::new(Expr::BoolLit {
+                    value: false,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 7,
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -2498,11 +2899,20 @@ mod tests {
             &mut out,
             &Expr::LogicalOr {
                 lhs: Box::new(Expr::LogicalAnd {
-                    lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
-                    rhs: Box::new(Expr::IntLit { value: 1, span: s() }),
+                    lhs: Box::new(Expr::BoolLit {
+                        value: true,
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    }),
                     span: s(),
                 }),
-                rhs: Box::new(Expr::IntLit { value: 2, span: s() }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -2525,7 +2935,13 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() }],
+            params: vec![Param {
+                name: "x".into(),
+                kind: ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            }],
             return_type: None,
             captures: vec![],
             body,
@@ -2553,8 +2969,16 @@ mod tests {
             value: Expr::BuiltinCall {
                 name: "+".into(),
                 args: vec![
-                    Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                    Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                    Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    },
+                    Expr::VarRef {
+                        name: "b".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -2564,8 +2988,15 @@ mod tests {
         let default_b = Expr::BuiltinCall {
             name: "+".into(),
             args: vec![
-                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                Expr::IntLit { value: 1, span: s() },
+                Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2573,8 +3004,20 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
-                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: Some(Box::new(default_b)), span: s() },
+                Param {
+                    name: "a".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "b".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: Some(Box::new(default_b)),
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
@@ -2604,18 +3047,37 @@ mod tests {
     fn emit_direct_call_pads_omitted_defaults() {
         // Build a module with f(a, b = ...) so FN_ARITY[f] == 2, then a
         // `main` whose body is `f(5)` — one arg short.
-        let default_b = Expr::IntLit { value: 99, span: s() };
+        let default_b = Expr::IntLit {
+            value: 99,
+            span: s(),
+        };
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
-                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: Some(Box::new(default_b)), span: s() },
+                Param {
+                    name: "a".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "b".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: Some(Box::new(default_b)),
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -2631,7 +3093,10 @@ mod tests {
                 stmts: vec![],
                 value: Expr::DirectCall {
                     fn_name: "f".into(),
-                    args: vec![Expr::IntLit { value: 5, span: s() }],
+                    args: vec![Expr::IntLit {
+                        value: 5,
+                        span: s(),
+                    }],
                     effects: EffectSet::PURE,
                     span: s(),
                 },
@@ -2668,12 +3133,32 @@ mod tests {
         let f = Function {
             name: "g".into(),
             params: vec![
-                Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
-                Param { name: "b".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "b".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -2688,8 +3173,14 @@ mod tests {
                 value: Expr::DirectCall {
                     fn_name: "g".into(),
                     args: vec![
-                        Expr::IntLit { value: 1, span: s() },
-                        Expr::IntLit { value: 2, span: s() },
+                        Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
+                        Expr::IntLit {
+                            value: 2,
+                            span: s(),
+                        },
                     ],
                     effects: EffectSet::PURE,
                     span: s(),
@@ -2734,14 +3225,30 @@ mod tests {
         Function {
             name: "greet".into(),
             params: vec![
-                Param { name: "greeting".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
-                Param { name: "name".into(), kind: ParamKind::Keyword, sir_type: None, default: Some(Box::new(default_name)), span: s() },
+                Param {
+                    name: "greeting".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "name".into(),
+                    kind: ParamKind::Keyword,
+                    sir_type: None,
+                    default: Some(Box::new(default_name)),
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "name".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "name".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -2751,7 +3258,10 @@ mod tests {
     }
 
     fn kw_str(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     fn main_calling(call: Expr) -> Function {
@@ -2760,7 +3270,11 @@ mod tests {
             params: vec![],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: call, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: call,
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -2829,7 +3343,8 @@ mod tests {
             "supplied keyword should resolve to positional; got:\n{out}"
         );
         // No sentinel — the keyword was supplied, not omitted.
-        assert!(!out.contains("greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"));
+        assert!(!out
+            .contains("greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"));
     }
 
     /// Call side, keyword OMITTED: `greet("hi")` fills the omitted
@@ -2848,9 +3363,7 @@ mod tests {
         let m = module_of(vec![greet_fn(kw_str("world")), main_calling(call)]);
         let out = emit_module_with_arity_table(&m);
         assert!(
-            out.contains(
-                "greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"
-            ),
+            out.contains("greet(__sir::Value::Str(::std::rc::Rc::from(\"hi\")), __sir::missing())"),
             "omitted optional keyword should pad the sentinel; got:\n{out}"
         );
     }
@@ -2865,12 +3378,35 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "x".into(), kind: ParamKind::Keyword, sir_type: None, default: None, span: s() },
-                Param { name: "y".into(), kind: ParamKind::Keyword, sir_type: None, default: Some(Box::new(Expr::IntLit { value: 2, span: s() })), span: s() },
+                Param {
+                    name: "x".into(),
+                    kind: ParamKind::Keyword,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "y".into(),
+                    kind: ParamKind::Keyword,
+                    sir_type: None,
+                    default: Some(Box::new(Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    })),
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::VarRef { name: "x".into(), scope: Scope::Param, span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::VarRef {
+                    name: "x".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -2879,7 +3415,10 @@ mod tests {
             fn_name: "f".into(),
             args: vec![Expr::KeywordArg {
                 name: "x".into(),
-                value: Box::new(Expr::IntLit { value: 1, span: s() }),
+                value: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
                 span: s(),
             }],
             effects: EffectSet::PURE,
@@ -2907,7 +3446,10 @@ mod tests {
                 captures: vec![],
                 body: Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
                 effects: EffectSet::PURE,
@@ -2932,7 +3474,10 @@ mod tests {
     fn emit_function_sanitises_span_in_comment() {
         let body = Block {
             stmts: vec![],
-            value: Expr::IntLit { value: 0, span: s() },
+            value: Expr::IntLit {
+                value: 0,
+                span: s(),
+            },
             span: s(),
         };
         let f = Function {
@@ -2961,7 +3506,11 @@ mod tests {
     // ── SIR16 MutableBindings + Loops ──────────────────────────────
 
     fn block(stmts: Vec<Stmt>, value: Expr) -> Block {
-        Block { stmts, value, span: s() }
+        Block {
+            stmts,
+            value,
+            span: s(),
+        }
     }
 
     fn nil() -> Expr {
@@ -2969,11 +3518,18 @@ mod tests {
     }
 
     fn int(v: i64) -> Expr {
-        Expr::IntLit { value: v, span: s() }
+        Expr::IntLit {
+            value: v,
+            span: s(),
+        }
     }
 
     fn local(name: &str) -> Expr {
-        Expr::VarRef { name: name.into(), scope: Scope::Local, span: s() }
+        Expr::VarRef {
+            name: name.into(),
+            scope: Scope::Local,
+            span: s(),
+        }
     }
 
     #[test]
@@ -3005,7 +3561,10 @@ mod tests {
             },
             1,
         );
-        assert!(out.contains("__sir::global_set(&__sir::intern(\"counter\")"), "got: {out}");
+        assert!(
+            out.contains("__sir::global_set(&__sir::intern(\"counter\")"),
+            "got: {out}"
+        );
         assert!(out.contains("__sir::Value::Int(7i64)"), "got: {out}");
     }
 
@@ -3041,7 +3600,10 @@ mod tests {
         };
         let mut out = String::new();
         emit_function(&mut out, &f);
-        assert!(out.contains("let mut acc: __sir::Value = __sir::Value::Int(0i64);"), "got: {out}");
+        assert!(
+            out.contains("let mut acc: __sir::Value = __sir::Value::Int(0i64);"),
+            "got: {out}"
+        );
         assert!(out.contains("acc = __sir::Value::Int(1i64);"), "got: {out}");
     }
 
@@ -3067,7 +3629,10 @@ mod tests {
         };
         let mut out = String::new();
         emit_function(&mut out, &f);
-        assert!(out.contains("let k: __sir::Value = __sir::Value::Int(3i64);"), "got: {out}");
+        assert!(
+            out.contains("let k: __sir::Value = __sir::Value::Int(3i64);"),
+            "got: {out}"
+        );
         assert!(!out.contains("let mut k"), "got: {out}");
     }
 
@@ -3077,13 +3642,19 @@ mod tests {
         emit_stmt(
             &mut out,
             &Stmt::While {
-                cond: Expr::BoolLit { value: true, span: s() },
+                cond: Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                },
                 body: block(vec![], nil()),
                 span: s(),
             },
             1,
         );
-        assert!(out.contains("while __sir::truthy(&(__sir::Value::Bool(true)))"), "got: {out}");
+        assert!(
+            out.contains("while __sir::truthy(&(__sir::Value::Bool(true)))"),
+            "got: {out}"
+        );
         assert!(out.trim_end().ends_with('}'), "got: {out}");
     }
 
@@ -3103,10 +3674,19 @@ mod tests {
             1,
         );
         // stop/step are cached into i64 temps so they are evaluated once.
-        assert!(out.contains("let __sir_stop_0: i64 = __sir::as_int("), "got: {out}");
-        assert!(out.contains("let __sir_step_0: i64 = __sir::as_int("), "got: {out}");
+        assert!(
+            out.contains("let __sir_stop_0: i64 = __sir::as_int("),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("let __sir_step_0: i64 = __sir::as_int("),
+            "got: {out}"
+        );
         // The loop var is rebound each turn as an Int Value.
-        assert!(out.contains("let i: __sir::Value = __sir::Value::Int(__sir_i_0);"), "got: {out}");
+        assert!(
+            out.contains("let i: __sir::Value = __sir::Value::Int(__sir_i_0);"),
+            "got: {out}"
+        );
         // Direction-aware condition + step advance.
         assert!(out.contains("if __sir_step_0 >= 0 { __sir_i_0 < __sir_stop_0 } else { __sir_i_0 > __sir_stop_0 }"), "got: {out}");
         assert!(out.contains("__sir_i_0 += __sir_step_0;"), "got: {out}");
@@ -3153,7 +3733,10 @@ mod tests {
             },
             1,
         );
-        assert!(out.contains("for x in __sir::seq_iter(&(xs.clone()))"), "got: {out}");
+        assert!(
+            out.contains("for x in __sir::seq_iter(&(xs.clone()))"),
+            "got: {out}"
+        );
     }
 
     #[test]
@@ -3182,7 +3765,10 @@ mod tests {
         let mut out = String::new();
         emit_expr(
             &mut out,
-            &Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: s() },
+            &Expr::SeqLit {
+                items: vec![int(1), int(2), int(3)],
+                span: s(),
+            },
             0,
         );
         assert_eq!(
@@ -3203,7 +3789,10 @@ mod tests {
             },
             0,
         );
-        assert_eq!(out, "__sir::seq_index(&(xs.clone()), &(__sir::Value::Int(0i64)))");
+        assert_eq!(
+            out,
+            "__sir::seq_index(&(xs.clone()), &(__sir::Value::Int(0i64)))"
+        );
     }
 
     #[test]
@@ -3211,7 +3800,10 @@ mod tests {
         let mut out = String::new();
         emit_expr(
             &mut out,
-            &Expr::SeqLen { seq: Box::new(local("xs")), span: s() },
+            &Expr::SeqLen {
+                seq: Box::new(local("xs")),
+                span: s(),
+            },
             0,
         );
         assert_eq!(out, "__sir::seq_len(&(xs.clone()))");
@@ -3226,11 +3818,17 @@ mod tests {
             &Expr::MapLit {
                 entries: vec![
                     MapEntry {
-                        key: Expr::StrLit { value: "a".into(), span: s() },
+                        key: Expr::StrLit {
+                            value: "a".into(),
+                            span: s(),
+                        },
                         value: int(1),
                     },
                     MapEntry {
-                        key: Expr::StrLit { value: "b".into(), span: s() },
+                        key: Expr::StrLit {
+                            value: "b".into(),
+                            span: s(),
+                        },
                         value: int(2),
                     },
                 ],
@@ -3239,8 +3837,18 @@ mod tests {
             0,
         );
         assert!(out.starts_with("__sir::map_lit(vec!["), "got: {out}");
-        assert!(out.contains("(__sir::Value::Str(::std::rc::Rc::from(\"a\")), __sir::Value::Int(1i64))"), "got: {out}");
-        assert!(out.contains("(__sir::Value::Str(::std::rc::Rc::from(\"b\")), __sir::Value::Int(2i64))"), "got: {out}");
+        assert!(
+            out.contains(
+                "(__sir::Value::Str(::std::rc::Rc::from(\"a\")), __sir::Value::Int(1i64))"
+            ),
+            "got: {out}"
+        );
+        assert!(
+            out.contains(
+                "(__sir::Value::Str(::std::rc::Rc::from(\"b\")), __sir::Value::Int(2i64))"
+            ),
+            "got: {out}"
+        );
     }
 
     #[test]
@@ -3250,7 +3858,10 @@ mod tests {
             &mut out,
             &Expr::MapGet {
                 map: Box::new(local("d")),
-                key: Box::new(Expr::StrLit { value: "k".into(), span: s() }),
+                key: Box::new(Expr::StrLit {
+                    value: "k".into(),
+                    span: s(),
+                }),
                 span: s(),
             },
             0,
@@ -3287,7 +3898,10 @@ mod tests {
             &mut out,
             &Stmt::MapSet {
                 map: local("d"),
-                key: Expr::StrLit { value: "k".into(), span: s() },
+                key: Expr::StrLit {
+                    value: "k".into(),
+                    span: s(),
+                },
                 value: int(7),
                 span: s(),
             },
@@ -3327,7 +3941,10 @@ mod tests {
             &mut out,
             &Stmt::MapSet {
                 map: local("d"),
-                key: Expr::StrLit { value: "k".into(), span: s() },
+                key: Expr::StrLit {
+                    value: "k".into(),
+                    span: s(),
+                },
                 value: int(2),
                 span: s(),
             },
@@ -3349,13 +3966,19 @@ mod tests {
             &mut out,
             &Stmt::ForEach {
                 var: "x".into(),
-                iter: Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: s() },
+                iter: Expr::SeqLit {
+                    items: vec![int(1), int(2), int(3)],
+                    span: s(),
+                },
                 body: block(vec![], nil()),
                 span: s(),
             },
             1,
         );
-        assert!(out.contains("for x in __sir::seq_iter(&(__sir::seq_lit(vec!["), "got: {out}");
+        assert!(
+            out.contains("for x in __sir::seq_iter(&(__sir::seq_lit(vec!["),
+            "got: {out}"
+        );
     }
 
     #[test]
@@ -3369,13 +3992,31 @@ mod tests {
             captures: vec![],
             body: block(
                 vec![
-                    Stmt::LetBinding { name: "acc".into(), sir_type: None, value: int(0), span: s() },
-                    Stmt::LetBinding { name: "xs".into(), sir_type: None, value: Expr::SeqLit { items: vec![int(0)], span: s() }, span: s() },
+                    Stmt::LetBinding {
+                        name: "acc".into(),
+                        sir_type: None,
+                        value: int(0),
+                        span: s(),
+                    },
+                    Stmt::LetBinding {
+                        name: "xs".into(),
+                        sir_type: None,
+                        value: Expr::SeqLit {
+                            items: vec![int(0)],
+                            span: s(),
+                        },
+                        span: s(),
+                    },
                     Stmt::SeqSet {
                         seq: local("xs"),
                         index: int(0),
                         value: Expr::Block(Box::new(block(
-                            vec![Stmt::Assign { name: "acc".into(), scope: Scope::Local, value: int(1), span: s() }],
+                            vec![Stmt::Assign {
+                                name: "acc".into(),
+                                scope: Scope::Local,
+                                value: int(1),
+                                span: s(),
+                            }],
                             local("acc"),
                         ))),
                         span: s(),
@@ -3389,21 +4030,36 @@ mod tests {
         };
         let mut out = String::new();
         emit_function(&mut out, &f);
-        assert!(out.contains("let mut acc: __sir::Value = __sir::Value::Int(0i64);"), "got: {out}");
+        assert!(
+            out.contains("let mut acc: __sir::Value = __sir::Value::Int(0i64);"),
+            "got: {out}"
+        );
     }
 
     // ── E4: exception emission shape ───────────────────────────────
 
     fn constref(name: &str) -> Expr {
-        Expr::VarRef { name: name.into(), scope: Scope::Const, span: s() }
+        Expr::VarRef {
+            name: name.into(),
+            scope: Scope::Const,
+            span: s(),
+        }
     }
 
     fn builtin(name: &str, args: Vec<Expr>) -> Expr {
-        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+        Expr::BuiltinCall {
+            name: name.into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
     }
 
     fn strlit(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     /// `puts` routes to the **variadic** `__sir::puts(vec![…])` helper, so
@@ -3419,9 +4075,16 @@ mod tests {
 
         // Multiple args, both forwarded.
         let mut out2 = String::new();
-        emit_expr(&mut out2, &builtin("puts", vec![strlit("a"), strlit("b")]), 0);
+        emit_expr(
+            &mut out2,
+            &builtin("puts", vec![strlit("a"), strlit("b")]),
+            0,
+        );
         assert!(out2.starts_with("__sir::puts(vec!["), "got: {out2}");
-        assert!(out2.contains(r#""a""#) && out2.contains(r#""b""#), "got: {out2}");
+        assert!(
+            out2.contains(r#""a""#) && out2.contains(r#""b""#),
+            "got: {out2}"
+        );
 
         // No args — a bare `puts`.
         let mut out0 = String::new();
@@ -3449,7 +4112,11 @@ mod tests {
     fn emit_raise_const_class_defaults_message_to_class_name() {
         // `raise RuntimeError` → __sir::raise("RuntimeError", Str("RuntimeError"))
         let mut out = String::new();
-        emit_expr(&mut out, &builtin("raise", vec![constref("RuntimeError")]), 0);
+        emit_expr(
+            &mut out,
+            &builtin("raise", vec![constref("RuntimeError")]),
+            0,
+        );
         assert!(out.contains(r#"__sir::raise("RuntimeError""#), "got: {out}");
         assert!(out.contains(r#"Rc::from("RuntimeError")"#), "got: {out}");
     }
@@ -3459,7 +4126,10 @@ mod tests {
         // `raise "boom"` → __sir::raise("RuntimeError", <arg>)
         let mut out = String::new();
         emit_expr(&mut out, &builtin("raise", vec![strlit("boom")]), 0);
-        assert!(out.contains(r#"__sir::raise("RuntimeError", "#), "got: {out}");
+        assert!(
+            out.contains(r#"__sir::raise("RuntimeError", "#),
+            "got: {out}"
+        );
         assert!(out.contains(r#""boom""#), "got: {out}");
     }
 
@@ -3482,7 +4152,10 @@ mod tests {
             rescues: vec![semantic_ir::RescueClause {
                 exception_types: vec!["StandardError".into()],
                 binding: Some("e".into()),
-                body: vec![Stmt::ExprStmt { expr: local("e"), span: s() }],
+                body: vec![Stmt::ExprStmt {
+                    expr: local("e"),
+                    span: s(),
+                }],
                 span: s(),
             }],
             ensure_body: None,
@@ -3493,15 +4166,24 @@ mod tests {
         assert!(out.contains("std::panic::catch_unwind"), "got: {out}");
         assert!(out.contains("std::panic::AssertUnwindSafe"), "got: {out}");
         assert!(out.contains("match __r {"), "got: {out}");
-        assert!(out.contains("let __exc = __sir::exc_from_payload(__payload);"), "got: {out}");
+        assert!(
+            out.contains("let __exc = __sir::exc_from_payload(__payload);"),
+            "got: {out}"
+        );
         assert!(
             out.contains(r#"if __sir::rescue_matches(&__exc, &["StandardError"])"#),
             "got: {out}"
         );
         // `=> e` binds the exception value.
-        assert!(out.contains("let e: __sir::Value = __sir::exc_value(&__exc);"), "got: {out}");
+        assert!(
+            out.contains("let e: __sir::Value = __sir::exc_value(&__exc);"),
+            "got: {out}"
+        );
         // No rescue matched → re-raise.
-        assert!(out.contains("std::panic::resume_unwind(Box::new(__exc));"), "got: {out}");
+        assert!(
+            out.contains("std::panic::resume_unwind(Box::new(__exc));"),
+            "got: {out}"
+        );
     }
 
     #[test]
@@ -3516,7 +4198,10 @@ mod tests {
             rescues: vec![semantic_ir::RescueClause {
                 exception_types: vec!["TypeError".into()],
                 binding: None,
-                body: vec![Stmt::ExprStmt { expr: int(1), span: s() }],
+                body: vec![Stmt::ExprStmt {
+                    expr: int(1),
+                    span: s(),
+                }],
                 span: s(),
             }],
             ensure_body: Some(vec![Stmt::ExprStmt {
@@ -3530,14 +4215,20 @@ mod tests {
         // The ensure body (`print(9)`) must appear three times: Ok arm,
         // matched arm, unmatched-else arm.
         let count = out.matches("__sir::print(__sir::Value::Int(9i64))").count();
-        assert_eq!(count, 3, "ensure should run on all 3 paths; got {count}:\n{out}");
+        assert_eq!(
+            count, 3,
+            "ensure should run on all 3 paths; got {count}:\n{out}"
+        );
     }
 
     #[test]
     fn emit_try_catch_no_rescue_runs_ensure_then_reraises() {
         // begin; …; ensure …; end  (no rescue) → ensure then resume_unwind.
         let tc = Stmt::TryCatch {
-            body: vec![Stmt::ExprStmt { expr: int(1), span: s() }],
+            body: vec![Stmt::ExprStmt {
+                expr: int(1),
+                span: s(),
+            }],
             rescues: vec![],
             ensure_body: Some(vec![Stmt::ExprStmt {
                 expr: builtin("print", vec![int(9)]),
@@ -3551,7 +4242,10 @@ mod tests {
         // ensure appears in both Ok and Err arms.
         let count = out.matches("__sir::print(__sir::Value::Int(9i64))").count();
         assert_eq!(count, 2, "got {count}:\n{out}");
-        assert!(out.contains("std::panic::resume_unwind(Box::new(__exc));"), "got: {out}");
+        assert!(
+            out.contains("std::panic::resume_unwind(Box::new(__exc));"),
+            "got: {out}"
+        );
     }
 
     #[test]
@@ -3567,7 +4261,10 @@ mod tests {
         emit_stmt(&mut out, &cd, 1);
         assert!(out.contains("class MyErr < StandardError"), "got: {out}");
         // No runtime statement is emitted for the class body.
-        assert!(!out.contains("__sir::"), "class def should emit no runtime code; got: {out}");
+        assert!(
+            !out.contains("__sir::"),
+            "class def should emit no runtime code; got: {out}"
+        );
     }
 
     // ── O5: user-defined-class OOP emission shape ──────────────────────
@@ -3620,7 +4317,10 @@ mod tests {
     #[test]
     fn emit_super_routes_to_call_super() {
         // super("x") inside Cat#describe → __super__("describe","Cat","x").
-        let e = builtin("__super__", vec![strlit("describe"), strlit("Cat"), strlit("x")]);
+        let e = builtin(
+            "__super__",
+            vec![strlit("describe"), strlit("Cat"), strlit("x")],
+        );
         assert_eq!(
             emit_e(&e),
             r#"__sir::call_super("describe", "Cat", vec![__sir::Value::Str(::std::rc::Rc::from("x"))])"#
@@ -3630,24 +4330,47 @@ mod tests {
     #[test]
     fn emit_def_method_routes_to_def_method() {
         // def speak; end in class Dog → __def_method__("Dog","speak",<closure>).
-        let closure = Expr::MakeClosure { fn_name: "Dog_speak".into(), captures: vec![], span: s() };
-        let e = builtin("__def_method__", vec![strlit("Dog"), strlit("speak"), closure]);
+        let closure = Expr::MakeClosure {
+            fn_name: "Dog_speak".into(),
+            captures: vec![],
+            span: s(),
+        };
+        let e = builtin(
+            "__def_method__",
+            vec![strlit("Dog"), strlit("speak"), closure],
+        );
         let out = emit_e(&e);
-        assert!(out.starts_with(r#"__sir::def_method("Dog", "speak", "#), "got: {out}");
+        assert!(
+            out.starts_with(r#"__sir::def_method("Dog", "speak", "#),
+            "got: {out}"
+        );
         assert!(out.contains("__sir::Value::Closure"), "got: {out}");
     }
 
     #[test]
     fn emit_def_class_method_routes_to_def_class_method() {
-        let closure = Expr::MakeClosure { fn_name: "Dog_count".into(), captures: vec![], span: s() };
-        let e = builtin("__def_class_method__", vec![strlit("Dog"), strlit("count"), closure]);
+        let closure = Expr::MakeClosure {
+            fn_name: "Dog_count".into(),
+            captures: vec![],
+            span: s(),
+        };
+        let e = builtin(
+            "__def_class_method__",
+            vec![strlit("Dog"), strlit("count"), closure],
+        );
         let out = emit_e(&e);
-        assert!(out.starts_with(r#"__sir::def_class_method("Dog", "count", "#), "got: {out}");
+        assert!(
+            out.starts_with(r#"__sir::def_class_method("Dog", "count", "#),
+            "got: {out}"
+        );
     }
 
     #[test]
     fn emit_self_routes_to_current_self() {
-        assert_eq!(emit_e(&builtin("__self__", vec![])), "__sir::current_self()");
+        assert_eq!(
+            emit_e(&builtin("__self__", vec![])),
+            "__sir::current_self()"
+        );
     }
 
     // ── MX6 mixins: include / extend / class-method emit shapes ────────
@@ -3662,19 +4385,31 @@ mod tests {
     #[test]
     fn emit_extend_routes_to_extend_module() {
         let e = builtin("__extend__", vec![strlit("Registry"), strlit("Counting")]);
-        assert_eq!(emit_e(&e), r#"__sir::extend_module("Registry", "Counting")"#);
+        assert_eq!(
+            emit_e(&e),
+            r#"__sir::extend_module("Registry", "Counting")"#
+        );
     }
 
     #[test]
     fn emit_class_method_routes_to_call_class_method() {
         // `Registry.total` → __class_method__("Registry","total") → call.
-        let e = builtin("__class_method__", vec![strlit("Registry"), strlit("total")]);
-        assert_eq!(emit_e(&e), r#"__sir::call_class_method("Registry", "total", vec![])"#);
+        let e = builtin(
+            "__class_method__",
+            vec![strlit("Registry"), strlit("total")],
+        );
+        assert_eq!(
+            emit_e(&e),
+            r#"__sir::call_class_method("Registry", "total", vec![])"#
+        );
     }
 
     #[test]
     fn emit_class_method_with_args_passes_them_through() {
-        let e = builtin("__class_method__", vec![strlit("Math"), strlit("add"), int(1), int(2)]);
+        let e = builtin(
+            "__class_method__",
+            vec![strlit("Math"), strlit("add"), int(1), int(2)],
+        );
         assert_eq!(
             emit_e(&e),
             r#"__sir::call_class_method("Math", "add", vec![__sir::Value::Int(1i64), __sir::Value::Int(2i64)])"#
@@ -3686,21 +4421,36 @@ mod tests {
         // `Registry.total` where `Registry` is a bare constant → a `Const`
         // VarRef in the owner slot, LIFTED to a `&str` literal (never a
         // runtime constant read), exactly as `__new__`/`__super__` lift.
-        let owner = Expr::VarRef { name: "Registry".into(), scope: Scope::Const, span: s() };
+        let owner = Expr::VarRef {
+            name: "Registry".into(),
+            scope: Scope::Const,
+            span: s(),
+        };
         let e = builtin("__class_method__", vec![owner, strlit("total")]);
-        assert_eq!(emit_e(&e), r#"__sir::call_class_method("Registry", "total", vec![])"#);
+        assert_eq!(
+            emit_e(&e),
+            r#"__sir::call_class_method("Registry", "total", vec![])"#
+        );
     }
 
     #[test]
     fn emit_ivar_read_routes_to_ivar_get() {
         // `@name` (Scope::Instance, sigil preserved) → ivar_get("@name").
-        let e = Expr::VarRef { name: "@name".into(), scope: Scope::Instance, span: s() };
+        let e = Expr::VarRef {
+            name: "@name".into(),
+            scope: Scope::Instance,
+            span: s(),
+        };
         assert_eq!(emit_e(&e), r#"__sir::ivar_get("@name")"#);
     }
 
     #[test]
     fn emit_cvar_read_routes_to_cvar_get() {
-        let e = Expr::VarRef { name: "@@count".into(), scope: Scope::ClassVar, span: s() };
+        let e = Expr::VarRef {
+            name: "@@count".into(),
+            scope: Scope::ClassVar,
+            span: s(),
+        };
         assert_eq!(emit_e(&e), r#"__sir::cvar_get("@@count")"#);
     }
 

--- a/code/packages/rust/semantic-ir-to-rust/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/lib.rs
@@ -28,8 +28,8 @@ mod emit;
 mod runtime;
 
 use semantic_ir::{
-    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr, Feature, Module,
-    ParamKind, Scope, Stmt,
+    Artifact, ArtifactMetadata, Backend, BackendError, BackendErrorKind, Expr, Feature, IndexArg,
+    Module, ParamKind, Scope, Stmt,
 };
 
 pub use emit::sanitize_ident;
@@ -370,7 +370,9 @@ fn reject_stateful_class(module: &Module) -> Option<BackendError> {
 fn stateful_class_in_stmts(stmts: &[Stmt]) -> Option<BackendError> {
     for s in stmts {
         match s {
-            Stmt::ClassDef { name, body, span, .. } => {
+            Stmt::ClassDef {
+                name, body, span, ..
+            } => {
                 if !body.is_empty() {
                     return Some(BackendError {
                         kind: BackendErrorKind::UnsupportedFeature,
@@ -390,7 +392,9 @@ fn stateful_class_in_stmts(stmts: &[Stmt]) -> Option<BackendError> {
             // has no object model for (and would reach the `Stmt::ModuleDef`
             // emit path), so reject it cleanly HERE — mirroring the ClassDef
             // rule — rather than letting emit produce nonsense.
-            Stmt::ModuleDef { name, body, span, .. } => {
+            Stmt::ModuleDef {
+                name, body, span, ..
+            } => {
                 if !body.is_empty() {
                     return Some(BackendError {
                         kind: BackendErrorKind::UnsupportedFeature,
@@ -410,7 +414,12 @@ fn stateful_class_in_stmts(stmts: &[Stmt]) -> Option<BackendError> {
                     return Some(e);
                 }
             }
-            Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+            Stmt::TryCatch {
+                body,
+                rescues,
+                ensure_body,
+                ..
+            } => {
                 if let Some(e) = stateful_class_in_stmts(body) {
                     return Some(e);
                 }
@@ -473,28 +482,47 @@ fn const_ref_in_stmt(s: &Stmt) -> Option<BackendError> {
         Stmt::LetBinding { value, .. }
         | Stmt::LetStarBinding { value, .. }
         | Stmt::ExprStmt { expr: value, .. } => const_ref_in_expr(value),
-        Stmt::Assign { scope: Scope::Const, span, .. } => Some(unsupported_const(span.clone())),
+        Stmt::Assign {
+            scope: Scope::Const,
+            span,
+            ..
+        } => Some(unsupported_const(span.clone())),
         Stmt::Assign { value, .. } => const_ref_in_expr(value),
         Stmt::While { cond, body, .. } => {
             const_ref_in_expr(cond).or_else(|| const_ref_in_block(body))
         }
-        Stmt::ForRange { start, stop, step, body, .. } => const_ref_in_expr(start)
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => const_ref_in_expr(start)
             .or_else(|| const_ref_in_expr(stop))
             .or_else(|| const_ref_in_expr(step))
             .or_else(|| const_ref_in_block(body)),
         Stmt::ForEach { iter, body, .. } => {
             const_ref_in_expr(iter).or_else(|| const_ref_in_block(body))
         }
-        Stmt::SeqSet { seq, index, value, .. } => const_ref_in_expr(seq)
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => const_ref_in_expr(seq)
             .or_else(|| const_ref_in_expr(index))
             .or_else(|| const_ref_in_expr(value)),
-        Stmt::MapSet { map, key, value, .. } => const_ref_in_expr(map)
+        Stmt::MapSet {
+            map, key, value, ..
+        } => const_ref_in_expr(map)
             .or_else(|| const_ref_in_expr(key))
             .or_else(|| const_ref_in_expr(value)),
         Stmt::ClassDef { body, .. }
         | Stmt::ModuleDef { body, .. }
         | Stmt::SingletonClassDef { body, .. } => const_ref_in_stmts(body),
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             if let Some(e) = const_ref_in_stmts(body) {
                 return Some(e);
             }
@@ -510,6 +538,35 @@ fn const_ref_in_stmt(s: &Stmt) -> Option<BackendError> {
             }
             None
         }
+        // SIR22 array/matrix indexed assignment: `Feature::NDArrays` /
+        // `Feature::MatrixOps` are not in this backend's accepted-features
+        // list, so `check_module` rejects any module using `IndexSet`
+        // before this analysis ever runs. Still scan `target`, each index
+        // sub-expression, and `value` faithfully — same recursive style as
+        // the `SeqSet`/`MapSet` arms above (this function never takes a
+        // "rejected elsewhere" shortcut).
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            if let Some(e) = const_ref_in_expr(target) {
+                return Some(e);
+            }
+            for idx in indices {
+                let inner = match idx {
+                    IndexArg::Scalar(inner) | IndexArg::Range(inner) => Some(inner.as_ref()),
+                    IndexArg::Whole => None,
+                };
+                if let Some(inner) = inner {
+                    if let Some(e) = const_ref_in_expr(inner) {
+                        return Some(e);
+                    }
+                }
+            }
+            const_ref_in_expr(value)
+        }
     }
 }
 
@@ -521,14 +578,21 @@ fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
     match e {
         // A `Const` VarRef standing alone (not a raise class name) cannot be
         // lowered — flag it.
-        Expr::VarRef { scope: Scope::Const, span, .. } => Some(unsupported_const(span.clone())),
+        Expr::VarRef {
+            scope: Scope::Const,
+            span,
+            ..
+        } => Some(unsupported_const(span.clone())),
         // `raise` is one allowed home for a `Const`: its first argument may
         // be a `Const` class name (lifted to a string).  Skip that slot;
         // still scan the remaining arguments (the message expression, etc.).
         Expr::BuiltinCall { name, args, .. } if name == "raise" => {
             let skip_first = matches!(
                 args.first(),
-                Some(Expr::VarRef { scope: Scope::Const, .. })
+                Some(Expr::VarRef {
+                    scope: Scope::Const,
+                    ..
+                })
             );
             let start = if skip_first { 1 } else { 0 };
             for a in &args[start.min(args.len())..] {
@@ -613,7 +677,12 @@ fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
             }
             None
         }
-        Expr::If { cond, then_branch, else_branch, .. } => const_ref_in_expr(cond)
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => const_ref_in_expr(cond)
             .or_else(|| const_ref_in_block(then_branch))
             .or_else(|| const_ref_in_block(else_branch)),
         Expr::Block(b) => const_ref_in_block(b),
@@ -644,9 +713,7 @@ fn const_ref_in_expr(e: &Expr) -> Option<BackendError> {
             }
             None
         }
-        Expr::MapGet { map, key, .. } => {
-            const_ref_in_expr(map).or_else(|| const_ref_in_expr(key))
-        }
+        Expr::MapGet { map, key, .. } => const_ref_in_expr(map).or_else(|| const_ref_in_expr(key)),
         // A closure's captured values are ordinary expressions emitted at the
         // capture site — a `Const` VarRef hiding in a capture would otherwise
         // slip past this gate and reach the `Scope::Const` emit panic (a
@@ -700,7 +767,10 @@ mod tests {
                 captures: vec![],
                 body: Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
                 effects: EffectSet::PURE,
@@ -741,11 +811,8 @@ mod tests {
 
     #[test]
     fn end_to_end_twig_to_rust_id_function() {
-        let module = twig_to_semantic_ir::compile_source(
-            "(define (id x) x)\n(id 42)",
-            "demo",
-        )
-        .expect("lower");
+        let module = twig_to_semantic_ir::compile_source("(define (id x) x)\n(id 42)", "demo")
+            .expect("lower");
         let a = compile(&module).expect("compile");
         assert!(a.source.contains("fn id(x: __sir::Value) -> __sir::Value"));
         assert!(a.source.contains("x.clone()"));
@@ -774,18 +841,17 @@ mod tests {
         .expect("lower");
         let a = compile(&module).expect("compile");
         assert!(a.source.contains("fn __lambda_0("));
-        assert!(a.source.contains("__sir::Value::Closure(::std::rc::Rc::new"));
+        assert!(a
+            .source
+            .contains("__sir::Value::Closure(::std::rc::Rc::new"));
         assert!(a.source.contains("__sir::apply_closure"));
         assert!(a.source.contains("Globals (initialised in _init): add5"));
     }
 
     #[test]
     fn output_is_deterministic() {
-        let module = twig_to_semantic_ir::compile_source(
-            "(define (id x) x)\n(id 7)",
-            "demo",
-        )
-        .expect("lower");
+        let module = twig_to_semantic_ir::compile_source("(define (id x) x)\n(id 7)", "demo")
+            .expect("lower");
         let a = compile(&module).expect("compile");
         let b = compile(&module).expect("compile again");
         assert_eq!(a.source, b.source);
@@ -876,7 +942,10 @@ mod tests {
                 value: Expr::DirectCall {
                     fn_name: "f".into(),
                     args: vec![
-                        Expr::StrLit { value: "hi".into(), span: s() },
+                        Expr::StrLit {
+                            value: "hi".into(),
+                            span: s(),
+                        },
                         Expr::KeywordArg {
                             name: "name".into(),
                             value: Box::new(Expr::StrLit {
@@ -946,15 +1015,30 @@ mod tests {
         // Reorder to the M3-legal `Required* Keyword* KwRest?`: keyword
         // BEFORE the KwRest slot (a `**opts` must come last).
         f.params = vec![
-            Param { name: "a".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+            Param {
+                name: "a".into(),
+                kind: ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            },
             Param {
                 name: "name".into(),
                 kind: ParamKind::Keyword,
                 sir_type: None,
-                default: Some(Box::new(Expr::StrLit { value: "world".into(), span: s() })),
+                default: Some(Box::new(Expr::StrLit {
+                    value: "world".into(),
+                    span: s(),
+                })),
                 span: s(),
             },
-            Param { name: "opts".into(), kind: ParamKind::KwRest, sir_type: None, default: None, span: s() },
+            Param {
+                name: "opts".into(),
+                kind: ParamKind::KwRest,
+                sir_type: None,
+                default: None,
+                span: s(),
+            },
         ];
         let m = kw_module(vec![f, main_calling_f_by_keyword()]);
         let err = compile(&m).expect_err("keyword + **kwrest must be rejected");
@@ -969,12 +1053,21 @@ mod tests {
         let f = Function {
             name: "greet".into(),
             params: vec![
-                Param { name: "greeting".into(), kind: ParamKind::Required, sir_type: None, default: None, span: s() },
+                Param {
+                    name: "greeting".into(),
+                    kind: ParamKind::Required,
+                    sir_type: None,
+                    default: None,
+                    span: s(),
+                },
                 Param {
                     name: "name".into(),
                     kind: ParamKind::Keyword,
                     sir_type: None,
-                    default: Some(Box::new(Expr::StrLit { value: "world".into(), span: s() })),
+                    default: Some(Box::new(Expr::StrLit {
+                        value: "world".into(),
+                        span: s(),
+                    })),
                     span: s(),
                 },
             ],
@@ -982,7 +1075,11 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "name".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "name".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -998,7 +1095,10 @@ mod tests {
                 stmts: vec![],
                 value: Expr::DirectCall {
                     fn_name: "greet".into(),
-                    args: vec![Expr::StrLit { value: "hi".into(), span: s() }],
+                    args: vec![Expr::StrLit {
+                        value: "hi".into(),
+                        span: s(),
+                    }],
                     effects: EffectSet::PURE,
                     span: s(),
                 },
@@ -1033,8 +1133,15 @@ mod tests {
             expr: Expr::BuiltinCall {
                 name: "raise".into(),
                 args: vec![
-                    Expr::VarRef { name: cls.into(), scope: Scope::Const, span: s() },
-                    Expr::StrLit { value: "m".into(), span: s() },
+                    Expr::VarRef {
+                        name: cls.into(),
+                        scope: Scope::Const,
+                        span: s(),
+                    },
+                    Expr::StrLit {
+                        value: "m".into(),
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -1057,13 +1164,21 @@ mod tests {
             span: s(),
         };
         let a = compile(&exc_module(vec![tc], &[Feature::Constants])).expect("exceptions accepted");
-        assert!(a.source.contains("std::panic::catch_unwind"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("std::panic::catch_unwind"),
+            "got:\n{}",
+            a.source
+        );
         assert!(
             a.source.contains(r#"__sir::raise("ArgumentError", "#),
             "got:\n{}",
             a.source
         );
-        assert!(a.source.contains("__sir::install_panic_hook();"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains("__sir::install_panic_hook();"),
+            "got:\n{}",
+            a.source
+        );
     }
 
     #[test]
@@ -1077,7 +1192,8 @@ mod tests {
         let a = compile(&exc_module(vec![cd], &[Feature::Classes]))
             .expect("empty-body exception subclass accepted");
         assert!(
-            a.source.contains(r#"__sir::register_ancestry(&[("MyErr", "StandardError")]);"#),
+            a.source
+                .contains(r#"__sir::register_ancestry(&[("MyErr", "StandardError")]);"#),
             "got:\n{}",
             a.source
         );
@@ -1090,7 +1206,10 @@ mod tests {
             name: "Widget".into(),
             superclass: None,
             body: vec![Stmt::ExprStmt {
-                expr: Expr::IntLit { value: 1, span: s() },
+                expr: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             }],
             span: s(),
@@ -1098,7 +1217,11 @@ mod tests {
         let err = compile(&exc_module(vec![cd], &[Feature::Classes]))
             .expect_err("stateful class rejected");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
-        assert!(err.message.contains("non-empty body"), "got: {}", err.message);
+        assert!(
+            err.message.contains("non-empty body"),
+            "got: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1107,13 +1230,21 @@ mod tests {
         let stmt = Stmt::LetBinding {
             name: "x".into(),
             sir_type: None,
-            value: Expr::VarRef { name: "PI".into(), scope: Scope::Const, span: s() },
+            value: Expr::VarRef {
+                name: "PI".into(),
+                scope: Scope::Const,
+                span: s(),
+            },
             span: s(),
         };
         let err = compile(&exc_module(vec![stmt], &[Feature::Constants]))
             .expect_err("bare const ref rejected");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
-        assert!(err.message.contains("constant reference"), "got: {}", err.message);
+        assert!(
+            err.message.contains("constant reference"),
+            "got: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1129,7 +1260,11 @@ mod tests {
                 fn_name: "lam".into(),
                 captures: vec![semantic_ir::CaptureValue {
                     name: "c".into(),
-                    value: Expr::VarRef { name: "PI".into(), scope: Scope::Const, span: s() },
+                    value: Expr::VarRef {
+                        name: "PI".into(),
+                        scope: Scope::Const,
+                        span: s(),
+                    },
                 }],
                 span: s(),
             },
@@ -1142,16 +1277,27 @@ mod tests {
             name: "lam".into(),
             params: vec![],
             return_type: None,
-            captures: vec![semantic_ir::Capture { name: "c".into(), sir_type: None }],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            captures: vec![semantic_ir::Capture {
+                name: "c".into(),
+                sir_type: None,
+            }],
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
         });
-        let err = compile(&m)
-            .expect_err("const ref in closure capture must be rejected, not panic");
+        let err =
+            compile(&m).expect_err("const ref in closure capture must be rejected, not panic");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
-        assert!(err.message.contains("constant reference"), "got: {}", err.message);
+        assert!(
+            err.message.contains("constant reference"),
+            "got: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1159,7 +1305,11 @@ mod tests {
         // `raise Foo, "m"` — the Const is the class name → allowed.
         let a = compile(&exc_module(vec![raise_stmt("Foo")], &[Feature::Constants]))
             .expect("raise-class-name const is allowed");
-        assert!(a.source.contains(r#"__sir::raise("Foo", "#), "got:\n{}", a.source);
+        assert!(
+            a.source.contains(r#"__sir::raise("Foo", "#),
+            "got:\n{}",
+            a.source
+        );
     }
 
     // ── O5: user-defined-class OOP acceptance + soundness ──────────────
@@ -1180,14 +1330,29 @@ mod tests {
         // A real OOP module: `class Dog`, a `__def_method__`, a `Dog.new`,
         // and an `@ivar` write — all now ACCEPTED and routed to the runtime.
         let stmts = vec![
-            Stmt::ClassDef { name: "Dog".into(), superclass: None, body: vec![], span: s() },
+            Stmt::ClassDef {
+                name: "Dog".into(),
+                superclass: None,
+                body: vec![],
+                span: s(),
+            },
             Stmt::ExprStmt {
                 expr: Expr::BuiltinCall {
                     name: "__def_method__".into(),
                     args: vec![
-                        Expr::StrLit { value: "Dog".into(), span: s() },
-                        Expr::StrLit { value: "speak".into(), span: s() },
-                        Expr::MakeClosure { fn_name: "Dog_speak".into(), captures: vec![], span: s() },
+                        Expr::StrLit {
+                            value: "Dog".into(),
+                            span: s(),
+                        },
+                        Expr::StrLit {
+                            value: "speak".into(),
+                            span: s(),
+                        },
+                        Expr::MakeClosure {
+                            fn_name: "Dog_speak".into(),
+                            captures: vec![],
+                            span: s(),
+                        },
                     ],
                     effects: EffectSet::PURE,
                     span: s(),
@@ -1197,13 +1362,19 @@ mod tests {
             Stmt::Assign {
                 name: "@name".into(),
                 scope: Scope::Instance,
-                value: Expr::StrLit { value: "Rex".into(), span: s() },
+                value: Expr::StrLit {
+                    value: "Rex".into(),
+                    span: s(),
+                },
                 span: s(),
             },
             Stmt::ExprStmt {
                 expr: Expr::BuiltinCall {
                     name: "__new__".into(),
-                    args: vec![Expr::StrLit { value: "Dog".into(), span: s() }],
+                    args: vec![Expr::StrLit {
+                        value: "Dog".into(),
+                        span: s(),
+                    }],
                     effects: EffectSet::PURE,
                     span: s(),
                 },
@@ -1228,7 +1399,11 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "@name".into(), scope: Scope::Instance, span: s() },
+                value: Expr::VarRef {
+                    name: "@name".into(),
+                    scope: Scope::Instance,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -1236,16 +1411,32 @@ mod tests {
             span: s(),
         });
         let a = compile(&m).expect("real OOP module should be accepted");
-        assert!(a.source.contains(r#"__sir::def_method("Dog", "speak", "#), "got:\n{}", a.source);
-        assert!(a.source.contains(r#"__sir::call_new("Dog", vec![])"#), "got:\n{}", a.source);
-        assert!(a.source.contains(r#"__sir::ivar_set("@name", "#), "got:\n{}", a.source);
+        assert!(
+            a.source.contains(r#"__sir::def_method("Dog", "speak", "#),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains(r#"__sir::call_new("Dog", vec![])"#),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains(r#"__sir::ivar_set("@name", "#),
+            "got:\n{}",
+            a.source
+        );
     }
 
     #[test]
     fn accepts_empty_module_def() {
         // `module Foo … end` with method defs hoisted (empty body) → accepted,
         // emits only a comment marker.
-        let md = Stmt::ModuleDef { name: "Foo".into(), body: vec![], span: s() };
+        let md = Stmt::ModuleDef {
+            name: "Foo".into(),
+            body: vec![],
+            span: s(),
+        };
         let a = compile(&feat_module(vec![md], &[Feature::Modules]))
             .expect("empty module def accepted");
         assert!(a.source.contains("// module Foo"), "got:\n{}", a.source);
@@ -1257,7 +1448,10 @@ mod tests {
         let md = Stmt::ModuleDef {
             name: "Foo".into(),
             body: vec![Stmt::ExprStmt {
-                expr: Expr::IntLit { value: 1, span: s() },
+                expr: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             }],
             span: s(),
@@ -1265,7 +1459,11 @@ mod tests {
         let err = compile(&feat_module(vec![md], &[Feature::Modules]))
             .expect_err("stateful module rejected");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
-        assert!(err.message.contains("non-empty body"), "got: {}", err.message);
+        assert!(
+            err.message.contains("non-empty body"),
+            "got: {}",
+            err.message
+        );
     }
 
     #[test]
@@ -1275,14 +1473,25 @@ mod tests {
         let st = Stmt::ExprStmt {
             expr: Expr::BuiltinCall {
                 name: "__new__".into(),
-                args: vec![Expr::VarRef { name: "Dog".into(), scope: Scope::Const, span: s() }],
+                args: vec![Expr::VarRef {
+                    name: "Dog".into(),
+                    scope: Scope::Const,
+                    span: s(),
+                }],
                 effects: EffectSet::PURE,
                 span: s(),
             },
             span: s(),
         };
-        let a = compile(&feat_module(vec![st], &[Feature::Classes, Feature::Constants]))
-            .expect("const class name in __new__ is allowed");
-        assert!(a.source.contains(r#"__sir::call_new("Dog", vec![])"#), "got:\n{}", a.source);
+        let a = compile(&feat_module(
+            vec![st],
+            &[Feature::Classes, Feature::Constants],
+        ))
+        .expect("const class name in __new__ is allowed");
+        assert!(
+            a.source.contains(r#"__sir::call_new("Dog", vec![])"#),
+            "got:\n{}",
+            a.source
+        );
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use std::fmt::Write;
 
 use semantic_ir::{
-    Block, Expr, Feature, Function, Global, Module, ParamKind, Scope, Stmt,
+    Block, Expr, Feature, Function, Global, IndexArg, Module, ParamKind, Scope, Stmt,
 };
 
 use crate::runtime::RUNTIME;
@@ -123,7 +123,12 @@ fn collect_ancestry_in_stmt(
     seen: &mut HashSet<String>,
 ) {
     match s {
-        Stmt::ClassDef { name, superclass, body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
             if let Some(sup) = superclass {
                 if seen.insert(name.clone()) {
                     pairs.push((name.clone(), sup.clone()));
@@ -134,12 +139,15 @@ fn collect_ancestry_in_stmt(
         Stmt::ModuleDef { body, .. } | Stmt::SingletonClassDef { body, .. } => {
             collect_ancestry_in_stmts(body, pairs, seen);
         }
-        Stmt::While { body, .. }
-        | Stmt::ForRange { body, .. }
-        | Stmt::ForEach { body, .. } => {
+        Stmt::While { body, .. } | Stmt::ForRange { body, .. } | Stmt::ForEach { body, .. } => {
             collect_ancestry_in_block(body, pairs, seen);
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             collect_ancestry_in_stmts(body, pairs, seen);
             for r in rescues {
                 collect_ancestry_in_stmts(&r.body, pairs, seen);
@@ -154,16 +162,47 @@ fn collect_ancestry_in_stmt(
         | Stmt::ExprStmt { expr: value, .. } => {
             collect_ancestry_in_expr(value, pairs, seen);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             collect_ancestry_in_expr(seq, pairs, seen);
             collect_ancestry_in_expr(index, pairs, seen);
             collect_ancestry_in_expr(value, pairs, seen);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             collect_ancestry_in_expr(map, pairs, seen);
             collect_ancestry_in_expr(key, pairs, seen);
             collect_ancestry_in_expr(value, pairs, seen);
         }
+        // SIR22: `target[indices...] = value` carries only sub-*expressions*
+        // (target/indices/value), never a statement block, so it can nest no
+        // `ClassDef` — same reasoning as `SeqSet`/`MapSet` above, just walked
+        // for completeness in case a future frontend surprises us.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            collect_ancestry_in_expr(target, pairs, seen);
+            for idx in indices {
+                collect_ancestry_in_index_arg(idx, pairs, seen);
+            }
+            collect_ancestry_in_expr(value, pairs, seen);
+        }
+    }
+}
+
+fn collect_ancestry_in_index_arg(
+    idx: &IndexArg,
+    pairs: &mut Vec<(String, String)>,
+    seen: &mut HashSet<String>,
+) {
+    match idx {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => collect_ancestry_in_expr(e, pairs, seen),
+        IndexArg::Whole => {}
     }
 }
 
@@ -173,7 +212,11 @@ fn collect_ancestry_in_expr(
     seen: &mut HashSet<String>,
 ) {
     match e {
-        Expr::If { then_branch, else_branch, .. } => {
+        Expr::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
             collect_ancestry_in_block(then_branch, pairs, seen);
             collect_ancestry_in_block(else_branch, pairs, seen);
         }
@@ -218,7 +261,9 @@ fn uses_range(m: &Module) -> bool {
 /// per-concern imports for builtins that carry no `Feature` flag.  Exhaustive
 /// over `Stmt`/`Expr` so a new node can't silently hide a use.
 fn module_uses_builtin(m: &Module, name: &str) -> bool {
-    m.functions.iter().any(|f| block_uses_builtin(&f.body, name))
+    m.functions
+        .iter()
+        .any(|f| block_uses_builtin(&f.body, name))
 }
 
 fn block_uses_builtin(b: &Block, name: &str) -> bool {
@@ -238,7 +283,13 @@ fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
         Stmt::While { cond, body, .. } => {
             expr_uses_builtin(cond, name) || block_uses_builtin(body, name)
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             expr_uses_builtin(start, name)
                 || expr_uses_builtin(stop, name)
                 || expr_uses_builtin(step, name)
@@ -247,12 +298,16 @@ fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
         Stmt::ForEach { iter, body, .. } => {
             expr_uses_builtin(iter, name) || block_uses_builtin(body, name)
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             expr_uses_builtin(seq, name)
                 || expr_uses_builtin(index, name)
                 || expr_uses_builtin(value, name)
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             expr_uses_builtin(map, name)
                 || expr_uses_builtin(key, name)
                 || expr_uses_builtin(value, name)
@@ -260,11 +315,38 @@ fn stmt_uses_builtin(s: &Stmt, name: &str) -> bool {
         Stmt::ClassDef { body, .. }
         | Stmt::ModuleDef { body, .. }
         | Stmt::SingletonClassDef { body, .. } => stmts_use_builtin(body, name),
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             stmts_use_builtin(body, name)
                 || rescues.iter().any(|r| stmts_use_builtin(&r.body, name))
-                || ensure_body.as_deref().is_some_and(|e| stmts_use_builtin(e, name))
+                || ensure_body
+                    .as_deref()
+                    .is_some_and(|e| stmts_use_builtin(e, name))
         }
+        // SIR22: `target[indices...] = value` — recurse into every operand
+        // (mirrors `SeqSet`/`MapSet` above) so a builtin nested inside an
+        // index expression is still detected.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            expr_uses_builtin(target, name)
+                || indices.iter().any(|idx| index_arg_uses_builtin(idx, name))
+                || expr_uses_builtin(value, name)
+        }
+    }
+}
+
+fn index_arg_uses_builtin(idx: &IndexArg, name: &str) -> bool {
+    match idx {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => expr_uses_builtin(e, name),
+        IndexArg::Whole => false,
     }
 }
 
@@ -277,7 +359,12 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         Expr::IndirectCall { target, args, .. } => {
             expr_uses_builtin(target, name) || args.iter().any(|a| expr_uses_builtin(a, name))
         }
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             expr_uses_builtin(cond, name)
                 || block_uses_builtin(then_branch, name)
                 || block_uses_builtin(else_branch, name)
@@ -306,6 +393,34 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
         // (its runtime meaning) so this builtin-usage scan stays faithful.
         // Real support pending KW2–KW6.
         Expr::KeywordArg { value, .. } => expr_uses_builtin(value, name),
+        // SIR22 compile-compat stubs: this backend does not accept
+        // `Feature::NDArrays`/`Feature::MatrixOps` (see `accepts_features` in
+        // lib.rs), so `check_module` rejects any module using these nodes
+        // before emission — but the scan still recurses into every operand
+        // so it stays faithful if that ever changes.
+        Expr::ArrayLit { rows, .. } => rows
+            .iter()
+            .any(|row| row.iter().any(|e| expr_uses_builtin(e, name))),
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            expr_uses_builtin(start, name)
+                || step.as_deref().is_some_and(|s| expr_uses_builtin(s, name))
+                || expr_uses_builtin(stop, name)
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::Transpose { target, .. } => expr_uses_builtin(target, name),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            expr_uses_builtin(target, name)
+                || indices.iter().any(|idx| index_arg_uses_builtin(idx, name))
+        }
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -444,7 +559,11 @@ fn emit_module_footer(out: &mut String, m: &Module) {
 // ---------------------------------------------------------------------------
 
 fn emit_function(out: &mut String, f: &Function) {
-    let _ = writeln!(out, "// SIR span: {}", sanitize_comment(&f.span.to_string()));
+    let _ = writeln!(
+        out,
+        "// SIR span: {}",
+        sanitize_comment(&f.span.to_string())
+    );
     let _ = write!(out, "function {}(", sanitize_ident(&f.name));
     // Captures are positional and come BEFORE params, matching the
     // lowerer's MakeClosure convention.
@@ -595,7 +714,12 @@ fn collect_assigned_locals(b: &Block, out: &mut HashSet<String>) {
 
 fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
     match s {
-        Stmt::Assign { name, scope: Scope::Local, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Local,
+            value,
+            ..
+        } => {
             out.insert(name.clone());
             collect_expr_assigned(value, out);
         }
@@ -608,7 +732,13 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
             collect_expr_assigned(cond, out);
             collect_assigned_locals(body, out);
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             collect_expr_assigned(start, out);
             collect_expr_assigned(stop, out);
             collect_expr_assigned(step, out);
@@ -618,19 +748,28 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
             collect_expr_assigned(iter, out);
             collect_assigned_locals(body, out);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             collect_expr_assigned(seq, out);
             collect_expr_assigned(index, out);
             collect_expr_assigned(value, out);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             collect_expr_assigned(map, out);
             collect_expr_assigned(key, out);
             collect_expr_assigned(value, out);
         }
         // A try/rescue/ensure carries bare statement lists that may reassign
         // an outer local, so descend into every one.
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             for st in body {
                 collect_stmt_assigned(st, out);
             }
@@ -648,12 +787,40 @@ fn collect_stmt_assigned(s: &Stmt, out: &mut HashSet<String>) {
         // Class/module bodies are rejected at the capability check for this
         // backend; nothing to collect.
         Stmt::ClassDef { .. } | Stmt::ModuleDef { .. } | Stmt::SingletonClassDef { .. } => {}
+        // SIR22 compile-compat stub: rejected by `check_module` before this
+        // backend ever emits (no `Feature::NDArrays`/`Feature::MatrixOps` in
+        // `accepts_features`), but recurse into every operand — mirroring
+        // `SeqSet`/`MapSet` above — so the scan stays faithful regardless.
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            collect_expr_assigned(target, out);
+            for idx in indices {
+                collect_index_arg_assigned(idx, out);
+            }
+            collect_expr_assigned(value, out);
+        }
+    }
+}
+
+fn collect_index_arg_assigned(idx: &IndexArg, out: &mut HashSet<String>) {
+    match idx {
+        IndexArg::Scalar(e) | IndexArg::Range(e) => collect_expr_assigned(e, out),
+        IndexArg::Whole => {}
     }
 }
 
 fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
     match e {
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             collect_expr_assigned(cond, out);
             collect_assigned_locals(then_branch, out);
             collect_assigned_locals(else_branch, out);
@@ -708,6 +875,39 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         // — its runtime meaning — so assigned-local collection stays faithful.
         // Real support pending KW2–KW6.
         Expr::KeywordArg { value, .. } => collect_expr_assigned(value, out),
+        // SIR22 compile-compat stubs: rejected by `check_module` before this
+        // backend ever emits (no `Feature::NDArrays`/`Feature::MatrixOps` in
+        // `accepts_features`), but recurse into every operand so the scan
+        // stays faithful regardless.
+        Expr::ArrayLit { rows, .. } => {
+            for row in rows {
+                for e in row {
+                    collect_expr_assigned(e, out);
+                }
+            }
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            collect_expr_assigned(start, out);
+            if let Some(s) = step {
+                collect_expr_assigned(s, out);
+            }
+            collect_expr_assigned(stop, out);
+        }
+        Expr::MatMul { lhs, rhs, .. } | Expr::ElementwiseOp { lhs, rhs, .. } => {
+            collect_expr_assigned(lhs, out);
+            collect_expr_assigned(rhs, out);
+        }
+        Expr::Transpose { target, .. } => collect_expr_assigned(target, out),
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            collect_expr_assigned(target, out);
+            for idx in indices {
+                collect_index_arg_assigned(idx, out);
+            }
+        }
         // Leaves with no nested blocks/exprs that could hold an Assign.
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
@@ -748,7 +948,13 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             } else {
                 "const"
             };
-            let _ = write!(out, "{}{} {}: __Sir.Val = ", pad, keyword, sanitize_ident(name));
+            let _ = write!(
+                out,
+                "{}{} {}: __Sir.Val = ",
+                pad,
+                keyword,
+                sanitize_ident(name)
+            );
             emit_expr(out, value, indent);
             out.push_str(";\n");
         }
@@ -783,7 +989,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             out.push_str(";\n");
         }
         // `seq[index] = value` — cast through the array view of `Val`.
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             out.push_str(&pad);
             out.push_str("((");
             emit_expr(out, seq, indent);
@@ -794,7 +1002,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             out.push_str(";\n");
         }
         // `map[key] = value` — `Map.set` on the map view of `Val`.
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             out.push_str(&pad);
             out.push_str("((");
             emit_expr(out, map, indent);
@@ -820,7 +1030,14 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // block-scoped temporaries (matching Python's `range`), and the
         // loop condition is direction-aware so a negative `step` counts
         // down correctly.
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             let id = fresh_loop_id();
             let v = sanitize_ident(var);
             let inner = indent + 2;
@@ -855,7 +1072,9 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         }
         // `for (const var of iter) { body }` — iterate a Seq.  The
         // binding uses `let` if the body reassigns the loop variable.
-        Stmt::ForEach { var, iter, body, .. } => {
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => {
             let kw = if MUTABLE_NAMES.with(|m| m.borrow().contains(var)) {
                 "let"
             } else {
@@ -870,13 +1089,23 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // ── SIR17 scopes (assignment) ───────────────────────────────
         // `@x = v` → current-self instance-variable write via the OOP
         // runtime (no native `this` — methods are receiver-less).
-        Stmt::Assign { name, scope: Scope::Instance, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Instance,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}__SirOop.ivarSet({}, ", pad, quote_ts_string(name));
             emit_expr(out, value, indent);
             out.push_str(");\n");
         }
         // `@@x = v` → class-variable store write.
-        Stmt::Assign { name, scope: Scope::ClassVar, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::ClassVar,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}__SirOop.cvarSet({}, ", pad, quote_ts_string(name));
             emit_expr(out, value, indent);
             out.push_str(");\n");
@@ -884,15 +1113,27 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // `CONST = v` → an ordinary module-level binding.  Constants are
         // assign-once in Ruby, so `const` is faithful; reads elsewhere
         // emit the bare identifier (see `emit_var_ref`).
-        Stmt::Assign { name, scope: Scope::Const, value, .. } => {
+        Stmt::Assign {
+            name,
+            scope: Scope::Const,
+            value,
+            ..
+        } => {
             let _ = write!(out, "{}const {}: __Sir.Val = ", pad, sanitize_ident(name));
             emit_expr(out, value, indent);
             out.push_str(";\n");
         }
         // `Assign` to a builtin is never produced by any frontend (you
         // cannot rebind `+`); a validated module never reaches here.
-        Stmt::Assign { scope: Scope::Builtin, span, .. } => {
-            panic!("ts backend reached an assign to a Builtin-scoped name at {} — invalid SIR", span);
+        Stmt::Assign {
+            scope: Scope::Builtin,
+            span,
+            ..
+        } => {
+            panic!(
+                "ts backend reached an assign to a Builtin-scoped name at {} — invalid SIR",
+                span
+            );
         }
         // ── SIR17 class / module / singleton declarations ───────────
         // The Ruby→SIR frontend hoists method `def`s to top-level
@@ -900,8 +1141,18 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // statements (constant / class-variable assigns).  We register
         // the class in the OOP runtime (for ancestry-aware `is_a?`) and
         // emit the body statements in source order.
-        Stmt::ClassDef { name, superclass, body, .. } => {
-            let _ = write!(out, "{}__SirOop.defineClass({}, ", pad, quote_ts_string(name));
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "{}__SirOop.defineClass({}, ",
+                pad,
+                quote_ts_string(name)
+            );
             match superclass {
                 Some(sup) => {
                     let _ = write!(out, "{}", quote_ts_string(sup));
@@ -916,7 +1167,12 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // A module is a namespace with no superclass; register it so it
         // can participate in `is_a?`/ancestry, then emit its body.
         Stmt::ModuleDef { name, body, .. } => {
-            let _ = write!(out, "{}__SirOop.defineClass({}, null);\n", pad, quote_ts_string(name));
+            let _ = write!(
+                out,
+                "{}__SirOop.defineClass({}, null);\n",
+                pad,
+                quote_ts_string(name)
+            );
             for st in body {
                 emit_stmt(out, st, indent);
             }
@@ -935,7 +1191,12 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
         // the exception runtime `rescueMatches(exc, [class names])` for each
         // clause in source order and re-`throw`s if none match (matching
         // Ruby's "propagate when unrescued").
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             let pad = " ".repeat(indent);
             let _ = write!(out, "{}try {{\n", pad);
             emit_stmt_block(out, body, indent + 2);
@@ -983,6 +1244,18 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
             }
             out.push('\n');
         }
+        // SIR22 array/matrix indexed assignment.  This backend does not
+        // declare `Feature::NDArrays`/`Feature::MatrixOps` in
+        // `accepts_features` (see lib.rs), so `Backend::check_module`
+        // rejects any module containing this node before it ever reaches
+        // emission.  Panic here to catch a backend/validator drift, mirroring
+        // the `Expr::Intrinsic` guard below.
+        Stmt::IndexSet { span, .. } => {
+            panic!(
+                "typescript backend reached a deferred SIR22 array/matrix statement (index-set) at {} — not accepted yet",
+                span
+            );
+        }
     }
 }
 
@@ -991,7 +1264,10 @@ fn emit_stmt(out: &mut String, s: &Stmt, indent: usize) {
 fn pick_global_set(e: &Expr) -> Option<(&str, &Expr)> {
     if let Expr::BuiltinCall { name, args, .. } = e {
         if name == "global_set" && args.len() == 2 {
-            if let Expr::SymLit { name: global_name, .. } = &args[0] {
+            if let Expr::SymLit {
+                name: global_name, ..
+            } = &args[0]
+            {
                 return Some((global_name.as_str(), &args[1]));
             }
         }
@@ -1019,7 +1295,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             let _ = write!(out, "{}", quote_ts_string(value));
         }
         Expr::VarRef { name, scope, .. } => emit_var_ref(out, name, *scope),
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             out.push_str("(__Sir.truthy(");
             emit_expr(out, cond, indent);
             out.push_str(") ? (");
@@ -1042,7 +1323,9 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             out.push_str("])");
         }
         Expr::BuiltinCall { name, args, .. } => emit_builtin_call(out, name, args, indent),
-        Expr::MakeClosure { fn_name, captures, .. } => {
+        Expr::MakeClosure {
+            fn_name, captures, ..
+        } => {
             // Render: new __Sir.Closure((..._a) => <fn>(<cap0>, <cap1>, ..._a))
             out.push_str("new __Sir.Closure((..._a: __Sir.Val[]) => ");
             let _ = write!(out, "{}(", sanitize_ident(fn_name));
@@ -1151,6 +1434,25 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             panic!(
                 "typescript backend reached a bare keyword-arg expression at {} — a KeywordArg must be collapsed by emit_call_args, never emitted as a value",
                 span
+            );
+        }
+        // SIR22 array/matrix expressions (`ArrayLit`/`Range`/`MatMul`/
+        // `ElementwiseOp`/`Transpose`/`IndexGet`).  This backend does not
+        // declare `Feature::NDArrays`/`Feature::MatrixOps` in
+        // `accepts_features` (see lib.rs), so `Backend::check_module` rejects
+        // any module using these nodes before it ever reaches emission.
+        // Panic here to catch a backend/validator drift (mirrors the
+        // `Intrinsic` guard above).
+        Expr::ArrayLit { .. }
+        | Expr::Range { .. }
+        | Expr::MatMul { .. }
+        | Expr::ElementwiseOp { .. }
+        | Expr::Transpose { .. }
+        | Expr::IndexGet { .. } => {
+            panic!(
+                "typescript backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                e.span()
             );
         }
     }
@@ -1371,14 +1673,17 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
             out.push_str("__SirOop.callMethod(");
             emit_expr(out, &args[0], indent);
             let _ = write!(out, ", {}", quote_ts_string(meth));
-            let is_class_pred =
-                matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
+            let is_class_pred = matches!(meth.as_str(), "is_a?" | "kind_of?" | "instance_of?");
             for (i, a) in args[2..].iter().enumerate() {
                 out.push_str(", ");
                 match a {
                     // First operand of a class predicate, given as a
                     // constant class name → emit the name as a string.
-                    Expr::VarRef { name: cn, scope: Scope::Const, .. } if is_class_pred && i == 0 => {
+                    Expr::VarRef {
+                        name: cn,
+                        scope: Scope::Const,
+                        ..
+                    } if is_class_pred && i == 0 => {
                         out.push_str(&quote_ts_string(cn));
                     }
                     // A `&:sym` / `&proc` block argument on a dispatched call
@@ -1493,7 +1798,11 @@ fn emit_builtin_call(out: &mut String, name: &str, args: &[Expr], indent: usize)
         out.push_str("__SirExc.raiseError(");
         match args.first() {
             None => {}
-            Some(Expr::VarRef { name: cn, scope: Scope::Const, .. }) => {
+            Some(Expr::VarRef {
+                name: cn,
+                scope: Scope::Const,
+                ..
+            }) => {
                 out.push_str(&quote_ts_string(cn));
                 if let Some(msg) = args.get(1) {
                     out.push_str(", ");
@@ -1888,7 +2197,10 @@ mod tests {
     fn emit_function_sanitises_span_in_comment() {
         let body = Block {
             stmts: vec![],
-            value: Expr::IntLit { value: 0, span: s() },
+            value: Expr::IntLit {
+                value: 0,
+                span: s(),
+            },
             span: s(),
         };
         let f = Function {
@@ -1963,16 +2275,37 @@ mod tests {
     #[test]
     fn emit_int_literal() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::IntLit { value: 42, span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::IntLit {
+                value: 42,
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, "42");
     }
 
     #[test]
     fn emit_bool_and_nil() {
         let mut a = String::new();
-        emit_expr(&mut a, &Expr::BoolLit { value: true, span: s() }, 0);
+        emit_expr(
+            &mut a,
+            &Expr::BoolLit {
+                value: true,
+                span: s(),
+            },
+            0,
+        );
         let mut b = String::new();
-        emit_expr(&mut b, &Expr::BoolLit { value: false, span: s() }, 0);
+        emit_expr(
+            &mut b,
+            &Expr::BoolLit {
+                value: false,
+                span: s(),
+            },
+            0,
+        );
         let mut c = String::new();
         emit_expr(&mut c, &Expr::NilLit { span: s() }, 0);
         assert_eq!(a, "true");
@@ -1983,7 +2316,14 @@ mod tests {
     #[test]
     fn emit_symbol_interns() {
         let mut out = String::new();
-        emit_expr(&mut out, &Expr::SymLit { name: "foo".into(), span: s() }, 0);
+        emit_expr(
+            &mut out,
+            &Expr::SymLit {
+                name: "foo".into(),
+                span: s(),
+            },
+            0,
+        );
         assert_eq!(out, r#"__Sir.intern("foo")"#);
     }
 
@@ -2025,8 +2365,14 @@ mod tests {
             &Expr::BuiltinCall {
                 name: "+".into(),
                 args: vec![
-                    Expr::IntLit { value: 1, span: s() },
-                    Expr::IntLit { value: 2, span: s() },
+                    Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -2043,7 +2389,10 @@ mod tests {
             &mut out,
             &Expr::DirectCall {
                 fn_name: "id".into(),
-                args: vec![Expr::IntLit { value: 7, span: s() }],
+                args: vec![Expr::IntLit {
+                    value: 7,
+                    span: s(),
+                }],
                 effects: EffectSet::PURE,
                 span: s(),
             },
@@ -2063,7 +2412,10 @@ mod tests {
                     scope: Scope::Local,
                     span: s(),
                 }),
-                args: vec![Expr::IntLit { value: 5, span: s() }],
+                args: vec![Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }],
                 effects: EffectSet::PURE,
                 span: s(),
             },
@@ -2081,7 +2433,10 @@ mod tests {
                 fn_name: "__lambda_0".into(),
                 captures: vec![semantic_ir::CaptureValue {
                     name: "n".into(),
-                    value: Expr::IntLit { value: 5, span: s() },
+                    value: Expr::IntLit {
+                        value: 5,
+                        span: s(),
+                    },
                 }],
                 span: s(),
             },
@@ -2106,7 +2461,13 @@ mod tests {
         };
         let f = Function {
             name: "id".into(),
-            params: vec![Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() }],
+            params: vec![Param {
+                name: "x".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
             return_type: None,
             captures: vec![],
             body,
@@ -2129,8 +2490,15 @@ mod tests {
         let default_b = Expr::BuiltinCall {
             name: "+".into(),
             args: vec![
-                Expr::VarRef { name: "a".into(), scope: Scope::Param, span: s() },
-                Expr::IntLit { value: 1, span: s() },
+                Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2138,7 +2506,13 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
                 Param {
                     name: "b".into(),
                     sir_type: None,
@@ -2151,7 +2525,11 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::VarRef { name: "b".into(), scope: Scope::Param, span: s() },
+                value: Expr::VarRef {
+                    name: "b".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -2176,13 +2554,35 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
-                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, default: None, span: s() },
-                Param { name: "opts".into(), sir_type: None, kind: ParamKind::KwRest, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "rest".into(),
+                    sir_type: None,
+                    kind: ParamKind::Rest,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "opts".into(),
+                    sir_type: None,
+                    kind: ParamKind::KwRest,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -2209,7 +2609,10 @@ mod tests {
                 captures: vec![],
                 body: Block {
                     stmts: vec![],
-                    value: Expr::IntLit { value: 42, span: s() },
+                    value: Expr::IntLit {
+                        value: 42,
+                        span: s(),
+                    },
                     span: s(),
                 },
                 effects: EffectSet::PURE,
@@ -2236,8 +2639,14 @@ mod tests {
         let e = Expr::BuiltinCall {
             name: "global_set".into(),
             args: vec![
-                Expr::SymLit { name: "counter".into(), span: s() },
-                Expr::IntLit { value: 0, span: s() },
+                Expr::SymLit {
+                    name: "counter".into(),
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -2254,7 +2663,13 @@ mod tests {
     // M2 — `&:sym` symbol-to-proc on a method-dispatch call.
 
     fn method_call(recv: Expr, meth: &str, extra: Vec<Expr>) -> Expr {
-        let mut args = vec![recv, Expr::StrLit { value: meth.into(), span: s() }];
+        let mut args = vec![
+            recv,
+            Expr::StrLit {
+                value: meth.into(),
+                span: s(),
+            },
+        ];
         args.extend(extra);
         Expr::BuiltinCall {
             name: "__method__".into(),
@@ -2276,11 +2691,19 @@ mod tests {
     // ── O1: OOP object-model builtin emit arms ───────────────────────────────
 
     fn ts_str_lit(v: &str) -> Expr {
-        Expr::StrLit { value: v.into(), span: s() }
+        Expr::StrLit {
+            value: v.into(),
+            span: s(),
+        }
     }
 
     fn ts_builtin(name: &str, args: Vec<Expr>) -> Expr {
-        Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+        Expr::BuiltinCall {
+            name: name.into(),
+            args,
+            effects: EffectSet::PURE,
+            span: s(),
+        }
     }
 
     #[test]
@@ -2309,7 +2732,10 @@ mod tests {
             captures: vec![],
             span: s(),
         };
-        let e = ts_builtin("__def_method__", vec![ts_str_lit("Dog"), ts_str_lit("speak"), closure]);
+        let e = ts_builtin(
+            "__def_method__",
+            vec![ts_str_lit("Dog"), ts_str_lit("speak"), closure],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert!(
@@ -2348,7 +2774,10 @@ mod tests {
     #[test]
     fn class_method_call_emits_call_class_method_ts() {
         // __class_method__("Counter", "zero") → __SirOop.callClassMethod("Counter", "zero").
-        let e = ts_builtin("__class_method__", vec![ts_str_lit("Counter"), ts_str_lit("zero")]);
+        let e = ts_builtin(
+            "__class_method__",
+            vec![ts_str_lit("Counter"), ts_str_lit("zero")],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(out, r#"__SirOop.callClassMethod("Counter", "zero")"#);
@@ -2357,7 +2786,10 @@ mod tests {
     #[test]
     fn mixin_include_emits_include_module_ts() {
         // __include__("Greeter", "Loud") → __SirOop.includeModule("Greeter", "Loud").
-        let e = ts_builtin("__include__", vec![ts_str_lit("Greeter"), ts_str_lit("Loud")]);
+        let e = ts_builtin(
+            "__include__",
+            vec![ts_str_lit("Greeter"), ts_str_lit("Loud")],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(out, r#"__SirOop.includeModule("Greeter", "Loud")"#);
@@ -2366,7 +2798,10 @@ mod tests {
     #[test]
     fn mixin_extend_emits_extend_module_ts() {
         // __extend__("Widget", "Describable") → __SirOop.extendModule("Widget", "Describable").
-        let e = ts_builtin("__extend__", vec![ts_str_lit("Widget"), ts_str_lit("Describable")]);
+        let e = ts_builtin(
+            "__extend__",
+            vec![ts_str_lit("Widget"), ts_str_lit("Describable")],
+        );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
         assert_eq!(out, r#"__SirOop.extendModule("Widget", "Describable")"#);
@@ -2376,9 +2811,16 @@ mod tests {
     fn sym_block_pass_on_dispatch_emits_sym_to_proc() {
         // arr.map(&:to_s) → callMethod(arr, "map", symToProc(intern("to_s")))
         let e = method_call(
-            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            Expr::VarRef {
+                name: "arr".into(),
+                scope: Scope::Local,
+                span: s(),
+            },
             "map",
-            vec![block_pass(Expr::SymLit { name: "to_s".into(), span: s() })],
+            vec![block_pass(Expr::SymLit {
+                name: "to_s".into(),
+                span: s(),
+            })],
         );
         let mut out = String::new();
         emit_expr(&mut out, &e, 0);
@@ -2392,7 +2834,11 @@ mod tests {
     fn proc_block_pass_on_dispatch_unwraps_to_value() {
         // arr.each(&p) → callMethod(arr, "each", p) — the proc IS the block.
         let e = method_call(
-            Expr::VarRef { name: "arr".into(), scope: Scope::Local, span: s() },
+            Expr::VarRef {
+                name: "arr".into(),
+                scope: Scope::Local,
+                span: s(),
+            },
             "each",
             vec![block_pass(Expr::VarRef {
                 name: "p".into(),
@@ -2409,7 +2855,14 @@ mod tests {
     fn sym_block_pass_as_plain_arg_emits_sym_to_proc() {
         // The general emit_arg path also handles a surviving block_pass.
         let mut out = String::new();
-        emit_arg(&mut out, &block_pass(Expr::SymLit { name: "upcase".into(), span: s() }), 0);
+        emit_arg(
+            &mut out,
+            &block_pass(Expr::SymLit {
+                name: "upcase".into(),
+                span: s(),
+            }),
+            0,
+        );
         assert_eq!(out, r#"__SirOop.symToProc(__Sir.intern("upcase"))"#);
     }
 }

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,110 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.21.0 — SIR22: array/matrix IR extension
+
+Implements [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md) — the
+narrow-waist vocabulary for dense numeric-array languages (MATLAB/Octave today;
+APL/J/K/Scilab/IDL per HML00 tomorrow). Additive only, following the exact
+discipline SIR16 used to add loops/sequences: every existing SIR10/SIR16/SIR17/
+SIR18/SIR21 module remains valid; no existing `Expr`/`Stmt`/`SirType`/`Feature`
+variant, validator rule, or backend behaviour changed.
+
+**New `SirType` variants** (`types.rs`):
+- `NDArray { elem: Box<SirType>, rank: Option<usize> }` — dense N-D numeric
+  array; `rank: None` means unknown/dynamic rank (a frontend that can't prove
+  rank statically leaves it absent — backends handle the absence, they never
+  infer it). Prints `(ndarray T)` / `(ndarray T n)`.
+- `Rational` — exact rational scalar (arbitrary-precision numerator/
+  denominator left to the backend runtime). Prints `rational`.
+- `Complex` — complex scalar (`{ re: f64, im: f64 }`). Prints `complex`.
+- `Rational`/`Complex` are type-level carriers only — no numerator/denominator
+  or re/im storage at the type level (a runtime concern) — shared with the
+  future SIR23 symbolic-math extension, landed once here.
+
+**New `Expr` variants** (`nodes.rs`), every one mapped 1:1 onto an existing
+`array_runtime::execute()` op shape so a MATLAB/Octave frontend's job is
+picking the right node, not inventing new semantics:
+- `ArrayLit { rows: Vec<Vec<Expr>>, span }` — matrix literal `[1 2; 3 4]`.
+- `Range { start, step: Option<Box<Expr>>, stop, span }` — `1:5`, `0:2:10`;
+  `step: None` means step = 1.
+- `MatMul { lhs, rhs, span }` — matrix multiplication (MATLAB `*`), distinct
+  from `ElementwiseOp(Mul, ...)` (MATLAB `.*`).
+- `ElementwiseOp { op: ElementwiseOpKind, lhs, rhs, span }` — the five dotted
+  operators `.+ .- .* ./ .^` via the new `ElementwiseOpKind` enum
+  (`Add`/`Sub`/`Mul`/`Div`/`Pow`).
+- `Transpose { target, conjugate: bool, span }` — MATLAB `'` (conjugate,
+  `true`) vs `.'` (plain, `false`); both map to the same runtime op.
+- `IndexGet { target, indices: Vec<IndexArg>, span }` — indexed *read*
+  (`A(2, :)`, `A(1:3)`). `IndexArg` is `Scalar(Box<Expr>)` (already 0-based —
+  the frontend resolves `end`-relative subscripts before emitting this; the
+  IR never sees `end`) / `Whole` (`:`) / `Range(Box<Expr>)`.
+
+**New `Stmt` variant** (`nodes.rs`):
+- `IndexSet { target, indices: Vec<IndexArg>, value, span }` — indexed
+  *write* (`A(2, :) = v`). Per the spec, this is lowered as a `Stmt`-position
+  mutation (like `Assign`), **not** a value-producing `Expr` — the one
+  exception to "every new SIR22 node is Pure." Verified structurally: there
+  is no `Expr::IndexSet` variant for the type system to construct.
+
+**New `Feature` flags** (`manifest.rs`): `NDArrays`, `MatrixOps`, `Rationals`,
+`Complex`, `ArrayColumnMajor` (the last states explicitly, at the manifest
+level, that array storage is column-major/Fortran order — matching
+`array_runtime::Array`'s internal layout — since a JS backend owns its own
+buffer representation and needs that convention stated rather than left
+implicit).
+
+**Effects** (`validator.rs`): every new `Expr` variant observes `Pure`
+semantics implicitly (no `EffectSet` field — same as `SeqLit`/`MapLit`/other
+pure SIR16 literals). The validator's `check_expr`/`check_stmt_seq` observe
+the matching `Feature`(s) for each new node (`ArrayLit`/`Range`/`IndexGet`/
+`IndexSet` → `NDArrays`; `MatMul`/`ElementwiseOp`/`Transpose` → `MatrixOps`;
+`ArrayLit`/`MatMul`/`ElementwiseOp`/`Transpose` → `ArrayColumnMajor`), so a
+module using these nodes without declaring the feature is a validator error,
+exactly like every other SIR16/17/18 feature-observation rule.
+
+**Walker** (`walker.rs`, `backend.rs`): both the public `Visitor` traversal and
+`backend.rs`'s internal `walk_intrinsics_in_{stmt,expr}` (used for the
+intrinsic-whitelist check) recurse into every new node's children, including a
+shared `walk_index_args`/`walk_intrinsics_in_index_args` helper for the three
+`IndexArg` shapes.
+
+**Printer** (`text/printer.rs`): new S-expression forms — `(array (row ...) ...)`,
+`(range start [step] stop)`, `(matmul lhs rhs)`, `(elementwise-op <kind> lhs rhs)`,
+`(transpose target conjugate|plain)`, `(index-get target (idx-scalar e) (idx-whole)
+(idx-range e) ...)`, `(index-set target ...indices... value)`.
+
+**Backend capability rejection**: no backend changes are required for this
+spec to land safely, per the SIR22 spec's "Backend impact" — a backend that
+doesn't declare `NDArrays`/`MatrixOps` in `accepts_features()` cleanly rejects
+any module using these nodes via the existing SIR10 capability-check
+mechanism (`Backend::check_module`), proven with new `backend.rs` tests
+constructing a real `ArrayLit`/`MatMul`-using module. Verified this claim
+against the actual mechanism rather than just asserting it: all five existing
+Rust-workspace backends (`semantic-ir-to-{javascript,typescript,rust,go,python}`)
+and three frontends (`{javascript,ruby,python}-to-semantic-ir`) had exhaustive
+`match` statements over `Expr`/`Stmt` that would otherwise fail to compile;
+each gained the minimal panic-guard arm (never real codegen) needed to keep
+`cargo build --workspace` green, following the exact precedent SIR16 set for
+its own four-backend rollout (their `ACCEPTED_FEATURES` lists are unchanged,
+so the capability check rejects a SIR22-using module before any panic arm is
+ever reached — the panic exists only to catch a future capability-check
+regression). `twig-to-semantic-ir` required no changes.
+
+**Versioning** (`metadata.rs`): `CURRENT_SIR_VERSION` bumped `"1"` → `"2"`,
+following the same "adding a feature is a v.bump" / "new text tokens" policy
+that moved `"0"` → `"1"` in SIR21 T1b — SIR22 introduces new `SirType`/`Expr`/
+`Stmt` surface with new printed text tokens. A frontend lowering MATLAB/Octave
+sets `metadata.sir_version` to `"2"` when its module uses any SIR22 node. The
+two `v1`-asserting golden tests (`lib.rs`, `text/printer.rs`) were updated to
+`v2`.
+
+Extensive unit tests added for every new node kind (construction, span
+handling, printer round-trip, walker traversal, validator feature-observation,
+and the `IndexSet`-is-a-`Stmt`-not-an-`Expr` design rule) plus new
+`backend.rs` tests proving the capability-rejection path against real
+`ArrayLit`/`MatMul` node usage, not just a hand-set manifest flag.
+
 ## 0.20.0 — SIR21 T3c-2: complete the op-selection rule (concat + comparison)
 
 Completes the `op_select` rule begun in T3c-1. Where `resolve_numeric` decides

--- a/code/packages/rust/semantic-ir/Cargo.toml
+++ b/code/packages/rust/semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Narrow-waist Semantic IR (SIR10): a language-neutral intermediate representation between frontends and backends."
 

--- a/code/packages/rust/semantic-ir/README.md
+++ b/code/packages/rust/semantic-ir/README.md
@@ -49,6 +49,8 @@ use semantic_ir::{
     Span, Metadata, CURRENT_SIR_VERSION,
     validate, Backend, BackendRegistry, Artifact,
     print_module, print_expr,
+    // SIR22: array/matrix IR extension
+    ElementwiseOpKind, IndexArg,
 };
 ```
 
@@ -79,9 +81,22 @@ What's covered:
 - DirectCall, IndirectCall, BuiltinCall
 - MakeClosure
 - Intrinsic with escape-hatch discipline
-- SirType (Dynamic, Int(IntSpec), Bool, Nil, Symbol, Str, Pair, Closure, Fn, Float, Seq, Map, Ptr, Struct, Optional)
+- SirType (Dynamic, Int(IntSpec), Bool, Nil, Symbol, Str, Pair, Closure, Fn, Float, Seq, Map, Ptr, Struct, Optional,
+  NDArray, Rational, Complex)
   — SIR21: `Int` carries an `IntSpec { width, signed, overflow }`; `Dynamic` (was `Any`) is the top type;
   `Ptr`/`Struct`/`Optional` (T1b) are source-fidelity types for typed frontends
+  — SIR22: `NDArray { elem, rank }` is a dense N-D numeric array (rank `None` = unknown/dynamic);
+  `Rational`/`Complex` are exact-rational and complex scalar carriers, shared with the future SIR23
+  symbolic-math extension
+- SIR22 array/matrix nodes (additive, numeric-array languages — MATLAB/Octave and future
+  APL/J/K/Scilab/IDL frontends): `Expr::ArrayLit` (matrix literal `[1 2; 3 4]`), `Expr::Range`
+  (`1:5`, `0:2:10`), `Expr::MatMul`, `Expr::ElementwiseOp` (the five dotted ops `.+ .- .* ./ .^`
+  via `ElementwiseOpKind`), `Expr::Transpose` (`'` vs `.'` via a `conjugate` flag), `Expr::IndexGet`
+  / `Stmt::IndexSet` (indexed read/write via `IndexArg::{Scalar,Whole,Range}` — write is a `Stmt`,
+  mirroring how SIR16's `Assign` is a `Stmt` and not an `Expr`). New features:
+  `NDArrays`/`MatrixOps`/`Rationals`/`Complex`/`ArrayColumnMajor`. Every new node kind maps 1:1 onto
+  an `array_runtime::execute()` op shape — see
+  [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
 - `int_const` — the `int.max`/`int.min`/`int.width` reflection const-intrinsics (T3a);
   pure, const-folding functions of an `IntSpec` (`IntConst::eval`), `None` for arbitrary-precision
 - `op_select` — type-directed op selection (T3c): `resolve_binary(op, lhs, rhs)` chooses

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -63,7 +63,11 @@ pub struct BackendError {
 
 impl fmt::Display for BackendError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "backend error [{:?}] at {}: {}", self.kind, self.span, self.message)
+        write!(
+            f,
+            "backend error [{:?}] at {}: {}",
+            self.kind, self.span, self.message
+        )
     }
 }
 
@@ -127,10 +131,7 @@ pub trait Backend {
             if !whitelist.contains(&name) {
                 errs.push(BackendError {
                     kind: BackendErrorKind::UnsupportedIntrinsic,
-                    message: format!(
-                        "backend `{}` does not accept intrinsic `{}`",
-                        target, name
-                    ),
+                    message: format!("backend `{}` does not accept intrinsic `{}`", target, name),
                     span: span.clone(),
                 });
                 return;
@@ -138,10 +139,7 @@ pub trait Backend {
             if !targets.iter().any(|t| t == target) {
                 errs.push(BackendError {
                     kind: BackendErrorKind::UnsupportedIntrinsic,
-                    message: format!(
-                        "intrinsic `{}` not tagged for target `{}`",
-                        name, target
-                    ),
+                    message: format!("intrinsic `{}` not tagged for target `{}`", name, target),
                     span: span.clone(),
                 });
             }
@@ -193,7 +191,13 @@ where
             }
             walk_intrinsics_in_expr(&body.value, f, depth + 1);
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             walk_intrinsics_in_expr(start, f, depth + 1);
             walk_intrinsics_in_expr(stop, f, depth + 1);
             walk_intrinsics_in_expr(step, f, depth + 1);
@@ -209,12 +213,16 @@ where
             }
             walk_intrinsics_in_expr(&body.value, f, depth + 1);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             walk_intrinsics_in_expr(seq, f, depth + 1);
             walk_intrinsics_in_expr(index, f, depth + 1);
             walk_intrinsics_in_expr(value, f, depth + 1);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             walk_intrinsics_in_expr(map, f, depth + 1);
             walk_intrinsics_in_expr(key, f, depth + 1);
             walk_intrinsics_in_expr(value, f, depth + 1);
@@ -242,7 +250,12 @@ where
                 walk_intrinsics_in_stmt(s, f, depth + 1);
             }
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             // Recurse into the try body, each rescue body, and the
             // optional ensure body (Ruby Phase 16a).
             for s in body {
@@ -258,6 +271,36 @@ where
                     walk_intrinsics_in_stmt(s, f, depth + 1);
                 }
             }
+        }
+        crate::nodes::Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            // SIR22: `target[indices...] = value` — recurse into the
+            // target, every index-arg subexpression, and the value so
+            // any nested Intrinsic is still observed.
+            walk_intrinsics_in_expr(target, f, depth + 1);
+            walk_intrinsics_in_index_args(indices, f, depth + 1);
+            walk_intrinsics_in_expr(value, f, depth + 1);
+        }
+    }
+}
+
+/// Shared helper mirroring `walker.rs`'s `walk_index_args`: walk every
+/// `Expr` nested inside a slice of `IndexArg`s looking for `Intrinsic`
+/// nodes (SIR22).
+fn walk_intrinsics_in_index_args<F>(indices: &[crate::nodes::IndexArg], f: &mut F, depth: usize)
+where
+    F: FnMut(&str, &[String], &Span),
+{
+    use crate::nodes::IndexArg;
+    for arg in indices {
+        match arg {
+            IndexArg::Scalar(e) => walk_intrinsics_in_expr(e, f, depth),
+            IndexArg::Whole => {}
+            IndexArg::Range(e) => walk_intrinsics_in_expr(e, f, depth),
         }
     }
 }
@@ -276,7 +319,12 @@ where
         | Expr::SymLit { .. }
         | Expr::StrLit { .. }
         | Expr::VarRef { .. } => {}
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             walk_intrinsics_in_expr(cond, f, depth + 1);
             for s in &then_branch.stmts {
                 walk_intrinsics_in_stmt(s, f, depth + 1);
@@ -309,7 +357,13 @@ where
                 walk_intrinsics_in_expr(&c.value, f, depth + 1);
             }
         }
-        Expr::Intrinsic { targets, name, args, span, .. } => {
+        Expr::Intrinsic {
+            targets,
+            name,
+            args,
+            span,
+            ..
+        } => {
             f(name.as_str(), targets, span);
             for a in args {
                 walk_intrinsics_in_expr(a, f, depth + 1);
@@ -354,6 +408,41 @@ where
         Expr::KeywordArg { value, .. } => {
             walk_intrinsics_in_expr(value, f, depth + 1);
         }
+
+        // ── SIR22: array/matrix nodes ───────────────────────────────
+        Expr::ArrayLit { rows, .. } => {
+            for row in rows {
+                for item in row {
+                    walk_intrinsics_in_expr(item, f, depth + 1);
+                }
+            }
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            walk_intrinsics_in_expr(start, f, depth + 1);
+            if let Some(step) = step {
+                walk_intrinsics_in_expr(step, f, depth + 1);
+            }
+            walk_intrinsics_in_expr(stop, f, depth + 1);
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            walk_intrinsics_in_expr(lhs, f, depth + 1);
+            walk_intrinsics_in_expr(rhs, f, depth + 1);
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            walk_intrinsics_in_expr(lhs, f, depth + 1);
+            walk_intrinsics_in_expr(rhs, f, depth + 1);
+        }
+        Expr::Transpose { target, .. } => {
+            walk_intrinsics_in_expr(target, f, depth + 1);
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            walk_intrinsics_in_expr(target, f, depth + 1);
+            walk_intrinsics_in_index_args(indices, f, depth + 1);
+        }
     }
 }
 
@@ -365,7 +454,9 @@ pub struct BackendRegistry {
 
 impl BackendRegistry {
     pub fn new() -> Self {
-        Self { entries: Vec::new() }
+        Self {
+            entries: Vec::new(),
+        }
     }
 
     pub fn register<B: Backend + Send + Sync + 'static>(&mut self, b: B) {
@@ -534,7 +625,98 @@ mod tests {
             span: s(),
         });
         let errs = b.check_module(&m);
-        assert!(errs.iter().any(|e| e.message.contains("not tagged for target")));
+        assert!(errs
+            .iter()
+            .any(|e| e.message.contains("not tagged for target")));
+    }
+
+    // ── SIR22: capability-rejection tests ────────────────────────────
+    //
+    // Per the SIR22 spec's "Backend impact" / "New Feature flags"
+    // sections: "A backend that doesn't declare NDArrays/MatrixOps in
+    // accepts_features() cleanly rejects any module using these nodes
+    // (SIR10's existing capability-check mechanism — no new mechanism
+    // needed)."  These tests prove that claim against the *actual*
+    // mechanism (`Backend::check_module`), not just by reasoning about
+    // it — the same style as `rejects_unsupported_feature` above, using
+    // an SIR22 feature instead of `Closures`.
+
+    #[test]
+    fn backend_without_ndarrays_rejects_module_declaring_it() {
+        let b = NoFeaturesBackend;
+        let m = module_with_feature(Feature::NDArrays);
+        let errs = b.check_module(&m);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].kind, BackendErrorKind::UnsupportedFeature);
+        assert!(errs[0].message.contains("nd-arrays"));
+    }
+
+    #[test]
+    fn backend_without_matrix_ops_rejects_module_declaring_it() {
+        let b = NoFeaturesBackend;
+        let m = module_with_feature(Feature::MatrixOps);
+        let errs = b.check_module(&m);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].kind, BackendErrorKind::UnsupportedFeature);
+        assert!(errs[0].message.contains("matrix-ops"));
+    }
+
+    #[test]
+    fn backend_accepting_all_features_allows_ndarrays_and_matrix_ops() {
+        let b = AllFeaturesBackend;
+        let m = module_with_feature(Feature::NDArrays);
+        assert!(b.check_module(&m).is_empty());
+        let m2 = module_with_feature(Feature::MatrixOps);
+        assert!(b.check_module(&m2).is_empty());
+    }
+
+    /// End-to-end version of the two rejection tests above: build a real
+    /// module whose body contains an `ArrayLit` and a `MatMul` node (the
+    /// concrete SIR22 nodes named in the spec), declare the matching
+    /// manifest features, and confirm a backend that only accepts the
+    /// SIR v0 baseline still rejects it — proving the rejection path
+    /// works from actual node usage, not just a hand-set manifest flag.
+    #[test]
+    fn backend_rejects_module_whose_body_uses_array_lit_and_matmul() {
+        let b = NoFeaturesBackend;
+        let mut m = module_with_feature(Feature::NDArrays);
+        m.manifest.add(Feature::MatrixOps);
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::MatMul {
+                    lhs: Box::new(Expr::ArrayLit {
+                        rows: vec![vec![Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        }]],
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::ArrayLit {
+                        rows: vec![vec![Expr::IntLit {
+                            value: 2,
+                            span: s(),
+                        }]],
+                        span: s(),
+                    }),
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let errs = b.check_module(&m);
+        // Both declared-but-unaccepted features are reported.
+        assert_eq!(errs.len(), 2);
+        assert!(errs
+            .iter()
+            .all(|e| e.kind == BackendErrorKind::UnsupportedFeature));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/lib.rs
+++ b/code/packages/rust/semantic-ir/src/lib.rs
@@ -42,10 +42,10 @@
 
 pub mod backend;
 pub mod effects;
+pub mod int_const;
 pub mod limits;
 pub mod manifest;
 pub mod metadata;
-pub mod int_const;
 pub mod nodes;
 pub mod op_select;
 pub mod span;
@@ -64,19 +64,21 @@ pub use backend::{
 };
 pub use effects::{Effect, EffectSet};
 pub use int_const::{eval_named as eval_int_const_named, IntConst};
-pub use op_select::{resolve_binary, resolve_numeric, BinaryLowering, NumericLowering};
 pub use limits::MAX_IR_DEPTH;
 pub use manifest::{Feature, FeatureManifest};
 pub use metadata::{Metadata, CURRENT_SIR_VERSION};
 pub use nodes::{
-    Block, Capture, CaptureValue, ExportName, Expr, Function, Global, Import, ImportName, MapEntry,
-    Module, Param, ParamKind, RescueClause, Scope, Stmt,
+    Block, Capture, CaptureValue, ElementwiseOpKind, ExportName, Expr, Function, Global, Import,
+    ImportName, IndexArg, MapEntry, Module, Param, ParamKind, RescueClause, Scope, Stmt,
 };
+pub use op_select::{resolve_binary, resolve_numeric, BinaryLowering, NumericLowering};
 pub use span::Span;
 pub use text::{print_block, print_expr, print_function, print_module};
 pub use types::{IntSpec, IntWidth, Overflow, SirType};
 pub use validator::{validate, Severity, ValidationResult, ValidatorIssue};
-pub use walker::{walk_expr_default, walk_function_default, walk_module_default, walk_stmt_default, Visitor};
+pub use walker::{
+    walk_expr_default, walk_function_default, walk_module_default, walk_stmt_default, Visitor,
+};
 
 #[cfg(test)]
 mod smoke {
@@ -98,7 +100,7 @@ mod smoke {
         let r = validate(&m);
         assert!(r.is_ok());
         let t = print_module(&m);
-        assert!(t.contains("(sir-module empty v1"));
+        assert!(t.contains("(sir-module empty v2"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -35,6 +35,11 @@ use std::fmt;
 /// | `Pointers`                 | a `SirType::Ptr`                      |
 /// | `Structs`                  | a `SirType::Struct`                   |
 /// | `Bignum`                   | an arbitrary-precision `Int`          |
+/// | `NDArrays`                 | a `SirType::NDArray` or `Expr::ArrayLit`/`IndexGet`/`Range` |
+/// | `MatrixOps`                | a `MatMul`, `ElementwiseOp`, or `Transpose` node |
+/// | `Rationals`                | a `SirType::Rational`                 |
+/// | `Complex`                  | a `SirType::Complex`                  |
+/// | `ArrayColumnMajor`         | any `ArrayLit`/matrix op — column-major storage convention |
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Feature {
     Closures,
@@ -156,6 +161,39 @@ pub enum Feature {
     /// dynamic backends implicitly support this; the flag makes the
     /// requirement explicit for the sized-integer cascade.)
     Bignum,
+    // ── SIR22 (array/matrix numeric-language IR extension) ───────────
+    /// The module uses a dense N-D numeric array — a `SirType::NDArray`
+    /// type annotation, or any of `Expr::ArrayLit` / `Expr::IndexGet` /
+    /// `Expr::Range` / `Stmt::IndexSet`.  A backend that doesn't declare
+    /// this in `accepts_features()` cleanly rejects the module via the
+    /// existing capability-check mechanism (SIR10) — no new mechanism
+    /// needed.  See
+    /// [SIR22](../../../../specs/SIR22-array-matrix-semantic-ir.md).
+    NDArrays,
+    /// The module uses a matrix operator: `Expr::MatMul`,
+    /// `Expr::ElementwiseOp`, or `Expr::Transpose`.  Split out from
+    /// `NDArrays` because a backend could in principle carry array
+    /// *values* (e.g. via an opaque intrinsic) without supporting these
+    /// specific operators, though the first-wave frontends declare both
+    /// together.
+    MatrixOps,
+    /// The module uses an exact rational scalar (`SirType::Rational`).
+    /// Shared with the future SIR23 symbolic extension.
+    Rationals,
+    /// The module uses a complex scalar (`SirType::Complex`).  Shared
+    /// with the future SIR23 symbolic extension.  Named `Complex` to
+    /// match the `SirType::Complex` variant it gates (not to be
+    /// confused with `SirType`'s own naming — this is a `Feature`).
+    Complex,
+    /// Declared whenever any `ArrayLit`/matrix op appears in the
+    /// module: states explicitly (per the SIR22 spec's "Storage
+    /// convention") that array storage is column-major (Fortran/MATLAB
+    /// order), matching `array_runtime::Array`'s internal layout. A JS
+    /// backend's own array representation needs this fact stated
+    /// explicitly rather than left implicit, since it owns its own
+    /// buffer layout and must match the same `(r, c) → c * nrows + r`
+    /// indexing formula.
+    ArrayColumnMajor,
 }
 
 impl Feature {
@@ -193,6 +231,11 @@ impl Feature {
         Feature::Pointers,
         Feature::Structs,
         Feature::Bignum,
+        Feature::NDArrays,
+        Feature::MatrixOps,
+        Feature::Rationals,
+        Feature::Complex,
+        Feature::ArrayColumnMajor,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -230,6 +273,11 @@ impl Feature {
             Feature::Pointers => "pointers",
             Feature::Structs => "structs",
             Feature::Bignum => "bignum",
+            Feature::NDArrays => "nd-arrays",
+            Feature::MatrixOps => "matrix-ops",
+            Feature::Rationals => "rationals",
+            Feature::Complex => "complex",
+            Feature::ArrayColumnMajor => "array-column-major",
         }
     }
 
@@ -371,11 +419,8 @@ mod tests {
 
     #[test]
     fn manifest_dedupes() {
-        let m = FeatureManifest::from_features(&[
-            Feature::Closures,
-            Feature::Pairs,
-            Feature::Closures,
-        ]);
+        let m =
+            FeatureManifest::from_features(&[Feature::Closures, Feature::Pairs, Feature::Closures]);
         assert_eq!(m.len(), 2);
         assert!(m.contains(Feature::Closures));
         assert!(m.contains(Feature::Pairs));
@@ -383,11 +428,8 @@ mod tests {
 
     #[test]
     fn manifest_display_is_space_separated() {
-        let m = FeatureManifest::from_features(&[
-            Feature::Closures,
-            Feature::Pairs,
-            Feature::Globals,
-        ]);
+        let m =
+            FeatureManifest::from_features(&[Feature::Closures, Feature::Pairs, Feature::Globals]);
         assert_eq!(format!("{}", m), "closures pairs globals");
     }
 

--- a/code/packages/rust/semantic-ir/src/metadata.rs
+++ b/code/packages/rust/semantic-ir/src/metadata.rs
@@ -9,7 +9,7 @@
 //!
 //! - `source_language` — frontend identifier (`"twig"`, `"python"`, …)
 //! - `source_version`  — version string of the source language
-//! - `sir_version`     — IR spec version (`"1"` in this build)
+//! - `sir_version`     — IR spec version (`"2"` in this build)
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -22,7 +22,16 @@ use std::fmt;
 ///   sized-integer / pointer / struct / bignum flags (T1a + T1b).  The
 ///   bump lands in T1b, the first milestone whose surface introduces
 ///   *new text tokens* a reader would need to understand.
-pub const CURRENT_SIR_VERSION: &str = "1";
+/// - `"2"` — SIR22: the array/matrix IR extension.  New `SirType`
+///   variants (`NDArray`/`Rational`/`Complex`), new `Expr` variants
+///   (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+///   `IndexGet`), a new `Stmt` variant (`IndexSet`), and five new
+///   `Feature` flags — all additive, all introducing new SIR text
+///   tokens, so the same "adding a feature is a v.bump" policy that
+///   moved `"0"` → `"1"` applies again here.  A frontend lowering
+///   MATLAB/Octave sets `metadata.sir_version` to this value when its
+///   module uses any SIR22 node.
+pub const CURRENT_SIR_VERSION: &str = "2";
 
 /// Advisory metadata.  All fields are optional.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -113,7 +122,7 @@ mod tests {
             .with_sir_version(CURRENT_SIR_VERSION);
         assert_eq!(m.source_language.as_deref(), Some("twig"));
         assert_eq!(m.source_version.as_deref(), Some("0.7"));
-        assert_eq!(m.sir_version.as_deref(), Some("1"));
+        assert_eq!(m.sir_version.as_deref(), Some("2"));
         assert!(!m.is_empty());
     }
 
@@ -130,14 +139,19 @@ mod tests {
 
     #[test]
     fn extra_fields_round_trip() {
-        let m = Metadata::new().with_extra("origin", "test").with_extra("foo", "bar");
+        let m = Metadata::new()
+            .with_extra("origin", "test")
+            .with_extra("foo", "bar");
         // BTreeMap orders by key alphabetically.
         assert_eq!(format!("{}", m), "(metadata (foo bar) (origin test))");
     }
 
     #[test]
-    fn current_sir_version_is_one() {
-        // Bumped 0 → 1 in SIR21 T1b (new type/manifest text tokens).
-        assert_eq!(CURRENT_SIR_VERSION, "1");
+    fn current_sir_version_is_two() {
+        // Bumped 1 → 2 in SIR22 (array/matrix IR extension: new
+        // SirType/Expr/Stmt/Feature text tokens), following the same
+        // "adding a feature is a v.bump" policy that moved 0 → 1 in
+        // SIR21 T1b.
+        assert_eq!(CURRENT_SIR_VERSION, "2");
     }
 }

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -508,6 +508,30 @@ pub enum Stmt {
         ensure_body: Option<Vec<Stmt>>,
         span: Span,
     },
+
+    // ── SIR22: array/matrix indexed assignment ─────────────────────
+    /// `target[indices...] = value` — mutate an element, row, column,
+    /// or sub-range of an `NDArray` (MATLAB/Octave `A(2, :) = v`).
+    ///
+    /// Introduced by [SIR22](../../../../specs/SIR22-array-matrix-semantic-ir.md)
+    /// as the mutation-shaped counterpart of [`Expr::IndexGet`] — indexed
+    /// *reads* are a value-producing `Expr`, but an indexed *write* has a
+    /// mutation effect indistinguishable in shape from [`Stmt::Assign`], so
+    /// it lives in `Stmt` rather than `Expr`, exactly as SIR16's `Assign`
+    /// does relative to a plain `VarRef`.  This is the one exception noted
+    /// in the SIR22 spec's "Effects" section: every other new SIR22 node is
+    /// `Pure`.
+    ///
+    /// `indices` mirrors [`Expr::IndexGet`]'s `indices: Vec<IndexArg>` —
+    /// the frontend has already resolved 1-based/`end`-relative MATLAB
+    /// indexing down to concrete 0-based [`IndexArg`]s before emitting this
+    /// node; the IR never sees `end`.
+    IndexSet {
+        target: Box<Expr>,
+        indices: Vec<IndexArg>,
+        value: Box<Expr>,
+        span: Span,
+    },
 }
 
 impl Stmt {
@@ -526,6 +550,7 @@ impl Stmt {
             Stmt::ModuleDef { span, .. } => span,
             Stmt::SingletonClassDef { span, .. } => span,
             Stmt::TryCatch { span, .. } => span,
+            Stmt::IndexSet { span, .. } => span,
         }
     }
 }
@@ -605,11 +630,25 @@ impl Scope {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     // ── atomic literals ────────────────────────────────────────────
-    IntLit { value: i64, span: Span },
-    BoolLit { value: bool, span: Span },
-    NilLit { span: Span },
-    SymLit { name: String, span: Span },
-    StrLit { value: String, span: Span },
+    IntLit {
+        value: i64,
+        span: Span,
+    },
+    BoolLit {
+        value: bool,
+        span: Span,
+    },
+    NilLit {
+        span: Span,
+    },
+    SymLit {
+        name: String,
+        span: Span,
+    },
+    StrLit {
+        value: String,
+        span: Span,
+    },
 
     // ── reference ───────────────────────────────────────────────────
     VarRef {
@@ -669,11 +708,17 @@ pub enum Expr {
 
     // ── SIR16: floats ──────────────────────────────────────────────
     /// 64-bit floating-point literal.
-    FloatLit { value: f64, span: Span },
+    FloatLit {
+        value: f64,
+        span: Span,
+    },
 
     // ── SIR16: sequences ───────────────────────────────────────────
     /// `[item0, item1, ...]` literal.
-    SeqLit { items: Vec<Expr>, span: Span },
+    SeqLit {
+        items: Vec<Expr>,
+        span: Span,
+    },
     /// `seq[index]` — 0-indexed.  Out-of-bounds behaviour is target-
     /// language-defined.
     SeqIndex {
@@ -685,11 +730,17 @@ pub enum Expr {
     /// so backends can emit native length access (`xs.length` /
     /// `len(xs)` / `xs.len()`).  Frontends should prefer this node
     /// over the builtin form.
-    SeqLen { seq: Box<Expr>, span: Span },
+    SeqLen {
+        seq: Box<Expr>,
+        span: Span,
+    },
 
     // ── SIR16: maps ────────────────────────────────────────────────
     /// `{key: value, ...}` literal.
-    MapLit { entries: Vec<MapEntry>, span: Span },
+    MapLit {
+        entries: Vec<MapEntry>,
+        span: Span,
+    },
     /// `map[key]` — missing-key behaviour is target-language-defined.
     MapGet {
         map: Box<Expr>,
@@ -730,7 +781,10 @@ pub enum Expr {
     /// Invariant: `parts.len() >= 2`.  A zero- or one-part concat is
     /// degenerate — frontends emit a bare `StrLit` (empty string) or the
     /// single part directly rather than wrapping it.
-    StrConcat { parts: Vec<Expr>, span: Span },
+    StrConcat {
+        parts: Vec<Expr>,
+        span: Span,
+    },
 
     // ── KW1: keyword arguments ─────────────────────────────────────
     /// A keyword argument at a call site: `name: value` (Ruby `f(a: 1)`,
@@ -751,7 +805,160 @@ pub enum Expr {
     ///
     /// `value` is boxed for the same fixed-size reason as the other
     /// single-child expression variants (`SeqLen`, `MapGet`, …).
-    KeywordArg { name: String, value: Box<Expr>, span: Span },
+    KeywordArg {
+        name: String,
+        value: Box<Expr>,
+        span: Span,
+    },
+
+    // ── SIR22: array/matrix literals, ranges, and operators ────────
+    //
+    // Every node kind below is deliberately mapped 1:1 onto an existing
+    // `array_runtime::execute()` op shape (see the SIR22 spec's
+    // "Motivation") so that a MATLAB/Octave frontend's job is picking the
+    // right node, not inventing new semantics.  All are `Pure` (see
+    // `effects.rs`'s SIR22 doc note) — array construction, indexing, and
+    // arithmetic have no observable side effects distinct from the value
+    // they compute.  `IndexSet` (the one mutation-shaped exception) is a
+    // `Stmt`, not an `Expr` — see its doc comment above.
+    /// `[1 2; 3 4]` — a matrix/array literal.  `rows` is row-major *in
+    /// the literal syntax*; reconciling that with the column-major
+    /// storage convention (`Feature::ArrayColumnMajor`, see the SIR22
+    /// spec's "Storage convention") is the frontend's job, not the IR's.
+    /// A 1-row literal (`rows.len() == 1`) is a row vector; a frontend
+    /// wanting a column vector emits one single-element row per element.
+    ArrayLit {
+        rows: Vec<Vec<Expr>>,
+        span: Span,
+    },
+
+    /// `start:stop` / `start:step:stop` — a numeric range (MATLAB `1:5`,
+    /// `0:2:10`).  `step` of `None` means step = 1, matching the MATLAB
+    /// two-argument colon form.  Half-open vs. closed is left to
+    /// `array_runtime::execute(Range, …)`'s own semantics — the IR node
+    /// only carries the three operand slots the runtime op already takes.
+    Range {
+        start: Box<Expr>,
+        step: Option<Box<Expr>>,
+        stop: Box<Expr>,
+        span: Span,
+    },
+
+    /// Matrix multiplication (MATLAB `*` on two matrices) — distinct
+    /// from [`Expr::ElementwiseOp`]`(Mul, …)` (MATLAB `.*`), which
+    /// multiplies same-shape arrays element-by-element.  Shape
+    /// compatibility is an `array_runtime` runtime concern, not a SIR
+    /// validation rule (SIR10 "types carry, don't verify").
+    MatMul {
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+        span: Span,
+    },
+
+    /// An elementwise (broadcast) binary arithmetic op — MATLAB's
+    /// dotted operators `.+` `.-` `.*` `./` `.^` (plain `+`/`-` are
+    /// already elementwise in MATLAB, since they don't have a
+    /// non-elementwise reading the way `*` does).  `op` selects which
+    /// of the five [`ElementwiseOpKind`]s applies.
+    ElementwiseOp {
+        op: ElementwiseOpKind,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+        span: Span,
+    },
+
+    /// Matrix transpose.  `conjugate: true` is MATLAB `'` (conjugate /
+    /// Hermitian transpose); `conjugate: false` is `.'` (plain
+    /// transpose, no conjugation).  Both map onto the same
+    /// `array_runtime::execute(Transpose, …)` op; the frontend picks the
+    /// flag at lowering time (the `'`-transpose-vs-string lexer decision
+    /// is orthogonal to and unaffected by this node — see the SIR22
+    /// spec).
+    Transpose {
+        target: Box<Expr>,
+        conjugate: bool,
+        span: Span,
+    },
+
+    /// `target(indices...)` / `target[indices...]` — an indexed *read*
+    /// (MATLAB `A(2, :)`, `A(1:3)`).  Each entry of `indices` is an
+    /// [`IndexArg`]; the frontend has already resolved 1-based and
+    /// `end`-relative MATLAB subscripts down to concrete 0-based
+    /// `IndexArg`s (the IR never sees `end` — see the SIR22 spec's note
+    /// on `end`-relative indices).  The mutating counterpart is
+    /// [`Stmt::IndexSet`], not a variant here — see that type's doc
+    /// comment for why indexed *write* is a statement while indexed
+    /// *read* is this expression.
+    IndexGet {
+        target: Box<Expr>,
+        indices: Vec<IndexArg>,
+        span: Span,
+    },
+}
+
+/// The five elementwise (broadcast) binary arithmetic operators
+/// (SIR22) — MATLAB's dotted operators `.+ .- .* ./ .^`.  Carried by
+/// [`Expr::ElementwiseOp`] rather than five separate `Expr` variants
+/// so a backend's `match` has one arm to open and a `match op` inside
+/// it, mirroring how `Scope`/`ParamKind` are small closed enums rather
+/// than a variant explosion on their parent node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ElementwiseOpKind {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Pow,
+}
+
+impl ElementwiseOpKind {
+    /// Kebab-case name used by the SIR text format (matches the
+    /// convention set by [`Scope::name`] / [`Feature::name`]).
+    pub fn name(&self) -> &'static str {
+        match self {
+            ElementwiseOpKind::Add => "add",
+            ElementwiseOpKind::Sub => "sub",
+            ElementwiseOpKind::Mul => "mul",
+            ElementwiseOpKind::Div => "div",
+            ElementwiseOpKind::Pow => "pow",
+        }
+    }
+
+    /// Inverse of [`Self::name`].  Returns `None` for unknown names.
+    pub fn from_name(s: &str) -> Option<ElementwiseOpKind> {
+        Some(match s {
+            "add" => ElementwiseOpKind::Add,
+            "sub" => ElementwiseOpKind::Sub,
+            "mul" => ElementwiseOpKind::Mul,
+            "div" => ElementwiseOpKind::Div,
+            "pow" => ElementwiseOpKind::Pow,
+            _ => return None,
+        })
+    }
+}
+
+/// One subscript argument to [`Expr::IndexGet`] / [`Stmt::IndexSet`]
+/// (SIR22).  A MATLAB index expression `A(i, :, 1:3)` lowers to three
+/// `IndexArg`s, one per axis, in source order.
+///
+/// ```text
+/// A(3)      →  [IndexArg::Scalar(IntLit(2))]     -- already 0-based
+/// A(:, 2)   →  [IndexArg::Whole, IndexArg::Scalar(IntLit(1))]
+/// A(1:5)    →  [IndexArg::Range(Range { .. })]
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum IndexArg {
+    /// A single-element subscript on this axis (MATLAB `A(3)`) —
+    /// already translated to a 0-based index expression by the
+    /// frontend (including any `end`-relative resolution; see the
+    /// SIR22 spec).
+    Scalar(Box<Expr>),
+    /// `:` — every element on this axis (MATLAB `A(:, k)`).
+    Whole,
+    /// A range subscript on this axis (MATLAB `A(1:5)`) — reuses
+    /// [`Expr::Range`] as the index argument rather than duplicating
+    /// its three operand slots here.
+    Range(Box<Expr>),
 }
 
 /// A single capture provided to `MakeClosure`.  The `name` matches a
@@ -797,6 +1004,12 @@ impl Expr {
             Expr::LogicalOr { span, .. } => span,
             Expr::StrConcat { span, .. } => span,
             Expr::KeywordArg { span, .. } => span,
+            Expr::ArrayLit { span, .. } => span,
+            Expr::Range { span, .. } => span,
+            Expr::MatMul { span, .. } => span,
+            Expr::ElementwiseOp { span, .. } => span,
+            Expr::Transpose { span, .. } => span,
+            Expr::IndexGet { span, .. } => span,
         }
     }
 
@@ -827,6 +1040,12 @@ impl Expr {
             Expr::LogicalOr { .. } => "or",
             Expr::StrConcat { .. } => "str-concat",
             Expr::KeywordArg { .. } => "keyword-arg",
+            Expr::ArrayLit { .. } => "array",
+            Expr::Range { .. } => "range",
+            Expr::MatMul { .. } => "matmul",
+            Expr::ElementwiseOp { .. } => "elementwise-op",
+            Expr::Transpose { .. } => "transpose",
+            Expr::IndexGet { .. } => "index-get",
         }
     }
 }
@@ -842,7 +1061,10 @@ mod tests {
 
     #[test]
     fn expr_span_helper() {
-        let e = Expr::IntLit { value: 42, span: s() };
+        let e = Expr::IntLit {
+            value: 42,
+            span: s(),
+        };
         assert_eq!(e.span(), &s());
         assert_eq!(e.kind_name(), "int");
     }
@@ -878,11 +1100,17 @@ mod tests {
             Stmt::Assign {
                 name: "x".into(),
                 scope: Scope::Local,
-                value: Expr::IntLit { value: 1, span: s() },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             },
             Stmt::While {
-                cond: Expr::BoolLit { value: true, span: s() },
+                cond: Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                },
                 body: Block {
                     stmts: vec![],
                     value: Expr::NilLit { span: s() },
@@ -892,9 +1120,18 @@ mod tests {
             },
             Stmt::ForRange {
                 var: "i".into(),
-                start: Expr::IntLit { value: 0, span: s() },
-                stop: Expr::IntLit { value: 10, span: s() },
-                step: Expr::IntLit { value: 1, span: s() },
+                start: Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                },
+                stop: Expr::IntLit {
+                    value: 10,
+                    span: s(),
+                },
+                step: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 body: Block {
                     stmts: vec![],
                     value: Expr::NilLit { span: s() },
@@ -904,7 +1141,10 @@ mod tests {
             },
             Stmt::ForEach {
                 var: "x".into(),
-                iter: Expr::SeqLit { items: vec![], span: s() },
+                iter: Expr::SeqLit {
+                    items: vec![],
+                    span: s(),
+                },
                 body: Block {
                     stmts: vec![],
                     value: Expr::NilLit { span: s() },
@@ -913,15 +1153,35 @@ mod tests {
                 span: s(),
             },
             Stmt::SeqSet {
-                seq: Expr::VarRef { name: "xs".into(), scope: Scope::Local, span: s() },
-                index: Expr::IntLit { value: 0, span: s() },
-                value: Expr::IntLit { value: 1, span: s() },
+                seq: Expr::VarRef {
+                    name: "xs".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                },
+                index: Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             },
             Stmt::MapSet {
-                map: Expr::VarRef { name: "d".into(), scope: Scope::Local, span: s() },
-                key: Expr::StrLit { value: "k".into(), span: s() },
-                value: Expr::IntLit { value: 1, span: s() },
+                map: Expr::VarRef {
+                    name: "d".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                },
+                key: Expr::StrLit {
+                    value: "k".into(),
+                    span: s(),
+                },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 span: s(),
             },
         ];
@@ -934,12 +1194,27 @@ mod tests {
     fn sir16_expr_kind_names() {
         let span = s();
         let cases: Vec<(Expr, &'static str)> = vec![
-            (Expr::FloatLit { value: 3.14, span: span.clone() }, "float"),
-            (Expr::SeqLit { items: vec![], span: span.clone() }, "seq"),
+            (
+                Expr::FloatLit {
+                    value: 3.14,
+                    span: span.clone(),
+                },
+                "float",
+            ),
+            (
+                Expr::SeqLit {
+                    items: vec![],
+                    span: span.clone(),
+                },
+                "seq",
+            ),
             (
                 Expr::SeqIndex {
                     seq: Box::new(Expr::NilLit { span: span.clone() }),
-                    index: Box::new(Expr::IntLit { value: 0, span: span.clone() }),
+                    index: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: span.clone(),
+                    }),
                     span: span.clone(),
                 },
                 "seq-index",
@@ -951,7 +1226,13 @@ mod tests {
                 },
                 "seq-len",
             ),
-            (Expr::MapLit { entries: vec![], span: span.clone() }, "map"),
+            (
+                Expr::MapLit {
+                    entries: vec![],
+                    span: span.clone(),
+                },
+                "map",
+            ),
             (
                 Expr::MapGet {
                     map: Box::new(Expr::NilLit { span: span.clone() }),
@@ -962,16 +1243,28 @@ mod tests {
             ),
             (
                 Expr::LogicalAnd {
-                    lhs: Box::new(Expr::BoolLit { value: true, span: span.clone() }),
-                    rhs: Box::new(Expr::BoolLit { value: false, span: span.clone() }),
+                    lhs: Box::new(Expr::BoolLit {
+                        value: true,
+                        span: span.clone(),
+                    }),
+                    rhs: Box::new(Expr::BoolLit {
+                        value: false,
+                        span: span.clone(),
+                    }),
                     span: span.clone(),
                 },
                 "and",
             ),
             (
                 Expr::LogicalOr {
-                    lhs: Box::new(Expr::BoolLit { value: true, span: span.clone() }),
-                    rhs: Box::new(Expr::BoolLit { value: false, span: span.clone() }),
+                    lhs: Box::new(Expr::BoolLit {
+                        value: true,
+                        span: span.clone(),
+                    }),
+                    rhs: Box::new(Expr::BoolLit {
+                        value: false,
+                        span: span.clone(),
+                    }),
                     span: span.clone(),
                 },
                 "or",
@@ -979,8 +1272,14 @@ mod tests {
             (
                 Expr::StrConcat {
                     parts: vec![
-                        Expr::StrLit { value: "a".into(), span: span.clone() },
-                        Expr::StrLit { value: "b".into(), span: span.clone() },
+                        Expr::StrLit {
+                            value: "a".into(),
+                            span: span.clone(),
+                        },
+                        Expr::StrLit {
+                            value: "b".into(),
+                            span: span.clone(),
+                        },
                     ],
                     span: span.clone(),
                 },
@@ -998,11 +1297,23 @@ mod tests {
         // f64::NAN is never equal to itself — Expr only impls
         // PartialEq, not Eq, and that's the reason.  This test pins
         // the contract.
-        let a = Expr::FloatLit { value: f64::NAN, span: s() };
-        let b = Expr::FloatLit { value: f64::NAN, span: s() };
+        let a = Expr::FloatLit {
+            value: f64::NAN,
+            span: s(),
+        };
+        let b = Expr::FloatLit {
+            value: f64::NAN,
+            span: s(),
+        };
         assert_ne!(a, b);
-        let c = Expr::FloatLit { value: 3.14, span: s() };
-        let d = Expr::FloatLit { value: 3.14, span: s() };
+        let c = Expr::FloatLit {
+            value: 3.14,
+            span: s(),
+        };
+        let d = Expr::FloatLit {
+            value: 3.14,
+            span: s(),
+        };
         assert_eq!(c, d);
     }
 
@@ -1012,7 +1323,10 @@ mod tests {
     fn keyword_arg_span_and_kind_name() {
         let e = Expr::KeywordArg {
             name: "a".into(),
-            value: Box::new(Expr::IntLit { value: 1, span: s() }),
+            value: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
             span: s(),
         };
         assert_eq!(e.span(), &s());
@@ -1035,7 +1349,10 @@ mod tests {
             name: "y".into(),
             sir_type: None,
             kind: ParamKind::Keyword,
-            default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+            default: Some(Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            })),
             span: s(),
         };
         assert_eq!(required.kind, ParamKind::Keyword);
@@ -1048,7 +1365,12 @@ mod tests {
             name: name.into(),
             sir_type: None,
             kind: ParamKind::Keyword,
-            default: default.map(|v| Box::new(Expr::IntLit { value: v, span: s() })),
+            default: default.map(|v| {
+                Box::new(Expr::IntLit {
+                    value: v,
+                    span: s(),
+                })
+            }),
             span: s(),
         }
     }
@@ -1059,7 +1381,11 @@ mod tests {
             params,
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1070,10 +1396,22 @@ mod tests {
     fn keyword_params_helper_selects_only_keyword_kind() {
         // def f(a, x:, y: 1, **rest) → keyword_params() == [x, y].
         let f = fn_with_params(vec![
-            Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+            Param {
+                name: "a".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            },
             kw_param("x", None),
             kw_param("y", Some(1)),
-            Param { name: "rest".into(), sir_type: None, kind: ParamKind::KwRest, default: None, span: s() },
+            Param {
+                name: "rest".into(),
+                sir_type: None,
+                kind: ParamKind::KwRest,
+                default: None,
+                span: s(),
+            },
         ]);
         let kws: Vec<&str> = f.keyword_params().iter().map(|p| p.name.as_str()).collect();
         assert_eq!(kws, vec!["x", "y"]);
@@ -1105,16 +1443,339 @@ mod tests {
         assert!(f.missing_keywords(&["x", "y", "z"]).is_empty());
     }
 
+    // ── SIR22: array/matrix nodes ───────────────────────────────────
+
+    #[test]
+    fn index_set_is_a_stmt_not_an_expr() {
+        // SIR22 §"Effects": IndexSet is lowered as a Stmt-position
+        // mutation (like Assign), not a value-producing Expr — pin that
+        // by constructing it as a Stmt and confirming span() dispatches
+        // through Stmt::span, exactly like the sir16_stmt_kinds test does
+        // for Assign/SeqSet/MapSet.
+        let st = Stmt::IndexSet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![IndexArg::Scalar(Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }))],
+            value: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(st.span(), &s());
+        // There is no Expr::IndexSet variant — the type system itself
+        // enforces "not an Expr": this file would fail to compile if
+        // such a variant existed and this test tried to skip it, so the
+        // absence is exercised implicitly by every other test in this
+        // module compiling against the real Expr enum.
+    }
+
+    #[test]
+    fn sir22_stmt_index_set_has_span() {
+        let cases: Vec<Stmt> = vec![Stmt::IndexSet {
+            target: Box::new(Expr::VarRef {
+                name: "m".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![
+                IndexArg::Whole,
+                IndexArg::Scalar(Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                })),
+            ],
+            value: Box::new(Expr::IntLit {
+                value: 9,
+                span: s(),
+            }),
+            span: s(),
+        }];
+        for st in &cases {
+            assert_eq!(st.span(), &s());
+        }
+    }
+
+    #[test]
+    fn sir22_expr_kind_names_and_spans() {
+        let span = s();
+        let cases: Vec<(Expr, &'static str)> = vec![
+            (
+                Expr::ArrayLit {
+                    rows: vec![
+                        vec![
+                            Expr::IntLit {
+                                value: 1,
+                                span: span.clone(),
+                            },
+                            Expr::IntLit {
+                                value: 2,
+                                span: span.clone(),
+                            },
+                        ],
+                        vec![
+                            Expr::IntLit {
+                                value: 3,
+                                span: span.clone(),
+                            },
+                            Expr::IntLit {
+                                value: 4,
+                                span: span.clone(),
+                            },
+                        ],
+                    ],
+                    span: span.clone(),
+                },
+                "array",
+            ),
+            (
+                Expr::Range {
+                    start: Box::new(Expr::IntLit {
+                        value: 1,
+                        span: span.clone(),
+                    }),
+                    step: None,
+                    stop: Box::new(Expr::IntLit {
+                        value: 5,
+                        span: span.clone(),
+                    }),
+                    span: span.clone(),
+                },
+                "range",
+            ),
+            (
+                Expr::MatMul {
+                    lhs: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    }),
+                    rhs: Box::new(Expr::VarRef {
+                        name: "b".into(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    }),
+                    span: span.clone(),
+                },
+                "matmul",
+            ),
+            (
+                Expr::ElementwiseOp {
+                    op: ElementwiseOpKind::Mul,
+                    lhs: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    }),
+                    rhs: Box::new(Expr::VarRef {
+                        name: "b".into(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    }),
+                    span: span.clone(),
+                },
+                "elementwise-op",
+            ),
+            (
+                Expr::Transpose {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    }),
+                    conjugate: true,
+                    span: span.clone(),
+                },
+                "transpose",
+            ),
+            (
+                Expr::IndexGet {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Local,
+                        span: span.clone(),
+                    }),
+                    indices: vec![IndexArg::Whole],
+                    span: span.clone(),
+                },
+                "index-get",
+            ),
+        ];
+        for (e, expected) in &cases {
+            assert_eq!(e.kind_name(), *expected);
+            assert_eq!(e.span(), &span);
+        }
+    }
+
+    #[test]
+    fn range_with_explicit_step() {
+        // 0:2:10 — step is `Some`, distinct from the default-step form.
+        let r = Expr::Range {
+            start: Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }),
+            step: Some(Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            })),
+            stop: Box::new(Expr::IntLit {
+                value: 10,
+                span: s(),
+            }),
+            span: s(),
+        };
+        match r {
+            Expr::Range {
+                step: Some(step), ..
+            } => {
+                assert_eq!(
+                    *step,
+                    Expr::IntLit {
+                        value: 2,
+                        span: s()
+                    }
+                );
+            }
+            _ => panic!("expected Range with explicit step"),
+        }
+    }
+
+    #[test]
+    fn transpose_conjugate_flag_distinguishes_tick_from_dot_tick() {
+        // MATLAB `A'` (conjugate transpose) vs `A.'` (plain transpose) —
+        // the SIR22 spec maps both onto the same node, distinguished only
+        // by `conjugate`.
+        let tick = Expr::Transpose {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            conjugate: true,
+            span: s(),
+        };
+        let dot_tick = Expr::Transpose {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            conjugate: false,
+            span: s(),
+        };
+        assert_ne!(tick, dot_tick);
+    }
+
+    #[test]
+    fn elementwise_op_kind_name_round_trips() {
+        for op in [
+            ElementwiseOpKind::Add,
+            ElementwiseOpKind::Sub,
+            ElementwiseOpKind::Mul,
+            ElementwiseOpKind::Div,
+            ElementwiseOpKind::Pow,
+        ] {
+            assert_eq!(ElementwiseOpKind::from_name(op.name()), Some(op));
+        }
+        assert_eq!(ElementwiseOpKind::from_name("bogus"), None);
+    }
+
+    #[test]
+    fn index_arg_variants_construct() {
+        // Scalar / Whole / Range — the three IndexArg shapes from the
+        // SIR22 spec's worked examples (`A(3)`, `A(:, 2)`, `A(1:5)`).
+        let scalar = IndexArg::Scalar(Box::new(Expr::IntLit {
+            value: 2,
+            span: s(),
+        }));
+        let whole = IndexArg::Whole;
+        let range = IndexArg::Range(Box::new(Expr::Range {
+            start: Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }),
+            step: None,
+            stop: Box::new(Expr::IntLit {
+                value: 5,
+                span: s(),
+            }),
+            span: s(),
+        }));
+        assert!(matches!(scalar, IndexArg::Scalar(_)));
+        assert!(matches!(whole, IndexArg::Whole));
+        assert!(matches!(range, IndexArg::Range(_)));
+    }
+
+    #[test]
+    fn index_get_carries_multiple_axes() {
+        // A(i, :, 1:3) — one IndexArg per axis, in source order.
+        let e = Expr::IndexGet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![
+                IndexArg::Scalar(Box::new(Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                })),
+                IndexArg::Whole,
+                IndexArg::Range(Box::new(Expr::Range {
+                    start: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }),
+                    step: None,
+                    stop: Box::new(Expr::IntLit {
+                        value: 3,
+                        span: s(),
+                    }),
+                    span: s(),
+                })),
+            ],
+            span: s(),
+        };
+        if let Expr::IndexGet { indices, .. } = &e {
+            assert_eq!(indices.len(), 3);
+        } else {
+            panic!("expected IndexGet");
+        }
+    }
+
     #[test]
     fn expr_kind_names_exhaustive() {
         let span = s();
         let cases: Vec<Expr> = vec![
-            Expr::IntLit { value: 1, span: span.clone() },
-            Expr::BoolLit { value: true, span: span.clone() },
+            Expr::IntLit {
+                value: 1,
+                span: span.clone(),
+            },
+            Expr::BoolLit {
+                value: true,
+                span: span.clone(),
+            },
             Expr::NilLit { span: span.clone() },
-            Expr::SymLit { name: "x".into(), span: span.clone() },
-            Expr::StrLit { value: "y".into(), span: span.clone() },
-            Expr::VarRef { name: "z".into(), scope: Scope::Local, span: span.clone() },
+            Expr::SymLit {
+                name: "x".into(),
+                span: span.clone(),
+            },
+            Expr::StrLit {
+                value: "y".into(),
+                span: span.clone(),
+            },
+            Expr::VarRef {
+                name: "z".into(),
+                scope: Scope::Local,
+                span: span.clone(),
+            },
             Expr::DirectCall {
                 fn_name: "f".into(),
                 args: vec![],
@@ -1137,8 +1798,15 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "int", "bool", "nil", "sym", "str", "var-ref",
-                "direct-call", "builtin-call", "make-closure"
+                "int",
+                "bool",
+                "nil",
+                "sym",
+                "str",
+                "var-ref",
+                "direct-call",
+                "builtin-call",
+                "make-closure"
             ]
         );
     }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -128,11 +128,25 @@ fn print_function_indented(out: &mut String, f: &Function, indent: usize) {
         // OPTIONAL keyword (`(x: any (default (int 1)))`, Ruby `x: 1`) from
         // a REQUIRED one (`(x: any)`, Ruby `x:`).
         if let Some(default) = &p.default {
-            let _ = write!(out, "({}{}{} {} (default ", prefix, p.name, suffix, type_or_any(p.sir_type.as_ref()));
+            let _ = write!(
+                out,
+                "({}{}{} {} (default ",
+                prefix,
+                p.name,
+                suffix,
+                type_or_any(p.sir_type.as_ref())
+            );
             print_expr_inline_depth(out, default, 0);
             out.push_str("))");
         } else {
-            let _ = write!(out, "({}{}{} {})", prefix, p.name, suffix, type_or_any(p.sir_type.as_ref()));
+            let _ = write!(
+                out,
+                "({}{}{} {})",
+                prefix,
+                p.name,
+                suffix,
+                type_or_any(p.sir_type.as_ref())
+            );
         }
     }
     let _ = write!(out, ") {}", type_or_any(f.return_type.as_ref()));
@@ -149,7 +163,8 @@ fn print_function_indented(out: &mut String, f: &Function, indent: usize) {
 }
 
 fn type_or_any(t: Option<&SirType>) -> String {
-    t.map(|t| t.to_string()).unwrap_or_else(|| "any".to_string())
+    t.map(|t| t.to_string())
+        .unwrap_or_else(|| "any".to_string())
 }
 
 /// Render a block.  `indent` is the column the *contents* should
@@ -186,7 +201,12 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
         return;
     }
     match s {
-        Stmt::LetBinding { name, sir_type, value, .. } => {
+        Stmt::LetBinding {
+            name,
+            sir_type,
+            value,
+            ..
+        } => {
             let _ = write!(out, "(let {}", name);
             if let Some(t) = sir_type {
                 let _ = write!(out, " {}", t);
@@ -195,7 +215,12 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
-        Stmt::LetStarBinding { name, sir_type, value, .. } => {
+        Stmt::LetStarBinding {
+            name,
+            sir_type,
+            value,
+            ..
+        } => {
             let _ = write!(out, "(let* {}", name);
             if let Some(t) = sir_type {
                 let _ = write!(out, " {}", t);
@@ -209,7 +234,9 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_expr_inline_depth(out, expr, depth + 1);
             out.push(')');
         }
-        Stmt::Assign { name, scope, value, .. } => {
+        Stmt::Assign {
+            name, scope, value, ..
+        } => {
             let _ = write!(out, "(assign {} {} ", name, scope.name());
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
@@ -221,7 +248,14 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_block_depth(out, body, indent + 2, depth + 1);
             out.push(')');
         }
-        Stmt::ForRange { var, start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             let _ = write!(out, "(for-range {} ", var);
             print_expr_inline_depth(out, start, depth + 1);
             out.push(' ');
@@ -232,14 +266,18 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_block_depth(out, body, indent + 2, depth + 1);
             out.push(')');
         }
-        Stmt::ForEach { var, iter, body, .. } => {
+        Stmt::ForEach {
+            var, iter, body, ..
+        } => {
             let _ = write!(out, "(for-each {} ", var);
             print_expr_inline_depth(out, iter, depth + 1);
             let _ = write!(out, "\n{}  ", " ".repeat(indent));
             print_block_depth(out, body, indent + 2, depth + 1);
             out.push(')');
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             let _ = write!(out, "(seq-set ");
             print_expr_inline_depth(out, seq, depth + 1);
             out.push(' ');
@@ -248,7 +286,9 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             let _ = write!(out, "(map-set ");
             print_expr_inline_depth(out, map, depth + 1);
             out.push(' ');
@@ -257,7 +297,12 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
-        Stmt::ClassDef { name, superclass, body, .. } => {
+        Stmt::ClassDef {
+            name,
+            superclass,
+            body,
+            ..
+        } => {
             // `(class-def Name)` for the empty base-class case;
             // `(class-def Name (< Super))` when the class inherits
             // (Ruby Phase 14c `class Foo < Bar`); body statements, if
@@ -294,7 +339,12 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
             }
             out.push(')');
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             // `(try-catch <body…> (rescue …) … (ensure …))` — exception
             // handling (Ruby Phase 16a).  Each clause prints on its own
             // indented line.
@@ -325,6 +375,20 @@ fn print_stmt(out: &mut String, s: &Stmt, indent: usize, depth: usize) {
                 }
                 out.push(')');
             }
+            out.push(')');
+        }
+        // ── SIR22: array/matrix indexed assignment ──────────────────
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            let _ = write!(out, "(index-set ");
+            print_expr_inline_depth(out, target, depth + 1);
+            print_index_args(out, indices, depth);
+            out.push(' ');
+            print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
     }
@@ -362,7 +426,12 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
         Expr::VarRef { name, scope, .. } => {
             let _ = write!(out, "(var-ref {} {})", name, scope.name());
         }
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             let _ = write!(out, "(if ");
             print_expr_inline_depth(out, cond, depth + 1);
             out.push(' ');
@@ -374,13 +443,23 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
         Expr::Block(b) => {
             print_block_depth(out, b, 0, depth + 1);
         }
-        Expr::DirectCall { fn_name, args, effects, .. } => {
+        Expr::DirectCall {
+            fn_name,
+            args,
+            effects,
+            ..
+        } => {
             let _ = write!(out, "(direct-call {} ", fn_name);
             print_effects(out, effects);
             print_args(out, args, depth);
             out.push(')');
         }
-        Expr::IndirectCall { target, args, effects, .. } => {
+        Expr::IndirectCall {
+            target,
+            args,
+            effects,
+            ..
+        } => {
             let _ = write!(out, "(indirect-call ");
             print_expr_inline_depth(out, target, depth + 1);
             out.push(' ');
@@ -388,13 +467,20 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             print_args(out, args, depth);
             out.push(')');
         }
-        Expr::BuiltinCall { name, args, effects, .. } => {
+        Expr::BuiltinCall {
+            name,
+            args,
+            effects,
+            ..
+        } => {
             let _ = write!(out, "(builtin-call {} ", name);
             print_effects(out, effects);
             print_args(out, args, depth);
             out.push(')');
         }
-        Expr::MakeClosure { fn_name, captures, .. } => {
+        Expr::MakeClosure {
+            fn_name, captures, ..
+        } => {
             let _ = write!(out, "(make-closure {}", fn_name);
             for c in captures {
                 let _ = write!(out, " ({} ", c.name);
@@ -403,8 +489,21 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             }
             out.push(')');
         }
-        Expr::Intrinsic { targets, name, args, return_type, effects, .. } => {
-            let _ = write!(out, "(intrinsic ({}) {} {} ", join_strs(targets), name, return_type);
+        Expr::Intrinsic {
+            targets,
+            name,
+            args,
+            return_type,
+            effects,
+            ..
+        } => {
+            let _ = write!(
+                out,
+                "(intrinsic ({}) {} {} ",
+                join_strs(targets),
+                name,
+                return_type
+            );
             print_effects(out, effects);
             print_args(out, args, depth);
             out.push(')');
@@ -479,6 +578,100 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
+
+        // ── SIR22: array/matrix nodes ────────────────────────────────
+        // `(array (row (int 1) (int 2)) (row (int 3) (int 4)))` — one
+        // `(row ...)` group per row, preserving the row-major literal
+        // order the SIR22 spec documents (the frontend reconciles this
+        // with the column-major storage convention, not the printer).
+        Expr::ArrayLit { rows, .. } => {
+            let _ = write!(out, "(array");
+            for row in rows {
+                let _ = write!(out, " (row");
+                for item in row {
+                    out.push(' ');
+                    print_expr_inline_depth(out, item, depth + 1);
+                }
+                out.push(')');
+            }
+            out.push(')');
+        }
+        // `(range <start> <stop>)` when step is absent (step = 1);
+        // `(range <start> <step> <stop>)` when explicit — matching
+        // MATLAB's own two-arg-vs-three-arg colon distinction, so a
+        // round-tripped `1:5` doesn't grow a spurious `(int 1)` step.
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            let _ = write!(out, "(range ");
+            print_expr_inline_depth(out, start, depth + 1);
+            out.push(' ');
+            if let Some(step) = step {
+                print_expr_inline_depth(out, step, depth + 1);
+                out.push(' ');
+            }
+            print_expr_inline_depth(out, stop, depth + 1);
+            out.push(')');
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            let _ = write!(out, "(matmul ");
+            print_expr_inline_depth(out, lhs, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, rhs, depth + 1);
+            out.push(')');
+        }
+        Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+            let _ = write!(out, "(elementwise-op {} ", op.name());
+            print_expr_inline_depth(out, lhs, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, rhs, depth + 1);
+            out.push(')');
+        }
+        // `(transpose <target> conjugate)` / `(transpose <target> plain)`
+        // — MATLAB `'` vs `.'` (see Expr::Transpose's doc comment).
+        Expr::Transpose {
+            target, conjugate, ..
+        } => {
+            let _ = write!(out, "(transpose ");
+            print_expr_inline_depth(out, target, depth + 1);
+            let _ = write!(out, " {})", if *conjugate { "conjugate" } else { "plain" });
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            let _ = write!(out, "(index-get ");
+            print_expr_inline_depth(out, target, depth + 1);
+            print_index_args(out, indices, depth);
+            out.push(')');
+        }
+    }
+}
+
+/// Render a slice of `IndexArg`s, one space-prefixed `(…)` form per
+/// entry, shared by `Expr::IndexGet` and `Stmt::IndexSet` (SIR22).
+///
+/// ```text
+/// Scalar(e)  →  " (idx-scalar <e>)"
+/// Whole      →  " (idx-whole)"
+/// Range(e)   →  " (idx-range <e>)"
+/// ```
+fn print_index_args(out: &mut String, indices: &[IndexArg], depth: usize) {
+    for arg in indices {
+        match arg {
+            IndexArg::Scalar(e) => {
+                let _ = write!(out, " (idx-scalar ");
+                print_expr_inline_depth(out, e, depth + 1);
+                out.push(')');
+            }
+            IndexArg::Whole => {
+                out.push_str(" (idx-whole)");
+            }
+            IndexArg::Range(e) => {
+                let _ = write!(out, " (idx-range ");
+                print_expr_inline_depth(out, e, depth + 1);
+                out.push(')');
+            }
+        }
     }
 }
 
@@ -489,7 +682,11 @@ fn format_float(v: f64) -> String {
     if v.is_nan() {
         "nan".into()
     } else if v.is_infinite() {
-        if v.is_sign_negative() { "-inf".into() } else { "inf".into() }
+        if v.is_sign_negative() {
+            "-inf".into()
+        } else {
+            "inf".into()
+        }
     } else if v == v.trunc() && v.abs() < 1e16 {
         format!("{:.1}", v)
     } else {
@@ -559,7 +756,7 @@ mod tests {
     fn print_empty_module() {
         let m = module_with(vec![], FeatureManifest::new());
         let t = print_module(&m);
-        assert!(t.starts_with("(sir-module demo v1"));
+        assert!(t.starts_with("(sir-module demo v2"));
         assert!(t.contains("(metadata"));
         assert!(t.ends_with(")\n"));
     }
@@ -572,13 +769,19 @@ mod tests {
 
     #[test]
     fn print_integer_literal() {
-        let e = Expr::IntLit { value: 42, span: s() };
+        let e = Expr::IntLit {
+            value: 42,
+            span: s(),
+        };
         assert_eq!(print_expr(&e), "(int 42)");
     }
 
     #[test]
     fn print_negative_integer() {
-        let e = Expr::IntLit { value: -7, span: s() };
+        let e = Expr::IntLit {
+            value: -7,
+            span: s(),
+        };
         assert_eq!(print_expr(&e), "(int -7)");
     }
 
@@ -588,18 +791,40 @@ mod tests {
         // each part printed inline like a builtin-call's args.
         let e = Expr::StrConcat {
             parts: vec![
-                Expr::StrLit { value: "hi ".into(), span: s() },
-                Expr::VarRef { name: "name".into(), scope: Scope::Local, span: s() },
+                Expr::StrLit {
+                    value: "hi ".into(),
+                    span: s(),
+                },
+                Expr::VarRef {
+                    name: "name".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                },
             ],
             span: s(),
         };
-        assert_eq!(print_expr(&e), "(str-concat (str \"hi \") (var-ref name local))");
+        assert_eq!(
+            print_expr(&e),
+            "(str-concat (str \"hi \") (var-ref name local))"
+        );
     }
 
     #[test]
     fn print_booleans_and_nil() {
-        assert_eq!(print_expr(&Expr::BoolLit { value: true, span: s() }), "(bool true)");
-        assert_eq!(print_expr(&Expr::BoolLit { value: false, span: s() }), "(bool false)");
+        assert_eq!(
+            print_expr(&Expr::BoolLit {
+                value: true,
+                span: s()
+            }),
+            "(bool true)"
+        );
+        assert_eq!(
+            print_expr(&Expr::BoolLit {
+                value: false,
+                span: s()
+            }),
+            "(bool false)"
+        );
         assert_eq!(print_expr(&Expr::NilLit { span: s() }), "(nil)");
     }
 
@@ -654,8 +879,14 @@ mod tests {
         let e = Expr::BuiltinCall {
             name: "+".into(),
             args: vec![
-                Expr::IntLit { value: 1, span: s() },
-                Expr::IntLit { value: 2, span: s() },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
             ],
             effects: EffectSet::PURE,
             span: s(),
@@ -670,7 +901,10 @@ mod tests {
     fn print_builtin_call_with_effects() {
         let e = Expr::BuiltinCall {
             name: "print".into(),
-            args: vec![Expr::IntLit { value: 99, span: s() }],
+            args: vec![Expr::IntLit {
+                value: 99,
+                span: s(),
+            }],
             effects: EffectSet::PURE.with(Effect::MayPrint),
             span: s(),
         };
@@ -695,14 +929,14 @@ mod tests {
             fn_name: "__lambda_0".into(),
             captures: vec![CaptureValue {
                 name: "n".into(),
-                value: Expr::IntLit { value: 5, span: s() },
+                value: Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                },
             }],
             span: s(),
         };
-        assert_eq!(
-            print_expr(&e),
-            "(make-closure __lambda_0 (n (int 5)))"
-        );
+        assert_eq!(print_expr(&e), "(make-closure __lambda_0 (n (int 5)))");
     }
 
     #[test]
@@ -731,8 +965,20 @@ mod tests {
         let f = Function {
             name: "add".into(),
             params: vec![
-                Param { name: "x".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
-                Param { name: "y".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "x".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "y".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
@@ -747,7 +993,9 @@ mod tests {
         );
         let text = print_module(&m);
         assert!(text.contains("(function add ((x any) (y any)) any (effects pure)"));
-        assert!(text.contains("(builtin-call + (effects pure) (var-ref x param) (var-ref y param))"));
+        assert!(
+            text.contains("(builtin-call + (effects pure) (var-ref x param) (var-ref y param))")
+        );
     }
 
     #[test]
@@ -762,9 +1010,27 @@ mod tests {
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
-                Param { name: "rest".into(), sir_type: None, kind: ParamKind::Rest, default: None, span: s() },
-                Param { name: "opts".into(), sir_type: None, kind: ParamKind::KwRest, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "rest".into(),
+                    sir_type: None,
+                    kind: ParamKind::Rest,
+                    default: None,
+                    span: s(),
+                },
+                Param {
+                    name: "opts".into(),
+                    sir_type: None,
+                    kind: ParamKind::KwRest,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
@@ -801,10 +1067,19 @@ mod tests {
                     name: "a".into(),
                     sir_type: None,
                     kind: ParamKind::Required,
-                    default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+                    default: Some(Box::new(Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    })),
                     span: s(),
                 },
-                Param { name: "b".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
@@ -828,16 +1103,29 @@ mod tests {
     fn print_keyword_params_render_colon_suffix() {
         // KW1: `def f(x:, y: 1)` → a REQUIRED keyword `x` renders `(x: any)`
         // and an OPTIONAL keyword `y` renders `(y: any (default (int 1)))`.
-        let body = Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() };
+        let body = Block {
+            stmts: vec![],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        };
         let f = Function {
             name: "f".into(),
             params: vec![
-                Param { name: "x".into(), sir_type: None, kind: ParamKind::Keyword, default: None, span: s() },
+                Param {
+                    name: "x".into(),
+                    sir_type: None,
+                    kind: ParamKind::Keyword,
+                    default: None,
+                    span: s(),
+                },
                 Param {
                     name: "y".into(),
                     sir_type: None,
                     kind: ParamKind::Keyword,
-                    default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+                    default: Some(Box::new(Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    })),
                     span: s(),
                 },
             ],
@@ -867,10 +1155,16 @@ mod tests {
         let e = Expr::DirectCall {
             fn_name: "f".into(),
             args: vec![
-                Expr::IntLit { value: 1, span: s() },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
                 Expr::KeywordArg {
                     name: "a".into(),
-                    value: Box::new(Expr::IntLit { value: 2, span: s() }),
+                    value: Box::new(Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    }),
                     span: s(),
                 },
             ],
@@ -887,19 +1181,34 @@ mod tests {
     fn print_float_lit_emits_decimal_form() {
         // Integer-valued floats render with explicit `.0` so the
         // round-trip parser can distinguish them from int literals.
-        let e = Expr::FloatLit { value: 3.0, span: s() };
+        let e = Expr::FloatLit {
+            value: 3.0,
+            span: s(),
+        };
         assert_eq!(print_expr(&e), "(float 3.0)");
-        let e = Expr::FloatLit { value: 3.14, span: s() };
+        let e = Expr::FloatLit {
+            value: 3.14,
+            span: s(),
+        };
         assert_eq!(print_expr(&e), "(float 3.14)");
     }
 
     #[test]
     fn print_float_lit_handles_non_finite() {
-        let nan = Expr::FloatLit { value: f64::NAN, span: s() };
+        let nan = Expr::FloatLit {
+            value: f64::NAN,
+            span: s(),
+        };
         assert_eq!(print_expr(&nan), "(float nan)");
-        let posinf = Expr::FloatLit { value: f64::INFINITY, span: s() };
+        let posinf = Expr::FloatLit {
+            value: f64::INFINITY,
+            span: s(),
+        };
         assert_eq!(print_expr(&posinf), "(float inf)");
-        let neginf = Expr::FloatLit { value: f64::NEG_INFINITY, span: s() };
+        let neginf = Expr::FloatLit {
+            value: f64::NEG_INFINITY,
+            span: s(),
+        };
         assert_eq!(print_expr(&neginf), "(float -inf)");
     }
 
@@ -907,16 +1216,28 @@ mod tests {
     fn print_seq_and_map_literals() {
         let seq = Expr::SeqLit {
             items: vec![
-                Expr::IntLit { value: 1, span: s() },
-                Expr::IntLit { value: 2, span: s() },
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
             ],
             span: s(),
         };
         assert_eq!(print_expr(&seq), "(seq (int 1) (int 2))");
         let map = Expr::MapLit {
             entries: vec![MapEntry {
-                key: Expr::StrLit { value: "a".into(), span: s() },
-                value: Expr::IntLit { value: 1, span: s() },
+                key: Expr::StrLit {
+                    value: "a".into(),
+                    span: s(),
+                },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
             }],
             span: s(),
         };
@@ -926,8 +1247,14 @@ mod tests {
     #[test]
     fn print_logical_short_circuit() {
         let e = Expr::LogicalAnd {
-            lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
-            rhs: Box::new(Expr::BoolLit { value: false, span: s() }),
+            lhs: Box::new(Expr::BoolLit {
+                value: true,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::BoolLit {
+                value: false,
+                span: s(),
+            }),
             span: s(),
         };
         assert_eq!(print_expr(&e), "(and (bool true) (bool false))");
@@ -940,7 +1267,10 @@ mod tests {
             stmts: vec![Stmt::LetBinding {
                 name: "x".into(),
                 sir_type: None,
-                value: Expr::IntLit { value: 1, span: s_.clone() },
+                value: Expr::IntLit {
+                    value: 1,
+                    span: s_.clone(),
+                },
                 span: s_.clone(),
             }],
             value: Expr::VarRef {
@@ -994,7 +1324,10 @@ mod tests {
                 body: vec![Stmt::LetBinding {
                     name: "y".into(),
                     sir_type: None,
-                    value: Expr::IntLit { value: 2, span: s_.clone() },
+                    value: Expr::IntLit {
+                        value: 2,
+                        span: s_.clone(),
+                    },
                     span: s_.clone(),
                 }],
                 span: s_.clone(),
@@ -1041,7 +1374,10 @@ mod tests {
                 body: vec![Stmt::LetBinding {
                     name: "v".into(),
                     sir_type: None,
-                    value: Expr::IntLit { value: 3, span: s_.clone() },
+                    value: Expr::IntLit {
+                        value: 3,
+                        span: s_.clone(),
+                    },
                     span: s_.clone(),
                 }],
                 span: s_.clone(),
@@ -1110,7 +1446,10 @@ mod tests {
         let lb = |name: &str| Stmt::LetBinding {
             name: name.into(),
             sir_type: None,
-            value: Expr::IntLit { value: 1, span: s_.clone() },
+            value: Expr::IntLit {
+                value: 1,
+                span: s_.clone(),
+            },
             span: s_.clone(),
         };
         let block = Block {
@@ -1130,12 +1469,262 @@ mod tests {
         };
         let mut out = String::new();
         print_block(&mut out, &block, 0);
-        assert!(out.contains("(try-catch"), "expected try-catch head, got:\n{}", out);
+        assert!(
+            out.contains("(try-catch"),
+            "expected try-catch head, got:\n{}",
+            out
+        );
         assert!(
             out.contains("(rescue (types StandardError) (bind e)"),
             "expected rescue clause, got:\n{}",
             out
         );
-        assert!(out.contains("(ensure"), "expected ensure clause, got:\n{}", out);
+        assert!(
+            out.contains("(ensure"),
+            "expected ensure clause, got:\n{}",
+            out
+        );
+    }
+
+    // ── SIR22: array/matrix printer tests ────────────────────────────
+
+    #[test]
+    fn print_array_lit_renders_rows() {
+        // [1 2; 3 4]
+        let e = Expr::ArrayLit {
+            rows: vec![
+                vec![
+                    Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    },
+                ],
+                vec![
+                    Expr::IntLit {
+                        value: 3,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 4,
+                        span: s(),
+                    },
+                ],
+            ],
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(array (row (int 1) (int 2)) (row (int 3) (int 4)))"
+        );
+    }
+
+    #[test]
+    fn print_array_lit_empty() {
+        let e = Expr::ArrayLit {
+            rows: vec![],
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(array)");
+    }
+
+    #[test]
+    fn print_range_without_step() {
+        // 1:5 — step absent means step = 1; the printer must not
+        // synthesise one.
+        let e = Expr::Range {
+            start: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            step: None,
+            stop: Box::new(Expr::IntLit {
+                value: 5,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(range (int 1) (int 5))");
+    }
+
+    #[test]
+    fn print_range_with_step() {
+        // 0:2:10
+        let e = Expr::Range {
+            start: Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }),
+            step: Some(Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            })),
+            stop: Box::new(Expr::IntLit {
+                value: 10,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(range (int 0) (int 2) (int 10))");
+    }
+
+    #[test]
+    fn print_matmul() {
+        let e = Expr::MatMul {
+            lhs: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::VarRef {
+                name: "b".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(matmul (var-ref a local) (var-ref b local))"
+        );
+    }
+
+    #[test]
+    fn print_elementwise_op_all_kinds() {
+        // Every ElementwiseOpKind renders its kebab-case op name.
+        for (kind, name) in [
+            (ElementwiseOpKind::Add, "add"),
+            (ElementwiseOpKind::Sub, "sub"),
+            (ElementwiseOpKind::Mul, "mul"),
+            (ElementwiseOpKind::Div, "div"),
+            (ElementwiseOpKind::Pow, "pow"),
+        ] {
+            let e = Expr::ElementwiseOp {
+                op: kind,
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            };
+            assert_eq!(
+                print_expr(&e),
+                format!("(elementwise-op {} (int 1) (int 2))", name)
+            );
+        }
+    }
+
+    #[test]
+    fn print_transpose_conjugate_vs_plain() {
+        // MATLAB `'` (conjugate) vs `.'` (plain) — see Expr::Transpose.
+        let tick = Expr::Transpose {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            conjugate: true,
+            span: s(),
+        };
+        assert_eq!(print_expr(&tick), "(transpose (var-ref a local) conjugate)");
+        let dot_tick = Expr::Transpose {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            conjugate: false,
+            span: s(),
+        };
+        assert_eq!(print_expr(&dot_tick), "(transpose (var-ref a local) plain)");
+    }
+
+    #[test]
+    fn print_index_get_scalar_whole_and_range_args() {
+        // a(i, :, 1:3)
+        let e = Expr::IndexGet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![
+                IndexArg::Scalar(Box::new(Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                })),
+                IndexArg::Whole,
+                IndexArg::Range(Box::new(Expr::Range {
+                    start: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }),
+                    step: None,
+                    stop: Box::new(Expr::IntLit {
+                        value: 3,
+                        span: s(),
+                    }),
+                    span: s(),
+                })),
+            ],
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(index-get (var-ref a local) (idx-scalar (int 0)) (idx-whole) (idx-range (range (int 0) (int 3))))"
+        );
+    }
+
+    #[test]
+    fn print_index_get_no_indices() {
+        let e = Expr::IndexGet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![],
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(index-get (var-ref a local))");
+    }
+
+    #[test]
+    fn print_index_set_stmt() {
+        // a(1) = 9 — printed via print_block since IndexSet is a Stmt.
+        let block = Block {
+            stmts: vec![Stmt::IndexSet {
+                target: Box::new(Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                }),
+                indices: vec![IndexArg::Scalar(Box::new(Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                }))],
+                value: Box::new(Expr::IntLit {
+                    value: 9,
+                    span: s(),
+                }),
+                span: s(),
+            }],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        };
+        let mut out = String::new();
+        print_block(&mut out, &block, 0);
+        assert!(
+            out.contains("(index-set (var-ref a local) (idx-scalar (int 0)) (int 9))"),
+            "got:\n{}",
+            out
+        );
     }
 }

--- a/code/packages/rust/semantic-ir/src/types.rs
+++ b/code/packages/rust/semantic-ir/src/types.rs
@@ -168,12 +168,20 @@ impl IntSpec {
     /// a fixed 64-bit width.  A frontend that means a machine `i64`
     /// must now say so explicitly via [`Self::sized`].
     pub const fn arbitrary() -> Self {
-        IntSpec { width: IntWidth::Arbitrary, signed: true, overflow: Overflow::Arbitrary }
+        IntSpec {
+            width: IntWidth::Arbitrary,
+            signed: true,
+            overflow: Overflow::Arbitrary,
+        }
     }
 
     /// A fixed-width integer with an explicit overflow mode.
     pub const fn sized(width: IntWidth, signed: bool, overflow: Overflow) -> Self {
-        IntSpec { width, signed, overflow }
+        IntSpec {
+            width,
+            signed,
+            overflow,
+        }
     }
 
     /// `true` iff this is the arbitrary-precision (dynamic) integer.
@@ -193,7 +201,11 @@ impl IntSpec {
         // −2^127 == `i128::MIN` is — so special-case rather than
         // computing `-(1i128 << 127)`, which negates `i128::MIN` and
         // panics on overflow in debug builds.
-        Some(if bits >= 128 { i128::MIN } else { -(1i128 << (bits - 1)) })
+        Some(if bits >= 128 {
+            i128::MIN
+        } else {
+            -(1i128 << (bits - 1))
+        })
     }
 
     /// The largest representable value, or `None` if unbounded.
@@ -204,7 +216,11 @@ impl IntSpec {
             // 2^(bits-1) − 1.  Same 128-bit corner as `min`: the answer
             // 2^127−1 == `i128::MAX` is representable but the naive
             // `(1i128 << 127) − 1` overflows the intermediate.
-            Some(if bits >= 128 { i128::MAX } else { (1i128 << (bits - 1)) - 1 })
+            Some(if bits >= 128 {
+                i128::MAX
+            } else {
+                (1i128 << (bits - 1)) - 1
+            })
         } else {
             // 2^n - 1.  Fits i128 for n ≤ 127; W128 unsigned max is the
             // one case that would overflow i128, so compute in u128 and
@@ -261,6 +277,9 @@ impl fmt::Display for IntSpec {
 /// | `Ptr { pointee, nullable }` | C/C++ pointer or reference (SIR21 T1b) |
 /// | `Struct { name, fields }`   | nominal record / struct    (SIR21 T1b) |
 /// | `Optional { inner }`        | nullable `T`-or-nil        (SIR21 T1b) |
+/// | `NDArray { elem, rank }`    | dense N-D numeric array     (SIR22)    |
+/// | `Rational`                  | exact rational scalar       (SIR22/SIR23) |
+/// | `Complex`                   | complex scalar `{re, im}`   (SIR22/SIR23) |
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SirType {
     /// Top type — unknown/any.  The default; renamed from `Any` in SIR21.
@@ -273,7 +292,10 @@ pub enum SirType {
     Str,
     Pair,
     Closure,
-    Fn { params: Vec<SirType>, ret: Box<SirType> },
+    Fn {
+        params: Vec<SirType>,
+        ret: Box<SirType>,
+    },
     // ── SIR16 (Python / JavaScript interop) ──────────────────────────
     /// 64-bit IEEE-754 float carrier.
     Float,
@@ -288,23 +310,61 @@ pub enum SirType {
     /// null pointer from a reference that is guaranteed non-null.
     /// Dynamic targets (Ruby/JS) lower `Ptr` to a plain reference;
     /// targets without pointers declare so in their manifest and reject.
-    Ptr { pointee: Box<SirType>, nullable: bool },
+    Ptr {
+        pointee: Box<SirType>,
+        nullable: bool,
+    },
     /// A nominal record — a C `struct`, or a class's field bag.  `name`
     /// is the declared type name; `fields` are `(field-name, type)` in
     /// declaration order (order matters for C layout / positional init).
     /// Dynamic targets lower it to a record/object; targets without
     /// structs reject via the manifest.
-    Struct { name: String, fields: Vec<(String, SirType)> },
+    Struct {
+        name: String,
+        fields: Vec<(String, SirType)>,
+    },
     /// A nullable value: `inner`-or-nil.  The type-level counterpart of
     /// an `Optional`/`Maybe`/`T?`.  Distinct from `Ptr { nullable }`
     /// (which is specifically a pointer) — `Optional` wraps *any* type.
-    Optional { inner: Box<SirType> },
+    Optional {
+        inner: Box<SirType>,
+    },
+    // ── SIR22 (array/matrix numeric-language IR extension) ───────────
+    /// A dense N-dimensional numeric array (the MATLAB/Octave
+    /// "everything is a matrix" model — see
+    /// [SIR22](../../../../specs/SIR22-array-matrix-semantic-ir.md)).
+    /// `rank` is `None` when a frontend cannot prove the dimensionality
+    /// statically ("unknown/dynamic rank" per the spec); backends must
+    /// handle the absent case explicitly rather than inferring one.
+    /// Storage order (row- vs. column-major) is *not* part of the type —
+    /// it is a manifest-level fact (`Feature::ArrayColumnMajor`), because
+    /// it's a representation choice, not part of the array's shape.
+    NDArray {
+        elem: Box<SirType>,
+        rank: Option<usize>,
+    },
+    /// An exact rational scalar (arbitrary-precision numerator/
+    /// denominator).  This is a type-level carrier only — SIR22 adds no
+    /// numerator/denominator *storage* at the type level (that's a
+    /// runtime concern for the backend); the pair representation itself
+    /// is shared with the future symbolic-math extension
+    /// [SIR23](../../../../specs/SIR23-symbolic-pattern-semantic-ir.md),
+    /// landed once here rather than twice.
+    Rational,
+    /// A complex scalar (`{ re: f64, im: f64 }`).  Like `Rational`, this
+    /// is a type-level carrier with no additional fields — the value
+    /// representation is a backend/runtime concern — shared with the
+    /// future SIR23 symbolic extension.
+    Complex,
 }
 
 impl SirType {
     /// Convenience constructor for `Fn`.
     pub fn function(params: Vec<SirType>, ret: SirType) -> Self {
-        SirType::Fn { params, ret: Box::new(ret) }
+        SirType::Fn {
+            params,
+            ret: Box::new(ret),
+        }
     }
 
     /// The arbitrary-precision integer — the default `Int` (Ruby/Python
@@ -327,17 +387,34 @@ impl SirType {
     /// A pointer/reference to `pointee`.  `nullable` marks a possibly-
     /// null pointer (vs a guaranteed non-null reference).
     pub fn ptr(pointee: SirType, nullable: bool) -> Self {
-        SirType::Ptr { pointee: Box::new(pointee), nullable }
+        SirType::Ptr {
+            pointee: Box::new(pointee),
+            nullable,
+        }
     }
 
     /// A nominal record `name` with ordered `(field, type)` members.
     pub fn struct_type(name: impl Into<String>, fields: Vec<(String, SirType)>) -> Self {
-        SirType::Struct { name: name.into(), fields }
+        SirType::Struct {
+            name: name.into(),
+            fields,
+        }
     }
 
     /// A nullable `inner`-or-nil value.
     pub fn optional(inner: SirType) -> Self {
-        SirType::Optional { inner: Box::new(inner) }
+        SirType::Optional {
+            inner: Box::new(inner),
+        }
+    }
+
+    /// A dense N-D numeric array of `elem`.  `rank = None` means
+    /// unknown/dynamic rank (SIR22).
+    pub fn ndarray(elem: SirType, rank: Option<usize>) -> Self {
+        SirType::NDArray {
+            elem: Box::new(elem),
+            rank,
+        }
     }
 }
 
@@ -384,6 +461,14 @@ impl fmt::Display for SirType {
                 write!(f, ")")
             }
             SirType::Optional { inner } => write!(f, "(optional {})", inner),
+            // SIR22 tokens.  An unknown/dynamic rank prints `(ndarray T)`;
+            // a statically-known rank prints `(ndarray T n)`.
+            SirType::NDArray { elem, rank } => match rank {
+                Some(r) => write!(f, "(ndarray {} {})", elem, r),
+                None => write!(f, "(ndarray {})", elem),
+            },
+            SirType::Rational => write!(f, "rational"),
+            SirType::Complex => write!(f, "complex"),
         }
     }
 }
@@ -407,7 +492,10 @@ mod tests {
 
     #[test]
     fn display_fn_type() {
-        let t = SirType::function(vec![SirType::int_default(), SirType::int_default()], SirType::Bool);
+        let t = SirType::function(
+            vec![SirType::int_default(), SirType::int_default()],
+            SirType::Bool,
+        );
         assert_eq!(format!("{}", t), "(fn (int int) bool)");
     }
 
@@ -444,7 +532,11 @@ mod tests {
     fn default_int_is_arbitrary_precision() {
         // The behaviour-preserving remap: v0 `Int` == arbitrary.
         assert_eq!(SirType::int_default(), SirType::Int(IntSpec::arbitrary()));
-        let IntSpec { width, signed, overflow } = IntSpec::arbitrary();
+        let IntSpec {
+            width,
+            signed,
+            overflow,
+        } = IntSpec::arbitrary();
         assert_eq!(width, IntWidth::Arbitrary);
         assert!(signed);
         assert_eq!(overflow, Overflow::Arbitrary);
@@ -548,11 +640,20 @@ mod tests {
         let s = SirType::struct_type(
             "Point",
             vec![
-                ("x".into(), SirType::int(IntWidth::W32, true, Overflow::Wrap)),
-                ("y".into(), SirType::int(IntWidth::W32, true, Overflow::Wrap)),
+                (
+                    "x".into(),
+                    SirType::int(IntWidth::W32, true, Overflow::Wrap),
+                ),
+                (
+                    "y".into(),
+                    SirType::int(IntWidth::W32, true, Overflow::Wrap),
+                ),
             ],
         );
-        assert_eq!(format!("{}", s), "(struct Point (x (int i32 wrap)) (y (int i32 wrap)))");
+        assert_eq!(
+            format!("{}", s),
+            "(struct Point (x (int i32 wrap)) (y (int i32 wrap)))"
+        );
     }
 
     #[test]
@@ -582,5 +683,59 @@ mod tests {
         let a = SirType::ptr(SirType::Str, false);
         let b = SirType::ptr(SirType::Str, true);
         assert_ne!(a, b);
+    }
+
+    // ── SIR22 array/matrix type tests ─────────────────────────────────
+
+    #[test]
+    fn display_ndarray_unknown_rank() {
+        // rank: None — a frontend that can't prove rank statically.
+        let t = SirType::ndarray(SirType::Float, None);
+        assert_eq!(format!("{}", t), "(ndarray float)");
+    }
+
+    #[test]
+    fn display_ndarray_known_rank() {
+        let t = SirType::ndarray(SirType::Float, Some(2));
+        assert_eq!(format!("{}", t), "(ndarray float 2)");
+    }
+
+    #[test]
+    fn display_rational_and_complex() {
+        assert_eq!(format!("{}", SirType::Rational), "rational");
+        assert_eq!(format!("{}", SirType::Complex), "complex");
+    }
+
+    #[test]
+    fn ndarray_rank_affects_equality() {
+        let a = SirType::ndarray(SirType::Float, Some(1));
+        let b = SirType::ndarray(SirType::Float, Some(2));
+        let c = SirType::ndarray(SirType::Float, None);
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn ndarray_elem_type_affects_equality() {
+        let a = SirType::ndarray(SirType::Float, Some(2));
+        let b = SirType::ndarray(SirType::int_default(), Some(2));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn new_sir22_variants_are_not_dynamic() {
+        assert!(!SirType::ndarray(SirType::Float, None).is_dynamic());
+        assert!(!SirType::Rational.is_dynamic());
+        assert!(!SirType::Complex.is_dynamic());
+    }
+
+    #[test]
+    fn ndarray_can_nest_ndarray_elem() {
+        // A frontend representing a "ragged" higher-rank array as
+        // nested NDArrays (rather than a single flat NDArray with a
+        // known rank) is representable — the elem type is unconstrained.
+        let inner = SirType::ndarray(SirType::Float, Some(1));
+        let outer = SirType::ndarray(inner, None);
+        assert_eq!(format!("{}", outer), "(ndarray (ndarray float 1))");
     }
 }

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -185,10 +185,7 @@ impl<'m> ValidatorState<'m> {
             if !self.depth_overflow_reported {
                 self.depth_overflow_reported = true;
                 self.error(
-                    format!(
-                        "expression nesting exceeds MAX_IR_DEPTH ({})",
-                        MAX_IR_DEPTH
-                    ),
+                    format!("expression nesting exceeds MAX_IR_DEPTH ({})", MAX_IR_DEPTH),
                     span,
                 );
             }
@@ -243,10 +240,7 @@ impl<'m> ValidatorState<'m> {
     fn collect_top_level_names(&mut self) {
         for f in &self.module.functions {
             if !self.function_names.insert(f.name.clone()) {
-                self.error(
-                    format!("duplicate function name `{}`", f.name),
-                    &f.span,
-                );
+                self.error(format!("duplicate function name `{}`", f.name), &f.span);
             }
             // Cache the call-arity profile (SIR10 default-param call-arity
             // rule).  `variadic` is set when the callee carries a
@@ -255,9 +249,10 @@ impl<'m> ValidatorState<'m> {
             // enforced at the call site (deferred — see the `DirectCall`
             // arm).  A duplicate name keeps the first profile, matching how
             // `function_names` reports-but-keeps the first binding.
-            let variadic = f.params.iter().any(|p| {
-                p.kind != ParamKind::Required || p.name == "__sir_block__"
-            });
+            let variadic = f
+                .params
+                .iter()
+                .any(|p| p.kind != ParamKind::Required || p.name == "__sir_block__");
             self.fn_arity.entry(f.name.clone()).or_insert(FnArity {
                 min: f.required_param_count(),
                 max: f.params.len(),
@@ -266,10 +261,7 @@ impl<'m> ValidatorState<'m> {
         }
         for g in &self.module.globals {
             if !self.global_names.insert(g.name.clone()) {
-                self.error(
-                    format!("duplicate global name `{}`", g.name),
-                    &g.span,
-                );
+                self.error(format!("duplicate global name `{}`", g.name), &g.span);
             }
         }
         if !self.module.globals.is_empty() {
@@ -301,10 +293,7 @@ impl<'m> ValidatorState<'m> {
         let no_captures: HashSet<String> = HashSet::new();
         for p in &f.params {
             if !param_names.insert(p.name.clone()) {
-                self.error(
-                    format!("duplicate parameter `{}`", p.name),
-                    &p.span,
-                );
+                self.error(format!("duplicate parameter `{}`", p.name), &p.span);
             }
             if p.sir_type.is_some() {
                 self.observed.add(Feature::OptionalTypeAnnotations);
@@ -376,13 +365,19 @@ impl<'m> ValidatorState<'m> {
                     }
                     if keyword_seen {
                         self.error(
-                            format!("rest parameter `*{}` must precede keyword parameters", p.name),
+                            format!(
+                                "rest parameter `*{}` must precede keyword parameters",
+                                p.name
+                            ),
                             &p.span,
                         );
                     }
                     if kwrest_seen {
                         self.error(
-                            format!("rest parameter `*{}` must precede the keyword-rest parameter", p.name),
+                            format!(
+                                "rest parameter `*{}` must precede the keyword-rest parameter",
+                                p.name
+                            ),
                             &p.span,
                         );
                     }
@@ -393,7 +388,10 @@ impl<'m> ValidatorState<'m> {
                     // follow positionals, the `*rest`, and other keywords.
                     if kwrest_seen {
                         self.error(
-                            format!("keyword parameter `{}` must precede the keyword-rest parameter", p.name),
+                            format!(
+                                "keyword parameter `{}` must precede the keyword-rest parameter",
+                                p.name
+                            ),
                             &p.span,
                         );
                     }
@@ -418,17 +416,26 @@ impl<'m> ValidatorState<'m> {
                     }
                     if kwrest_seen {
                         self.error(
-                            format!("required parameter `{}` must precede the keyword-rest parameter", p.name),
+                            format!(
+                                "required parameter `{}` must precede the keyword-rest parameter",
+                                p.name
+                            ),
                             &p.span,
                         );
                     } else if keyword_seen {
                         self.error(
-                            format!("required parameter `{}` must precede keyword parameters", p.name),
+                            format!(
+                                "required parameter `{}` must precede keyword parameters",
+                                p.name
+                            ),
                             &p.span,
                         );
                     } else if rest_seen {
                         self.error(
-                            format!("required parameter `{}` must precede the rest parameter", p.name),
+                            format!(
+                                "required parameter `{}` must precede the rest parameter",
+                                p.name
+                            ),
                             &p.span,
                         );
                     }
@@ -529,7 +536,10 @@ impl<'m> ValidatorState<'m> {
                     // Check every RHS in the *outer* env (no new
                     // names added yet).
                     for k in i..j {
-                        if let Stmt::LetBinding { value, sir_type, .. } = &stmts[k] {
+                        if let Stmt::LetBinding {
+                            value, sir_type, ..
+                        } = &stmts[k]
+                        {
                             self.check_expr(value, env, depth + 1);
                             if sir_type.is_some() {
                                 self.observed.add(Feature::OptionalTypeAnnotations);
@@ -544,7 +554,12 @@ impl<'m> ValidatorState<'m> {
                     }
                     i = j;
                 }
-                Stmt::LetStarBinding { name, sir_type, value, .. } => {
+                Stmt::LetStarBinding {
+                    name,
+                    sir_type,
+                    value,
+                    ..
+                } => {
                     self.check_expr(value, env, depth + 1);
                     env.add_local(name.clone());
                     if sir_type.is_some() {
@@ -556,7 +571,12 @@ impl<'m> ValidatorState<'m> {
                     self.check_expr(expr, env, depth + 1);
                     i += 1;
                 }
-                Stmt::Assign { name, scope, value, span } => {
+                Stmt::Assign {
+                    name,
+                    scope,
+                    value,
+                    span,
+                } => {
                     self.observed.add(Feature::MutableBindings);
                     self.check_expr(value, env, depth + 1);
                     self.check_varref(name, *scope, span, env);
@@ -568,7 +588,14 @@ impl<'m> ValidatorState<'m> {
                     self.check_block(body, env, depth + 1);
                     i += 1;
                 }
-                Stmt::ForRange { var, start, stop, step, body, .. } => {
+                Stmt::ForRange {
+                    var,
+                    start,
+                    stop,
+                    step,
+                    body,
+                    ..
+                } => {
                     self.observed.add(Feature::Loops);
                     self.check_expr(start, env, depth + 1);
                     self.check_expr(stop, env, depth + 1);
@@ -580,7 +607,9 @@ impl<'m> ValidatorState<'m> {
                     env.rewind(inner_mark);
                     i += 1;
                 }
-                Stmt::ForEach { var, iter, body, .. } => {
+                Stmt::ForEach {
+                    var, iter, body, ..
+                } => {
                     self.observed.add(Feature::Loops);
                     self.check_expr(iter, env, depth + 1);
                     let inner_mark = env.mark();
@@ -589,17 +618,39 @@ impl<'m> ValidatorState<'m> {
                     env.rewind(inner_mark);
                     i += 1;
                 }
-                Stmt::SeqSet { seq, index, value, .. } => {
+                Stmt::SeqSet {
+                    seq, index, value, ..
+                } => {
                     self.observed.add(Feature::Sequences);
                     self.check_expr(seq, env, depth + 1);
                     self.check_expr(index, env, depth + 1);
                     self.check_expr(value, env, depth + 1);
                     i += 1;
                 }
-                Stmt::MapSet { map, key, value, .. } => {
+                Stmt::MapSet {
+                    map, key, value, ..
+                } => {
                     self.observed.add(Feature::Maps);
                     self.check_expr(map, env, depth + 1);
                     self.check_expr(key, env, depth + 1);
+                    self.check_expr(value, env, depth + 1);
+                    i += 1;
+                }
+                Stmt::IndexSet {
+                    target,
+                    indices,
+                    value,
+                    ..
+                } => {
+                    // SIR22: `target[indices...] = value` — the mutation-
+                    // shaped counterpart of SeqSet/MapSet above (and, per
+                    // the spec, the one exception to "every new SIR22 node
+                    // is Pure").  `target` is an arbitrary expression (not
+                    // a bound name), so — like SeqSet/MapSet, and unlike
+                    // Assign — there's no `check_varref` here.
+                    self.observed.add(Feature::NDArrays);
+                    self.check_expr(target, env, depth + 1);
+                    self.check_index_args(indices, env, depth + 1);
                     self.check_expr(value, env, depth + 1);
                     i += 1;
                 }
@@ -663,7 +714,12 @@ impl<'m> ValidatorState<'m> {
                     env.rewind(singleton_mark);
                     i += 1;
                 }
-                Stmt::TryCatch { body, rescues, ensure_body, span } => {
+                Stmt::TryCatch {
+                    body,
+                    rescues,
+                    ensure_body,
+                    span,
+                } => {
                     // Structured exception handling (Ruby Phase 16a).
                     // Mark Feature::Exceptions, then depth-guard and walk
                     // each block in a fresh local-env scope so block-local
@@ -713,7 +769,12 @@ impl<'m> ValidatorState<'m> {
             Expr::VarRef { name, scope, span } => {
                 self.check_varref(name, *scope, span, env);
             }
-            Expr::If { cond, then_branch, else_branch, .. } => {
+            Expr::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
                 self.check_expr(cond, env, depth + 1);
                 self.check_block(then_branch, env, depth + 1);
                 self.check_block(else_branch, env, depth + 1);
@@ -809,7 +870,11 @@ impl<'m> ValidatorState<'m> {
                     self.check_expr(a, env, depth + 1);
                 }
             }
-            Expr::MakeClosure { fn_name, captures, span } => {
+            Expr::MakeClosure {
+                fn_name,
+                captures,
+                span,
+            } => {
                 self.observed.add(Feature::Closures);
                 if !self.function_names.contains(fn_name) {
                     self.error(
@@ -821,7 +886,12 @@ impl<'m> ValidatorState<'m> {
                     self.check_expr(&c.value, env, depth + 1);
                 }
             }
-            Expr::Intrinsic { targets, args, span, .. } => {
+            Expr::Intrinsic {
+                targets,
+                args,
+                span,
+                ..
+            } => {
                 self.observed.add(Feature::Intrinsics);
                 if targets.is_empty() {
                     self.error("intrinsic must declare at least one target tag", span);
@@ -875,10 +945,7 @@ impl<'m> ValidatorState<'m> {
                 // (it should have emitted the bare part instead).
                 if parts.len() < 2 {
                     self.error(
-                        format!(
-                            "str-concat needs at least 2 parts, got {}",
-                            parts.len()
-                        ),
+                        format!("str-concat needs at least 2 parts, got {}", parts.len()),
                         span,
                     );
                 }
@@ -911,6 +978,65 @@ impl<'m> ValidatorState<'m> {
                 self.in_call_args = false;
                 self.check_expr(value, env, depth + 1);
                 self.in_call_args = prev;
+            }
+
+            // ── SIR22: array/matrix nodes ───────────────────────────
+            Expr::ArrayLit { rows, .. } => {
+                self.observed.add(Feature::NDArrays);
+                self.observed.add(Feature::ArrayColumnMajor);
+                for row in rows {
+                    for item in row {
+                        self.check_expr(item, env, depth + 1);
+                    }
+                }
+            }
+            Expr::Range {
+                start, step, stop, ..
+            } => {
+                self.observed.add(Feature::NDArrays);
+                self.check_expr(start, env, depth + 1);
+                if let Some(step) = step {
+                    self.check_expr(step, env, depth + 1);
+                }
+                self.check_expr(stop, env, depth + 1);
+            }
+            Expr::MatMul { lhs, rhs, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(lhs, env, depth + 1);
+                self.check_expr(rhs, env, depth + 1);
+            }
+            Expr::ElementwiseOp { lhs, rhs, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(lhs, env, depth + 1);
+                self.check_expr(rhs, env, depth + 1);
+            }
+            Expr::Transpose { target, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(target, env, depth + 1);
+            }
+            Expr::IndexGet {
+                target, indices, ..
+            } => {
+                self.observed.add(Feature::NDArrays);
+                self.check_expr(target, env, depth + 1);
+                self.check_index_args(indices, env, depth + 1);
+            }
+        }
+    }
+
+    /// Validate the `Expr` nested inside every `IndexArg` of an
+    /// `IndexGet`/`IndexSet` (SIR22).  Factored out because both node
+    /// kinds share the exact same index-arg shape (mirroring how
+    /// `walker.rs`'s `walk_index_args` is shared between them).
+    fn check_index_args(&mut self, indices: &[IndexArg], env: &mut LocalEnv, depth: usize) {
+        for arg in indices {
+            match arg {
+                IndexArg::Scalar(e) => self.check_expr(e, env, depth + 1),
+                IndexArg::Whole => {}
+                IndexArg::Range(e) => self.check_expr(e, env, depth + 1),
             }
         }
     }
@@ -980,8 +1106,7 @@ impl<'m> ValidatorState<'m> {
                     // keyword unambiguously.
                     if seen_keyword {
                         self.error(
-                            "positional argument may not follow a keyword argument"
-                                .to_string(),
+                            "positional argument may not follow a keyword argument".to_string(),
                             a.span(),
                         );
                     }
@@ -1028,8 +1153,7 @@ impl<'m> ValidatorState<'m> {
         let Some(f) = self.module.functions.iter().find(|f| f.name == callee) else {
             return;
         };
-        let kw_names: HashSet<String> =
-            f.keyword_params().iter().map(|p| p.name.clone()).collect();
+        let kw_names: HashSet<String> = f.keyword_params().iter().map(|p| p.name.clone()).collect();
         let has_kwrest = f.params.iter().any(|p| p.kind == ParamKind::KwRest);
         let required_kw: Vec<String> = f
             .params
@@ -1060,10 +1184,7 @@ impl<'m> ValidatorState<'m> {
         for req in &required_kw {
             if !supplied.contains(&req.as_str()) {
                 self.error(
-                    format!(
-                        "call to `{}` is missing required keyword `{}`",
-                        callee, req
-                    ),
+                    format!("call to `{}` is missing required keyword `{}`", callee, req),
                     call_span,
                 );
             }
@@ -1090,7 +1211,10 @@ impl<'m> ValidatorState<'m> {
             Scope::Param => {
                 if !env.has_param(name) {
                     self.error(
-                        format!("var-ref scope=param references unknown parameter `{}`", name),
+                        format!(
+                            "var-ref scope=param references unknown parameter `{}`",
+                            name
+                        ),
                         span,
                     );
                 }
@@ -1098,7 +1222,10 @@ impl<'m> ValidatorState<'m> {
             Scope::Capture => {
                 if !env.has_capture(name) {
                     self.error(
-                        format!("var-ref scope=capture references unknown capture `{}`", name),
+                        format!(
+                            "var-ref scope=capture references unknown capture `{}`",
+                            name
+                        ),
                         span,
                     );
                 }
@@ -1311,7 +1438,13 @@ mod tests {
     }
 
     fn p(name: &str, kind: ParamKind) -> Param {
-        Param { name: name.into(), sir_type: None, kind, default: None, span: s() }
+        Param {
+            name: name.into(),
+            sir_type: None,
+            kind,
+            default: None,
+            span: s(),
+        }
     }
 
     #[test]
@@ -1328,10 +1461,7 @@ mod tests {
 
     #[test]
     fn two_rest_params_is_error() {
-        let m = module_with_params(vec![
-            p("a", ParamKind::Rest),
-            p("b", ParamKind::Rest),
-        ]);
+        let m = module_with_params(vec![p("a", ParamKind::Rest), p("b", ParamKind::Rest)]);
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(r.errors().any(|i| i.message.contains("more than one rest")));
@@ -1339,13 +1469,12 @@ mod tests {
 
     #[test]
     fn two_kwrest_params_is_error() {
-        let m = module_with_params(vec![
-            p("a", ParamKind::KwRest),
-            p("b", ParamKind::KwRest),
-        ]);
+        let m = module_with_params(vec![p("a", ParamKind::KwRest), p("b", ParamKind::KwRest)]);
         let r = validate(&m);
         assert!(!r.is_ok());
-        assert!(r.errors().any(|i| i.message.contains("more than one keyword-rest")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("more than one keyword-rest")));
     }
 
     #[test]
@@ -1357,7 +1486,9 @@ mod tests {
         ]);
         let r = validate(&m);
         assert!(!r.is_ok());
-        assert!(r.errors().any(|i| i.message.contains("must precede the keyword-rest")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("must precede the keyword-rest")));
     }
 
     /// SIR19: a parameter carrying a default-value expression validates
@@ -1365,23 +1496,29 @@ mod tests {
     #[test]
     fn param_with_default_validates_and_observes_feature() {
         // def f(a = 1) — one required param with a default literal `1`.
-        let mut m =
-            empty_module(FeatureManifest::from_features(&[
-                Feature::DynamicTyping,
-                Feature::DefaultParams,
-            ]));
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::DefaultParams,
+        ]));
         m.functions.push(Function {
             name: "f".into(),
             params: vec![Param {
                 name: "a".into(),
                 sir_type: None,
                 kind: ParamKind::Required,
-                default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+                default: Some(Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                })),
                 span: s(),
             }],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1398,24 +1535,30 @@ mod tests {
     fn default_expr_features_are_observed() {
         // def f(a = "x") — manifest must declare Strings (from the default)
         // as well as DefaultParams, or validation fails.
-        let mut m =
-            empty_module(FeatureManifest::from_features(&[
-                Feature::DynamicTyping,
-                Feature::DefaultParams,
-                Feature::Strings,
-            ]));
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::DefaultParams,
+            Feature::Strings,
+        ]));
         m.functions.push(Function {
             name: "f".into(),
             params: vec![Param {
                 name: "a".into(),
                 sir_type: None,
                 kind: ParamKind::Required,
-                default: Some(Box::new(Expr::StrLit { value: "x".into(), span: s() })),
+                default: Some(Box::new(Expr::StrLit {
+                    value: "x".into(),
+                    span: s(),
+                })),
                 span: s(),
             }],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1429,15 +1572,20 @@ mod tests {
     /// the params declared so far.
     #[test]
     fn default_expr_may_reference_earlier_param() {
-        let mut m =
-            empty_module(FeatureManifest::from_features(&[
-                Feature::DynamicTyping,
-                Feature::DefaultParams,
-            ]));
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::DefaultParams,
+        ]));
         m.functions.push(Function {
             name: "f".into(),
             params: vec![
-                Param { name: "a".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "a".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
                 Param {
                     name: "b".into(),
                     sir_type: None,
@@ -1452,7 +1600,11 @@ mod tests {
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1465,11 +1617,10 @@ mod tests {
     /// scope error — only params declared so far are in view.
     #[test]
     fn default_expr_cannot_reference_later_param() {
-        let mut m =
-            empty_module(FeatureManifest::from_features(&[
-                Feature::DynamicTyping,
-                Feature::DefaultParams,
-            ]));
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::DynamicTyping,
+            Feature::DefaultParams,
+        ]));
         m.functions.push(Function {
             name: "f".into(),
             params: vec![
@@ -1485,11 +1636,21 @@ mod tests {
                     })),
                     span: s(),
                 },
-                Param { name: "b".into(), sir_type: None, kind: ParamKind::Required, default: None, span: s() },
+                Param {
+                    name: "b".into(),
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: s(),
+                },
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1512,7 +1673,10 @@ mod tests {
             name: name.into(),
             sir_type: None,
             kind: ParamKind::Required,
-            default: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+            default: Some(Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            })),
             span: s(),
         }
     }
@@ -1531,13 +1695,20 @@ mod tests {
             params: callee_params,
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
         });
         let args: Vec<Expr> = (0..n_args)
-            .map(|i| Expr::IntLit { value: i as i64, span: s() })
+            .map(|i| Expr::IntLit {
+                value: i as i64,
+                span: s(),
+            })
             .collect();
         m.functions.push(Function {
             name: "g".into(),
@@ -1643,7 +1814,11 @@ mod tests {
             4,
         );
         let r = validate(&m);
-        assert!(r.is_ok(), "expected ok for variadic callee, got {:?}", r.issues);
+        assert!(
+            r.is_ok(),
+            "expected ok for variadic callee, got {:?}",
+            r.issues
+        );
     }
 
     #[test]
@@ -1664,7 +1839,11 @@ mod tests {
             params: vec![p("x", ParamKind::Required)],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1675,7 +1854,11 @@ mod tests {
             params: vec![],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1690,7 +1873,10 @@ mod tests {
                 value: Expr::DirectCall {
                     fn_name: "helper".into(),
                     args: vec![
-                        Expr::IntLit { value: 2, span: s() },
+                        Expr::IntLit {
+                            value: 2,
+                            span: s(),
+                        },
                         Expr::MakeClosure {
                             fn_name: "__block_0".into(),
                             captures: vec![],
@@ -1707,7 +1893,11 @@ mod tests {
             span: s(),
         });
         let r = validate(&m);
-        assert!(r.is_ok(), "block-passing call must validate, got {:?}", r.issues);
+        assert!(
+            r.is_ok(),
+            "block-passing call must validate, got {:?}",
+            r.issues
+        );
     }
 
     #[test]
@@ -1721,7 +1911,11 @@ mod tests {
             params: vec![p("a", ParamKind::Required), p("b", ParamKind::Required)],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1767,7 +1961,11 @@ mod tests {
             ],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1799,7 +1997,11 @@ mod tests {
             params,
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -1816,9 +2018,8 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok(), "a hole must fail validation");
         assert!(
-            r.errors().any(|i| i
-                .message
-                .contains("may not follow a defaulted parameter")),
+            r.errors()
+                .any(|i| i.message.contains("may not follow a defaulted parameter")),
             "expected the trailing-defaults error, got {:?}",
             r.issues
         );
@@ -1833,7 +2034,11 @@ mod tests {
             p_default("c"),
         ]);
         let r = validate(&m);
-        assert!(r.is_ok(), "trailing defaults must validate, got {:?}", r.issues);
+        assert!(
+            r.is_ok(),
+            "trailing defaults must validate, got {:?}",
+            r.issues
+        );
     }
 
     #[test]
@@ -1862,7 +2067,9 @@ mod tests {
         ]);
         let r = validate(&m);
         assert!(!r.is_ok());
-        assert!(r.errors().any(|i| i.message.contains("must precede the rest")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("must precede the rest")));
     }
 
     #[test]
@@ -1890,7 +2097,10 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::SymLit { name: "x".into(), span: s() },
+                value: Expr::SymLit {
+                    name: "x".into(),
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -1899,9 +2109,7 @@ mod tests {
         });
         let r = validate(&m);
         assert!(!r.is_ok());
-        assert!(r
-            .errors()
-            .any(|i| i.message.contains("symbols")));
+        assert!(r.errors().any(|i| i.message.contains("symbols")));
     }
 
     #[test]
@@ -2021,7 +2229,10 @@ mod tests {
                     Stmt::LetBinding {
                         name: "x".into(),
                         sir_type: None,
-                        value: Expr::IntLit { value: 1, span: s() },
+                        value: Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
                         span: s(),
                     },
                     Stmt::LetBinding {
@@ -2107,7 +2318,10 @@ mod tests {
         let mut e = Expr::NilLit { span: s() };
         for _ in 0..depth {
             e = Expr::If {
-                cond: Box::new(Expr::BoolLit { value: true, span: s() }),
+                cond: Box::new(Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                }),
                 then_branch: Box::new(Block {
                     stmts: vec![],
                     value: e,
@@ -2136,7 +2350,10 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![],
-                value: Expr::FloatLit { value: 3.14, span: s() },
+                value: Expr::FloatLit {
+                    value: 3.14,
+                    span: s(),
+                },
                 span: s(),
             },
             effects: EffectSet::PURE,
@@ -2158,7 +2375,10 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![Stmt::While {
-                    cond: Expr::BoolLit { value: false, span: s() },
+                    cond: Expr::BoolLit {
+                        value: false,
+                        span: s(),
+                    },
                     body: Block {
                         stmts: vec![],
                         value: Expr::NilLit { span: s() },
@@ -2190,9 +2410,18 @@ mod tests {
             body: Block {
                 stmts: vec![Stmt::ForRange {
                     var: "i".into(),
-                    start: Expr::IntLit { value: 0, span: s() },
-                    stop: Expr::IntLit { value: 10, span: s() },
-                    step: Expr::IntLit { value: 1, span: s() },
+                    start: Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    },
+                    stop: Expr::IntLit {
+                        value: 10,
+                        span: s(),
+                    },
+                    step: Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
                     body: Block {
                         stmts: vec![],
                         value: Expr::VarRef {
@@ -2227,9 +2456,18 @@ mod tests {
             body: Block {
                 stmts: vec![Stmt::ForRange {
                     var: "i".into(),
-                    start: Expr::IntLit { value: 0, span: s() },
-                    stop: Expr::IntLit { value: 10, span: s() },
-                    step: Expr::IntLit { value: 1, span: s() },
+                    start: Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    },
+                    stop: Expr::IntLit {
+                        value: 10,
+                        span: s(),
+                    },
+                    step: Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
                     body: Block {
                         stmts: vec![],
                         value: Expr::NilLit { span: s() },
@@ -2263,8 +2501,14 @@ mod tests {
             body: Block {
                 stmts: vec![],
                 value: Expr::LogicalAnd {
-                    lhs: Box::new(Expr::BoolLit { value: true, span: s() }),
-                    rhs: Box::new(Expr::BoolLit { value: false, span: s() }),
+                    lhs: Box::new(Expr::BoolLit {
+                        value: true,
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::BoolLit {
+                        value: false,
+                        span: s(),
+                    }),
                     span: s(),
                 },
                 span: s(),
@@ -2281,8 +2525,10 @@ mod tests {
     fn str_concat_observes_string_interpolation_feature() {
         // Phase 20b — a well-formed two-part `StrConcat` validates when
         // the manifest declares `StringInterpolation`.
-        let mut m =
-            empty_module(FeatureManifest::from_features(&[Feature::StringInterpolation, Feature::Strings]));
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::StringInterpolation,
+            Feature::Strings,
+        ]));
         m.functions.push(Function {
             name: "f".into(),
             params: vec![],
@@ -2292,8 +2538,14 @@ mod tests {
                 stmts: vec![],
                 value: Expr::StrConcat {
                     parts: vec![
-                        Expr::StrLit { value: "a".into(), span: s() },
-                        Expr::StrLit { value: "b".into(), span: s() },
+                        Expr::StrLit {
+                            value: "a".into(),
+                            span: s(),
+                        },
+                        Expr::StrLit {
+                            value: "b".into(),
+                            span: s(),
+                        },
                     ],
                     span: s(),
                 },
@@ -2312,8 +2564,10 @@ mod tests {
         // Phase 20b — a one-part concat is degenerate; the frontend
         // should have emitted the bare part instead.  The validator
         // flags it so a buggy lowerer is caught early.
-        let mut m =
-            empty_module(FeatureManifest::from_features(&[Feature::StringInterpolation, Feature::Strings]));
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::StringInterpolation,
+            Feature::Strings,
+        ]));
         m.functions.push(Function {
             name: "f".into(),
             params: vec![],
@@ -2322,7 +2576,10 @@ mod tests {
             body: Block {
                 stmts: vec![],
                 value: Expr::StrConcat {
-                    parts: vec![Expr::StrLit { value: "lonely".into(), span: s() }],
+                    parts: vec![Expr::StrLit {
+                        value: "lonely".into(),
+                        span: s(),
+                    }],
                     span: s(),
                 },
                 span: s(),
@@ -2349,7 +2606,10 @@ mod tests {
                     Stmt::LetStarBinding {
                         name: "x".into(),
                         sir_type: None,
-                        value: Expr::IntLit { value: 1, span: s() },
+                        value: Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
                         span: s(),
                     },
                     Stmt::LetStarBinding {
@@ -2418,7 +2678,10 @@ mod tests {
             vec![Stmt::LetBinding {
                 name: "MAX".into(),
                 sir_type: None,
-                value: Expr::IntLit { value: 10, span: s() },
+                value: Expr::IntLit {
+                    value: 10,
+                    span: s(),
+                },
                 span: s(),
             }],
         );
@@ -2472,7 +2735,10 @@ mod tests {
                         body: vec![Stmt::LetBinding {
                             name: "INNER".into(),
                             sir_type: None,
-                            value: Expr::IntLit { value: 1, span: s() },
+                            value: Expr::IntLit {
+                                value: 1,
+                                span: s(),
+                            },
                             span: s(),
                         }],
                         span: s(),
@@ -2521,7 +2787,10 @@ mod tests {
                     body: vec![Stmt::LetBinding {
                         name: "V".into(),
                         sir_type: None,
-                        value: Expr::IntLit { value: 3, span: s() },
+                        value: Expr::IntLit {
+                            value: 3,
+                            span: s(),
+                        },
                         span: s(),
                     }],
                     span: s(),
@@ -2623,7 +2892,10 @@ mod tests {
                     body: vec![Stmt::LetBinding {
                         name: "X".into(),
                         sir_type: None,
-                        value: Expr::IntLit { value: 1, span: s() },
+                        value: Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
                         span: s(),
                     }],
                     span: s(),
@@ -2849,18 +3121,34 @@ mod tests {
             captures: vec![],
             body: Block {
                 stmts: vec![Stmt::TryCatch {
-                    body: vec![lb("_t", Expr::IntLit { value: 1, span: s() })],
+                    body: vec![lb(
+                        "_t",
+                        Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
+                    )],
                     rescues: vec![RescueClause {
                         exception_types: vec!["Foo".into()],
                         binding: Some("e".into()),
                         // The rescue body reads the bound `e` — must resolve.
                         body: vec![lb(
                             "_r",
-                            Expr::VarRef { name: "e".into(), scope: Scope::Local, span: s() },
+                            Expr::VarRef {
+                                name: "e".into(),
+                                scope: Scope::Local,
+                                span: s(),
+                            },
                         )],
                         span: s(),
                     }],
-                    ensure_body: Some(vec![lb("_e", Expr::IntLit { value: 1, span: s() })]),
+                    ensure_body: Some(vec![lb(
+                        "_e",
+                        Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
+                    )]),
                     span: s(),
                 }],
                 value: Expr::NilLit { span: s() },
@@ -2915,7 +3203,11 @@ mod tests {
                     ensure_body: Some(vec![Stmt::LetBinding {
                         name: "_x".into(),
                         sir_type: None,
-                        value: Expr::VarRef { name: "e".into(), scope: Scope::Local, span: s() },
+                        value: Expr::VarRef {
+                            name: "e".into(),
+                            scope: Scope::Local,
+                            span: s(),
+                        },
                         span: s(),
                     }]),
                     span: s(),
@@ -2939,7 +3231,12 @@ mod tests {
             name: name.into(),
             sir_type: None,
             kind: ParamKind::Keyword,
-            default: default.map(|v| Box::new(Expr::IntLit { value: v, span: s() })),
+            default: default.map(|v| {
+                Box::new(Expr::IntLit {
+                    value: v,
+                    span: s(),
+                })
+            }),
             span: s(),
         }
     }
@@ -2948,7 +3245,10 @@ mod tests {
     fn kwarg(name: &str, v: i64) -> Expr {
         Expr::KeywordArg {
             name: name.into(),
-            value: Box::new(Expr::IntLit { value: v, span: s() }),
+            value: Box::new(Expr::IntLit {
+                value: v,
+                span: s(),
+            }),
             span: s(),
         }
     }
@@ -2971,7 +3271,11 @@ mod tests {
             params: callee_params,
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -3018,7 +3322,11 @@ mod tests {
             params: vec![kw("x", Some(1))],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -3038,7 +3346,11 @@ mod tests {
             params: vec![kw("a", Some(0))],
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -3094,7 +3406,11 @@ mod tests {
             params,
             return_type: None,
             captures: vec![],
-            body: Block { stmts: vec![], value: Expr::NilLit { span: s() }, span: s() },
+            body: Block {
+                stmts: vec![],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
             effects: EffectSet::PURE,
             metadata: Metadata::new(),
             span: s(),
@@ -3109,7 +3425,8 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors().any(|i| i.message.contains("must precede keyword parameters")),
+            r.errors()
+                .any(|i| i.message.contains("must precede keyword parameters")),
             "got {:?}",
             r.issues
         );
@@ -3150,7 +3467,13 @@ mod tests {
         // def f(a, x:); f(1, x: 2) — one positional then one keyword.
         let m = module_kw_call(
             vec![p("a", ParamKind::Required), kw("x", None)],
-            vec![Expr::IntLit { value: 1, span: s() }, kwarg("x", 2)],
+            vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                kwarg("x", 2),
+            ],
             &[],
         );
         let r = validate(&m);
@@ -3162,14 +3485,21 @@ mod tests {
         // f(x: 2, 1) — a positional after a keyword argument.
         let m = module_kw_call(
             vec![kw("x", Some(0)), p("a", ParamKind::Required)],
-            vec![kwarg("x", 2), Expr::IntLit { value: 1, span: s() }],
+            vec![
+                kwarg("x", 2),
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+            ],
             &[],
         );
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors()
-                .any(|i| i.message.contains("positional argument may not follow a keyword")),
+            r.errors().any(|i| i
+                .message
+                .contains("positional argument may not follow a keyword")),
             "got {:?}",
             r.issues
         );
@@ -3186,7 +3516,8 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors().any(|i| i.message.contains("duplicate keyword argument")),
+            r.errors()
+                .any(|i| i.message.contains("duplicate keyword argument")),
             "got {:?}",
             r.issues
         );
@@ -3202,7 +3533,8 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors().any(|i| i.message.contains("unknown keyword `y`")),
+            r.errors()
+                .any(|i| i.message.contains("unknown keyword `y`")),
             "got {:?}",
             r.issues
         );
@@ -3212,11 +3544,7 @@ mod tests {
     fn unknown_keyword_with_kwrest_is_accepted() {
         // def f(**opts); f(y: 1) — the **opts absorbs the unmatched keyword,
         // so an otherwise-unknown keyword name is accepted.
-        let m = module_kw_call(
-            vec![p("opts", ParamKind::KwRest)],
-            vec![kwarg("y", 1)],
-            &[],
-        );
+        let m = module_kw_call(vec![p("opts", ParamKind::KwRest)], vec![kwarg("y", 1)], &[]);
         let r = validate(&m);
         assert!(r.is_ok(), "expected ok with **kwrest, got {:?}", r.issues);
     }
@@ -3228,7 +3556,8 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors().any(|i| i.message.contains("missing required keyword `x`")),
+            r.errors()
+                .any(|i| i.message.contains("missing required keyword `x`")),
             "got {:?}",
             r.issues
         );
@@ -3313,15 +3642,26 @@ mod tests {
         // DirectCall path.  def f(x:); g() = f(x: 1).
         let m = module_kw_call(vec![kw("x", None)], vec![kwarg("x", 1)], &[]);
         let r = validate(&m);
-        assert!(r.is_ok(), "direct keyword call must still validate, got {:?}", r.issues);
+        assert!(
+            r.is_ok(),
+            "direct keyword call must still validate, got {:?}",
+            r.issues
+        );
     }
 
     #[test]
     fn indirect_call_with_only_positionals_still_validates() {
         // DoD (c): an indirect call with only positional args is unaffected.
-        let m = module_indirect_call(vec![Expr::IntLit { value: 1, span: s() }]);
+        let m = module_indirect_call(vec![Expr::IntLit {
+            value: 1,
+            span: s(),
+        }]);
         let r = validate(&m);
-        assert!(r.is_ok(), "positional indirect call must validate, got {:?}", r.issues);
+        assert!(
+            r.is_ok(),
+            "positional indirect call must validate, got {:?}",
+            r.issues
+        );
     }
 
     #[test]
@@ -3346,7 +3686,13 @@ mod tests {
                         scope: Scope::Param,
                         span: s(),
                     }),
-                    args: vec![kwarg("x", 1), Expr::IntLit { value: 2, span: s() }],
+                    args: vec![
+                        kwarg("x", 1),
+                        Expr::IntLit {
+                            value: 2,
+                            span: s(),
+                        },
+                    ],
                     effects: EffectSet::PURE,
                     span: s(),
                 },
@@ -3359,8 +3705,9 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors()
-                .any(|i| i.message.contains("positional argument may not follow a keyword")),
+            r.errors().any(|i| i
+                .message
+                .contains("positional argument may not follow a keyword")),
             "got {:?}",
             r.issues
         );
@@ -3444,7 +3791,10 @@ mod tests {
         // f(a: (b: 1)) — the inner `(b: 1)` is invalid.
         let inner = Expr::KeywordArg {
             name: "b".into(),
-            value: Box::new(Expr::IntLit { value: 1, span: s() }),
+            value: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
             span: s(),
         };
         let outer = Expr::KeywordArg {
@@ -3452,11 +3802,7 @@ mod tests {
             value: Box::new(inner),
             span: s(),
         };
-        let m = module_kw_call(
-            vec![p("opts", ParamKind::KwRest)],
-            vec![outer],
-            &[],
-        );
+        let m = module_kw_call(vec![p("opts", ParamKind::KwRest)], vec![outer], &[]);
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
@@ -3487,9 +3833,470 @@ mod tests {
         let r = validate(&m);
         assert!(!r.is_ok());
         assert!(
-            r.errors().any(|i| i.message.contains("unknown name `ghost`")),
+            r.errors()
+                .any(|i| i.message.contains("unknown name `ghost`")),
             "got {:?}",
             r.issues
         );
+    }
+
+    // ── SIR22: array/matrix validator tests ──────────────────────────
+
+    fn module_with_fn_body_value(manifest: FeatureManifest, value: Expr) -> Module {
+        let mut m = empty_module(manifest);
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value,
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        m
+    }
+
+    #[test]
+    fn array_lit_observes_nd_arrays_and_column_major_features() {
+        // [1 2; 3 4] used without declaring NDArrays/ArrayColumnMajor → error.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::ArrayLit {
+                rows: vec![
+                    vec![
+                        Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        },
+                        Expr::IntLit {
+                            value: 2,
+                            span: s(),
+                        },
+                    ],
+                    vec![
+                        Expr::IntLit {
+                            value: 3,
+                            span: s(),
+                        },
+                        Expr::IntLit {
+                            value: 4,
+                            span: s(),
+                        },
+                    ],
+                ],
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("nd-arrays")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn array_lit_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::NDArrays, Feature::ArrayColumnMajor]),
+            Expr::ArrayLit {
+                rows: vec![vec![Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }]],
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn range_observes_nd_arrays_feature() {
+        // 1:5 — a bare Range doesn't need MatrixOps or ArrayColumnMajor,
+        // only NDArrays.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Range {
+                start: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                step: None,
+                stop: Box::new(Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("nd-arrays")));
+        assert!(!r.errors().any(|i| i.message.contains("matrix-ops")));
+    }
+
+    #[test]
+    fn range_with_declared_nd_arrays_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::NDArrays]),
+            Expr::Range {
+                start: Box::new(Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                }),
+                step: Some(Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                })),
+                stop: Box::new(Expr::IntLit {
+                    value: 10,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn matmul_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::MatMul {
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn matmul_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::MatMul {
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn elementwise_op_observes_matrix_ops_feature() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::ElementwiseOp {
+                op: ElementwiseOpKind::Mul,
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+    }
+
+    #[test]
+    fn transpose_observes_matrix_ops_feature() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Transpose {
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                conjugate: true,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+    }
+
+    #[test]
+    fn index_get_observes_nd_arrays_feature_and_validates_index_args() {
+        // a(i, :, 1:3) — the Scalar index `ghost` is an unresolvable
+        // local, so both the missing-feature error and the scope error
+        // are expected.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::IndexGet {
+                target: Box::new(Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Global,
+                    span: s(),
+                }),
+                indices: vec![
+                    IndexArg::Scalar(Box::new(Expr::VarRef {
+                        name: "ghost".into(),
+                        scope: Scope::Local,
+                        span: s(),
+                    })),
+                    IndexArg::Whole,
+                ],
+                span: s(),
+            },
+        );
+        // `a` is referenced with Scope::Global but never declared as a
+        // module global — expect a scope error on `a` too, plus one on
+        // `ghost`, plus the missing-feature error.  We only assert the
+        // two things this test targets: the feature observation and
+        // that IndexArg::Scalar's nested expr is actually validated.
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("nd-arrays")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    #[test]
+    fn index_get_with_declared_feature_and_valid_args_is_valid() {
+        // `a` is scope-checked via a function param (Scope::Param) rather
+        // than a local/global, keeping this test focused on the
+        // feature-observation + index-arg validation path.  The param's
+        // `sir_type: None` is itself what triggers `Feature::DynamicTyping`,
+        // hence declaring it in the manifest below.
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::NDArrays, Feature::DynamicTyping]),
+            Expr::IndexGet {
+                target: Box::new(Expr::VarRef {
+                    name: "a".into(),
+                    scope: Scope::Param,
+                    span: s(),
+                }),
+                indices: vec![IndexArg::Whole],
+                span: s(),
+            },
+        );
+        let mut m = m;
+        m.functions[0].params.push(Param {
+            name: "a".into(),
+            sir_type: None,
+            kind: ParamKind::Required,
+            default: None,
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn index_set_observes_nd_arrays_feature() {
+        // a(1) = 9 — IndexSet without NDArrays declared → error.
+        let mut m = empty_module(FeatureManifest::new());
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![Param {
+                name: "a".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::IndexSet {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    }),
+                    indices: vec![IndexArg::Scalar(Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }))],
+                    value: Box::new(Expr::IntLit {
+                        value: 9,
+                        span: s(),
+                    }),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("nd-arrays")));
+    }
+
+    #[test]
+    fn index_set_with_declared_feature_is_valid() {
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::DynamicTyping,
+        ]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![Param {
+                name: "a".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::IndexSet {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    }),
+                    indices: vec![IndexArg::Whole],
+                    value: Box::new(Expr::IntLit {
+                        value: 9,
+                        span: s(),
+                    }),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn index_set_value_expression_is_validated() {
+        // a(0) = ghost — the RHS value expr must still be scope-checked.
+        let mut m = empty_module(FeatureManifest::from_features(&[Feature::NDArrays]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![Param {
+                name: "a".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::IndexSet {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    }),
+                    indices: vec![IndexArg::Scalar(Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }))],
+                    value: Box::new(Expr::VarRef {
+                        name: "ghost".into(),
+                        scope: Scope::Local,
+                        span: s(),
+                    }),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    /// Pin the SIR22 "IndexSet is a Stmt, not an Expr" design rule at the
+    /// validator layer: an `IndexSet` can only ever be reached via
+    /// `check_stmt_seq` (it's not a variant of `Expr` at all, so
+    /// `check_expr` cannot dispatch to it — this is enforced by the type
+    /// system, not a runtime check). This test documents that a
+    /// well-formed `IndexSet` statement validates cleanly through the
+    /// statement path, confirming the mutation semantics SIR16's `Assign`
+    /// established are followed here too (target checked, value checked,
+    /// no `Expr`-position use possible).
+    #[test]
+    fn index_set_validates_via_stmt_path_only() {
+        let mut m = empty_module(FeatureManifest::from_features(&[
+            Feature::NDArrays,
+            Feature::DynamicTyping,
+        ]));
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![Param {
+                name: "a".into(),
+                sir_type: None,
+                kind: ParamKind::Required,
+                default: None,
+                span: s(),
+            }],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::IndexSet {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Param,
+                        span: s(),
+                    }),
+                    indices: vec![IndexArg::Whole],
+                    value: Box::new(Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    }),
+                    span: s(),
+                }],
+                // The block's trailing *value* position is a plain Expr —
+                // IndexSet could not be placed here even if we wanted to,
+                // since Expr has no IndexSet variant to construct.
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
     }
 }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -109,7 +109,13 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
             v.visit_expr(cond);
             v.visit_block(body);
         }
-        Stmt::ForRange { start, stop, step, body, .. } => {
+        Stmt::ForRange {
+            start,
+            stop,
+            step,
+            body,
+            ..
+        } => {
             v.visit_expr(start);
             v.visit_expr(stop);
             v.visit_expr(step);
@@ -119,12 +125,16 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
             v.visit_expr(iter);
             v.visit_block(body);
         }
-        Stmt::SeqSet { seq, index, value, .. } => {
+        Stmt::SeqSet {
+            seq, index, value, ..
+        } => {
             v.visit_expr(seq);
             v.visit_expr(index);
             v.visit_expr(value);
         }
-        Stmt::MapSet { map, key, value, .. } => {
+        Stmt::MapSet {
+            map, key, value, ..
+        } => {
             v.visit_expr(map);
             v.visit_expr(key);
             v.visit_expr(value);
@@ -151,7 +161,12 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
                 v.visit_stmt(stmt);
             }
         }
-        Stmt::TryCatch { body, rescues, ensure_body, .. } => {
+        Stmt::TryCatch {
+            body,
+            rescues,
+            ensure_body,
+            ..
+        } => {
             // Exception handling (Ruby Phase 16a): recurse into the try
             // body, each rescue clause's body, and the optional ensure
             // body, so visitors see every nested statement.
@@ -169,6 +184,35 @@ pub fn walk_stmt_default<V: Visitor>(v: &mut V, s: &Stmt) {
                 }
             }
         }
+        Stmt::IndexSet {
+            target,
+            indices,
+            value,
+            ..
+        } => {
+            // SIR22: `target[indices...] = value`. Recurse into the
+            // target, every index-arg subexpression, and the value —
+            // same shape as SeqSet/MapSet above.
+            v.visit_expr(target);
+            walk_index_args(v, indices);
+            v.visit_expr(value);
+        }
+    }
+}
+
+/// Shared helper: visit every `Expr` nested inside a slice of
+/// [`IndexArg`]s (SIR22).  `Whole` has no children; `Scalar`/`Range`
+/// each carry exactly one nested expression.  Used by both
+/// [`walk_stmt_default`] (for `Stmt::IndexSet`) and
+/// [`walk_expr_default`] (for `Expr::IndexGet`) so the two index-arg
+/// walks can't drift apart.
+fn walk_index_args<V: Visitor>(v: &mut V, indices: &[IndexArg]) {
+    for arg in indices {
+        match arg {
+            IndexArg::Scalar(e) => v.visit_expr(e),
+            IndexArg::Whole => {}
+            IndexArg::Range(e) => v.visit_expr(e),
+        }
     }
 }
 
@@ -183,7 +227,12 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
         | Expr::StrLit { .. }
         | Expr::VarRef { .. } => {}
 
-        Expr::If { cond, then_branch, else_branch, .. } => {
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+            ..
+        } => {
             v.visit_expr(cond);
             v.visit_block(then_branch);
             v.visit_block(else_branch);
@@ -267,6 +316,41 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
         Expr::KeywordArg { value, .. } => {
             v.visit_expr(value);
         }
+
+        // ── SIR22: array/matrix nodes ───────────────────────────────
+        Expr::ArrayLit { rows, .. } => {
+            for row in rows {
+                for item in row {
+                    v.visit_expr(item);
+                }
+            }
+        }
+        Expr::Range {
+            start, step, stop, ..
+        } => {
+            v.visit_expr(start);
+            if let Some(step) = step {
+                v.visit_expr(step);
+            }
+            v.visit_expr(stop);
+        }
+        Expr::MatMul { lhs, rhs, .. } => {
+            v.visit_expr(lhs);
+            v.visit_expr(rhs);
+        }
+        Expr::ElementwiseOp { lhs, rhs, .. } => {
+            v.visit_expr(lhs);
+            v.visit_expr(rhs);
+        }
+        Expr::Transpose { target, .. } => {
+            v.visit_expr(target);
+        }
+        Expr::IndexGet {
+            target, indices, ..
+        } => {
+            v.visit_expr(target);
+            walk_index_args(v, indices);
+        }
     }
 }
 
@@ -305,8 +389,14 @@ mod tests {
             value: Expr::BuiltinCall {
                 name: "+".into(),
                 args: vec![
-                    Expr::IntLit { value: 1, span: s() },
-                    Expr::IntLit { value: 2, span: s() },
+                    Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    },
                 ],
                 effects: EffectSet::PURE,
                 span: s(),
@@ -338,7 +428,10 @@ mod tests {
     #[test]
     fn visitor_walks_full_tree() {
         let m = sample_module();
-        let mut c = Counter { builtins: 0, ints: 0 };
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
         c.visit_module(&m);
         assert_eq!(c.builtins, 1);
         assert_eq!(c.ints, 2);
@@ -351,7 +444,10 @@ mod tests {
             stmts: vec![Stmt::LetBinding {
                 name: "x".into(),
                 sir_type: None,
-                value: Expr::IntLit { value: 5, span: s() },
+                value: Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                },
                 span: s(),
             }],
             value: Expr::VarRef {
@@ -381,9 +477,12 @@ mod tests {
             metadata: Metadata::new(),
             span: s(),
         };
-        let mut c = Counter { builtins: 0, ints: 0 };
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
         c.visit_module(&m);
-        assert_eq!(c.ints, 1);  // the literal 5 in the let RHS
+        assert_eq!(c.ints, 1); // the literal 5 in the let RHS
     }
 
     #[test]
@@ -401,7 +500,10 @@ mod tests {
                 name: "a".into(),
                 sir_type: None,
                 kind: ParamKind::Required,
-                default: Some(Box::new(Expr::IntLit { value: 7, span: s() })),
+                default: Some(Box::new(Expr::IntLit {
+                    value: 7,
+                    span: s(),
+                })),
                 span: s(),
             }],
             return_type: None,
@@ -421,9 +523,15 @@ mod tests {
             metadata: Metadata::new(),
             span: s(),
         };
-        let mut c = Counter { builtins: 0, ints: 0 };
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
         c.visit_module(&m);
-        assert_eq!(c.ints, 1, "walker should visit the default-value expression");
+        assert_eq!(
+            c.ints, 1,
+            "walker should visit the default-value expression"
+        );
     }
 
     #[test]
@@ -436,7 +544,10 @@ mod tests {
                 fn_name: "f".into(),
                 args: vec![Expr::KeywordArg {
                     name: "a".into(),
-                    value: Box::new(Expr::IntLit { value: 2, span: s() }),
+                    value: Box::new(Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    }),
                     span: s(),
                 }],
                 effects: EffectSet::PURE,
@@ -464,7 +575,10 @@ mod tests {
             metadata: Metadata::new(),
             span: s(),
         };
-        let mut c = Counter { builtins: 0, ints: 0 };
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
         c.visit_module(&m);
         assert_eq!(c.ints, 1, "walker should visit the keyword-arg value");
     }
@@ -473,18 +587,27 @@ mod tests {
     fn visitor_visits_if_branches() {
         let then_block = Block {
             stmts: vec![],
-            value: Expr::IntLit { value: 1, span: s() },
+            value: Expr::IntLit {
+                value: 1,
+                span: s(),
+            },
             span: s(),
         };
         let else_block = Block {
             stmts: vec![],
-            value: Expr::IntLit { value: 2, span: s() },
+            value: Expr::IntLit {
+                value: 2,
+                span: s(),
+            },
             span: s(),
         };
         let body = Block {
             stmts: vec![],
             value: Expr::If {
-                cond: Box::new(Expr::BoolLit { value: true, span: s() }),
+                cond: Box::new(Expr::BoolLit {
+                    value: true,
+                    span: s(),
+                }),
                 then_branch: Box::new(then_block),
                 else_branch: Box::new(else_block),
                 span: s(),
@@ -511,8 +634,271 @@ mod tests {
             metadata: Metadata::new(),
             span: s(),
         };
-        let mut c = Counter { builtins: 0, ints: 0 };
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
         c.visit_module(&m);
-        assert_eq!(c.ints, 2);  // both branches counted
+        assert_eq!(c.ints, 2); // both branches counted
+    }
+
+    // ── SIR22: array/matrix walker tests ─────────────────────────────
+
+    fn module_with_body_value(value: Expr) -> Module {
+        let f = Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value,
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        Module {
+            name: "m".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f],
+            globals: vec![],
+            metadata: Metadata::new(),
+            span: s(),
+        }
+    }
+
+    #[test]
+    fn visitor_walks_array_lit_rows() {
+        // [1 2; 3 4] — all four IntLits must be visited.
+        let m = module_with_body_value(Expr::ArrayLit {
+            rows: vec![
+                vec![
+                    Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 2,
+                        span: s(),
+                    },
+                ],
+                vec![
+                    Expr::IntLit {
+                        value: 3,
+                        span: s(),
+                    },
+                    Expr::IntLit {
+                        value: 4,
+                        span: s(),
+                    },
+                ],
+            ],
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 4);
+    }
+
+    #[test]
+    fn visitor_walks_range_with_and_without_step() {
+        // 1:5 — no step: two ints (start, stop).
+        let m = module_with_body_value(Expr::Range {
+            start: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            step: None,
+            stop: Box::new(Expr::IntLit {
+                value: 5,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+
+        // 0:2:10 — with step: three ints.
+        let m2 = module_with_body_value(Expr::Range {
+            start: Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }),
+            step: Some(Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            })),
+            stop: Box::new(Expr::IntLit {
+                value: 10,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c2 = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c2.visit_module(&m2);
+        assert_eq!(c2.ints, 3);
+    }
+
+    #[test]
+    fn visitor_walks_matmul_and_elementwise_op_operands() {
+        let matmul = module_with_body_value(Expr::MatMul {
+            lhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&matmul);
+        assert_eq!(c.ints, 2);
+
+        let ew = module_with_body_value(Expr::ElementwiseOp {
+            op: ElementwiseOpKind::Add,
+            lhs: Box::new(Expr::IntLit {
+                value: 3,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 4,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c2 = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c2.visit_module(&ew);
+        assert_eq!(c2.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_transpose_target() {
+        let m = module_with_body_value(Expr::Transpose {
+            target: Box::new(Expr::IntLit {
+                value: 7,
+                span: s(),
+            }),
+            conjugate: true,
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_index_get_target_and_index_args() {
+        // a(i, :, 1:3) — target `a` isn't an IntLit, but the Scalar `i`
+        // index and the Range's start/stop are, so 3 ints total.
+        let m = module_with_body_value(Expr::IndexGet {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            indices: vec![
+                IndexArg::Scalar(Box::new(Expr::IntLit {
+                    value: 0,
+                    span: s(),
+                })),
+                IndexArg::Whole,
+                IndexArg::Range(Box::new(Expr::Range {
+                    start: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }),
+                    step: None,
+                    stop: Box::new(Expr::IntLit {
+                        value: 3,
+                        span: s(),
+                    }),
+                    span: s(),
+                })),
+            ],
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 3);
+    }
+
+    #[test]
+    fn visitor_walks_index_set_stmt() {
+        // a(1) = 9 — Stmt::IndexSet is a statement, not the block's value
+        // expr, so it's exercised via a non-empty `stmts` list this time.
+        let f = Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![Stmt::IndexSet {
+                    target: Box::new(Expr::VarRef {
+                        name: "a".into(),
+                        scope: Scope::Local,
+                        span: s(),
+                    }),
+                    indices: vec![IndexArg::Scalar(Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }))],
+                    value: Box::new(Expr::IntLit {
+                        value: 9,
+                        span: s(),
+                    }),
+                    span: s(),
+                }],
+                value: Expr::NilLit { span: s() },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let m = Module {
+            name: "m".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![f],
+            globals: vec![],
+            metadata: Metadata::new(),
+            span: s(),
+        };
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        // The index-arg IntLit(0) and the value IntLit(9) — 2 total.
+        assert_eq!(c.ints, 2);
     }
 }


### PR DESCRIPTION
## Summary

- Implements [SIR22](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/SIR22-array-matrix-semantic-ir.md): the narrow-waist IR vocabulary for dense numeric-array languages (MATLAB/Octave today; APL/J/K/Scilab/IDL per HML00 tomorrow). Purely additive, following the same discipline SIR16 used for loops/sequences and SIR21 T1b used for Ptr/Struct/Optional — no existing `Expr`/`Stmt`/`SirType`/`Feature` variant, validator rule, or backend behaviour changed.
- New `SirType`: `NDArray { elem, rank: Option<usize> }`, `Rational`, `Complex` (the latter two shared with the future SIR23 symbolic-math extension).
- New `Expr`: `ArrayLit`, `Range`, `MatMul`, `ElementwiseOp` (`Add`/`Sub`/`Mul`/`Div`/`Pow` via `ElementwiseOpKind`), `Transpose`, `IndexGet` — each mapped 1:1 onto an existing `array_runtime::execute()` op shape.
- New `Stmt`: `IndexSet` — per the spec this is a mutation-shaped statement (like `Assign`), not a value-producing `Expr`; there is no `Expr::IndexSet`.
- New `Feature` flags: `NDArrays`, `MatrixOps`, `Rationals`, `Complex`, `ArrayColumnMajor`.
- Validator/walker/printer wired uniformly: depth-guard coverage for every new node kind verified explicitly (not just asserted) against the existing `check_depth`/`MAX_IR_DEPTH` mechanisms.
- No backend accepts `NDArrays`/`MatrixOps` yet, so a module using SIR22 nodes is cleanly rejected by the existing SIR10 capability-check mechanism before reaching any backend's code generator — proven with new tests that construct real `ArrayLit`/`MatMul` modules and confirm rejection through the actual `Backend::check_module` path (not just a hand-set manifest flag).
- Five Rust-workspace backends (`semantic-ir-to-{javascript,typescript,rust,go,python}`) and three frontends (`{javascript,ruby,python}-to-semantic-ir`) needed minimal compile-compat arms (never real codegen) to keep their pre-existing exhaustive `Expr`/`Stmt` matches compiling — each verified unreachable in practice given the capability gate.
- `CURRENT_SIR_VERSION` bumped `"1"` → `"2"`, following the same policy SIR21 T1b used.
- Bumped `semantic-ir` 0.20.0 → 0.21.0 (additive public API). CHANGELOG.md/README.md updated.

## Test plan

- [x] `cargo test -p semantic-ir --lib` — 253 tests pass
- [x] `cargo test --lib` across all 11 semantic-ir-related crates (core + 5 backends + 3 frontends + `twig-to-semantic-ir` + `sir-conformance`) — all green
- [x] `cargo build --workspace` — clean except pre-existing, unrelated platform-specific failures (font-parser Python/Ruby local linking, Windows-only paint-vm crates on macOS, `uefi` panic-handler conflict) — none reference `semantic-ir` or any touched crate
- [x] `/security-review` — 5 parallel reviews (core crate, frontends, JS/TS backends, Go/Python backends, Rust backend) all passed clean, with the capability-rejection mechanism independently verified end-to-end (validator's AST-observed features vs. backend-declared features, no bypass path)
- [x] Diff intentionally trimmed: reverted 45 files the implementing pass had reformatted via `cargo fmt` despite zero functional connection to SIR22 (verified via grep — no reference to any new type/node name, and the identical drift already exists on `main`) — keeping only the 23 files with real SIR22-related changes to minimize review burden and merge-conflict risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)