### PR TITLE
feat(latex): LTXDOC03 S6 cross-reference report (composes S1–S5 end-to-end)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.42.0] — 2026-07-06
+
+### Added — cross-reference resolution: the cross-reference report (LTXDOC03 S6)
+
+The **consumer** rung that proves S1–S5 compose. S1 bound each `\ref`, S2 each `\cite`, S4 numbered
+the labels, S5 numbered the citations — but nothing yet **assembled** them into a single
+consumer-facing artifact. S6 is that assembly: one method that walks S1's resolved `\ref`s and S2's
+resolved `\cite`s and produces an owned, plain-data report where each entry carries its rendered
+**number** (from S4/S5) alongside its key/command/kind. No new AST walk, no new parsing.
+
+- **Composes the five passes.** `Document::cross_reference_report()` runs S1 + S2, numbers each family
+  **once** with S4 (`number_labels`) / S5 (`number_citations`), then *looks each key up* in the
+  resulting number table — never a per-entry re-numbering (the anti-pattern `ref_number`/`cite_number`
+  warn about in a loop). The whole report costs a constant number of the existing bounded passes.
+- **Two resolved families.** A resolved `\ref` with an S4 number → a `RefEntry { key, command, kind,
+  number }` (`\ref{sec:intro}` → Section `"1.2"`); a resolved `\cite` key → a `CiteEntry { key,
+  number }` (`\cite{b}` → `"[2]"`). A multi-key `\cite{a,b}` yields one `CiteEntry` per key (S2 already
+  split them), numbered `[1]`/`[2]` independently.
+- **Dangling refs/cites surfaced *separately*.** A `\ref{missing}` (S1's `unresolved`) and a
+  `\cite{ghost}` (S2's `unresolved`) — LaTeX's `??` / `[?]` undefined markers — go in their own
+  `dangling_refs` / `dangling_cites` key vectors, never folded in among the resolved entries. This
+  makes "resolved vs dangling" a type-level fact rather than a field the caller must remember to check.
+- **The one subtlety, documented.** A resolved `\ref` to an *inline/equation* `\label` (which S4 leaves
+  unnumbered — deferred) has no number, so it is **omitted** from `refs` (it is neither dangling — its
+  label exists — nor renderable). Every row in `refs` therefore carries a real number, no placeholder.
+  Citations have no analogous gap (a winning `\bibitem` is always S5-numbered).
+- **A stable plain-text rendering.** `CrossReferenceReport::to_plain_text()` renders a deterministic,
+  pinned string: `\ref{<key>} -> <Kind> <number>` lines, then `\cite{<key>} -> <number>` lines, then
+  optional `Dangling references: …` / `Dangling citations: …` footers — joined by single `\n`, no
+  trailing newline. An empty report renders the fixed marker `(no cross-references)` (never the empty
+  string).
+- **New API.** `Document::cross_reference_report() -> CrossReferenceReport { refs: Vec<RefEntry>,
+  cites: Vec<CiteEntry>, dangling_refs: Vec<String>, dangling_cites: Vec<String> }` with `RefEntry`,
+  `CiteEntry`, and `CrossReferenceReport::to_plain_text() -> String`. All owned plain data (`String`s +
+  `Copy` `LabelKind`), mirroring S4/S5, exported from the crate root.
+- **Pure & additive.** The S1–S5 result types are unchanged; S6 only *reads* their results and copies
+  owned data out, mutating nothing about the tree or any prior pass. Total & panic-free (no
+  `unwrap`/`expect`, no unchecked indexing), reusing the bounded passes (no new recursion).
+
+### Deferred (honest boundary, inherited from S4/S5)
+
+- **Equation numbers** — a `\ref` to an equation/inline label is omitted from the report (S4 does not
+  number those yet; an equation body is an opaque `Block::DisplayMath` string with no label field).
+- **Author-year / natbib sorted citation styles** and **external `.bib`/`.bbl` databases** — out of
+  scope at S2/S5, so the report covers only what those passes resolved (in-document `thebibliography`,
+  numeric/unsorted style).
+
 ## [0.41.0] — 2026-07-06
 
 ### Added — cross-reference resolution: citation numbering (LTXDOC03 S5)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -53,6 +53,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S3 — target → `NodeRef` exposure** | The depth-add on S1+S2: both bound each target's **bytes** (a `Span`) but not the target **node**. `Document::node_for_span(span) -> Option<NodeRef>` returns the walked body node whose span **exactly equals** `span` (half-open equality of start **and** end; *equality*, not `node_at`'s containment) — or `None` for a span that is no walked node's own (empty doc, un-walked preamble/metadata, fabricated span). Thin accessors `ref_target_node(&ResolvedRef)`, `cite_target_node(&ResolvedCite)`, `label_def_node(&LabelDef)` take a resolved record and hand back the node, so a caller can read its `kind()` and — for a `Block` — descend into its children (a `\ref`→section enumerates its paragraphs; a `\ref`→figure reaches its caption). **Verified reachability:** every S1/S2 target span matches exactly one walked node (zero collisions); a `\ref`→section/figure/table yields a `NodeRef::Block`, an inline `\eqref`→`\label` a `NodeRef::Inline` (`CrossRef`), and — the once-uncertain case — a `\cite`→`\bibitem` **is** walked (an `Inline::Raw` inside the `thebibliography`), so `cite_target_node` returns `Some`, not `None`. Purely additive (S1/S2 result types keep owned `Span`s, no lifetimes; the `NodeRef` is fetched on demand); tie-break = first-in-pre-order (defensive, does not fire). Numbering + external BibTeX remain out of scope. Total & panic-free, reuses the bounded `walk`. | ✅ |
 | **LTXDOC03 S4 — document numbering (hierarchical sections + flat float counters)** | `Document::number_labels() -> Numbering` — the number a `\ref` *prints*, computed in one `walk` (LaTeX's second `.aux` pass, done statically). **Section numbers** are hierarchical with deeper-reset: a numbered `\section`…`\subparagraph` increments its depth's counter, resets deeper depths to `0`, and renders the dotted join from the top level down (`1`, `1.1`, `1.2`, `1.2.1`, `2`); a starred `\section*` (`numbered == false`) fires no counter and is skipped. **Float counters** are flat and independent: every `figure` advances a running figure counter (`1, 2, …`), every `table` its own (`1, 2, …`) — labeled *or not* (a `\label` only captures the value; an unlabeled figure between two labeled ones takes `2`). Missing-parent rule: a document that starts deep renders honest leading `0`s (a lone `\subsection` → `0.1`), a plain top-level `\section` → `1`. Returns one owned `NumberedLabel { key, kind, number }` per defined numberable label, with `number_for(key)`; `ref_number(&ResolvedRef) -> Option<String>` ties S1 resolution to S4 numbering (`\ref{sec:intro}` → `"1.2"`). Equation numbers, citation `[1]` numbers, and other counters deferred to S5+. Pure, additive, tree-unchanged; fixed 7-slot counter array (no unchecked indexing). Total & panic-free, reuses the bounded `walk`. | ✅ |
 | **LTXDOC03 S5 — citation numbering (bracketed bibliography numbers)** | `Document::number_citations() -> CitationNumbering` — the bracketed number a `\cite` *prints* (`[2]`), the citation-family analogue of S4's `ref_number`. In the default numeric/unsorted style each `\bibitem` is numbered by its **listing position**, so S5 numbers S2's already-ordered winning `entries` by index: `entries[0]` → `[1]`, `entries[1]` → `[2]`, …. A first-`\bibitem`-wins **duplicate** is in `duplicate_entries`, not `entries`, so it consumes **no** number and the entries after it are unshifted (`a, b, c` + a later dup `\bibitem{a}` keeps `c` at `[3]`). A **dangling** `\cite` is in S2's `unresolved`, so it has no entry and `number_for` returns `None` (LaTeX's `[?]`). Returns one owned `NumberedCitation { key, ordinal, number }` per numbered entry, with `number_for(key) -> Option<&str>`; `cite_number(&ResolvedCite) -> Option<String>` ties S2 resolution to S5 numbering (`\cite{foo}` → `"[2]"`). Bracket style single-sourced in one helper. Equation numbers (blocked on `DisplayMath` carrying no label field), author-year/natbib sorted styles, and external `.bib` remain future rungs. Pure, additive, tree-unchanged. Total & panic-free. | ✅ |
+| **LTXDOC03 S6 — the cross-reference report (consumer composing S1/S2/S4/S5)** | `Document::cross_reference_report() -> CrossReferenceReport` — the consumer rung that proves the passes **compose**: it walks S1's resolved `\ref`s and S2's resolved `\cite`s and assembles an owned, plain-data report where each entry carries its rendered **number** (S4/S5) alongside key/command/kind. **No new AST walk** — it numbers each family **once** (`number_labels`/`number_citations`) then looks each key up (never per-item re-numbering). Produces `refs: Vec<RefEntry { key, command, kind, number }>` (one per resolved **and numbered** `\ref`, in S1 order — a resolved `\ref` to an *unnumbered* inline/equation label is **omitted**), `cites: Vec<CiteEntry { key, number }>` (one per resolved `\cite` key, in S2 order), and `dangling_refs`/`dangling_cites: Vec<String>` (S1/S2 `unresolved` keys — LaTeX's `??`/`[?]`, surfaced **separately**). `CrossReferenceReport::to_plain_text() -> String` renders a stable, pinned string (`\ref{k} -> Section 1.2` / `\cite{k} -> [2]` lines, optional `Dangling …:` footers, joined by `\n`, no trailing newline; empty → `(no cross-references)`). Pure composition, reads S1–S5 unchanged, tree untouched. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -89,8 +90,13 @@ of scope (in-document `thebibliography` only). **S5 assigns the bracketed number
 (`Document::number_citations` + `cite_number`) — the citation-family analogue of `ref_number`:
 numbering S2's listing-ordered `entries` by index so the first `\bibitem` is `[1]`, the second `[2]`,
 … (first-`\bibitem`-wins duplicates consume no number; dangling `\cite`s are unnumbered), so
-`\cite{foo}` resolves to `"[2]"`. Equation numbers (blocked on the `DisplayMath` AST carrying no
-label field), author-year/natbib sorted styles, and external `.bib` remain future rungs.
+`\cite{foo}` resolves to `"[2]"`. **S6 assembles the cross-reference report**
+(`Document::cross_reference_report`) — the consumer that **composes** S1/S2/S4/S5 into one owned
+artifact: every resolved `\ref` and `\cite` with its rendered number (`\ref{sec:intro} ->
+Section 1.2`, `\cite{smith} -> [2]`), dangling refs/cites surfaced separately, plus a stable
+`to_plain_text()` rendering — adding no new AST walk (each family numbered once, then looked up).
+Equation numbers (blocked on the `DisplayMath` AST carrying no label field), author-year/natbib
+sorted styles, and external `.bib` remain future rungs.
 
 ## The Document layer (LTXDOC01)
 
@@ -397,6 +403,58 @@ unshifted); a dangling `\cite` has no entry, so `number_for` returns `None` (LaT
 numbers (blocked on the `DisplayMath` AST carrying no label field), author-year/natbib sorted styles,
 and external `.bib` databases remain future rungs. Like S4, S5 is pure, additive analysis — it never
 mutates the tree, so the S1–S4 outputs are unchanged.
+
+### The cross-reference report (LTXDOC03 S6)
+
+S1–S5 each produced their own result type; S6 is the **consumer** that composes them into one
+auditable artifact. `Document::cross_reference_report()` walks S1's resolved `\ref`s and S2's resolved
+`\cite`s and returns an owned report where each entry carries its rendered number (from S4/S5). It
+adds no new AST walk — it numbers each family once and looks each key up:
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+See Section~\ref{sec:intro} and \cite{lamport}. Also \ref{nope} and \cite{ghost}.
+
+\begin{thebibliography}{9}
+\bibitem{knuth} Knuth, D. The TeXbook. 1984.
+\bibitem{lamport} Lamport, L. LaTeX. 1986.
+\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+
+let rep = doc.cross_reference_report();
+
+// Each resolved reference carries its S4 number, kind, and command.
+assert_eq!(rep.refs.len(), 1);
+assert_eq!(rep.refs[0].key, "sec:intro");
+assert_eq!(rep.refs[0].number, "1"); // \ref{sec:intro} → Section 1
+
+// Each resolved citation carries its S5 bracketed number.
+assert_eq!(rep.cites.len(), 1);
+assert_eq!(rep.cites[0].key, "lamport");
+assert_eq!(rep.cites[0].number, "[2]"); // the second \bibitem
+
+// Dangling refs/cites are surfaced separately (LaTeX's `??` / `[?]`).
+assert_eq!(rep.dangling_refs, vec!["nope".to_string()]);
+assert_eq!(rep.dangling_cites, vec!["ghost".to_string()]);
+
+// A stable, human-readable rendering (pinned format):
+assert_eq!(
+    rep.to_plain_text(),
+    "\\ref{sec:intro} -> Section 1\n\
+     \\cite{lamport} -> [2]\n\
+     Dangling references: nope\n\
+     Dangling citations: ghost",
+);
+```
+
+`cross_reference_report()` returns a `CrossReferenceReport { refs, cites, dangling_refs,
+dangling_cites }` with `RefEntry { key, command, kind, number }` and `CiteEntry { key, number }`. A
+resolved `\ref` to an *unnumbered* inline/equation label is omitted from `refs` (it has no S4 number —
+deferred), so every row carries a real number. Like S1–S5, S6 is pure, additive analysis — it reads
+the prior passes and mutates nothing, so their outputs are unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -100,9 +100,9 @@ pub use document::{
     Metadata, NodeRef, Package, Preamble, Provenance,
 };
 pub use references::{
-    BibEntry, CitationResolution, Duplicate, DuplicateBib, LabelDef, LabelKind, NumberedLabel,
-    Numbering, ReferenceResolution, ResolvedCite, ResolvedRef, UnresolvedCite, UnresolvedRef,
-    CITE_COMMAND, REF_COMMANDS,
+    BibEntry, CiteEntry, CitationResolution, CrossReferenceReport, Duplicate, DuplicateBib,
+    LabelDef, LabelKind, NumberedLabel, Numbering, RefEntry, ReferenceResolution, ResolvedCite,
+    ResolvedRef, UnresolvedCite, UnresolvedRef, CITE_COMMAND, REF_COMMANDS,
 };
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1428,6 +1428,296 @@ impl Document {
     }
 }
 
+// =================================================================================================
+// LTXDOC03 S6 — the cross-reference report (the consumer that composes S1/S2/S4/S5).
+//
+// S1 bound each `\ref` to its `\label`; S2 bound each `\cite` to its `\bibitem`; S4 numbered the
+// labels; S5 numbered the citations. Each pass produced its own owned result type, but **nothing yet
+// assembles them into a single consumer-facing artifact**. S6 is that assembly: one method that walks
+// S1's resolved `\ref`s and S2's resolved `\cite`s and produces an **owned, plain-data report** where
+// each entry carries its rendered *number* (from S4/S5) alongside its key/command/kind. It is the
+// payoff rung — the proof that the five analysis passes *compose* into an auditable whole, exactly the
+// shape a byte-provenance consumer wants: "here is every cross-reference in this document, what it
+// points at, and the number it prints."
+//
+// ## What S6 is, and (just as importantly) what it is *not*
+//
+// S6 is a **pure consumer**. It adds **no new AST walk** of its own: it calls S1
+// ([`resolve_references`](Document::resolve_references)) and S2
+// ([`resolve_citations`](Document::resolve_citations)) — each of which already reuses the bounded
+// [`Document::walk`] — and S4 ([`number_labels`](Document::number_labels)) / S5
+// ([`number_citations`](Document::number_citations)) to number each family **once**, then *looks each
+// key up* in the resulting number table. So the whole report costs a constant number of the existing
+// bounded passes (never a per-entry re-numbering — the anti-pattern the S4/S5 convenience methods
+// [`ref_number`](Document::ref_number) / [`cite_number`](Document::cite_number) warn about when called
+// in a loop). There is no new parsing, no AST change, no new recursion.
+//
+// ## The two families, side by side
+//
+// | family | source pass (binding) | number pass | report entry |
+// |--------|-----------------------|-------------|--------------|
+// | `\ref`  | S1 `ResolvedRef { key, command, kind }` | S4 `Numbering::number_for(key)` | [`RefEntry`]  |
+// | `\cite` | S2 `ResolvedCite { key }`               | S5 `CitationNumbering::number_for(key)` | [`CiteEntry`] |
+//
+// ## Dangling references and citations — surfaced *separately* (the "??" / "[?]" markers)
+//
+// A `\ref{missing}` (no such `\label`) lands in S1's `unresolved`; a `\cite{ghost}` (no such
+// `\bibitem`) lands in S2's `unresolved`. These are LaTeX's tell-tale `??` (undefined reference) and
+// `[?]` (undefined citation) markers. S6 does **not** silently drop them and does **not** fold them in
+// among the resolved entries with some fake number — it surfaces them in their **own** vectors
+// ([`dangling_refs`](CrossReferenceReport::dangling_refs) /
+// [`dangling_cites`](CrossReferenceReport::dangling_cites)), each holding just the offending *key*. A
+// consumer building a "problems" list reads exactly those two vectors; a consumer building the
+// resolved cross-reference index reads `refs`/`cites`. This separation is the deliberate, documented
+// choice (the alternative — one list with `number: Option<String>` — buries the distinction inside a
+// field the caller must remember to check; two vectors make "resolved vs dangling" a *type-level*
+// fact).
+//
+// ## The one subtlety: a *resolved* `\ref` whose target is not *numbered*
+//
+// Every entry in S1's `resolved` has a matching `\label` — but not every `\label` is *numbered*. S4
+// numbers sections and figure/table floats; an **inline `\label`** (typically an equation label) is
+// deliberately left unnumbered (deferred to a future equation-numbering rung — see S4/S5). So a
+// `\ref{eq:x}` to an inline `\label{eq:x}` *resolves* (it is in S1's `resolved`) yet has **no** S4
+// number. S6's rule for such an entry: **omit it from `refs`**. The report's `refs` therefore lists
+// exactly the `\ref`s that both resolve *and* carry a printable number — the ones a consumer can
+// render as "see Section 1.2". (An unnumbered-but-resolved `\ref` is neither a *dangling* reference —
+// its label exists — nor a *renderable* one, so it belongs in neither `refs` nor `dangling_refs`; it
+// is simply below S4's numbering horizon and reappears once equation numbering ships. Documenting this
+// keeps the report honest: every row in `refs` has a real number, no placeholder.) Citations have no
+// analogous gap — every *resolved* `\cite` names a winning `\bibitem`, which S5 always numbers — so
+// every S2-resolved cite becomes a [`CiteEntry`].
+//
+// ## What stays OUT of S6 (inherited honest boundaries)
+//
+// - **Equation numbers** — deferred at S4/S5 (an equation body is an opaque [`Block::DisplayMath`]
+//   string with no label field); a `\ref` to an equation label is therefore *omitted* from `refs`
+//   (see above), not invented.
+// - **Author-year / natbib sorted citation styles** and **external `.bib`/`.bbl` databases** — out of
+//   scope at S2/S5, so out of scope here too (S6 reports only what those passes resolved).
+//
+// ## The result types and the rendered report
+//
+// [`Document::cross_reference_report`] returns a [`CrossReferenceReport`]: `refs` (one [`RefEntry`]
+// per numbered resolved `\ref`, in S1 pre-order), `cites` (one [`CiteEntry`] per resolved `\cite`, in
+// S2 pre-order), and the two dangling-key vectors. All owned plain data (`String`s + `Copy`
+// [`LabelKind`]), mirroring S4/S5, so the report outlives any borrow of the source and can be
+// stored/serialized. [`CrossReferenceReport::to_plain_text`] renders it to a stable, deterministic,
+// human-readable string (the exact format is pinned in that method's docs and in the tests).
+// =================================================================================================
+
+/// A **human-readable name** for a label kind, capitalised for the plain-text report: `"Section"`,
+/// `"Table"`, `"Figure"`, `"Inline"`. This is the display form S6 prints (`\ref{s:i} -> Section 1`),
+/// distinct from [`LabelKind::as_str`]'s lowercase structural name (`"section"`). Kept as a single
+/// helper so the capitalisation convention lives in exactly one place. Pure and total — a fixed match,
+/// no allocation beyond the returned `&'static str`, no panic.
+fn kind_display_name(kind: LabelKind) -> &'static str {
+    match kind {
+        LabelKind::Section => "Section",
+        LabelKind::Table => "Table",
+        LabelKind::Figure => "Figure",
+        LabelKind::Inline => "Inline",
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// The report record types (plain, Clone-able, owned data — mirroring S4/S5's owned-String rows).
+// -------------------------------------------------------------------------------------------------
+
+/// One **resolved-and-numbered reference** row of the cross-reference report: a `\ref`/`\eqref`/
+/// `\pageref` that both resolved (S1) *and* carries a rendered S4 number. It fuses S1's binding
+/// (`key`, `command`, `kind`) with S4's `number` — everything a consumer needs to render "see
+/// Section 1.2" without re-consulting the passes.
+///
+/// - `key` — the referenced label key, verbatim (`"sec:intro"`), from S1's [`ResolvedRef::key`].
+/// - `command` — the reference command used (`"ref"`, `"eqref"`, or `"pageref"`), from
+///   [`ResolvedRef::command`].
+/// - `kind` — the [`LabelKind`] of the node the reference points at (section / table / figure), from
+///   [`ResolvedRef::target_kind`]. (An [`LabelKind::Inline`] target is *not* numbered by S4, so it
+///   never becomes a `RefEntry` — see the S6 module docs — hence in practice `kind` is one of
+///   Section/Table/Figure.)
+/// - `number` — the rendered number S4 assigns the target (`"1.2"`, `"3"`, …), from
+///   [`Numbering::number_for`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefEntry {
+    /// The referenced label key, verbatim, without braces (`"sec:intro"`).
+    pub key: String,
+    /// The reference command used (`"ref"`, `"eqref"`, or `"pageref"`).
+    pub command: String,
+    /// The kind of node the reference resolved to (section / table / figure).
+    pub kind: LabelKind,
+    /// The rendered number the target prints (`"1.2"`, `"3"`, …), from S4.
+    pub number: String,
+}
+
+/// One **resolved-and-numbered citation** row of the cross-reference report: a `\cite` key that
+/// resolved (S2) and carries its rendered S5 bracketed number. Every resolved `\cite` yields a
+/// `CiteEntry` (unlike references, there is no "resolved-but-unnumbered" gap — a winning `\bibitem` is
+/// always numbered by S5).
+///
+/// - `key` — the citation key, verbatim (`"smith2020"`), from S2's [`ResolvedCite::key`]. A multi-key
+///   `\cite{a,b}` produces one `CiteEntry` **per key** (S2 already split them), so `a` and `b` are two
+///   separate rows.
+/// - `number` — the rendered bracketed number S5 assigns the entry (`"[1]"`, `"[2]"`, …), from
+///   [`CitationNumbering::number_for`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CiteEntry {
+    /// The citation key, verbatim, without braces (`"smith2020"`).
+    pub key: String,
+    /// The rendered bracketed number the citation prints (`"[1]"`, `"[2]"`, …), from S5.
+    pub number: String,
+}
+
+/// The full result of [`Document::cross_reference_report`]: the assembled cross-reference report — the
+/// consumer artifact that composes S1 (resolve refs) + S2 (resolve cites) + S4 (label numbers) + S5
+/// (citation numbers) into one auditable table. All plain, owned data (`String`s + `Copy`
+/// [`LabelKind`]), so the report outlives any borrow of the source and can be stored/serialized,
+/// mirroring S1/S2/S4/S5's owned aggregates.
+///
+/// **Ordering.** `refs` is in S1 pre-order (the order the `\ref`s appear in the body, filtered to the
+/// numbered ones); `cites` is in S2 pre-order (body order, one row per key of each `\cite`);
+/// `dangling_refs` is in S1's `unresolved` order and `dangling_cites` in S2's `unresolved` order.
+/// Every ordering is deterministic and source-derived, so the report (and its
+/// [`to_plain_text`](CrossReferenceReport::to_plain_text) rendering) is stable across runs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CrossReferenceReport {
+    /// One row per **resolved and numbered** `\ref`, in S1 pre-order. A resolved `\ref` whose target
+    /// is an (unnumbered) inline/equation label is *omitted* (it has no S4 number — see the S6 docs).
+    pub refs: Vec<RefEntry>,
+    /// One row per **resolved** `\cite` key, in S2 pre-order (one per key of a multi-key `\cite`).
+    pub cites: Vec<CiteEntry>,
+    /// The keys of **dangling** `\ref`s (S1's `unresolved`) — LaTeX's `??` undefined references.
+    pub dangling_refs: Vec<String>,
+    /// The keys of **dangling** `\cite`s (S2's `unresolved`) — LaTeX's `[?]` undefined citations.
+    pub dangling_cites: Vec<String>,
+}
+
+impl CrossReferenceReport {
+    /// Render this report to a **stable, deterministic, human-readable** plain-text string (LTXDOC03
+    /// S6). The exact format — pinned so tests and consumers can rely on it byte-for-byte:
+    ///
+    /// - One line per resolved reference, in `refs` order:
+    ///   `` \ref{<key>} -> <Kind> <number> `` — e.g. `` \ref{sec:intro} -> Section 1.2 ``. The
+    ///   command shown is always `\ref` (the canonical reference form) regardless of the actual
+    ///   `\eqref`/`\pageref` spelling, so the line names the *binding*, not the surface command;
+    ///   `<Kind>` is the capitalised kind name ([`kind_display_name`]).
+    /// - One line per resolved citation, in `cites` order:
+    ///   `` \cite{<key>} -> <number> `` — e.g. `` \cite{smith} -> [2] ``.
+    /// - **Only if** `dangling_refs` is non-empty, a footer line:
+    ///   `Dangling references: <k1>, <k2>, …` (keys joined by `", "`, in order).
+    /// - **Only if** `dangling_cites` is non-empty, a footer line:
+    ///   `Dangling citations: <k1>, <k2>, …`.
+    ///
+    /// Lines are joined by a single `\n` with **no trailing newline** and no trailing whitespace on
+    /// any line. An **empty report** (no refs, cites, or dangling keys) renders the fixed string
+    /// `"(no cross-references)"` so the output is never the empty string (a stable, greppable
+    /// "nothing here" marker). Sections appear in a fixed order — resolved refs, resolved cites,
+    /// dangling refs, dangling cites — so the whole rendering is a pure function of the report.
+    ///
+    /// Total & panic-free: string building only (no indexing, no `unwrap`), allocating just the output
+    /// `String`.
+    pub fn to_plain_text(&self) -> String {
+        let mut lines: Vec<String> = Vec::new();
+
+        // Resolved references: `\ref{key} -> Kind number`.
+        for r in &self.refs {
+            lines.push(format!(r"\ref{{{}}} -> {} {}", r.key, kind_display_name(r.kind), r.number));
+        }
+        // Resolved citations: `\cite{key} -> number`.
+        for c in &self.cites {
+            lines.push(format!(r"\cite{{{}}} -> {}", c.key, c.number));
+        }
+        // Dangling footers, each only when non-empty (keys joined by ", ").
+        if !self.dangling_refs.is_empty() {
+            lines.push(format!("Dangling references: {}", self.dangling_refs.join(", ")));
+        }
+        if !self.dangling_cites.is_empty() {
+            lines.push(format!("Dangling citations: {}", self.dangling_cites.join(", ")));
+        }
+
+        if lines.is_empty() {
+            // A stable, greppable marker so the rendering is never the empty string.
+            "(no cross-references)".to_string()
+        } else {
+            lines.join("\n")
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// The report assembly.
+// -------------------------------------------------------------------------------------------------
+
+impl Document {
+    /// Assemble the **cross-reference report** for this document (LTXDOC03 S6) — the consumer artifact
+    /// that composes S1/S2/S4/S5 into one owned, auditable table.
+    ///
+    /// The assembly, with **no new AST walk** (each family is numbered **once**, then looked up):
+    ///
+    /// 1. Run S1 [`resolve_references`](Document::resolve_references) and number the labels **once**
+    ///    with S4 [`number_labels`](Document::number_labels). For each [`ResolvedRef`], look its `key`
+    ///    up in the [`Numbering`] via [`number_for`](Numbering::number_for): a `Some(number)` becomes a
+    ///    [`RefEntry`] (key + command + kind + number); a `None` (a resolved `\ref` to an *unnumbered*
+    ///    inline/equation label — see the S6 module docs) is **omitted**. S1's `unresolved` keys become
+    ///    [`dangling_refs`](CrossReferenceReport::dangling_refs).
+    /// 2. Run S2 [`resolve_citations`](Document::resolve_citations) and number the entries **once** with
+    ///    S5 [`number_citations`](Document::number_citations). For each [`ResolvedCite`], look its `key`
+    ///    up in the [`CitationNumbering`] → a [`CiteEntry`] (key + bracketed number). (A resolved cite
+    ///    always names a winning entry, which S5 always numbers, so this lookup is `Some` in practice;
+    ///    a defensive `None` is simply skipped, never a panic.) S2's `unresolved` keys become
+    ///    [`dangling_cites`](CrossReferenceReport::dangling_cites).
+    ///
+    /// **Numbered once, not per-item.** Numbering the two families a single time (then O(1)-ish
+    /// `number_for` lookups) is deliberate: it avoids the per-entry re-numbering the
+    /// [`ref_number`](Document::ref_number) / [`cite_number`](Document::cite_number) convenience
+    /// methods do (fine for a one-off, wasteful in a loop). So the report costs a *constant* number of
+    /// the existing bounded passes — S1, S2, S4, S5 — no more.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing; it only *calls* the S1/S2/
+    /// S4/S5 passes (each of which reuses the bounded [`Document::walk`]) and copies owned data out of
+    /// their results — introducing no new recursion. Borrows `self` immutably; the returned
+    /// [`CrossReferenceReport`] is owned plain data, so it outlives any borrow of the source. The tree
+    /// is **not** mutated — the report is pure composition, leaving S1–S5 outputs byte-for-byte
+    /// unchanged.
+    pub fn cross_reference_report(&self) -> CrossReferenceReport {
+        // ---- References (S1 binding × S4 numbering) ----
+        let references = self.resolve_references();
+        let label_numbers = self.number_labels(); // numbered ONCE, reused for every lookup below.
+
+        let mut refs: Vec<RefEntry> = Vec::new();
+        for r in &references.resolved {
+            // A resolved `\ref` with an S4 number becomes a row; a resolved-but-unnumbered one
+            // (inline/equation label — deferred) is omitted, so every row carries a real number.
+            if let Some(number) = label_numbers.number_for(&r.key) {
+                refs.push(RefEntry {
+                    key: r.key.clone(),
+                    command: r.command.clone(),
+                    kind: r.target_kind,
+                    number: number.to_string(),
+                });
+            }
+        }
+        let dangling_refs: Vec<String> =
+            references.unresolved.iter().map(|u| u.key.clone()).collect();
+
+        // ---- Citations (S2 binding × S5 numbering) ----
+        let citations = self.resolve_citations();
+        let cite_numbers = self.number_citations(); // numbered ONCE, reused for every lookup below.
+
+        let mut cites: Vec<CiteEntry> = Vec::new();
+        for c in &citations.resolved {
+            // A resolved cite always names a winning, numbered entry; a defensive `None` is skipped.
+            if let Some(number) = cite_numbers.number_for(&c.key) {
+                cites.push(CiteEntry { key: c.key.clone(), number: number.to_string() });
+            }
+        }
+        let dangling_cites: Vec<String> =
+            citations.unresolved.iter().map(|u| u.key.clone()).collect();
+
+        CrossReferenceReport { refs, cites, dangling_refs, dangling_cites }
+    }
+}
+
 // -------------------------------------------------------------------------------------------------
 // Tests.
 // -------------------------------------------------------------------------------------------------
@@ -2489,6 +2779,181 @@ See Section~\ref{sec:intro} and \cite{smith2020}.
         assert!(
             doc.cite_target_node(&cites_before.resolved[0]).is_some(),
             "S3 lookup still resolves after citation numbering"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S6 — the cross-reference report (consumer composing S1/S2/S4/S5).
+    // ---------------------------------------------------------------------------------------------
+
+    /// Parse `src` and build its cross-reference report — the shared S6 harness.
+    fn report(src: &str) -> CrossReferenceReport {
+        parse_document(src).expect("parse").cross_reference_report()
+    }
+
+    #[test]
+    fn report_composes_a_ref_and_a_cite_with_their_numbers() {
+        // A doc with BOTH a labeled `\section`+`\ref` AND a `thebibliography`+`\cite`: the report
+        // fuses S1's binding with S4's number for the ref, and S2's binding with S5's number for the
+        // cite — one RefEntry (Section 1) and one CiteEntry ([2]).
+        let src = r"\begin{document}\section{Intro}\label{s:i}
+
+See Section~\ref{s:i} and \cite{b}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\end{thebibliography}\end{document}";
+        let rep = report(src);
+
+        // One resolved-and-numbered reference, EVERY field exact.
+        assert_eq!(rep.refs.len(), 1, "one numbered ref");
+        assert_eq!(rep.refs[0].key, "s:i");
+        assert_eq!(rep.refs[0].command, "ref");
+        assert_eq!(rep.refs[0].kind, LabelKind::Section);
+        assert_eq!(rep.refs[0].number, "1");
+
+        // One resolved-and-numbered citation, EVERY field exact (the SECOND \bibitem → [2]).
+        assert_eq!(rep.cites.len(), 1, "one numbered cite");
+        assert_eq!(rep.cites[0].key, "b");
+        assert_eq!(rep.cites[0].number, "[2]");
+
+        // No dangling entries.
+        assert!(rep.dangling_refs.is_empty());
+        assert!(rep.dangling_cites.is_empty());
+    }
+
+    #[test]
+    fn report_to_plain_text_renders_the_exact_pinned_string() {
+        // LOAD-BEARING: the plain-text rendering is a stable, pinned multi-line string — a resolved
+        // ref line and a resolved cite line, joined by a single `\n`, no trailing newline.
+        let src = r"\begin{document}\section{Intro}\label{s:i}
+
+See Section~\ref{s:i} and \cite{b}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\end{thebibliography}\end{document}";
+        let rep = report(src);
+        assert_eq!(
+            rep.to_plain_text(),
+            "\\ref{s:i} -> Section 1\n\\cite{b} -> [2]",
+            "the pinned resolved-only rendering"
+        );
+    }
+
+    #[test]
+    fn report_surfaces_dangling_refs_and_cites_separately() {
+        // A dangling `\ref{nope}` and dangling `\cite{ghost}` appear in the dangling vecs (exact
+        // keys), NOT in `refs`/`cites`; the plain-text footer lists them.
+        let src = r"\begin{document}See \ref{nope} and \cite{ghost}.\end{document}";
+        let rep = report(src);
+
+        assert!(rep.refs.is_empty(), "the dangling ref is NOT a resolved row");
+        assert!(rep.cites.is_empty(), "the dangling cite is NOT a resolved row");
+        assert_eq!(rep.dangling_refs, vec!["nope".to_string()], "dangling ref key surfaced");
+        assert_eq!(rep.dangling_cites, vec!["ghost".to_string()], "dangling cite key surfaced");
+
+        // The plain-text footer lists both dangling families, no resolved lines above them.
+        assert_eq!(
+            rep.to_plain_text(),
+            "Dangling references: nope\nDangling citations: ghost",
+            "the pinned dangling-only rendering"
+        );
+    }
+
+    #[test]
+    fn report_numbers_each_key_of_a_multi_key_cite() {
+        // A multi-key `\cite{a,b}` → two CiteEntry rows numbered [1] and [2] (each key looks up its
+        // own entry's list position).
+        let src = r"\begin{document}See \cite{a,b}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\end{thebibliography}\end{document}";
+        let rep = report(src);
+
+        assert_eq!(rep.cites.len(), 2, "one row per key of the multi-key \\cite");
+        assert_eq!(rep.cites[0].key, "a");
+        assert_eq!(rep.cites[0].number, "[1]");
+        assert_eq!(rep.cites[1].key, "b");
+        assert_eq!(rep.cites[1].number, "[2]");
+        assert!(rep.refs.is_empty());
+        assert!(rep.dangling_cites.is_empty());
+
+        // Both cite lines render in order.
+        assert_eq!(
+            rep.to_plain_text(),
+            "\\cite{a} -> [1]\n\\cite{b} -> [2]",
+            "both multi-key cite lines, in order"
+        );
+    }
+
+    #[test]
+    fn report_omits_resolved_but_unnumbered_inline_label_ref() {
+        // A `\ref{eq:x}` to an INLINE `\label{eq:x}` resolves (S1) but has NO S4 number (inline labels
+        // are deferred): it is OMITTED from `refs` (neither a numbered row nor a dangling one). A
+        // numbered section ref alongside proves the numbered one IS included.
+        let src = r"\begin{document}\section{Intro}\label{s:i}
+
+The identity \label{eq:x} holds. See \ref{s:i} and \eqref{eq:x}.\end{document}";
+        let rep = report(src);
+
+        // Only the section ref is a numbered row; the inline-label ref is omitted.
+        assert_eq!(rep.refs.len(), 1, "the unnumbered inline-label ref is omitted");
+        assert_eq!(rep.refs[0].key, "s:i");
+        assert_eq!(rep.refs[0].number, "1");
+        // And it is NOT reported as dangling either (its label exists — it is simply unnumbered).
+        assert!(!rep.dangling_refs.contains(&"eq:x".to_string()), "resolved, so not dangling");
+        assert!(rep.dangling_refs.is_empty());
+    }
+
+    #[test]
+    fn report_empty_document_is_empty_and_renders_stable_marker_no_panic() {
+        // An empty document → an entirely empty report, and `to_plain_text` renders the pinned
+        // "(no cross-references)" marker (never the empty string), with no panic.
+        let rep = report(r"\begin{document}\end{document}");
+        assert_eq!(rep, CrossReferenceReport::default(), "empty doc → empty report");
+        assert_eq!(
+            rep.to_plain_text(),
+            "(no cross-references)",
+            "empty report renders the stable marker"
+        );
+    }
+
+    #[test]
+    fn report_does_not_mutate_the_tree_s1_through_s5_unchanged() {
+        // REGRESSION: the report is pure composition — building it leaves S1/S2/S3/S4/S5 outputs
+        // byte-for-byte unchanged (the tree is never mutated).
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+See Section~\ref{sec:intro} and \cite{smith2020}.
+
+\begin{thebibliography}{9}
+\bibitem{smith2020} Smith, J. Title. 2020.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let refs_before = doc.resolve_references();
+        let cites_before = doc.resolve_citations();
+        let num_before = doc.number_labels();
+        let cite_num_before = doc.number_citations();
+
+        // Build the report (exercises the S6 composition).
+        let rep = doc.cross_reference_report();
+        assert_eq!(rep.refs.len(), 1);
+        assert_eq!(rep.cites.len(), 1);
+
+        // S1–S5 outputs are all untouched, and an S3 node lookup still agrees.
+        assert_eq!(doc.resolve_references(), refs_before, "S1 output unchanged by S6");
+        assert_eq!(doc.resolve_citations(), cites_before, "S2 output unchanged by S6");
+        assert_eq!(doc.number_labels(), num_before, "S4 output unchanged by S6");
+        assert_eq!(doc.number_citations(), cite_num_before, "S5 output unchanged by S6");
+        assert!(
+            doc.ref_target_node(&refs_before.resolved[0]).is_some(),
+            "S3 lookup still resolves after building the report"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -511,3 +511,118 @@ multi-key `\cite{a,c}` numbers its resolved records to `"[1]"` and `"[3]"`; a da
 shift the others (`b` stays `"[2]"`, `c` stays `"[3]"`) and consumes no number; an empty document /
 document with no `thebibliography` → empty numbering; and a regression that citation numbering leaves
 the S1/S2/S3/S4 outputs byte-for-byte unchanged (the tree is never mutated).
+
+## 12. S6 — the cross-reference report (consumer composing S1/S2/S4/S5)
+
+S1 bound each `\ref`; S2 bound each `\cite`; S4 numbered the labels; S5 numbered the citations. Each
+pass produced its own owned result type, but **nothing yet assembles them into a single
+consumer-facing artifact**. S6 is that assembly: one method that walks S1's resolved `\ref`s and S2's
+resolved `\cite`s and produces an **owned, plain-data report** where each entry carries its rendered
+*number* (from S4/S5) alongside its key/command/kind. It is the **payoff rung** — the proof that the
+five analysis passes *compose* into an auditable whole, exactly the shape a byte-provenance consumer
+wants: "here is every cross-reference in this document, what it points at, and the number it prints."
+
+### 12.1 A pure consumer — no new AST walk
+
+S6 adds **no new walk** of its own. It calls S1 (`resolve_references`) and S2 (`resolve_citations`) —
+each of which already reuses the bounded `Document::walk` — and S4 (`number_labels`) / S5
+(`number_citations`) to number each family **once**, then *looks each key up* in the resulting number
+table. So the whole report costs a *constant* number of the existing bounded passes (never a per-entry
+re-numbering — the anti-pattern the S4/S5 convenience methods `ref_number`/`cite_number` warn about
+when called in a loop). No new parsing, no AST change, no new recursion.
+
+| family | source pass (binding) | number pass | report entry |
+|--------|-----------------------|-------------|--------------|
+| `\ref`  | S1 `ResolvedRef { key, command, target_kind }` | S4 `Numbering::number_for(key)` | `RefEntry`  |
+| `\cite` | S2 `ResolvedCite { key }`                      | S5 `CitationNumbering::number_for(key)` | `CiteEntry` |
+
+### 12.2 The three rules
+
+1. **Dangling refs/cites surfaced separately.** A `\ref{missing}` (S1's `unresolved`) and a
+   `\cite{ghost}` (S2's `unresolved`) — LaTeX's `??` (undefined reference) and `[?]` (undefined
+   citation) markers — are **not** dropped and **not** folded in among the resolved entries with a fake
+   number. They go in their own `dangling_refs` / `dangling_cites` key vectors. This separation is
+   deliberate: two vectors make "resolved vs dangling" a *type-level* fact, rather than burying it in a
+   `number: Option<String>` field the caller must remember to check.
+2. **A resolved `\ref` whose target is not numbered is omitted.** Every entry in S1's `resolved` has a
+   matching `\label`, but not every `\label` is *numbered*: S4 numbers sections and figure/table
+   floats, but an **inline `\label`** (typically an equation label) is deliberately unnumbered
+   (deferred to a future equation-numbering rung). So a `\ref{eq:x}` to an inline `\label{eq:x}`
+   *resolves* yet has **no** S4 number. S6 **omits** such an entry from `refs`, so every row in `refs`
+   carries a real number (no placeholder). It is neither *dangling* (its label exists) nor
+   *renderable*; it reappears once equation numbering ships. Citations have no analogous gap — a
+   winning `\bibitem` is always S5-numbered — so every resolved `\cite` becomes a `CiteEntry`.
+3. **Multi-key `\cite` yields one row per key.** S2 already split `\cite{a,b}` into per-key
+   `ResolvedCite`s, so S6 emits one `CiteEntry` per key, each numbered independently (`a`→`[1]`,
+   `b`→`[2]`).
+
+### 12.3 Public API
+
+```rust
+impl Document {
+    /// Assemble the cross-reference report: composes S1 (resolve refs) + S2 (resolve cites) + S4
+    /// (label numbers) + S5 (citation numbers) into one owned artifact. No new AST walk — each
+    /// family is numbered once, then looked up. Total & panic-free; the tree is not mutated.
+    pub fn cross_reference_report(&self) -> CrossReferenceReport;
+}
+
+pub struct CrossReferenceReport {
+    pub refs: Vec<RefEntry>,         // one per resolved & numbered `\ref`, in S1 pre-order
+    pub cites: Vec<CiteEntry>,       // one per resolved `\cite` key, in S2 pre-order
+    pub dangling_refs: Vec<String>,  // keys of unresolved `\ref` (S1's `unresolved`) — LaTeX's `??`
+    pub dangling_cites: Vec<String>, // keys of unresolved `\cite` (S2's `unresolved`) — LaTeX's `[?]`
+}
+impl CrossReferenceReport {
+    /// Render a stable, deterministic, human-readable report (see §12.4 for the pinned format).
+    pub fn to_plain_text(&self) -> String;
+}
+
+pub struct RefEntry  { pub key: String, pub command: String, pub kind: LabelKind, pub number: String }
+pub struct CiteEntry { pub key: String, pub number: String }
+```
+
+All plain, owned data (`String`s + `Copy` `LabelKind`), mirroring S4/S5, so the report outlives any
+borrow of the source and can be stored/serialized. `RefEntry`, `CiteEntry`, and `CrossReferenceReport`
+are exported from the crate root.
+
+### 12.4 The pinned plain-text format
+
+`to_plain_text()` renders a stable string a test can pin byte-for-byte:
+
+- One line per resolved reference, in `refs` order: `\ref{<key>} -> <Kind> <number>` (e.g.
+  `\ref{sec:intro} -> Section 1.2`). The command shown is always `\ref` (naming the *binding*, not the
+  surface `\eqref`/`\pageref` spelling); `<Kind>` is the capitalised kind name (`Section`/`Table`/
+  `Figure`).
+- One line per resolved citation, in `cites` order: `\cite{<key>} -> <number>` (e.g.
+  `\cite{smith} -> [2]`).
+- **Only if** non-empty, a footer `Dangling references: <k1>, <k2>, …` (keys joined by `", "`).
+- **Only if** non-empty, a footer `Dangling citations: <k1>, <k2>, …`.
+
+Lines are joined by a single `\n` with **no trailing newline** and no trailing whitespace. An **empty**
+report renders the fixed marker `(no cross-references)` (never the empty string). Sections appear in a
+fixed order (resolved refs, resolved cites, dangling refs, dangling cites), so the rendering is a pure
+function of the report.
+
+### 12.5 What is DEFERRED (honest boundary, inherited from S4/S5)
+
+- **Equation numbers** — a `\ref` to an equation/inline label is *omitted* from `refs` (S4 does not
+  number those yet — an equation body is an opaque `Block::DisplayMath` string with no label field), not
+  invented.
+- **Author-year / natbib sorted citation styles** and **external `.bib`/`.bbl` databases** — out of
+  scope at S2/S5, so the report covers only what those passes resolved (in-document `thebibliography`,
+  numeric/unsorted style).
+
+### 12.6 Verification (S6)
+
+`cargo test -p latex` green (7 new `references` S6 tests); `cargo clippy -p latex --all-targets
+-- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build
+-p latex --no-default-features` builds. No `cargo fmt`, no grammar regen. The tests assert the
+**actual composed data and rendered strings**: a doc with both a labeled `\section`+`\ref` and a
+`thebibliography`+`\cite` → one `RefEntry` (key `"s:i"`, command `"ref"`, kind `Section`, number
+`"1"`) and one `CiteEntry` (key `"b"`, number `"[2]"`), each field exact; `to_plain_text()` renders the
+pinned multi-line string; a dangling `\ref{nope}`/`\cite{ghost}` appear in `dangling_refs`/
+`dangling_cites` (not in `refs`/`cites`) and in the footer; a multi-key `\cite{a,b}` → two `CiteEntry`s
+numbered `[1]`/`[2]`; a resolved-but-unnumbered inline-label `\ref` is omitted from `refs` (and not
+dangling); an empty document → an empty report with `to_plain_text()` == `"(no cross-references)"` (no
+panic); and a regression that building the report leaves the S1/S2/S3/S4/S5 outputs byte-for-byte
+unchanged (the tree is never mutated).


### PR DESCRIPTION
## LTXDOC03 S6 — cross-reference report (composes S1–S5 end-to-end)

Sixth slice of the LTXDOC03 cross-reference-resolution arc in the dependency-free `latex` crate. S1–S5 built five analysis passes over a parsed `Document` (resolve `\ref`, resolve `\cite`, expose target nodes, number labels, number citations) but nothing yet **assembled** them into one consumer-facing artifact. **S6 is that consumer**: a report that walks S1's resolved `\ref`s and S2's resolved `\cite`s and attaches each one's rendered **number** (from S4/S5) — the payoff that proves the five passes compose. No AST change, no new parsing.

### What it adds (all in `src/references.rs`, one module extended)
```rust
impl Document { pub fn cross_reference_report(&self) -> CrossReferenceReport; }
pub struct CrossReferenceReport {
    pub refs: Vec<RefEntry>,          // resolved & numbered \ref, S1 pre-order
    pub cites: Vec<CiteEntry>,        // resolved \cite key, S2 pre-order
    pub dangling_refs: Vec<String>,   // S1 unresolved keys (LaTeX "??")
    pub dangling_cites: Vec<String>,  // S2 unresolved keys (LaTeX "[?]")
}
impl CrossReferenceReport { pub fn to_plain_text(&self) -> String; }
pub struct RefEntry  { pub key: String, pub command: String, pub kind: LabelKind, pub number: String }
pub struct CiteEntry { pub key: String, pub number: String }
```
- **Composes S1/S2/S4/S5** — numbers each family **once** (`number_labels()` / `number_citations()`) then looks each key up via `number_for` (NOT `ref_number`/`cite_number` per item — those re-number the whole doc per call; the report avoids the O(n²) loop). Resolved `\ref`s → `RefEntry` with S4 number; resolved `\cite`s → `CiteEntry` with S5 number (`[2]`).
- **Dangling handling** — S1/S2 `unresolved` keys are surfaced in **separate** `dangling_refs`/`dangling_cites` vecs (LaTeX's `??`/`[?]` undefined markers), never folded into the resolved lists.
- **Resolved-but-unnumbered** — a `\ref` to an **inline `\label`** (equation-style, `LabelKind::Inline`) resolves in S1 but has no S4 number (inline numbering is deferred); such entries are **omitted** (neither dangling nor renderable) — documented.
- **`to_plain_text()`** — deterministic, pinned format: `\ref{<key>} -> <Kind> <number>` and `\cite{<key>} -> <number>` in report order, then optional `Dangling references: ...` / `Dangling citations: ...` footers; empty report → the fixed marker `(no cross-references)`. No trailing newline.

### Safety
Pure read-only analysis over the already-bounded S1/S2/S4/S5 results (no new tree walk, no new recursion): no file I/O, no network, no new deps, **no `unsafe`**, no `unwrap`/`expect` on the public path; `to_plain_text` builds via `format!`/`join` bounded by input size. The tree is **not** mutated; S1–S5 outputs are unchanged.

### Deferred to S7+
Equation numbers (needs a DisplayMath AST carrying the equation label — currently source-kept raw; so inline-label refs stay omitted from the report), author-year / sorted citation styles, and external `.bib`/BibTeX databases (against the crate's no-I/O design). Noted in the spec's future section.

### Tests (7 new; assert exact report strings)
- a doc with `\section{Intro}\label{s:i}` + `\ref{s:i}` and a `thebibliography`/`\cite{b}` → `refs[0]` = {key `"s:i"`, command `"ref"`, kind Section, number `"1"`}; `cites[0]` = {key `"b"`, number `"[2]"`}.
- `to_plain_text()` renders the **exact** pinned string `"\ref{s:i} -> Section 1\n\cite{b} -> [2]"`.
- dangling `\ref{...}` + `\cite{...}` → surfaced in `dangling_refs`/`dangling_cites` (exact keys), NOT in `refs`/`cites`.
- multi-key `\cite{a,b}` → two `CiteEntry`s numbered `[1]` and `[2]`.
- a resolved-but-inline-label `\ref` → omitted from `refs`.
- empty document → empty report, `to_plain_text()` = `"(no cross-references)"`, no panic.
- regression: building the report does not mutate the tree; S1–S5 outputs unchanged.

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → **345 passed** (was 338 + 7 new S6 tests) + doctest.
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected).
- `cargo build -p latex --no-default-features` → builds.

Crate bumped `0.41.0` → `0.42.0`; CHANGELOG, README (usage + sample output + feature row), and the LTXDOC03 spec (new §12 S6) updated. Security-reviewed (Rust, panic/DoS-focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
