### PR TITLE
Tighten ruby repair evidence

### DIFF
--- a/code/packages/rust/html-parser/tests/whatwg_ruby_audit_test.rs
+++ b/code/packages/rust/html-parser/tests/whatwg_ruby_audit_test.rs
@@ -18,6 +18,13 @@ struct RubyCrossAxisCase {
     suites: &'static [(&'static str, &'static str, &'static str)],
 }
 
+struct RubyRepairEvidence {
+    id: &'static str,
+    source: &'static str,
+    axis: &'static str,
+    data_snippet: &'static str,
+}
+
 const RUBY_SHELL_CROSS_AXIS_SUITES: &[(&str, &str, &str)] = &[
     (
         "document-shell",
@@ -86,7 +93,12 @@ const RUBY_CROSS_AXIS_CASES: &[RubyCrossAxisCase] = &[
         suites: RUBY_BLOCK_CROSS_AXIS_SUITES,
     },
 ];
-const POST_PARSE_REPAIR_EVIDENCE: &[(&str, &str)] = &[("ruby-dat-387", "rt-boundary")];
+const POST_PARSE_REPAIR_EVIDENCE: &[RubyRepairEvidence] = &[RubyRepairEvidence {
+    id: "ruby-dat-387",
+    source: "ruby.dat:387",
+    axis: "rt-boundary",
+    data_snippet: "<html><ruby>a<rb>b<rt></ruby></html>",
+}];
 
 #[derive(Debug, Deserialize)]
 struct RubyAuditSuite {
@@ -249,18 +261,32 @@ fn whatwg_ruby_audit_tracks_post_parse_repair_evidence() {
         .map(|case| (case.source.clone(), case))
         .collect::<HashMap<_, _>>();
 
-    for (case_id, expected_axis) in POST_PARSE_REPAIR_EVIDENCE {
-        let audit_case = audit_cases.get(case_id).unwrap_or_else(|| {
-            panic!("post-parse repair evidence case `{case_id}` should be audited")
+    for evidence in POST_PARSE_REPAIR_EVIDENCE {
+        let audit_case = audit_cases.get(evidence.id).unwrap_or_else(|| {
+            panic!(
+                "post-parse repair evidence case `{}` should be audited",
+                evidence.id
+            )
         });
         assert_eq!(
-            audit_case.axis, *expected_axis,
-            "post-parse repair evidence case `{case_id}` should stay on its focused audit axis"
+            audit_case.source, evidence.source,
+            "post-parse repair evidence case `{}` should stay tied to its smoke fixture row",
+            evidence.id
+        );
+        assert_eq!(
+            audit_case.axis, evidence.axis,
+            "post-parse repair evidence case `{}` should stay on its focused audit axis",
+            evidence.id
         );
 
         let source_case = smoke_cases
-            .get(&audit_case.source)
-            .unwrap_or_else(|| panic!("case `{case_id}` should exist in smoke fixture"));
+            .get(evidence.source)
+            .unwrap_or_else(|| panic!("case `{}` should exist in smoke fixture", evidence.id));
+        assert!(
+            source_case.data.contains(evidence.data_snippet),
+            "post-parse repair evidence row `{}` should stay tied to its html5lib input",
+            evidence.id
+        );
         let actual = actual_dom_dump_for_tree_case(source_case).unwrap_or_else(|error| {
             panic!(
                 "case `{}` ({}) parse failed: {error}",


### PR DESCRIPTION
## Summary
- convert the ruby post-parse repair evidence row from a tuple into a structured source/axis/snippet record
- pin `ruby-dat-387` to the exact `ruby.dat:387` html5lib row and input snippet
- keep the executable DOM-dump assertion for the repair evidence case

## Verification
- `cargo test -p coding-adventures-html-parser whatwg_ruby_audit_tracks_post_parse_repair_evidence`
- `cargo test -p coding-adventures-html-parser whatwg_post_parse_repair_audit`
- `cargo test -p coding-adventures-html-parser whatwg_character_reference_audit_keeps_character_reference_axis_cases_cross_axis`
- `cargo test -p coding-adventures-html-parser whatwg_character_reference_audit`
- `cargo test -p coding-adventures-html-parser`
- `CARGO_BUILD_JOBS=2 cargo test -p state-machine-tokenizer -p coding-adventures-html-lexer -p coding-adventures-html-parser`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/html-browser-readiness.json >/dev/null`
- `python3 -m json.tool code/packages/rust/html-parser/tests/fixtures/whatwg-post-parse-repair-audit.json >/dev/null`
- `python3 code/packages/rust/html-parser/tests/fixtures/generate_whatwg_post_parse_repair_audit_fixture.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_manifest.py --check`
- `python3 code/packages/rust/html-parser/tests/fixtures/check_whatwg_audit_rust_tests.py --check`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_generated_html_fixtures.py`
- `python3 code/packages/rust/html-lexer/tests/fixtures/check_html_fixture_readme_inventory.py`
- `git diff --check`