### PR TITLE
feat(adj-ladder): rung-78 endocrinology insulin-titration index (quotient minus a product, a/b-c*d)

### DIFF
--- a/code/specs/data/adj-ladder/rung78_insulin_titration/gen_items.py
+++ b/code/specs/data/adj-ladder/rung78_insulin_titration/gen_items.py
@@ -1,0 +1,246 @@
+"""Generate rung-78 (endocrinology insulin-titration index) items.json for the ADJ-LADDER.
+
+Rung 78 opens the **endocrinology / insulin-titration** panel on the quantitative band — the arithmetic of a net
+insulin-titration dose. A titration forms a `correction component` (a `glucose_excess` divided by a `sensitivity_factor`)
+and, independently, an `offset component` (a `carb_load` times a `coverage_gain` already delivered), then SUBTRACTS the
+offset from the correction. Two INDEPENDENT binary terms — one a pure quotient, one a pure product — with the product
+subtracted from the quotient introduces a genuinely NEW arithmetic shape on the ladder: a **quotient MINUS a product** —
+`a/b-c*d`, i.e. `(a/b)-(c*d)`.
+
+This is the deliberate MINUS-counterpart of rung-77's `a/b+c*d` (a quotient plus a product). Like rung-77 — and unlike
+rungs 69-74, which chained the `+`/`-` and the `*`/`/` through a SHARED operand — the two sides of the `-` are DISJOINT
+two-operand terms: `a/b` uses only the first pair, `c*d` only the second, so the shape is a difference of two
+independent binary sub-results. The operation order matters: `a/b-c*d` is `(a/b)-(c*d)` by precedence (divide and
+multiply bind before subtract), NOT `a/(b-c)*d` (subtracting into the denominator) and NOT `a*b-c/d` (swapping which
+pair divides and which multiplies) — the two distractors exploit exactly those confusions.
+
+The setup: a `glucose_excess`, a `sensitivity_factor`, a `carb_load`, and a `coverage_gain`. The net titration is:
+
+  NET TITRATION         glucose_excess / sensitivity_factor - carb_load * coverage_gain   [ quotient minus product ]
+  CORRECTION COMPONENT  glucose_excess / sensitivity_factor                               [ the quotient term ]
+  OFFSET COMPONENT      carb_load * coverage_gain                                         [ the product term ]
+
+The **net titration** is what makes this rung distinctive — it is the ladder's first **quotient MINUS a product** (a
+difference of two disjoint binary terms). (The correction component `glucose_excess / sensitivity_factor` and the offset
+component `carb_load * coverage_gain` ride alongside as component readouts, so the panel teaches the whole calculation —
+exactly as rungs 47-77 shipped their component sums/products/differences/ratios beside the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the division of the glucose excess by the sensitivity factor, the multiplication of the carb
+load by the coverage gain, and the subtraction of the two independent terms (multiply/divide before subtract) — and the
+harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs
+8/16/.../76/77. This rung exercises the engine across **a quotient minus a product** — the fact that `a/b-c*d` is
+`(a/b)-(c*d)` and NOT `a/(b-c)*d` and NOT `a*b-c/d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `/`, `*`, and `-`
+— **no structural constants** — so no numeric literal appears in any program, and neither the correction component, the
+offset component, nor any net figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`glucose_excess`, `sensitivity_factor`, `carb_load`, `coverage_gain`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    glucose_excess / (sensitivity_factor - carb_load) * coverage_gain   SUBTRACT the carb load FROM the
+                                                                                 sensitivity factor in the denominator
+                                                                                 instead of keeping two independent
+                                                                                 terms (the classic `a/b-c*d` vs
+                                                                                 `a/(b-c)*d` error), and
+  SWAPPED    glucose_excess * sensitivity_factor - carb_load / coverage_gain     MULTIPLY the first pair and DIVIDE the
+                                                                                 second — swapping which pair divides
+                                                                                 and which multiplies (`a*b-c/d`
+                                                                                 instead of `a/b-c*d`),
+
+which are exactly the mistakes a student makes (folding the second operand into the denominator, or swapping the divide
+and the multiply between the two pairs). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts;
+all five always appear as options.
+
+Distinctness: all four observed quantities are strictly positive; the sensitivity factor exceeds the carb load
+(`sensitivity_factor > carb_load`) so the crossed denominator stays positive, and the correction component exceeds the
+offset component (`glucose_excess / sensitivity_factor > carb_load * coverage_gain`) so the **headline net titration
+stays positive**; the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (GLUCOSE_EXCESS, SENSITIVITY_FACTOR, CARB_LOAD, COVERAGE_GAIN) — a glucose excess to divide, a sensitivity factor to
+# divide by, a carb load to multiply, and a coverage gain to scale it by, all plain positive numbers with
+# sensitivity_factor > carb_load (so the crossed denominator stays positive) and glucose_excess / sensitivity_factor >
+# carb_load * coverage_gain (so the headline net titration stays positive). The five family values are asserted
+# pairwise-distinct below.
+TABLES = [
+    (40, 4, 2, 3),
+    (60, 5, 2, 4),
+    (36, 6, 1, 5),
+    (50, 5, 3, 2),
+    (45, 9, 1, 3),
+    (48, 4, 2, 4),
+    (54, 6, 2, 3),
+]
+
+# The option family (5 members), all built from the four observed quantities via /, *, and -. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "net_titration",
+        "net insulin-titration dose (the correction component minus the offset component)",
+        "glucose_excess / sensitivity_factor - carb_load * coverage_gain",
+    ),
+    (
+        "correction_component",
+        "the correction component (glucose excess over the sensitivity factor)",
+        "glucose_excess / sensitivity_factor",
+    ),
+    (
+        "offset_component",
+        "the offset component (carb load times the coverage gain)",
+        "carb_load * coverage_gain",
+    ),
+    (
+        "crossed",
+        "the glucose excess divided by the DIFFERENCE of the sensitivity factor and carb load, then scaled by the coverage gain, not two independent terms (a wrong grouping)",
+        "glucose_excess / (sensitivity_factor - carb_load) * coverage_gain",
+    ),
+    (
+        "swapped",
+        "the glucose excess MULTIPLIED by the sensitivity factor minus the carb load DIVIDED by the coverage gain, the operations swapped (a wrong grouping)",
+        "glucose_excess * sensitivity_factor - carb_load / coverage_gain",
+    ),
+]
+QUERIED = ["net_titration", "correction_component", "offset_component"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(glucose_excess, sensitivity_factor, carb_load, coverage_gain):
+    # Operation order mirrors the ADJ programs exactly (the divide and the multiply bind before the subtract, per
+    # precedence), so the Python option value and the engine result are the same IEEE-double (well within the harness's
+    # 1e-9 match tolerance).
+    return {
+        "net_titration": glucose_excess / sensitivity_factor - carb_load * coverage_gain,
+        "correction_component": glucose_excess / sensitivity_factor,
+        "offset_component": carb_load * coverage_gain,
+        "crossed": glucose_excess / (sensitivity_factor - carb_load) * coverage_gain,
+        "swapped": glucose_excess * sensitivity_factor - carb_load / coverage_gain,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for glucose_excess, sensitivity_factor, carb_load, coverage_gain in TABLES:
+        assert (
+            glucose_excess > 0
+            and sensitivity_factor > 0
+            and carb_load > 0
+            and coverage_gain > 0
+        ), (glucose_excess, sensitivity_factor, carb_load, coverage_gain)
+        # Sensitivity factor exceeds the carb load so the crossed denominator stays positive, and the correction
+        # component exceeds the offset component so the headline net titration stays positive.
+        assert sensitivity_factor > carb_load, (glucose_excess, sensitivity_factor, carb_load, coverage_gain)
+        assert glucose_excess / sensitivity_factor > carb_load * coverage_gain, (
+            glucose_excess,
+            sensitivity_factor,
+            carb_load,
+            coverage_gain,
+        )
+        fv = family_values(glucose_excess, sensitivity_factor, carb_load, coverage_gain)
+        for key, v in fv.items():
+            assert v > 0, (key, glucose_excess, sensitivity_factor, carb_load, coverage_gain, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    glucose_excess,
+                    sensitivity_factor,
+                    carb_load,
+                    coverage_gain,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                glucose_excess,
+                sensitivity_factor,
+                carb_load,
+                coverage_gain,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r78ins-{idx + 1:02d}",
+                "qtype": "insulin_titration",
+                "stem": (
+                    f"An insulin titration records a glucose excess of {num(glucose_excess)}, a sensitivity factor of "
+                    f"{num(sensitivity_factor)} to divide by, a carb load of {num(carb_load)} and a coverage gain of "
+                    f"{num(coverage_gain)} to scale it by. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe glucose_excess({num(glucose_excess)})\n"
+                    f"observe sensitivity_factor({num(sensitivity_factor)})\n"
+                    f"observe carb_load({num(carb_load)})\n"
+                    f"observe coverage_gain({num(coverage_gain)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 78 — endocrinology insulin-titration index from four stated quantities (a NEW panel: "
+            "endocrinology / insulin-titration). From a glucose excess to divide, a sensitivity factor to divide by, a "
+            "carb load to multiply, and a coverage gain to scale by, compute the net titration "
+            "(glucose_excess/sensitivity_factor - carb_load*coverage_gain), the correction component "
+            "(glucose_excess/sensitivity_factor), or the offset component (carb_load*coverage_gain). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries "
+            "the arithmetic — a NEW shape, QUOTIENT MINUS A PRODUCT a/b-c*d (two INDEPENDENT binary terms — a pure "
+            "quotient and a pure product — with the product subtracted from the quotient, divide/multiply before "
+            "subtract; the minus-counterpart of rung-77 a/b+c*d; contrast rungs 69-74 which chained the +/- and */÷ "
+            "through a SHARED operand; here the two sides of the - are disjoint 2-operand terms, so a/b-c*d = "
+            "(a/b)-(c*d), not a/(b-c)*d and not a*b-c/d) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via /, *, and - — no "
+            "constant leaks, and neither the correction component, the offset component, nor any net figure ever "
+            "appears as a literal (each is computed) — and the observed quantities carry digit-free identifiers so no "
+            "numeral hides inside a variable name. The five options are a family over the same four quantities, so the "
+            "distractors are exactly the slips students make: SUBTRACTING the carb load INTO the denominator "
+            "(a/(b-c)*d, a wrong grouping) and SWAPPING the multiply and divide between the two pairs (a*b-c/d, a wrong "
+            "grouping). The core confusion tested is that a/b-c*d is (a/b)-(c*d), not a/(b-c)*d and not a*b-c/d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung78_insulin_titration/items.json
+++ b/code/specs/data/adj-ladder/rung78_insulin_titration/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 78 \u2014 endocrinology insulin-titration index from four stated quantities (a NEW panel: endocrinology / insulin-titration). From a glucose excess to divide, a sensitivity factor to divide by, a carb load to multiply, and a coverage gain to scale by, compute the net titration (glucose_excess/sensitivity_factor - carb_load*coverage_gain), the correction component (glucose_excess/sensitivity_factor), or the offset component (carb_load*coverage_gain). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, QUOTIENT MINUS A PRODUCT a/b-c*d (two INDEPENDENT binary terms \u2014 a pure quotient and a pure product \u2014 with the product subtracted from the quotient, divide/multiply before subtract; the minus-counterpart of rung-77 a/b+c*d; contrast rungs 69-74 which chained the +/- and */\u00f7 through a SHARED operand; here the two sides of the - are disjoint 2-operand terms, so a/b-c*d = (a/b)-(c*d), not a/(b-c)*d and not a*b-c/d) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via /, *, and - \u2014 no constant leaks, and neither the correction component, the offset component, nor any net figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: SUBTRACTING the carb load INTO the denominator (a/(b-c)*d, a wrong grouping) and SWAPPING the multiply and divide between the two pairs (a*b-c/d, a wrong grouping). The core confusion tested is that a/b-c*d is (a/b)-(c*d), not a/(b-c)*d and not a*b-c/d.",
+  "items": [
+    {
+      "id": "r78ins-01",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 40, a sensitivity factor of 4 to divide by, a carb load of 2 and a coverage gain of 3 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(40)\nobserve sensitivity_factor(4)\nobserve carb_load(2)\nobserve coverage_gain(3)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 60.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 159.33333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r78ins-02",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 40, a sensitivity factor of 4 to divide by, a carb load of 2 and a coverage gain of 3 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(40)\nobserve sensitivity_factor(4)\nobserve carb_load(2)\nobserve coverage_gain(3)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 60.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 159.33333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r78ins-03",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 40, a sensitivity factor of 4 to divide by, a carb load of 2 and a coverage gain of 3 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(40)\nobserve sensitivity_factor(4)\nobserve carb_load(2)\nobserve coverage_gain(3)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 60.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 159.33333333333334,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r78ins-04",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 60, a sensitivity factor of 5 to divide by, a carb load of 2 and a coverage gain of 4 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(60)\nobserve sensitivity_factor(5)\nobserve carb_load(2)\nobserve coverage_gain(4)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 299.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r78ins-05",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 60, a sensitivity factor of 5 to divide by, a carb load of 2 and a coverage gain of 4 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(60)\nobserve sensitivity_factor(5)\nobserve carb_load(2)\nobserve coverage_gain(4)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 80.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 299.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r78ins-06",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 60, a sensitivity factor of 5 to divide by, a carb load of 2 and a coverage gain of 4 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(60)\nobserve sensitivity_factor(5)\nobserve carb_load(2)\nobserve coverage_gain(4)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 80.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 299.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r78ins-07",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 36, a sensitivity factor of 6 to divide by, a carb load of 1 and a coverage gain of 5 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(36)\nobserve sensitivity_factor(6)\nobserve carb_load(1)\nobserve coverage_gain(5)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 36.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 215.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r78ins-08",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 36, a sensitivity factor of 6 to divide by, a carb load of 1 and a coverage gain of 5 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(36)\nobserve sensitivity_factor(6)\nobserve carb_load(1)\nobserve coverage_gain(5)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 36.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 215.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r78ins-09",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 36, a sensitivity factor of 6 to divide by, a carb load of 1 and a coverage gain of 5 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(36)\nobserve sensitivity_factor(6)\nobserve carb_load(1)\nobserve coverage_gain(5)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 215.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r78ins-10",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 50, a sensitivity factor of 5 to divide by, a carb load of 3 and a coverage gain of 2 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(50)\nobserve sensitivity_factor(5)\nobserve carb_load(3)\nobserve coverage_gain(2)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 248.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r78ins-11",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 50, a sensitivity factor of 5 to divide by, a carb load of 3 and a coverage gain of 2 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(50)\nobserve sensitivity_factor(5)\nobserve carb_load(3)\nobserve coverage_gain(2)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 248.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r78ins-12",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 50, a sensitivity factor of 5 to divide by, a carb load of 3 and a coverage gain of 2 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(50)\nobserve sensitivity_factor(5)\nobserve carb_load(3)\nobserve coverage_gain(2)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 50.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 248.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r78ins-13",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 45, a sensitivity factor of 9 to divide by, a carb load of 1 and a coverage gain of 3 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(45)\nobserve sensitivity_factor(9)\nobserve carb_load(1)\nobserve coverage_gain(3)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.875,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 404.6666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r78ins-14",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 45, a sensitivity factor of 9 to divide by, a carb load of 1 and a coverage gain of 3 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(45)\nobserve sensitivity_factor(9)\nobserve carb_load(1)\nobserve coverage_gain(3)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.875,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 404.6666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r78ins-15",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 45, a sensitivity factor of 9 to divide by, a carb load of 1 and a coverage gain of 3 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(45)\nobserve sensitivity_factor(9)\nobserve carb_load(1)\nobserve coverage_gain(3)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16.875,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 404.6666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r78ins-16",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 48, a sensitivity factor of 4 to divide by, a carb load of 2 and a coverage gain of 4 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(48)\nobserve sensitivity_factor(4)\nobserve carb_load(2)\nobserve coverage_gain(4)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 96.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 191.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r78ins-17",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 48, a sensitivity factor of 4 to divide by, a carb load of 2 and a coverage gain of 4 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(48)\nobserve sensitivity_factor(4)\nobserve carb_load(2)\nobserve coverage_gain(4)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 96.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 191.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r78ins-18",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 48, a sensitivity factor of 4 to divide by, a carb load of 2 and a coverage gain of 4 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(48)\nobserve sensitivity_factor(4)\nobserve carb_load(2)\nobserve coverage_gain(4)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 96.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 191.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r78ins-19",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 54, a sensitivity factor of 6 to divide by, a carb load of 2 and a coverage gain of 3 to scale it by. What is the net insulin-titration dose (the correction component minus the offset component)?",
+      "program": "observe glucose_excess(54)\nobserve sensitivity_factor(6)\nobserve carb_load(2)\nobserve coverage_gain(3)\nlet answer = glucose_excess / sensitivity_factor - carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 323.3333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r78ins-20",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 54, a sensitivity factor of 6 to divide by, a carb load of 2 and a coverage gain of 3 to scale it by. What is the the correction component (glucose excess over the sensitivity factor)?",
+      "program": "observe glucose_excess(54)\nobserve sensitivity_factor(6)\nobserve carb_load(2)\nobserve coverage_gain(3)\nlet answer = glucose_excess / sensitivity_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 323.3333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r78ins-21",
+      "qtype": "insulin_titration",
+      "stem": "An insulin titration records a glucose excess of 54, a sensitivity factor of 6 to divide by, a carb load of 2 and a coverage gain of 3 to scale it by. What is the the offset component (carb load times the coverage gain)?",
+      "program": "observe glucose_excess(54)\nobserve sensitivity_factor(6)\nobserve carb_load(2)\nobserve coverage_gain(3)\nlet answer = carb_load * coverage_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 323.3333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -115,6 +115,7 @@ SELF_CONTAINED_RUNGS = (
     "rung75_hearing_threshold",
     "rung76_fluid_resuscitation",
     "rung77_gas_uptake",
+    "rung78_insulin_titration",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-78 — endocrinology insulin-titration index (a quotient MINUS a product, `a/b-c*d`)

Next quantitative rung on the ADJ-LADDER spine. Opens a **new clinical panel** (endocrinology / insulin-titration) on a **genuinely new arithmetic shape**: a **quotient MINUS a product** — `a/b-c*d`, i.e. `(a/b)-(c*d)`.

### Why the shape is new
This is the deliberate **minus-counterpart** of rung-77's `a/b+c*d`. Like rung-77 — and unlike rungs 69-74, which chained the `+`/`-` and `*`/`/` through a **shared** operand — the two sides of the `-` are **disjoint two-operand terms**: `a/b` uses only the first pair, `c*d` only the second. So it's a **difference of two independent binary sub-results**. Precedence makes `a/b-c*d = (a/b)-(c*d)` (divide/multiply bind before subtract), NOT `a/(b-c)*d` and NOT `a*b-c/d`.

Shapes used so far: rung-67 `(a-b)*c/d`, 68 `(a+b)*c/d`, 69 `a*b/c+d`, 70 `a*b/c-d`, 71 `a/b*c+d`, 72 `a/b*c-d`, 73 `a-b/c*d`, 74 `a+b/c*d`, 75 `(a-b)/c*d`, 76 `(a+b)/c*d`, 77 `a/b+c*d` → **78 `a/b-c*d`**.

### The panel
From a `glucose_excess`, a `sensitivity_factor` to divide by, a `carb_load`, and a `coverage_gain` to scale by:

| readout | formula |
|---|---|
| **net titration** (headline) | `glucose_excess/sensitivity_factor - carb_load*coverage_gain` |
| correction component | `glucose_excess/sensitivity_factor` |
| offset component | `carb_load*coverage_gain` |

The correction component (the `/` term) and the offset component (the `*` term) ride alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-77 shipped their components beside the headline figure.

### Distractors (classic student slips)
- **crossed** `a/(b-c)*d` — subtracts the carb load **into the denominator** instead of keeping two independent terms.
- **swapped** `a*b-c/d` — swaps **which pair divides and which multiplies**.

Gold rotates A-E by index; all five family members always appear as options. QUERIED (gold-eligible) = the three real readouts.

### Positivity + contamination-safety
Guards keep the gold difference **positive**: `sensitivity_factor > carb_load` (so the crossed denominator stays positive) and `glucose_excess/sensitivity_factor > carb_load*coverage_gain` (so `a/b-c*d > 0`). Every formula is built ONLY from the four observed quantities via `/`, `*`, `-` — **no structural constants**, so no numeric literal appears in any program, and no readout is ever a literal (each is computed). Observed quantities carry **digit-free identifiers**. Distinctness (all values positive + pairwise-distinct > 1e-6) asserted at build time; a standalone checker confirmed it before generation.

### Mechanics
Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing `compute_dimensioned` extractor. **No harness/engine change** — same pattern as rungs 8/16/…/76/77. 7 tables × 3 queried = **21 items**.

### Verification
- `python3 -m pytest test_ladder_eval.py -k rung78 -q` → **3 passed**.
- `gen_items.py` (run from the rung subdir) → `wrote items.json: 21 items`, gold rotating A-E.
- Files: exactly 3 (`rung78_insulin_titration/gen_items.py`, `rung78_insulin_titration/items.json`, `test_ladder_eval.py` — one line registering `rung78_insulin_titration` in `SELF_CONTAINED_RUNGS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
