### PR TITLE
[codex] Expand post-parse repair audit evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py
+++ b/code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py
@@ -21,6 +21,14 @@ DEFAULT_OUTPUT = FIXTURE_DIR / "whatwg-post-parse-repair-audit.json"
 
 CASE_GROUPS = (
     {
+        "axis": "adoption-table-foster-parenting",
+        "reason": (
+            "remaining repair evidence for adoption-agency formatting inside "
+            "table foster-parenting recovery"
+        ),
+        "sources": ("adoption01.dat:6",),
+    },
+    {
         "axis": "fostered-nobr-cell-continuation",
         "reason": (
             "remaining finish-time recovery for fostered nobr continuation "
@@ -38,6 +46,22 @@ CASE_GROUPS = (
             "nested table sequence"
         ),
         "sources": ("tricky01.dat:8",),
+    },
+    {
+        "axis": "tricky-center-table-void-recovery",
+        "reason": (
+            "remaining repair evidence for center, font, and void-element "
+            "recovery through table cell insertion modes"
+        ),
+        "sources": ("tricky01.dat:6",),
+    },
+    {
+        "axis": "tricky-paragraph-rowgroup-recovery",
+        "reason": (
+            "remaining repair evidence for paragraph and anchor recovery "
+            "crossing table row-group insertion modes"
+        ),
+        "sources": ("tricky01.dat:7",),
     },
 )
 
@@ -124,7 +148,8 @@ def build_fixture(sources: list[str]) -> dict[str, object]:
         "format": "whatwg-html-post-parse-repair-audit/v1",
         "description": (
             "Focused parser audit over the remaining html5lib tree-construction "
-            "cases that justify finish-time post-parse repair shims."
+            "cases that justify post-parse repair shims or adjacent repair "
+            "coverage."
         ),
         "source_fixture": "html5lib-tree-construction-smoke.dat",
         "case_count": len(selected),

--- a/code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json
+++ b/code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json
@@ -1,6 +1,12 @@
 {
-  "case_count": 3,
+  "case_count": 6,
   "cases": [
+    {
+      "axis": "adoption-table-foster-parenting",
+      "id": "adoption01-dat-6",
+      "reason": "remaining repair evidence for adoption-agency formatting inside table foster-parenting recovery",
+      "source": "adoption01.dat:6"
+    },
     {
       "axis": "fostered-nobr-cell-continuation",
       "id": "tests26-dat-1251",
@@ -14,6 +20,18 @@
       "source": "tests26.dat:4"
     },
     {
+      "axis": "tricky-center-table-void-recovery",
+      "id": "tricky01-dat-6",
+      "reason": "remaining repair evidence for center, font, and void-element recovery through table cell insertion modes",
+      "source": "tricky01.dat:6"
+    },
+    {
+      "axis": "tricky-paragraph-rowgroup-recovery",
+      "id": "tricky01-dat-7",
+      "reason": "remaining repair evidence for paragraph and anchor recovery crossing table row-group insertion modes",
+      "source": "tricky01.dat:7"
+    },
+    {
       "axis": "insanely-badly-nested-table-sequence",
       "id": "tricky01-dat-8",
       "reason": "remaining finish-time recovery for html5lib's insanely badly nested table sequence",
@@ -21,10 +39,13 @@
     }
   ],
   "counts_by_axis": {
+    "adoption-table-foster-parenting": 1,
     "fostered-nobr-cell-continuation": 2,
-    "insanely-badly-nested-table-sequence": 1
+    "insanely-badly-nested-table-sequence": 1,
+    "tricky-center-table-void-recovery": 1,
+    "tricky-paragraph-rowgroup-recovery": 1
   },
-  "description": "Focused parser audit over the remaining html5lib tree-construction cases that justify finish-time post-parse repair shims.",
+  "description": "Focused parser audit over the remaining html5lib tree-construction cases that justify post-parse repair shims or adjacent repair coverage.",
   "format": "whatwg-html-post-parse-repair-audit/v1",
   "source_fixture": "html5lib-tree-construction-smoke.dat"
 }

--- a/code/packages/rust/html-parser/tests/whatwg_post_parse_repair_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_post_parse_repair_audit_test.rs
@@ -17,6 +17,12 @@ struct PostParseRepairEvidence {
 
 const POST_PARSE_REPAIR_EVIDENCE: &[PostParseRepairEvidence] = &[
     PostParseRepairEvidence {
+        id: "adoption01-dat-6",
+        source: "adoption01.dat:6",
+        axis: "adoption-table-foster-parenting",
+        data_snippet: "<table><a>1<p>2</a>3</p>",
+    },
+    PostParseRepairEvidence {
         id: "tests26-dat-4",
         source: "tests26.dat:4",
         axis: "fostered-nobr-cell-continuation",
@@ -33,6 +39,18 @@ const POST_PARSE_REPAIR_EVIDENCE: &[PostParseRepairEvidence] = &[
         source: "tricky01.dat:8",
         axis: "insanely-badly-nested-table-sequence",
         data_snippet: "This page contains an insanely badly-nested tag sequence.",
+    },
+    PostParseRepairEvidence {
+        id: "tricky01-dat-6",
+        source: "tricky01.dat:6",
+        axis: "tricky-center-table-void-recovery",
+        data_snippet: "<table><center> <font>a</center> <img> <tr><td> </td> </tr> </table>",
+    },
+    PostParseRepairEvidence {
+        id: "tricky01-dat-7",
+        source: "tricky01.dat:7",
+        axis: "tricky-paragraph-rowgroup-recovery",
+        data_snippet: "<table><tr><p><a><p>You should see this text.",
     },
 ];
 
@@ -62,9 +80,12 @@ fn whatwg_post_parse_repair_audit_fixture_parses() {
     assert_eq!(suite.source_fixture, "html5lib-tree-construction-smoke.dat");
     assert!(!suite.description.is_empty());
     assert_eq!(suite.case_count, suite.cases.len());
-    assert_eq!(suite.case_count, 3);
+    assert_eq!(suite.case_count, 6);
+    assert_axis_count(&suite, "adoption-table-foster-parenting", 1);
     assert_axis_count(&suite, "fostered-nobr-cell-continuation", 2);
     assert_axis_count(&suite, "insanely-badly-nested-table-sequence", 1);
+    assert_axis_count(&suite, "tricky-center-table-void-recovery", 1);
+    assert_axis_count(&suite, "tricky-paragraph-rowgroup-recovery", 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expand the WHATWG post-parse repair audit from 3 to 6 executable html5lib repair rows
- add adoption/table foster-parenting plus tricky table recovery axes to the generator
- pin the new evidence rows in the Rust DOM-dump replay test

## Validation
- cargo test -p coding-adventures-html-parser whatwg_post_parse_repair_audit
- cargo test -p coding-adventures-html-parser whatwg_character_reference_audit_keeps_character_reference_axis_cases_cross_axis
- cargo test -p coding-adventures-html-parser whatwg_character_reference_audit
- cargo test -p coding-adventures-html-parser
- CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null
- python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json >/dev/null
- python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py --check
- python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check
- python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py
- python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py
- git diff --check