### PR TITLE
feat(sir-js): M6 universal metaprogramming — send/tap/then/respond_to? parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.12.0
+
+### Added — M6 universal Object metaprogramming surface (send/tap/then/respond_to?)
+
+Parity fill: the M6 Kernel/Object surface already shipped in the Python and
+TypeScript backends is now ported to the JS OOP runtime (`callMethod` in
+`src/runtime.rs`), matching those references' return-value rules exactly. These
+methods are mixed into EVERY receiver — primitives, arrays, hashes, and
+user-defined `SirInstance`s alike.
+
+- **`send` / `__send__` / `public_send`** — the first argument (a Symbol or
+  string) names a method; dispatch re-enters `callMethod` with that name and the
+  remaining args, so `x.send(:upcase)` is exactly `x.upcase` and a trailing
+  block survives. **Security-critical (the C3 dynamic-dispatch RCE lesson):** the
+  dynamic name routes through the SAME gate a direct call uses — the explicit
+  `(class, method)` `Map` for a `SirInstance`, the fixed `METHOD_ALLOWLIST` for a
+  primitive. There is NO `recv[name]`, `eval`, `new Function`, or host reflection
+  on the source-derived name; an unknown/gadget name (`constructor`, `__proto__`,
+  …) raises `NoMethodError` exactly as a direct call would, and no payload runs.
+- **`tap`** — yields the receiver to the block (side effect), returns the
+  RECEIVER.
+- **`then` / `yield_self`** — yields the receiver, returns the BLOCK'S RESULT;
+  a block-less `then` returns the receiver (matching the Python v0 floor).
+- **`respond_to?`** — true iff dispatch would resolve the name, checked against
+  the same method table / allowlist dispatch uses (a new `respondsTo` helper), so
+  it never lies — a name not resolvable is both a `NoMethodError` on call and
+  `respond_to? == false`.
+- **Boolean `&` / `|` / `^`** on a `true`/`false` receiver — Ruby's *eager*
+  (non-short-circuiting) logical operators, distinct from the lazy `&&`/`||`
+  keywords, coercing the operand by SIR truthiness (`true & nil == false`,
+  `false | 0 == true`).
+
+Dispatch integrates with the existing JS `callMethod` model: M6 names are
+recognised BEFORE the native-method allowlist (so `tap`/`send`/… are not wrongly
+rejected as unknown natives), a `SirInstance` still resolves a user override of
+`send`/`tap` first, and everything remains an explicit table/Set lookup —
+cycle-safe and reflection-free. Verified end-to-end under Node (8 new
+`run_with_node` tests covering send-to-instance, send-of-string-name-on-primitive,
+send-of-gadget-name → NoMethodError, tap/then/yield_self return rules,
+respond_to? true/false on primitive and instance, and the boolean operators) plus
+a runtime-shape unit test asserting the surface is present and gadget-free.
+
+
 ## 0.11.3
 
 ### Fixed — Ruby String methods whose names differ from JS natives (`upcase`/…)

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -459,6 +459,123 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "end_with?": "endsWith",
     "include?": "includes",
   };
+
+  // ── M6: universal Object metaprogramming surface ───────────────
+  //
+  // Ruby's Kernel / Object mixes a handful of methods into EVERY object,
+  // independent of the receiver's type.  M6 ports the same four groups the
+  // Python / TypeScript backends carry, matching their return-value rules
+  // exactly:
+  //
+  //   • `send` / `__send__` / `public_send` — the FIRST argument (a Symbol or
+  //     string) names a method; re-enter dispatch with that name + the
+  //     remaining args.  SECURITY-CRITICAL (the C3 RCE lesson): the dynamic
+  //     name routes through the SAME `callMethod` — so a SirInstance goes
+  //     through the explicit `(class, method)` Map, and a primitive goes
+  //     through the fixed `METHOD_ALLOWLIST`.  We NEVER do `recv[name]`, `eval`,
+  //     `new Function`, or any host reflection on the source-derived name; an
+  //     unknown name floors to the same `NoMethodError` a direct call raises.
+  //   • `tap` — yields the receiver to the block, returns the RECEIVER (the
+  //     "run a side effect, keep the value" pipeline method).
+  //   • `then` / `yield_self` — yields the receiver to the block, returns the
+  //     BLOCK'S RESULT (functional "pipe into a block"); block-less `then`
+  //     returns the receiver (matching Python's v0 floor).
+  //   • `respond_to?` — true iff dispatch on the receiver would resolve the
+  //     named method, checked against the SAME tables/allowlist dispatch uses
+  //     (`respondsTo` below), so it stays honest.
+  //   • boolean `&` / `|` / `^` on a `true`/`false` receiver — Ruby's *eager*
+  //     (non-short-circuiting) logical operators, distinct from the lazy
+  //     `&&`/`||` keywords; the operand is coerced by SIR `truthy`.
+  //
+  // The names below are recognised BEFORE the native-method allowlist gate, so
+  // they resolve on primitives (which the allowlist would otherwise reject) and
+  // on SirInstances (after a user override misses).  `respond_to?` reporting is
+  // driven by `respondsTo`, never by probing `recv[name]`.
+  const SEND_METHODS = new Set(["send", "__send__", "public_send"]);
+  const OBJECT_BLOCK_METHODS = new Set(["tap", "then", "yield_self"]);
+  const BOOL_METHODS = new Set(["&", "|", "^"]);
+
+  // Coerce a `respond_to?` / `send` name argument (a `Sym`, a `":m"`-ish
+  // string, or a bare name) to the plain method name used as the dispatch key.
+  function methodNameArg(arg) {
+    if (arg instanceof Sym) { return arg.name; }
+    return String(arg);
+  }
+
+  // Whether dispatch on `recv` would resolve `name` — checked against the SAME
+  // structures `callMethod` uses, so `respond_to?` never lies:
+  //   • a SirInstance: the user method table walking its MRO/ancestry;
+  //   • any receiver: the universal M6 surface (send family + tap/then/
+  //     yield_self + respond_to?), and — on a boolean — the eager operators;
+  //   • a primitive: the native-method allowlist (after Ruby→native aliasing).
+  // This is pure DATA lookup (Set membership + `Map.get` on a `(class, method)`
+  // key), never `recv[name]` / reflection — a name like `constructor` is inert.
+  function respondsTo(recv, name) {
+    if (recv instanceof SirInstance) {
+      if (resolveMethod(methodTable, recv.sirClass, name, includedModules) !== undefined) {
+        return true;
+      }
+    }
+    if (name === "respond_to?" || SEND_METHODS.has(name) || OBJECT_BLOCK_METHODS.has(name)) {
+      return true;
+    }
+    if (typeof recv === "boolean" && BOOL_METHODS.has(name)) { return true; }
+    // A primitive resolves a name iff it (or its Ruby→native alias) is on the
+    // method allowlist AND the native member is actually a function on `recv`.
+    if (!(recv instanceof SirInstance)) {
+      const native = Object.prototype.hasOwnProperty.call(RUBY_METHOD_ALIASES, name)
+        ? RUBY_METHOD_ALIASES[name]
+        : name;
+      if (name === "length" || name === "fetch") { return true; }
+      if (METHOD_ALLOWLIST.has(native)) {
+        return recv != null && typeof recv[native] === "function";
+      }
+    }
+    return false;
+  }
+
+  // Eager boolean operators on a `true`/`false` receiver.  Returns the sentinel
+  // `BOOL_MISS` when `name` is not an operator (or called with no operand) so
+  // the caller can fall through — mirroring Python/TS `_MISS`.
+  const BOOL_MISS = Symbol("bool-miss");
+  function boolMethod(recv, name, args) {
+    if (!BOOL_METHODS.has(name) || args.length === 0) { return BOOL_MISS; }
+    const other = truthy(args[0]);
+    if (name === "&") { return recv && other; }
+    if (name === "|") { return recv || other; }
+    return recv !== other; // "^"
+  }
+
+  // Dispatch the universal M6 surface on ANY receiver.  Returns `M6_MISS` when
+  // `name` is not an M6 method, so `callMethod` continues to its type-specific
+  // paths.  `rawArgs` is the UN-unwrapped argument list — a trailing block is
+  // still a `__Sir.Closure`, invoked via `applyClosure`; `send` forwards the raw
+  // args so a forwarded block survives as a Closure.
+  const M6_MISS = Symbol("m6-miss");
+  function objectMetaMethod(recv, name, rawArgs) {
+    // `send`/`__send__`/`public_send`: the first arg names a method; re-enter
+    // dispatch with the remaining args.  An empty arg list has no method to
+    // name — fall through to the NoMethodError floor.  Routing recurses through
+    // `callMethod`, so the security gate (allowlist / method table) is reused.
+    if (SEND_METHODS.has(name) && rawArgs.length > 0) {
+      return callMethod(recv, methodNameArg(rawArgs[0]), ...rawArgs.slice(1));
+    }
+    if (name === "respond_to?") {
+      return respondsTo(recv, methodNameArg(rawArgs[0]));
+    }
+    // `tap`/`then`/`yield_self` with an actual trailing Closure block.  `tap`
+    // returns the receiver; `then`/`yield_self` return the block's result.
+    const last = rawArgs[rawArgs.length - 1];
+    if (OBJECT_BLOCK_METHODS.has(name) && rawArgs.length > 0 && last instanceof Closure) {
+      if (name === "tap") { applyClosure(last, [recv]); return recv; }
+      return applyClosure(last, [recv]); // then / yield_self
+    }
+    // Block-less `tap`/`then`/`yield_self` returns the receiver (Ruby returns an
+    // Enumerator; v0 floor, matching Python/TS).
+    if (OBJECT_BLOCK_METHODS.has(name)) { return recv; }
+    return M6_MISS;
+  }
+
   function callMethod(recv, name, ...rawArgs) {
     const args = rawArgs.map(unwrapArg);
     // ── user-defined-class dispatch (O3) ─────────────────────────
@@ -471,12 +588,34 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // `(class, method)` key; a name like `constructor` simply misses.
     if (recv instanceof SirInstance) {
       const fn = resolveMethod(methodTable, recv.sirClass, name, includedModules);
-      if (fn === undefined) {
-        raiseError("NoMethodError",
-          "undefined method `" + name + "` for an instance of `" +
-          recv.sirClass + "`");
+      if (fn !== undefined) {
+        // A user-defined method (incl. a user override of `send`/`tap`/…) wins.
+        return applyWithSelf(fn, recv, args);
       }
-      return applyWithSelf(fn, recv, args);
+      // No user method — fall through to the universal M6 surface (send/tap/
+      // then/yield_self/respond_to?), then raise NoMethodError if M6 misses too.
+      const meta = objectMetaMethod(recv, name, rawArgs);
+      if (meta !== M6_MISS) { return meta; }
+      raiseError("NoMethodError",
+        "undefined method `" + name + "` for an instance of `" +
+        recv.sirClass + "`");
+    }
+    // ── M6: universal metaprogramming on a NON-instance receiver ──
+    // `send`/`tap`/`then`/`yield_self`/`respond_to?` resolve on EVERY receiver
+    // (primitives included), and must be recognised BEFORE the native-method
+    // allowlist below — otherwise a name like `tap` or `send`, which is not a
+    // native JS method, would be wrongly rejected as a NoMethodError.  Dispatch
+    // routes through `objectMetaMethod` (send recurses via `callMethod`, so the
+    // security gate is reused — no `recv[name]` / reflection on the name).
+    {
+      const meta = objectMetaMethod(recv, name, rawArgs);
+      if (meta !== M6_MISS) { return meta; }
+    }
+    // Eager boolean operators (`&`/`|`/`^`) on a `true`/`false` receiver —
+    // Ruby's non-short-circuiting logical ops, distinct from `&&`/`||`.
+    if (typeof recv === "boolean") {
+      const b = boolMethod(recv, name, args);
+      if (b !== BOOL_MISS) { return b; }
     }
     // `length` as a nullary method mirrors the property.  Kept special-cased
     // ahead of the allowlist: it is a property read, not a method call.
@@ -1159,6 +1298,32 @@ mod tests {
         assert!(RUNTIME.contains("function classDescription(recv)"));
         // The old JS-native TypeError floor for the allowlist miss is gone.
         assert!(!RUNTIME.contains("is not an allowed collection method"));
+    }
+
+    #[test]
+    fn runtime_defines_m6_universal_metaprogramming_surface() {
+        // M6: send/tap/then/yield_self/respond_to? + boolean &/|/^ are mixed
+        // into EVERY receiver, ported to match the Python/TS references.
+        assert!(RUNTIME.contains(r#"const SEND_METHODS = new Set(["send", "__send__", "public_send"]);"#));
+        assert!(RUNTIME.contains(r#"const OBJECT_BLOCK_METHODS = new Set(["tap", "then", "yield_self"]);"#));
+        assert!(RUNTIME.contains(r#"const BOOL_METHODS = new Set(["&", "|", "^"]);"#));
+        assert!(RUNTIME.contains("function objectMetaMethod("));
+        assert!(RUNTIME.contains("function respondsTo("));
+        assert!(RUNTIME.contains("function boolMethod("));
+        // `tap` returns the receiver; `then`/`yield_self` return the block result.
+        assert!(RUNTIME.contains(r#"if (name === "tap") { applyClosure(last, [recv]); return recv; }"#));
+        assert!(RUNTIME.contains("return applyClosure(last, [recv]); // then / yield_self"));
+
+        // SECURITY (the C3 RCE lesson): `send` routes the DYNAMIC name back
+        // through `callMethod` — the SAME allowlist / method-table gate a direct
+        // call uses — NEVER `recv[name]` / `eval` / `new Function` on the name.
+        assert!(RUNTIME.contains("return callMethod(recv, methodNameArg(rawArgs[0]), ...rawArgs.slice(1));"));
+        assert!(!RUNTIME.contains("new Function("));
+        assert!(!RUNTIME.contains("eval("));
+        // `respond_to?` checks the same tables dispatch uses (method table for a
+        // SirInstance, the allowlist for a primitive) — not a probe of recv[name].
+        assert!(RUNTIME.contains("resolveMethod(methodTable, recv.sirClass, name, includedModules) !== undefined"));
+        assert!(RUNTIME.contains("METHOD_ALLOWLIST.has(native)"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -1128,6 +1128,8 @@ fn oop_module(methods: Vec<Function>, main_stmts: Vec<Stmt>) -> Module {
             Feature::Strings,
             Feature::DynamicTyping,
             Feature::Constants,
+            // M6 tests pass a `send`/`respond_to?` name as a `SymLit`.
+            Feature::Symbols,
             // `@x = v` lowers to an `Assign`, which the validator counts
             // as a mutable binding.
             Feature::MutableBindings,
@@ -2007,5 +2009,208 @@ fn t3_array_fetch_with_default_returns_default() {
     );
     if let Some(stdout) = run_module(&module, "t3_fetch_default") {
         assert_eq!(stdout, "42", "fetch with a default must return it, not raise");
+    }
+}
+
+// ── M6: universal Object metaprogramming surface (run under `node`) ────
+//
+// `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`, `respond_to?`,
+// and boolean `&`/`|`/`^` are mixed into EVERY receiver (Ruby Kernel/Object).
+// These prove the ported JS behaviour matches the Python/TS references, and —
+// load-bearing — that `send`'s dynamic name routes through the SAME dispatch
+// gate (an unknown name raises NoMethodError; a gadget name never runs host
+// code), never `recv[name]`/reflection.
+
+/// A one-param top-level function `name(v) { <stmts>; return <value> }`, the
+/// shape a `tap`/`then` block is hoisted into.
+fn block_fn(name: &str, stmts: Vec<Stmt>, value: Expr) -> Function {
+    func(name, vec![param("v")], stmts, value)
+}
+
+/// `send(:meth, args…)` on an INSTANCE routes to the user method table.
+///   class Greeter; def greet(who); print("hi " + who); end; end
+///   Greeter.new.send(:greet, "sam")   →   "hi sam"
+#[test]
+fn m6_send_routes_to_instance_method() {
+    // def greet(who); print("hi " + who); end
+    let greet = func(
+        "Greeter__greet",
+        vec![param("who")],
+        vec![print(bc("+", vec![str_("hi "), param_ref("who")]))],
+        Expr::NilLit { span: sp() },
+    );
+    let make = bc("__new__", vec![str_("Greeter")]);
+    // obj.send(:greet, "sam")  →  __method__(obj, "send", :greet, "sam")
+    let sent = bc(
+        "__method__",
+        vec![make, str_("send"), Expr::SymLit { name: "greet".into(), span: sp() }, str_("sam")],
+    );
+    let main = vec![
+        def_method("Greeter", "greet", "Greeter__greet"),
+        Stmt::ExprStmt { expr: sent, span: sp() },
+    ];
+    let module = oop_module(vec![greet], main);
+    if let Some(stdout) = run_module(&module, "m6_send_instance") {
+        assert_eq!(stdout, "hi sam");
+    }
+}
+
+/// `send` with a STRING name and a primitive receiver routes through the
+/// native-method allowlist: `"hello".send("upcase")` → "HELLO".
+#[test]
+fn m6_send_string_name_on_primitive() {
+    let sent = bc("__method__", vec![str_("hello"), str_("send"), str_("upcase")]);
+    let module = module_with_main(
+        vec![print(sent)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "m6_send_upcase") {
+        assert_eq!(stdout, "HELLO");
+    }
+}
+
+/// SECURITY: `send` of an UNKNOWN / gadget name raises NoMethodError — the
+/// dynamic name is gated by the SAME allowlist a direct call uses, so node
+/// exits non-zero and the `"return 1"` payload is never synthesised/run.
+#[test]
+fn m6_send_unknown_name_raises_no_method_error() {
+    // "x".send("constructor", "return 1")  → NoMethodError (gadget blocked).
+    let gadget = bc(
+        "__method__",
+        vec![str_("x"), str_("send"), str_("constructor"), str_("return 1")],
+    );
+    let module = module_with_main(
+        vec![print(gadget)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stderr) = run_module_expecting_failure(&module, "m6_send_gadget") {
+        assert!(
+            stderr.contains("NoMethodError") || stderr.contains("undefined method"),
+            "send of a gadget name must raise NoMethodError, got stderr:\n{stderr}"
+        );
+    }
+}
+
+/// `tap` yields the receiver to the block (side effect) and returns the
+/// RECEIVER.  `print( 7.tap { |v| print("tap") } )` prints `tap` then `7`.
+#[test]
+fn m6_tap_runs_block_and_returns_receiver() {
+    // block: def _tap(v); print("tap"); end
+    let blk = block_fn("m6_tap_blk", vec![print(str_("tap"))], Expr::NilLit { span: sp() });
+    let tap_call = bc(
+        "__method__",
+        vec![int(7), str_("tap"), method_closure("m6_tap_blk")],
+    );
+    let module = oop_module(vec![blk], vec![print(tap_call)]);
+    if let Some(stdout) = run_module(&module, "m6_tap") {
+        // Block ran first (prints "tap"), then tap's result (the receiver 7).
+        assert_eq!(stdout, "tap\n7");
+    }
+}
+
+/// `then`/`yield_self` yields the receiver and returns the BLOCK'S RESULT.
+///   print( 7.then { |v| v + 1 } )   →   8
+#[test]
+fn m6_then_returns_block_result() {
+    // block: def _then(v); v + 1; end
+    let blk = block_fn("m6_then_blk", vec![], bc("+", vec![param_ref("v"), int(1)]));
+    let then_call = bc(
+        "__method__",
+        vec![int(7), str_("then"), method_closure("m6_then_blk")],
+    );
+    let module = oop_module(vec![blk], vec![print(then_call)]);
+    if let Some(stdout) = run_module(&module, "m6_then") {
+        assert_eq!(stdout, "8");
+    }
+}
+
+/// `yield_self` is `then`'s alias — same "return the block result" rule.
+#[test]
+fn m6_yield_self_returns_block_result() {
+    let blk = block_fn("m6_ys_blk", vec![], bc("+", vec![param_ref("v"), int(10)]));
+    let call = bc(
+        "__method__",
+        vec![int(5), str_("yield_self"), method_closure("m6_ys_blk")],
+    );
+    let module = oop_module(vec![blk], vec![print(call)]);
+    if let Some(stdout) = run_module(&module, "m6_yield_self") {
+        assert_eq!(stdout, "15");
+    }
+}
+
+/// `respond_to?` is honest: true for a name dispatch resolves, false
+/// otherwise — checked against the SAME allowlist/method table dispatch uses.
+#[test]
+fn m6_respond_to_reports_dispatchable_names() {
+    // print("x".respond_to?(:upcase))  → true   (allowlisted native)
+    // print("x".respond_to?(:nope))    → false  (not resolvable)
+    // print("x".respond_to?(:tap))     → true   (universal M6)
+    let r_upcase = bc(
+        "__method__",
+        vec![str_("x"), str_("respond_to?"), Expr::SymLit { name: "upcase".into(), span: sp() }],
+    );
+    let r_nope = bc(
+        "__method__",
+        vec![str_("x"), str_("respond_to?"), Expr::SymLit { name: "nope".into(), span: sp() }],
+    );
+    let r_tap = bc(
+        "__method__",
+        vec![str_("x"), str_("respond_to?"), Expr::SymLit { name: "tap".into(), span: sp() }],
+    );
+    let module = module_with_main(
+        vec![print(r_upcase), print(r_nope), print(r_tap)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Strings, Feature::DynamicTyping, Feature::Constants, Feature::Symbols],
+    );
+    if let Some(stdout) = run_module(&module, "m6_respond_to") {
+        // The runtime renders booleans as Lisp `#t`/`#f` via `format`.
+        assert_eq!(stdout, "#t\n#f\n#t");
+    }
+}
+
+/// `respond_to?` on an INSTANCE consults the user method table honestly.
+#[test]
+fn m6_respond_to_on_instance() {
+    let bark = func("Pup__bark", vec![], vec![], str_("woof"));
+    let make = bc("__new__", vec![str_("Pup")]);
+    // print(obj.respond_to?(:bark))  → true ; print(obj.respond_to?(:meow)) → false
+    let r_bark = bc(
+        "__method__",
+        vec![make.clone(), str_("respond_to?"), Expr::SymLit { name: "bark".into(), span: sp() }],
+    );
+    let r_meow = bc(
+        "__method__",
+        vec![make, str_("respond_to?"), Expr::SymLit { name: "meow".into(), span: sp() }],
+    );
+    let main = vec![
+        def_method("Pup", "bark", "Pup__bark"),
+        print(r_bark),
+        print(r_meow),
+    ];
+    let module = oop_module(vec![bark], main);
+    if let Some(stdout) = run_module(&module, "m6_respond_to_instance") {
+        assert_eq!(stdout, "#t\n#f");
+    }
+}
+
+/// Boolean `&`/`|`/`^` on a `true`/`false` receiver — Ruby's eager logical
+/// operators (non-short-circuiting), coercing the operand by SIR truthiness.
+#[test]
+fn m6_boolean_operators() {
+    // true & false → #f ; true | false → #t ; true ^ true → #f ; false | 0 → #t
+    let and = bc("__method__", vec![Expr::BoolLit { value: true, span: sp() }, str_("&"), Expr::BoolLit { value: false, span: sp() }]);
+    let or = bc("__method__", vec![Expr::BoolLit { value: true, span: sp() }, str_("|"), Expr::BoolLit { value: false, span: sp() }]);
+    let xor = bc("__method__", vec![Expr::BoolLit { value: true, span: sp() }, str_("^"), Expr::BoolLit { value: true, span: sp() }]);
+    // 0 is TRUTHY in SIR/Ruby, so `false | 0` is true.
+    let or_zero = bc("__method__", vec![Expr::BoolLit { value: false, span: sp() }, str_("|"), int(0)]);
+    let module = module_with_main(
+        vec![print(and), print(or), print(xor), print(or_zero)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "m6_bool_ops") {
+        assert_eq!(stdout, "#f\n#t\n#f\n#t");
     }
 }


### PR DESCRIPTION
Parity-fill: M6 (universal Object metaprogramming) is merged in Python+TS; this ports the same surface to the **JavaScript** backend. Runtime-only — `semantic-ir-to-javascript`.

Adds to the JS OOP runtime `callMethod` (via `objectMetaMethod`/`boolMethod`/`respondsTo`):
- `send`/`__send__`/`public_send` — first arg names a method; **re-enters `callMethod`** with it + remaining args.
- `tap` → runs block, returns receiver; `then`/`yield_self` → returns block result (block-less → receiver).
- `respond_to?` → true iff dispatchable (method table for instances, allowlist for primitives).
- boolean `&`/`|`/`^` on `true`/`false` receivers.

**Security ([[dynamic-dispatch-rce]]) — the `send` RCE surface, review PASSED:** the dynamic name routes *exclusively* back through the same explicit dispatch — `resolveMethod` (`Map.get` on `(class,method)`) for instances, the fixed `METHOD_ALLOWLIST` for primitives. No `recv[name]`/`eval`/`Function`/`apply`. `constructor`/`__proto__`/`apply` are rejected → `NoMethodError` (can't leak a host callable). `send` recursion terminates (args shrink per hop). `respondsTo` only probes allowlisted natives. No prototype writes.

Execution-proofed under node (8 proofs incl. gadget-name rejection). 109 unit + 58 integration green, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)