### PR TITLE
feat(sir-go): M6 universal metaprogramming — send/tap/then/respond_to? parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.14.0
 
+### Security (review-driven)
+
+- Arity guards on `equal?` and boolean `&`/`|`/`^`: these became reachable with
+  ZERO args via the new `send` surface (`obj.send(:equal?)`, `true.send(:&)`),
+  where indexing `args[0]` was a raw Go index-out-of-range panic (catchable only
+  as `StandardError`, or a native crash if uncaught). They now raise a typed
+  `ArgumentError` ("wrong number of arguments (given 0, expected 1)") — matching
+  Ruby. Regression: `send_zero_arg_method_raises_argument_error_not_native_panic`.
+
 ### Added — M6 universal Object metaprogramming (send / tap / then / respond_to? / boolean &|^)
 
 Parity-fill: M6 shipped in the Python + TypeScript `sir-runtime-oop` backends;

--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.14.0
+
+### Added — M6 universal Object metaprogramming (send / tap / then / respond_to? / boolean &|^)
+
+Parity-fill: M6 shipped in the Python + TypeScript `sir-runtime-oop` backends;
+this ports the SAME surface into the Go runtime's method-dispatch path
+(`_sir_call_method`), so a translated Ruby program's `send`/`tap`/`then`/
+`respond_to?` and boolean `&`/`|`/`^` now execute on the Go backend instead of
+hitting the `NoMethodError` floor.
+
+- **`send`/`__send__`/`public_send`** — the first argument names a method; the
+  dispatcher re-enters `_sir_call_method` with that name and the remaining args
+  (a trailing block survives as a trailing arg). **Security ([[dynamic-dispatch-rce]]):**
+  the dynamic name is coerced to a string and used ONLY as the key into the
+  SAME explicit catalog/switch a normal call walks — an unknown name surfaces
+  the ordinary `NoMethodError`. NEVER Go `reflect`/`MethodByName` on the
+  source-derived name.
+- **`tap`** — yields the receiver to the block and returns the RECEIVER; a
+  block-less `tap` returns the receiver (v0 Enumerator-less floor).
+- **`then`/`yield_self`** — yields the receiver and returns the BLOCK RESULT;
+  block-less returns the receiver.
+- **`respond_to?`** — true iff dispatch resolves the name, consulting the same
+  reflective / `define_method` / type-specific + universal catalog tiers a real
+  call uses (`_sir_responds_to` + per-catalog `_sir_*_responds` predicates kept
+  in lockstep with the dispatch switches). Out-of-catalog → honest `false`.
+- **Boolean `&`/`|`/`^`** on `true`/`false` — Ruby's EAGER (non-short-circuit)
+  logical operators, coercing the argument by SIR truthiness (`true & nil` is
+  `false`, `false | 0` is `true`, `^` is XOR).
+- Also filled the universal `Object` table: `inspect`, `equal?` (identity —
+  value-equal for interned primitives, pointer-equal for `*Seq`/`*Map`/
+  `*SirInstance`), `freeze`/`frozen?`, `dup`/`clone` (shallow copy of the
+  mutable handles), and `nil.to_a == []` / `Array#to_a == self`.
+- Exec-proof via `go run` (`tests/compile_and_run_m6_meta.rs`):
+  `"hello".send(:upcase)` → `HELLO`, `[1,2,3].send(:map,&blk)` → `[2,4,6]`,
+  `5.tap{…}` → `5`, `5.then{|x|x*2}` → `10`, `respond_to?` true/false honesty,
+  the boolean operators, and an unknown `send(:bogus)` failing cleanly through
+  the NoMethodError floor (no reflection).
+
+
 ## 0.13.2
 
 ### Fixed — `or`/`and` builtins (Ruby `||`/`&&`) were unimplemented

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1251,6 +1251,13 @@ func _sir_call_method(recv Value, name string, args []Value) Value {
 			defer _sir_pop_self()
 			return _sir_apply(fn, args)
 		}
+		// M6: `send`/`tap`/`then` apply to a user instance too, AFTER its own
+		// methods (so a user-defined `send`/`tap` override wins, resolution
+		// order #2).  These recurse / apply a block, so route them here before
+		// the universal Object fallback.
+		if v, ok := _sir_meta_method(recv, name, args); ok {
+			return v
+		}
 		// Universal Object methods (class/nil?/==/…) still apply to an
 		// instance; anything else is the controlled NoMethodError floor.
 		if v, ok := _sir_object_method(recv, name, args); ok {
@@ -1271,8 +1278,12 @@ func _sir_call_method(recv Value, name string, args []Value) Value {
 			return v
 		}
 	case bool:
-		// bool has no dedicated catalog here beyond the universal
-		// methods handled below; fall through.
+		// M6: `TrueClass`/`FalseClass` logical operators (`&`/`|`/`^`)
+		// resolve BEFORE the universal Object table so `true & false`
+		// runs rather than bottoming out at NoMethodError.
+		if v, ok := _sir_bool_method(r, name, args); ok {
+			return v
+		}
 	case int64, int, float64:
 		if v, ok := _sir_numeric_method(recv, name, args); ok {
 			return v
@@ -1285,6 +1296,14 @@ func _sir_call_method(recv Value, name string, args []Value) Value {
 		if v, ok := _sir_hash_method(r, name, args); ok {
 			return v
 		}
+	}
+	// M6 universal metaprogramming (`send`/`tap`/`then`/`yield_self`):
+	// dispatched AFTER the type-specific catalogs (so a catalog method of the
+	// same name wins) and BEFORE the universal Object fallback.  `send`
+	// re-enters dispatch with a dynamic name; `tap`/`then` apply a trailing
+	// block.  See `_sir_meta_method`.
+	if v, ok := _sir_meta_method(recv, name, args); ok {
+		return v
 	}
 	// Universal Object methods available on every receiver.
 	if v, ok := _sir_object_method(recv, name, args); ok {
@@ -1352,10 +1371,300 @@ func _sir_object_method(recv Value, name string, args []Value) (Value, bool) {
 		return _sir_ruby_class_name(recv), true
 	case "to_s":
 		return _sir_ruby_to_s(recv), true
+	case "inspect":
+		// Ruby `inspect` renders a debuggable form: strings are quoted,
+		// `nil`/`true`/`false` are their keywords.  `_sir_format` already
+		// produces the debug surface for collections/strings; the only
+		// divergence from `_sir_format` is booleans (`#t`/`#f` → true/false)
+		// and nil (already `nil`), so route through it after fixing bools.
+		if b, ok := recv.(bool); ok {
+			if b {
+				return "true", true
+			}
+			return "false", true
+		}
+		return _sir_format(recv), true
 	case "itself":
+		return recv, true
+	case "equal?":
+		// Ruby `equal?` is object identity.  Immutable primitives compare by
+		// value (Ruby interns them); the shared handles (`*Seq`/`*Map`/
+		// `*SirInstance`) compare by pointer identity — Go `==` on interface
+		// values does exactly this for these cases.  NEVER reflection.
+		return _sir_value_identical(recv, args[0]), true
+	case "respond_to?":
+		// M6 honesty: true iff dispatch on `recv` resolves the named method,
+		// consulting the SAME reflective/`define_method`/catalog tiers a real
+		// call uses (see `_sir_responds_to`).  The name is coerced from a
+		// Symbol/string argument and used only as a map/switch KEY — never to
+		// reflect a Go method.
+		if len(args) == 0 {
+			return false, true
+		}
+		return _sir_responds_to(recv, _sir_method_name(args[0])), true
+	case "freeze":
+		// v0 has no true immutability — identity-returning, matching Ruby's
+		// API shape (`freeze` returns the receiver).
+		return recv, true
+	case "frozen?":
+		// v0: only the always-frozen immutable primitives report frozen.
+		switch recv.(type) {
+		case nil, bool, int64, int, float64, *Symbol:
+			return true, true
+		}
+		return false, true
+	case "dup", "clone":
+		// Shallow copy for the mutable handles; primitives are their own dup.
+		switch r := recv.(type) {
+		case *Seq:
+			out := make([]Value, len(r.Items))
+			copy(out, r.Items)
+			return &Seq{Items: out}, true
+		case *Map:
+			out := make([]MapEntry, len(r.Entries))
+			copy(out, r.Entries)
+			return &Map{Entries: out}, true
+		}
+		return recv, true
+	case "to_a":
+		// Ruby: `nil.to_a == []`, `Array#to_a == self`; other receivers have
+		// no universal `to_a`, so miss and fall through to the honest floor.
+		if recv == nil {
+			return &Seq{Items: []Value{}}, true
+		}
+		if s, ok := recv.(*Seq); ok {
+			return s, true
+		}
+		return nil, false
+	case "tap":
+		// Block-less `tap` (no trailing `Closure` reached `_sir_meta_method`)
+		// still returns the receiver — Ruby's Enumerator-less v0 floor.
+		return recv, true
+	case "then", "yield_self":
+		// Block-less `then`/`yield_self` returns the receiver (v0 floor).
 		return recv, true
 	}
 	return nil, false
+}
+
+// Object identity for `equal?`.  Immutable primitives (nil/bool/int/float/
+// Symbol/string) are compared by VALUE — Ruby interns these, so two `:sym`
+// or two `5`s are the same object.  The mutable handles (`*Seq`/`*Map`/
+// `*SirInstance`/`*Closure`) are compared by POINTER identity via Go `==`
+// on the interface, which is exactly reference identity for pointer types.
+func _sir_value_identical(a Value, b Value) bool {
+	switch a.(type) {
+	case nil, bool, int64, int, float64, string, *Symbol:
+		return _sir_value_eq(a, b)
+	}
+	return a == b
+}
+
+// Coerce a `respond_to?`/`send` first argument (a `*Symbol`, a `":m"`-ish
+// string, or a bare name) to the plain method name used as the catalog key.
+// The result is used ONLY as a switch/map key — never to reflect a Go method
+// (the C3 dynamic-dispatch RCE lesson).
+func _sir_method_name(arg Value) string {
+	switch a := arg.(type) {
+	case *Symbol:
+		return a.Name
+	case string:
+		return a
+	}
+	return _sir_ruby_to_s(arg)
+}
+
+// ── M6 universal metaprogramming: send / tap / then / yield_self ───────
+//
+// These are Ruby Kernel/Object methods that apply to EVERY receiver and are
+// special because they either re-enter dispatch with a dynamic name (`send`)
+// or drive a trailing block (`tap`/`then`).  They are split out of
+// `_sir_object_method` (which is value-returning, block-unaware) because
+// `send` recurses through `_sir_call_method` and the block methods need the
+// peeled-off `*Closure`.  Dispatched by `_sir_call_method` after the
+// type-specific catalogs; a block-less `tap`/`then` MISSES here and falls
+// through to `_sir_object_method`'s receiver-identity floor.
+//
+// SECURITY (the C3 RCE lesson): `send`'s dynamic name is taken from the first
+// argument, coerced to a string by `_sir_method_name`, and handed to
+// `_sir_call_method` — the SAME explicit catalog/switch a normal call walks.
+// An unknown name therefore surfaces the ordinary NoMethodError floor.  The
+// name is NEVER used to reflect a Go method/field (no `reflect.MethodByName`).
+func _sir_meta_method(recv Value, name string, args []Value) (Value, bool) {
+	switch name {
+	case "send", "__send__", "public_send":
+		// First arg names the method; re-enter dispatch with the remaining
+		// args (a trailing block survives as a trailing arg).  An empty arg
+		// list bottoms out at the honest floor rather than raising.
+		if len(args) == 0 {
+			return nil, false
+		}
+		return _sir_call_method(recv, _sir_method_name(args[0]), args[1:]), true
+	case "tap":
+		// `tap` yields the receiver to the block and returns the RECEIVER
+		// (the "peek in a pipeline" method).  Only with a trailing block;
+		// block-less `tap` misses → `_sir_object_method` returns the receiver.
+		if _, block := _sir_split_block(args); block != nil {
+			_sir_apply(block, []Value{recv})
+			return recv, true
+		}
+		return nil, false
+	case "then", "yield_self":
+		// `then`/`yield_self` yields the receiver and returns the BLOCK RESULT
+		// (functional "pipe into a block").  Block-less → miss → floor returns
+		// the receiver.
+		if _, block := _sir_split_block(args); block != nil {
+			return _sir_apply(block, []Value{recv}), true
+		}
+		return nil, false
+	}
+	return nil, false
+}
+
+// ── M6 boolean logic: TrueClass/FalseClass `&`/`|`/`^` ─────────────────
+//
+// Ruby's `&`/`|`/`^` on a boolean are EAGER (non-short-circuiting) logical
+// operators — every operand is evaluated, unlike the lazy `&&`/`||`
+// keywords — and they coerce the argument by Ruby truthiness (`nil`/`false`
+// are falsy, everything else — `0`, `""` — is truthy).  So `true & nil` is
+// `false` and `false | 0` is `true`.  `^` is logical XOR.
+func _sir_bool_method(recv bool, name string, args []Value) (Value, bool) {
+	switch name {
+	case "&":
+		return recv && _sir_truthy(args[0]), true
+	case "|":
+		return recv || _sir_truthy(args[0]), true
+	case "^":
+		return recv != _sir_truthy(args[0]), true
+	}
+	return nil, false
+}
+
+// ── M6 respond_to? — dispatch-honest membership ────────────────────────
+//
+// Whether dispatch on `recv` resolves `name`, consulting the SAME tiers a
+// real call walks: the reflective built-ins, the user `define_method` table
+// (for a `*SirInstance`), and the type-specific + universal catalogs.  This
+// is the honest discriminator behind `respond_to?` — a catalog method → true,
+// an out-of-catalog method → false (and that call returns the NoMethodError
+// floor).  `name` is an explicit membership KEY only, never reflection.
+func _sir_responds_to(recv Value, name string) bool {
+	// Reflective built-ins the frontend/`class` support on every receiver.
+	switch name {
+	case "is_a?", "kind_of?", "instance_of?", "class":
+		return true
+	}
+	// Universal Object + M6 metaprogramming methods (every receiver).
+	if _sir_object_responds(name) {
+		return true
+	}
+	// A user instance: consult its class ancestry method table.
+	if inst, ok := recv.(*SirInstance); ok {
+		if _, found := _sir_resolve_instance_method(inst.Class, name); found {
+			return true
+		}
+		return false
+	}
+	// `nil.to_a == []` is a universal method only for the nil receiver.
+	if recv == nil && name == "to_a" {
+		return true
+	}
+	// Type-specific catalogs — mirror `_sir_call_method`'s receiver switch.
+	switch recv.(type) {
+	case string:
+		return _sir_string_responds(name)
+	case *Symbol:
+		return _sir_symbol_responds(name)
+	case bool:
+		switch name {
+		case "&", "|", "^":
+			return true
+		}
+		return false
+	case int64, int, float64:
+		return _sir_numeric_responds(name)
+	case *Seq:
+		return _sir_array_responds(name)
+	case *Map:
+		return _sir_hash_responds(name)
+	}
+	return false
+}
+
+// The universal names resolved on EVERY receiver by `_sir_object_method` +
+// `_sir_meta_method`.  Kept in lockstep with those switches.
+func _sir_object_responds(name string) bool {
+	switch name {
+	case "nil?", "==", "!=", "class", "to_s", "inspect", "itself",
+		"equal?", "respond_to?", "freeze", "frozen?", "dup", "clone",
+		"send", "__send__", "public_send", "tap", "then", "yield_self":
+		return true
+	case "to_a":
+		// `to_a` is universal only for nil/Array; the collection catalogs
+		// report it for their own receivers, so keep it out of the universal
+		// set and let the type-specific `_sir_*_responds` decide.
+		return false
+	}
+	return false
+}
+
+// The following `_sir_*_responds` predicates mirror EXACTLY the `case`
+// labels of the matching catalog switch, so `respond_to?` stays honest as
+// the catalogs grow.  They list block-taking method names too (a real call
+// resolves them when a block is present).
+func _sir_string_responds(name string) bool {
+	switch name {
+	case "length", "size", "upcase", "downcase", "reverse", "strip",
+		"lstrip", "rstrip", "empty?", "include?", "start_with?", "end_with?",
+		"split", "chars", "to_i", "to_f", "to_sym":
+		return true
+	}
+	return false
+}
+
+func _sir_symbol_responds(name string) bool {
+	switch name {
+	case "to_s", "to_sym", "length", "size", "upcase", "downcase", "empty?":
+		return true
+	}
+	return false
+}
+
+func _sir_numeric_responds(name string) bool {
+	switch name {
+	case "times", "abs", "to_i", "to_f", "even?", "odd?", "zero?",
+		"positive?", "negative?", "succ", "next", "pred":
+		return true
+	}
+	return false
+}
+
+func _sir_array_responds(name string) bool {
+	switch name {
+	// Non-block Array methods.
+	case "length", "size", "count", "first", "last", "empty?", "include?",
+		"index", "push", "append", "<<", "pop", "shift", "reverse", "sort",
+		"join", "fetch", "to_a":
+		return true
+	// Block-taking Array/Enumerable methods.
+	case "each", "map", "collect", "select", "filter", "reject", "reduce",
+		"inject", "find", "detect", "any?", "all?", "none?":
+		return true
+	}
+	return false
+}
+
+func _sir_hash_responds(name string) bool {
+	switch name {
+	// Non-block Hash methods.
+	case "keys", "values", "has_key?", "key?", "include?", "member?",
+		"has_value?", "value?", "size", "length", "empty?", "fetch":
+		return true
+	// Block-taking Hash methods.
+	case "each", "each_pair", "map", "select", "filter", "reject":
+		return true
+	}
+	return false
 }
 
 // ── Array (*Seq) catalog ───────────────────────────────────────

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1391,6 +1391,13 @@ func _sir_object_method(recv Value, name string, args []Value) (Value, bool) {
 		// value (Ruby interns them); the shared handles (`*Seq`/`*Map`/
 		// `*SirInstance`) compare by pointer identity — Go `==` on interface
 		// values does exactly this for these cases.  NEVER reflection.
+		// Arity guard: `equal?` is newly reachable with zero args via `send`
+		// (`obj.send(:equal?)`), so index `args[0]` only after checking length
+		// — Ruby raises a catchable `ArgumentError`, not a native Go panic.
+		if len(args) == 0 {
+			panic(_sir_new_error("ArgumentError",
+				Value("wrong number of arguments (given 0, expected 1)")))
+		}
 		return _sir_value_identical(recv, args[0]), true
 	case "respond_to?":
 		// M6 honesty: true iff dispatch on `recv` resolves the named method,
@@ -1529,6 +1536,16 @@ func _sir_meta_method(recv Value, name string, args []Value) (Value, bool) {
 // are falsy, everything else — `0`, `""` — is truthy).  So `true & nil` is
 // `false` and `false | 0` is `true`.  `^` is logical XOR.
 func _sir_bool_method(recv bool, name string, args []Value) (Value, bool) {
+	switch name {
+	case "&", "|", "^":
+		// Arity guard: these are newly reachable with zero args via `send`
+		// (`true.send(:&)`), so require the operand before indexing `args[0]`
+		// — Ruby raises a catchable `ArgumentError`, not a native Go panic.
+		if len(args) == 0 {
+			panic(_sir_new_error("ArgumentError",
+				Value("wrong number of arguments (given 0, expected 1)")))
+		}
+	}
 	switch name {
 	case "&":
 		return recv && _sir_truthy(args[0]), true

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_m6_meta.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_m6_meta.rs
@@ -1,0 +1,315 @@
+//! End-to-end proof for **M6 universal Object metaprogramming** in the Go
+//! backend — the Go analogue of the Python/TS `sir-runtime-oop` M6 surface
+//! (`send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`,
+//! `respond_to?`, and boolean `&`/`|`/`^`).
+//!
+//! Unit tests (`src/emit.rs` / `src/runtime.rs`) assert the runtime *carries*
+//! the M6 helpers.  This test goes the whole way: it hand-builds SIR modules
+//! that exercise the surface, emits Go, runs it under a real `go run`, and
+//! diffs stdout against the values the Ruby/Python/TS reference produce for
+//! the SAME operation:
+//!
+//!   * `"hello".send(:upcase)` re-enters dispatch → `"HELLO"`.
+//!   * `[1,2,3].send(:map, &block)` forwards the trailing block → `[2,4,6]`.
+//!   * `5.tap { … }` runs the block and returns the RECEIVER → `5`.
+//!   * `5.then { |x| x*2 }` returns the BLOCK RESULT → `10`.
+//!   * `"x".respond_to?(:upcase)` → true ; `:bogus` → false.
+//!   * `true & false` / `true | false` / `true ^ true` — eager boolean logic.
+//!
+//! A separate module proves an **unknown `send`** (`[1].send(:bogus_xyz)`)
+//! fails CLEANLY — a non-zero `go run` exit carrying the controlled
+//! "undefined method" message routed through the SAME catalog a direct call
+//! walks (the C3 dynamic-dispatch discipline: no reflection on the name).
+//!
+//! Gated on `go version`: a missing toolchain logs a skip rather than
+//! reddening the build (mirrors `compile_and_run_coll_methods.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn blit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymLit { name: name.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn var_p(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
+fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
+    let mut args = vec![recv, slit(name)];
+    args.extend(extra);
+    builtin("__method__", args)
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// One-parameter lambda `fn_name(x) -> body`, registered top-level; the caller
+/// builds a `MakeClosure` referencing it.
+fn lambda_fn(fn_name: &str, param: &str, body: Expr) -> Function {
+    Function {
+        name: fn_name.into(),
+        params: vec![semantic_ir::Param {
+            name: param.into(),
+            kind: semantic_ir::ParamKind::Required,
+            sir_type: None,
+            default: None,
+            span: s(),
+        }],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn closure(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: vec![], span: s() }
+}
+
+fn manifest() -> FeatureManifest {
+    FeatureManifest::from_features(&[
+        Feature::Closures,
+        Feature::Sequences,
+        Feature::Maps,
+        Feature::Strings,
+        Feature::Symbols,
+        Feature::MutableBindings,
+        Feature::DynamicTyping,
+    ])
+}
+
+fn program(functions: Vec<Function>) -> Module {
+    Module {
+        name: "m6_meta_demo".into(),
+        manifest: manifest(),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// The M6 demo `main`.  Each printed line's expected value is what the
+/// Ruby/Python/TS reference runtime yields for the identical operation.
+fn m6_module() -> Module {
+    // Blocks the meta methods drive.
+    let double = lambda_fn("__lam_double", "x", builtin("*", vec![var_p("x"), ilit(2)]));
+    // `tap`'s block has a side effect but its result is DISCARDED (tap returns
+    // the receiver); we make it a pure identity so it is observable only via
+    // the returned receiver.
+    let ident = lambda_fn("__lam_ident", "x", var_p("x"));
+
+    let stmts = vec![
+        // "hello".send(:upcase) → "HELLO"  (send re-enters dispatch)
+        print_stmt(method(slit("hello"), "send", vec![sym("upcase")])),
+        // "hi".__send__(:upcase) → "HI"
+        print_stmt(method(slit("hi"), "__send__", vec![sym("upcase")])),
+        // "yo".public_send(:upcase) → "YO"
+        print_stmt(method(slit("yo"), "public_send", vec![sym("upcase")])),
+        // [1,2,3].send(:map, &double) → [2, 4, 6]  (trailing block forwarded)
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(3)]),
+            "send",
+            vec![sym("map"), closure("__lam_double")],
+        )),
+        // "abc".send(:length) → 3  (send with a numeric result)
+        print_stmt(method(slit("abc"), "send", vec![sym("length")])),
+        // 5.tap { |x| x } → 5  (tap returns the RECEIVER)
+        print_stmt(method(ilit(5), "tap", vec![closure("__lam_ident")])),
+        // 5.then { |x| x*2 } → 10  (then returns the BLOCK RESULT)
+        print_stmt(method(ilit(5), "then", vec![closure("__lam_double")])),
+        // 5.yield_self { |x| x*2 } → 10  (alias of then)
+        print_stmt(method(ilit(5), "yield_self", vec![closure("__lam_double")])),
+        // 7.tap (block-less) → 7  (v0 floor: returns receiver)
+        print_stmt(method(ilit(7), "tap", vec![])),
+        // "x".respond_to?(:upcase) → #t  (catalog method)
+        print_stmt(method(slit("x"), "respond_to?", vec![sym("upcase")])),
+        // "x".respond_to?(:bogus_xyz) → #f  (out-of-catalog → honest false)
+        print_stmt(method(slit("x"), "respond_to?", vec![sym("bogus_xyz")])),
+        // [1].respond_to?(:map) → #t  (block method reported)
+        print_stmt(method(seq(vec![ilit(1)]), "respond_to?", vec![sym("map")])),
+        // 5.respond_to?(:send) → #t  (universal M6 method on every receiver)
+        print_stmt(method(ilit(5), "respond_to?", vec![sym("send")])),
+        // true & false → #f
+        print_stmt(method(blit(true), "&", vec![blit(false)])),
+        // true | false → #t
+        print_stmt(method(blit(true), "|", vec![blit(false)])),
+        // false | true → #t
+        print_stmt(method(blit(false), "|", vec![blit(true)])),
+        // true ^ true → #f
+        print_stmt(method(blit(true), "^", vec![blit(true)])),
+        // true ^ false → #t
+        print_stmt(method(blit(true), "^", vec![blit(false)])),
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![double, ident, main])
+}
+
+/// A module that `send`s an out-of-catalog method — must fail cleanly through
+/// the SAME NoMethodError floor a direct call hits (no reflection).
+fn unknown_send_module() -> Module {
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print_stmt(method(
+                seq(vec![ilit(1)]),
+                "send",
+                vec![sym("bogus_xyz")],
+            ))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    program(vec![main])
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_go(source: &str, tag: &str) -> std::process::Output {
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_m6_{tag}_{nonce}.go"));
+    std::fs::write(&src_path, source).expect("write temp source");
+    let out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    out
+}
+
+#[test]
+fn m6_metaprogramming_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&m6_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "meta");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "HELLO",     // "hello".send(:upcase)
+            "HI",        // "hi".__send__(:upcase)
+            "YO",        // "yo".public_send(:upcase)
+            "[2, 4, 6]", // [1,2,3].send(:map, &double)
+            "3",         // "abc".send(:length)
+            "5",         // 5.tap { x } → receiver
+            "10",        // 5.then { x*2 } → block result
+            "10",        // 5.yield_self { x*2 }
+            "7",         // 7.tap (block-less) → receiver
+            "#t",        // "x".respond_to?(:upcase)
+            "#f",        // "x".respond_to?(:bogus_xyz)
+            "#t",        // [1].respond_to?(:map)
+            "#t",        // 5.respond_to?(:send)
+            "#f",        // true & false
+            "#t",        // true | false
+            "#t",        // false | true
+            "#f",        // true ^ true
+            "#t",        // true ^ false
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn unknown_send_fails_cleanly() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&unknown_send_module()).expect("compiles to Go");
+    let run_out = run_go(&artifact.source, "unknown_send");
+    // A controlled failure: non-zero exit AND the "undefined method" message,
+    // routed through the SAME catalog a direct `.bogus_xyz` call walks — NOT a
+    // reflective dispatch, NOT a silent nil.
+    assert!(
+        !run_out.status.success(),
+        "unknown send must fail, not succeed; stdout: {}",
+        String::from_utf8_lossy(&run_out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&run_out.stderr);
+    assert!(
+        stderr.contains("undefined method") && stderr.contains("bogus_xyz"),
+        "expected a controlled undefined-method panic; stderr:\n{stderr}"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_m6_meta.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_m6_meta.rs
@@ -226,6 +226,59 @@ fn unknown_send_module() -> Module {
     program(vec![main])
 }
 
+// `obj.send(:equal?)` — `send` with a name but NO further args — makes the
+// universal `equal?` reachable with zero operands.  The arity guard must
+// surface a typed `ArgumentError` (Ruby's wrong-number-of-arguments) via the
+// `_sir_new_error` floor, NOT a raw Go `index out of range` panic.  (Same
+// shape as `unknown_send_fails_cleanly`: assert the controlled error message,
+// which — unlike a native runtime panic — is a `SirError` a `rescue` catches.)
+fn send_zero_arg_arity_module() -> Module {
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print_stmt(method(
+                seq(vec![ilit(1)]),
+                "send",
+                vec![sym("equal?")],
+            ))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    program(vec![main])
+}
+
+#[test]
+fn send_zero_arg_method_raises_argument_error_not_native_panic() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&send_zero_arg_arity_module()).expect("compiles to Go");
+    let run_out = run_go(&artifact.source, "send_zero_arg");
+    assert!(
+        !run_out.status.success(),
+        "zero-arg send(:equal?) must raise, not succeed; stdout: {}",
+        String::from_utf8_lossy(&run_out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&run_out.stderr);
+    // The typed ArgumentError floor, NOT a raw Go slice panic.
+    assert!(
+        stderr.contains("ArgumentError") && stderr.contains("wrong number of arguments"),
+        "expected a typed ArgumentError; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("index out of range"),
+        "the arity guard must prevent a native index-out-of-range panic; stderr:\n{stderr}"
+    );
+}
+
 fn go_available() -> bool {
     Command::new("go")
         .arg("version")


### PR DESCRIPTION
Parity-fill: M6 (universal Object metaprogramming) is merged in Python+TS; this ports the same surface to the **Go** backend — completing M6 across all 5 backends. Runtime-only — `semantic-ir-to-go`.

Adds to the Go OOP runtime `_sir_call_method` (via `_sir_meta_method`/`_sir_bool_method`/`_sir_responds_to`):
- `send`/`__send__`/`public_send` — first arg names a method; **re-enters `_sir_call_method`** with it + remaining args (block forwarded).
- `tap` → runs block, returns receiver; `then`/`yield_self` → block result (block-less → receiver).
- `respond_to?` → honest membership across the same catalog/`define_method`/reflective tiers a real call uses.
- boolean `&`/`|`/`^` on bool receivers; plus universal `inspect`/`equal?`/`freeze`/`frozen?`/`dup`/`clone`.

**Security ([[dynamic-dispatch-rce]]) — review PASSED (send surface clean), 2 LOW fixed:** the `send` name is only a `switch`/map key into the same explicit dispatch (no `reflect`/`MethodByName`; unknown → typed `NoMethodError`); recursion terminates (args shrink per hop). Review found `equal?` and boolean `&`/`|`/`^` indexed `args[0]` unguarded — newly reachable with **zero args** via `send` (`obj.send(:equal?)`) as a raw Go index-out-of-range panic. **Fixed:** both arity-guard and raise a typed `ArgumentError` (Ruby's wrong-number-of-arguments). Regression `send_zero_arg_method_raises_argument_error_not_native_panic` added.

Exec-proofed via `go run`. 97 unit + all integration green (Scope warning pre-existing in an untouched test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)