### PR TITLE
feat(latex): LTXDOC03 S4 document numbering — \ref numbers (hierarchical sections + flat float counters)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.40.0] — 2026-07-06
+
+### Added — cross-reference resolution: document numbering (LTXDOC03 S4)
+
+The number a `\ref` actually *prints*. S1 bound each `\ref` to its target's **bytes** and S3 lifted
+that to the target **node**, but neither gives the rendered **number** ("Section 1.2", "Figure 3").
+S4 assigns those numbers in one walk over the parsed `Document` — the static analogue of LaTeX's
+second `.aux` pass, computing each numbered target's value directly (no `.aux` file, no second parse).
+
+- **Hierarchical section numbers with deeper-reset.** A numbered `\section`…`\subparagraph` shares a
+  nested counter family: incrementing a coarser level **resets every finer one to 0**, and the number
+  is the dotted join from the top level down to that depth — `1`, `1.1`, `1.2`, `1.2.1`, `2`. A
+  starred `\section*` (`numbered == false`) fires **no** counter and is skipped, so the next numbered
+  section keeps the number it would have had (a `\section*` between `1` and the next `\section` leaves
+  it `2`, not `3`).
+- **Flat, independent float counters.** `figure` and `table` each own a running counter that only
+  increments: figures `1, 2, 3, …`, tables their **own** `1, 2, 3, …` (a table after two figures is
+  `1`, not `3`). **Every** float advances its counter — labeled or not — mirroring LaTeX, where a
+  `\label` merely *captures* the value; an unlabeled figure between two labeled ones takes `2`, so the
+  labeled ones read `1` and `3`.
+- **Missing-parent rule (a document that starts deep).** A `\subsection` before any `\section` has no
+  opened parent, so its parent counter sits at its initial `0`; we render from the `\section` depth
+  down, surfacing an honest leading `0` — a lone leading `\subsection` numbers `0.1`, a lone
+  `\subsubsection` `0.0.1`. A plain top-level `\section` is just `1` (it *is* the reference depth). The
+  rule is documented, deterministic, and total — never a panic on the degenerate input.
+- **New public API.** `Document::number_labels(&self) -> Numbering` returns one owned `NumberedLabel`
+  row per **defined, numberable** label key (section/figure/table), each carrying its `LabelKind` and
+  rendered `number: String`, with a `Numbering::number_for(key) -> Option<&str>` lookup. The payoff
+  convenience `Document::ref_number(&self, r: &ResolvedRef) -> Option<String>` ties S1 resolution to
+  S4 numbering: `\ref{sec:intro}` → `"1.2"`. Inline/equation labels carry no S4 counter and are
+  omitted (deferred to S5).
+- **Deferred to S5+ (honest boundary).** Equation numbers, citation `[1]` order-of-first-appearance
+  numbers, and other `\label`-able counters (enumerate items, theorems, footnotes) are **not** yet
+  assigned — each needs a per-environment counter context S4 does not thread.
+- **Pure, additive analysis.** No new parsing, no I/O, no tree mutation; reuses the bounded
+  `Document::walk` (no new recursion), a fixed-size 7-slot counter array (no unchecked indexing), and
+  no `unwrap`/`expect`. A regression test asserts numbering leaves the S1/S2/S3 outputs byte-for-byte
+  unchanged. `to_latex` round-trip fixed point preserved.
+
 ## [0.39.0] — 2026-07-06
 
 ### Added — cross-reference resolution: target → `NodeRef` exposure (LTXDOC03 S3)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -51,6 +51,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S1 — cross-reference resolution (label table + `\ref` binding)** | `Document::resolve_references() -> ReferenceResolution` — a pure, additive pass (no parser/fold/`walk`/`node_at`/span change) that binds each cross-reference to the `\label` that defines it, **with byte spans on both sides**. Collects the label table from hoisted section/table/figure labels (`Block::…{ label: Some(k) }`) and inline `\label{k}` (`Inline::CrossRef`); resolves the reference family `{ref, eqref, pageref}` against it → `ResolvedRef` (ref-span **and** target def-span + `LabelKind`) or `UnresolvedRef` (dangling key + ref-span); reports `Duplicate` keys with **first-def-wins**. `\cite` is a separate table, bound by S2. The static analogue of LaTeX's two-pass `.aux` machinery, binding *structure* not numbers/pages. Total & panic-free, reuses the bounded `walk` (no new recursion). | ✅ |
 | **LTXDOC03 S2 — `\cite` → bibliography binding** | `Document::resolve_citations() -> CitationResolution` — the *parallel* pass to S1 for the **citation** family, binding each `\cite` key to the `\bibitem` that defines it, **with byte spans on both sides**. Collects the bibliography table from every `\bibitem{k}` inside a `thebibliography` environment (`BibEntry { key, span }`, span = the tight `\bibitem{k}` construct), first-entry-wins with `DuplicateBib`; then, for each `\cite` (the `CITE_COMMAND` family), splits `target` on commas into individual trimmed keys and resolves each → `ResolvedCite` (the shared `\cite` `cite_span` **and** the entry's `entry_span`) or `UnresolvedCite` (dangling key + `cite_span`). A multi-key `\cite{a,b,c}` yields one record **per key**, all sharing that `\cite`'s span; `\cite[note]{k}` keeps the note out of the key. External `.bib`/BibTeX databases and citation numbering stay out of scope (in-document `thebibliography` only). Disjoint from and non-interfering with S1. Total & panic-free, reuses the bounded `walk` + a `MAX_DEPTH`-bounded env descent. | ✅ |
 | **LTXDOC03 S3 — target → `NodeRef` exposure** | The depth-add on S1+S2: both bound each target's **bytes** (a `Span`) but not the target **node**. `Document::node_for_span(span) -> Option<NodeRef>` returns the walked body node whose span **exactly equals** `span` (half-open equality of start **and** end; *equality*, not `node_at`'s containment) — or `None` for a span that is no walked node's own (empty doc, un-walked preamble/metadata, fabricated span). Thin accessors `ref_target_node(&ResolvedRef)`, `cite_target_node(&ResolvedCite)`, `label_def_node(&LabelDef)` take a resolved record and hand back the node, so a caller can read its `kind()` and — for a `Block` — descend into its children (a `\ref`→section enumerates its paragraphs; a `\ref`→figure reaches its caption). **Verified reachability:** every S1/S2 target span matches exactly one walked node (zero collisions); a `\ref`→section/figure/table yields a `NodeRef::Block`, an inline `\eqref`→`\label` a `NodeRef::Inline` (`CrossRef`), and — the once-uncertain case — a `\cite`→`\bibitem` **is** walked (an `Inline::Raw` inside the `thebibliography`), so `cite_target_node` returns `Some`, not `None`. Purely additive (S1/S2 result types keep owned `Span`s, no lifetimes; the `NodeRef` is fetched on demand); tie-break = first-in-pre-order (defensive, does not fire). Numbering + external BibTeX remain out of scope. Total & panic-free, reuses the bounded `walk`. | ✅ |
+| **LTXDOC03 S4 — document numbering (hierarchical sections + flat float counters)** | `Document::number_labels() -> Numbering` — the number a `\ref` *prints*, computed in one `walk` (LaTeX's second `.aux` pass, done statically). **Section numbers** are hierarchical with deeper-reset: a numbered `\section`…`\subparagraph` increments its depth's counter, resets deeper depths to `0`, and renders the dotted join from the top level down (`1`, `1.1`, `1.2`, `1.2.1`, `2`); a starred `\section*` (`numbered == false`) fires no counter and is skipped. **Float counters** are flat and independent: every `figure` advances a running figure counter (`1, 2, …`), every `table` its own (`1, 2, …`) — labeled *or not* (a `\label` only captures the value; an unlabeled figure between two labeled ones takes `2`). Missing-parent rule: a document that starts deep renders honest leading `0`s (a lone `\subsection` → `0.1`), a plain top-level `\section` → `1`. Returns one owned `NumberedLabel { key, kind, number }` per defined numberable label, with `number_for(key)`; `ref_number(&ResolvedRef) -> Option<String>` ties S1 resolution to S4 numbering (`\ref{sec:intro}` → `"1.2"`). Equation numbers, citation `[1]` numbers, and other counters deferred to S5+. Pure, additive, tree-unchanged; fixed 7-slot counter array (no unchecked indexing). Total & panic-free, reuses the bounded `walk`. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -79,8 +80,12 @@ reported. **S3 lifts both bindings from bytes to nodes** (`Document::node_for_sp
 `ref_target_node`/`cite_target_node`/`label_def_node`) — given a resolved reference/citation, hand
 back the actual walked `NodeRef` so a consumer can read its `kind()` and descend into a `Block`'s
 children (a verified reachability check confirmed every target — including the `\cite`→`\bibitem`
-inside `thebibliography` — is a walked node). External `.bib`/BibTeX databases and citation numbering
-remain out of scope (in-document `thebibliography` only).
+inside `thebibliography` — is a walked node). **S4 assigns the numbers a `\ref` prints**
+(`Document::number_labels` + `ref_number`) — hierarchical section numbers with deeper-reset (`1.2.1`,
+`\section*` skipped) and independent flat figure/table counters (every float advancing its counter,
+labeled or not), so `\ref{sec:intro}` resolves to `"1.2"`. External `.bib`/BibTeX databases stay out
+of scope (in-document `thebibliography` only); equation numbers, citation `[1]` numbers, and other
+counters are deferred to S5+.
 
 ## The Document layer (LTXDOC01)
 
@@ -314,6 +319,42 @@ for any genuine reference/citation; `None` is reserved for the honest edge (empt
 preamble/metadata, fabricated spans). The lookup is span-**equality** (not `node_at`'s containment),
 with a first-in-pre-order tie-break that no real target hits. The S1/S2 result types are unchanged
 (they keep owned `Span`s) — the `NodeRef` is fetched on demand, so S3 is purely additive.
+
+### Document numbering (LTXDOC03 S4)
+
+S1–S3 bind each `\ref` to its target's bytes and node, but not the **number** it prints. S4 assigns
+those numbers — LaTeX's second `.aux` pass, done in one walk over the parsed `Document`:
+hierarchical **section** numbers (`1`, `1.1`, `1.2`, `2`, with deeper-reset on each coarser step, and
+`\section*` skipped), and independent flat **figure**/**table** counters (each `1, 2, 3, …`, every
+float advancing its counter whether labeled or not). `Document::ref_number` is the payoff — the number
+a resolved `\ref` prints:
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+\subsection{Scope}\label{sec:scope}
+
+See Section~\ref{sec:scope}.\end{document}";
+let doc = parse_document(src).unwrap();
+
+// Number every defined label, then look one up:
+let num = doc.number_labels();
+assert_eq!(num.number_for("sec:intro"), Some("1"));
+assert_eq!(num.number_for("sec:scope"), Some("1.1")); // subsection under section 1
+
+// The payoff: a resolved `\ref` → the number it prints.
+let refs = doc.resolve_references();
+let r = refs.resolved.iter().find(|r| r.key == "sec:scope").unwrap();
+assert_eq!(doc.ref_number(r), Some("1.1".to_string())); // \ref{sec:scope} → "1.1"
+```
+
+`number_labels()` returns a `Numbering` of one `NumberedLabel { key, kind, number }` per defined,
+numberable label (section/figure/table). A document that starts deep applies the documented
+missing-parent rule (a lone leading `\subsection` numbers `0.1`). Inline/equation labels, citation
+`[1]` numbers, and other counters (enumerate/theorem/…) are deferred to S5+. Numbering is pure,
+additive analysis — it never mutates the tree, so the S1/S2/S3 outputs are unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -100,8 +100,9 @@ pub use document::{
     Metadata, NodeRef, Package, Preamble, Provenance,
 };
 pub use references::{
-    BibEntry, CitationResolution, Duplicate, DuplicateBib, LabelDef, LabelKind, ReferenceResolution,
-    ResolvedCite, ResolvedRef, UnresolvedCite, UnresolvedRef, CITE_COMMAND, REF_COMMANDS,
+    BibEntry, CitationResolution, Duplicate, DuplicateBib, LabelDef, LabelKind, NumberedLabel,
+    Numbering, ReferenceResolution, ResolvedCite, ResolvedRef, UnresolvedCite, UnresolvedRef,
+    CITE_COMMAND, REF_COMMANDS,
 };
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -67,7 +67,7 @@
 //! This is pure *analysis* over the tree — it changes nothing about the parser, the fold,
 //! [`Document::walk`], [`Document::node_at`], any span, or the `to_latex` round-trip fixed point.
 
-use crate::ast::{Node, NodeKind};
+use crate::ast::{Node, NodeKind, SectionLevel};
 use crate::document::{Block, Document, Inline, NodeRef};
 use crate::document_to_latex;
 use crate::token::Span;
@@ -879,6 +879,364 @@ impl Document {
     }
 }
 
+// =================================================================================================
+// LTXDOC03 S4 — document numbering (hierarchical section numbers + flat float counters).
+//
+// S1 bound each `\ref` to the *bytes* of its `\label`'s node; S3 lifted that to the target *node*.
+// Neither gives the **rendered number** a `\ref` prints — the "1.2" in "see Section~1.2", the "3" in
+// "Figure~3". S4 assigns those numbers. It is the static, single-pass analogue of LaTeX's **second
+// `.aux` pass**: on the first `latex` run each `\refstepcounter` (fired by every numbered `\section`,
+// `figure`, `table`, …) writes the counter's value into `document.aux` next to the label; on the
+// second run `\ref{key}` reads that value back. We do the same binding **in one walk** over the
+// already-parsed [`Document`] — no `.aux` file, no second parse — computing each numbered target's
+// value directly.
+//
+// ## The two counter models LaTeX uses, and which we implement
+//
+// LaTeX has two shapes of counter, and S4 models both:
+//
+// 1. **Hierarchical section counters (with deeper-reset).** `\part` … `\subparagraph` share a
+//    *nested* counter family: incrementing a coarser counter **resets every finer one to zero**. So
+//    after `\section` (→ `1`), a `\subsection` is `1.1`, another is `1.2`, and the *next* `\section`
+//    bumps to `2` **and** resets the subsection counter, so its first child is `2.1` again. The
+//    printed number is the **dotted join** of the counters from the top level down to this heading's
+//    depth: `1`, `1.1`, `1.2`, `1.2.1`, `2`. (Real LaTeX starts the dotted join at the *class's*
+//    top-numbered level — `\section` for `article`, `\chapter` for `report`/`book` — and omits
+//    levels above it. We do **not** know the class here, so we join from the coarsest level that has
+//    actually been *seen* down to this heading's depth; see the missing-parent rule below.)
+//
+// 2. **Flat float counters (no reset, no hierarchy).** `figure` and `table` each own an *independent*
+//    running counter that only ever **increments**: figures are `1, 2, 3, …` in document order, and
+//    tables are their **own** `1, 2, 3, …` — a `table` after two figures is `1`, not `3`. (In
+//    `article` these are document-global; in `report`/`book` they reset per chapter, which — being a
+//    class-dependent, chapter-scoped rule we cannot see — S4 does *not* model. The honest, class-free
+//    choice is a single global run per float type.)
+//
+// ## Every float consumes a counter — labeled or not
+//
+// LaTeX advances a float's counter **every time** the float appears; a `\label` merely *captures*
+// whatever the counter reads at that moment. So an **unlabeled** figure between two labeled ones
+// still consumes a number: the labeled figures come out `1` and `3`, with the unlabeled one having
+// silently taken `2`. S4 mirrors this exactly — we walk **every** [`Block::Figure`]/[`Block::Table`]
+// and advance its counter, then *expose* the value only for the ones that carry a `label`. (Starred
+// unnumbered sections are the opposite case: `\section*` sets `numbered == false`, fires no counter,
+// and is **skipped** entirely — the following numbered `\section` keeps the number it would have had.)
+//
+// ## The missing-parent rule (a document that starts deep)
+//
+// A well-formed document opens with a top-level heading, but nothing *stops* an author writing a
+// `\subsection` before any `\section` — the exploratory parse confirmed such a document parses fine
+// (a lone `Block::Section { level: Subsection, numbered: true, .. }`). Its parent `\section` counter
+// was never incremented, so it sits at its initial **0**. S4's rule: **treat a missing parent as 0**
+// (we never clamp it away, and we never skip the heading). We render from the `\section` depth (the
+// article default top-numbered level) down to the heading, so the un-opened parent slots surface
+// their honest `0`: a lone leading `\subsection` numbers **`0.1`**, a lone `\subsubsection` **`0.0.1`**.
+// A plain top-level `\section` itself is just **`1`** (it *is* the reference depth, so there is no
+// parent to zero-fill). This is total (no panic), deterministic, and honestly reflects "no parent
+// section has been opened yet" — surfacing the `0` rather than silently inventing a `1` the source
+// never wrote, the faithful, auditable choice for a byte-provenance model. (The exact leading-zero
+// depth is a documented convention, not a LaTeX fact — LaTeX would warn and print `0.1` too, but the
+// point is that S4 *picks a rule and sticks to it* rather than panicking on the degenerate input.)
+//
+// ## What S4 numbers, and what is DEFERRED
+//
+// S4 numbers **sections** (hierarchical) and **figure/table floats** (flat) — the counters whose
+// values a `\ref` most commonly prints. It deliberately does **not** yet assign:
+//
+// - **Equation numbers** — `equation`/`align` bodies are kept as opaque [`Block::DisplayMath`]
+//   source strings (never parsed here), and `\label`s inside them are inline labels with no counter
+//   context. Numbering them needs an equation counter threaded through the math island — an S5 rung.
+// - **Citation `[1]` numbers** — the order-of-first-appearance number `\cite` prints in a numeric
+//   bibliography style. That is a *citation-order* traversal over S2's resolution, a separate rung.
+// - **Other `\label`-able counters** — `enumerate` item numbers, theorem/footnote counters, etc.
+//   These need per-environment counter contexts; also S5+.
+//
+// This honest boundary mirrors S1/S2/S3: we assign only the numbers we can compute *faithfully* from
+// the parsed structure, and name the rest as future work rather than guessing.
+//
+// ## The result type
+//
+// [`Document::number_labels`] returns a [`Numbering`]: one owned row per **defined label key**,
+// carrying the label's [`LabelKind`] and its rendered number `String`. It mirrors S1/S2's dedicated,
+// owned-`String` result types (so it outlives any borrow of the source) and provides a
+// [`number_for`](Numbering::number_for) lookup. [`Document::ref_number`] is the payoff convenience:
+// given a [`ResolvedRef`] (S1), it returns that reference's target's rendered number — closing the
+// loop `\ref{sec:intro}` → `"1.2"`.
+// =================================================================================================
+
+/// The number of hierarchical section-counter slots: one per [`SectionLevel`] rank, `\part` (0)
+/// through `\subparagraph` (6). A fixed-size array of exactly this many `u32`s carries the live
+/// section counters through the numbering walk — no growth, no allocation, no unchecked indexing.
+const SECTION_DEPTHS: usize = 7;
+
+/// The **rank** (0-based depth) of a sectioning level: `0` for the coarsest (`\part`) up to `6` for
+/// the finest (`\subparagraph`). This is the index into the section-counter array a heading of that
+/// level increments, and the depth down to which its dotted number is joined.
+///
+/// | level | rank |
+/// |-------|------|
+/// | `Part` | 0 |
+/// | `Chapter` | 1 |
+/// | `Section` | 2 |
+/// | `Subsection` | 3 |
+/// | `Subsubsection` | 4 |
+/// | `Paragraph` | 5 |
+/// | `Subparagraph` | 6 |
+///
+/// This mirrors [`document::rank`](crate::document)'s private sectioning-fold rank (they must agree —
+/// both are the [`SectionLevel`] declaration order), kept as a local copy so S4 does not need that
+/// private helper exported. A pure lookup: it cannot panic and allocates nothing.
+fn section_rank(level: SectionLevel) -> usize {
+    match level {
+        SectionLevel::Part => 0,
+        SectionLevel::Chapter => 1,
+        SectionLevel::Section => 2,
+        SectionLevel::Subsection => 3,
+        SectionLevel::Subsubsection => 4,
+        SectionLevel::Paragraph => 5,
+        SectionLevel::Subparagraph => 6,
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// The record types (plain, Clone-able, owned data — parallel to S1/S2's result rows).
+// -------------------------------------------------------------------------------------------------
+
+/// One **numbered label**: a defined label `key`, the [`LabelKind`] of the node it defines, and the
+/// rendered **number** LaTeX would print for a `\ref` to it. This is one row of S4's numbering table
+/// — the static analogue of an `.aux` `\newlabel{key}{{number}{page}…}` line, capturing the number
+/// (not the page).
+///
+/// The `number` is already rendered to its display string: a dotted section number (`"1"`, `"1.2"`,
+/// `"1.2.1"`, or `"0.1"` for a lone-deep heading — see the missing-parent rule) for a
+/// [`LabelKind::Section`], or a flat float count (`"1"`, `"2"`, …) for a [`LabelKind::Figure`] /
+/// [`LabelKind::Table`]. A [`LabelKind::Inline`] label carries **no** counter S4 assigns (its target
+/// is typically an equation — deferred to S5), so inline labels are **omitted** from the numbering
+/// table entirely (see [`Document::number_labels`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NumberedLabel {
+    /// The label key, verbatim, without braces (`"sec:intro"`).
+    pub key: String,
+    /// What kind of node this label defines (section / figure / table).
+    pub kind: LabelKind,
+    /// The rendered number LaTeX would print for a `\ref` to this label (`"1.2"`, `"3"`, …).
+    pub number: String,
+}
+
+/// The full result of [`Document::number_labels`]: the numbering table — one [`NumberedLabel`] row
+/// per **defined, numberable** label key (sections + figure/table floats; inline/equation labels are
+/// omitted, deferred to S5). All plain, owned data (keys + numbers are `String`s), so the numbering
+/// outlives any borrow of the source and can be stored/serialized — mirroring S1's
+/// [`ReferenceResolution`] and S2's [`CitationResolution`].
+///
+/// **Ordering.** `labels` is in [`Document::walk`] pre-order — the source order the labels' defining
+/// nodes appear in — so the table reads top-to-bottom like the document. As with S1's "first
+/// definition wins", only the **first** definition of a duplicated key is numbered (the value the
+/// winning [`LabelDef`] would carry); a later duplicate does not add a second row.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Numbering {
+    /// One row per defined, numberable label key, in pre-order.
+    pub labels: Vec<NumberedLabel>,
+}
+
+impl Numbering {
+    /// The rendered number of `key`, if it is a defined numberable label, else `None`. Linear over
+    /// `labels` (small: one row per distinct label); no allocation. `&str` borrow into the owned row.
+    pub fn number_for(&self, key: &str) -> Option<&str> {
+        self.labels.iter().find(|l| l.key == key).map(|l| l.number.as_str())
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// The numbering pass.
+// -------------------------------------------------------------------------------------------------
+
+/// A small carrier for the live counters during the numbering walk: the hierarchical section
+/// counters (one slot per rank) plus the two independent flat float counters. Kept as a struct so the
+/// single walk threads exactly one mutable state, and each `step_*` method reads like the LaTeX
+/// operation it mimics.
+struct Counters {
+    /// The hierarchical section counters, `section[rank]` = the current value at that depth. All
+    /// start at `0`; a coarser step resets every finer slot (deeper-reset).
+    section: [u32; SECTION_DEPTHS],
+    /// The flat `figure` counter — only ever increments (one global run).
+    figure: u32,
+    /// The flat `table` counter — only ever increments (one global run), independent of `figure`.
+    table: u32,
+}
+
+impl Counters {
+    /// Fresh counters — every section depth, the figure counter, and the table counter at `0` (no
+    /// heading/float seen yet).
+    fn new() -> Self {
+        Counters { section: [0; SECTION_DEPTHS], figure: 0, table: 0 }
+    }
+
+    /// Advance the section counters for a numbered heading at `rank`, and render its dotted number.
+    ///
+    /// The LaTeX `\refstepcounter{<level>}` semantics, in three steps:
+    /// 1. **Increment** `section[rank]` by one.
+    /// 2. **Reset** every *finer* slot (`rank+1 ..`) to `0` — the deeper-reset that makes the next
+    ///    `\section` restart its subsections at `1`.
+    /// 3. **Render** the dotted join from the coarsest *opened* ancestor down to this depth (see
+    ///    [`render_section`]) — `1`, `1.1`, `1.2.1` for opened parents, and a single leading `0` for
+    ///    a lone deep heading whose parent was never opened (the missing-parent rule → `0.1`).
+    fn step_section(&mut self, rank: usize) -> String {
+        // `rank` is always a valid index (`section_rank` yields 0..=6, and the array has 7 slots),
+        // but guard defensively so no unchecked indexing can ever panic.
+        if rank >= SECTION_DEPTHS {
+            return String::new();
+        }
+        self.section[rank] = self.section[rank].saturating_add(1);
+        for slot in self.section.iter_mut().skip(rank + 1) {
+            *slot = 0;
+        }
+        render_section(&self.section, rank)
+    }
+
+    /// Advance and return the flat `figure` counter (`1` on the first figure, `2` on the next, …).
+    fn step_figure(&mut self) -> u32 {
+        self.figure = self.figure.saturating_add(1);
+        self.figure
+    }
+
+    /// Advance and return the flat `table` counter, independent of the figure counter.
+    fn step_table(&mut self) -> u32 {
+        self.table = self.table.saturating_add(1);
+        self.table
+    }
+}
+
+/// The rank of `\section` — the `article` class's top *numbered* sectioning level, and S4's
+/// class-free reference depth for the missing-parent rule (see [`render_section`]).
+const SECTION_LEVEL_RANK: usize = 2;
+
+/// Render a section's dotted number from the counter array, for a heading at `rank`.
+///
+/// The dotted join runs from a **start depth** down to `rank` inclusive. The start depth is chosen so
+/// that opened parents appear with their real values and a document that starts deep shows honest
+/// leading `0`s for the un-opened parents (the missing-parent rule):
+///
+/// - **Opened ancestor present.** If any ancestor slot (`0..rank`) is non-zero, start at the
+///   **coarsest** such slot. Every in-between slot is then included with its current value. So under
+///   `\section` (slot 2 = `1`), a first `\subsection` (slot 3) joins `section[2..=3]` = `1.1`, and a
+///   nested `\subsubsection` joins `section[2..=4]` = `1.2.1`.
+/// - **No ancestor opened, and this heading is at or above `\section`** (`rank <= `[`SECTION_LEVEL_RANK`]).
+///   Start at `rank` itself — a plain top-level `\section`/`\chapter`/`\part` is just its own number,
+///   `1`, with no spurious leading `0`.
+/// - **No ancestor opened, but this heading is *deeper* than `\section`** (a document that starts
+///   deep). The missing-parent rule: start at [`SECTION_LEVEL_RANK`] (the `\section` depth), so the
+///   un-opened section counter renders as a leading `0`. A lone leading `\subsection` (rank 3) reads
+///   `section[2..=3]` = `0.1`; a lone `\subsubsection` (rank 4) reads `0.0.1`. Each un-opened parent
+///   contributes an honest `0` rather than inventing a `1` the source never wrote.
+///
+/// Total: every index used is within `0..SECTION_DEPTHS` (range-checked), so no unchecked indexing.
+fn render_section(section: &[u32; SECTION_DEPTHS], rank: usize) -> String {
+    // Guard (mirrors `step_section`): an out-of-range rank renders empty rather than indexing wild.
+    if rank >= SECTION_DEPTHS {
+        return String::new();
+    }
+    // The coarsest opened (non-zero) ancestor slot strictly above this heading, if any.
+    let first_nonzero = (0..rank).find(|&i| section[i] != 0);
+    let start = match first_nonzero {
+        // An opened ancestor: the number naturally begins there.
+        Some(i) => i,
+        // No opened ancestor: a heading at/above `\section` is just its own number; a deeper one
+        // (document starts deep) begins at the `\section` depth so un-opened parents read `0`.
+        None if rank <= SECTION_LEVEL_RANK => rank,
+        None => SECTION_LEVEL_RANK,
+    };
+    // Join `section[start..=rank]` with dots. `start <= rank < SECTION_DEPTHS`, so the slice is in
+    // bounds; iterating the sub-slice (rather than indexing by a range variable) is the panic-free,
+    // allocation-minimal way to render the dotted number.
+    section[start..=rank].iter().map(u32::to_string).collect::<Vec<_>>().join(".")
+}
+
+impl Document {
+    /// Assign every defined, numberable label its rendered **number** (LTXDOC03 S4).
+    ///
+    /// Walks the body **once** in [`Document::walk`] pre-order, threading a single [`Counters`]
+    /// state. For each block:
+    ///
+    /// - a **numbered** [`Block::Section`] (`numbered == true`) increments its depth's section
+    ///   counter, resets deeper depths, and — if it carries a hoisted `label` — records that label's
+    ///   dotted number. A **starred** `\section*` (`numbered == false`) is skipped: it fires no
+    ///   counter and is never numbered.
+    /// - **every** [`Block::Figure`] advances the flat figure counter; **every** [`Block::Table`]
+    ///   advances the flat table counter (labeled or not — a `\label` only *captures* the value). A
+    ///   figure/table that carries a `label` records that label's flat number.
+    ///
+    /// Inline (`\label` in prose / after an equation) labels carry **no** S4 counter — their target
+    /// is typically an equation, deferred to S5 — so they are **omitted** from the returned
+    /// [`Numbering`]. Only the first definition of a duplicated key is numbered (matching S1's
+    /// first-definition-wins).
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (the counter array is
+    /// fixed-size and every index is range-checked); reuses the bounded [`Document::walk`] (no new
+    /// recursion). Borrows `self` immutably; the returned [`Numbering`] is owned plain data (keys +
+    /// numbers copied out), so it outlives any borrow of the source. The tree is **not** mutated —
+    /// numbering is pure analysis, leaving S1/S2/S3 outputs byte-for-byte unchanged.
+    pub fn number_labels(&self) -> Numbering {
+        let mut counters = Counters::new();
+        let mut labels: Vec<NumberedLabel> = Vec::new();
+
+        // Record the first definition of each key only (first-wins, matching S1).
+        let mut record = |key: &str, kind: LabelKind, number: String| {
+            if !labels.iter().any(|l| l.key == key) {
+                labels.push(NumberedLabel { key: key.to_string(), kind, number });
+            }
+        };
+
+        for node in self.walk() {
+            let NodeRef::Block(block) = node else {
+                continue; // Only blocks carry the section/float counters S4 assigns.
+            };
+            match block {
+                // A numbered section: step the counter (reset deeper), number its label if any.
+                Block::Section { level, numbered: true, label, .. } => {
+                    let number = counters.step_section(section_rank(*level));
+                    if let Some(key) = label {
+                        record(key, LabelKind::Section, number);
+                    }
+                }
+                // A starred `\section*`: fires no counter, is never numbered — skipped.
+                Block::Section { numbered: false, .. } => {}
+                // Every figure advances the flat figure counter (labeled or not).
+                Block::Figure { label, .. } => {
+                    let n = counters.step_figure();
+                    if let Some(key) = label {
+                        record(key, LabelKind::Figure, n.to_string());
+                    }
+                }
+                // Every table advances the independent flat table counter (labeled or not).
+                Block::Table { label, .. } => {
+                    let n = counters.step_table();
+                    if let Some(key) = label {
+                        record(key, LabelKind::Table, n.to_string());
+                    }
+                }
+                // Any other block carries no counter S4 assigns.
+                _ => {}
+            }
+        }
+
+        Numbering { labels }
+    }
+
+    /// The rendered **number** a resolved reference prints (LTXDOC03 S4) — the payoff that ties S1
+    /// resolution to S4 numbering: given a [`ResolvedRef`] (`\ref{sec:intro}`), return its target's
+    /// number (`"1.2"`), or `None` if the target is not a numberable label (an inline/equation label,
+    /// deferred to S5) — a **documented, total** outcome, never a panic.
+    ///
+    /// Convenience over [`number_labels`](Document::number_labels): it numbers the document, then
+    /// looks the reference's `key` up. (A caller numbering *many* references should call
+    /// `number_labels` once and reuse the [`Numbering`]; this method re-numbers per call, which is
+    /// O(nodes) each — fine for a one-off lookup.)
+    pub fn ref_number(&self, r: &ResolvedRef) -> Option<String> {
+        self.number_labels().number_for(&r.key).map(str::to_string)
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // Tests.
 // -------------------------------------------------------------------------------------------------
@@ -1543,5 +1901,236 @@ See Section~\ref{sec:intro} and \cite{smith2020}.
         // Re-resolving yields the identical result (nothing mutated).
         assert_eq!(doc.resolve_references(), refs_before, "S1 output unchanged by S3");
         assert_eq!(doc.resolve_citations(), cites_before, "S2 output unchanged by S3");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S4 — document numbering (hierarchical sections + flat float counters).
+    // ---------------------------------------------------------------------------------------------
+
+    /// Parse `src` and number its labels — the shared S4 harness.
+    fn number(src: &str) -> Numbering {
+        parse_document(src).expect("parse").number_labels()
+    }
+
+    #[test]
+    fn nested_sections_number_hierarchically_with_deeper_reset() {
+        // \section{A} = 1, \subsection{B} = 1.1, \subsection{C} = 1.2, \section{D} = 2.
+        // The two `\n\n` after each `\label` keep it a lone paragraph so LTXDOC01 hoists it.
+        let src = r"\begin{document}\section{A}\label{s:a}
+
+\subsection{B}\label{s:b}
+
+\subsection{C}\label{s:c}
+
+\section{D}\label{s:d}
+
+Body.\end{document}";
+        let num = number(src);
+
+        assert_eq!(num.number_for("s:a"), Some("1"), "first section is 1");
+        assert_eq!(num.number_for("s:b"), Some("1.1"), "first subsection under 1 is 1.1");
+        assert_eq!(num.number_for("s:c"), Some("1.2"), "second subsection is 1.2");
+        assert_eq!(num.number_for("s:d"), Some("2"), "the next section bumps to 2 (deeper reset)");
+
+        // All four are Section-kind rows, in source (pre-order).
+        assert_eq!(num.labels.len(), 4);
+        assert!(num.labels.iter().all(|l| l.kind == LabelKind::Section));
+        assert_eq!(num.labels[0].key, "s:a");
+        assert_eq!(num.labels[3].key, "s:d");
+    }
+
+    #[test]
+    fn subsubsection_nests_three_deep() {
+        // \section = 1, \subsection = 1.1, \subsubsection = 1.1.1.
+        let src = r"\begin{document}\section{A}\label{s:a}
+
+\subsection{B}\label{s:b}
+
+\subsubsection{C}\label{s:c}
+
+Text.\end{document}";
+        let num = number(src);
+        assert_eq!(num.number_for("s:a"), Some("1"));
+        assert_eq!(num.number_for("s:b"), Some("1.1"));
+        assert_eq!(num.number_for("s:c"), Some("1.1.1"));
+    }
+
+    #[test]
+    fn starred_section_consumes_no_number() {
+        // A `\section*{Unnumbered}` between two numbered sections does NOT advance the counter: the
+        // following numbered section is still 2, not 3.
+        let src = r"\begin{document}\section{First}\label{s:1}
+
+\section*{Unnumbered}
+
+\section{Third}\label{s:3}
+
+Body.\end{document}";
+        let num = number(src);
+
+        assert_eq!(num.number_for("s:1"), Some("1"), "first numbered section is 1");
+        assert_eq!(
+            num.number_for("s:3"),
+            Some("2"),
+            "the starred section consumed no number, so this is 2 (not 3)"
+        );
+        // The starred section carries no label and contributes no row.
+        assert_eq!(num.labels.len(), 2, "only the two numbered sections are numbered");
+    }
+
+    #[test]
+    fn figures_and_tables_are_independent_flat_counters() {
+        // Two labeled figures → 1 and 2; a labeled table → 1 (its OWN counter, not continuing figs).
+        let src = r"\begin{document}\begin{figure}\includegraphics{a.png}\caption{A}\label{fig:a}\end{figure}
+
+\begin{figure}\includegraphics{b.png}\caption{B}\label{fig:b}\end{figure}
+
+\begin{table}\begin{tabular}{lc}x & y\end{tabular}\caption{T}\label{tab:t}\end{table}
+
+Body.\end{document}";
+        let num = number(src);
+
+        assert_eq!(num.number_for("fig:a"), Some("1"), "first figure is 1");
+        assert_eq!(num.number_for("fig:b"), Some("2"), "second figure is 2");
+        assert_eq!(num.number_for("tab:t"), Some("1"), "the table is 1 on its OWN counter");
+
+        // Kinds are right.
+        assert_eq!(num.labels.iter().find(|l| l.key == "fig:a").map(|l| l.kind), Some(LabelKind::Figure));
+        assert_eq!(num.labels.iter().find(|l| l.key == "tab:t").map(|l| l.kind), Some(LabelKind::Table));
+    }
+
+    #[test]
+    fn unlabeled_float_still_consumes_a_number() {
+        // An UNlabeled figure between two labeled figures: the labeled ones come out 1 and 3 (the
+        // unlabeled figure silently took 2) — proving every float advances the counter.
+        let src = r"\begin{document}\begin{figure}\includegraphics{a.png}\caption{A}\label{fig:a}\end{figure}
+
+\begin{figure}\includegraphics{mid.png}\caption{Mid}\end{figure}
+
+\begin{figure}\includegraphics{c.png}\caption{C}\label{fig:c}\end{figure}
+
+Body.\end{document}";
+        let num = number(src);
+
+        assert_eq!(num.number_for("fig:a"), Some("1"), "first labeled figure is 1");
+        assert_eq!(
+            num.number_for("fig:c"),
+            Some("3"),
+            "the unlabeled figure consumed 2, so the next labeled one is 3"
+        );
+        // Only the two LABELED figures are numbered rows; the unlabeled one has no key to record.
+        assert_eq!(num.labels.len(), 2, "only labeled floats appear in the table");
+    }
+
+    #[test]
+    fn ref_number_ties_s1_resolution_to_s4_numbering() {
+        // LOAD-BEARING payoff: a `\ref{s:b}` to a `\subsection` under a `\section` prints "1.1".
+        let src = r"\begin{document}\section{A}\label{s:a}
+
+\subsection{B}\label{s:b}
+
+See Section~\ref{s:b}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+
+        // The `\ref{s:b}` resolved (S1) …
+        let r = refs.resolved.iter().find(|r| r.key == "s:b").expect("the \\ref{s:b} resolves");
+        // … and its target's rendered number (S4) is "1.1".
+        assert_eq!(
+            doc.ref_number(r),
+            Some("1.1".to_string()),
+            "\\ref{{s:b}} → its subsection's number 1.1"
+        );
+    }
+
+    #[test]
+    fn ref_number_for_undefined_key_is_none_no_panic() {
+        // A `\ref` to a key with no definition → its number is None (no panic).
+        let src = r"\begin{document}See \ref{nope} here.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let refs = doc.resolve_references();
+        // The dangling ref is not in `resolved`, so we synthesize a ResolvedRef-shaped lookup via the
+        // Numbering directly: an undefined key has no number.
+        assert!(doc.number_labels().number_for("nope").is_none(), "undefined key → no number");
+        assert!(refs.resolved.is_empty(), "and it never resolved in the first place");
+    }
+
+    #[test]
+    fn empty_document_yields_empty_numbering_no_panic() {
+        // An empty document → empty numbering, no panic.
+        let num = number(r"\begin{document}\end{document}");
+        assert_eq!(num, Numbering::default(), "empty doc → empty numbering");
+        assert!(num.number_for("anything").is_none());
+    }
+
+    #[test]
+    fn lone_deep_subsection_uses_documented_missing_parent_rule() {
+        // The missing-parent rule: a document that starts with a `\subsection` (no `\section` opened)
+        // numbers it "0.1" — one honest leading `0` for the un-opened parent section.
+        let src = r"\begin{document}\subsection{Deep}\label{s:deep}
+
+Text.\end{document}";
+        let num = number(src);
+        assert_eq!(
+            num.number_for("s:deep"),
+            Some("0.1"),
+            "a lone leading \\subsection numbers as 0.1 (missing parent = 0)"
+        );
+    }
+
+    #[test]
+    fn plain_top_level_section_is_just_one() {
+        // A plain top-level `\section` (no ancestors) is "1", NOT "0.1" — it is itself the reference
+        // depth, so there is no parent to zero-fill (the counterpart of the missing-parent rule).
+        let src = r"\begin{document}\section{Top}\label{s:top}
+
+Text.\end{document}";
+        let num = number(src);
+        assert_eq!(num.number_for("s:top"), Some("1"), "a plain top-level section is 1");
+    }
+
+    #[test]
+    fn inline_and_equation_labels_are_not_numbered_yet() {
+        // An inline `\label` (deferred to S5) is NOT numbered — it does not appear in the table, and
+        // its number lookup is None (documented, total). We keep a numbered section alongside to prove
+        // the section IS numbered while the inline label is skipped.
+        let src = r"\begin{document}\section{S}\label{sec:s}
+
+The identity \label{eq:x} holds here.
+
+Text.\end{document}";
+        let num = number(src);
+        assert_eq!(num.number_for("sec:s"), Some("1"), "the section is numbered");
+        assert!(num.number_for("eq:x").is_none(), "the inline \\label is deferred to S5 (not numbered)");
+        assert_eq!(num.labels.len(), 1, "only the section label is a numbered row");
+    }
+
+    #[test]
+    fn numbering_does_not_mutate_the_tree_s1_s2_s3_unchanged() {
+        // REGRESSION: numbering is pure analysis — running it leaves S1/S2/S3 outputs byte-for-byte
+        // unchanged (the tree is never mutated).
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+See Section~\ref{sec:intro} and \cite{smith2020}.
+
+\begin{thebibliography}{9}
+\bibitem{smith2020} Smith, J. Title. 2020.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let refs_before = doc.resolve_references();
+        let cites_before = doc.resolve_citations();
+
+        // Number the labels (exercises the S4 walk).
+        let num = doc.number_labels();
+        assert_eq!(num.number_for("sec:intro"), Some("1"));
+
+        // S1/S2 outputs are untouched, and S3 node lookup still agrees.
+        assert_eq!(doc.resolve_references(), refs_before, "S1 output unchanged by S4");
+        assert_eq!(doc.resolve_citations(), cites_before, "S2 output unchanged by S4");
+        assert!(
+            doc.ref_target_node(&refs_before.resolved[0]).is_some(),
+            "S3 lookup still resolves after numbering"
+        );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -327,3 +327,93 @@ inline `\eqref` returns the `CrossRef` inline whose span slices back to `\label{
 → `None` (no panic), `node_for_span(target_span)` agrees with `ref_target_node`, empty-document
 lookups → `None`, and a regression that exercising the S3 accessors leaves S1's `resolve_references`
 and S2's `resolve_citations` outputs byte-for-byte unchanged.
+
+## 10. S4 — document numbering (hierarchical sections + flat float counters)
+
+S1 bound each `\ref` to its target's **bytes**; S3 lifted that to the target **node**. Neither gives
+the rendered **number** a `\ref` prints — the "1.2" in "see Section~1.2", the "3" in "Figure~3". S4
+assigns those numbers: it is the static, single-pass analogue of LaTeX's **second `.aux` pass**. On
+the first `latex` run each `\refstepcounter` (fired by every numbered `\section`/`figure`/`table`/…)
+writes the counter value into `document.aux` next to the label; on the second run `\ref{key}` reads it
+back. S4 does the same binding **in one walk** over the already-parsed `Document` — no `.aux` file, no
+second parse — computing each numbered target's value directly. S3's target-node exposure is what
+unblocks it: the counters are assigned by walking exactly the nodes S3 made addressable.
+
+### 10.1 The two counter models
+
+1. **Hierarchical section counters (deeper-reset).** `\part` … `\subparagraph` share a nested counter
+   family: incrementing a coarser counter **resets every finer one to 0**. The printed number is the
+   dotted join of the counters from the top level down to that heading's depth: `1`, `1.1`, `1.2`,
+   `1.2.1`, `2`. `rank(level)` (0 = `\part` … 6 = `\subparagraph`, mirroring the D3 sectioning-fold
+   rank) is the array index a heading increments and the depth its number is joined to.
+2. **Flat float counters (no reset, no hierarchy).** `figure` and `table` each own an *independent*
+   running counter that only increments: figures `1, 2, 3, …`, tables their **own** `1, 2, 3, …` (a
+   table after two figures is `1`, not `3`).
+
+**Every float consumes a counter — labeled or not.** LaTeX advances a float's counter every time the
+float appears; a `\label` merely *captures* the current value. So an unlabeled figure between two
+labeled ones still takes a number: the labeled ones read `1` and `3`, the unlabeled one having taken
+`2`. S4 walks **every** `Block::Figure`/`Block::Table` and advances its counter, exposing the value
+only for the labeled ones. **Starred `\section*`** (`numbered == false`) is the opposite: it fires no
+counter and is **skipped**, so the following numbered section keeps the number it would have had.
+
+### 10.2 The missing-parent rule (a document that starts deep)
+
+A well-formed document opens with a top-level heading, but nothing stops an author writing a
+`\subsection` before any `\section`. An exploratory parse confirmed such a document parses fine (a
+lone `Block::Section { level: Subsection, numbered: true, .. }`), and its parent `\section` counter
+sits at its initial **0**. **S4's rule: treat a missing parent as 0** — we render from the `\section`
+depth (rank 2, the article default top-numbered level) down to the heading, surfacing the un-opened
+parent slots' honest `0`. So a lone leading `\subsection` numbers **`0.1`**, a lone `\subsubsection`
+**`0.0.1`**; a plain top-level `\section` is just **`1`** (it *is* the reference depth, no parent to
+zero-fill). This is total (no panic), deterministic, and honestly reflects "no parent section opened
+yet" rather than silently inventing a `1` the source never wrote — the faithful, auditable choice for
+a byte-provenance model. (It is a documented convention, not a LaTeX fact: the point is that S4 picks
+a rule and sticks to it on degenerate input rather than crashing.)
+
+### 10.3 Public API
+
+```rust
+impl Document {
+    /// One `NumberedLabel { key, kind, number }` per DEFINED numberable label (section/figure/table),
+    /// in pre-order. Inline/equation labels carry no S4 counter and are omitted (deferred to S5).
+    pub fn number_labels(&self) -> Numbering;
+    /// The number a resolved `\ref` prints — `number_labels().number_for(r.key)`; ties S1 → S4.
+    pub fn ref_number(&self, r: &ResolvedRef) -> Option<String>;
+}
+
+pub struct Numbering { pub labels: Vec<NumberedLabel> }
+impl Numbering { pub fn number_for(&self, key: &str) -> Option<&str>; }
+
+pub struct NumberedLabel { pub key: String, pub kind: LabelKind, pub number: String }
+```
+
+`Numbering`/`NumberedLabel` are dedicated, owned-`String` result types mirroring S1's
+`ReferenceResolution` and S2's `CitationResolution`, so a numbering outlives any borrow of the source.
+`ref_number` is the **payoff**: `\ref{sec:intro}` → `"1.2"`, closing the loop from S1 resolution to
+S4 numbering. Only the **first** definition of a duplicated key is numbered (matching S1's
+first-definition-wins).
+
+### 10.4 What is DEFERRED (honest boundary, mirroring S1/S2/S3)
+
+- **Equation numbers** — `equation`/`align` bodies are opaque `Block::DisplayMath` source strings
+  (never parsed here); numbering needs an equation counter threaded through the math island. S5.
+- **Citation `[1]` numbers** — the order-of-first-appearance number a numeric bibliography style
+  prints; a citation-order traversal over S2's resolution. A separate rung.
+- **Other `\label`-able counters** — `enumerate` item numbers, theorem/footnote counters — each needs
+  a per-environment counter context. S5+.
+
+### 10.5 Verification (S4)
+
+`cargo test -p latex` green (12 new `references` S4 tests); `cargo clippy -p latex --all-targets
+-- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build
+-p latex --no-default-features` builds. No `cargo fmt`, no grammar regen. The tests assert the
+**actual number string**: nested `\section`/`\subsection`/`\subsection`/`\section` → `1`/`1.1`/`1.2`/
+`2` (deeper-reset); a `\section*` between two numbered sections leaves the second `2` not `3`; two
+labeled figures → `1`/`2` and a labeled table → `1` (independent counter); an unlabeled figure between
+two labeled ones makes the second labeled one `3` (every float advances); `ref_number` for
+`\ref{s:b}` (a subsection under a section) → `"1.1"` (the load-bearing S1→S4 payoff); an undefined key
+→ `None` (no panic); an empty document → empty numbering; a lone leading `\subsection` → `0.1` (the
+missing-parent rule); a plain top-level `\section` → `1`; an inline `\label` is **not** numbered
+(deferred); and a regression that numbering leaves the S1/S2/S3 outputs byte-for-byte unchanged (the
+tree is never mutated).


### PR DESCRIPTION
## LTXDOC03 S4 — document numbering (`\ref` numbers: hierarchical sections + flat float counters)

Fourth slice of the LTXDOC03 cross-reference-resolution arc in the dependency-free `latex` crate. S1 bound `\ref`→`\label`, S2 bound `\cite`→`\bibitem`, S3 exposed the target **node** (`node_for_span`). None of them gives the rendered **number** a `\ref` prints ("Section 1.2", "Figure 3"). **S4 assigns those numbers** — LaTeX's second `.aux` pass — now unblocked because S3 surfaced the target nodes to number.

### What it adds (all in `src/references.rs`, one module extended)
- **Hierarchical section numbers** — a single ordered `walk()` threads a fixed 7-slot section-counter array. Each **numbered** `Block::Section` (`numbered == true`) steps its depth's counter (via `section_rank(level)`), **resets deeper depths**, and renders the dotted join from the top level down: `1`, `1.1`, `1.2`, `1.2.1`, `2`. A **starred** `\section*` (`numbered == false`) is skipped — it fires no counter and is never numbered.
- **Flat float counters** — independent figure and table counters: **every** `Block::Figure`/`Block::Table` advances its counter (labeled or not — a `\label` only *captures* the current value), so an unlabeled float still consumes a number. Figures and tables count on separate sequences.
- **Public API**:
  ```rust
  impl Document {
      pub fn number_labels(&self) -> Numbering;                 // per-label rendered number + kind
      pub fn ref_number(&self, r: &ResolvedRef) -> Option<String>; // the S1→S4 payoff: \ref{sec:x} → "1.2"
  }
  pub struct Numbering { pub labels: Vec<NumberedLabel> }
  impl Numbering { pub fn number_for(&self, key: &str) -> Option<&str> }
  pub struct NumberedLabel { pub key: String, pub kind: LabelKind, pub number: String }
  ```
  Owned plain-data result (keys + numbers copied out), mirroring S1/S2; first-definition-wins on duplicate keys (matches S1). Inline/equation labels carry no S4 counter and are omitted (deferred to S5).

### Missing-parent rule (documented, total)
A document that starts deep (e.g. a lone leading `\subsection`, no enclosing `\section`) treats missing parents as **0**: a lone `\subsection` → `0.1`, a lone `\subsubsection` → `0.0.1`; a plain top-level `\section` → `1`. Deterministic, total, and honest — it surfaces the `0` rather than inventing a `1`.

### Safety
Pure read-only analysis over the in-memory AST: no file I/O, no network, no new deps, **no `unsafe`**, no `unwrap`/`expect` on the public path. The counter array is fixed-size (`SECTION_DEPTHS = 7`) with a `rank >= SECTION_DEPTHS` guard; `section_rank` is an exhaustive match over `SectionLevel` (0–6); all counters use `saturating_add` (no overflow panic). Reuses the existing MAX_DEPTH-bounded `walk()` — no new recursion. The tree is **not** mutated; S1/S2/S3 outputs are byte-for-byte unchanged.

### Deferred to S5+
Equation numbering (needs numbered-equation identification), citation `[1]` order-of-first-appearance numbers, and `\label` on other counters (enumerate items). Noted in the spec's future section.

### Tests (12 new; assert exact number strings)
- nested `\section`/`\subsection`/`\subsection`/`\section` → `1`, `1.1`, `1.2`, `2` (deeper-reset); three-deep → `1`, `1.1`, `1.1.1`.
- `\section*` between two numbered sections consumes **no** number (the next numbered section stays `2`).
- two labeled figures → `1`, `2`; a labeled table → `1` on its **own** counter; an **unlabeled** figure between two labeled ones proves every float advances the counter.
- `ref_number(\ref{s:b})` → `"1.1"` (the load-bearing S1→S4 payoff); undefined key → `None`; empty document → empty numbering; missing-parent lone `\subsection` → `"0.1"`.
- regression: numbering does not mutate the tree; S1/S2/S3 outputs unchanged.

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → **331 passed** (was 319 + 12 new S4 tests) + doctest.
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected).
- `cargo build -p latex --no-default-features` → builds.

Crate bumped `0.39.0` → `0.40.0`; CHANGELOG, README (usage + feature row), and the LTXDOC03 spec (new §10 S4) updated. Security-reviewed (Rust, panic/DoS-focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
