### PR TITLE
feat(latex): LTXDOC02 S4 — precise node_at (region-coarse caveat retired for body nodes)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.35.0] — 2026-07-04
+
+### Changed — precise `node_at` + region-coarse caveat retired for body nodes (LTXDOC02 S4)
+
+With S3's tight body spans in place, `Document::node_at(byte)` now **formally** resolves to the
+**true per-token leaf** — the narrowest node whose *precise* span contains the byte (ties → the
+deepest node in pre-order). A byte inside `widgets` resolves to the `Text` run owning `widgets`, not
+to the enclosing `Paragraph`/`Section`; a byte inside a `\section` title resolves to the title
+inline, not the whole `Section` block.
+
+- **Documentation only for `node_at`/`walk` — no logic change.** `node_at` already returned the
+  narrowest-span walked node; S4 retires the hedging wording now that the spans are precise. Updated
+  the `node_at` doc-comment (the "Resolution" paragraph), the `Provenance` struct docs, the
+  `NodeRef::span` doc, the D6 module comment block, and the module-level span-policy note to state
+  plainly that body resolution is precise. Preamble/metadata spans stay **honestly region-coarse**
+  (the preamble is classified out of `\documentclass`/`\usepackage` *directives*, not walked, and
+  `node_at` never resolves into it) — the `DocumentClass`/`Package` field docs keep that note.
+- **New leaf-resolution tests.** `node_at_resolves_to_text_leaf_not_paragraph`,
+  `node_at_in_section_title_resolves_to_heading_inline`, `node_at_in_textbf_resolves_to_inner_leaf` —
+  each plants a byte inside a word/title/inner-run and asserts `node_at` returns exactly that `Text`
+  leaf and its span slices back to precisely that word (`&src[prov.span] == "widgets"`).
+- **New honest body byte-coverage test.** `body_bytes_resolve_to_containing_node` asserts that for a
+  representative multi-node document (section, `\textbf`, inline math, an `itemize`), every
+  non-whitespace body byte both resolves and resolves to a node whose precise span actually contains
+  it. Scoped to a representative input (not the whole LTXDOC01 corpus) — the tightest-covering-leaf
+  capstone remains S5.
+
+Round-trip fixed point, totality/no-panic, no `unsafe`, and `MAX_DEPTH`-bounded recursion all
+preserved. Spec `LTXDOC02-precise-token-spans.md` §5 S4 marked shipped; the LTXDOC01 §4/§5 D6
+region-coarse caveats updated to say body resolution is now precise (preamble stays coarse).
+
 ## [0.34.0] — 2026-07-04
 
 ### Changed — precise Document fold (LTXDOC02 S3)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -42,10 +42,11 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **D3 sectioning fold** | folds the flat block stream into the **nested sectioning forest**: each heading OWNS the run of following blocks up to the next heading of same-or-higher level (`\part > \chapter > \section > … > \subparagraph`, via `rank(level)`); deeper headings nest. A trailing `\label{key}` is hoisted onto its section's new `label` field. Applies to every block-list (top-level + environment/list/table bodies). Total & panic-free; `to_latex` fixed point; `flatten(fold(flat)) == flat` property test; folded-section span = union of heading ∪ children spans | ✅ |
 | **D4 metadata** | extracts `\title`/`\author{A \and B}`/`\date` and the `abstract` env into a typed `Metadata` record on `Document`, as an **additive projection** — the underlying nodes stay in `preamble`/`body`, so `to_latex` round-trips unchanged and re-parsing repopulates the same `Metadata` (fixed point). Both preamble and body scanned; first title/date wins; every `\author` (each `\and`-split) contributes; `\maketitle` is a metadata no-op. Total & panic-free; never fabricated. (Inline normalization — `\textbf`/`\emph`/`\texttt`/`$…$`/`\ref`/accents — already lands in D2/D3's `lower_inline`.) | ✅ |
 | **D5 floats/code/display-math** | specializes the generic environment fold by name: `figure`/`figure*` → `Block::Figure` and `table`/`table*` → the inner `Block::Table`, each with `\caption{…}` → `Caption` + a hoisted `\label`; `verbatim`/`lstlisting` → `Block::CodeBlock` (raw text kept unparsed); `equation`/`align`/`gather`/… → `Block::DisplayMath` (source kept, delegated to the math frontend on demand); `quote`/`quotation` → `Block::Quote`; any other env → recursed `Block::Environment`. `to_latex` fixed point; total & panic-free; body spans precise per node as of 0.34.0 (S3) | ✅ |
-| **D6 provenance API (capstone)** | the byte-provenance surface: `Document::walk()` — a pre-order, depth-first `impl Iterator<Item = NodeRef>` over every body block + nested inline; `Document::node_at(byte)` — the innermost walked node whose span contains a source byte, returned as `Provenance { node, span }`; `NodeRef::{span,kind}`. A capstone real-paper corpus (article + abstract + tabular + itemize + inline/display math + figure+caption+label + `\cite`) proves a `to_latex` fixed point, a non-panicking `walk()`, and **byte coverage**: every non-whitespace body-region byte is owned by ≥1 walked node. Panic-free (`saturating_sub`); spans region-coarse at D6, made precise by LTXDOC02 S3 (below). | ✅ |
+| **D6 provenance API (capstone)** | the byte-provenance surface: `Document::walk()` — a pre-order, depth-first `impl Iterator<Item = NodeRef>` over every body block + nested inline; `Document::node_at(byte)` — the innermost walked node whose span contains a source byte, returned as `Provenance { node, span }`; `NodeRef::{span,kind}`. A capstone real-paper corpus (article + abstract + tabular + itemize + inline/display math + figure+caption+label + `\cite`) proves a `to_latex` fixed point, a non-panicking `walk()`, and **byte coverage**: every non-whitespace body-region byte is owned by ≥1 walked node. Panic-free (`saturating_sub`); spans region-coarse at D6, made precise by LTXDOC02 S3, and `node_at` resolves to the true body leaf as of S4 (below). | ✅ |
 | **LTXDOC02 S1 — spanned L1 nodes** | `Node` restructured to `{ kind: NodeKind, span: Span }`; `parse()` threads each token's exact byte span onto the node it builds, so `&src[node.span()]` slices back to the node's own source (`\textbf{x}`, `{…}` incl. braces, `$…$` incl. delimiters, `\begin{env}…\end{env}`, a `Text` run's exact chars). Span is orthogonal to shape; `PartialEq` ignores it (round-trip = fixed point **modulo spans**); `Unsupported`'s bespoke tuple folded onto the uniform `Node.span`. `to_latex` unchanged. The one parser-level rung of the precise-spans arc (recognition-pass + Document-fold precision = S2/S3). | ✅ |
 | **LTXDOC02 S2 — spanned recognition passes** | the opt-in recognition passes now give each *synthesised* node the exact union of its constituents' real S1 spans: `recognize_structure` (`Section`/`CrossRef`/`Preamble`/`Styled` = recognizing command ∪ each argument), `recognize_accents` (`Accent` = command ∪ argument), `recognize_tables` (`Tabular` = `\begin{tabular}…\end{tabular}` ∪ every cell; `List` = `\begin{env}…\end{env}` ∪ every item). `&src[node.span()]` slices back to the exact source extent for a Section (heading through owned body), an Accent, a Tabular, and an itemize List. Unions over real child spans (never substring search); `to_latex` + round-trip-modulo-spans unchanged. Document-fold precision = S3. | ✅ |
 | **LTXDOC02 S3 — precise Document fold** | `build_document` reads each source `Node`'s carried, precise span instead of the coarse enclosing `region`, so **every body `Block`/`Inline` span is now the node's tight source range**: `&src[inline.span]` slices back to exactly a `Text` run's word, a `\textbf{…}`, an inline `$…$`, a `\cite{…}`. Composites union their children's real spans (`Paragraph` = ∪ its inlines; `Section` = heading ∪ owned body; `List`/`Tabular`/`Environment`/`Figure` = the `\begin…\end` extent; captioned `table` float = tabular ∪ float; `DocListItem` = term ∪ body; `Caption` = ∪ its content). The `region` parameter is deleted from the fold helpers (a fallback-only seed survives on `lower_blocks`). Preamble/`DocumentClass`/`Package` stay honestly preamble-region-coarse (classified, not walked). `to_latex` + round-trip-modulo-spans unchanged; precise `node_at` + coverage capstone = S4/S5. | ✅ |
+| **LTXDOC02 S4 — precise `node_at`, region-coarse caveat retired** | with S3's tight body spans, `Document::node_at(byte)` **formally** resolves to the **true per-token leaf** — the narrowest node whose *precise* span contains the byte (ties → deepest in pre-order): a byte inside `widgets` → the `Text` run owning `widgets` (not the enclosing `Paragraph`/`Section`); a byte inside a `\section` title → the title inline (not the whole `Section`). Docs-and-tests rung (no `node_at`/`walk` logic change): retired the region-coarse hedging on `node_at`/`Provenance`/`walk`/module note for **body** nodes, kept the honest coarse note on `Preamble`/`DocumentClass`/`Package`. New leaf-resolution tests + an honest body byte-coverage test (every non-whitespace body byte resolves to a node whose precise span contains it, on a representative input; whole-corpus tightest-leaf capstone = S5). | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -54,10 +55,12 @@ normalization (D4) → floats/code/display-math (D5) → provenance API + byte-c
 The **precise per-token spans** arc (LTXDOC02) is now under way: **S1 shipped spanned L1 nodes**
 (`parse()` retains the exact byte range it already computed for each node), **S2 shipped spanned
 recognition passes** (each synthesised `Section`/`CrossRef`/`Preamble`/`Styled`/`Accent`/`Tabular`/
-`List` node carries the exact union of its constituents' spans), and **S3 shipped the precise
+`List` node carries the exact union of its constituents' spans), **S3 shipped the precise
 Document fold** (every body `Block`/`Inline` span is now the node's tight source range, composites
-union their children's real spans, and the coarse `region` plumbing is deleted) — with S4/S5
-(precise `node_at` + coverage capstone, retiring the last region-coarse caveat) to follow.
+union their children's real spans, and the coarse `region` plumbing is deleted), and **S4 retired
+the region-coarse caveat for body nodes** (`node_at(byte)` now formally resolves to the true
+per-token leaf; preamble/metadata stay honestly coarse) — with S5 (the whole-corpus
+tightest-covering-leaf coverage capstone) to follow.
 
 ## The Document layer (LTXDOC01)
 
@@ -142,7 +145,8 @@ Caption/label extraction mirrors D3's `\label` hoist and never drops float conte
 re-emits the `figure`/`table` wrapper (with `\caption`/`\label`), `verbatim` fences, and `$$…$$`
 so `parse(to_latex(d)).strip_spans() == d.strip_spans()` remains a fixed point.
 
-**Body spans are precise as of 0.34.0 (LTXDOC02 S3):** every body block/inline span is the source
+**Body spans are precise as of 0.34.0 (LTXDOC02 S3), and `node_at` resolves to the true body leaf as
+of 0.35.0 (S4):** every body block/inline span is the source
 node's own tight byte range (`&src[node.span]` slices back to exactly its source), and a composite's
 span is the **union** of its children's real spans — so every child span ⊆ its parent ⊆ the
 `Document` span still holds, and now the leaves are tight. Only `Preamble` / `DocumentClass` /
@@ -163,19 +167,23 @@ let d = parse_document(r"\begin{document}\section{Intro}Body text.\end{document}
 let kinds: Vec<&str> = d.walk().map(|n| n.kind()).collect();
 // e.g. ["Section", "Text", "Paragraph", "Text", …] — a parent precedes its children.
 
-// node_at(byte): the innermost (narrowest-span) node whose span contains the byte.
+// node_at(byte): the true per-token leaf — the narrowest node whose precise span contains the byte.
 if let Some(p) = d.node_at(35) {
     let _ = (p.node.kind(), p.span); // NodeRef + its span
 }
 assert!(d.node_at(usize::MAX).is_none()); // out of range → None, never panics
 ```
 
-**Granularity.** As of 0.34.0 (S3) body spans are precise, so `node_at` returns the narrowest-span
-node containing a byte — the genuine per-token leaf in the common case. The *formal* "always
-resolves to the true leaf" guarantee (and the removal of the last hedging wording on `node_at` /
-`Provenance`) is **S4**; the leaf-tightness coverage capstone is **S5**. The current capstone
-byte-coverage test asserts every non-whitespace byte inside the document **body region** is owned by
-≥1 walked node — coverage preserved under S3's tightening.
+**Granularity.** As of 0.35.0 (S4) body spans are precise and `node_at(byte)` **formally resolves to
+the true per-token leaf** — the narrowest node whose precise span contains the byte (ties → the
+deepest node in pre-order). A byte inside `widgets` resolves to the `Text` run owning `widgets`, not
+to the enclosing `Paragraph`/`Section`; a byte inside a `\section` title resolves to the title
+inline, not the whole `Section`. This holds for **body** nodes (the ones `walk` visits);
+`Preamble`/`DocumentClass`/`Package` stay honestly preamble-region-coarse (classified out of
+directives, not walked, and `node_at` never resolves into them). The current capstone byte-coverage
+test asserts every non-whitespace byte inside the document **body region** is owned by ≥1 walked
+node; the **whole-corpus** tightest-covering-leaf capstone (proving no strictly-narrower node exists
+for any body byte) is **S5**.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/document.rs
+++ b/code/packages/rust/latex/src/document.rs
@@ -30,7 +30,7 @@
 //!    [`Block::DisplayMath`]; other environments recurse into [`Block::Environment`]; inline
 //!    runs collect into a [`Block::Paragraph`].
 //!
-//! ## Span policy (LTXDOC02 S3 — precise body spans)
+//! ## Span policy (LTXDOC02 S3/S4 — precise body spans, precise `node_at`)
 //!
 //! Every [`Document`]/[`Preamble`]/[`Block`]/[`Inline`] node carries a [`Span`]. As of **LTXDOC02
 //! S3**, the fold reads each source [`Node`]'s **carried, precise byte [`Span`]** (S1 threaded
@@ -60,9 +60,11 @@
 //!   fold), but `Metadata` is an additive index over preamble/body nodes and is likewise not
 //!   walked.
 //!
-//! `Document::node_at`'s full precision (resolving to the true leaf, and retiring the remaining
-//! "region-coarse" wording on its own doc-comment) lands in **S4**; S3 only makes the `Document`
-//! `Block`/`Inline` span *values* precise.
+//! As of **LTXDOC02 S4**, [`Document::node_at`] is formally the precise counterpart: because body
+//! spans are now tight, `node_at(byte)` returns the **true per-token leaf** — the narrowest node
+//! whose precise span contains the byte (ties → deepest in pre-order). The old "region-coarse"
+//! hedging on `node_at`/[`Provenance`] is **retired** for body nodes; only the preamble/metadata
+//! spans below stay honestly coarse.
 //!
 //! ## Totality
 //!
@@ -175,9 +177,10 @@ pub struct DocumentClass {
     pub class: String,
     /// The `[options]` list rendered back to source, e.g. `Some("11pt,twocolumn")`.
     pub options: Option<String>,
-    /// The preamble-region span. **Honestly region-coarse** (S3): the preamble is classified out
-    /// of directives rather than walked as per-node body content, so a preamble-region span is the
-    /// right granularity here (this node is not visited by [`Document::walk`]).
+    /// The preamble-region span. **Honestly region-coarse** (and stays so past S4, which only made
+    /// *body* nodes precise): the preamble is classified out of directives rather than walked as
+    /// per-node body content, so a preamble-region span is the right granularity here (this node is
+    /// not visited by [`Document::walk`], and `node_at` never resolves into it).
     pub span: Span,
 }
 
@@ -191,9 +194,10 @@ pub struct Package {
     /// Which directive introduced it (`"usepackage"` or `"RequirePackage"`), preserved so the
     /// package round-trips to the exact command it came from.
     pub command: String,
-    /// The preamble-region span. **Honestly region-coarse** (S3): the preamble is classified out
-    /// of directives rather than walked as per-node body content, so a preamble-region span is the
-    /// right granularity here (this node is not visited by [`Document::walk`]).
+    /// The preamble-region span. **Honestly region-coarse** (and stays so past S4, which only made
+    /// *body* nodes precise): the preamble is classified out of directives rather than walked as
+    /// per-node body content, so a preamble-region span is the right granularity here (this node is
+    /// not visited by [`Document::walk`], and `node_at` never resolves into it).
     pub span: Span,
 }
 
@@ -396,21 +400,25 @@ pub enum Inline {
 // source byte, *which document node owns it* — the exact source→node correlation the reasoning
 // stack audits against.
 //
-// ## Span granularity (S3: body Block/Inline spans are now precise)
+// ## Span granularity (S3/S4: body Block/Inline spans are precise; `node_at` resolves to the leaf)
 //
 // As of **LTXDOC02 S3**, the D2 fold reads each source node's carried, precise byte span (S1/S2)
 // instead of the old enclosing-region parameter. So a body `Block`/`Inline` span is the node's
 // *tight* source range — a `Section`'s title inline, its child paragraphs, and their `Text` runs
 // no longer share one region span; each slices back to exactly its own source. `walk()` visits
-// every body node in structural pre-order (unchanged), and every yielded span is now precise.
+// every body node in structural pre-order (unchanged), and every yielded span is precise.
 //
-// **What S3 does *not* yet retire:** the [`Document::node_at`] doc-comment still describes its
-// resolution conservatively. `node_at` already returns the narrowest-span walked node containing a
-// byte, and with precise spans that *is* the true leaf — but the formal "resolves to the true
-// leaf" guarantee, its dedicated test, and the removal of the remaining "region-coarse" wording on
-// `node_at`/[`Provenance`] are **S4** (spec §5). S3's job is only to make the span *values*
-// precise. The capstone byte-coverage test still asserts the honest, S3-true property (every
-// non-whitespace body byte is owned by ≥1 walked node); S5 tightens it to leaf-tightness.
+// **S4 retires the region-coarse caveat for body nodes.** Because the spans are tight,
+// [`Document::node_at`] returns the **true per-token leaf**: the narrowest node whose precise span
+// contains the queried byte (ties → the deepest node in pre-order). A byte inside `widgets`
+// resolves to the `Text` node owning `widgets`, not to the enclosing `Paragraph`/`Section`. The
+// dedicated leaf-resolution tests (`node_at_resolves_to_text_leaf_not_paragraph`,
+// `node_at_in_section_title_resolves_to_heading_inline`,
+// `node_at_in_textbf_resolves_to_inner_leaf`) pin this down, and the honest body byte-coverage test
+// (`body_bytes_resolve_to_containing_node`) asserts every non-whitespace body byte resolves to a
+// node whose precise span actually contains it. What stays coarse is **only** the preamble/metadata
+// (classified out of directives, not walked). The full tightest-covering-leaf capstone over the
+// whole LTXDOC01 corpus (no strictly-narrower node exists) is **S5**.
 // ---------------------------------------------------------------------------------------------
 
 /// A borrowed reference to one node visited by [`Document::walk`]: either a body [`Block`] or an
@@ -428,7 +436,8 @@ pub enum NodeRef<'a> {
 }
 
 impl<'a> NodeRef<'a> {
-    /// This node's byte [`Span`] — precise for body nodes as of S3 (see the module span note).
+    /// This node's byte [`Span`] — precise (tight source range) for body nodes (see the module span
+    /// note); `node_at` uses it to resolve a byte to the true per-token leaf (S4).
     pub fn span(&self) -> Span {
         match self {
             NodeRef::Block(b) => block_span(b),
@@ -473,15 +482,15 @@ impl<'a> NodeRef<'a> {
 /// span contains the queried byte, plus that node's [`Span`] (surfaced directly so the caller need
 /// not re-derive it).
 ///
-/// The `span` is the returned node's own byte range — **precise** for body nodes as of S3 (see the
-/// module span note). `node_at` returns the node with the *narrowest* such span. The formal
-/// "resolves to the true leaf" guarantee and the retirement of the last node_at caveat wording are
-/// S4; S3 makes the span values precise.
+/// The `span` is the returned node's own byte range — **precise** for body nodes (see the module
+/// span note). `node_at` returns the node with the *narrowest* such span, which as of **S4** is the
+/// true per-token leaf: a byte inside a word resolves to the `Text` run owning that word, not to an
+/// enclosing `Paragraph`/`Section`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Provenance<'a> {
-    /// The narrowest node owning the queried byte.
+    /// The narrowest node owning the queried byte — the true per-token leaf for body nodes (S4).
     pub node: NodeRef<'a>,
-    /// That node's span (precise for body nodes as of S3).
+    /// That node's precise span (for body nodes).
     pub span: Span,
 }
 
@@ -1475,11 +1484,16 @@ impl Document {
     /// *later* in pre-order — i.e. the deepest descendant, the tightest fit when a parent and child
     /// share a span.
     ///
-    /// **Resolution (S3 precise spans):** body spans are now the nodes' tight source ranges (S3),
-    /// so the narrowest-covering node this returns is the genuine per-token leaf in the common
-    /// case. The *formal* "always resolves to the true leaf" guarantee — plus its dedicated test
-    /// and the removal of this hedging wording — is **S4** (spec §5); S3's contribution is making
-    /// the span values precise. Totally panic-free: no `unwrap`/`expect`, no unchecked indexing,
+    /// **Resolution (S4 — precise, region-coarse caveat retired):** body spans are the nodes' tight
+    /// source ranges (S3 propagated the real per-node spans), so the narrowest-covering node this
+    /// returns **is the true per-token leaf** — the narrowest node whose precise span contains the
+    /// byte. A byte inside `widgets` resolves to the `Text` node owning `widgets`, not to the
+    /// enclosing `Paragraph`/`Section`; a byte inside a `\section` title resolves to the heading's
+    /// title inline, not to the whole `Section` block. This holds for **body** nodes (the ones
+    /// `walk` visits); the preamble/metadata are classified out of directives rather than walked, so
+    /// their spans stay honestly region-coarse and `node_at` does not resolve into them. The S5 rung
+    /// adds the whole-corpus tightest-covering-leaf capstone (proving no strictly-narrower node
+    /// exists for every body byte). Totally panic-free: no `unwrap`/`expect`, no unchecked indexing,
     /// guarded subtraction.
     pub fn node_at(&self, byte: usize) -> Option<Provenance<'_>> {
         let mut best: Option<NodeRef<'_>> = None;
@@ -2756,6 +2770,118 @@ mod tests {
         assert!(doc.node_at(src.len() + 100).is_none());
         // usize::MAX never panics (saturating width, no unchecked indexing).
         assert!(doc.node_at(usize::MAX).is_none());
+    }
+
+    // -- S4: precise `node_at` — resolution to the true per-token leaf -------------------------
+    //
+    // With S3's tight body spans, `node_at(byte)` no longer stops at an enclosing region: it
+    // resolves to the *narrowest* node whose precise span contains the byte — the genuine
+    // per-token leaf. These tests prove that a byte inside a word/title/inner-run resolves to the
+    // leaf that owns it (and that the resolved span slices back to exactly that leaf's source), not
+    // to the enclosing `Paragraph`/`Section`/composite. This is the region-coarse caveat, retired.
+
+    #[test]
+    fn node_at_resolves_to_text_leaf_not_paragraph() {
+        // A byte inside the word "widgets" must resolve to the `Text` leaf owning "widgets" — and
+        // its span must slice back to EXACTLY "widgets", not to the enclosing paragraph.
+        let src = r"\begin{document}We study widgets everywhere\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let byte = src.find("widgets").expect("widgets present") + 2; // inside the word
+        let prov = doc.node_at(byte).expect("a node owns this byte");
+        // The resolved node is the `Text` leaf whose text is exactly "widgets".
+        assert!(
+            matches!(prov.node, NodeRef::Inline(Inline::Text(t, _)) if t == "widgets"),
+            "node_at should resolve to the `widgets` Text leaf, got kind {:?}",
+            prov.node.kind()
+        );
+        // And its span slices back to exactly that word — NOT the enclosing paragraph.
+        assert_eq!(&src[prov.span.start..prov.span.end], "widgets");
+    }
+
+    #[test]
+    fn node_at_in_section_title_resolves_to_heading_inline() {
+        // A byte inside a `\section` heading's title must resolve to the title *inline* (the Text
+        // leaf), NOT to the whole `Section` block that unions the heading + its owned body.
+        let src = r"\begin{document}\section{Introduction}Body text here.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let byte = src.find("Introduction").expect("title present") + 3; // inside the title word
+        let prov = doc.node_at(byte).expect("a node owns this byte");
+        assert!(
+            matches!(prov.node, NodeRef::Inline(Inline::Text(t, _)) if t == "Introduction"),
+            "node_at should resolve to the heading title inline, got kind {:?} span {:?}",
+            prov.node.kind(),
+            prov.span
+        );
+        // The resolved span is the tight title word, strictly narrower than the Section span.
+        assert_eq!(&src[prov.span.start..prov.span.end], "Introduction");
+        let Block::Section { span: sec_span, .. } = &doc.body[0] else { panic!("expected Section") };
+        let sec_width = sec_span.end.saturating_sub(sec_span.start);
+        let title_width = prov.span.end.saturating_sub(prov.span.start);
+        assert!(
+            title_width < sec_width,
+            "title span {:?} must be strictly narrower than the Section span {sec_span:?}",
+            prov.span
+        );
+    }
+
+    #[test]
+    fn node_at_in_textbf_resolves_to_inner_leaf() {
+        // A byte inside `\textbf{bold}`'s inner text resolves to the inner `Text` leaf ("bold"),
+        // NOT to the whole `\textbf{…}` composite inline.
+        let src = r"\begin{document}see \textbf{bold} now\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let byte = src.find("bold").expect("bold present") + 1; // inside the inner word
+        let prov = doc.node_at(byte).expect("a node owns this byte");
+        assert!(
+            matches!(prov.node, NodeRef::Inline(Inline::Text(t, _)) if t == "bold"),
+            "node_at should resolve to the inner `bold` Text leaf, got kind {:?}",
+            prov.node.kind()
+        );
+        assert_eq!(&src[prov.span.start..prov.span.end], "bold");
+    }
+
+    #[test]
+    fn body_bytes_resolve_to_containing_node() {
+        // HONEST BODY BYTE-COVERAGE (S4 scope, NOT the S5 whole-corpus capstone):
+        //
+        // For a representative multi-node document, every NON-WHITESPACE body byte both (a) resolves
+        // (`node_at(byte).is_some()`) AND (b) resolves to a node whose PRECISE span actually
+        // contains that byte (`span.start <= byte < span.end`). We assert this on a representative
+        // input only — S4 proves leaf-resolution here; the tightest-covering-leaf guarantee over the
+        // full LTXDOC01 corpus (no strictly-narrower node exists for any byte) is the S5 capstone.
+        let src = concat!(
+            r"\begin{document}",
+            r"\section{Widgets}",
+            r"We study \textbf{widgets} and $E = mc^2$ here.",
+            r"\begin{itemize}\item First.\item Second.\end{itemize}",
+            r"\end{document}",
+        );
+        let doc = parse_document(src).expect("parse");
+
+        let begin = r"\begin{document}";
+        let end = r"\end{document}";
+        let body_start = src.find(begin).expect("begin marker") + begin.len();
+        let body_end = src[body_start..].find(end).expect("end marker") + body_start;
+
+        let bytes = src.as_bytes();
+        let mut checked = 0usize;
+        for (byte, &b) in bytes.iter().enumerate().take(body_end).skip(body_start) {
+            if b.is_ascii_whitespace() {
+                continue; // whitespace is not required to be owned (honest scope)
+            }
+            checked += 1;
+            let prov = doc
+                .node_at(byte)
+                .unwrap_or_else(|| panic!("unresolved non-whitespace body byte {byte} = {:?}", b as char));
+            // (b): the resolved node's PRECISE span genuinely contains the byte.
+            assert!(
+                prov.span.start <= byte && byte < prov.span.end,
+                "resolved span {:?} does not contain byte {byte} = {:?}",
+                prov.span,
+                b as char
+            );
+        }
+        assert!(checked > 40, "sanity: the body should have many non-whitespace bytes, got {checked}");
     }
 
     #[test]

--- a/code/specs/LTXDOC01-latex-document-ast.md
+++ b/code/specs/LTXDOC01-latex-document-ast.md
@@ -149,15 +149,20 @@ impl<'a> NodeRef<'a> { pub fn span(&self) -> Span; pub fn kind(&self) -> &'stati
 pub struct Provenance<'a> { pub node: NodeRef<'a>, pub span: Span }  // narrowest node owning the byte
 ```
 
-**D6 honesty caveat — region-coarse spans (as shipped).** D2–D5 attach *region-granular* spans:
-many sibling blocks/inlines share the enclosing region they were lowered from (the parser does not
-yet thread exact per-token spans into lowered nodes). Consequently `walk()` is faithful (visits every
-body node once, pre-order), but `node_at(byte)` resolves to the **innermost node at region
-granularity** — the narrowest-span node containing the byte — **not** an exact byte→leaf. `walk()`
-covers the document **body** (Blocks + their Inlines, the provenance surface); preamble/metadata
-directives are indexed into `Preamble`/`Metadata`, not per-node walked. The byte-coverage guarantee
-below is therefore stated honestly at this granularity; precise per-byte→leaf resolution is future
-work once the parser threads token spans.
+**D6 provenance granularity — precise body spans (updated by LTXDOC02 S4).** As shipped, D2–D5
+attached *region-granular* spans (many sibling blocks/inlines shared the enclosing region they were
+lowered from), so `node_at(byte)` resolved only to the innermost node *at region granularity*.
+**LTXDOC02** retired that caveat for **body** nodes: S1/S2 thread exact per-token spans through the
+parser and recognition passes, S3 propagates them into every body `Block`/`Inline`, and **S4** makes
+`node_at(byte)` resolve to the **true per-token leaf** — the narrowest node whose *precise* span
+contains the byte (ties → deepest in pre-order). A byte inside `widgets` now resolves to the `Text`
+run owning `widgets`, not to the enclosing `Paragraph`/`Section`; a byte inside a `\section` title
+resolves to the title inline, not the whole `Section`. `walk()` covers the document **body** (Blocks
++ their Inlines, the provenance surface); **preamble/metadata** directives are indexed into
+`Preamble`/`Metadata`, not per-node walked, so their spans remain honestly region-coarse and
+`node_at` never resolves into them. (See `code/specs/LTXDOC02-precise-token-spans.md`. The
+whole-corpus *tightest-covering-leaf* capstone — proving no strictly-narrower node exists for any
+body byte — is LTXDOC02 S5.)
 
 `parse_document(src)` = `build_document(recognize_structure(recognize_accents(parse(src)?)),
 src.len())` after the L3b table/list recognition runs — i.e. it composes the shipped LTX01 passes and
@@ -206,12 +211,14 @@ warnings` clean; a byte-span on every node asserted in tests.
 - **D6 — provenance API + round-trip corpus + capstone.** ✅ *(shipped)* `Document::node_at(byte)`
   (innermost node owning a source byte), `walk()` pre-order iterator, and `to_latex()` fixed-point
   over a corpus of real papers (a sectioned article with abstract, a `tabular`, an `itemize`, inline
-  + display math, a figure with caption+label, a `\cite`). **Byte coverage, stated honestly at
-  region granularity:** because D2–D5 spans are region-coarse (not per-token), the capstone asserts
-  that every **non-whitespace byte inside the document body region** is owned by **≥1** walked node
-  (not "exactly one leaf" — that precise-leaf claim awaits the parser threading token spans). This
-  is the provenance surface the ADJ pipeline consumes; the granularity is documented, not
-  overclaimed. **This rung completes the LTXDOC01 D1–D6 arc — LaTeX → `Document` AST end-to-end.**
+  + display math, a figure with caption+label, a `\cite`). **Byte coverage:** the capstone asserts
+  that every **non-whitespace byte inside the document body region** is owned by **≥1** walked node.
+  As shipped this was stated honestly at *region* granularity (D2–D5 spans were region-coarse, not
+  per-token); **LTXDOC02** then threaded exact per-token spans (S1–S3) and made `node_at` resolve to
+  the true per-token leaf for body nodes (S4), so the precise-leaf claim that D6 deferred is now
+  delivered. Preamble/metadata remain honestly region-coarse (not per-node walked). This is the
+  provenance surface the ADJ pipeline consumes; the granularity is documented, not overclaimed.
+  **This rung completes the LTXDOC01 D1–D6 arc — LaTeX → `Document` AST end-to-end.**
 
 **Explicitly out of scope (documented, not built):** counter resolution / printed numbers, ToC/index
 generation, BibTeX resolution (we keep `\cite{key}` as a `CrossRef`, not the formatted citation),

--- a/code/specs/LTXDOC02-precise-token-spans.md
+++ b/code/specs/LTXDOC02-precise-token-spans.md
@@ -78,9 +78,17 @@ table. Both double the surface and de-sync from `Node` under edits; carrying the
 - **S3 — precise Document fold.** `build_document` reads carried node spans instead of the `region`;
   `Block`/`Inline` spans become tight. Delete the region-coarse span assignment; containment tests tighten
   from "⊆ region" to "== node source range".
-- **S4 — precise `node_at` + retire the caveat.** With tight spans, `node_at(byte)` returns the true leaf;
-  update its doc-comment and the LTXDOC01 §4/§5 caveats to drop "region-coarse". Add a test: a byte inside a
-  `Text` leaf resolves to that `Text`, and the resolved span slices back to exactly that word.
+- **S4 — precise `node_at` + retire the caveat.** ✅ *(shipped, latex 0.35.0)* With tight spans,
+  `node_at(byte)` returns the true per-token leaf — the narrowest node whose *precise* span contains the byte
+  (ties → deepest in pre-order). Retired the "region-coarse" hedging on `node_at`/`Provenance`/`walk` and the
+  module span note for **body** nodes; kept the honest region-coarse notes on `Preamble`/`DocumentClass`/`Package`
+  (classified out of directives, not walked) and updated the LTXDOC01 §4/§5 caveats to say body resolution is now
+  precise. Added leaf-resolution tests (`node_at_resolves_to_text_leaf_not_paragraph`,
+  `node_at_in_section_title_resolves_to_heading_inline`, `node_at_in_textbf_resolves_to_inner_leaf`) — a byte inside a
+  `Text`/title/inner-run resolves to that leaf and its span slices back to exactly the word — plus an honest body
+  byte-coverage test (`body_bytes_resolve_to_containing_node`) asserting every non-whitespace body byte both resolves
+  and resolves to a node whose precise span contains it (representative input only; the whole-corpus
+  tightest-covering-leaf capstone stays S5). No `node_at`/`walk` logic changed.
 - **S5 — precise byte-coverage capstone.** Over the LTXDOC01 capstone corpus, assert every non-whitespace
   body byte resolves (`node_at(byte).is_some()`) AND the resolved node is a **leaf** whose span is the
   tightest covering range (no strictly-narrower node also contains the byte). The precise counterpart of


### PR DESCRIPTION
## LTXDOC02 S4 — precise `node_at` (region-coarse caveat retired for body nodes)

Fourth implementation rung of the precise-per-token-spans arc (spec `LTXDOC02`; follows S1 #7609, S2 #7618, S3 #7622, all merged). With S3 having made every body `Block`/`Inline` carry its exact `Node::span()`, `Document::node_at(byte)` — which returns the narrowest-span walked node containing the byte (ties → deepest in pre-order) — **now resolves to the true per-token leaf**. S4 formally **retires the "region-coarse" caveat** and **proves** leaf-resolution.

### Docs-and-tests rung — no logic change
`node_at`/`walk`/`build_document`/the lowering fold are **byte-for-byte unchanged**: S3 already made the spans tight, and `node_at`'s narrowest-covering choice over tight spans *is* the leaf. S4's job is to (a) retire the hedging wording now that the guarantee holds and (b) lock it with tests.

### Wording retired
Dropped the "S3 makes span values precise / the formal guarantee is S4" hedging from:
- `node_at`'s doc-comment → now: **"Resolution (S4 — precise, region-coarse caveat retired): … the narrowest-covering node this returns is the true per-token leaf."**
- the `Provenance` struct docs, `NodeRef::span`, the D6 module comment block, and the module-level span-policy note.
- the LTXDOC01 §4 D6 caveat + §5 D6 ladder prose (body resolution now precise; preamble stays coarse).
- LTXDOC02 §5 S4 marked shipped.

**Kept honestly coarse:** `DocumentClass`/`Package` (preamble) field docs — the preamble is classified out of `\documentclass`/`\usepackage` directives, not walked as body content, so those spans remain region-coarse past S4 (documented).

### Tests added (289 lib tests, +4)
- `node_at_resolves_to_text_leaf_not_paragraph` — a byte inside `widgets` resolves to the `Text` leaf; `&src[prov.span] == "widgets"`, **not** the enclosing paragraph.
- `node_at_in_section_title_resolves_to_heading_inline` — a byte inside a `\section` title resolves to the title `Text` inline (`"Introduction"`), asserted **strictly narrower** than the `Section` span.
- `node_at_in_textbf_resolves_to_inner_leaf` — a byte inside `\textbf{bold}`'s inner text resolves to the inner `"bold"` leaf, not the composite.
- `body_bytes_resolve_to_containing_node` — honest **body byte-coverage** on a representative multi-node document: every non-whitespace body byte both resolves (`node_at(byte).is_some()`) **and** resolves to a node whose precise span actually contains it (`span.start <= byte < span.end`). A comment notes this is representative-input only — the whole-corpus **tightest-covering-leaf** capstone is **S5**.

### Verification
- `cargo test -p latex`: **289 passed** (+4 S4 tests) + 1 doc-test.
- `cargo clippy -p latex --all-targets -- -D warnings`: clean.
- Downstream `cargo test -p adj-lang -p adj-lang-cli`: all passed.
- `cargo build -p latex --no-default-features`: builds.
- `to_latex` round-trip fixed point preserved; totality/no-panic; no `unsafe`; `MAX_DEPTH`-bounded.

latex 0.34.0 → 0.35.0. Files: `src/document.rs` (docs + tests), `Cargo.toml`, `CHANGELOG.md`, `README.md`, `code/specs/LTXDOC01-latex-document-ast.md`.

Next: **S5** (precise byte-coverage capstone — over the LTXDOC01 corpus, assert every non-whitespace body byte resolves AND the resolved node is a **leaf** whose span is the tightest covering range: no strictly-narrower node also contains the byte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
