### PR TITLE
feat(sir-rust): Ruby stdlib breadth — Array collection methods parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.15.0 — Array aggregate / reshape parity (min / max / sum / uniq / flatten / compact / to_a / each_with_index)
+
+Ports the remaining `Array`/`Enumerable` aggregate and reshape methods —
+already present in the Python and TypeScript backends (`sir-runtime-oop`) — to
+the Rust backend's inlined `__sir` runtime, so a collection program produces
+identical output on every backend. Runtime-only change (no core semantic-IR, no
+frontend, no emitter change): the frontend already lowers `arr.min`, `arr.uniq`,
+`arr.each_with_index { … }`, etc. to the `__method__` dispatch envelope; this
+teaches `array_method` to resolve them via new EXPLICIT `match` arms (never
+reflection — [[dynamic-dispatch-rce]]).
+
+All eight were ABSENT before this change; each is newly added:
+
+- **`min` / `max`** — element-wise via the runtime's numeric ordering
+  (`num_lt`, the same source of truth `sort`/`<` use); an empty array yields
+  `nil`. A stable left-fold keeps the first element on a tie. The vector is
+  snapshotted before folding so no `RefCell` borrow is held across the scan.
+- **`sum`** — numeric fold seeded at `0` (or the explicit `sum(init)` seed arg,
+  matching the Python/TS reference). Each step reuses `plus`, so integer-only
+  inputs stay `Int` while any float promotes to `Float`; `[].sum == 0`.
+- **`uniq`** — first-occurrence-order de-duplication using the runtime's
+  structural `value_eq` (so `[1, 1.0]` collapses, as do equal nested arrays),
+  into a fresh `Vec`.
+- **`flatten`** — recursively splices nested `Seq`s into one freshly-allocated
+  flat `Seq`. **CYCLE GUARD:** a `visited` set of seq handle-addresses (the
+  same discipline `puts`/`format`/`value_eq` use) bounds the walk so a
+  self-referential array terminates; every level snapshots its items — dropping
+  the `RefCell` borrow — BEFORE recursing, so no borrow is ever held across a
+  re-entrant call and no input handle is aliased into the result.
+- **`compact`** — a fresh `Seq` with every `nil` removed.
+- **`to_a`** — returns the receiver itself (Ruby `Array#to_a` identity).
+- **`each_with_index`** — yields `(element, index)` to the block via
+  `apply_closure` and returns the receiver; each element is cloned out of the
+  snapshot BEFORE the block runs, so no `RefCell` borrow is held across the
+  (re-entrant) closure call.
+- New `compile_and_run_array_aggregates` exec proof: hand-builds SIR for
+  `[3,1,2].max`/`.min`, `[1,2,3].sum`, `[1,2,2,3].uniq`, `[[1,[2]],3].flatten`,
+  `[1,nil,2].compact`, `[1,2,3].to_a`, and `[10,20].each_with_index { |x,i| … }`,
+  emits Rust, compiles it with `rustc`, and diffs stdout against the values the
+  Python/TS reference produces for the same module.
+
 ## 0.14.0 — M6 universal metaprogramming surface (send / tap / then / respond_to?)
 
 Ports the **M6** universal `Object`/`Kernel` metaprogramming surface — already

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1679,6 +1679,128 @@ pub const RUNTIME: &str = r##"mod __sir {
                 }
                 acc
             }
+            // ── aggregate / reshape Array methods (non-block) ─────
+            //
+            // `min`/`max`: element-wise via the runtime's numeric ordering
+            // (`num_lt`, the same source of truth `sort`/`<` use).  An empty
+            // array yields `nil` (Ruby `[].min == nil`).  We snapshot the
+            // vector first (no borrow held across the fold) and keep the
+            // FIRST element on a tie, matching a stable left-fold.
+            "min" => {
+                let snapshot = items_rc.borrow().clone();
+                let mut iter = snapshot.into_iter();
+                match iter.next() {
+                    Some(mut best) => {
+                        for item in iter {
+                            if num_lt(&item, &best) {
+                                best = item;
+                            }
+                        }
+                        best
+                    }
+                    None => Value::Nil,
+                }
+            }
+            "max" => {
+                let snapshot = items_rc.borrow().clone();
+                let mut iter = snapshot.into_iter();
+                match iter.next() {
+                    Some(mut best) => {
+                        for item in iter {
+                            if num_lt(&best, &item) {
+                                best = item;
+                            }
+                        }
+                        best
+                    }
+                    None => Value::Nil,
+                }
+            }
+            // `sum`: numeric fold seeded at `0` (or the explicit seed arg,
+            // matching Ruby `sum(init)` and the Python/TS reference's
+            // `total = args[0] if args else 0`).  Each step reuses `plus`,
+            // so integer-only inputs stay `Int` while any float promotes to
+            // `Float` — `[].sum == 0`, `[1,2,3].sum == 6`, `[1.5,2].sum == 3.5`.
+            "sum" => {
+                let seed = pos.into_iter().next().unwrap_or(Value::Int(0));
+                let snapshot = items_rc.borrow().clone();
+                let mut acc = seed;
+                for item in snapshot {
+                    acc = plus(vec![acc, item]);
+                }
+                acc
+            }
+            // `uniq`: first-occurrence-order de-duplication using the
+            // runtime's structural `value_eq` (so `[1, 1.0]` collapses and
+            // `[[1],[1]]` collapses too).  A fresh `Vec`; the snapshot is
+            // taken up front so no borrow is held while we scan `out`.
+            "uniq" => {
+                let snapshot = items_rc.borrow().clone();
+                let mut out: Vec<Value> = Vec::new();
+                for item in snapshot {
+                    if !out.iter().any(|kept| value_eq(kept, &item)) {
+                        out.push(item);
+                    }
+                }
+                seq_lit(out)
+            }
+            // `flatten`: recursively splice nested `Seq`s into one flat,
+            // freshly-allocated `Seq`.  CYCLE GUARD: a `visited` set of seq
+            // handle-addresses (the same discipline `puts`/`format`/`value_eq`
+            // use) bounds the walk so a self-referential array terminates —
+            // a handle already on the stack is treated as already-flattened
+            // and skipped rather than re-entered.  Every level snapshots its
+            // items (dropping the `RefCell` borrow) BEFORE recursing, so no
+            // borrow is ever held across a re-entrant call.
+            "flatten" => {
+                fn flatten_into(
+                    items: &Rc<RefCell<Vec<Value>>>,
+                    out: &mut Vec<Value>,
+                    visited: &mut std::collections::HashSet<usize>,
+                ) {
+                    let id = seq_handle_id(items);
+                    if !visited.insert(id) {
+                        return;
+                    }
+                    let snapshot = items.borrow().clone();
+                    for item in snapshot {
+                        match item {
+                            Value::Seq(inner) => flatten_into(&inner, out, visited),
+                            other => out.push(other),
+                        }
+                    }
+                    visited.remove(&id);
+                }
+                let mut out: Vec<Value> = Vec::new();
+                let mut visited: std::collections::HashSet<usize> =
+                    std::collections::HashSet::new();
+                flatten_into(&items_rc, &mut out, &mut visited);
+                seq_lit(out)
+            }
+            // `compact`: a fresh `Seq` with every `nil` removed.
+            "compact" => seq_lit(
+                items_rc
+                    .borrow()
+                    .iter()
+                    .filter(|x| !matches!(x, Value::Nil))
+                    .cloned()
+                    .collect(),
+            ),
+            // `to_a`: Ruby `Array#to_a` returns the receiver itself (identity),
+            // so downstream mutation is observed — we hand back `recv`.
+            "to_a" => recv,
+            // `each_with_index`: yields `(element, index)` to the block via
+            // `apply_closure` and returns the receiver.  The item is cloned
+            // out of the snapshot BEFORE the block runs, so no `RefCell`
+            // borrow is held across the (re-entrant) closure call.
+            "each_with_index" => {
+                if let Some(b) = &block {
+                    for (index, item) in items_rc.borrow().clone().into_iter().enumerate() {
+                        apply_closure(b, vec![item, Value::Int(index as i64)]);
+                    }
+                }
+                recv
+            }
             _ => no_method_error(&recv, name),
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -1,0 +1,267 @@
+//! End-to-end proof for the C6 **aggregate / reshape Array methods** in the
+//! Rust backend: `min`, `max`, `sum`, `uniq`, `flatten`, `compact`, `to_a`,
+//! and the block-taking `each_with_index`.
+//!
+//! These join the collection catalog that reaches every backend as the
+//! narrow-waist envelope
+//! `BuiltinCall("__method__", [recv, StrLit("meth"), …args, block?])`, which
+//! this backend emits as `__sir::call_method(recv, "meth", vec![…])` into an
+//! inline `__sir` runtime.  The catalog is an EXPLICIT `(type, name)` match
+//! (never reflection), ported from the Python/TypeScript `sir-runtime-oop`
+//! reference for behavioural parity.
+//!
+//! This test hand-builds SIR modules that exercise each new method, emits
+//! Rust, compiles it with `rustc`, runs the binary, and diffs stdout against
+//! the values the Python/TS reference produces for the SAME SIR module:
+//!
+//!   * `[3, 1, 2].max`                       → `3`
+//!   * `[3, 1, 2].min`                       → `1`
+//!   * `[1, 2, 3].sum`                       → `6`
+//!   * `[1, 2, 2, 3].uniq`                   → `[1, 2, 3]`
+//!   * `[[1, [2]], 3].flatten`               → `[1, 2, 3]`
+//!   * `[1, nil, 2].compact`                 → `[1, 2]`
+//!   * `[1, 2, 3].to_a`                      → `[1, 2, 3]` (identity)
+//!   * `[10, 20].each_with_index { |x, i| print x + i }`  → `10`, `21`
+//!     (block sees element AND index; receiver returned)
+//!
+//! If `rustc` (or a usable linker) is unavailable the test logs a skip rather
+//! than failing; a missing host tool must never redden a build.  The host can
+//! point the test at a working linker via `SIR_TEST_RUSTC_LINKER` (e.g. the
+//! toolchain's bundled `rust-lld`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, CaptureValue, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn nil() -> Expr {
+    Expr::NilLit { span: s() }
+}
+
+fn param(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, Expr::StrLit { value: name.into(), span: s() }];
+    all.append(&mut args);
+    Expr::BuiltinCall {
+        name: "__method__".into(),
+        args: all,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+/// A no-capture block closure over a top-level block function.
+fn block(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: Vec::<CaptureValue>::new(), span: s() }
+}
+
+fn print_expr(expr: Expr) -> Expr {
+    Expr::BuiltinCall {
+        name: "print".into(),
+        args: vec![expr],
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        span: s(),
+    }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt { expr: print_expr(expr), span: s() }
+}
+
+fn block_fn(name: &str, params: &[&str], value: Expr) -> Function {
+    Function {
+        name: name.into(),
+        params: params
+            .iter()
+            .map(|p| semantic_ir::Param {
+                name: (*p).into(),
+                kind: semantic_ir::ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            })
+            .collect(),
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
+    let mut functions = vec![Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }];
+    functions.extend(block_fns);
+
+    Module {
+        name: "array_aggregates_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn full_demo() -> Module {
+    // { |x, i| print x + i } — proves the block receives (element, index).
+    let block_fns =
+        vec![block_fn("__blk_ewi", &["x", "i"], print_expr(call("+", vec![param("x"), param("i")])))];
+
+    let main_stmts = vec![
+        // 1. [3, 1, 2].max  → 3
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "max", vec![])),
+        // 2. [3, 1, 2].min  → 1
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "min", vec![])),
+        // 3. [1, 2, 3].sum  → 6
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "sum", vec![])),
+        // 4. [1, 2, 2, 3].uniq  → [1, 2, 3]
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(2), ilit(3)]), "uniq", vec![])),
+        // 5. [[1, [2]], 3].flatten  → [1, 2, 3]
+        print_stmt(method(
+            seq(vec![seq(vec![ilit(1), seq(vec![ilit(2)])]), ilit(3)]),
+            "flatten",
+            vec![],
+        )),
+        // 6. [1, nil, 2].compact  → [1, 2]
+        print_stmt(method(seq(vec![ilit(1), nil(), ilit(2)]), "compact", vec![])),
+        // 7. [1, 2, 3].to_a  → [1, 2, 3] (identity)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "to_a", vec![])),
+        // 8. [10, 20].each_with_index { |x, i| print x + i }
+        //      → prints 10 (10+0) then 21 (20+1); the receiver is returned.
+        print_stmt(method(
+            seq(vec![ilit(10), ilit(20)]),
+            "each_with_index",
+            vec![block("__blk_ewi")],
+        )),
+    ];
+
+    demo_module(main_stmts, block_fns)
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn array_aggregates_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&full_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_array_aggregates_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_array_aggregates_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Diff against the Python/TS reference output for the same SIR module.
+    assert_eq!(
+        lines,
+        vec![
+            "3",         // [3,1,2].max
+            "1",         // [3,1,2].min
+            "6",         // [1,2,3].sum
+            "[1, 2, 3]", // [1,2,2,3].uniq
+            "[1, 2, 3]", // [[1,[2]],3].flatten
+            "[1, 2]",    // [1,nil,2].compact
+            "[1, 2, 3]", // [1,2,3].to_a
+            "10",        // each_with_index: 10 + 0
+            "21",        // each_with_index: 20 + 1
+            "[10, 20]",  // each_with_index returns receiver
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Runtime-only stdlib-breadth cascade for the **Rust** backend — adds the everyday Ruby Array methods that Python + TS already have, so real Ruby programs using them translate correctly. First wave: **Array collection methods** (more families — Symbol/Hash/Numeric — may follow on this branch).

Added to `fn array_method` (all 8 were absent): `min`, `max`, `sum`, `uniq`, `flatten`, `compact`, `to_a`, `each_with_index`. Semantics matched to the Python/TS reference:
- `min`/`max` element-wise (empty → nil); `sum` folds via the promoting `plus` (empty → 0, int/float aware); `uniq` first-occurrence dedup via `value_eq`; `compact` drops nils; `to_a` returns self; `each_with_index` yields `(el, idx)` and returns the receiver.
- `flatten` recursively flattens nested `Seq` into a **fresh** Vec, **cycle-guarded** (DFS-ancestor `HashSet` of `Rc::as_ptr` handles — a self-referential array terminates instead of overflowing the stack).

Security review: **PASSED** — cycle-guard correct & unbypassable, no RefCell borrow held across re-entrant calls (snapshot-before-recurse/yield), explicit `match` dispatch (no reflection), fresh Vecs (no input aliasing), `sum` inherits existing `plus` arithmetic.

Execution-proofed via rustc (`compile_and_run_array_aggregates.rs`): max/min/sum/uniq/flatten/compact/to_a/each_with_index vs reference values. 123 unit + all exec suites green, 0 new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)