### PR TITLE
Add Chief smart-home service execution readiness brief

### DIFF
--- a/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 
 ## Unreleased
 
+- Added `smart_home.get_service_execution_readiness_brief`, a read-only Chief
+  adapter tool that composes existing D23 controller handoff, command-risk,
+  authorization-gap, and capability-grant signals into one Home
+  Assistant-style service execution gate without dispatching commands or owning
+  smart-home state.
 - Added `smart_home.list_platform_event_ops_review` and
   `smart_home.get_platform_event_ops_review_summary`, read-only Chief adapter
   tools that roll up existing D23 event delivery, event log, and pending-work

--- a/code/packages/rust/chief-of-staff-smart-home-tools/README.md
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/README.md
@@ -107,6 +107,7 @@ Chief of Staff job/session/agent
   -> activation-risk list and summary reads for policy-tier/surface rollout risk
   -> activation dependency graph list and summary reads for prerequisite edges
   -> runtime snapshot, morning-brief, platform-brief, pending-work, attention-overview,
+     system-health, operator-action, service-execution readiness,
      remediation-plan, operations-brief, safety-brief, readiness-brief,
      maintenance-brief, incident-brief, recovery-brief, escalation-brief,
      continuity-brief, desired-state, and pairing-session inventory reads
@@ -295,6 +296,7 @@ Chief of Staff job/session/agent
 - `smart_home.get_attention_overview`
 - `smart_home.get_system_health_brief`
 - `smart_home.get_operator_action_brief`
+- `smart_home.get_service_execution_readiness_brief`
 - `smart_home.get_remediation_plan`
 - `smart_home.get_operations_brief`
 - `smart_home.get_safety_brief`

--- a/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
+++ b/code/packages/rust/chief-of-staff-smart-home-tools/src/lib.rs
@@ -326,6 +326,8 @@ pub const SMART_HOME_GET_ATTENTION_OVERVIEW_TOOL_ID: &str = "smart_home.get_atte
 pub const SMART_HOME_GET_SYSTEM_HEALTH_BRIEF_TOOL_ID: &str = "smart_home.get_system_health_brief";
 pub const SMART_HOME_GET_OPERATOR_ACTION_BRIEF_TOOL_ID: &str =
     "smart_home.get_operator_action_brief";
+pub const SMART_HOME_GET_SERVICE_EXECUTION_READINESS_BRIEF_TOOL_ID: &str =
+    "smart_home.get_service_execution_readiness_brief";
 pub const SMART_HOME_GET_REMEDIATION_PLAN_TOOL_ID: &str = "smart_home.get_remediation_plan";
 pub const SMART_HOME_GET_OPERATIONS_BRIEF_TOOL_ID: &str = "smart_home.get_operations_brief";
 pub const SMART_HOME_GET_SAFETY_BRIEF_TOOL_ID: &str = "smart_home.get_safety_brief";
@@ -2501,6 +2503,14 @@ impl SmartHomeToolBridge {
                 SMART_HOME_GET_OPERATOR_ACTION_BRIEF_TOOL_ID => {
                     let _ = expect_object(&arguments)?;
                     get_operator_action_brief_output_handler_output(
+                        &mut runtime,
+                        principal_id,
+                        now_ms,
+                    )
+                }
+                SMART_HOME_GET_SERVICE_EXECUTION_READINESS_BRIEF_TOOL_ID => {
+                    let _ = expect_object(&arguments)?;
+                    get_service_execution_readiness_brief_output_handler_output(
                         &mut runtime,
                         principal_id,
                         now_ms,
@@ -6717,6 +6727,7 @@ pub fn smart_home_tool_definitions() -> Vec<ToolDefinition> {
         get_attention_overview_definition(),
         get_system_health_brief_definition(),
         get_operator_action_brief_definition(),
+        get_service_execution_readiness_brief_definition(),
         get_remediation_plan_definition(),
         get_operations_brief_definition(),
         get_safety_brief_definition(),
@@ -7907,6 +7918,56 @@ fn get_operator_action_brief_definition() -> ToolDefinition {
                 "next_action",
                 "actions",
                 "watchlist",
+                "system_health",
+                "source_tools",
+            ],
+            false,
+        ),
+    )
+}
+
+fn get_service_execution_readiness_brief_definition() -> ToolDefinition {
+    read_definition(
+        SMART_HOME_GET_SERVICE_EXECUTION_READINESS_BRIEF_TOOL_ID,
+        "Get smart-home service execution readiness brief",
+        "Compose Chief-visible D23 controller handoff, command-risk, authorization-gap, and capability-grant signals into a Home Assistant-style service execution readiness gate without dispatching commands or mutating smart-home state.",
+        empty_object_schema(),
+        object_schema(
+            vec![
+                SchemaProperty::new("generated_at_ms", JsonSchema::Integer),
+                SchemaProperty::new("status", JsonSchema::String),
+                SchemaProperty::new("ready", JsonSchema::Boolean),
+                SchemaProperty::new("service_execution_ready", JsonSchema::Boolean),
+                SchemaProperty::new("has_blockers", JsonSchema::Boolean),
+                SchemaProperty::new("total_attention_count", JsonSchema::Integer),
+                SchemaProperty::new("total_blocked_count", JsonSchema::Integer),
+                SchemaProperty::new("summary", JsonSchema::Any),
+                SchemaProperty::new("next_action", JsonSchema::Any),
+                SchemaProperty::new(
+                    "readiness_gates",
+                    JsonSchema::Array {
+                        items: Box::new(JsonSchema::Any),
+                    },
+                ),
+                SchemaProperty::new("system_health", JsonSchema::Any),
+                SchemaProperty::new(
+                    "source_tools",
+                    JsonSchema::Array {
+                        items: Box::new(JsonSchema::String),
+                    },
+                ),
+            ],
+            vec![
+                "generated_at_ms",
+                "status",
+                "ready",
+                "service_execution_ready",
+                "has_blockers",
+                "total_attention_count",
+                "total_blocked_count",
+                "summary",
+                "next_action",
+                "readiness_gates",
                 "system_health",
                 "source_tools",
             ],
@@ -46950,6 +47011,147 @@ fn get_operator_action_brief_output_handler_output(
     ))
 }
 
+fn get_service_execution_readiness_brief_output_handler_output(
+    runtime: &mut SmartHomeRuntime,
+    principal_id: AgentId,
+    now_ms: u64,
+) -> Result<ToolHandlerOutput, ToolCallError> {
+    let snapshot_output = runtime
+        .execute_read_tool(
+            principal_id.clone(),
+            RuntimeReadToolRequest::GetRuntimeSnapshot,
+            now_ms,
+        )
+        .map_err(runtime_error)?;
+    let RuntimeReadToolOutput::RuntimeSnapshot(snapshot) = snapshot_output else {
+        return Err(ToolCallError::new(
+            ToolErrorKind::ToolExecutionError,
+            "service execution readiness brief expected runtime snapshot output",
+        ));
+    };
+    let topology_output = runtime
+        .execute_read_tool(
+            principal_id.clone(),
+            RuntimeReadToolRequest::GetTopologySummary,
+            now_ms,
+        )
+        .map_err(runtime_error)?;
+    let RuntimeReadToolOutput::TopologySummary { summary: topology } = topology_output else {
+        return Err(ToolCallError::new(
+            ToolErrorKind::ToolExecutionError,
+            "service execution readiness brief expected topology summary output",
+        ));
+    };
+    let capability_grant_output = runtime
+        .execute_read_tool(
+            principal_id.clone(),
+            RuntimeReadToolRequest::GetCapabilityGrantSummary {
+                query: RuntimeCapabilityGrantQuery::new(),
+            },
+            now_ms,
+        )
+        .map_err(runtime_error)?;
+    let RuntimeReadToolOutput::CapabilityGrantSummary {
+        summary: capability_grants,
+    } = capability_grant_output
+    else {
+        return Err(ToolCallError::new(
+            ToolErrorKind::ToolExecutionError,
+            "service execution readiness brief expected capability grant summary output",
+        ));
+    };
+
+    let (_, command_risk) = command_risk_audit_rows(
+        runtime,
+        principal_id.clone(),
+        now_ms,
+        &default_command_risk_audit_query(),
+    )?;
+    let (_, authorization_gap) = authorization_gap_audit_rows(
+        runtime,
+        principal_id.clone(),
+        now_ms,
+        &default_authorization_gap_audit_query(),
+    )?;
+    let (_, event_delivery) = event_delivery_audit_rows(
+        runtime,
+        principal_id.clone(),
+        now_ms,
+        &default_event_delivery_audit_query(),
+    )?;
+    let (_, desired_state_drift) = desired_state_drift_audit_rows(
+        runtime,
+        principal_id.clone(),
+        now_ms,
+        &default_desired_state_drift_audit_query(),
+    )?;
+    let (_, state_transition) = state_transition_audit_rows(
+        runtime,
+        principal_id.clone(),
+        now_ms,
+        &default_state_transition_audit_query(),
+    )?;
+    let (_, supervision_remediation) = supervision_remediation_rows(
+        runtime,
+        principal_id,
+        now_ms,
+        &default_supervision_remediation_query(),
+    )?;
+
+    let readiness = controller_platform_readiness(&snapshot, &topology);
+    let total_attention_count = service_execution_readiness_attention_count(
+        readiness,
+        &capability_grants,
+        &command_risk,
+        &authorization_gap,
+    );
+    let total_blocked_count = service_execution_readiness_blocked_count(
+        readiness,
+        &capability_grants,
+        &command_risk,
+        &authorization_gap,
+    );
+    let status = service_execution_readiness_status(
+        readiness,
+        &capability_grants,
+        &command_risk,
+        &authorization_gap,
+    );
+    let next_tool = service_execution_readiness_next_tool(
+        readiness,
+        &capability_grants,
+        &command_risk,
+        &authorization_gap,
+    );
+
+    Ok(
+        ToolHandlerOutput::new(service_execution_readiness_brief_output_json(
+            &snapshot,
+            &topology,
+            &capability_grants,
+            &command_risk,
+            &authorization_gap,
+            &event_delivery,
+            &desired_state_drift,
+            &state_transition,
+            &supervision_remediation,
+        ))
+        .with_event(
+            ToolEventKind::Progress,
+            object([
+                ("operation", string("get_service_execution_readiness_brief")),
+                ("status", string(status)),
+                (
+                    "total_attention_count",
+                    integer(total_attention_count as i64),
+                ),
+                ("total_blocked_count", integer(total_blocked_count as i64)),
+                ("next_tool", string(next_tool)),
+            ]),
+        ),
+    )
+}
+
 fn get_remediation_plan_output_handler_output(
     runtime: &mut SmartHomeRuntime,
     principal_id: AgentId,
@@ -51586,6 +51788,237 @@ fn operator_action_brief_output_json(
                 SMART_HOME_LIST_STATE_TRANSITION_AUDIT_TOOL_ID,
                 SMART_HOME_LIST_DESIRED_STATE_DRIFT_AUDIT_TOOL_ID,
                 SMART_HOME_LIST_EVENT_DELIVERY_AUDIT_TOOL_ID,
+            ]),
+        ),
+    ])
+}
+
+fn service_execution_readiness_brief_output_json(
+    snapshot: &RuntimeReadSnapshot,
+    topology: &RegistryTopologySummary,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+    event_delivery: &EventDeliveryAuditSummary,
+    desired_state_drift: &DesiredStateDriftAuditSummary,
+    state_transition: &StateTransitionAuditSummary,
+    supervision_remediation: &SupervisionRemediationSummary,
+) -> JsonValue {
+    let readiness = controller_platform_readiness(snapshot, topology);
+    let command_ready = !command_risk.has_command_risks();
+    let authorization_ready = !authorization_gap.has_authorization_gaps();
+    let grants_ready = service_execution_readiness_grants_ready(capability_grants);
+    let service_execution_ready =
+        readiness.commands_services_scenes && command_ready && authorization_ready && grants_ready;
+    let total_attention_count = service_execution_readiness_attention_count(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    );
+    let total_blocked_count = service_execution_readiness_blocked_count(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    );
+    let status = service_execution_readiness_status(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    );
+    let next_tool = service_execution_readiness_next_tool(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    );
+    let next_action = service_execution_readiness_next_action(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    );
+    let next_owner_lane = service_execution_readiness_owner_lane(next_tool);
+
+    object([
+        ("generated_at_ms", integer(snapshot.generated_at_ms as i64)),
+        ("status", string(status)),
+        ("ready", JsonValue::Bool(status == "ready")),
+        (
+            "service_execution_ready",
+            JsonValue::Bool(service_execution_ready),
+        ),
+        ("has_blockers", JsonValue::Bool(total_blocked_count > 0)),
+        (
+            "total_attention_count",
+            integer(total_attention_count as i64),
+        ),
+        ("total_blocked_count", integer(total_blocked_count as i64)),
+        (
+            "summary",
+            object([
+                (
+                    "boundary",
+                    string(
+                        "Chief reads D23 runtime and platform primitives; it does not dispatch services or own smart-home controller state.",
+                    ),
+                ),
+                ("controller_ready", JsonValue::Bool(readiness.ready())),
+                (
+                    "commands_services_scenes_ready",
+                    JsonValue::Bool(readiness.commands_services_scenes),
+                ),
+                ("command_ready", JsonValue::Bool(command_ready)),
+                (
+                    "authorization_ready",
+                    JsonValue::Bool(authorization_ready),
+                ),
+                ("capability_grants_ready", JsonValue::Bool(grants_ready)),
+                (
+                    "active_grants",
+                    integer(capability_grants.active_grants as i64),
+                ),
+                (
+                    "command_risk_attention_count",
+                    integer(command_risk.requires_attention_rows as i64),
+                ),
+                (
+                    "authorization_attention_count",
+                    integer(authorization_gap.requires_attention_rows as i64),
+                ),
+                ("next_tool", string(next_tool)),
+                ("next_action", string(next_action)),
+                ("next_owner_lane", string(next_owner_lane)),
+            ]),
+        ),
+        (
+            "next_action",
+            object([
+                ("recommended_tool", string(next_tool)),
+                ("recommended_action", string(next_action)),
+                ("owner_lane", string(next_owner_lane)),
+                (
+                    "reason",
+                    string(service_execution_readiness_next_reason(
+                        readiness,
+                        capability_grants,
+                        command_risk,
+                        authorization_gap,
+                    )),
+                ),
+            ]),
+        ),
+        (
+            "readiness_gates",
+            JsonValue::Array(vec![
+                operations_brief_section_json(
+                    "service_affordance",
+                    "Service command affordance",
+                    readiness.commands_services_scenes,
+                    usize::from(!readiness.commands_services_scenes),
+                    usize::from(!readiness.commands_services_scenes),
+                    SMART_HOME_GET_CONTROLLER_HANDOFF_SUMMARY_TOOL_ID,
+                    if readiness.commands_services_scenes {
+                        "monitor_service_scene_catalog"
+                    } else {
+                        "inspect_controller_service_affordances"
+                    },
+                    object([
+                        (
+                            "total_capabilities",
+                            integer(topology.total_capabilities as i64),
+                        ),
+                        ("scenes", integer(topology.scenes as i64)),
+                        ("scene_actions", integer(topology.scene_actions as i64)),
+                    ]),
+                ),
+                operations_brief_section_json(
+                    "capability_grants",
+                    "Capability grants",
+                    grants_ready,
+                    service_execution_readiness_grant_attention_count(capability_grants),
+                    service_execution_readiness_grant_blocked_count(capability_grants),
+                    SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID,
+                    if grants_ready {
+                        "monitor_capability_grants"
+                    } else {
+                        "seed_runtime_capability_grants"
+                    },
+                    capability_grant_inventory_summary_json(capability_grants),
+                ),
+                operations_brief_section_json(
+                    "authorization",
+                    "Runtime authorization",
+                    authorization_ready,
+                    authorization_gap.requires_attention_rows,
+                    authorization_gap.blocked_rows,
+                    SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID,
+                    remediation_plan_authorization_action(authorization_gap),
+                    authorization_gap_audit_summary_json(authorization_gap),
+                ),
+                operations_brief_section_json(
+                    "command_safety",
+                    "Command safety",
+                    command_ready,
+                    command_risk.requires_attention_rows,
+                    command_risk.blocked_rows,
+                    SMART_HOME_LIST_COMMAND_RISK_AUDIT_TOOL_ID,
+                    remediation_plan_command_action(command_risk),
+                    command_risk_audit_summary_json(command_risk),
+                ),
+                operations_brief_section_json(
+                    "controller_handoff",
+                    "Controller handoff",
+                    readiness.ready(),
+                    readiness.attention_category_count(),
+                    0,
+                    SMART_HOME_GET_CONTROLLER_HANDOFF_SUMMARY_TOOL_ID,
+                    if readiness.ready() {
+                        "monitor_controller_handoff"
+                    } else {
+                        "inspect_controller_handoff"
+                    },
+                    object([
+                        (
+                            "category_count",
+                            integer(readiness.category_count() as i64),
+                        ),
+                        (
+                            "ready_category_count",
+                            integer(readiness.ready_category_count() as i64),
+                        ),
+                        (
+                            "attention_category_count",
+                            integer(readiness.attention_category_count() as i64),
+                        ),
+                    ]),
+                ),
+            ]),
+        ),
+        (
+            "system_health",
+            system_health_brief_output_json(
+                snapshot,
+                command_risk,
+                authorization_gap,
+                event_delivery,
+                desired_state_drift,
+                state_transition,
+                supervision_remediation,
+            ),
+        ),
+        (
+            "source_tools",
+            attention_string_array(&[
+                SMART_HOME_GET_CONTROLLER_HANDOFF_SUMMARY_TOOL_ID,
+                SMART_HOME_GET_RUNTIME_SNAPSHOT_TOOL_ID,
+                SMART_HOME_GET_TOPOLOGY_SUMMARY_TOOL_ID,
+                SMART_HOME_LIST_COMMAND_RISK_AUDIT_TOOL_ID,
+                SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID,
+                SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID,
+                SMART_HOME_GET_SYSTEM_HEALTH_BRIEF_TOOL_ID,
             ]),
         ),
     ])
@@ -59111,6 +59544,154 @@ fn operations_brief_section_status(
         "attention"
     } else {
         "idle"
+    }
+}
+
+fn service_execution_readiness_status(
+    readiness: ControllerPlatformReadiness,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+) -> &'static str {
+    if service_execution_readiness_blocked_count(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    ) > 0
+    {
+        "blocked"
+    } else if service_execution_readiness_attention_count(
+        readiness,
+        capability_grants,
+        command_risk,
+        authorization_gap,
+    ) > 0
+    {
+        "attention"
+    } else {
+        "ready"
+    }
+}
+
+fn service_execution_readiness_grants_ready(
+    capability_grants: &CapabilityGrantInventorySummary,
+) -> bool {
+    capability_grants.active_grants > 0
+        && (capability_grants.all_smart_home_grants > 0
+            || capability_grants.capability_grants > 0
+            || capability_grants.entity_capability_grants > 0)
+}
+
+fn service_execution_readiness_grant_attention_count(
+    capability_grants: &CapabilityGrantInventorySummary,
+) -> usize {
+    capability_grants.pending_grants
+        + capability_grants.revoked_grants
+        + capability_grants.expired_grants
+        + usize::from(!service_execution_readiness_grants_ready(capability_grants))
+}
+
+fn service_execution_readiness_grant_blocked_count(
+    capability_grants: &CapabilityGrantInventorySummary,
+) -> usize {
+    usize::from(!service_execution_readiness_grants_ready(capability_grants))
+}
+
+fn service_execution_readiness_attention_count(
+    readiness: ControllerPlatformReadiness,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+) -> usize {
+    readiness.attention_category_count()
+        + service_execution_readiness_grant_attention_count(capability_grants)
+        + command_risk.requires_attention_rows
+        + authorization_gap.requires_attention_rows
+}
+
+fn service_execution_readiness_blocked_count(
+    readiness: ControllerPlatformReadiness,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+) -> usize {
+    usize::from(!readiness.commands_services_scenes)
+        + service_execution_readiness_grant_blocked_count(capability_grants)
+        + command_risk.blocked_rows
+        + authorization_gap.blocked_rows
+}
+
+fn service_execution_readiness_next_tool(
+    readiness: ControllerPlatformReadiness,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+) -> &'static str {
+    if !readiness.commands_services_scenes {
+        SMART_HOME_GET_CONTROLLER_HANDOFF_SUMMARY_TOOL_ID
+    } else if !service_execution_readiness_grants_ready(capability_grants) {
+        SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID
+    } else if authorization_gap.has_blockers() || authorization_gap.has_authorization_gaps() {
+        SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID
+    } else if command_risk.has_blockers() || command_risk.has_command_risks() {
+        SMART_HOME_LIST_COMMAND_RISK_AUDIT_TOOL_ID
+    } else if !readiness.ready() {
+        SMART_HOME_GET_CONTROLLER_HANDOFF_SUMMARY_TOOL_ID
+    } else {
+        SMART_HOME_GET_PLATFORM_BRIEF_TOOL_ID
+    }
+}
+
+fn service_execution_readiness_next_action(
+    readiness: ControllerPlatformReadiness,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+) -> &'static str {
+    if !readiness.commands_services_scenes {
+        "inspect_controller_service_affordances"
+    } else if !service_execution_readiness_grants_ready(capability_grants) {
+        "seed_runtime_capability_grants"
+    } else if authorization_gap.has_blockers() || authorization_gap.has_authorization_gaps() {
+        remediation_plan_authorization_action(authorization_gap)
+    } else if command_risk.has_blockers() || command_risk.has_command_risks() {
+        remediation_plan_command_action(command_risk)
+    } else if !readiness.ready() {
+        "inspect_controller_handoff"
+    } else {
+        "monitor_service_execution_readiness"
+    }
+}
+
+fn service_execution_readiness_owner_lane(next_tool: &str) -> &'static str {
+    match next_tool {
+        SMART_HOME_GET_CAPABILITY_GRANT_SUMMARY_TOOL_ID
+        | SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID => "policy",
+        SMART_HOME_LIST_COMMAND_RISK_AUDIT_TOOL_ID => "safety",
+        SMART_HOME_GET_CONTROLLER_HANDOFF_SUMMARY_TOOL_ID => "platform",
+        _ => "operations",
+    }
+}
+
+fn service_execution_readiness_next_reason(
+    readiness: ControllerPlatformReadiness,
+    capability_grants: &CapabilityGrantInventorySummary,
+    command_risk: &CommandRiskAuditSummary,
+    authorization_gap: &AuthorizationGapAuditSummary,
+) -> &'static str {
+    if !readiness.commands_services_scenes {
+        "service_affordance_gap"
+    } else if !service_execution_readiness_grants_ready(capability_grants) {
+        "capability_grant_gap"
+    } else if authorization_gap.has_blockers() || authorization_gap.has_authorization_gaps() {
+        "authorization_gap"
+    } else if command_risk.has_blockers() || command_risk.has_command_risks() {
+        "command_risk"
+    } else if !readiness.ready() {
+        "controller_handoff_attention"
+    } else {
+        "ready_signal"
     }
 }
 
@@ -92410,7 +92991,7 @@ mod tests {
         let definitions = smart_home_tool_definitions();
         let export = ToolCatalogExport::from_definitions(definitions.iter());
 
-        assert_eq!(definitions.len(), 316);
+        assert_eq!(definitions.len(), 317);
         assert!(
             export.ok(),
             "tool export validation failed: {:?}",
@@ -92443,6 +93024,9 @@ mod tests {
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_OPERATOR_ACTION_BRIEF_TOOL_ID));
+        assert!(export
+            .tool_ids()
+            .contains(&SMART_HOME_GET_SERVICE_EXECUTION_READINESS_BRIEF_TOOL_ID));
         assert!(export
             .tool_ids()
             .contains(&SMART_HOME_GET_REMEDIATION_PLAN_TOOL_ID));
@@ -93317,7 +93901,7 @@ mod tests {
             .contains(&SMART_HOME_GET_RUNTIME_MAINTENANCE_CLOSEOUT_SUMMARY_TOOL_ID));
         assert_eq!(
             export.summary.required_capability_count("smart_home:read"),
-            308
+            309
         );
         assert_eq!(
             export
@@ -94013,6 +94597,10 @@ mod tests {
         assert!(smart_home_tool_definition(SMART_HOME_GET_ATTENTION_OVERVIEW_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_SYSTEM_HEALTH_BRIEF_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_OPERATOR_ACTION_BRIEF_TOOL_ID).is_some());
+        assert!(smart_home_tool_definition(
+            SMART_HOME_GET_SERVICE_EXECUTION_READINESS_BRIEF_TOOL_ID
+        )
+        .is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_REMEDIATION_PLAN_TOOL_ID).is_some());
         assert!(smart_home_tool_definition(SMART_HOME_GET_PLATFORM_BRIEF_TOOL_ID).is_some());
         assert!(
@@ -94585,6 +95173,105 @@ mod tests {
             Some(&string(SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID))
         );
         assert!(field(output, "system_health").is_some());
+        assert_eq!(
+            field(field(output, "system_health").unwrap(), "status"),
+            Some(&string("blocked"))
+        );
+    }
+
+    #[test]
+    fn service_execution_readiness_brief_blocks_on_authorization_gaps() {
+        let runtime = Rc::new(RefCell::new(hue_lighting_runtime()));
+        runtime.borrow_mut().registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_capability(
+                CapabilityGrantId::trusted("grant-service-command-tool-only"),
+                AgentId::trusted(AGENT_ID),
+                CapabilityId::trusted("smart_home.command.light"),
+                PrivilegeTier::LowRisk,
+                "user:test",
+                1_000,
+            ),
+        );
+        let bridge = SmartHomeToolBridge::new(runtime.clone(), AgentId::trusted(AGENT_ID));
+        let mut tool_runtime = InMemoryToolRuntime::new();
+        bridge.register_all(&mut tool_runtime).unwrap();
+
+        let denied_command = tool_runtime.invoke_with_events(&request(
+            "call-service-readiness-denied-command",
+            SMART_HOME_COMMAND_TOOL_ID,
+            object([
+                ("entity_id", string("entity-light-1")),
+                ("command_type", string("turn_on")),
+            ]),
+            2_100,
+        ));
+        assert!(!denied_command.result.ok);
+
+        runtime.borrow_mut().registry_mut().upsert_capability_grant(
+            CapabilityGrant::for_all_smart_home(
+                CapabilityGrantId::trusted("grant-service-readiness-read"),
+                AgentId::trusted(AGENT_ID),
+                PrivilegeTier::HumanApproval,
+                "user:test",
+                2_101,
+            ),
+        );
+
+        let request = request(
+            "call-service-execution-readiness-brief",
+            SMART_HOME_GET_SERVICE_EXECUTION_READINESS_BRIEF_TOOL_ID,
+            object([]),
+            2_102,
+        );
+        let trace = tool_runtime.invoke_with_events(&request);
+        assert!(trace.result.ok);
+        assert_eq!(trace.summary().progress_event_count, 1);
+
+        let output = trace.result.output.as_ref().unwrap();
+        assert_eq!(field(output, "status"), Some(&string("blocked")));
+        assert_eq!(field(output, "ready"), Some(&JsonValue::Bool(false)));
+        assert_eq!(
+            field(output, "service_execution_ready"),
+            Some(&JsonValue::Bool(false))
+        );
+        assert_eq!(field(output, "has_blockers"), Some(&JsonValue::Bool(true)));
+        assert!(integer_value(field(output, "total_blocked_count").unwrap()).unwrap() >= 1);
+        assert_eq!(
+            array_len(field(output, "readiness_gates").unwrap()),
+            Some(5)
+        );
+
+        let next_action = field(output, "next_action").unwrap();
+        assert_eq!(
+            field(next_action, "recommended_tool"),
+            Some(&string(SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID))
+        );
+        assert_eq!(field(next_action, "owner_lane"), Some(&string("policy")));
+        assert_eq!(
+            field(next_action, "reason"),
+            Some(&string("authorization_gap"))
+        );
+
+        let grants_gate = array_item(field(output, "readiness_gates").unwrap(), 1).unwrap();
+        assert_eq!(
+            field(grants_gate, "section_id"),
+            Some(&string("capability_grants"))
+        );
+        assert_eq!(field(grants_gate, "ready"), Some(&JsonValue::Bool(true)));
+
+        let authorization_gate = array_item(field(output, "readiness_gates").unwrap(), 2).unwrap();
+        assert_eq!(
+            field(authorization_gate, "section_id"),
+            Some(&string("authorization"))
+        );
+        assert_eq!(
+            field(authorization_gate, "recommended_tool"),
+            Some(&string(SMART_HOME_LIST_AUTHORIZATION_GAP_AUDIT_TOOL_ID))
+        );
+        assert_eq!(
+            field(authorization_gate, "status"),
+            Some(&string("blocked"))
+        );
         assert_eq!(
             field(field(output, "system_health").unwrap(), "status"),
             Some(&string("blocked"))
@@ -97138,11 +97825,11 @@ mod tests {
         let tool_catalog_summary = field(tool_catalog_summary_output, "summary").unwrap();
         assert_eq!(
             field(tool_catalog_summary, "total_tools"),
-            Some(&integer(316))
+            Some(&integer(317))
         );
         assert_eq!(
             field(tool_catalog_summary, "read_tools"),
-            Some(&integer(308))
+            Some(&integer(309))
         );
         assert_eq!(
             field(tool_catalog_summary, "risky_tool_count"),

--- a/code/packages/rust/smart-home-core/src/lib.rs
+++ b/code/packages/rust/smart-home-core/src/lib.rs
@@ -1694,6 +1694,7 @@ pub enum SmartHomeTool {
     GetAttentionOverview,
     GetSystemHealthBrief,
     GetOperatorActionBrief,
+    GetServiceExecutionReadinessBrief,
     GetRemediationPlan,
     GetOperationsBrief,
     GetSafetyBrief,
@@ -2452,6 +2453,9 @@ impl SmartHomeTool {
             Self::GetAttentionOverview => read_tool("smart_home.get_attention_overview"),
             Self::GetSystemHealthBrief => read_tool("smart_home.get_system_health_brief"),
             Self::GetOperatorActionBrief => read_tool("smart_home.get_operator_action_brief"),
+            Self::GetServiceExecutionReadinessBrief => {
+                read_tool("smart_home.get_service_execution_readiness_brief")
+            }
             Self::GetRemediationPlan => read_tool("smart_home.get_remediation_plan"),
             Self::GetOperationsBrief => read_tool("smart_home.get_operations_brief"),
             Self::GetSafetyBrief => read_tool("smart_home.get_safety_brief"),
@@ -3385,6 +3389,7 @@ pub fn smart_home_tool_catalog() -> Vec<ToolDescriptor> {
         SmartHomeTool::GetAttentionOverview,
         SmartHomeTool::GetSystemHealthBrief,
         SmartHomeTool::GetOperatorActionBrief,
+        SmartHomeTool::GetServiceExecutionReadinessBrief,
         SmartHomeTool::GetRemediationPlan,
         SmartHomeTool::GetOperationsBrief,
         SmartHomeTool::GetSafetyBrief,
@@ -4249,7 +4254,7 @@ mod tests {
             .find(|tool| tool.tool_id == "smart_home.command")
             .unwrap();
 
-        assert_eq!(catalog.len(), 316);
+        assert_eq!(catalog.len(), 317);
         assert!(catalog
             .iter()
             .any(|tool| tool.tool_id == "smart_home.list_command_risk_audit"
@@ -5511,6 +5516,10 @@ mod tests {
             == "smart_home.get_integration_mesh_preflight_guardrail_readiness_summary"
             && tool.side_effects == ToolSideEffects::Read
             && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
+        assert!(catalog.iter().any(|tool| tool.tool_id
+            == "smart_home.get_service_execution_readiness_brief"
+            && tool.side_effects == ToolSideEffects::Read
+            && tool.required_capabilities == vec![CapabilityId::trusted("smart_home.read")]));
     }
 
     #[test]
@@ -5518,15 +5527,15 @@ mod tests {
         let summary = smart_home_tool_catalog_summary();
         let pair_bridge = SmartHomeTool::PairBridge.descriptor();
 
-        assert_eq!(summary.total_tools, 316);
-        assert_eq!(summary.read_tools, 308);
+        assert_eq!(summary.total_tools, 317);
+        assert_eq!(summary.read_tools, 309);
         assert_eq!(summary.write_tools, 2);
         assert_eq!(summary.external_tools, 6);
-        assert_eq!(summary.read_only_tier_tools, 308);
+        assert_eq!(summary.read_only_tier_tools, 309);
         assert_eq!(summary.low_risk_tier_tools, 6);
         assert_eq!(summary.high_risk_tier_tools, 0);
         assert_eq!(summary.human_approval_tier_tools, 2);
-        assert_eq!(summary.total_required_capabilities, 316);
+        assert_eq!(summary.total_required_capabilities, 317);
         assert_eq!(summary.risky_tool_count(), 8);
         assert_eq!(summary.approval_gated_tool_count(), 2);
         assert!(pair_bridge.requires_human_approval());


### PR DESCRIPTION
## Summary
- add `smart_home.get_service_execution_readiness_brief` as a read-only Chief adapter over D23 controller handoff, command-risk, authorization-gap, and capability-grant signals
- expose service execution gates, next action, embedded system health, source-tool lineage, and shared core catalog coverage
- document the new Chief smart-home tool and add a blocked authorization-gap regression

## Validation
- `cargo fmt -p chief-of-staff-smart-home-tools -p smart-home-core`
- `cargo test -p chief-of-staff-smart-home-tools -- --nocapture`
- `cargo test -p smart-home-core -- --nocapture`
- `cargo test -p smart-home-platform-http -- --nocapture`
- `sh BUILD` in `code/packages/rust/chief-of-staff-smart-home-tools`
- `sh BUILD` in `code/packages/rust/smart-home-core`
- `sh BUILD` in `code/packages/rust/smart-home-platform-http`

Note: removed generated `code/packages/rust/Cargo.lock` after validation.