### PR TITLE
feat(latex): LTXDOC03 S3 — target → NodeRef exposure

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.39.0] — 2026-07-06
+
+### Added — cross-reference resolution: target → `NodeRef` exposure (LTXDOC03 S3)
+
+The natural depth-add on S1+S2. Both prior slices bound each `\ref`/`\cite` to the **bytes** of its
+target (a `Span`) but not the target **node** itself. S3 exposes the actual walked `NodeRef` for a
+resolved reference/citation (and for a label/bib definition), so a consumer can read the target's
+`kind()` and — for a `Block` — descend into its children (a `\ref` to a section can now enumerate the
+section's paragraphs; a `\ref` to a figure can reach its caption). No new parsing, numbering, or I/O
+— pure, additive analysis over the existing `Document::walk`.
+
+- **New load-bearing primitive:** `Document::node_for_span(&self, span: Span) -> Option<NodeRef<'_>>`
+  — returns the walked body node whose span **exactly equals** `span` (half-open equality of *both*
+  `start` and `end`), or `None` if no walked node matches. This is *equality*, not *containment*
+  (containment is `node_at`'s job, S4): a resolved S1/S2 target span is, by construction, some walked
+  node's own span, so equality is the correct predicate. O(nodes) — one reuse of the bounded `walk`,
+  no new recursion, panic-free.
+- **Ergonomic accessors (take a resolved record, return the node):**
+  `Document::ref_target_node(&self, r: &ResolvedRef)`, `Document::cite_target_node(&self, c:
+  &ResolvedCite)`, and `Document::label_def_node(&self, d: &LabelDef)` — each a thin wrapper over
+  `node_for_span`. The caller never hand-threads spans.
+- **Purely additive — S1/S2 result types unchanged.** `ResolvedRef`/`ResolvedCite`/`LabelDef`/… still
+  carry only owned `Span`s (no lifetimes), so a resolution still outlives any borrow of the source;
+  the `NodeRef` is fetched **on demand** through these `Document` methods (a `NodeRef` borrows the
+  doc, so it cannot live on the owned result types). A regression test asserts calling the S3
+  accessors leaves the S1/S2 resolutions byte-for-byte identical.
+- **Reachability — verified, not assumed.** An exploratory parse confirmed **every** S1/S2 target
+  span corresponds to **exactly one** walked node (zero identical-span collisions among walked nodes):
+  a `\ref`→section/figure/table yields the `NodeRef::Block` (kind `"Section"`/`"Figure"`/`"Table"`);
+  an inline `\eqref`→`\label` yields the `NodeRef::Inline` (kind `"CrossRef"`); and — the one
+  genuinely uncertain case — a `\cite`→`\bibitem` **is** reachable: the `\bibitem` inside a
+  `thebibliography` `Block::Environment` survives D2 as an `Inline::Raw` command inside a
+  `Block::Paragraph`, which `walk` visits, so `cite_target_node` returns `Some(NodeRef::Inline)` (kind
+  `"Raw"`), **not** `None`.
+- **`None` is a documented, total outcome.** `node_for_span` returns `None` for any span that is not
+  some walked body node's own span — an empty document, a preamble/metadata region (deliberately not
+  walked), or a fabricated span between nodes — never a panic. Because every *resolved* target is a
+  walked node, the accessors never return `None` for a genuine reference/citation in a well-formed
+  document; `None` is reserved for the honest edge.
+- **Tie-break (defensive, does not fire in practice).** If two walked nodes ever shared an identical
+  span, `node_for_span` returns the **first in pre-order** (the outermost/earliest). No real target
+  hits this — it is documented for determinism, not because callers reach it.
+- **9 new tests** (all `#[cfg(test)]`, load-bearing — assert the NODE, not just `is_some`): a
+  `\ref`→section returns the real `Block::Section` and we descend into its title + owned paragraph; a
+  `\ref`→figure reaches its caption text; an inline `\eqref` returns the `CrossRef` inline
+  span-matching `\label{eq:x}`; a `\cite`→`\bibitem` returns the walked `Inline::Raw` slicing back to
+  exactly `\bibitem{key}`; `label_def_node` returns the defining node; a non-matching span → `None`
+  (no panic); `node_for_span(target_span)` agrees with `ref_target_node`; empty-document lookups →
+  `None`; and the S1/S2-unchanged additivity regression.
+- **Out of scope (future rungs):** citation/reference *numbering* and *external BibTeX* remain
+  deferred, as in S1/S2.
+
 ## [0.38.0] — 2026-07-06
 
 ### Added — cross-reference resolution: `\cite` → bibliography binding (LTXDOC03 S2)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -50,6 +50,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC02 S5 — precise byte-coverage capstone (arc COMPLETE)** | the capstone `capstone_every_body_byte_resolves_to_tightest_covering_node` proves, over the same LTXDOC01 D6 representative corpus, that **every** non-whitespace body byte (a) resolves (`node_at(b).is_some()`) AND (b) resolves to the **tightest-covering** walked node — no *other* walked node whose span is a strict subset also contains the byte. Honest, not overclaimed: the load-bearing gate is tightest-covering, **not** "always a `Text` leaf" — structural bytes (`\section`/`\item`/`\begin{…}` machinery, inter-child delimiters) legitimately resolve to their enclosing composite, which is the tightest cover there (a soft signal records that the *majority* of content bytes still land on leaves). No `node_at`/parser/fold logic change (S1–S4 already made spans precise + `node_at` leaf-resolving); pure test rung. Corpus fixed/bounded ⇒ O(len), not a DoS. **Completes the LTXDOC02 precise-per-token-spans arc.** | ✅ |
 | **LTXDOC03 S1 — cross-reference resolution (label table + `\ref` binding)** | `Document::resolve_references() -> ReferenceResolution` — a pure, additive pass (no parser/fold/`walk`/`node_at`/span change) that binds each cross-reference to the `\label` that defines it, **with byte spans on both sides**. Collects the label table from hoisted section/table/figure labels (`Block::…{ label: Some(k) }`) and inline `\label{k}` (`Inline::CrossRef`); resolves the reference family `{ref, eqref, pageref}` against it → `ResolvedRef` (ref-span **and** target def-span + `LabelKind`) or `UnresolvedRef` (dangling key + ref-span); reports `Duplicate` keys with **first-def-wins**. `\cite` is a separate table, bound by S2. The static analogue of LaTeX's two-pass `.aux` machinery, binding *structure* not numbers/pages. Total & panic-free, reuses the bounded `walk` (no new recursion). | ✅ |
 | **LTXDOC03 S2 — `\cite` → bibliography binding** | `Document::resolve_citations() -> CitationResolution` — the *parallel* pass to S1 for the **citation** family, binding each `\cite` key to the `\bibitem` that defines it, **with byte spans on both sides**. Collects the bibliography table from every `\bibitem{k}` inside a `thebibliography` environment (`BibEntry { key, span }`, span = the tight `\bibitem{k}` construct), first-entry-wins with `DuplicateBib`; then, for each `\cite` (the `CITE_COMMAND` family), splits `target` on commas into individual trimmed keys and resolves each → `ResolvedCite` (the shared `\cite` `cite_span` **and** the entry's `entry_span`) or `UnresolvedCite` (dangling key + `cite_span`). A multi-key `\cite{a,b,c}` yields one record **per key**, all sharing that `\cite`'s span; `\cite[note]{k}` keeps the note out of the key. External `.bib`/BibTeX databases and citation numbering stay out of scope (in-document `thebibliography` only). Disjoint from and non-interfering with S1. Total & panic-free, reuses the bounded `walk` + a `MAX_DEPTH`-bounded env descent. | ✅ |
+| **LTXDOC03 S3 — target → `NodeRef` exposure** | The depth-add on S1+S2: both bound each target's **bytes** (a `Span`) but not the target **node**. `Document::node_for_span(span) -> Option<NodeRef>` returns the walked body node whose span **exactly equals** `span` (half-open equality of start **and** end; *equality*, not `node_at`'s containment) — or `None` for a span that is no walked node's own (empty doc, un-walked preamble/metadata, fabricated span). Thin accessors `ref_target_node(&ResolvedRef)`, `cite_target_node(&ResolvedCite)`, `label_def_node(&LabelDef)` take a resolved record and hand back the node, so a caller can read its `kind()` and — for a `Block` — descend into its children (a `\ref`→section enumerates its paragraphs; a `\ref`→figure reaches its caption). **Verified reachability:** every S1/S2 target span matches exactly one walked node (zero collisions); a `\ref`→section/figure/table yields a `NodeRef::Block`, an inline `\eqref`→`\label` a `NodeRef::Inline` (`CrossRef`), and — the once-uncertain case — a `\cite`→`\bibitem` **is** walked (an `Inline::Raw` inside the `thebibliography`), so `cite_target_node` returns `Some`, not `None`. Purely additive (S1/S2 result types keep owned `Span`s, no lifetimes; the `NodeRef` is fetched on demand); tie-break = first-in-pre-order (defensive, does not fire). Numbering + external BibTeX remain out of scope. Total & panic-free, reuses the bounded `walk`. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -74,8 +75,12 @@ duplicate and dangling references. **S2 ships `\cite` → bibliography binding**
 (`Document::resolve_citations`) — the parallel pass that binds each `\cite` key to the `\bibitem`
 inside a `thebibliography` environment, multi-key `\cite{a,b,c}` aware (one binding per key, all
 sharing the `\cite` span), first-entry-wins for duplicate `\bibitem`s, and dangling `\cite`s
-reported. External `.bib`/BibTeX databases and citation numbering remain out of scope (in-document
-`thebibliography` only).
+reported. **S3 lifts both bindings from bytes to nodes** (`Document::node_for_span` +
+`ref_target_node`/`cite_target_node`/`label_def_node`) — given a resolved reference/citation, hand
+back the actual walked `NodeRef` so a consumer can read its `kind()` and descend into a `Block`'s
+children (a verified reachability check confirmed every target — including the `\cite`→`\bibitem`
+inside `thebibliography` — is a walked node). External `.bib`/BibTeX databases and citation numbering
+remain out of scope (in-document `thebibliography` only).
 
 ## The Document layer (LTXDOC01)
 
@@ -271,6 +276,44 @@ one `\cite` span); `\cite[note]{k}` keeps the `[note]` out of the key; a duplica
 `DuplicateBib` with **first-entry-wins**. Only an **in-document** `thebibliography`/`\bibitem`
 bibliography is bound — an external `.bib`/BibTeX database and citation numbering/sorting stay out of
 scope (a `\cite` whose key lives only in a `.bib` is reported unresolved here).
+
+### Target → `NodeRef` exposure (LTXDOC03 S3)
+
+S1/S2 bind each target's **bytes** (a `Span`); S3 hands back the actual target **node**, so a
+consumer can read its `kind()` and — for a `Block` — descend into its children. The primitive is
+`Document::node_for_span(span)` (the walked node whose span **exactly equals** `span`, else `None`);
+the ergonomic accessors take a resolved record and return its node.
+
+```rust
+use latex::{parse_document, NodeRef, Block};
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+First paragraph. See Section~\ref{sec:intro}.\end{document}";
+let doc = parse_document(src).unwrap();
+let refs = doc.resolve_references();
+
+// S1 bound the ref's *bytes*; S3 hands back the *node*.
+let r = &refs.resolved[0];
+let node = doc.ref_target_node(r).expect("the resolved target is a walked node");
+assert_eq!(node.kind(), "Section");
+
+// It is the REAL section block — descend into the paragraphs it owns.
+if let NodeRef::Block(Block::Section { body, .. }) = node {
+    assert!(body.iter().any(|b| matches!(b, Block::Paragraph(..))));
+}
+
+// A span that is no walked node's own → `None` (never a panic).
+assert!(doc.node_for_span(latex::Span::new(9000, 9001)).is_none());
+```
+
+`cite_target_node(&ResolvedCite)` returns the `\bibitem` node (an `Inline::Raw`, kind `"Raw"` — the
+bibitem inside `thebibliography` **is** walked) and `label_def_node(&LabelDef)` returns a
+definition's node. Every S1/S2 target span matches exactly one walked node, so these return `Some`
+for any genuine reference/citation; `None` is reserved for the honest edge (empty docs, un-walked
+preamble/metadata, fabricated spans). The lookup is span-**equality** (not `node_at`'s containment),
+with a first-in-pre-order tie-break that no real target hits. The S1/S2 result types are unchanged
+(they keep owned `Span`s) — the `NodeRef` is fetched on demand, so S3 is purely additive.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -745,6 +745,140 @@ fn resolve_cites(
     (resolved, unresolved)
 }
 
+// =================================================================================================
+// LTXDOC03 S3 — target → NodeRef exposure.
+//
+// S1 bound each `\ref` to the *bytes* of its `\label`'s node (a [`Span`]); S2 bound each `\cite` to
+// the *bytes* of its `\bibitem`'s node. Both hand back a [`Span`] — a source-byte range you can
+// slice — but **not** the node itself. So a consumer that resolves `\ref{sec:intro}` learns *where*
+// the section is in the source, yet cannot ask "what *kind* of node is this?" or "walk into the
+// section's paragraphs". S3 closes that gap: given a resolved target's [`Span`], it hands back the
+// actual walked [`NodeRef`], so the caller can read its [`kind`](NodeRef::kind) and — for a
+// [`NodeRef::Block`] — descend into its children (a `\ref` to a section can now enumerate the
+// section's paragraphs; a `\ref` to a figure can reach its caption text).
+//
+// ## The lookup: span-equality against the body walk
+//
+// The primitive is [`Document::node_for_span`]: it walks the body ([`Document::walk`], pre-order) and
+// returns the node whose [`span`](NodeRef::span) **exactly equals** the requested one — half-open
+// equality of *both* `start` and `end`. This is deliberately *equality*, not *containment*: a
+// resolved target's span is, by construction, some walked node's own span (S1 recorded a block's or
+// cross-ref's span; S2 recorded a `\bibitem`'s `Inline::Raw` span), so the node we want is the one
+// that *is* that span, not merely one that *encloses* it. (Containment is [`Document::node_at`]'s job,
+// S4 — a different question: "which leaf owns this arbitrary byte?".)
+//
+// ## Reachability — which targets yield a node, which yield `None`
+//
+// The exploratory parse (recorded in the S3 spec) confirmed that **every** S1/S2 target span
+// corresponds to **exactly one** walked node — there were *zero* pairs of distinct walked nodes
+// sharing an identical span — so the lookup is unambiguous in practice:
+//
+// | target | walked node it resolves to | reachable? |
+// |--------|----------------------------|------------|
+// | `\ref`→`\section` (hoisted label) | the [`Block::Section`] | **yes** ([`NodeRef::Block`], kind `"Section"`) |
+// | `\ref`→`figure` float | the [`Block::Figure`] | **yes** (kind `"Figure"`) |
+// | `\ref`→`table` float | the [`Block::Table`] | **yes** (kind `"Table"`) |
+// | `\eqref`→ inline `\label` | the [`Inline::CrossRef`] | **yes** ([`NodeRef::Inline`], kind `"CrossRef"`) |
+// | `\cite`→`\bibitem` | the [`Inline::Raw`] `\bibitem` command | **yes** (kind `"Raw"`) — see below |
+//
+// **The `\bibitem` target *is* walked.** A `\bibitem{key}` sits inside a `thebibliography`
+// [`Block::Environment`], whose body [`Document::walk`] descends into; the `\bibitem` survives D2 as an
+// [`Inline::Raw`] command inside a [`Block::Paragraph`], which `walk` visits. So its span **does**
+// match a walked node and [`Document::cite_target_node`] returns `Some(NodeRef::Inline(..))` (kind
+// `"Raw"`), *not* `None`. (This was the one genuinely uncertain case — bibitems could have lived in a
+// non-walked region — so it was verified rather than assumed.)
+//
+// **When `None` is returned.** `node_for_span` returns `None` for any span that is *not* some walked
+// body node's own span: a span from an empty document, a preamble/metadata span (those regions are
+// classified out of directives and deliberately **not** walked — see [`Document::walk`]), or any
+// caller-fabricated span that lands between nodes. This is a *documented, total* outcome — never a
+// panic — so a caller can treat "no node" as an ordinary result. Because every S1/S2 *resolved*
+// target span is a walked node's span, the accessors below never return `None` for a genuinely
+// resolved reference/citation in a well-formed document; `None` is reserved for the honest edge
+// (fabricated spans, empty docs).
+//
+// ## Tie-break (defensive, does not fire in practice)
+//
+// If two walked nodes ever shared an identical span, `node_for_span` returns the **first in pre-order**
+// — the outermost/earliest, since `walk` yields a parent before its children and an earlier sibling
+// before a later one. The exploratory parse found no such collision for real targets, so this rule is
+// a defensive tie-break for totality, not a behaviour real callers hit; it is documented so the choice
+// is deterministic rather than incidental.
+//
+// ## Additivity, borrowing, and bounds
+//
+// S3 is **purely additive**: the S1/S2 result types ([`ResolvedRef`], [`ResolvedCite`], [`LabelDef`],
+// [`BibEntry`], …) are **unchanged** — they still carry only owned [`Span`]s (no lifetimes), so a
+// resolution still outlives any borrow of the source. The [`NodeRef`] is fetched *on demand* through
+// these [`Document`] methods (a `NodeRef` borrows the doc, so it cannot live on the owned result
+// types). Each lookup is O(nodes) — one reuse of the bounded [`Document::walk`] — introducing no new
+// recursion, no allocation beyond `walk`'s own vector, and no panic (no `unwrap`/`expect`, no unchecked
+// indexing).
+// =================================================================================================
+
+impl Document {
+    /// The walked body node whose [`span`](NodeRef::span) **exactly equals** `span` (half-open
+    /// equality of *both* `start` and `end`), or `None` if no walked node matches (LTXDOC03 S3).
+    ///
+    /// This is the load-bearing primitive under S3's ergonomic accessors ([`ref_target_node`],
+    /// [`cite_target_node`], [`label_def_node`]). It answers "**which node** *is* these bytes?" —
+    /// distinct from [`node_at`](Document::node_at)'s "which leaf *contains* this byte?" (containment,
+    /// S4). A resolved S1/S2 target span is, by construction, some walked node's own span, so equality
+    /// is the right predicate here.
+    ///
+    /// **Reachability & `None`.** Every S1/S2 *resolved* target — a section/table/figure block, an
+    /// inline `\label`, or a `\bibitem` [`Inline::Raw`] — is a walked body node, so this returns
+    /// `Some` for them. It returns `None` for a span that is not any walked node's own span: an empty
+    /// document, a preamble/metadata region (not walked — see [`walk`](Document::walk)), or a
+    /// fabricated span between nodes. `None` is an ordinary, documented result, never a panic.
+    ///
+    /// **Tie-break.** If two walked nodes ever shared an identical span (none do for real targets —
+    /// the exploratory parse found zero collisions), the **first in pre-order** wins (the outermost /
+    /// earliest, since `walk` yields parents before children and earlier siblings first).
+    ///
+    /// **Total, O(nodes), panic-free.** One reuse of the bounded [`walk`](Document::walk) — no new
+    /// recursion, no `unwrap`/`expect`, no unchecked indexing.
+    pub fn node_for_span(&self, span: Span) -> Option<NodeRef<'_>> {
+        // `find` yields the first (pre-order) node whose span equals `span` — the documented
+        // tie-break — and short-circuits once found.
+        self.walk().find(|node| node.span() == span)
+    }
+
+    /// The actual target **node** a resolved reference points at (LTXDOC03 S3) — the section, figure,
+    /// table, or inline `\label` [`NodeRef`] whose span is `r.target_span`, or `None` if that span is
+    /// not a walked node (it always is for a genuinely [`ResolvedRef`], so `None` is the honest edge —
+    /// see [`node_for_span`](Document::node_for_span)).
+    ///
+    /// This lifts S1's byte-level binding to a node-level one: from `r.target_span` (the target's
+    /// *bytes*) to the target *node*, so the caller can read its [`kind`](NodeRef::kind) and, for a
+    /// [`NodeRef::Block`], descend into its children — e.g. `ref_target_node` for a `\ref{sec:intro}`
+    /// yields the [`Block::Section`], from which one can enumerate the section's paragraphs.
+    pub fn ref_target_node(&self, r: &ResolvedRef) -> Option<NodeRef<'_>> {
+        self.node_for_span(r.target_span)
+    }
+
+    /// The actual target **node** a resolved citation points at (LTXDOC03 S3) — the `\bibitem`
+    /// [`Inline::Raw`] [`NodeRef`] (kind `"Raw"`) whose span is `c.entry_span`, or `None` if that span
+    /// is not a walked node (it always is for a genuinely [`ResolvedCite`] — the `\bibitem` inside a
+    /// `thebibliography` *is* walked, as the exploratory parse confirmed — so `None` is the honest
+    /// edge).
+    ///
+    /// This lifts S2's byte-level binding to a node-level one: from `c.entry_span` (the entry's
+    /// *bytes*) to the `\bibitem` node itself.
+    pub fn cite_target_node(&self, c: &ResolvedCite) -> Option<NodeRef<'_>> {
+        self.node_for_span(c.entry_span)
+    }
+
+    /// The defining **node** of a label definition (LTXDOC03 S3) — the section/table/figure
+    /// [`NodeRef::Block`] or inline `\label` [`NodeRef::Inline`] whose span is `d.span`, or `None` if
+    /// that span is not a walked node (it always is for a genuine [`LabelDef`], so `None` is the honest
+    /// edge). The definition-side companion to [`ref_target_node`](Document::ref_target_node): given a
+    /// row of the label table, hand back the node that *defines* it.
+    pub fn label_def_node(&self, d: &LabelDef) -> Option<NodeRef<'_>> {
+        self.node_for_span(d.span)
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // Tests.
 // -------------------------------------------------------------------------------------------------
@@ -1211,5 +1345,203 @@ See Section~\ref{sec:intro} and \cite{smith2020}.
         assert!(cites.unresolved.is_empty(), "\\ref is NOT a dangling cite");
         // The `sec:intro` label key never leaks into the citation table.
         assert!(cites.entry("sec:intro").is_none(), "a \\label key is not a bib entry");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S3 — target → NodeRef exposure.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn ref_target_node_for_section_is_the_real_section_block() {
+        // A `\ref{sec:intro}` → `\section` resolves (S1), and `ref_target_node` returns the ACTUAL
+        // `Block::Section` node — kind "Section", span slices back to the `\section` source — and we
+        // can DESCEND into it (its `body`/`title` are populated), proving it is the real node, not a
+        // hollow handle.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+First paragraph of the intro. See Section~\ref{sec:intro}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+
+        let r = &refs.resolved[0];
+        let node = doc.ref_target_node(r).expect("resolved ref must yield its target node");
+
+        // It is a Block, of the Section kind, whose span slices back to the defining `\section`.
+        assert_eq!(node.kind(), "Section", "target node is the section block");
+        let NodeRef::Block(Block::Section { title, body, .. }) = node else {
+            panic!("expected a Section block, got {}", node.kind());
+        };
+        let span = node.span();
+        assert!(
+            src[span.start..span.end].starts_with(r"\section{Intro}"),
+            "the node's span slices back to the defining \\section"
+        );
+        // DESCEND: the section's title inline is reachable (the real "Intro" heading), and its owned
+        // body carries the following paragraph — a hollow handle could not expose these.
+        assert!(!title.is_empty(), "the section's title inlines are reachable");
+        assert!(
+            body.iter().any(|b| matches!(b, Block::Paragraph(..))),
+            "the section owns the following paragraph (we can walk into its children)"
+        );
+    }
+
+    #[test]
+    fn ref_target_node_for_figure_reaches_its_caption() {
+        // A `\ref{fig:plot}` → figure: `ref_target_node` returns the figure Block; kind == "Figure",
+        // and we can reach its caption text — proving descent into the real float.
+        let src = r"\begin{document}\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:plot}\end{figure}
+
+As shown in Figure~\ref{fig:plot}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+
+        let r = &refs.resolved[0];
+        let node = doc.ref_target_node(r).expect("resolved figure ref must yield its node");
+
+        assert_eq!(node.kind(), "Figure");
+        let NodeRef::Block(Block::Figure { caption, .. }) = node else {
+            panic!("expected a Figure block, got {}", node.kind());
+        };
+        // DESCEND: the figure's caption is reachable and holds the "A plot" text — we slice the
+        // caption's text inline back to source to prove we reached the real caption content.
+        let cap = caption.as_ref().expect("the figure carries a \\caption");
+        let has_plot_text = cap.content.iter().any(|i| match i {
+            Inline::Text(t, _) => t.contains("plot"),
+            _ => false,
+        });
+        assert!(has_plot_text, "the figure's caption text ('A plot') is reachable via the node");
+    }
+
+    #[test]
+    fn ref_target_node_for_inline_label_is_the_crossref_inline() {
+        // An inline `\eqref{eq:x}` → inline `\label` CrossRef: `ref_target_node` returns the
+        // `NodeRef::Inline` for that CrossRef (kind "CrossRef"), span-matching the `\label{eq:x}`.
+        let src = r"\begin{document}The identity \label{eq:x} holds.
+
+By \eqref{eq:x} we conclude.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+
+        let r = &refs.resolved[0];
+        let node = doc.ref_target_node(r).expect("resolved eqref must yield the inline label node");
+
+        assert_eq!(node.kind(), "CrossRef", "an inline \\label target is a CrossRef inline");
+        assert!(matches!(node, NodeRef::Inline(Inline::CrossRef { .. })));
+        let span = node.span();
+        assert_eq!(
+            &src[span.start..span.end],
+            r"\label{eq:x}",
+            "the node's span slices back to the inline \\label"
+        );
+    }
+
+    #[test]
+    fn cite_target_node_is_the_walked_bibitem_raw_inline() {
+        // A `\cite{smith2020}` → `\bibitem`: the exploratory parse confirmed the `\bibitem` inside a
+        // `thebibliography` IS walked (as an `Inline::Raw` command). So `cite_target_node` returns
+        // `Some` — kind "Raw", span slicing back to exactly `\bibitem{smith2020}`.
+        let src = r"\begin{document}As in \cite{smith2020}.
+
+\begin{thebibliography}{9}
+\bibitem{smith2020} Smith, J. A Title. 2020.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let cites = doc.resolve_citations();
+
+        let c = &cites.resolved[0];
+        let node = doc
+            .cite_target_node(c)
+            .expect("a \\bibitem IS walked, so the cite target node must resolve");
+
+        assert_eq!(node.kind(), "Raw", "a \\bibitem lowers to an Inline::Raw command");
+        assert!(matches!(node, NodeRef::Inline(Inline::Raw(..))));
+        let span = node.span();
+        assert_eq!(
+            &src[span.start..span.end],
+            r"\bibitem{smith2020}",
+            "the bibitem node's span slices back to exactly the \\bibitem construct"
+        );
+    }
+
+    #[test]
+    fn label_def_node_returns_the_defining_node() {
+        // `label_def_node` (the definition-side companion) returns the node that DEFINES a label —
+        // here the `Block::Section`.
+        let src = r"\begin{document}\section{Body}\label{sec:body}
+
+Text.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+
+        let def = &refs.definitions[0];
+        let node = doc.label_def_node(def).expect("a definition's node must resolve");
+        assert_eq!(node.kind(), "Section");
+        assert_eq!(node.span(), def.span, "the def node's span is the definition's span");
+    }
+
+    #[test]
+    fn node_for_span_with_no_matching_span_returns_none() {
+        // A span that matches NO walked node → `None` (no panic). We fabricate a span well past the
+        // end of the source, which no node can own.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+Body.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        // A span between two nodes / off the end matches nothing.
+        assert!(doc.node_for_span(Span::new(9000, 9001)).is_none(), "no walked node → None");
+        // A zero-width off-by-one span (start of one node, but not its end) also matches nothing.
+        assert!(doc.node_for_span(Span::new(16, 17)).is_none(), "half-open equality is exact");
+    }
+
+    #[test]
+    fn node_for_span_agrees_with_ref_target_node() {
+        // `node_for_span(r.target_span)` returns the SAME node as `ref_target_node(r)` — the accessor
+        // is a thin wrapper over the primitive.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+Body. See \ref{sec:intro}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+        let r = &refs.resolved[0];
+
+        let via_primitive = doc.node_for_span(r.target_span);
+        let via_accessor = doc.ref_target_node(r);
+        assert_eq!(via_primitive, via_accessor, "accessor == node_for_span(target_span)");
+        assert!(via_primitive.is_some(), "the resolved target IS a walked node");
+    }
+
+    #[test]
+    fn empty_document_node_lookups_yield_none_no_panic() {
+        // An empty document has no walked nodes; any span lookup yields `None` and never panics.
+        let doc = parse_document(r"\begin{document}\end{document}").expect("parse");
+        assert!(doc.node_for_span(Span::new(0, 0)).is_none());
+        assert!(doc.node_for_span(Span::new(5, 10)).is_none());
+    }
+
+    #[test]
+    fn s3_is_purely_additive_s1_s2_outputs_unchanged() {
+        // REGRESSION: the S3 methods are purely additive — calling them does not perturb the S1/S2
+        // resolutions, which remain byte-for-byte what they were before S3.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+See Section~\ref{sec:intro} and \cite{smith2020}.
+
+\begin{thebibliography}{9}
+\bibitem{smith2020} Smith, J. Title. 2020.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let refs_before = doc.resolve_references();
+        let cites_before = doc.resolve_citations();
+
+        // Exercise every S3 accessor.
+        let _ = doc.ref_target_node(&refs_before.resolved[0]);
+        let _ = doc.cite_target_node(&cites_before.resolved[0]);
+        let _ = doc.label_def_node(&refs_before.definitions[0]);
+        let _ = doc.node_for_span(refs_before.resolved[0].target_span);
+
+        // Re-resolving yields the identical result (nothing mutated).
+        assert_eq!(doc.resolve_references(), refs_before, "S1 output unchanged by S3");
+        assert_eq!(doc.resolve_citations(), cites_before, "S2 output unchanged by S3");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -228,3 +228,102 @@ wins under a duplicate `\bibitem`, a `\cite` with no bibliography reported unres
 panicking, an empty document yielding empty results, and a regression that S1's `resolve_references`
 and S2's `resolve_citations` coexist on a document with **both** families without disturbing each
 other.
+
+## 9. S3 — target → `NodeRef` exposure
+
+S1 and S2 each bind a cross-reference to the **bytes** of its target: a `ResolvedRef` carries
+`target_span: Span`, a `ResolvedCite` carries `entry_span: Span`, a `LabelDef`/`BibEntry` carries
+`span: Span`. A `Span` is a source-byte range you can *slice* (`&src[span]`) — but it is not the
+target **node**, so a consumer cannot ask "what *kind* of node is this?" or "walk into the section's
+paragraphs / the figure's caption". S3 is the natural depth-add on S1+S2: given a resolved target's
+span, hand back the actual walked `NodeRef`, so the caller can read its `kind()` and — for a
+`NodeRef::Block` — descend into its children. No new parsing, no numbering, no I/O — pure, additive
+analysis over the existing `Document::walk`.
+
+### 9.1 Scope
+
+- **In (S3):** a span→node lookup primitive `Document::node_for_span(span) -> Option<NodeRef>`, and
+  three thin accessors that take a resolved S1/S2 record and return its node —
+  `ref_target_node(&ResolvedRef)`, `cite_target_node(&ResolvedCite)`, `label_def_node(&LabelDef)`.
+- **Out (S3):** everything S1/S2 already excluded — citation/reference **numbering**, **external
+  BibTeX**, natbib families, hyperref anchors — remains deferred to later rungs. S3 changes no parser,
+  fold, `walk`, `node_at`, or span logic, and does **not** alter the S1/S2 result types.
+
+### 9.2 The lookup: span-equality against the body walk
+
+`node_for_span` walks the body (`Document::walk`, pre-order) and returns the node whose
+`span()` **exactly equals** the requested span — half-open equality of *both* `start` and `end`. This
+is deliberately **equality**, not **containment**: a resolved S1/S2 target span is, by construction,
+some walked node's own span (S1 recorded a block's or a cross-ref's span; S2 recorded a `\bibitem`'s
+`Inline::Raw` span), so the node we want is the one that *is* that span, not merely one that
+*encloses* it. Containment — "which leaf owns this arbitrary byte?" — is `Document::node_at`'s job
+(S4), a different question. The lookup is O(nodes): one reuse of the bounded `walk`, no new recursion.
+
+**Tie-break (defensive).** If two walked nodes ever shared an identical span, `node_for_span` returns
+the **first in pre-order** — the outermost/earliest, since `walk` yields a parent before its children
+and an earlier sibling before a later one. The exploratory parse (below) found **zero** such
+collisions among real targets, so this rule is documented for determinism, not because callers reach
+it.
+
+### 9.3 Reachability (confirmed against the parsed AST, not assumed)
+
+An exploratory parse over a document exercising every target family confirmed that **every** S1/S2
+target span corresponds to **exactly one** walked node — there were zero pairs of distinct walked
+nodes sharing an identical span:
+
+| target | walked node it resolves to | reachable? |
+|--------|----------------------------|------------|
+| `\ref`→`\section` (hoisted label) | the `Block::Section` | **yes** — `NodeRef::Block`, `kind()=="Section"` |
+| `\ref`→`figure` float | the `Block::Figure` | **yes** — `kind()=="Figure"` |
+| `\ref`→`table` float | the `Block::Table` | **yes** — `kind()=="Table"` |
+| `\eqref`→ inline `\label` | the `Inline::CrossRef` | **yes** — `NodeRef::Inline`, `kind()=="CrossRef"` |
+| `\cite`→`\bibitem` | the `Inline::Raw` `\bibitem` command | **yes** — `kind()=="Raw"` (see below) |
+
+**The `\bibitem` target *is* walked** — the one genuinely uncertain case, so it was *verified*, not
+assumed. A `\bibitem{key}` sits inside a `thebibliography` `Block::Environment`, whose body `walk`
+descends into; the `\bibitem` survives D2 as an `Inline::Raw` command inside a `Block::Paragraph`,
+which `walk` visits. Its span therefore matches a walked node and `cite_target_node` returns
+`Some(NodeRef::Inline(..))` (`kind()=="Raw"`), **not** `None`.
+
+**When `None` is returned.** `node_for_span` returns `None` for any span that is *not* some walked
+body node's own span: a span from an empty document, a preamble/metadata span (those regions are
+classified out of directives and deliberately **not** walked — see `Document::walk`), or any
+caller-fabricated span landing between nodes. This is a **documented, total** outcome — never a panic.
+Because every *resolved* S1/S2 target span is a walked node's span, the accessors never return `None`
+for a genuinely resolved reference/citation in a well-formed document; `None` is reserved for the
+honest edge.
+
+### 9.4 Public API
+
+```rust
+impl Document {
+    /// The walked body node whose span EXACTLY equals `span`, else `None`. First-in-pre-order on tie.
+    pub fn node_for_span(&self, span: Span) -> Option<NodeRef<'_>>;
+    /// The target node of a resolved reference (= `node_for_span(r.target_span)`).
+    pub fn ref_target_node(&self, r: &ResolvedRef) -> Option<NodeRef<'_>>;
+    /// The `\bibitem` node of a resolved citation (= `node_for_span(c.entry_span)`).
+    pub fn cite_target_node(&self, c: &ResolvedCite) -> Option<NodeRef<'_>>;
+    /// The defining node of a label definition (= `node_for_span(d.span)`).
+    pub fn label_def_node(&self, d: &LabelDef) -> Option<NodeRef<'_>>;
+}
+```
+
+**Additivity & borrowing.** The S1/S2 result types (`ResolvedRef`, `ResolvedCite`, `LabelDef`,
+`BibEntry`, …) are **unchanged** — they still carry only owned `Span`s (no lifetimes), so a resolution
+still outlives any borrow of the source. A `NodeRef` borrows the doc, so it cannot live on those owned
+types; instead it is fetched **on demand** through these `Document` methods, keeping S3 purely
+additive and lifetime-clean.
+
+### 9.5 Verification (S3)
+
+`cargo test -p latex` green (9 new `references` S3 tests); `cargo clippy -p latex --all-targets
+-- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build
+-p latex --no-default-features` builds. No `cargo fmt`, no grammar regen. The load-bearing tests
+assert the **actual node**, not just `.is_some()`: a `\ref`→section returns the real `Block::Section`
+and we descend into its title inlines + owned paragraph; a `\ref`→figure reaches its caption text; an
+inline `\eqref` returns the `CrossRef` inline whose span slices back to `\label{eq:x}`; a
+`\cite`→`\bibitem` returns the walked `Inline::Raw` whose span slices back to exactly
+`\bibitem{key}`. The suite also pins: `label_def_node` returns the defining node, a non-matching span
+→ `None` (no panic), `node_for_span(target_span)` agrees with `ref_target_node`, empty-document
+lookups → `None`, and a regression that exercising the S3 accessors leaves S1's `resolve_references`
+and S2's `resolve_citations` outputs byte-for-byte unchanged.


### PR DESCRIPTION
## LTXDOC03 S3 — target → NodeRef exposure

Third rung of the LTXDOC03 cross-reference-resolution arc (follows S1 #7643 `\ref`→`\label`, S2 #7647 `\cite`→`\bibitem`, both merged). S1/S2 bound each cross-reference to its target's **byte span**. S3 hands back the target **node** itself, so a consumer can read the target's `kind()` and descend into a Block's children — the natural depth-add on both S1 and S2, with no new parsing, no numbering, no file I/O.

### What it adds — a pure additive lookup, no parser/span change
Four new methods on `Document` (reusing the existing bounded `Document::walk()`; S1/S2 result types unchanged — still owned `Span`s, no lifetimes; the `NodeRef` is fetched on demand):

```rust
impl Document {
    pub fn node_for_span(&self, span: Span) -> Option<NodeRef<'_>>;      // primitive: exact half-open span equality (start AND end), first-in-pre-order tie-break, None if no walked node matches
    pub fn ref_target_node(&self, r: &ResolvedRef) -> Option<NodeRef<'_>>;   // = node_for_span(r.target_span)
    pub fn cite_target_node(&self, c: &ResolvedCite) -> Option<NodeRef<'_>>; // = node_for_span(c.entry_span)
    pub fn label_def_node(&self, d: &LabelDef) -> Option<NodeRef<'_>>;       // = node_for_span(d.span)
}
```

`node_for_span` is the load-bearing primitive: it returns the walked node whose `.span()` exactly equals the given span, or `None` when no walked node owns that span (empty doc, fabricated span, or preamble/metadata which aren't body-walked). O(nodes), panic-free, no `unsafe`.

### Discovered span→node reachability (investigated, then baked into tests)
- **Every** S1/S2 target span matches **exactly one** walked node; there were **zero** identical-span pairs among all walked nodes, so span→node is unambiguous (the defensive first-in-pre-order tie-break never fires in practice).
- The genuinely uncertain case resolved: **`\bibitem` targets ARE reachable via `walk()`**. A `\bibitem{key}` inside a `thebibliography` `Block::Environment` survives as an `Inline::Raw(Command{name:"bibitem"})` inside a `Block::Paragraph`, which `walk` visits — so `cite_target_node` returns `Some(NodeRef::Inline)` (kind `"Raw"`), **not** `None`.
- Section→`NodeRef::Block` (kind `"Section"`), figure→`"Figure"`, table→`"Table"`, inline `\label`→`NodeRef::Inline` (kind `"CrossRef"`) — all span-match.

### Tests (9 new, all real — `#[cfg(test)]`, assert the actual node not `is_some`)
`ref_target_node` for a `\section` destructures the returned `NodeRef::Block(Block::Section { title, body, .. })`, asserts kind + slice-back, and **descends** (title non-empty, body contains a `Paragraph`) — proving it's the real node, not a hollow handle; the figure case reaches into the returned figure's caption text; the inline `\eqref` case returns the `NodeRef::Inline` CrossRef; `cite_target_node` returns the walked `\bibitem` Raw inline (kind + slice-back); `node_for_span` with a non-matching span returns `None` (no panic); `node_for_span` agrees with `ref_target_node`; empty-doc → `None`. Plus a regression that S1/S2 outputs are byte-for-byte unchanged (the methods are purely additive).

### Verification (independently re-run)
- `cargo test -p latex`: **319 passed** (9 new) + 1 doc-test.
- `cargo clippy -p latex --all-targets -- -D warnings`: clean.
- Downstream `cargo test -p adj-lang -p adj-lang-cli`: all green.
- `cargo build -p latex --no-default-features`: builds.

latex **0.38.0 → 0.39.0**. Files: `src/references.rs` (S3 methods + tests + docs), `Cargo.toml`, `CHANGELOG.md`, `README.md`, spec `code/specs/LTXDOC03-cross-reference-resolution.md` (new S3 §). Citation **numbering** and external **`.bib`/BibTeX** databases remain the out-of-scope future rungs.

### Payoff
A resolved `\ref`/`\cite` now yields the exact target **node** (its kind + children), not merely its bytes — a consumer can point at the *specific structural node* a reference names and read into it (a `\ref` to a section can enumerate its paragraphs; to a figure, reach its caption). Deepens the byte-faithful cross-reference graph the ADJ byte-provenance pipeline audits against, and cleanly unblocks numbering (S4 numbers the nodes S3 can now reach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
