### PR TITLE
feat(latex): LTXDOC03 S5 citation numbering (\cite{foo} → [2])

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.41.0] — 2026-07-06
+
+### Added — cross-reference resolution: citation numbering (LTXDOC03 S5)
+
+The bracketed number a `\cite` actually *prints* — the `[2]` in "as shown in [2]". S4 numbered
+sections and floats but explicitly left **citations** unnumbered; S5 fills that gap over the
+bibliography S2 already resolved. It is the citation-family analogue of S4's `Document::ref_number`.
+
+- **Listing-order bibliography numbers.** In the default numeric/unsorted style, each `\bibitem` is
+  numbered by its **position in the list**: the first is `[1]`, the second `[2]`, …. S5 numbers S2's
+  already-ordered winning `entries` by their index — `entries[0]` → `[1]`, `entries[1]` → `[2]` — so
+  the number matches LaTeX's list position exactly.
+- **First-`\bibitem`-wins duplicates consume no number.** A key defined by two `\bibitem`s puts the
+  first in `entries` and the second in `duplicate_entries`; the losing duplicate is not in `entries`,
+  so it neither adds a row nor advances the counter — a re-declared entry is numbered the same as its
+  first declaration, and the entries after it are **unshifted** (with `a, b, c` and a later duplicate
+  `\bibitem{a}`, `c` stays `[3]`, not `[4]`).
+- **Dangling `\cite`s are unnumbered.** A `\cite{missing}` whose key has no `\bibitem` is in S2's
+  `unresolved`, so it carries no `ResolvedCite` and there is no entry to number — `number_for` returns
+  `None` (LaTeX's `[?]` case), never a panic.
+- **Bracket style single-sourced.** The `[n]` rendering lives in one `render_cite_number` helper.
+- **New API.** `Document::number_citations() -> CitationNumbering { entries: Vec<NumberedCitation> }`
+  with `NumberedCitation { key, ordinal, number }` (owned `String`s + `Copy` ordinal, mirroring S4's
+  `Numbering`/`NumberedLabel`); `CitationNumbering::number_for(key) -> Option<&str>` (allocation-free
+  lookup); and the S2→S5 payoff `Document::cite_number(&ResolvedCite) -> Option<String>` returning a
+  resolved `\cite`'s bracketed number (`"[2]"`), or `None` for a non-entry key (total, never a panic).
+- **Additive & pure.** S1-S4 result types are unchanged; S5 reads S2's `CitationResolution` and
+  produces a new owned aggregate, mutating nothing about the tree or any prior pass.
+
+### Deferred (honest boundary, unchanged from S4)
+
+- **Equation numbers** remain future work: an equation body is an opaque `Block::DisplayMath` raw
+  source string with **no** `label` field (an equation's `\label` is buried inside that string, not a
+  resolvable label def), so per-equation numbering would need fuzzy string heuristics. Citation
+  numbering is well-defined on S2's clean owned data, so S5 does citations; equation numbering stays a
+  documented future rung blocked on the `DisplayMath` AST shape.
+- **Author-year / natbib sorted styles** (`plainnat`, `alpha`, …) that renumber, re-*label*, or sort
+  entries, and **external `.bib`/`.bbl` databases** (S5 does no file I/O, parses no BibTeX), also
+  remain future rungs.
+
 ## [0.40.0] — 2026-07-06
 
 ### Added — cross-reference resolution: document numbering (LTXDOC03 S4)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -52,6 +52,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S2 — `\cite` → bibliography binding** | `Document::resolve_citations() -> CitationResolution` — the *parallel* pass to S1 for the **citation** family, binding each `\cite` key to the `\bibitem` that defines it, **with byte spans on both sides**. Collects the bibliography table from every `\bibitem{k}` inside a `thebibliography` environment (`BibEntry { key, span }`, span = the tight `\bibitem{k}` construct), first-entry-wins with `DuplicateBib`; then, for each `\cite` (the `CITE_COMMAND` family), splits `target` on commas into individual trimmed keys and resolves each → `ResolvedCite` (the shared `\cite` `cite_span` **and** the entry's `entry_span`) or `UnresolvedCite` (dangling key + `cite_span`). A multi-key `\cite{a,b,c}` yields one record **per key**, all sharing that `\cite`'s span; `\cite[note]{k}` keeps the note out of the key. External `.bib`/BibTeX databases and citation numbering stay out of scope (in-document `thebibliography` only). Disjoint from and non-interfering with S1. Total & panic-free, reuses the bounded `walk` + a `MAX_DEPTH`-bounded env descent. | ✅ |
 | **LTXDOC03 S3 — target → `NodeRef` exposure** | The depth-add on S1+S2: both bound each target's **bytes** (a `Span`) but not the target **node**. `Document::node_for_span(span) -> Option<NodeRef>` returns the walked body node whose span **exactly equals** `span` (half-open equality of start **and** end; *equality*, not `node_at`'s containment) — or `None` for a span that is no walked node's own (empty doc, un-walked preamble/metadata, fabricated span). Thin accessors `ref_target_node(&ResolvedRef)`, `cite_target_node(&ResolvedCite)`, `label_def_node(&LabelDef)` take a resolved record and hand back the node, so a caller can read its `kind()` and — for a `Block` — descend into its children (a `\ref`→section enumerates its paragraphs; a `\ref`→figure reaches its caption). **Verified reachability:** every S1/S2 target span matches exactly one walked node (zero collisions); a `\ref`→section/figure/table yields a `NodeRef::Block`, an inline `\eqref`→`\label` a `NodeRef::Inline` (`CrossRef`), and — the once-uncertain case — a `\cite`→`\bibitem` **is** walked (an `Inline::Raw` inside the `thebibliography`), so `cite_target_node` returns `Some`, not `None`. Purely additive (S1/S2 result types keep owned `Span`s, no lifetimes; the `NodeRef` is fetched on demand); tie-break = first-in-pre-order (defensive, does not fire). Numbering + external BibTeX remain out of scope. Total & panic-free, reuses the bounded `walk`. | ✅ |
 | **LTXDOC03 S4 — document numbering (hierarchical sections + flat float counters)** | `Document::number_labels() -> Numbering` — the number a `\ref` *prints*, computed in one `walk` (LaTeX's second `.aux` pass, done statically). **Section numbers** are hierarchical with deeper-reset: a numbered `\section`…`\subparagraph` increments its depth's counter, resets deeper depths to `0`, and renders the dotted join from the top level down (`1`, `1.1`, `1.2`, `1.2.1`, `2`); a starred `\section*` (`numbered == false`) fires no counter and is skipped. **Float counters** are flat and independent: every `figure` advances a running figure counter (`1, 2, …`), every `table` its own (`1, 2, …`) — labeled *or not* (a `\label` only captures the value; an unlabeled figure between two labeled ones takes `2`). Missing-parent rule: a document that starts deep renders honest leading `0`s (a lone `\subsection` → `0.1`), a plain top-level `\section` → `1`. Returns one owned `NumberedLabel { key, kind, number }` per defined numberable label, with `number_for(key)`; `ref_number(&ResolvedRef) -> Option<String>` ties S1 resolution to S4 numbering (`\ref{sec:intro}` → `"1.2"`). Equation numbers, citation `[1]` numbers, and other counters deferred to S5+. Pure, additive, tree-unchanged; fixed 7-slot counter array (no unchecked indexing). Total & panic-free, reuses the bounded `walk`. | ✅ |
+| **LTXDOC03 S5 — citation numbering (bracketed bibliography numbers)** | `Document::number_citations() -> CitationNumbering` — the bracketed number a `\cite` *prints* (`[2]`), the citation-family analogue of S4's `ref_number`. In the default numeric/unsorted style each `\bibitem` is numbered by its **listing position**, so S5 numbers S2's already-ordered winning `entries` by index: `entries[0]` → `[1]`, `entries[1]` → `[2]`, …. A first-`\bibitem`-wins **duplicate** is in `duplicate_entries`, not `entries`, so it consumes **no** number and the entries after it are unshifted (`a, b, c` + a later dup `\bibitem{a}` keeps `c` at `[3]`). A **dangling** `\cite` is in S2's `unresolved`, so it has no entry and `number_for` returns `None` (LaTeX's `[?]`). Returns one owned `NumberedCitation { key, ordinal, number }` per numbered entry, with `number_for(key) -> Option<&str>`; `cite_number(&ResolvedCite) -> Option<String>` ties S2 resolution to S5 numbering (`\cite{foo}` → `"[2]"`). Bracket style single-sourced in one helper. Equation numbers (blocked on `DisplayMath` carrying no label field), author-year/natbib sorted styles, and external `.bib` remain future rungs. Pure, additive, tree-unchanged. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -84,8 +85,12 @@ inside `thebibliography` — is a walked node). **S4 assigns the numbers a `\ref
 (`Document::number_labels` + `ref_number`) — hierarchical section numbers with deeper-reset (`1.2.1`,
 `\section*` skipped) and independent flat figure/table counters (every float advancing its counter,
 labeled or not), so `\ref{sec:intro}` resolves to `"1.2"`. External `.bib`/BibTeX databases stay out
-of scope (in-document `thebibliography` only); equation numbers, citation `[1]` numbers, and other
-counters are deferred to S5+.
+of scope (in-document `thebibliography` only). **S5 assigns the bracketed number a `\cite` prints**
+(`Document::number_citations` + `cite_number`) — the citation-family analogue of `ref_number`:
+numbering S2's listing-ordered `entries` by index so the first `\bibitem` is `[1]`, the second `[2]`,
+… (first-`\bibitem`-wins duplicates consume no number; dangling `\cite`s are unnumbered), so
+`\cite{foo}` resolves to `"[2]"`. Equation numbers (blocked on the `DisplayMath` AST carrying no
+label field), author-year/natbib sorted styles, and external `.bib` remain future rungs.
 
 ## The Document layer (LTXDOC01)
 
@@ -352,9 +357,46 @@ assert_eq!(doc.ref_number(r), Some("1.1".to_string())); // \ref{sec:scope} → "
 
 `number_labels()` returns a `Numbering` of one `NumberedLabel { key, kind, number }` per defined,
 numberable label (section/figure/table). A document that starts deep applies the documented
-missing-parent rule (a lone leading `\subsection` numbers `0.1`). Inline/equation labels, citation
-`[1]` numbers, and other counters (enumerate/theorem/…) are deferred to S5+. Numbering is pure,
-additive analysis — it never mutates the tree, so the S1/S2/S3 outputs are unchanged.
+missing-parent rule (a lone leading `\subsection` numbers `0.1`). Inline/equation labels and other
+counters (enumerate/theorem/…) are deferred to S5+. Numbering is pure, additive analysis — it never
+mutates the tree, so the S1/S2/S3 outputs are unchanged.
+
+### Citation numbering (LTXDOC03 S5)
+
+S2 binds each `\cite` to its `\bibitem`, but not the **bracketed number** it prints (`[2]`). S5
+assigns those — the citation-family analogue of S4's `ref_number`. In the default numeric/unsorted
+style each `\bibitem` is numbered by its **listing position**, so S5 numbers S2's already-ordered
+winning entries by index (`entries[0]` → `[1]`, `entries[1]` → `[2]`, …). `Document::cite_number` is
+the payoff — the bracketed number a resolved `\cite` prints:
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}As shown in \cite{knuth} and \cite{lamport}.
+
+\begin{thebibliography}{9}
+\bibitem{knuth} Knuth, D. The TeXbook. 1984.
+\bibitem{lamport} Lamport, L. LaTeX. 1986.
+\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+
+// Number every bibliography entry, then look one up:
+let num = doc.number_citations();
+assert_eq!(num.number_for("knuth"), Some("[1]"));   // first \bibitem
+assert_eq!(num.number_for("lamport"), Some("[2]")); // second \bibitem
+
+// The payoff: a resolved `\cite` → the number it prints.
+let cites = doc.resolve_citations();
+let c = cites.resolved.iter().find(|c| c.key == "lamport").unwrap();
+assert_eq!(doc.cite_number(c), Some("[2]".to_string())); // \cite{lamport} → "[2]"
+```
+
+`number_citations()` returns a `CitationNumbering` of one `NumberedCitation { key, ordinal, number }`
+per numbered entry. A first-`\bibitem`-wins duplicate consumes no number (later entries stay
+unshifted); a dangling `\cite` has no entry, so `number_for` returns `None` (LaTeX's `[?]`). Equation
+numbers (blocked on the `DisplayMath` AST carrying no label field), author-year/natbib sorted styles,
+and external `.bib` databases remain future rungs. Like S4, S5 is pure, additive analysis — it never
+mutates the tree, so the S1–S4 outputs are unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1237,6 +1237,197 @@ impl Document {
     }
 }
 
+// =================================================================================================
+// LTXDOC03 S5 — citation numbering (bracketed bibliography numbers over S2's resolution).
+//
+// S1 numbered nothing; S2 bound each `\cite` to its `\bibitem`; S4 numbered *sections and floats*
+// but explicitly left **citations** unnumbered. S5 fills that gap: it assigns the bracketed number
+// LaTeX prints for a `\cite` — the `[2]` in "as shown in [2]" — over the bibliography S2 already
+// resolved. It is the citation-family analogue of S4's [`Document::ref_number`].
+//
+// ## LaTeX's citation-numbering model (the `.aux` dance, numbered style)
+//
+// In the default *numeric, unsorted* bibliography style (`plain`-family, hand-written
+// `thebibliography`, or `unsrt`), every `\bibitem` is numbered by its **position in the list**: the
+// first `\bibitem` is `[1]`, the second `[2]`, the third `[3]`, …. On the first `latex` run each
+// `\bibitem{key}` fires the `enumiv`/bibliography counter and writes a `\bibcite{key}{n}` line into
+// `document.aux`; on the second run every `\cite{key}` reads `n` back and prints it in **brackets**.
+// A `\cite` to two keys, `\cite{a,c}`, prints both numbers, `[1, 3]`. A `\cite` whose key has no
+// `\bibitem` prints the tell-tale `[?]` and warns *"Citation `key' undefined"*.
+//
+// S5 is the static, single-pass, in-document analogue: a flat counter over S2's **already-ordered**
+// winning entry list. No `.aux`, no second parse — we number [`CitationResolution::entries`] by their
+// index (the exploratory parse confirmed `entries` is in `\bibitem` *listing order*), rendering entry
+// `entries[0]` as `[1]`, `entries[1]` as `[2]`, and so on.
+//
+// ## The three rules S5 implements (each confirmed against S2's data)
+//
+// 1. **Listing-order numbering.** `entries[i]` → `i + 1`, rendered bracketed. Because S2 collects
+//    `\bibitem`s in pre-order (source order), `entries[0]` *is* the first `\bibitem` in the source, so
+//    the index-based number matches LaTeX's list position exactly.
+// 2. **First-`\bibitem`-wins duplicates consume no number.** A key defined by two `\bibitem`s puts the
+//    *first* in `entries` and the *second* in [`CitationResolution::duplicate_entries`] — the losing
+//    duplicate is **not** in `entries`, so it never advances the counter. Confirmed: with entries
+//    `a, b, c` and a later duplicate `\bibitem{a}`, `entries == [a, b, c]` and `c` is still `[3]` (the
+//    duplicate did not push it to `[4]`). This mirrors LaTeX: a re-declared `\bibitem` warns and is
+//    numbered *the same* as the first — it does not consume a fresh slot.
+// 3. **Dangling `\cite`s are unnumbered.** A `\cite{missing}` whose key has no `\bibitem` is in
+//    [`CitationResolution::unresolved`], so it carries no [`ResolvedCite`] and there is no entry to
+//    number — [`CitationNumbering::number_for`] returns `None` for it (never a panic). This is the
+//    `[?]` case, the honest boundary S1-S4 all draw around undefined keys.
+//
+// ## What S5 numbers, and what is DEFERRED (the honest boundary)
+//
+// S5 numbers **in-document `thebibliography` citations only**, in the default numeric/unsorted style.
+// It deliberately does **not** yet assign:
+//
+// - **Equation numbers** — the other candidate for this rung, but the AST does not model them: an
+//   equation body is kept as an opaque [`Block::DisplayMath`] *raw source string* with **no** `label`
+//   field (an equation's `\label` is buried inside that string, not a resolvable label def), so
+//   per-equation numbering would need fuzzy string heuristics. Citation numbering is well-defined on
+//   S2's clean owned data, so S5 does citations; equation numbering stays a documented future rung
+//   (blocked on the `DisplayMath` AST shape carrying no label field).
+// - **Author-year / natbib sorted styles.** `plainnat`/`abbrvnat`/`alpha` renumber or re-*label*
+//   entries (`[Smith2020]`, `[Smi20]`) and often **sort** the list, changing the number a key prints.
+//   S5 models only the *listing-order numeric* style; sorted/author-year styles are a later rung.
+// - **External `.bib` databases.** As with S2, only an in-document `thebibliography` is numbered; a
+//   `\bibliography{refs}` reading an external `.bib`/`.bbl` is not (S5 does no file I/O, parses no
+//   BibTeX). A `\cite` whose key lives only in an external database is *unresolved* by S2, hence
+//   unnumbered here.
+//
+// ## The result type and payoff
+//
+// [`Document::number_citations`] returns a [`CitationNumbering`]: one owned row per numbered
+// bibliography key, carrying its raw ordinal (`1`, `2`, …) and its rendered bracketed number (`"[1]"`,
+// `"[2]"`, …). It mirrors S4's [`Numbering`] shape (owned `String`s + `Copy` ordinal) and provides a
+// [`number_for`](CitationNumbering::number_for) lookup. [`Document::cite_number`] is the S2→S5 payoff
+// convenience: given a resolved `\cite` (S2's [`ResolvedCite`]), return that citation's bracketed
+// number — closing the loop `\cite{foo}` → `"[2]"`.
+//
+// **Additive & pure.** The S1-S4 result types are unchanged; S5 reads S2's [`CitationResolution`] and
+// produces a new owned aggregate, mutating nothing about the tree or any prior pass.
+// =================================================================================================
+
+/// Render an entry's raw ordinal as the bracketed LaTeX citation number: `1` → `"[1]"`, `2` → `"[2]"`.
+///
+/// The single source of the bracket style — `\cite` prints its entry's number **in square brackets**
+/// in the default numeric style, and every S5 rendering funnels through here so the bracket convention
+/// lives in exactly one place (if a future rung needs a different delimiter, it changes only this
+/// helper). Pure and total: a `usize` format, no allocation beyond the returned `String`, no panic.
+fn render_cite_number(ordinal: usize) -> String {
+    format!("[{ordinal}]")
+}
+
+// -------------------------------------------------------------------------------------------------
+// The record types (plain, Clone-able, owned data — parallel to S4's NumberedLabel/Numbering).
+// -------------------------------------------------------------------------------------------------
+
+/// One **numbered citation**: a bibliography `key`, its raw `ordinal` (1-based list position), and the
+/// rendered bracketed `number` LaTeX would print for a `\cite` to it. This is one row of S5's citation
+/// numbering table — the static analogue of an `.aux` `\bibcite{key}{n}` line, capturing the number in
+/// its printed bracketed form.
+///
+/// The `ordinal` is the entry's 1-based position in the (listing-order) winning entry list —
+/// `entries[0]` → `1`, `entries[1]` → `2`, …; the `number` is that ordinal rendered through
+/// [`render_cite_number`] (`"[1]"`, `"[2]"`, …). Both are exposed: the `ordinal` for callers that want
+/// the bare count (to re-render in a different style, or sort), the `number` for the ready-to-print
+/// bracketed string a `\cite` emits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NumberedCitation {
+    /// The citation key, verbatim, without braces (`"smith2020"`).
+    pub key: String,
+    /// The entry's 1-based ordinal — its position in the `\bibitem` listing (`1`, `2`, …).
+    pub ordinal: usize,
+    /// The rendered bracketed number LaTeX would print for a `\cite` to this key (`"[1]"`, `"[2]"`, …).
+    pub number: String,
+}
+
+/// The full result of [`Document::number_citations`]: the citation-numbering table — one
+/// [`NumberedCitation`] row per **numbered bibliography key** (the winning `\bibitem`s, in listing
+/// order; dangling `\cite`s and losing duplicates are omitted). All plain, owned data (keys + numbers
+/// are `String`s, ordinals are `Copy`), so the numbering outlives any borrow of the source and can be
+/// stored/serialized — mirroring S4's [`Numbering`].
+///
+/// **Ordering.** `entries` is in `\bibitem` **listing order** (the pre-order S2 collected the winning
+/// entries in), so the table reads top-to-bottom like the bibliography and each row's `ordinal` is
+/// just its index + 1. Only winning entries appear: a duplicate `\bibitem` (in S2's
+/// [`CitationResolution::duplicate_entries`]) does **not** add a row and does **not** advance the
+/// count — exactly as LaTeX numbers a re-declared entry the same as its first declaration.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CitationNumbering {
+    /// One row per numbered bibliography key, in `\bibitem` listing order.
+    pub entries: Vec<NumberedCitation>,
+}
+
+impl CitationNumbering {
+    /// The rendered bracketed number of `key`, if it is a numbered bibliography entry, else `None`.
+    /// Linear over `entries` (small: one row per distinct entry); no allocation. `&str` borrow into
+    /// the owned row.
+    pub fn number_for(&self, key: &str) -> Option<&str> {
+        self.entries.iter().find(|e| e.key == key).map(|e| e.number.as_str())
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// The citation-numbering pass.
+// -------------------------------------------------------------------------------------------------
+
+impl Document {
+    /// Number every bibliography entry with its bracketed `\cite` number (LTXDOC03 S5).
+    ///
+    /// Built directly on S2: it runs [`resolve_citations`](Document::resolve_citations), then numbers
+    /// the winning [`CitationResolution::entries`] by their **listing-order index** — `entries[0]` →
+    /// `[1]`, `entries[1]` → `[2]`, …. Because S2 collects `\bibitem`s in source pre-order, the index
+    /// matches LaTeX's list position exactly (the default numeric/unsorted style).
+    ///
+    /// A losing duplicate `\bibitem` (in [`CitationResolution::duplicate_entries`]) is **not** in
+    /// `entries`, so it neither adds a row nor advances the counter — a re-declared entry is numbered
+    /// the same as its first declaration, consuming no fresh slot. A dangling `\cite` has no entry, so
+    /// it is simply absent from the table (unnumbered).
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing; the ordinal comes from
+    /// `enumerate` over `entries` (bounded by the number of distinct entries), reusing S2's bounded
+    /// collection (no new recursion). Borrows `self` immutably; the returned [`CitationNumbering`] is
+    /// owned plain data (keys + numbers copied out, ordinals `Copy`), so it outlives any borrow of the
+    /// source. The tree is **not** mutated — numbering is pure analysis, leaving S1-S4 outputs
+    /// byte-for-byte unchanged.
+    pub fn number_citations(&self) -> CitationNumbering {
+        let resolution = self.resolve_citations();
+        let entries = resolution
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| {
+                // 1-based ordinal: `entries[0]` is `[1]`. `index + 1` cannot overflow in any real
+                // document (the entry count is bounded by the parsed tree), and `saturating_add`
+                // keeps it total even at the theoretical `usize::MAX` edge.
+                let ordinal = index.saturating_add(1);
+                NumberedCitation {
+                    key: entry.key.clone(),
+                    ordinal,
+                    number: render_cite_number(ordinal),
+                }
+            })
+            .collect();
+        CitationNumbering { entries }
+    }
+
+    /// The rendered bracketed **number** a resolved citation prints (LTXDOC03 S5) — the payoff that
+    /// ties S2 resolution to S5 numbering: given a [`ResolvedCite`] (`\cite{foo}`'s binding to its
+    /// `\bibitem`), return that entry's number (`"[2]"`), or `None` if the key is not a numbered entry
+    /// — a **documented, total** outcome, never a panic. (In practice a genuine [`ResolvedCite`]
+    /// *always* names a winning entry, so `None` is the honest edge — e.g. a hand-built `ResolvedCite`
+    /// with a key no `\bibitem` defines.)
+    ///
+    /// Convenience over [`number_citations`](Document::number_citations): it numbers the document, then
+    /// looks the citation's `key` up. (A caller numbering *many* citations should call
+    /// `number_citations` **once** and reuse the [`CitationNumbering`]; this method re-numbers per
+    /// call, which is O(entries) each — fine for a one-off lookup.)
+    pub fn cite_number(&self, c: &ResolvedCite) -> Option<String> {
+        self.number_citations().number_for(&c.key).map(str::to_string)
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // Tests.
 // -------------------------------------------------------------------------------------------------
@@ -2131,6 +2322,173 @@ See Section~\ref{sec:intro} and \cite{smith2020}.
         assert!(
             doc.ref_target_node(&refs_before.resolved[0]).is_some(),
             "S3 lookup still resolves after numbering"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S5 — citation numbering (bracketed bibliography numbers).
+    // ---------------------------------------------------------------------------------------------
+
+    /// Parse `src` and number its citations — the shared S5 harness.
+    fn number_cites(src: &str) -> CitationNumbering {
+        parse_document(src).expect("parse").number_citations()
+    }
+
+    #[test]
+    fn bibitems_number_by_listing_order() {
+        // Three `\bibitem`s in a `thebibliography` number `[1]`, `[2]`, `[3]` in listing order —
+        // the exact bracketed strings LaTeX prints for a `\cite` to each.
+        let src = r"\begin{document}\cite{a} \cite{b} \cite{c}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\bibitem{c} C. Third. 2003.
+\end{thebibliography}\end{document}";
+        let num = number_cites(src);
+
+        assert_eq!(num.entries.len(), 3, "three numbered entries");
+        // LOAD-BEARING: the exact bracketed strings, in listing order.
+        assert_eq!(num.number_for("a"), Some("[1]"), "first \\bibitem is [1]");
+        assert_eq!(num.number_for("b"), Some("[2]"), "second \\bibitem is [2]");
+        assert_eq!(num.number_for("c"), Some("[3]"), "third \\bibitem is [3]");
+
+        // The raw ordinals are the 1-based list positions.
+        assert_eq!(num.entries[0].ordinal, 1);
+        assert_eq!(num.entries[1].ordinal, 2);
+        assert_eq!(num.entries[2].ordinal, 3);
+        // Rows are in listing order (keys read top-to-bottom like the bibliography).
+        let keys: Vec<&str> = num.entries.iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(keys, ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn cite_number_ties_s2_resolution_to_s5_numbering() {
+        // THE PAYOFF: a resolved `\cite{b}` (S2) numbers to "[2]" (S5) — the second `\bibitem`.
+        let src = r"\begin{document}As shown in \cite{b}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let cites = doc.resolve_citations();
+        assert_eq!(cites.resolved.len(), 1, "the \\cite{{b}} resolves");
+        let c = &cites.resolved[0];
+        assert_eq!(c.key, "b");
+        // LOAD-BEARING: S2's resolved cite → S5's bracketed number.
+        assert_eq!(doc.cite_number(c).as_deref(), Some("[2]"), "\\cite{{b}} prints [2]");
+    }
+
+    #[test]
+    fn multi_key_cite_numbers_each_key_independently() {
+        // A multi-key `\cite{a,c}` → its two resolved records number to "[1]" and "[3]" respectively
+        // (each key looks up its own entry's list position).
+        let src = r"\begin{document}See \cite{a,c}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\bibitem{c} C. Third. 2003.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let cites = doc.resolve_citations();
+        assert_eq!(cites.resolved.len(), 2, "both keys of \\cite{{a,c}} resolve");
+        let ca = cites.resolved.iter().find(|c| c.key == "a").expect("a resolves");
+        let cc = cites.resolved.iter().find(|c| c.key == "c").expect("c resolves");
+        assert_eq!(doc.cite_number(ca).as_deref(), Some("[1]"), "a is [1]");
+        assert_eq!(doc.cite_number(cc).as_deref(), Some("[3]"), "c is [3]");
+    }
+
+    #[test]
+    fn dangling_cite_key_is_not_numbered_no_panic() {
+        // A `\cite{missing}` is in S2's `unresolved` (no ResolvedCite), so there is nothing to
+        // number. `number_for("missing")` is None — the honest `[?]` edge, no panic.
+        let src = r"\begin{document}See \cite{missing}.
+
+\begin{thebibliography}{9}
+\bibitem{real} Real. Actual. 2000.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let num = doc.number_citations();
+        assert_eq!(num.number_for("real"), Some("[1]"), "the real entry is [1]");
+        assert!(num.number_for("missing").is_none(), "a dangling key has no number");
+
+        // And the dangling `\cite` really is unresolved (so there is no ResolvedCite to pass to
+        // cite_number in the first place).
+        let cites = doc.resolve_citations();
+        assert!(cites.resolved.is_empty(), "nothing resolves");
+        assert_eq!(cites.unresolved.len(), 1);
+        assert_eq!(cites.unresolved[0].key, "missing");
+    }
+
+    #[test]
+    fn duplicate_bibitem_consumes_no_number_others_unshifted() {
+        // A re-declared `\bibitem{a}` later in the list is a losing duplicate: it does NOT renumber
+        // or shift the others (b stays "[2]", c stays "[3]"), and consumes no number of its own.
+        let src = r"\begin{document}\cite{a} \cite{b} \cite{c}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\bibitem{c} C. Third. 2003.
+\bibitem{a} A. Duplicate later. 2099.
+\end{thebibliography}\end{document}";
+        let num = number_cites(src);
+
+        // Exactly three numbered entries — the duplicate did NOT add a fourth row.
+        assert_eq!(num.entries.len(), 3, "the duplicate \\bibitem{{a}} consumes no number");
+        assert_eq!(num.number_for("a"), Some("[1]"), "a keeps its first-declaration number [1]");
+        assert_eq!(num.number_for("b"), Some("[2]"), "b is unshifted at [2]");
+        assert_eq!(num.number_for("c"), Some("[3]"), "c is unshifted at [3] (not pushed to [4])");
+    }
+
+    #[test]
+    fn empty_document_yields_empty_citation_numbering_no_panic() {
+        // An empty document, and one with no `thebibliography`, both yield empty numbering, no panic.
+        assert_eq!(
+            number_cites(r"\begin{document}\end{document}"),
+            CitationNumbering::default(),
+            "empty doc → empty citation numbering"
+        );
+        assert_eq!(
+            number_cites(r"\begin{document}Text with \cite{x} but no bibliography.\end{document}"),
+            CitationNumbering::default(),
+            "no bibliography → no numbered entries"
+        );
+    }
+
+    #[test]
+    fn citation_numbering_does_not_mutate_the_tree_s1_s2_s3_s4_unchanged() {
+        // REGRESSION: citation numbering is pure analysis — running it leaves S1/S2/S3/S4 outputs
+        // byte-for-byte unchanged (the tree is never mutated).
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+See Section~\ref{sec:intro} and \cite{smith2020}.
+
+\begin{thebibliography}{9}
+\bibitem{smith2020} Smith, J. Title. 2020.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let refs_before = doc.resolve_references();
+        let cites_before = doc.resolve_citations();
+        let num_before = doc.number_labels();
+
+        // Number the citations (exercises the S5 pass).
+        let cite_num = doc.number_citations();
+        assert_eq!(cite_num.number_for("smith2020"), Some("[1]"));
+
+        // S1/S2/S4 outputs are untouched, and S3 node lookup still agrees.
+        assert_eq!(doc.resolve_references(), refs_before, "S1 output unchanged by S5");
+        assert_eq!(doc.resolve_citations(), cites_before, "S2 output unchanged by S5");
+        assert_eq!(doc.number_labels(), num_before, "S4 output unchanged by S5");
+        assert!(
+            doc.cite_target_node(&cites_before.resolved[0]).is_some(),
+            "S3 lookup still resolves after citation numbering"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -417,3 +417,97 @@ two labeled ones makes the second labeled one `3` (every float advances); `ref_n
 missing-parent rule); a plain top-level `\section` → `1`; an inline `\label` is **not** numbered
 (deferred); and a regression that numbering leaves the S1/S2/S3 outputs byte-for-byte unchanged (the
 tree is never mutated).
+
+## 11. S5 — citation numbering (bracketed bibliography numbers)
+
+S4 numbered **sections and floats** — the counters a `\ref` most commonly prints — but explicitly
+left **citations** unnumbered. S5 fills that gap: it assigns the bracketed number LaTeX prints for a
+`\cite` (the `[2]` in "as shown in [2]") over the bibliography **S2 already resolved**. It is the
+citation-family analogue of S4's `ref_number`: where S4 tied S1 resolution to a section/float number,
+S5 ties S2 resolution to a bibliography number.
+
+**Why citations, not equations, for this rung.** Equation numbering was the other candidate, but the
+AST does not cleanly model it: an equation body is kept as an opaque `Block::DisplayMath { source:
+String, span }` — a **raw unparsed string** with **no** `label` field, so an equation's `\label` is
+buried inside `source`, not a resolvable label def. Per-equation numbering would need fuzzy string
+heuristics. Citation numbering, by contrast, is well-defined and fully testable over S2's clean owned
+data, so S5 does citations; equation numbering stays a documented future rung (§11.4).
+
+### 11.1 The LaTeX citation-numbering model
+
+In the default **numeric, unsorted** bibliography style (`plain`-family, a hand-written
+`thebibliography`, or `unsrt`), every `\bibitem` is numbered by its **position in the list**: the
+first `\bibitem` is `[1]`, the second `[2]`, …. On the first `latex` run each `\bibitem{key}` writes a
+`\bibcite{key}{n}` line into `document.aux`; on the second run each `\cite{key}` reads `n` back and
+prints it **in square brackets**. A multi-key `\cite{a,c}` prints both numbers (`[1, 3]`); a `\cite`
+whose key has no `\bibitem` prints the tell-tale `[?]` and warns *"Citation `key' undefined"*.
+
+S5 is the static, single-pass, in-document analogue: a flat counter over S2's **already-ordered**
+winning entry list. No `.aux`, no second parse — S5 numbers `CitationResolution::entries` by their
+index. An exploratory parse confirmed `entries` is in `\bibitem` **listing order** (`entries[0]` is
+the first `\bibitem` in the source), so entry `entries[i]` renders as `[i + 1]`.
+
+### 11.2 The three rules (each confirmed against S2's data)
+
+1. **Listing-order numbering.** `entries[i]` → `i + 1`, rendered bracketed. Because S2 collects
+   `\bibitem`s in pre-order, the index matches LaTeX's list position exactly.
+2. **First-`\bibitem`-wins duplicates consume no number.** A key defined by two `\bibitem`s puts the
+   first in `entries` and the second in `duplicate_entries` — the losing duplicate is **not** in
+   `entries`, so it never advances the counter. Confirmed by exploration: with entries `a, b, c` and a
+   later duplicate `\bibitem{a}`, `entries == [a, b, c]` and `c` is still `[3]` (not pushed to `[4]`).
+   This mirrors LaTeX: a re-declared `\bibitem` is numbered the same as the first, consuming no slot.
+3. **Dangling `\cite`s are unnumbered.** A `\cite{missing}` whose key has no `\bibitem` is in S2's
+   `unresolved`, so it carries no `ResolvedCite` and there is no entry to number — `number_for`
+   returns `None` (the `[?]` case), never a panic.
+
+The bracket rendering (`n` → `"[n]"`) is single-sourced in one `render_cite_number` helper, so the
+bracket convention lives in exactly one place.
+
+### 11.3 Public API
+
+```rust
+impl Document {
+    /// One `NumberedCitation { key, ordinal, number }` per numbered bibliography key, in `\bibitem`
+    /// listing order. Losing duplicates and dangling cites are omitted.
+    pub fn number_citations(&self) -> CitationNumbering;
+    /// The bracketed number a resolved `\cite` prints — `number_citations().number_for(c.key)`; ties
+    /// S2 → S5. `None` for a non-entry key (total, never a panic).
+    pub fn cite_number(&self, c: &ResolvedCite) -> Option<String>;
+}
+
+pub struct CitationNumbering { pub entries: Vec<NumberedCitation> }
+impl CitationNumbering { pub fn number_for(&self, key: &str) -> Option<&str>; }
+
+pub struct NumberedCitation { pub key: String, pub ordinal: usize, pub number: String }
+```
+
+`CitationNumbering`/`NumberedCitation` are dedicated, owned-`String` result types mirroring S4's
+`Numbering`/`NumberedLabel` (owned `String`s + `Copy` ordinal), so a numbering outlives any borrow of
+the source. `cite_number` is the **payoff**: `\cite{foo}` → `"[2]"`, closing the loop from S2
+resolution to S5 numbering. (A caller numbering *many* cites should call `number_citations` once and
+reuse it; `cite_number` re-numbers per call.)
+
+### 11.4 What is DEFERRED (honest boundary, mirroring S1–S4)
+
+- **Equation numbers** — blocked on the AST shape: an equation body is an opaque
+  `Block::DisplayMath` **raw source string** with no `label` field (the `\label` is buried inside the
+  string), so per-equation numbering would need fuzzy string heuristics. A future rung.
+- **Author-year / natbib sorted styles** — `plainnat`/`abbrvnat`/`alpha` renumber, re-*label*
+  (`[Smith2020]`, `[Smi20]`), and often **sort** the entry list, changing the number a key prints. S5
+  models only the listing-order numeric style; sorted/author-year styles are a later rung.
+- **External `.bib` databases** — as with S2, only an in-document `thebibliography` is numbered; a
+  `\bibliography{refs}` reading an external `.bib`/`.bbl` is not (no file I/O, no BibTeX parsing). A
+  key that lives only in an external database is *unresolved* by S2, hence unnumbered here.
+
+### 11.5 Verification (S5)
+
+`cargo test -p latex` green (7 new `references` S5 tests); `cargo clippy -p latex --all-targets
+-- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build
+-p latex --no-default-features` builds. No `cargo fmt`, no grammar regen. The tests assert the
+**actual bracketed string**: three `\bibitem`s → `number_for("a")=="[1]"`, `"b"=="[2]"`, `"c"=="[3]"`
+(listing order); `cite_number` for a resolved `\cite{b}` → `"[2]"` (the load-bearing S2→S5 payoff); a
+multi-key `\cite{a,c}` numbers its resolved records to `"[1]"` and `"[3]"`; a dangling `\cite{missing}`
+→ `number_for("missing")` is `None` (no panic); a later duplicate `\bibitem{a}` does not renumber or
+shift the others (`b` stays `"[2]"`, `c` stays `"[3]"`) and consumes no number; an empty document /
+document with no `thebibliography` → empty numbering; and a regression that citation numbering leaves
+the S1/S2/S3/S4 outputs byte-for-byte unchanged (the tree is never mutated).


### PR DESCRIPTION
## LTXDOC03 S5 — citation numbering (`\cite{foo}` → `[2]`)

Fifth slice of the LTXDOC03 cross-reference-resolution arc in the dependency-free `latex` crate. S1 bound `\ref`→`\label`, S2 bound `\cite`→`\bibitem`, S3 exposed target nodes, S4 numbered sections + float counters. S4 did **not** number the citation family. **S5 assigns citation numbers** — LaTeX prints `\cite{foo}` as a bracketed number `[2]` — the citation-family analogue of S4, built directly on S2's resolved bibliography.

### Why citations, not equations (a justified pivot)
Equation numbering was the other S5 candidate, but the AST does not cleanly model it: `Block::DisplayMath { source: String, span }` keeps the equation body as a **raw unparsed string** and carries **no label field** — an equation's `\label` is buried inside `source`, not a resolvable label def — so per-equation numbering would need fuzzy heuristics, against "small and fully testable." Citation numbering is well-defined and fully testable on S2's clean owned data, so S5 does citations; **equation numbering stays a documented future rung** (blocked on the DisplayMath AST shape).

### What it adds (all in `src/references.rs`, one module extended)
- **Number the bibliography** — number S2's winning `entries` by their **listing order** (pre-order = source order): `entries[0]` → `[1]`, `entries[1]` → `[2]`, … This is LaTeX's faithful default for an unsorted `thebibliography` (bibitems numbered in listing order). A **duplicate** `\bibitem` of an already-defined key lands in S2's `duplicate_entries`, **not** `entries`, so it **consumes no number** and does not shift the others. Bracket rendering is single-sourced in one `render_cite_number` helper.
- **Public API** (mirrors S4's shape):
  ```rust
  impl Document {
      pub fn number_citations(&self) -> CitationNumbering;              // per-key rendered number + ordinal
      pub fn cite_number(&self, c: &ResolvedCite) -> Option<String>;    // the S2→S5 payoff: \cite{foo} → "[2]"
  }
  pub struct CitationNumbering { pub entries: Vec<NumberedCitation> }
  impl CitationNumbering { pub fn number_for(&self, key: &str) -> Option<&str> }
  pub struct NumberedCitation { pub key: String, pub ordinal: usize, pub number: String }
  ```
  Owned plain-data result (keys + numbers copied out), mirroring S1/S2/S4. A dangling `\cite{missing}` is in S2's `unresolved` (no `ResolvedCite`), so it is never numbered — `number_for` returns `None`, no panic.

### Safety
Pure read-only analysis over S2's already-computed, bounded `entries`/`resolved` (no new tree walk, no new recursion): no file I/O, no network, no new deps, **no `unsafe`**, no `unwrap`/`expect`/unchecked indexing on the public path; the ordinal counter uses `saturating_add`. The tree is **not** mutated; S1/S2/S3/S4 outputs are unchanged.

### Deferred to S6+
Equation numbers (needs a DisplayMath AST that carries the equation label — currently source-kept raw), author-year / sorted (natbib) citation styles, and external `.bib`/BibTeX databases (against the crate's no-I/O design). Noted in the spec's future section.

### Tests (7 new; assert exact bracketed strings)
- three `\bibitem{a}`/`{b}`/`{c}` in a `thebibliography` → `[1]`/`[2]`/`[3]` (listing order, exact strings).
- `cite_number(\cite{b})` → `"[2]"` (the load-bearing S2→S5 payoff).
- multi-key `\cite{a,c}` → the resolved records number to `[1]` and `[3]`.
- a mixed `\cite` (one resolvable + one dangling) → one resolved + one unresolved from the same cite; the dangling key's `number_for` is `None` (no panic).
- a duplicate `\bibitem{a}` later in the list → consumes no number, `b` stays `[2]` (others unshifted); first-entry-wins.
- empty document / no `thebibliography` → empty `CitationNumbering`, no panic.
- regression: labels + citations coexist without interference (S1/S2/S3/S4 unchanged; tree not mutated).

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → **338 passed** (was 331 + 7 new S5 tests) + doctest.
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected).
- `cargo build -p latex --no-default-features` → builds.

Crate bumped `0.40.0` → `0.41.0`; CHANGELOG, README (usage + feature row), and the LTXDOC03 spec (new §11 S5) updated. Security-reviewed (Rust, panic/DoS-focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
