### PR TITLE
feat(adj-ladder): rung-84 ophthalmology intraocular pressure (grouped-sum product minus a term)

### DIFF
--- a/code/specs/data/adj-ladder/rung84_intraocular_pressure/gen_items.py
+++ b/code/specs/data/adj-ladder/rung84_intraocular_pressure/gen_items.py
@@ -1,0 +1,243 @@
+"""Generate rung-84 (ophthalmology intraocular-pressure index) items.json for the ADJ-LADDER.
+
+Rung 84 opens the **ophthalmology / intraocular-pressure** panel on the quantitative band — the arithmetic of a net
+intraocular pressure. An `aqueous_inflow` and a `venous_bias` are SUMMED (the two pressure sources feeding the globe),
+that sum is scaled by a `resistance_factor` (the outflow resistance the pressure builds against), and an `outflow_drain`
+is SUBTRACTED (the trabecular egress). A grouped SUM times a factor, minus a fourth term, introduces a genuinely NEW
+arithmetic shape on the ladder: a **grouped-sum product MINUS a term** — `(a+b)*c-d`, i.e. `((a+b)*c) - d`.
+
+This is genuinely new: rung-68 was `(a+b)*c/d` (`((a+b)*c)/d`, the grouped-sum product DIVIDED by the fourth term), and
+rung-81 was `(a+b)/c-d` (the grouped sum DIVIDED by c then minus d); here the grouped-sum product `(a+b)*c` has the
+fourth term SUBTRACTED from it. The operator order matters: `(a+b)*c-d` is `((a+b)*c) - d` by precedence (the
+parenthesised sum is formed first, multiplied by `c`, and only then is `d` subtracted), NOT `(a+b)*(c-d)` (subtracting
+`d` from `c` INSIDE the second factor) and NOT `(a-b)*c-d` (a MINUS inside the group instead of a plus) — the two
+distractors exploit exactly those confusions (and `(a-b)*c-d` is the same *outer* shape with the group's operator
+flipped, the classic wrong-grouping slip).
+
+The setup: an `aqueous_inflow`, a `venous_bias`, a `resistance_factor`, and an `outflow_drain`. The intraocular pressure
+is:
+
+  INTRAOCULAR PRESSURE   (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain   [ grouped-sum product minus a term ]
+  GROSS PRESSURE         (aqueous_inflow + venous_bias) * resistance_factor                   [ the grouped-sum product, before draining ]
+  INFLOW SUM             aqueous_inflow + venous_bias                                          [ the summed inflow, before scaling ]
+
+The **intraocular pressure** is what makes this rung distinctive — it is the ladder's first **grouped-sum product MINUS
+a term**. (The gross pressure `(a+b)*c` and the inflow sum `a+b` ride alongside as component readouts, so the panel
+teaches the whole calculation — exactly as rungs 47-83 shipped their component sums/products/differences/ratios beside
+the headline figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the summation of the aqueous inflow and the venous bias, the multiplication of that sum by the
+resistance factor, and the subtraction of the outflow drain (the parenthesised sum before the multiply, the multiply
+before the subtract) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No
+harness/engine change, exactly as rungs 8/16/.../82/83. This rung exercises the engine across **a grouped-sum product
+minus a term** — the fact that `(a+b)*c-d` is `((a+b)*c) - d` and NOT `(a+b)*(c-d)` and NOT `(a-b)*c-d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `*`, and `-`
+— **no structural constants** — so no numeric literal appears in any program, and neither the gross pressure, the inflow
+sum, nor any pressure figure is ever a literal (each is computed from the observed quantities). The observed quantities
+carry **digit-free identifiers** (`aqueous_inflow`, `venous_bias`, `resistance_factor`, `outflow_drain`) so no numeral
+hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (aqueous_inflow + venous_bias) * (resistance_factor - outflow_drain)   subtract the outflow drain from the
+                                                                                    resistance factor INSIDE the second
+                                                                                    factor, instead of after the product
+                                                                                    (the classic `(a+b)*c-d` vs
+                                                                                    `(a+b)*(c-d)` error), and
+  SWAPPED    (aqueous_inflow - venous_bias) * resistance_factor - outflow_drain     SUBTRACT the venous bias from the
+                                                                                    aqueous inflow inside the group
+                                                                                    instead of adding it (`(a-b)*c-d`
+                                                                                    instead of `(a+b)*c-d`, the group's
+                                                                                    operator flipped),
+
+which are exactly the mistakes a student makes (folding the final subtraction into the second factor, or mis-signing the
+grouped sum). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness and positivity: the tables keep the guards — `aqueous_inflow > venous_bias` (so the swapped group
+`(a-b)` stays positive), `resistance_factor > outflow_drain` (so the crossed factor `(c-d)` stays positive, and by at
+least two so the crossed value never collapses onto the inflow sum), `(aqueous_inflow+venous_bias)*resistance_factor >
+outflow_drain` (intraocular pressure positive), and `(aqueous_inflow-venous_bias)*resistance_factor > outflow_drain`
+(swapped positive) — so every family member, including the headline intraocular pressure `(a+b)*c-d`, is strictly
+positive; the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (AQUEOUS_INFLOW, VENOUS_BIAS, RESISTANCE_FACTOR, OUTFLOW_DRAIN) — an aqueous inflow and a venous bias to sum, a
+# resistance factor to scale that sum by, and an outflow drain to subtract from the scaled product, all plain positive
+# numbers. The tables satisfy the guards: aqueous_inflow > venous_bias (swapped group > 0), resistance_factor >
+# outflow_drain with a margin of at least two (crossed factor > 0 and crossed != inflow sum),
+# (aqueous_inflow+venous_bias)*resistance_factor > outflow_drain (intraocular pressure > 0), and
+# (aqueous_inflow-venous_bias)*resistance_factor > outflow_drain (swapped > 0). The five family values are asserted
+# pairwise-distinct below.
+TABLES = [
+    (6, 2, 5, 3),
+    (8, 2, 6, 4),
+    (5, 3, 7, 4),
+    (9, 3, 6, 4),
+    (10, 4, 7, 5),
+    (7, 5, 8, 6),
+    (8, 6, 9, 5),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, *, and -. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "intraocular_pressure",
+        "net intraocular pressure (the scaled inflow sum minus the outflow drain)",
+        "(aqueous_inflow + venous_bias) * resistance_factor - outflow_drain",
+    ),
+    (
+        "gross_pressure",
+        "the gross pressure (the summed inflow times the resistance factor, before draining)",
+        "(aqueous_inflow + venous_bias) * resistance_factor",
+    ),
+    (
+        "inflow_sum",
+        "the inflow sum (the aqueous inflow plus the venous bias)",
+        "aqueous_inflow + venous_bias",
+    ),
+    (
+        "crossed",
+        "the summed inflow scaled by the resistance factor MINUS the outflow drain, with the drain taken off the resistance factor inside the second factor instead of off the product (a wrong grouping)",
+        "(aqueous_inflow + venous_bias) * (resistance_factor - outflow_drain)",
+    ),
+    (
+        "swapped",
+        "the aqueous inflow MINUS the venous bias, scaled by the resistance factor then the outflow drain subtracted, the grouped sum's operator flipped (a wrong grouping)",
+        "(aqueous_inflow - venous_bias) * resistance_factor - outflow_drain",
+    ),
+]
+QUERIED = ["intraocular_pressure", "gross_pressure", "inflow_sum"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(aqueous_inflow, venous_bias, resistance_factor, outflow_drain):
+    # Operation order mirrors the ADJ programs exactly (the parenthesised sum is formed first, multiplied by the
+    # resistance factor, and only then the outflow drain subtracted, per precedence), so the Python option value and the
+    # engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "intraocular_pressure": (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain,
+        "gross_pressure": (aqueous_inflow + venous_bias) * resistance_factor,
+        "inflow_sum": aqueous_inflow + venous_bias,
+        "crossed": (aqueous_inflow + venous_bias) * (resistance_factor - outflow_drain),
+        "swapped": (aqueous_inflow - venous_bias) * resistance_factor - outflow_drain,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for aqueous_inflow, venous_bias, resistance_factor, outflow_drain in TABLES:
+        assert (
+            aqueous_inflow > 0
+            and venous_bias > 0
+            and resistance_factor > 0
+            and outflow_drain > 0
+        ), (aqueous_inflow, venous_bias, resistance_factor, outflow_drain)
+        fv = family_values(aqueous_inflow, venous_bias, resistance_factor, outflow_drain)
+        # The tables satisfy the guards, so every family member is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, aqueous_inflow, venous_bias, resistance_factor, outflow_drain, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    aqueous_inflow,
+                    venous_bias,
+                    resistance_factor,
+                    outflow_drain,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                aqueous_inflow,
+                venous_bias,
+                resistance_factor,
+                outflow_drain,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r84iop-{idx + 1:02d}",
+                "qtype": "intraocular_pressure_index",
+                "stem": (
+                    f"An eye is fed by an aqueous inflow of {num(aqueous_inflow)} plus a venous bias of "
+                    f"{num(venous_bias)}, this summed inflow building against a resistance factor of "
+                    f"{num(resistance_factor)}, with an outflow drain of {num(outflow_drain)} carried off. What is the "
+                    f"{name_of[key]}?"
+                ),
+                "program": (
+                    f"observe aqueous_inflow({num(aqueous_inflow)})\n"
+                    f"observe venous_bias({num(venous_bias)})\n"
+                    f"observe resistance_factor({num(resistance_factor)})\n"
+                    f"observe outflow_drain({num(outflow_drain)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 84 — ophthalmology intraocular-pressure index from four stated quantities (a NEW panel: "
+            "ophthalmology / intraocular-pressure). From an aqueous inflow and a venous bias to sum, a resistance factor "
+            "to scale that sum by, and an outflow drain to subtract, compute the intraocular pressure "
+            "((aqueous_inflow+venous_bias)*resistance_factor-outflow_drain), the gross pressure "
+            "((aqueous_inflow+venous_bias)*resistance_factor), or the inflow sum (aqueous_inflow+venous_bias). Each item "
+            "is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine "
+            "carries the arithmetic — a NEW shape, GROUPED-SUM PRODUCT MINUS A TERM (a+b)*c-d (sum a and b, times c, "
+            "subtract d, so (a+b)*c-d = ((a+b)*c)-d; distinct from rung-68 (a+b)*c/d = ((a+b)*c)/d and from rung-81 "
+            "(a+b)/c-d = ((a+b)/c)-d) — and the harness matches the scalar to the printed options. Contamination-safe: "
+            "every index is built only from the four observed quantities via +, *, and - — no constant leaks, and "
+            "neither the gross pressure, the inflow sum, nor any pressure figure ever appears as a literal (each is "
+            "computed) — and the observed quantities carry digit-free identifiers so no numeral hides inside a variable "
+            "name. The five options are a family over the same four quantities, so the distractors are exactly the slips "
+            "students make: taking the outflow drain off the resistance factor inside the second factor "
+            "((a+b)*(c-d), a wrong grouping) and mis-signing the grouped sum ((a-b)*c-d, a wrong grouping). The core "
+            "confusion tested is that (a+b)*c-d is ((a+b)*c)-d, not (a+b)*(c-d) and not (a-b)*c-d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung84_intraocular_pressure/items.json
+++ b/code/specs/data/adj-ladder/rung84_intraocular_pressure/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 84 \u2014 ophthalmology intraocular-pressure index from four stated quantities (a NEW panel: ophthalmology / intraocular-pressure). From an aqueous inflow and a venous bias to sum, a resistance factor to scale that sum by, and an outflow drain to subtract, compute the intraocular pressure ((aqueous_inflow+venous_bias)*resistance_factor-outflow_drain), the gross pressure ((aqueous_inflow+venous_bias)*resistance_factor), or the inflow sum (aqueous_inflow+venous_bias). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, GROUPED-SUM PRODUCT MINUS A TERM (a+b)*c-d (sum a and b, times c, subtract d, so (a+b)*c-d = ((a+b)*c)-d; distinct from rung-68 (a+b)*c/d = ((a+b)*c)/d and from rung-81 (a+b)/c-d = ((a+b)/c)-d) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, *, and - \u2014 no constant leaks, and neither the gross pressure, the inflow sum, nor any pressure figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: taking the outflow drain off the resistance factor inside the second factor ((a+b)*(c-d), a wrong grouping) and mis-signing the grouped sum ((a-b)*c-d, a wrong grouping). The core confusion tested is that (a+b)*c-d is ((a+b)*c)-d, not (a+b)*(c-d) and not (a-b)*c-d.",
+  "items": [
+    {
+      "id": "r84iop-01",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 6 plus a venous bias of 2, this summed inflow building against a resistance factor of 5, with an outflow drain of 3 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(6)\nobserve venous_bias(2)\nobserve resistance_factor(5)\nobserve outflow_drain(3)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r84iop-02",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 6 plus a venous bias of 2, this summed inflow building against a resistance factor of 5, with an outflow drain of 3 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(6)\nobserve venous_bias(2)\nobserve resistance_factor(5)\nobserve outflow_drain(3)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r84iop-03",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 6 plus a venous bias of 2, this summed inflow building against a resistance factor of 5, with an outflow drain of 3 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(6)\nobserve venous_bias(2)\nobserve resistance_factor(5)\nobserve outflow_drain(3)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r84iop-04",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 8 plus a venous bias of 2, this summed inflow building against a resistance factor of 6, with an outflow drain of 4 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(8)\nobserve venous_bias(2)\nobserve resistance_factor(6)\nobserve outflow_drain(4)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r84iop-05",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 8 plus a venous bias of 2, this summed inflow building against a resistance factor of 6, with an outflow drain of 4 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(8)\nobserve venous_bias(2)\nobserve resistance_factor(6)\nobserve outflow_drain(4)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 32,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 60,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r84iop-06",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 8 plus a venous bias of 2, this summed inflow building against a resistance factor of 6, with an outflow drain of 4 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(8)\nobserve venous_bias(2)\nobserve resistance_factor(6)\nobserve outflow_drain(4)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 60,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r84iop-07",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 5 plus a venous bias of 3, this summed inflow building against a resistance factor of 7, with an outflow drain of 4 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(5)\nobserve venous_bias(3)\nobserve resistance_factor(7)\nobserve outflow_drain(4)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r84iop-08",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 5 plus a venous bias of 3, this summed inflow building against a resistance factor of 7, with an outflow drain of 4 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(5)\nobserve venous_bias(3)\nobserve resistance_factor(7)\nobserve outflow_drain(4)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r84iop-09",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 5 plus a venous bias of 3, this summed inflow building against a resistance factor of 7, with an outflow drain of 4 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(5)\nobserve venous_bias(3)\nobserve resistance_factor(7)\nobserve outflow_drain(4)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r84iop-10",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 9 plus a venous bias of 3, this summed inflow building against a resistance factor of 6, with an outflow drain of 4 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(9)\nobserve venous_bias(3)\nobserve resistance_factor(6)\nobserve outflow_drain(4)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 32,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 68,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r84iop-11",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 9 plus a venous bias of 3, this summed inflow building against a resistance factor of 6, with an outflow drain of 4 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(9)\nobserve venous_bias(3)\nobserve resistance_factor(6)\nobserve outflow_drain(4)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r84iop-12",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 9 plus a venous bias of 3, this summed inflow building against a resistance factor of 6, with an outflow drain of 4 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(9)\nobserve venous_bias(3)\nobserve resistance_factor(6)\nobserve outflow_drain(4)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 68,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r84iop-13",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 10 plus a venous bias of 4, this summed inflow building against a resistance factor of 7, with an outflow drain of 5 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(10)\nobserve venous_bias(4)\nobserve resistance_factor(7)\nobserve outflow_drain(5)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 98,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 93,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 37,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r84iop-14",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 10 plus a venous bias of 4, this summed inflow building against a resistance factor of 7, with an outflow drain of 5 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(10)\nobserve venous_bias(4)\nobserve resistance_factor(7)\nobserve outflow_drain(5)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 93,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 98,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 37,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r84iop-15",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 10 plus a venous bias of 4, this summed inflow building against a resistance factor of 7, with an outflow drain of 5 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(10)\nobserve venous_bias(4)\nobserve resistance_factor(7)\nobserve outflow_drain(5)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 93,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 98,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 37,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r84iop-16",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 7 plus a venous bias of 5, this summed inflow building against a resistance factor of 8, with an outflow drain of 6 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(7)\nobserve venous_bias(5)\nobserve resistance_factor(8)\nobserve outflow_drain(6)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 96,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r84iop-17",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 7 plus a venous bias of 5, this summed inflow building against a resistance factor of 8, with an outflow drain of 6 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(7)\nobserve venous_bias(5)\nobserve resistance_factor(8)\nobserve outflow_drain(6)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 96,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r84iop-18",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 7 plus a venous bias of 5, this summed inflow building against a resistance factor of 8, with an outflow drain of 6 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(7)\nobserve venous_bias(5)\nobserve resistance_factor(8)\nobserve outflow_drain(6)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 90,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 96,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r84iop-19",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 8 plus a venous bias of 6, this summed inflow building against a resistance factor of 9, with an outflow drain of 5 carried off. What is the net intraocular pressure (the scaled inflow sum minus the outflow drain)?",
+      "program": "observe aqueous_inflow(8)\nobserve venous_bias(6)\nobserve resistance_factor(9)\nobserve outflow_drain(5)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor - outflow_drain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 126,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 121,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r84iop-20",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 8 plus a venous bias of 6, this summed inflow building against a resistance factor of 9, with an outflow drain of 5 carried off. What is the the gross pressure (the summed inflow times the resistance factor, before draining)?",
+      "program": "observe aqueous_inflow(8)\nobserve venous_bias(6)\nobserve resistance_factor(9)\nobserve outflow_drain(5)\nlet answer = (aqueous_inflow + venous_bias) * resistance_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 121,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 126,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r84iop-21",
+      "qtype": "intraocular_pressure_index",
+      "stem": "An eye is fed by an aqueous inflow of 8 plus a venous bias of 6, this summed inflow building against a resistance factor of 9, with an outflow drain of 5 carried off. What is the the inflow sum (the aqueous inflow plus the venous bias)?",
+      "program": "observe aqueous_inflow(8)\nobserve venous_bias(6)\nobserve resistance_factor(9)\nobserve outflow_drain(5)\nlet answer = aqueous_inflow + venous_bias\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 121,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 126,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 56,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -121,6 +121,7 @@ SELF_CONTAINED_RUNGS = (
     "rung81_cardiac_perfusion",
     "rung82_gfr_estimation",
     "rung83_hepatic_clearance",
+    "rung84_intraocular_pressure",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-84 — ophthalmology intraocular-pressure index (grouped-sum product minus a term, `(a+b)*c-d`)

Next quantitative rung on the ADJ-LADDER. Opens a **NEW clinical panel — ophthalmology / intraocular-pressure** and introduces a **genuinely new arithmetic shape**: a grouped SUM times a factor, with a fourth term subtracted **after** the product, `(a+b)*c-d` = `((a+b)*c) - d` — the parenthesised sum is formed first, multiplied by `c`, and only then is `d` subtracted (multiply before subtract; the group binds first).

### The shape (new on the ladder)
Shapes shipped through rung-83: 67 `(a-b)*c/d`, 68 `(a+b)*c/d`, 69 `a*b/c+d`, 70 `a*b/c-d`, 71 `a/b*c+d`, 72 `a/b*c-d`, 73 `a-b/c*d`, 74 `a+b/c*d`, 75 `(a-b)/c*d`, 76 `(a+b)/c*d`, 77 `a/b+c*d`, 78 `a/b-c*d`, 79 `a*b+c/d`, 80 `a*b-c/d`, 81 `(a+b)/c-d`, 82 `(a-b)/c+d`, 83 `a-b*c/d`. Rung-84 = **`(a+b)*c-d`**, genuinely new: rung-68 was `(a+b)*c/d` (the grouped-sum product DIVIDED by the fourth term) and rung-81 was `(a+b)/c-d` (the grouped sum DIVIDED by c, then minus d); here the grouped-sum **product** `(a+b)*c` has the fourth term SUBTRACTED from it.

### The panel
Four observed quantities: `aqueous_inflow`, `venous_bias`, `resistance_factor`, `outflow_drain`. Two pressure sources feed the globe (their sum), scaled by the outflow resistance, with the trabecular egress subtracted:

| readout | formula | |
|---|---|---|
| **intraocular pressure** (headline) | `(aqueous_inflow + venous_bias)*resistance_factor - outflow_drain` | grouped-sum product minus a term |
| gross pressure | `(aqueous_inflow + venous_bias)*resistance_factor` | the grouped-sum product, before draining |
| inflow sum | `aqueous_inflow + venous_bias` | the summed inflow, before scaling |

Each item is a constant-free `compute_dimensioned` program (`observe` four quantities + `let answer = formula`); the ADJ engine carries the arithmetic (sum, then multiply, then subtract) and the harness reads the scalar via the existing `compute_dimensioned` extractor. **No harness/engine change** — exactly as rungs 8/16/…/82/83.

### 5-member mutually-confusable family (over the SAME four quantities)
3 real readouts (queried as gold) + 2 classic student slips:
- **crossed** `(aqueous_inflow + venous_bias)*(resistance_factor - outflow_drain)` — fold the final subtraction INTO the second factor (`(a+b)*c-d` vs `(a+b)*(c-d)`).
- **swapped** `(aqueous_inflow - venous_bias)*resistance_factor - outflow_drain` — mis-sign the grouped sum, MINUS instead of PLUS inside the group (`(a+b)*c-d` vs `(a-b)*c-d`, the group's operator flipped).

Gold rotates A–E via `gold_pos = idx % 5`; 7 tables × 3 queried = **21 items**. The tables keep the guards — `aqueous_inflow > venous_bias` (swapped group positive), `resistance_factor > outflow_drain` by a margin of ≥2 (crossed factor positive, and crossed never collapses onto the inflow sum), `(a+b)*c > d` (headline positive), `(a-b)*c > d` (swapped positive) — so every family member is strictly positive; the five values are pairwise-distinct (>1e-6) asserted at build. **Contamination-safe**: no numeric constant in any program; every figure computed from the observed quantities; DIGIT-FREE identifiers.

### Verification
- `python3 gen_items.py` from the rung subdir → `wrote items.json: 21 items`.
- `python3 -m pytest test_ladder_eval.py -k rung84 -q` → **3 passed** (the 3 self-contained-rung parametrized gates).
- `rung84_intraocular_pressure` registered in the `SELF_CONTAINED_RUNGS` tuple.

3 files: `rung84_intraocular_pressure/gen_items.py`, `rung84_intraocular_pressure/items.json`, `test_ladder_eval.py` (one tuple line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
