### PR TITLE
feat(sir-go): Ruby stdlib breadth — Array collection methods parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.15.0
+
+### Added — Array collection-method parity (min / max / sum / uniq / flatten / compact / each_with_index)
+
+Parity-fill: these Ruby `Array` methods already shipped in the Python + TypeScript
+`sir-runtime-oop` backends; this ports the SAME surface into the Go runtime's
+array dispatch, so a translated Ruby program now executes them on the Go backend
+instead of hitting the `NoMethodError` floor. `to_a` was already present and is
+unchanged. Semantics match the Python/TS reference impls exactly.
+
+- **`min` / `max`** (non-block, v0) — element-wise extremum via `_sir_value_lt`
+  (Ruby's `<`/`>`); empty array ⇒ nil. Dispatched in `_sir_array_method`.
+- **`sum`** — folds with the polymorphic `_sir_plus` over an initial value
+  (default `0`, or the supplied `sum(init)` argument), preserving int/float;
+  empty array ⇒ the initial value. Dispatched in `_sir_array_method`.
+- **`uniq`** — order-preserving de-duplication via structural value-equality
+  (`_sir_value_eq`); returns a fresh `*Seq`. Dispatched in `_sir_array_method`.
+- **`flatten`** — recursively flattens nested `*Seq` into a fresh flat `*Seq`.
+  **Cycle-guarded** (CWE-674, uncontrolled recursion): the new
+  `_sir_flatten_into` helper threads a `visited` set of `*Seq` handle pointers
+  on the active recursion path — mirroring `_sir_puts_one` — so a self-referential
+  array (`a = []; a << a`) terminates instead of overflowing the Go stack.
+  Sibling (non-cyclic) occurrences still flatten in full.
+- **`compact`** — fresh `*Seq` with nil elements removed. Dispatched in
+  `_sir_array_method`.
+- **`each_with_index`** — block-taking; yields `(element, index)` pairs and
+  returns the receiver. Dispatched in `_sir_array_block_method`.
+- `_sir_array_responds` now advertises all of the above for `respond_to?` parity.
+
+Execution proof: `tests/compile_and_run_array_methods.rs`
+(`array_methods_compile_and_run`) hand-builds SIR exercising each method, emits
+Go, runs it under `go run`, and diffs stdout against the Python/TS reference
+values (`[3,1,2].max` → 3, `[1,2,2,3,1].uniq` → `[1,2,3]`, `[[1,[2]],3].flatten`
+→ `[1,2,3]`, `[1,nil,2,nil].compact` → `[1,2]`, `[1,2,3].sum` → 6,
+`[10,20].each_with_index` → `0:10`/`1:20` then the returned receiver).
+
 ## 0.14.0
 
 ### Security (review-driven)

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1670,11 +1670,12 @@ func _sir_array_responds(name string) bool {
 	// Non-block Array methods.
 	case "length", "size", "count", "first", "last", "empty?", "include?",
 		"index", "push", "append", "<<", "pop", "shift", "reverse", "sort",
+		"min", "max", "sum", "uniq", "flatten", "compact",
 		"join", "fetch", "to_a":
 		return true
 	// Block-taking Array/Enumerable methods.
-	case "each", "map", "collect", "select", "filter", "reject", "reduce",
-		"inject", "find", "detect", "any?", "all?", "none?":
+	case "each", "each_with_index", "map", "collect", "select", "filter",
+		"reject", "reduce", "inject", "find", "detect", "any?", "all?", "none?":
 		return true
 	}
 	return false
@@ -1823,10 +1824,102 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 					strconv.FormatInt(-n, 10)+"..."+strconv.FormatInt(n, 10))))
 		}
 		return recv.Items[idx], true
+	case "min", "max":
+		// Ruby `Array#min`/`#max` (no block, v0): element-wise extremum via
+		// `<`/`>` (modelled by `_sir_value_lt`).  Empty array ⇒ nil.  We seed
+		// with element 0 and keep the running extremum, matching the TS
+		// `reduce` and Python `min`/`max` references.
+		if len(recv.Items) == 0 {
+			return nil, true
+		}
+		best := recv.Items[0]
+		for _, x := range recv.Items[1:] {
+			if name == "min" {
+				if _sir_value_lt(x, best) {
+					best = x
+				}
+			} else if _sir_value_lt(best, x) {
+				best = x
+			}
+		}
+		return best, true
+	case "sum":
+		// Ruby `Array#sum`: fold with polymorphic `+` over an initial value
+		// (default 0, or the supplied `sum(init)` argument), preserving
+		// int/float exactly as `_sir_plus` does.  Empty array ⇒ the initial
+		// value (0 by default).  Matches the Python/TS references, which start
+		// `total` at `args[0] if args else 0` and accumulate with `+`.
+		var acc Value = int64(0)
+		if len(args) > 0 {
+			acc = args[0]
+		}
+		for _, x := range recv.Items {
+			acc = _sir_plus([]Value{acc, x})
+		}
+		return acc, true
+	case "uniq":
+		// Order-preserving de-duplication using structural value-equality
+		// (`_sir_value_eq`), matching the reference `_uniq`.  Fresh slice.
+		out := []Value{}
+		for _, x := range recv.Items {
+			dup := false
+			for _, y := range out {
+				if _sir_value_eq(x, y) {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				out = append(out, x)
+			}
+		}
+		return &Seq{Items: out}, true
+	case "flatten":
+		// Recursively flatten nested `*Seq` into a fresh flat `*Seq`.  A
+		// `*Seq` is a shared, mutable handle, so a program can build a *cyclic*
+		// array (`a = []; a << a`); an unguarded recursive flatten would
+		// overflow the Go stack (CWE-674).  We thread a `visited` set of the
+		// `*Seq` pointers on the active flatten path — exactly as `_sir_puts`
+		// does — and skip a handle already on its own path (a self-cycle
+		// contributes nothing, terminating the recursion).  Non-cyclic nested
+		// arrays flatten in full because each handle is removed from `visited`
+		// on exit, so sibling occurrences are unaffected.
+		out := []Value{}
+		_sir_flatten_into(&out, recv, make(map[Value]bool))
+		return &Seq{Items: out}, true
+	case "compact":
+		// Fresh array with nil elements removed (Ruby `Array#compact`).
+		out := []Value{}
+		for _, x := range recv.Items {
+			if x != nil {
+				out = append(out, x)
+			}
+		}
+		return &Seq{Items: out}, true
 	case "to_a":
 		return recv, true
 	}
 	return nil, false
+}
+
+// Cycle-guarded recursive flatten helper for `Array#flatten`.  Appends the
+// leaf (non-`*Seq`) elements of `seq` to `*out` in order, recursing into
+// nested `*Seq` handles.  `visited` holds the `*Seq` pointers currently on the
+// active recursion path; a handle already present is a self-cycle and is
+// skipped rather than recursed into (mirrors `_sir_puts_one`'s guard).
+func _sir_flatten_into(out *[]Value, seq *Seq, visited map[Value]bool) {
+	if visited[Value(seq)] {
+		return
+	}
+	visited[Value(seq)] = true
+	for _, item := range seq.Items {
+		if s, ok := item.(*Seq); ok {
+			_sir_flatten_into(out, s, visited)
+		} else {
+			*out = append(*out, item)
+		}
+	}
+	delete(visited, Value(seq))
 }
 
 // Block-taking Array/Enumerable methods.  `block` is applied via
@@ -1837,6 +1930,13 @@ func _sir_array_block_method(recv *Seq, name string, args []Value, block *Closur
 	case "each":
 		for _, x := range recv.Items {
 			_sir_apply(block, []Value{x})
+		}
+		return recv, true
+	case "each_with_index":
+		// Yields `(element, index)` pairs and returns the receiver, matching
+		// the Python/TS `enumerate`-style references.
+		for i, x := range recv.Items {
+			_sir_apply(block, []Value{x, int64(i)})
 		}
 		return recv, true
 	case "map", "collect":

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
@@ -1,0 +1,277 @@
+//! End-to-end proof for the Go backend's **Array collection-method parity**
+//! additions — `min`, `max`, `sum`, `uniq`, `flatten`, `compact`, `to_a`, and
+//! `each_with_index` — bringing the Go runtime level with the Python/TS
+//! `sir-runtime-oop` catalogs.
+//!
+//! Like `compile_and_run_coll_methods.rs`, this hand-builds SIR modules that
+//! exercise the new catalog entries, emits Go, runs it under a real `go run`,
+//! and diffs stdout against the values the Python/TS reference backends yield
+//! for the SAME operation (`[3,1,2].max` → `3`, `[1,2,2,3].uniq` → `[1,2,3]`,
+//! `[[1,[2]],3].flatten` → `[1,2,3]`, `[1,nil,2].compact` → `[1,2]`,
+//! `[1,2,3].sum` → `6`, `[10,20].each_with_index { |x,i| ... }` → the pairs).
+//!
+//! Gated on `go version`: a missing toolchain logs a skip rather than
+//! reddening the build (mirrors `compile_and_run_coll_methods.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope,
+    Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn nil() -> Expr {
+    Expr::NilLit { span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn var_p(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
+fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
+    let mut args = vec![recv, slit(name)];
+    args.extend(extra);
+    builtin("__method__", args)
+}
+
+fn closure(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: vec![], span: s() }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// `puts arg` — used by the `each_with_index` block so it emits one line per
+/// pair (interpolation is out of the Go backend's accepted set, so we `puts`
+/// a pre-joined string built with `+`).
+fn puts_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Two-parameter lambda (for `each_with_index`), registered top-level.
+fn lambda_fn2(fn_name: &str, p0: &str, p1: &str, body: Block) -> Function {
+    Function {
+        name: fn_name.into(),
+        params: vec![
+            semantic_ir::Param {
+                name: p0.into(),
+                kind: semantic_ir::ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            },
+            semantic_ir::Param {
+                name: p1.into(),
+                kind: semantic_ir::ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            },
+        ],
+        return_type: None,
+        captures: vec![],
+        body,
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn manifest() -> FeatureManifest {
+    FeatureManifest::from_features(&[
+        Feature::Closures,
+        Feature::Sequences,
+        Feature::Maps,
+        Feature::Strings,
+        Feature::Symbols,
+        Feature::MutableBindings,
+        Feature::DynamicTyping,
+    ])
+}
+
+fn program(functions: Vec<Function>) -> Module {
+    Module {
+        name: "array_methods_demo".into(),
+        manifest: manifest(),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// The parity demo `main`.  Each printed line's expected value is what the
+/// Python/TS reference runtime yields for the identical operation.
+fn catalog_module() -> Module {
+    // `each_with_index` block: `|x, i| puts (i.to_s + ":" + x.to_s)`.
+    // Builds "0:10", "1:20" — proving both element AND index reach the block.
+    let ewi_body = Block {
+        stmts: vec![puts_stmt(builtin(
+            "+",
+            vec![
+                builtin(
+                    "+",
+                    vec![method(var_p("i"), "to_s", vec![]), slit(":")],
+                ),
+                method(var_p("x"), "to_s", vec![]),
+            ],
+        ))],
+        value: nil(),
+        span: s(),
+    };
+    let ewi = lambda_fn2("__lam_ewi", "x", "i", ewi_body);
+
+    let stmts = vec![
+        // [3,1,2].min → 1
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "min", vec![])),
+        // [3,1,2].max → 3
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "max", vec![])),
+        // [].max → nil
+        print_stmt(method(seq(vec![]), "max", vec![])),
+        // [1,2,3].sum → 6
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "sum", vec![])),
+        // [].sum → 0
+        print_stmt(method(seq(vec![]), "sum", vec![])),
+        // [1,2,2,3,1].uniq → [1, 2, 3]  (first-occurrence order)
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(2), ilit(3), ilit(1)]),
+            "uniq",
+            vec![],
+        )),
+        // [[1,[2]],3].flatten → [1, 2, 3]  (recursive)
+        print_stmt(method(
+            seq(vec![seq(vec![ilit(1), seq(vec![ilit(2)])]), ilit(3)]),
+            "flatten",
+            vec![],
+        )),
+        // [1,nil,2,nil].compact → [1, 2]
+        print_stmt(method(
+            seq(vec![ilit(1), nil(), ilit(2), nil()]),
+            "compact",
+            vec![],
+        )),
+        // [1,2,3].to_a → [1, 2, 3]  (returns self)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "to_a", vec![])),
+        // [10,20].each_with_index { |x,i| puts "#{i}:#{x}" }  → 0:10 / 1:20
+        print_stmt(method(
+            seq(vec![ilit(10), ilit(20)]),
+            "each_with_index",
+            vec![closure("__lam_ewi")],
+        )),
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: nil(), span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![ewi, main])
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_go(source: &str, tag: &str) -> std::process::Output {
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_arr_{tag}_{nonce}.go"));
+    std::fs::write(&src_path, source).expect("write temp source");
+    let out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    out
+}
+
+#[test]
+fn array_methods_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&catalog_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "catalog");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "1",         // [3,1,2].min
+            "3",         // [3,1,2].max
+            "nil",       // [].max  (print of nil is "nil")
+            "6",         // [1,2,3].sum
+            "0",         // [].sum
+            "[1, 2, 3]", // [1,2,2,3,1].uniq
+            "[1, 2, 3]", // [[1,[2]],3].flatten
+            "[1, 2]",    // [1,nil,2,nil].compact
+            "[1, 2, 3]", // [1,2,3].to_a
+            "0:10",      // each_with_index pair 0
+            "1:20",      // each_with_index pair 1
+            "[10, 20]",  // each_with_index returns the receiver (then print's it)
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Runtime-only stdlib-breadth cascade for the **Go** backend — adds everyday Ruby Array methods that Python + TS already have. Companion to the Rust PR #7673.

Added (`to_a` already existed; 7 newly added) to `_sir_array_method` / `_sir_array_block_method`: `min`, `max`, `sum`, `uniq`, `flatten`, `compact`, `each_with_index`. Semantics matched to Python/TS: `min`/`max` element-wise (empty → nil), `sum` via promoting `_sir_plus` (empty → 0), `uniq` first-occurrence dedup via `_sir_value_eq`, `compact` drops nils, `each_with_index` yields `(el, idx)` returns receiver. `respond_to?` catalog updated for parity.

`flatten` recursively flattens nested `*Seq` into a **fresh** slice, **cycle-guarded** (`visited` set of `*Seq` handle pointers — a self-referential array terminates instead of overflowing the Go stack).

Security review: **PASSED** — cycle-guard sound (pointer-identity keys confirmed), explicit `switch` dispatch (no reflection), empty-array guards on min/max, fresh slices (no aliasing), `sum` inherits existing `_sir_plus` arithmetic, no new panics.

Execution-proofed via `go run` (`compile_and_run_array_methods.rs`). 97 unit + all integration green (Scope warning pre-existing/untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)