### PR TITLE
feat(wolfram): W-22 second head -- wire Expand[...] via cas-simplify

### DIFF
--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.19.0] — 2026-07-05
+
+The **W-22** deliverable (MA04 §2), second head: `Expand`. The blocker
+noted in 0.18.0's release ("Remaining: `Expand`, `Factor`, ...") is now
+cleared — a prior fix (`macsyma-runtime`, "add `cas_simplify::expand`,
+wire it as Macsyma's `Expand` handler") gave `cas-simplify` a real
+`expand()` function; this release wires it under the Wolfram head name the
+same thin way `Simplify` was wired.
+
+### Added (W-22 — `Expand`)
+
+- `Expand[expr]` — a thin call into `cas-simplify`'s existing `expand()`
+  (distributes `Mul` over `Add`/`Sub`, expands bounded non-negative integer
+  `Pow` via square-and-multiply), the exact function Macsyma's own
+  `expand()` surface function calls, including its internal
+  `EXPAND_MAX_POW`/`EXPAND_MAX_TERMS` DoS guards. No new algorithm or guard
+  — Wolfram and Macsyma now agree on every expansion this crate can
+  perform, by construction (a shared test pins the two call sites to the
+  same result on the same input, mirroring `Simplify`'s parity test).
+- Honest scope note (inherited from `cas-simplify`, not new to this
+  release): `Expand` does not collect like terms —
+  `Expand[(x+1)^2]` produces `1 + x + x + x*x`, not `1 + 2*x + x^2`.
+
+### Tests
+
+- 4 new tests: product-over-sum distribution, Wolfram/Macsyma call-site
+  parity, wrong-arity fail-soft (unevaluated), and one end-to-end test
+  through the full parser → lower → `WolframBackend` path — mirroring the
+  four `Simplify` tests added in 0.18.0.
+
 ## [0.18.0] — 2026-07-03
 
 The **W-22** deliverable (MA04 §2): the first head of the previously

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/README.md
+++ b/code/packages/rust/wolfram-runtime/README.md
@@ -623,12 +623,15 @@ the existing shared `cas-*` crate, not a reimplementation:
 |------|---------|--------|
 | `Simplify` | `Simplify[x + 0]` | `x` |
 | `Simplify` | `Simplify[2 + 3]` | `5` |
+| `Expand` | `Expand[(x + 1)^2]` | `1 + x + x + x*x` |
 
-`Simplify` calls `cas-simplify`'s existing `simplify()` — the exact function
-Macsyma's own `simplify()` surface function calls — so Wolfram and Macsyma
-agree on every simplification this crate can perform. Further heads
-(`Expand`, `Factor`, `Solve`, `D`, `Integrate`, …) land one at a time, each
-its own item.
+`Simplify` calls `cas-simplify`'s existing `simplify()`; `Expand` calls its
+existing `expand()` (distributes `Mul` over `Add`/`Sub`, expands bounded
+non-negative integer `Pow`, does **not** collect like terms — see
+`cas-simplify`'s own docs). Both are the exact functions Macsyma's own
+`simplify()`/`expand()` surface functions call — so Wolfram and Macsyma
+agree on every result this crate can produce. Further heads (`Factor`,
+`Solve`, `D`, `Integrate`, …) land one at a time, each its own item.
 
 ## Robustness
 
@@ -705,8 +708,9 @@ session-rebuild so a panic becomes a clean `Err` rather than a crash.
   whole expression only. Depth-bounded, loop-free, panic-free. Alternatives /
   conditions / `PatternTest` / sequences / `Repeated` / `Replace` level specs /
   `ReplaceRepeated` (`//.`) deferred to W-20. No grammar change.
-- **Future** — the full `cas-*` function surface under Wolfram names
-  (`Simplify`, `Expand`, `Factor`, `Solve`, …).
+- **Future** — the rest of the `cas-*` function surface under Wolfram names
+  (`Factor`, `Solve`, `D`, `Integrate`, …) — `Simplify` and `Expand` are
+  delivered, see the W-22 section above.
 
 ## Testing
 

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -64,8 +64,12 @@ use cas_pattern_matching::Bindings;
 // W-22: the shared `cas-*` algorithm surface, under Wolfram names. `simplify`
 // is the same canonical-form + constant-folding + identity-rule pass Macsyma's
 // `simplify_handler` calls (`macsyma-runtime/src/lib.rs`) — reused verbatim,
-// not reimplemented, per MA04 §2's "Future" item.
-use cas_simplify::simplify;
+// not reimplemented, per MA04 §2's "Future" item. `expand` is the second head:
+// the same distribute-then-simplify pass Macsyma's `expand_handler` calls
+// (`macsyma-runtime/src/lib.rs`) — also reused verbatim, including its own
+// internal term-count/exponent DoS guards, so Wolfram gets that hardening for
+// free.
+use cas_simplify::{expand, simplify};
 
 /// Iteration cap passed to [`cas_simplify::simplify`]. Matches the constant
 /// Macsyma's own `simplify_handler` uses (`macsyma-runtime/src/lib.rs`) — the
@@ -245,11 +249,13 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     m.insert("Sqrt".to_string(), handler_fn(sqrt_handler));
 
     // W-22 cas-* algorithm surface under Wolfram names (MA04 §2 "Future" item,
-    // now in progress). `Simplify` is the first entry — an ordinary eager
-    // `Head[args]` form reusing `cas-simplify` verbatim. Further heads
-    // (`Expand`, `Factor`, `Solve`, `D`, `Integrate`, ...) are added one at a
-    // time, each its own PR, per HML00's one-item-per-PR discipline.
+    // now in progress). `Simplify` was the first entry; `Expand` is the
+    // second — both ordinary eager `Head[args]` forms reusing `cas-simplify`
+    // verbatim. Further heads (`Factor`, `Solve`, `D`, `Integrate`, ...) are
+    // added one at a time, each its own PR, per HML00's one-item-per-PR
+    // discipline.
     m.insert("Simplify".to_string(), handler_fn(simplify_handler));
+    m.insert("Expand".to_string(), handler_fn(expand_handler));
 
     // W-18 pattern-matching predicates (MA04 §19). HELD (see `PATTERN_HEADS`):
     // each handler evaluates ONLY its subject and matches against the *literal*
@@ -3247,6 +3253,28 @@ fn simplify_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     simplify(expr.args[0].clone(), SIMPLIFY_MAX_ITERATIONS)
 }
 
+/// `Expand[expr]` → the fully distributed polynomial form: every
+/// `(a + b) * c`-shaped product is multiplied out into a flat sum of terms,
+/// then the result is fixed-pointed through the same simplifier `Simplify`
+/// uses so constants fold and identities collapse. Does **not** collect like
+/// terms (e.g. `Expand[x + x]` stays `x + x`, it does not become `2 x`) —
+/// that is a separate, not-yet-implemented `cas_simplify::expand` capability
+/// (see MA04 §24.2), not a Wolfram-wiring limitation.
+///
+/// A thin call into [`cas_simplify::expand`] — the exact function Macsyma's
+/// `expand_handler` calls (`macsyma-runtime/src/lib.rs`), reused verbatim so
+/// Wolfram and Macsyma agree on every expansion this crate can perform,
+/// including the internal `EXPAND_MAX_POW`/`EXPAND_MAX_TERMS` DoS guards —
+/// no new guard is needed here. Requires exactly one argument (the
+/// eagerly-evaluated expression); any other arity leaves the form
+/// unevaluated, matching every other W-22/W-15 built-in's fail-soft contract.
+fn expand_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
+    if expr.args.len() != 1 {
+        return unevaluated(expr);
+    }
+    expand(expr.args[0].clone())
+}
+
 // ---------------------------------------------------------------------------
 // W-12 string builtins
 // ---------------------------------------------------------------------------
@@ -5967,6 +5995,75 @@ mod tests {
                 vec![apply(sym(ADD), vec![sym("x"), int(0)])]
             )),
             sym("x")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // W-22 cas-* algorithm surface — Expand
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn expand_distributes_products_over_sums() {
+        // Expand[(x+1)^2] -> 1 + x + x + x*x (no like-term collection -- the
+        // same honest, documented scope as Macsyma's `expand()`, see
+        // `expand_distributes_polynomial_multiplication` in
+        // `macsyma-runtime/tests/test_runtime.rs`).
+        let x = sym("x");
+        let squared = apply(
+            sym(symbolic_ir::POW),
+            vec![apply(sym(ADD), vec![x.clone(), int(1)]), int(2)],
+        );
+        assert_eq!(
+            run("Expand", vec![squared]),
+            apply(
+                sym(ADD),
+                vec![
+                    int(1),
+                    x.clone(),
+                    x.clone(),
+                    apply(sym(MUL), vec![x.clone(), x])
+                ],
+            )
+        );
+    }
+
+    #[test]
+    fn expand_agrees_with_macsyma_on_the_same_underlying_call() {
+        // Both Wolfram's Expand and Macsyma's expand() call the exact same
+        // cas_simplify::expand -- this pins that the Wolfram wiring doesn't
+        // diverge from the reference call.
+        let expr = apply(
+            sym(MUL),
+            vec![apply(sym(ADD), vec![sym("x"), int(1)]), sym("y")],
+        );
+        assert_eq!(run("Expand", vec![expr.clone()]), cas_simplify::expand(expr));
+    }
+
+    #[test]
+    fn expand_with_wrong_arity_stays_unevaluated() {
+        assert_eq!(run("Expand", vec![]), apply(sym("Expand"), vec![]));
+        assert_eq!(
+            run("Expand", vec![int(1), int(2)]),
+            apply(sym("Expand"), vec![int(1), int(2)])
+        );
+    }
+
+    #[test]
+    fn expand_dispatches_end_to_end_through_the_wolfram_backend() {
+        // (x+1)*(x+2) fully distributes through the full parser -> lower ->
+        // backend path, exactly mirroring `simplify_dispatches_end_to_end_
+        // through_the_wolfram_backend` above.
+        let x = sym("x");
+        let product = apply(
+            sym(MUL),
+            vec![
+                apply(sym(ADD), vec![x.clone(), int(1)]),
+                apply(sym(ADD), vec![x.clone(), int(2)]),
+            ],
+        );
+        assert_eq!(
+            eval_full(apply(sym("Expand"), vec![product.clone()])),
+            cas_simplify::expand(product)
         );
     }
 

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -93,12 +93,13 @@ Following [HML00 §6](HML00-historical-math-languages-roadmap.md)'s breakdown:
   (with `checked_mul`) before allocation (§19.5). No grammar change.
 - **W-22 — the `cas-*` function surface under Wolfram names.** *(in
   progress — see §24.)* Wires the existing `cas-*` crates in one head at a
-  time, starting with `Simplify` (a thin call into `cas-simplify`'s
-  `simplify()`, the same function Macsyma's own `simplify()` calls, so the
-  two languages agree on every simplification this crate can perform).
-  Remaining: `Expand`, `Factor`, `Solve`, `D`, `Integrate`, each its own
-  item — no grammar change for any of them (all ordinary `Head[args]` forms
-  the existing grammar already parses).
+  time: `Simplify` (a thin call into `cas-simplify`'s `simplify()`) and
+  `Expand` (a thin call into `cas-simplify`'s `expand()`) are both
+  delivered — each the same function its Macsyma counterpart calls, so the
+  two languages agree on every result this crate can produce. Remaining:
+  `Factor`, `Solve`, `D`, `Integrate`, each its own item — no grammar
+  change for any of them (all ordinary `Head[args]` forms the existing
+  grammar already parses).
 
 ## §3 The supported surface (the grammar)
 
@@ -2097,7 +2098,7 @@ it). `ReplaceRepeated` retains its §22.4 hard iteration cap
 (`REPLACE_GROWTH_NODE_CAP`) — the `//.` operator lowers to the very same head, so
 the DoS bounds apply identically whether written as operator or `Head[args]`.
 
-## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify` (in progress)
+## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify`, `Expand` (in progress)
 
 W-22 starts closing §2's previously unnumbered "Future" item: wiring the
 existing `cas-*` algorithm crates under Wolfram's own head names. Unlike
@@ -2126,25 +2127,38 @@ Simplify[x + 0]     (* x *)
 Simplify[2 + 3]     (* 5 *)
 ```
 
-### §24.2 Remaining (not yet delivered)
+### §24.2 `Expand` (delivered)
+
+`Expand[expr]` is a thin call into `cas_simplify::expand(expr)` — **the
+exact function** Macsyma's own `expand()` surface function calls
+(`macsyma-runtime`'s `expand_handler`), including its internal
+`EXPAND_MAX_POW`/`EXPAND_MAX_TERMS` DoS guards (a faithful port of the
+Python reference's general recursive-distributor path: distributes `Mul`
+over `Add`/`Sub`, expands bounded non-negative integer `Pow` via
+square-and-multiply, guarded against the doubly-exponential term-count
+blowup a multi-term base can hit). No algorithm or guard is reimplemented
+for Wolfram; a test pins both languages' call sites to agree on the same
+input, exactly like `Simplify`'s §24.1 parity test.
+
+Like `Simplify` and every W-5+ built-in, `Expand` is an ordinary eager
+`Head[args]` form requiring exactly one argument; any other arity leaves
+the form unevaluated.
+
+```
+Expand[(x + 1)^2]           (* 1 + x + x + x*x *)
+Expand[(x + 1) * (x + 2)]   (* 2 + x + 2*x + x*x *)
+```
+
+**Honest scope note (inherited from `cas-simplify`, not a Wolfram-specific
+gap):** `expand` does not collect like terms — e.g. `Expand[(x+1)^2]`
+produces `1 + x + x + x*x`, not the fully-collected `1 + 2*x + x^2` —
+tracked as a separate follow-up (see `cas-simplify`'s own module docs).
+
+### §24.3 Remaining (not yet delivered)
 
 `Factor`, `Solve`, `D`, `Integrate`, and the rest of §2's original list —
 each is a separate future item, no grammar change required for any of them
 (all are ordinary `Head[args]` forms the existing grammar already parses).
-
-**`Expand` — the blocker is now cleared, wiring is the remaining step.**
-Macsyma's own `expand()` had no dedicated handler backing its `Expand` head
-in `symbolic-vm`'s `build_handler_table` (verified empirically:
-`expand((x+1)^2)` returned unevaluated) — that gap is now fixed via
-`cas_simplify::expand`, a faithful port of the Python reference's general
-recursive-distributor path (distributes `Mul` over `Add`/`Sub`, expands
-bounded non-negative integer `Pow`, guarded against the doubly-exponential
-term-count blowup square-and-multiply can hit on a multi-term base). Wiring
-Wolfram's `Expand[...]` is now the same thin `call the shared function` shape
-as `Simplify[...]` was. **Honest scope note (inherited from `cas-simplify`,
-not a Wolfram-specific gap):** `expand` does not collect like terms — e.g.
-`Expand[(x+1)^2]` will produce `1 + x + x + x*x`, not the fully-collected
-`1 + 2*x + x^2` — tracked as a separate follow-up.
 
 ### §6 References
 


### PR DESCRIPTION
## Summary
- Wires `Expand[expr]` into `wolfram-runtime` the same thin way `Simplify[expr]` was wired ([#7547](https://github.com/adhithyan15/coding-adventures/pull/7547)): a direct call into `cas_simplify::expand`, the exact function Macsyma's own `expand()` surface calls ([#7579](https://github.com/adhithyan15/coding-adventures/pull/7579)).
- No new algorithm and no new DoS guard -- `Expand` inherits `cas-simplify`'s own `EXPAND_MAX_POW`/`EXPAND_MAX_TERMS` caps verbatim, so Wolfram and Macsyma agree on every expansion this crate can perform (pinned by a parity test mirroring `Simplify`'s).
- `MA04-wolfram-language.md` §24.2 moved from "remaining" to "delivered"; §24.3 renumbered for the still-outstanding heads (`Factor`, `Solve`, `D`, `Integrate`).

## Notable side-finding (not fixed in this PR)
While running the full `wolfram-runtime` test suite to verify this change, two **pre-existing, unrelated** tests (`union_over_cap_stays_unevaluated`, `tally_over_cap_stays_unevaluated`) were found to take 30-40+ minutes at 100-200% CPU before finally hitting their DoS cap. Root cause: the shared `contains_element()` helper used by every W-13 set-op head (`Union`/`Intersection`/`Complement`/`DeleteDuplicates`/`MemberQ`/`Tally`) is an O(n) linear scan called per input element, so building a deduped accumulator up to the 1,000,000-element cap is O(n²) -- the cap check only fires *after* the expensive work is already done. Confirmed pre-existing on `origin/main`, unrelated to this diff. Filed as a separate backlog item to keep this PR's scope to `Expand` only.

## Test plan
- [x] 4 new unit tests (product-over-sum distribution, Wolfram/Macsyma call-site parity, wrong-arity fail-soft, full parser→lower→backend E2E)
- [x] Full suite green: 329 unit tests + 85 integration tests + 1 doctest, all passing (verified excluding the two pre-existing slow tests noted above, which are unrelated to this diff and were independently confirmed to pass, just slowly)
- [x] `cargo build -p coding-adventures-wolfram-runtime` clean
- [x] `/security-review` passed clean, first round, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)