### PR TITLE
feat(sir-rust): M6 universal metaprogramming — send/tap/then/respond_to? parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## 0.14.0 — M6 universal metaprogramming surface (send / tap / then / respond_to?)
+
+Ports the **M6** universal `Object`/`Kernel` metaprogramming surface — already
+merged in the Python and TypeScript backends (`sir-runtime-oop`) — to the Rust
+backend's inlined `__sir` runtime, so a metaprogramming program produces
+identical output on every backend. Runtime-only change (no core semantic-IR, no
+frontend, no emitter change): the frontend already lowers `recv.send(:m, …)`,
+`recv.tap { … }`, etc. to the `__method__` dispatch envelope; this milestone
+teaches `call_method` to resolve them.
+
+- **`send` / `__send__` / `public_send`** — the first argument NAMES a method;
+  dispatch RE-ENTERS `call_method` with that name plus the remaining args (a
+  trailing block survives as a trailing arg). Placed first so it applies to
+  EVERY receiver kind (primitive, collection, user instance) uniformly. A
+  user-defined `send` override on an instance wins (resolution order).
+  - **SECURITY ([[dynamic-dispatch-rce]]):** the dynamic name feeds back
+    through the SAME explicit, closed `call_method` a direct `recv.meth` call
+    takes — it indexes the identical hand-written catalogs / `METHOD_TABLE`, so
+    an unknown name bottoms out at the identical typed `NoMethodError`. There is
+    NO reflective lookup on the source-derived string; the name is inert data
+    that can only ever select an arm we spelled out.
+- **`tap { |x| … }`** — yields the receiver for a side effect, returns the
+  RECEIVER. **`then` / `yield_self { |x| … }`** — yields the receiver, returns
+  the BLOCK RESULT (block-less → the receiver, the v0 Enumerator-less floor).
+- **`respond_to?(:m)`** — true iff dispatch on the receiver resolves `m`,
+  consulting the SAME catalogs / user method table a real call walks (honest: a
+  `true` name is exactly one a real call would run; a `false` name is exactly
+  one that would raise `NoMethodError`). An explicit membership test, never
+  reflection. On a user instance it uses the same `resolve_instance_method`
+  ancestry/MRO walk `dispatch_user_method` uses.
+- **Boolean `&` / `|` / `^`** on a `true`/`false` receiver — Ruby's EAGER
+  (non-short-circuiting) logical operators, distinct from the lazy `&&`/`||`
+  keywords; the operand is coerced by Ruby truthiness (`true & nil == false`).
+- `dispatch_user_method` now falls through to the M6 universal methods on a
+  user-method miss (instead of raising immediately), so `instance.respond_to?` /
+  `.tap` / `.then` / `.to_s` resolve on instances too; only a name none of these
+  claim is a genuine `NoMethodError`.
+- New `compile_and_run_metaprogramming` exec proof (6 tests): `send` dispatches
+  through the catalog (primitive + collection + user instance), unknown `send`
+  raises a catchable `NoMethodError`, `tap` returns the receiver while `then`/
+  `yield_self` return the block result, `respond_to?` reports catalog membership
+  honestly, and boolean `&`/`|`/`^` match Ruby. Plus a `runtime.rs` unit-test
+  witness for the emitted M6 surface. All 123 lib + exec tests green, no new
+  warnings.
+
+
 ## 0.13.2
 
 ### Fixed — `or`/`and` builtins (Ruby `||`/`&&`) were unimplemented

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1239,6 +1239,50 @@ pub const RUNTIME: &str = r##"mod __sir {
     /// bottoms out at `unknown_method` (Ruby `nil`) — never a reflective
     /// fallthrough.
     pub fn call_method(recv: Value, name: &str, args: Vec<Value>) -> Value {
+        // ── M6 universal metaprogramming: `send`/`__send__`/`public_send` ─
+        //
+        // Ruby's `send(:meth, args…)` re-enters dispatch with a *dynamic*
+        // method name taken from the first argument (a Symbol or string),
+        // forwarding the rest unchanged — so `x.send(:upcase)` is exactly
+        // `x.upcase`, and a trailing block survives as a trailing arg.
+        //
+        // SECURITY ([[dynamic-dispatch-rce]]): the dynamic name is fed BACK
+        // through `call_method` — the SAME explicit, closed dispatch a normal
+        // `recv.meth` call takes.  It indexes the SAME hand-written catalogs /
+        // `METHOD_TABLE` a direct call does, so an unknown name bottoms out at
+        // the identical `no_method_error` boundary (a typed `NoMethodError`).
+        // There is NO reflective lookup on the source-derived name — the name
+        // is inert data that can only ever select an ARM we spelled out.
+        //
+        // A user-defined `send`/`tap`/etc. must win over the universal one
+        // (Ruby's resolution order), so for a `Value::Instance` receiver we
+        // check the user method table FIRST (below); only a genuine miss
+        // reaches these universal Kernel methods, via `object_method`.
+        //
+        // `send` is placed FIRST (before the instance branch) so it re-enters
+        // dispatch for EVERY receiver kind — an instance, a primitive, a
+        // collection — uniformly, exactly as Ruby's `Kernel#send`.  An empty
+        // arg list (`send` with no method name) floors to the honest
+        // `NoMethodError` rather than panicking on an out-of-bounds index.
+        // For an instance receiver we still honour a user-defined `send`
+        // override first (resolution order), matching the Python reference
+        // where the `define_method` table is consulted before `_SEND_METHODS`.
+        if matches!(name, "send" | "__send__" | "public_send") {
+            let user_send = match &recv {
+                Value::Instance(id) => resolve_instance_method(&instance_class(*id), name),
+                _ => None,
+            };
+            if user_send.is_none() {
+                let mut it = args.into_iter();
+                return match it.next() {
+                    Some(target) => {
+                        let target_name = method_name(&target);
+                        call_method(recv, &target_name, it.collect())
+                    }
+                    None => no_method_error(&recv, name),
+                };
+            }
+        }
         // ── user-defined-class dispatch (O5) ──────────────────────────
         // A `Value::Instance` receiver dispatches to the USER method table
         // (walking ancestry), with `self` bound for the call.  This branch
@@ -1248,7 +1292,10 @@ pub const RUNTIME: &str = r##"mod __sir {
         // `HashMap::get` on the `(class, method)` key (never reflection):
         // a name like `constructor` simply misses and floors to the same
         // honest `NoMethodError`/`Nil` boundary the collection catalog uses
-        // (`unknown_method`).  See `dispatch_user_method`.
+        // (`unknown_method`).  See `dispatch_user_method`.  A miss now falls
+        // through to the universal Object methods (`respond_to?`/`tap`/…)
+        // rather than raising immediately, matching the Python reference's
+        // "reflective built-ins after the user table" resolution order.
         if let Value::Instance(id) = &recv {
             return dispatch_user_method(*id, &recv, name, args);
         }
@@ -1266,6 +1313,18 @@ pub const RUNTIME: &str = r##"mod __sir {
             // everything else uses the universal display form.
             return Value::Str(Rc::from(format(&recv).as_str()));
         }
+        // ── M6 universal Object methods (respond_to?/tap/then/yield_self) ─
+        //
+        // These resolve on EVERY primitive receiver, *after* `to_s` but
+        // *before* the type-specific catalog so they never collide with a
+        // type method (there is no primitive `tap`/`then`/`respond_to?`).
+        // `object_method` returns `Some` when it claims the name; a `None`
+        // falls through to the type-specific catalog below.  Boolean `&`/`|`/
+        // `^` are handled inside `object_method` too (they resolve on a bool
+        // receiver before the `no_method_error` bool arm).
+        if let Some(v) = object_method(&recv, name, &args) {
+            return v;
+        }
         match &recv {
             Value::Seq(_) => array_method(recv, name, args),
             Value::Map(_) => map_method(recv, name, args),
@@ -1273,10 +1332,127 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Sym(_) => symbol_method(recv, name, args),
             // `bool` is checked before the numeric arm on purpose: a Ruby
             // `true`/`false` is not a Numeric, so it never resolves the
-            // numeric catalog.
+            // numeric catalog.  (Its `&`/`|`/`^` operators were handled by
+            // `object_method` above.)
             Value::Bool(_) => no_method_error(&recv, name),
             Value::Int(_) | Value::Float(_) => numeric_method(recv, name, args),
             _ => no_method_error(&recv, name),
+        }
+    }
+
+    // ── M6 universal Object / Kernel methods ──────────────────────────
+    //
+    // The Rust analogue of the Python/TS `sir-runtime-oop` universal Object
+    // table.  A method here resolves on ANY receiver (every value is-a
+    // `Object` in Ruby).  Returns `Some(value)` when `name` is a universal
+    // method it handles, or `None` to let the caller fall through to the
+    // type-specific catalog.  (`send`/`__send__`/`public_send` are handled
+    // separately in `call_method` because they RE-ENTER dispatch; `to_s`
+    // likewise, so it can render via `format`.)
+    //
+    // | method                  | yields | returns                    |
+    // |-------------------------|--------|----------------------------|
+    // | `respond_to?(name)`     | —      | bool — does dispatch resolve `name`? |
+    // | `tap { … }`             | recv   | **recv** (side-effect pipe)|
+    // | `then`/`yield_self { … }`| recv  | **block result** (functional pipe) |
+    // | `&`/`|`/`^` (bool recv) | —      | eager boolean logic        |
+    //
+    // Block-less `tap`/`then` return the receiver (Ruby returns an Enumerator;
+    // the v0 floor is the receiver, matching the Python reference).
+    fn object_method(recv: &Value, name: &str, args: &[Value]) -> Option<Value> {
+        // Boolean `&`/`|`/`^` — Ruby's EAGER, non-short-circuiting logical
+        // operators on a `true`/`false` receiver (distinct from the lazy
+        // `&&`/`||` keywords).  The operand is coerced by Ruby truthiness
+        // (`nil`/`false` falsy, everything else truthy), so `true & nil ==
+        // false` and `false | 0 == true`.  `^` is logical XOR.  Only a `Bool`
+        // receiver with an operand resolves these (a bare `true.&` with no
+        // arg falls through to the `no_method_error` bool arm).
+        if let Value::Bool(b) = recv {
+            if matches!(name, "&" | "|" | "^") {
+                if let Some(other) = args.first() {
+                    let o = truthy(other);
+                    return Some(Value::Bool(match name {
+                        "&" => *b && o,
+                        "|" => *b || o,
+                        _ => *b != o, // "^"
+                    }));
+                }
+            }
+        }
+        match name {
+            // `respond_to?(:m)` — true iff dispatch on `recv` resolves `m`,
+            // consulting the SAME catalogs/table a real call uses (so it is
+            // honest: an out-of-catalog name reports `false`, and that name
+            // would also raise `NoMethodError` if actually called).
+            "respond_to?" => {
+                let target = args.first().map(method_name).unwrap_or_default();
+                Some(Value::Bool(responds_to(recv, &target)))
+            }
+            // `tap { |x| … }` — run the block for its side effect, return the
+            // RECEIVER.  Block-less `tap` still returns the receiver (v0 floor).
+            "tap" => {
+                if let Some(Value::Closure(_)) = args.last() {
+                    apply_closure(args.last().unwrap(), vec![recv.clone()]);
+                }
+                Some(recv.clone())
+            }
+            // `then`/`yield_self { |x| … }` — pipe the receiver INTO the block,
+            // return the block's RESULT.  Block-less → the receiver (v0 floor).
+            "then" | "yield_self" => match args.last() {
+                Some(b @ Value::Closure(_)) => Some(apply_closure(b, vec![recv.clone()])),
+                _ => Some(recv.clone()),
+            },
+            _ => None,
+        }
+    }
+
+    // Does dispatch on `recv` resolve `name`?  Mirrors the Python reference's
+    // `_responds_to`: it consults the SAME closed catalogs / user method table
+    // that a real `call_method` would, so the answer is honest — a name it
+    // reports `true` for is exactly a name a real call would run, and a
+    // `false` name is exactly one that would raise `NoMethodError`.  It is an
+    // explicit membership test, never reflection on the source-derived name.
+    fn responds_to(recv: &Value, name: &str) -> bool {
+        // Universal methods available on every receiver.
+        if matches!(
+            name,
+            "to_s" | "respond_to?" | "send" | "__send__" | "public_send" | "tap"
+                | "then" | "yield_self"
+        ) {
+            return true;
+        }
+        match recv {
+            // A user instance responds to any method its class (or an ancestor
+            // / included module) defines — the SAME `resolve_instance_method`
+            // walk `dispatch_user_method` uses.
+            Value::Instance(id) => resolve_instance_method(&instance_class(*id), name).is_some(),
+            Value::Seq(_) => matches!(
+                name,
+                "length" | "size" | "first" | "last" | "[]" | "reverse" | "sort" | "join"
+                    | "include?" | "push" | "append" | "pop" | "fetch" | "each" | "map"
+                    | "collect" | "select" | "filter" | "reject" | "find" | "detect" | "any?"
+                    | "all?" | "none?" | "reduce" | "inject"
+            ),
+            Value::Map(_) => matches!(
+                name,
+                "keys" | "values" | "[]" | "size" | "length" | "has_key?" | "key?" | "include?"
+                    | "member?" | "fetch" | "each" | "each_pair" | "map" | "collect" | "select"
+                    | "filter"
+            ),
+            Value::Str(_) => matches!(
+                name,
+                "length" | "size" | "upcase" | "downcase" | "reverse" | "strip" | "include?"
+                    | "split"
+            ),
+            Value::Sym(_) => matches!(
+                name,
+                "to_s" | "to_sym" | "length" | "size" | "upcase" | "downcase"
+            ),
+            Value::Bool(_) => matches!(name, "&" | "|" | "^"),
+            Value::Int(_) | Value::Float(_) => {
+                matches!(name, "abs" | "to_i" | "to_f" | "even?" | "odd?" | "zero?" | "times")
+            }
+            _ => false,
         }
     }
 
@@ -2308,10 +2484,24 @@ pub const RUNTIME: &str = r##"mod __sir {
         };
         match resolve_instance_method(&class, name) {
             Some(f) => apply_with_self(&f, recv.clone(), args),
-            // An instance method genuinely absent from the class's table
-            // (and all ancestors) is a Ruby `NoMethodError` — surface it
-            // typed so `rescue NoMethodError` catches it.
-            None => no_method_error(recv, name),
+            // No user method resolved — fall through to the M6 universal
+            // Object methods (`respond_to?`/`tap`/`then`/`yield_self`), which
+            // every receiver (instances included) responds to.  `to_s` is a
+            // universal too: an instance with no user `to_s` renders via the
+            // default `#<Class>` `format` form.  Only a name NONE of these
+            // claim is a genuine Ruby `NoMethodError` — surfaced typed so a
+            // `rescue NoMethodError` catches it.  (`send`/`__send__`/
+            // `public_send` never reach here: `call_method` intercepts them
+            // for every receiver, re-entering dispatch with the dynamic name.)
+            None => {
+                if name == "to_s" {
+                    return Value::Str(Rc::from(format(recv).as_str()));
+                }
+                if let Some(v) = object_method(recv, name, &args) {
+                    return v;
+                }
+                no_method_error(recv, name)
+            }
         }
     }
 
@@ -2632,6 +2822,30 @@ mod tests {
         assert!(RUNTIME.contains("if !seen.insert(c.clone())"), "missing OOP cycle guard");
         // The instance dispatch branch is taken FIRST in `call_method`.
         assert!(RUNTIME.contains("fn dispatch_user_method"));
+    }
+
+    #[test]
+    fn runtime_declares_m6_metaprogramming_surface() {
+        // M6: the inline runtime must ship the universal Object/Kernel
+        // metaprogramming methods — `send`/`__send__`/`public_send`,
+        // `tap`, `then`/`yield_self`, `respond_to?`, and boolean `&`/`|`/`^`.
+        assert!(RUNTIME.contains("fn object_method"), "missing universal Object method dispatch");
+        assert!(RUNTIME.contains("fn responds_to"), "missing respond_to? resolver");
+        // `send` re-enters dispatch with the dynamic name (the security-
+        // critical routing: the name feeds back through the SAME closed
+        // `call_method`, never a reflective host lookup).
+        assert!(
+            RUNTIME.contains(r#""send" | "__send__" | "public_send""#),
+            "missing send/__send__/public_send routing"
+        );
+        assert!(
+            RUNTIME.contains("call_method(recv, &target_name, it.collect())"),
+            "send must re-enter the explicit call_method with the dynamic name"
+        );
+        // The block-taking universal pair and the boolean operators.
+        assert!(RUNTIME.contains(r#""then" | "yield_self""#), "missing then/yield_self");
+        assert!(RUNTIME.contains(r#""respond_to?" =>"#), "missing respond_to? arm");
+        assert!(RUNTIME.contains(r#"matches!(name, "&" | "|" | "^")"#), "missing bool operators");
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_metaprogramming.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_metaprogramming.rs
@@ -1,0 +1,419 @@
+//! End-to-end proof for the **M6 universal metaprogramming surface** in the
+//! Rust backend — Ruby's `Kernel`/`Object` reflection primitives:
+//!
+//!   * `send`/`__send__`/`public_send` — the first arg NAMES a method; dispatch
+//!     RE-ENTERS `call_method` with that name + the remaining args.  The dynamic
+//!     name indexes the SAME closed catalogs a direct `recv.meth` call uses, so
+//!     an unknown name raises the SAME typed `NoMethodError` — never reflection
+//!     on the source-derived string (the [[dynamic-dispatch-rce]] lesson).
+//!   * `tap { |x| … }`               — yield the receiver, return the RECEIVER.
+//!   * `then`/`yield_self { |x| … }` — yield the receiver, return the BLOCK
+//!     result (block-less → the receiver).
+//!   * `respond_to?(:m)`             — true iff dispatch resolves `m` (honest:
+//!     consults the same catalog/table a real call walks).
+//!   * boolean `&`/`|`/`^` on a `true`/`false` receiver — Ruby's EAGER logical
+//!     operators.
+//!
+//! Parity-fill: this surface is already merged in the Python + TypeScript
+//! backends (`sir-runtime-oop`); the Rust runtime ports the SAME behaviour so
+//! a metaprogramming program produces identical output on every backend.
+//!
+//! Like the other Rust exec-proofs, this hand-builds SIR modules, emits Rust,
+//! compiles with `rustc`, runs the binary, and checks stdout.  `StrLit`
+//! interpolation is unsupported, so assertions use INTEGER / bare-string
+//! markers the `print` path renders.  A missing `rustc`/linker is a SKIP.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, CaptureValue, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Param, ParamKind, RescueClause, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn symlit(v: &str) -> Expr {
+    Expr::SymLit { name: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn blit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, slit(name)];
+    all.append(&mut args);
+    Expr::BuiltinCall { name: "__method__".into(), args: all, effects: EffectSet::PURE, span: s() }
+}
+
+/// A no-capture block closure over a top-level block function.
+fn block(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: Vec::<CaptureValue>::new(), span: s() }
+}
+
+fn param(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: call("print", vec![expr]),
+        span: s(),
+    }
+}
+
+fn expr_stmt(e: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: e, span: s() }
+}
+
+/// A top-level block/method body function: `name(params…) { body; value }`.
+fn body_fn(name: &str, params: &[&str], body: Vec<Stmt>, value: Expr) -> Function {
+    Function {
+        name: name.into(),
+        params: params
+            .iter()
+            .map(|p| Param {
+                name: (*p).into(),
+                kind: ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            })
+            .collect(),
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: body, value, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+/// Assemble a module: a `main` body plus the referenced block/method functions.
+fn demo_module(main_stmts: Vec<Stmt>, mut fns: Vec<Function>, features: &[Feature]) -> Module {
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    fns.insert(0, main);
+    let mut feats = vec![
+        Feature::Sequences,
+        Feature::Strings,
+        Feature::Symbols,
+        Feature::Closures,
+        Feature::DynamicTyping,
+    ];
+    feats.extend_from_slice(features);
+    Module {
+        name: "metaprog_demo".into(),
+        manifest: FeatureManifest::from_features(&feats),
+        imports: vec![],
+        exports: vec![],
+        functions: fns,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// `begin <fault>; rescue <class>; <on_catch> end`.
+fn begin_rescue(fault: Stmt, class: &str, on_catch: Vec<Stmt>) -> Stmt {
+    Stmt::TryCatch {
+        body: vec![fault],
+        rescues: vec![RescueClause {
+            exception_types: vec![class.to_string()],
+            binding: None,
+            body: on_catch,
+            span: s(),
+        }],
+        ensure_body: None,
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Compile emitted Rust and run the binary → `(stdout, exit_success)`.  `None`
+/// on a missing linker (skip).  Mirrors the other Rust exec-proofs.
+fn compile_and_run(source: &str, tag: &str) -> Option<(String, bool)> {
+    let dir = std::env::temp_dir();
+    let nonce = format!("{}_{}", std::process::id(), tag);
+    let src_path = dir.join(format!("sir_m6_{nonce}.rs"));
+    let bin_path = dir.join(format!("sir_m6_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!("emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{source}");
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run_out.stdout).to_string();
+    let ok = run_out.status.success();
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    Some((stdout, ok))
+}
+
+/// `send(:meth, args…)` dispatches through the SAME closed catalog a direct
+/// call uses — for both a primitive and a collection receiver.
+///
+/// ```ruby
+/// puts "hello".send(:upcase)          # => HELLO
+/// puts [1, 2, 3].send(:length)        # => 3
+/// puts [3, 1, 2].__send__(:sort)      # => [1, 2, 3]
+/// ```
+#[test]
+fn send_dispatches_through_catalog() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let main = vec![
+        // "hello".send(:upcase) → HELLO
+        print_stmt(method(slit("hello"), "send", vec![symlit("upcase")])),
+        // [1,2,3].send(:length) → 3
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "send", vec![symlit("length")])),
+        // [3,1,2].__send__(:sort) → [1, 2, 3]
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "__send__", vec![symlit("sort")])),
+    ];
+    let m = demo_module(main, vec![], &[]);
+    let out = compile(&m).expect("compile send").source;
+    // Security witness: `send` re-enters the explicit `call_method` (no
+    // reflective host-name dispatch appears in the emitted runtime).
+    assert!(out.contains("fn call_method"), "dispatch must be the explicit call_method");
+    let Some((stdout, ok)) = compile_and_run(&out, "send") else { return };
+    assert!(ok, "send process should exit 0; stdout {stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["HELLO", "3", "[1, 2, 3]"], "got {stdout:?}");
+}
+
+/// An UNKNOWN `send` target raises a typed `NoMethodError` — the SAME boundary
+/// a direct unknown call hits (no silent nil, no reflection).
+///
+/// ```ruby
+/// begin
+///   "x".send(:bogus_xyz)
+/// rescue NoMethodError
+///   puts 9
+/// end                                 # => 9
+/// ```
+#[test]
+fn send_unknown_raises_no_method_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let main = vec![begin_rescue(
+        print_stmt(method(slit("x"), "send", vec![symlit("bogus_xyz")])),
+        "NoMethodError",
+        vec![print_stmt(ilit(9))],
+    )];
+    let m = demo_module(main, vec![], &[Feature::Exceptions]);
+    let out = compile(&m).expect("compile send-unknown").source;
+    let Some((stdout, ok)) = compile_and_run(&out, "send_unknown") else { return };
+    assert!(ok, "send-unknown process should exit 0 (caught); stdout {stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["9"], "got {stdout:?}");
+}
+
+/// `tap` runs the block for its side effect and returns the RECEIVER;
+/// `then`/`yield_self` return the BLOCK RESULT.
+///
+/// ```ruby
+/// puts 5.tap { |x| puts x }           # => 5 then 5   (block side-effect, then recv)
+/// puts 10.then { |x| x + 1 }          # => 11         (block result)
+/// puts 10.yield_self { |x| x + 2 }    # => 12
+/// ```
+#[test]
+fn tap_returns_receiver_then_returns_block_result() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fns = vec![
+        // tap block: { |x| puts x }  (side effect, value discarded)
+        body_fn("__blk_puts", &["x"], vec![print_stmt(param("x"))], Expr::NilLit { span: s() }),
+        // then block: { |x| x + 1 }
+        body_fn("__blk_inc", &["x"], vec![], call("+", vec![param("x"), ilit(1)])),
+        // yield_self block: { |x| x + 2 }
+        body_fn("__blk_inc2", &["x"], vec![], call("+", vec![param("x"), ilit(2)])),
+    ];
+    let main = vec![
+        // 5.tap { |x| puts x }  → prints 5 (block), then the tap value 5.
+        print_stmt(method(ilit(5), "tap", vec![block("__blk_puts")])),
+        // 10.then { |x| x + 1 }  → 11
+        print_stmt(method(ilit(10), "then", vec![block("__blk_inc")])),
+        // 10.yield_self { |x| x + 2 }  → 12
+        print_stmt(method(ilit(10), "yield_self", vec![block("__blk_inc2")])),
+    ];
+    let m = demo_module(main, fns, &[]);
+    let out = compile(&m).expect("compile tap/then").source;
+    let Some((stdout, ok)) = compile_and_run(&out, "tap_then") else { return };
+    assert!(ok, "tap/then process should exit 0; stdout {stdout:?}");
+    // tap prints the block's `5` first, then the tap expression's own `5`.
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["5", "5", "11", "12"], "got {stdout:?}");
+}
+
+/// `respond_to?` is honest: `true` for a catalog method, `false` for an
+/// out-of-catalog name (which a real call would `NoMethodError` on).
+///
+/// ```ruby
+/// puts "x".respond_to?(:upcase)       # => true
+/// puts "x".respond_to?(:bogus_xyz)    # => false
+/// puts [1].respond_to?(:map)          # => true
+/// ```
+#[test]
+fn respond_to_reports_catalog_membership() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let main = vec![
+        print_stmt(method(slit("x"), "respond_to?", vec![symlit("upcase")])),
+        print_stmt(method(slit("x"), "respond_to?", vec![symlit("bogus_xyz")])),
+        print_stmt(method(seq(vec![ilit(1)]), "respond_to?", vec![symlit("map")])),
+    ];
+    let m = demo_module(main, vec![], &[]);
+    let out = compile(&m).expect("compile respond_to?").source;
+    let Some((stdout, ok)) = compile_and_run(&out, "respond_to") else { return };
+    assert!(ok, "respond_to? process should exit 0; stdout {stdout:?}");
+    // The Rust `format` renders booleans as `#t`/`#f` (the runtime's display
+    // form), so a `true`/`false` prints `#t`/`#f`.
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["#t", "#f", "#t"], "got {stdout:?}");
+}
+
+/// Boolean `&`/`|`/`^` are Ruby's EAGER logical operators on a bool receiver.
+///
+/// ```ruby
+/// puts(true & false)                  # => false
+/// puts(false | true)                  # => true
+/// puts(true ^ true)                   # => false
+/// ```
+#[test]
+fn boolean_operators_on_bool_receiver() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let main = vec![
+        print_stmt(method(blit(true), "&", vec![blit(false)])),
+        print_stmt(method(blit(false), "|", vec![blit(true)])),
+        print_stmt(method(blit(true), "^", vec![blit(true)])),
+    ];
+    let m = demo_module(main, vec![], &[]);
+    let out = compile(&m).expect("compile bool-ops").source;
+    let Some((stdout, ok)) = compile_and_run(&out, "bool_ops") else { return };
+    assert!(ok, "bool-ops process should exit 0; stdout {stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["#f", "#t", "#f"], "got {stdout:?}");
+}
+
+/// `send` on a USER INSTANCE routes through the user method table (the same
+/// ancestry walk a direct call takes), and `respond_to?` reports a user method.
+///
+/// ```ruby
+/// class Box
+///   def initialize(v); @v = v; end
+///   def get; @v; end
+/// end
+/// b = Box.new(42)
+/// puts b.send(:get)                   # => 42
+/// puts b.respond_to?(:get)            # => true
+/// puts b.respond_to?(:missing_xyz)    # => false
+/// ```
+#[test]
+fn send_and_respond_to_on_user_instance() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let init = body_fn(
+        "Box_initialize",
+        &["v"],
+        vec![Stmt::Assign {
+            name: "@v".into(),
+            scope: Scope::Instance,
+            value: param("v"),
+            span: s(),
+        }],
+        Expr::NilLit { span: s() },
+    );
+    let get = body_fn("Box_get", &[], vec![], Expr::VarRef {
+        name: "@v".into(),
+        scope: Scope::Instance,
+        span: s(),
+    });
+    let def_method = |cls: &str, m: &str, fnn: &str| {
+        expr_stmt(call("__def_method__", vec![slit(cls), slit(m), block(fnn)]))
+    };
+    let main = vec![
+        Stmt::ClassDef { name: "Box".into(), superclass: None, body: vec![], span: s() },
+        def_method("Box", "initialize", "Box_initialize"),
+        def_method("Box", "get", "Box_get"),
+        // Box.new(42).send(:get) → 42  (routes through the user method table)
+        print_stmt(method(call("__new__", vec![slit("Box"), ilit(42)]), "send", vec![symlit("get")])),
+        // Box.new(42).respond_to?(:get) → true
+        print_stmt(method(call("__new__", vec![slit("Box"), ilit(1)]), "respond_to?", vec![symlit("get")])),
+        // Box.new(42).respond_to?(:missing_xyz) → false
+        print_stmt(method(call("__new__", vec![slit("Box"), ilit(1)]), "respond_to?", vec![symlit("missing_xyz")])),
+    ];
+    let m = demo_module(
+        main,
+        vec![init, get],
+        &[Feature::Classes, Feature::InstanceVars, Feature::MutableBindings],
+    );
+    let out = compile(&m).expect("compile instance send").source;
+    let Some((stdout, ok)) = compile_and_run(&out, "instance_send") else { return };
+    assert!(ok, "instance-send process should exit 0; stdout {stdout:?}");
+    assert_eq!(stdout.lines().collect::<Vec<_>>(), vec!["42", "#t", "#f"], "got {stdout:?}");
+}


### PR DESCRIPTION
Parity-fill: M6 (universal Object metaprogramming) is merged in Python+TS; this ports the same surface to the **Rust** backend. Runtime-only — `semantic-ir-to-rust`.

Adds to the Rust OOP runtime `call_method` (via `object_method`/`responds_to` + a `send` arm):
- `send`/`__send__`/`public_send` — first arg names a method; **re-enters `call_method`** with it + remaining args.
- `tap` → runs block, returns receiver; `then`/`yield_self` → returns block result (block-less → receiver).
- `respond_to?` → true iff dispatchable (reuses `resolve_instance_method` MRO walk for instances; per-catalog predicates for primitives).
- boolean `&`/`|`/`^` on `true`/`false` receivers. User `send`/`tap` overrides win (correct MRO).

**Security ([[dynamic-dispatch-rce]]) — review PASSED:** the `send` name is inert `String` data (closed `match` in `method_name`) routed back through the same explicit `call_method` catalogs + `METHOD_TABLE` HashMap — no reflective lookup; unknown → typed `NoMethodError`. Recursion terminates (args shrink per hop). RefCell borrows dropped before re-entrant calls (no borrow-panic); no `unsafe`; block-application guarded by `Value::Closure` match.

Execution-proofed via rustc (6 proofs incl. unknown-send → catchable NoMethodError). 123 lib + exec suites green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)