### PR TITLE
Audit HTML parser post-parse repair evidence

### DIFF
--- a/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
@@ -314,6 +314,13 @@ def default_checks() -> list[FixtureCheck]:
             ),
         ),
         FixtureCheck(
+            "whatwg-post-parse-repair-audit",
+            (
+                str(PARSER_FIXTURE_DIR / "generate_whatwg_post_parse_repair_audit_fixture.py"),
+                "--check",
+            ),
+        ),
+        FixtureCheck(
             "whatwg-parser-audit-coverage",
             (
                 str(PARSER_FIXTURE_DIR / "check_whatwg_audit_coverage.py"),

--- a/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
+++ b/code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_format_registry.py
@@ -201,6 +201,11 @@ FORMAT_REGISTRY: tuple[FixtureFormat, ...] = (
         "parser-audit",
     ),
     FixtureFormat(
+        "html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json",
+        "whatwg-html-post-parse-repair-audit/v1",
+        "parser-audit",
+    ),
+    FixtureFormat(
         "html-parser/tests/fixtures/whatwg-noscript-audit.json",
         "whatwg-html-noscript-audit/v1",
         "parser-audit",

--- a/code/packages/rust/html-lexer/tests/fixtures/html-fixture-scripts.txt
+++ b/code/packages/rust/html-lexer/tests/fixtures/html-fixture-scripts.txt
@@ -52,6 +52,7 @@ html-parser/tests/fixtures/generate_whatwg_list_item_audit_fixture.py
 html-parser/tests/fixtures/generate_whatwg_misc_recovery_audit_fixture.py
 html-parser/tests/fixtures/generate_whatwg_noscript_audit_fixture.py
 html-parser/tests/fixtures/generate_whatwg_paragraph_audit_fixture.py
+html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py
 html-parser/tests/fixtures/generate_whatwg_ruby_audit_fixture.py
 html-parser/tests/fixtures/generate_whatwg_select_list_audit_fixture.py
 html-parser/tests/fixtures/generate_whatwg_table_audit_fixture.py

--- a/code/packages/rust/html-parser/CHANGELOG.md
+++ b/code/packages/rust/html-parser/CHANGELOG.md
@@ -6,6 +6,9 @@ documented in this file.
 ## Unreleased
 
 ### Added
+- The WHATWG post-parse repair audit now has a focused fixture and Rust replay
+  guard over the remaining html5lib rows that still justify finish-time repair
+  shims.
 - The WHATWG formatting audit now includes a focused post-parse repair evidence
   guard for the html5lib cases that still justify legacy finish-time recovery
   shims.

--- a/code/packages/rust/html-parser/README.md
+++ b/code/packages/rust/html-parser/README.md
@@ -366,6 +366,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_select_lis
   --check
 ```
 
+The generated `tests/fixtures/whatwg-post-parse-repair-audit.json` fixture
+indexes the remaining html5lib rows that still justify finish-time post-parse
+repair shims:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py \
+  --check
+```
+
 The broad smoke test and the focused audit fixtures use the shared
 `tests/common` html5lib parser and DOM dump helpers, so new parser conformance
 fixtures exercise the same normalization path.

--- a/code/packages/rust/html-parser/tests/fixtures/README.md
+++ b/code/packages/rust/html-parser/tests/fixtures/README.md
@@ -441,6 +441,15 @@ python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_misc_recov
   --check
 ```
 
+`whatwg-post-parse-repair-audit.json` is a generated index over the remaining
+tree-construction rows that justify finish-time post-parse repair shims:
+
+```bash
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py
+python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py \
+  --check
+```
+
 `check_whatwg_audit_coverage.py` verifies that every source marker in
 `html5lib-tree-construction-smoke.dat` is indexed by at least one focused
 `whatwg-*-audit.json` parser fixture, and that those audit fixtures do not

--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+"""Generate Venture's focused WHATWG post-parse repair audit fixture."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+LEXER_FIXTURE_DIR = FIXTURE_DIR.parents[2] / "html-lexer" / "tests" / "fixtures"
+sys.path.insert(0, str(LEXER_FIXTURE_DIR))
+
+from generated_fixture_io import write_fixture_json
+
+DEFAULT_INPUT = FIXTURE_DIR / "html5lib-tree-construction-smoke.dat"
+DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-post-parse-repair-audit.json"
+
+CASE_GROUPS = (
+    {
+        "axis": "fostered-nobr-cell-continuation",
+        "reason": (
+            "remaining finish-time recovery for fostered nobr continuation "
+            "nodes that html5lib keeps inside the table cell"
+        ),
+        "sources": (
+            "tests26.dat:4",
+            "tests26.dat:1251",
+        ),
+    },
+    {
+        "axis": "insanely-badly-nested-table-sequence",
+        "reason": (
+            "remaining finish-time recovery for html5lib's insanely badly "
+            "nested table sequence"
+        ),
+        "sources": ("tricky01.dat:8",),
+    },
+)
+
+
+def main() -> int:
+    args = parse_args()
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    sources = parse_sources(input_path)
+    fixture = build_fixture(sources)
+    return write_fixture_json(output_path, fixture, check=args.check, ensure_ascii=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the focused WHATWG post-parse repair audit fixture."
+    )
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="html5lib tree-construction smoke fixture to index.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT),
+        help="Fixture path to write; defaults beside this script.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the checked-in fixture differs from generated output.",
+    )
+    return parser.parse_args()
+
+
+def parse_sources(path: Path) -> list[str]:
+    sources: list[str] = []
+    for line in path.read_text(errors="replace").splitlines():
+        if line.startswith("#source "):
+            sources.append(line.removeprefix("#source ").strip())
+    if not sources:
+        raise SystemExit(f"{path} does not contain any #source markers")
+    return sources
+
+
+def build_fixture(sources: list[str]) -> dict[str, object]:
+    case_by_source = configured_cases_by_source()
+    selected = []
+    seen = set()
+
+    for source in sources:
+        case = case_by_source.get(source)
+        if case is None:
+            continue
+        if source in seen:
+            raise SystemExit(f"duplicate selected source: {source}")
+        seen.add(source)
+        selected.append(
+            {
+                "id": stable_case_id(source),
+                "source": source,
+                "axis": case["axis"],
+                "reason": case["reason"],
+            }
+        )
+
+    missing_sources = [source for source in case_by_source if source not in seen]
+    if missing_sources:
+        raise SystemExit(
+            "missing configured post-parse repair sources: "
+            + ", ".join(missing_sources)
+        )
+
+    axes = [case_group["axis"] for case_group in CASE_GROUPS]
+    counts_by_axis = {
+        axis: sum(1 for case in selected if case["axis"] == axis) for axis in axes
+    }
+    missing_axes = [axis for axis, count in counts_by_axis.items() if count == 0]
+    if missing_axes:
+        raise SystemExit(f"missing selected cases for axes: {', '.join(missing_axes)}")
+
+    return {
+        "format": "whatwg-html-post-parse-repair-audit/v1",
+        "description": (
+            "Focused parser audit over the remaining html5lib tree-construction "
+            "cases that justify finish-time post-parse repair shims."
+        ),
+        "source_fixture": "html5lib-tree-construction-smoke.dat",
+        "case_count": len(selected),
+        "counts_by_axis": counts_by_axis,
+        "cases": selected,
+    }
+
+
+def configured_cases_by_source() -> dict[str, dict[str, str]]:
+    cases: dict[str, dict[str, str]] = {}
+    for case_group in CASE_GROUPS:
+        for source in case_group["sources"]:
+            if source in cases:
+                raise SystemExit(f"duplicate configured source: {source}")
+            cases[source] = {
+                "axis": case_group["axis"],
+                "reason": case_group["reason"],
+            }
+    return cases
+
+
+def stable_case_id(source: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json
@@ -1,0 +1,30 @@
+{
+  "case_count": 3,
+  "cases": [
+    {
+      "axis": "fostered-nobr-cell-continuation",
+      "id": "tests26-dat-1251",
+      "reason": "remaining finish-time recovery for fostered nobr continuation nodes that html5lib keeps inside the table cell",
+      "source": "tests26.dat:1251"
+    },
+    {
+      "axis": "fostered-nobr-cell-continuation",
+      "id": "tests26-dat-4",
+      "reason": "remaining finish-time recovery for fostered nobr continuation nodes that html5lib keeps inside the table cell",
+      "source": "tests26.dat:4"
+    },
+    {
+      "axis": "insanely-badly-nested-table-sequence",
+      "id": "tricky01-dat-8",
+      "reason": "remaining finish-time recovery for html5lib's insanely badly nested table sequence",
+      "source": "tricky01.dat:8"
+    }
+  ],
+  "counts_by_axis": {
+    "fostered-nobr-cell-continuation": 2,
+    "insanely-badly-nested-table-sequence": 1
+  },
+  "description": "Focused parser audit over the remaining html5lib tree-construction cases that justify finish-time post-parse repair shims.",
+  "format": "whatwg-html-post-parse-repair-audit/v1",
+  "source_fixture": "html5lib-tree-construction-smoke.dat"
+}

--- a/code/packages/rust/html-parser/tests/whatwg_post_parse_repair_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_post_parse_repair_audit_test.rs
@@ -1,0 +1,164 @@
+mod common;
+
+use common::{actual_dom_dump_for_tree_case, parse_tree_construction_cases};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+
+const TREE_CONSTRUCTION_SMOKE: &str = include_str!("fixtures/html5lib-tree-construction-smoke.dat");
+const WHATWG_POST_PARSE_REPAIR_AUDIT: &str =
+    include_str!("fixtures/whatwg-post-parse-repair-audit.json");
+
+struct PostParseRepairEvidence {
+    id: &'static str,
+    source: &'static str,
+    axis: &'static str,
+    data_snippet: &'static str,
+}
+
+const POST_PARSE_REPAIR_EVIDENCE: &[PostParseRepairEvidence] = &[
+    PostParseRepairEvidence {
+        id: "tests26-dat-4",
+        source: "tests26.dat:4",
+        axis: "fostered-nobr-cell-continuation",
+        data_snippet: "<b><nobr>1<table><tr><td><nobr></b><i><nobr>2<nobr></i>3",
+    },
+    PostParseRepairEvidence {
+        id: "tests26-dat-1251",
+        source: "tests26.dat:1251",
+        axis: "fostered-nobr-cell-continuation",
+        data_snippet: "<b><nobr>1<table><tr><td><nobr></b><i><nobr>2<nobr></i>3",
+    },
+    PostParseRepairEvidence {
+        id: "tricky01-dat-8",
+        source: "tricky01.dat:8",
+        axis: "insanely-badly-nested-table-sequence",
+        data_snippet: "This page contains an insanely badly-nested tag sequence.",
+    },
+];
+
+#[derive(Debug, Deserialize)]
+struct PostParseRepairAuditSuite {
+    format: String,
+    description: String,
+    source_fixture: String,
+    case_count: usize,
+    counts_by_axis: BTreeMap<String, usize>,
+    cases: Vec<PostParseRepairAuditCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PostParseRepairAuditCase {
+    id: String,
+    source: String,
+    axis: String,
+    reason: String,
+}
+
+#[test]
+fn whatwg_post_parse_repair_audit_fixture_parses() {
+    let suite = load_suite();
+
+    assert_eq!(suite.format, "whatwg-html-post-parse-repair-audit/v1");
+    assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
+    assert!(!suite.description.is_empty());
+    assert_eq!(suite.case_count, suite.cases.len());
+    assert_eq!(suite.case_count, 3);
+    assert_axis_count(&suite, "fostered-nobr-cell-continuation", 2);
+    assert_axis_count(&suite, "insanely-badly-nested-table-sequence", 1);
+}
+
+#[test]
+fn whatwg_post_parse_repair_audit_cases_match_parser_dom_dump() {
+    let suite = load_suite();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for case in &suite.cases {
+        assert!(
+            !case.id.is_empty() && !case.axis.is_empty() && !case.reason.is_empty(),
+            "case `{}` should carry audit metadata",
+            case.source
+        );
+        let source_case = smoke_cases
+            .get(&case.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", case.source));
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!("case `{}` ({}) parse failed: {error}", case.id, case.axis)
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "case `{}` ({}) failed for input {:?}",
+            case.id, case.axis, source_case.data
+        );
+    }
+}
+
+#[test]
+fn whatwg_post_parse_repair_audit_tracks_post_parse_repair_evidence() {
+    let suite = load_suite();
+    let audit_cases = suite
+        .cases
+        .iter()
+        .map(|case| (case.id.as_str(), case))
+        .collect::<HashMap<_, _>>();
+    let smoke_cases = parse_tree_construction_cases(TREE_CONSTRUCTION_SMOKE)
+        .into_iter()
+        .map(|case| (case.source.clone(), case))
+        .collect::<HashMap<_, _>>();
+
+    for evidence in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(evidence.id).unwrap_or_else(|| {
+            panic!(
+                "post-parse repair evidence case `{}` should be audited",
+                evidence.id
+            )
+        });
+        assert_eq!(
+            audit_case.source, evidence.source,
+            "post-parse repair evidence case `{}` should stay tied to its smoke fixture row",
+            evidence.id
+        );
+        assert_eq!(
+            audit_case.axis, evidence.axis,
+            "post-parse repair evidence case `{}` should stay on its focused audit axis",
+            evidence.id
+        );
+
+        let source_case = smoke_cases
+            .get(evidence.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "post-parse repair evidence row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
+        let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
+            panic!(
+                "case `{}` ({}) parse failed: {error}",
+                audit_case.id, audit_case.axis
+            )
+        });
+
+        assert_eq!(
+            actual, source_case.document,
+            "post-parse repair evidence case `{}` ({}) failed for input {:?}",
+            audit_case.id, audit_case.axis, source_case.data
+        );
+    }
+}
+
+fn load_suite() -> PostParseRepairAuditSuite {
+    serde_json::from_str(WHATWG_POST_PARSE_REPAIR_AUDIT)
+        .expect("WHATWG post-parse repair audit fixture should parse")
+}
+
+fn assert_axis_count(suite: &PostParseRepairAuditSuite, axis: &str, minimum: usize) {
+    let count = suite.counts_by_axis.get(axis).copied().unwrap_or_default();
+    assert!(
+        count >= minimum,
+        "expected at least {minimum} `{axis}` cases, found {count}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add a generated WHATWG post-parse repair audit fixture for the remaining html5lib tree-construction rows that justify finish-time repair shims.
- Add a Rust replay/evidence test that checks those rows against the parser DOM dump.
- Wire the fixture generator into the generated-fixture umbrella, script inventory, format registry, README docs, and changelog.

## Validation

- `cargo test -p coding-adventures-html-parser whatwg_post_parse_repair_audit`
- `cargo test -p coding-adventures-html-parser whatwg_character_reference_audit_keeps_character_reference_axis_cases_cross_axis`
- `cargo test -p coding-adventures-html-parser whatwg_character_reference_audit`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`