### PR TITLE
fix(sir-rust): arr[i] returns nil OOB + fetch(non-int) raises TypeError (#66, #67)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -818,12 +818,20 @@ pub const RUNTIME: &str = r##"mod __sir {
     pub fn seq_index(seq: &Value, index: &Value) -> Value {
         match seq {
             Value::Seq(items) => {
-                let i = as_i64(index);
+                let raw = as_i64(index);
                 let items = items.borrow();
-                if i < 0 || (i as usize) >= items.len() {
-                    panic!("sequence index out of range: {} (len {})", i, items.len());
+                let len = items.len() as i64;
+                // Ruby `arr[i]` (the `[]` op, NOT `arr.fetch(i)`): a negative
+                // index counts from the end (`-1` ⇒ last); an index still
+                // outside `0 .. len-1` returns `nil` — it does NOT raise (only
+                // `fetch` raises IndexError).  Previously this panicked on any
+                // OOB, diverging from Ruby and the other backends.
+                let idx = if raw < 0 { raw + len } else { raw };
+                if idx < 0 || idx >= len {
+                    Value::Nil
+                } else {
+                    items[idx as usize].clone()
                 }
-                items[i as usize].clone()
             }
             other => panic!("seq-index on non-sequence: {}", format(other)),
         }
@@ -1535,6 +1543,20 @@ pub const RUNTIME: &str = r##"mod __sir {
             // matches.  A supplied default arg (`fetch(i, default)`) is
             // returned instead of raising, matching Ruby.
             "fetch" => {
+                // Ruby `Array#fetch`: a non-integer index raises a catchable
+                // `TypeError` ("no implicit conversion of X into Integer"),
+                // matching Ruby — NOT the uncatchable `as_i64` "expected int"
+                // panic.  Checked before borrowing so no borrow is held across
+                // the raise/unwind.
+                if !matches!(pos.first(), Some(Value::Int(_))) {
+                    let cls = ruby_class_name(pos.first().unwrap_or(&Value::Nil));
+                    raise(
+                        "TypeError",
+                        Value::Str(Rc::from(
+                            format!("no implicit conversion of {} into Integer", cls).as_str(),
+                        )),
+                    );
+                }
                 let items = items_rc.borrow();
                 let len = items.len() as i64;
                 let raw = as_i64(pos.first().unwrap_or(&Value::Nil));

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_typed_runtime_errors.rs
@@ -292,6 +292,52 @@ fn lenient_index_reads_return_nil_no_overraise() {
     );
 }
 
+/// #66 — the SIR-native `SeqIndex` primitive (`arr[i]`, distinct from the OO
+/// `[]` method) must ALSO return nil out of bounds and let a negative index
+/// count from the end — it previously panicked on any OOB.  Prints
+/// `nil` / last / first / `nil` / in-range and exits 0.
+#[test]
+fn native_seq_index_out_of_bounds_returns_nil_and_negatives_wrap() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let arr = || seq(vec![ilit(10), ilit(20), ilit(30)]);
+    let at = |i: i64| Expr::SeqIndex {
+        seq: Box::new(arr()),
+        index: Box::new(ilit(i)),
+        span: s(),
+    };
+    let stmts = vec![
+        print_stmt(at(5)),  // OOB high → nil
+        print_stmt(at(-1)), // last     → 30
+        print_stmt(at(-3)), // first    → 10
+        print_stmt(at(-9)), // OOB low  → nil
+        print_stmt(at(1)),  // in range → 20
+    ];
+    let src = compile(&module_from_main(stmts, &[])).expect("compile").source;
+    let Some((stdout, ok)) = compile_and_run(&src, "native_seq_index_nil") else { return };
+    assert!(ok, "arr[oob] must not panic (exit 0); stdout={stdout:?}");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec!["nil", "30", "10", "nil", "20"],
+        "native SeqIndex OOB/negative handling wrong; got {stdout:?}"
+    );
+}
+
+/// #67 — `[1, 2].fetch("x")` (non-integer index) raises a catchable `TypeError`
+/// ("no implicit conversion of String into Integer") → caught → `8`, instead of
+/// the uncatchable `as_i64` "expected int" panic.
+#[test]
+fn array_fetch_non_integer_index_raises_type_error() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let fault = method(seq(vec![ilit(1), ilit(2)]), "fetch", vec![slit("x")]);
+    assert_typed_rescue_catches(fault, "TypeError", 8, "fetch_non_int_type_error");
+}
+
 /// `fetch` WITH a default arg does not raise: `[1].fetch(9, 42)` → `42`, and
 /// `{}.fetch("k", 42)` → `42`.  Confirms we do not over-raise when Ruby would
 /// return the default.


### PR DESCRIPTION
Rust-backend half of the index/`fetch` parity fixes ([Go in #7646](https://github.com/adhithyan15/coding-adventures/pull/7646)). Runtime-only. Discovered Rust's native `seq_index` had the **same** `arr[oob]` panic bug as Go — not just the documented Go one — so this fixes it there too.

- **#66** — `seq_index` (the SIR-native `arr[i]` primitive) previously **panicked** on any OOB and ignored negative indices. Now a negative index counts from the end and an index still outside `0..len-1` returns **nil** (Ruby `[]` never raises — only `fetch` does). (`seq_set`/`[]=` kept strict — auto-grow is a separate feature.)
- **#67** — `arr.fetch("x")` (non-integer index) hit the uncatchable `as_i64` "expected int" panic. Now raises a typed, catchable **`TypeError`** ("no implicit conversion of String into Integer") via a `matches!(pos.first(), Some(Int))` guard checked **before** `.borrow()` (nothing held across the raise/unwind).

Security review: **PASSED** — negative-index arithmetic can't overflow into an OOB read (bounds check precedes the `as usize` cast), no RefCell borrow held across the unwind, TypeError name is a fixed literal, no `unsafe`/reflection; strictly reduces panics.

Exec-proofed via rustc: native `SeqIndex` OOB/negative→nil/element; `fetch("x")`→`TypeError` caught by `rescue`. 123 lib + all exec suites green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)