### PR TITLE
feat(latex): LTXDOC03 S7 equation-label lifting (numbered LabelKind::Equation)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.43.0] — 2026-07-06
+
+### Added — cross-reference resolution: equation-label lifting (LTXDOC03 S7)
+
+Closes the one gap S6 left open. A `\ref`/`\eqref` to a `\label` that sits **inside** a display-math
+environment (`\begin{equation} E=mc^2 \label{eq:e} \end{equation}`) *resolved* in S1 but had **no** S4
+number, because `Block::DisplayMath` kept its whole body as one raw `source` string — the `\label` was
+swallowed into that string and never became a real label definition. So S6's `cross_reference_report()`
+**omitted** such refs (they were neither dangling nor renderable). S7 fixes exactly that.
+
+- **Lifts the `\label` out of the env body.** For a **non-starred** display-math environment
+  (`equation`, `align`, `gather`, `multline`, `eqnarray` — *not* the starred `equation*`/… forms, which
+  are unnumbered in LaTeX), the D5 lowering now pulls the first `\label{key}` out of the env body onto
+  the block and **removes** it from `source` (no duplication). `\begin{equation} E = mc^2 \label{eq:e}
+  \end{equation}` → `DisplayMath { source: "E = mc^2", label: Some("eq:e") }`.
+- **New `LabelKind::Equation`.** The lifted label is registered — in the *same* collection pass that
+  registers section/figure/table labels — as a real `LabelDef` tagged `LabelKind::Equation`
+  (`as_str()` → `"equation"`, display name `"Equation"`). So an `\eqref{eq:e}`/`\ref{eq:e}` now
+  **resolves** to it.
+- **`DisplayMath` carries the label.** `Block::DisplayMath` gains a `label: Option<String>` field,
+  mirroring how `Block::Figure`/`Block::Table` carry their lifted label. It is `Some` only for the
+  non-starred named-env path; the starred forms and the `\[…\]`/`$$…$$` islands keep `label: None`
+  (unchanged behaviour).
+- **No longer omitted from the S6 report.** A resolved `\ref`/`\eqref` to an equation label is now
+  **included** in `cross_reference_report().refs`, rendering `\ref{eq:e} -> Equation ?`.
+- **Numbering deferred to S8.** S7 does *not* wire the equation counter (`\theequation`). The equation
+  label carries the placeholder number `EQUATION_NUMBER_PLACEHOLDER` (`"?"`, echoing LaTeX's `??`) in
+  the report — enough to make it resolvable-and-reported; the real number is a future S8 rung.
+- **Round-trip preserved.** `Document::to_latex()` re-emits a lifted-label equation as
+  `\begin{equation}<body> \label{key}\end{equation}` (not `$$…$$`, which would drop the label), so
+  `parse(doc.to_latex())` re-lifts to an equal AST — the round-trip fixed point still holds.
+- **New/changed API.** `LabelKind::Equation`; `Block::DisplayMath { source, label, span }` (added
+  `label`); `pub const EQUATION_NUMBER_PLACEHOLDER: &str = "?"`, exported from the crate root. Additive
+  and pure: no existing S1–S6 behaviour changed except that equation-label refs stop being omitted.
+
 ## [0.42.0] — 2026-07-06
 
 ### Added — cross-reference resolution: the cross-reference report (LTXDOC03 S6)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -53,7 +53,8 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S3 — target → `NodeRef` exposure** | The depth-add on S1+S2: both bound each target's **bytes** (a `Span`) but not the target **node**. `Document::node_for_span(span) -> Option<NodeRef>` returns the walked body node whose span **exactly equals** `span` (half-open equality of start **and** end; *equality*, not `node_at`'s containment) — or `None` for a span that is no walked node's own (empty doc, un-walked preamble/metadata, fabricated span). Thin accessors `ref_target_node(&ResolvedRef)`, `cite_target_node(&ResolvedCite)`, `label_def_node(&LabelDef)` take a resolved record and hand back the node, so a caller can read its `kind()` and — for a `Block` — descend into its children (a `\ref`→section enumerates its paragraphs; a `\ref`→figure reaches its caption). **Verified reachability:** every S1/S2 target span matches exactly one walked node (zero collisions); a `\ref`→section/figure/table yields a `NodeRef::Block`, an inline `\eqref`→`\label` a `NodeRef::Inline` (`CrossRef`), and — the once-uncertain case — a `\cite`→`\bibitem` **is** walked (an `Inline::Raw` inside the `thebibliography`), so `cite_target_node` returns `Some`, not `None`. Purely additive (S1/S2 result types keep owned `Span`s, no lifetimes; the `NodeRef` is fetched on demand); tie-break = first-in-pre-order (defensive, does not fire). Numbering + external BibTeX remain out of scope. Total & panic-free, reuses the bounded `walk`. | ✅ |
 | **LTXDOC03 S4 — document numbering (hierarchical sections + flat float counters)** | `Document::number_labels() -> Numbering` — the number a `\ref` *prints*, computed in one `walk` (LaTeX's second `.aux` pass, done statically). **Section numbers** are hierarchical with deeper-reset: a numbered `\section`…`\subparagraph` increments its depth's counter, resets deeper depths to `0`, and renders the dotted join from the top level down (`1`, `1.1`, `1.2`, `1.2.1`, `2`); a starred `\section*` (`numbered == false`) fires no counter and is skipped. **Float counters** are flat and independent: every `figure` advances a running figure counter (`1, 2, …`), every `table` its own (`1, 2, …`) — labeled *or not* (a `\label` only captures the value; an unlabeled figure between two labeled ones takes `2`). Missing-parent rule: a document that starts deep renders honest leading `0`s (a lone `\subsection` → `0.1`), a plain top-level `\section` → `1`. Returns one owned `NumberedLabel { key, kind, number }` per defined numberable label, with `number_for(key)`; `ref_number(&ResolvedRef) -> Option<String>` ties S1 resolution to S4 numbering (`\ref{sec:intro}` → `"1.2"`). Equation numbers, citation `[1]` numbers, and other counters deferred to S5+. Pure, additive, tree-unchanged; fixed 7-slot counter array (no unchecked indexing). Total & panic-free, reuses the bounded `walk`. | ✅ |
 | **LTXDOC03 S5 — citation numbering (bracketed bibliography numbers)** | `Document::number_citations() -> CitationNumbering` — the bracketed number a `\cite` *prints* (`[2]`), the citation-family analogue of S4's `ref_number`. In the default numeric/unsorted style each `\bibitem` is numbered by its **listing position**, so S5 numbers S2's already-ordered winning `entries` by index: `entries[0]` → `[1]`, `entries[1]` → `[2]`, …. A first-`\bibitem`-wins **duplicate** is in `duplicate_entries`, not `entries`, so it consumes **no** number and the entries after it are unshifted (`a, b, c` + a later dup `\bibitem{a}` keeps `c` at `[3]`). A **dangling** `\cite` is in S2's `unresolved`, so it has no entry and `number_for` returns `None` (LaTeX's `[?]`). Returns one owned `NumberedCitation { key, ordinal, number }` per numbered entry, with `number_for(key) -> Option<&str>`; `cite_number(&ResolvedCite) -> Option<String>` ties S2 resolution to S5 numbering (`\cite{foo}` → `"[2]"`). Bracket style single-sourced in one helper. Equation numbers (blocked on `DisplayMath` carrying no label field), author-year/natbib sorted styles, and external `.bib` remain future rungs. Pure, additive, tree-unchanged. Total & panic-free. | ✅ |
-| **LTXDOC03 S6 — the cross-reference report (consumer composing S1/S2/S4/S5)** | `Document::cross_reference_report() -> CrossReferenceReport` — the consumer rung that proves the passes **compose**: it walks S1's resolved `\ref`s and S2's resolved `\cite`s and assembles an owned, plain-data report where each entry carries its rendered **number** (S4/S5) alongside key/command/kind. **No new AST walk** — it numbers each family **once** (`number_labels`/`number_citations`) then looks each key up (never per-item re-numbering). Produces `refs: Vec<RefEntry { key, command, kind, number }>` (one per resolved **and numbered** `\ref`, in S1 order — a resolved `\ref` to an *unnumbered* inline/equation label is **omitted**), `cites: Vec<CiteEntry { key, number }>` (one per resolved `\cite` key, in S2 order), and `dangling_refs`/`dangling_cites: Vec<String>` (S1/S2 `unresolved` keys — LaTeX's `??`/`[?]`, surfaced **separately**). `CrossReferenceReport::to_plain_text() -> String` renders a stable, pinned string (`\ref{k} -> Section 1.2` / `\cite{k} -> [2]` lines, optional `Dangling …:` footers, joined by `\n`, no trailing newline; empty → `(no cross-references)`). Pure composition, reads S1–S5 unchanged, tree untouched. Total & panic-free. | ✅ |
+| **LTXDOC03 S6 — the cross-reference report (consumer composing S1/S2/S4/S5)** | `Document::cross_reference_report() -> CrossReferenceReport` — the consumer rung that proves the passes **compose**: it walks S1's resolved `\ref`s and S2's resolved `\cite`s and assembles an owned, plain-data report where each entry carries its rendered **number** (S4/S5) alongside key/command/kind. **No new AST walk** — it numbers each family **once** (`number_labels`/`number_citations`) then looks each key up (never per-item re-numbering). Produces `refs: Vec<RefEntry { key, command, kind, number }>` (one per resolved **and numbered** `\ref`, in S1 order — a resolved `\ref` to an *unnumbered bare-inline* label is still **omitted**; an S7 equation label is included), `cites: Vec<CiteEntry { key, number }>` (one per resolved `\cite` key, in S2 order), and `dangling_refs`/`dangling_cites: Vec<String>` (S1/S2 `unresolved` keys — LaTeX's `??`/`[?]`, surfaced **separately**). `CrossReferenceReport::to_plain_text() -> String` renders a stable, pinned string (`\ref{k} -> Section 1.2` / `\cite{k} -> [2]` lines, optional `Dangling …:` footers, joined by `\n`, no trailing newline; empty → `(no cross-references)`). Pure composition, reads S1–S5 unchanged, tree untouched. Total & panic-free. | ✅ |
+| **LTXDOC03 S7 — equation-label lifting** | `Block::DisplayMath` gains a `label: Option<String>` and `LabelKind` gains an `Equation` variant. For a **non-starred** display-math environment (`equation`/`align`/`gather`/`multline`/`eqnarray` — not the starred forms), the D5 lowering now **lifts** the `\label{key}` out of the env body onto the block (removing it from `source`, no duplication) and registers it as a real `LabelKind::Equation` definition in the same pass as section/figure/table labels. So an `\eqref{eq:e}`/`\ref{eq:e}` to an in-equation label now **resolves** and is **included** in the S6 report (`\ref{eq:e} -> Equation ?`) instead of being omitted. The equation **number** (`\theequation`) is deferred to S8: the report carries the placeholder `EQUATION_NUMBER_PLACEHOLDER` (`"?"`). `to_latex()` re-emits a lifted-label equation as `\begin{equation}…\label{…}\end{equation}` so the round-trip fixed point holds. Starred forms and `\[…\]`/`$$…$$` keep `label: None`. Pure, additive; total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -95,8 +96,11 @@ numbering S2's listing-ordered `entries` by index so the first `\bibitem` is `[1
 artifact: every resolved `\ref` and `\cite` with its rendered number (`\ref{sec:intro} ->
 Section 1.2`, `\cite{smith} -> [2]`), dangling refs/cites surfaced separately, plus a stable
 `to_plain_text()` rendering — adding no new AST walk (each family numbered once, then looked up).
-Equation numbers (blocked on the `DisplayMath` AST carrying no label field), author-year/natbib
-sorted styles, and external `.bib` remain future rungs.
+**S7 lifts equation labels**: a non-starred display-math env's `\label` is now pulled onto its
+`Block::DisplayMath { label }` and registered as a `LabelKind::Equation` definition, so an `\eqref`
+to it resolves and is included in the S6 report (`\ref{eq:e} -> Equation ?`) instead of omitted — the
+equation **number** carries the placeholder `EQUATION_NUMBER_PLACEHOLDER` (`"?"`) until S8 wires the
+`\theequation` counter. Author-year/natbib sorted styles and external `.bib` remain future rungs.
 
 ## The Document layer (LTXDOC01)
 
@@ -172,8 +176,11 @@ assert!(doc.body.iter().any(|b| matches!(b, Block::DisplayMath { .. })));
   with no tabular degrades to a `Block::Figure`, so nothing is lost).
 - **`verbatim`/`lstlisting`** → `Block::CodeBlock` — the body is kept **unparsed** (code is source,
   not marked-up LaTeX).
-- **`equation`/`align`/`gather`/`displaymath`/…** → `Block::DisplayMath` — the inner LaTeX is kept
-  as a source string, delegated to the math frontend on demand (LTXDOC01 never parses math itself).
+- **`equation`/`align`/`gather`/`displaymath`/…** → `Block::DisplayMath { source, label }` — the
+  inner LaTeX is kept as a source string, delegated to the math frontend on demand (LTXDOC01 never
+  parses math itself). For a **non-starred** env (LTXDOC03 S7), a `\label{key}` in the body is lifted
+  into `label: Some(key)` (removed from `source`) — a real `LabelKind::Equation` definition; starred
+  forms and `\[…\]`/`$$…$$` keep `label: None`.
 - **`quote`/`quotation`** → `Block::Quote`; any other environment stays a recursed
   `Block::Environment`.
 
@@ -363,8 +370,9 @@ assert_eq!(doc.ref_number(r), Some("1.1".to_string())); // \ref{sec:scope} → "
 
 `number_labels()` returns a `Numbering` of one `NumberedLabel { key, kind, number }` per defined,
 numberable label (section/figure/table). A document that starts deep applies the documented
-missing-parent rule (a lone leading `\subsection` numbers `0.1`). Inline/equation labels and other
-counters (enumerate/theorem/…) are deferred to S5+. Numbering is pure, additive analysis — it never
+missing-parent rule (a lone leading `\subsection` numbers `0.1`). Bare-inline labels and other
+counters (enumerate/theorem/…) are deferred to S5+; a lifted **equation** label (S7) is numbered with
+the `EQUATION_NUMBER_PLACEHOLDER` (`"?"`) until S8. Numbering is pure, additive analysis — it never
 mutates the tree, so the S1/S2/S3 outputs are unchanged.
 
 ### Citation numbering (LTXDOC03 S5)
@@ -399,10 +407,10 @@ assert_eq!(doc.cite_number(c), Some("[2]".to_string())); // \cite{lamport} → "
 
 `number_citations()` returns a `CitationNumbering` of one `NumberedCitation { key, ordinal, number }`
 per numbered entry. A first-`\bibitem`-wins duplicate consumes no number (later entries stay
-unshifted); a dangling `\cite` has no entry, so `number_for` returns `None` (LaTeX's `[?]`). Equation
-numbers (blocked on the `DisplayMath` AST carrying no label field), author-year/natbib sorted styles,
-and external `.bib` databases remain future rungs. Like S4, S5 is pure, additive analysis — it never
-mutates the tree, so the S1–S4 outputs are unchanged.
+unshifted); a dangling `\cite` has no entry, so `number_for` returns `None` (LaTeX's `[?]`). The
+equation **counter** (`\theequation`, S8), author-year/natbib sorted styles, and external `.bib`
+databases remain future rungs. Like S4, S5 is pure, additive analysis — it never mutates the tree, so
+the S1–S4 outputs are unchanged.
 
 ### The cross-reference report (LTXDOC03 S6)
 
@@ -452,9 +460,41 @@ assert_eq!(
 
 `cross_reference_report()` returns a `CrossReferenceReport { refs, cites, dangling_refs,
 dangling_cites }` with `RefEntry { key, command, kind, number }` and `CiteEntry { key, number }`. A
-resolved `\ref` to an *unnumbered* inline/equation label is omitted from `refs` (it has no S4 number —
-deferred), so every row carries a real number. Like S1–S5, S6 is pure, additive analysis — it reads
-the prior passes and mutates nothing, so their outputs are unchanged.
+resolved `\ref` to an *unnumbered bare-inline* label is omitted from `refs` (it has no S4 number —
+deferred); an **equation** label (S7) is included with the placeholder number `"?"`. Like S1–S5, S6 is
+pure, additive analysis — it reads the prior passes and mutates nothing, so their outputs are unchanged.
+
+### Equation-label lifting (LTXDOC03 S7)
+
+A `\label` inside a **non-starred** display-math environment used to be swallowed into the
+`Block::DisplayMath` source string, so an `\eqref` to it resolved (S1) but had no number and was
+**omitted** from the S6 report. S7 lifts it out onto the block as a real `LabelKind::Equation`
+definition, so the reference is now resolvable and reported:
+
+```rust
+use latex::{parse_document, Block, LabelKind};
+
+let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}
+See \eqref{eq:e}.\end{document}";
+let doc = parse_document(src).unwrap();
+
+// The `\label` is lifted onto the block; `source` no longer contains it.
+let dm = doc.body.iter().find(|b| matches!(b, Block::DisplayMath { .. })).unwrap();
+assert!(matches!(dm, Block::DisplayMath { source, label: Some(k), .. }
+    if source == "E = mc^2" && k == "eq:e"));
+
+// It is a real Equation-kind definition, so the `\eqref` resolves and is REPORTED.
+let rep = doc.cross_reference_report();
+assert_eq!(rep.refs.len(), 1);
+assert_eq!(rep.refs[0].kind, LabelKind::Equation);
+assert_eq!(rep.refs[0].number, "?"); // EQUATION_NUMBER_PLACEHOLDER — real number is S8
+assert_eq!(rep.to_plain_text(), "\\ref{eq:e} -> Equation ?");
+```
+
+Starred forms (`equation*`, …) and `\[…\]`/`$$…$$` islands keep `label: None` (unnumbered in LaTeX,
+so unchanged). The equation **number** (`\theequation`) is deferred to S8; until then the label carries
+`EQUATION_NUMBER_PLACEHOLDER` (`"?"`). `to_latex()` re-emits a lifted-label equation as
+`\begin{equation}…\label{…}\end{equation}`, so the round-trip fixed point holds.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/document.rs
+++ b/code/packages/rust/latex/src/document.rs
@@ -281,8 +281,15 @@ pub enum Block {
     /// `equation`/`align`/`gather`, D5) — kept as its source string (delegated to the math frontend
     /// on demand, never parsed here).
     DisplayMath {
-        /// The exact inner math source.
+        /// The exact inner math source, with any lifted `\label{…}` **removed** (see `label`).
         source: String,
+        /// The lifted equation label key (LTXDOC03 S7), `Some(key)` only for a **non-starred** named
+        /// display-math environment (`equation`, `align`, `gather`, `multline`, `eqnarray`) whose body
+        /// contained a `\label{key}`. Lifting it here (out of `source`) turns it into a real,
+        /// resolvable [`LabelKind::Equation`](crate::references::LabelKind::Equation) definition, so an
+        /// `\eqref` to it is no longer omitted from the S6 cross-reference report. It is `None` for the
+        /// starred forms (`equation*`, …, which are unnumbered) and for `\[…\]`/`$$…$$` islands.
+        label: Option<String>,
         /// Precise span (S3): the display-math island's extent (`\[…\]`, `$$…$$`, or the named
         /// `\begin{equation}`…`\end{equation}`).
         span: Span,
@@ -1153,7 +1160,11 @@ fn lower_block(node: Node) -> Block {
             label: None,
             span, // the `\begin{tabular}`…`\end{tabular}` extent (S2).
         },
-        NodeKind::Math { display: true, content } => Block::DisplayMath { source: content, span },
+        // `\[…\]` / `$$…$$` display islands never carry a lifted label (they are unnumbered here —
+        // only named non-starred display-math *environments* lift a `\label`, in `lower_environment`).
+        NodeKind::Math { display: true, content } => {
+            Block::DisplayMath { source: content, label: None, span }
+        }
         // A `verbatim`/`verbatim*` environment is lexed raw (catcodes suspended) into a
         // `VerbatimEnv` node; its content is source code, not marked-up LaTeX, so we keep it
         // **unparsed** as a `CodeBlock` (D5).
@@ -1207,6 +1218,46 @@ fn is_display_math_env(name: &str) -> bool {
     )
 }
 
+/// The **numbered** (non-starred) display-math environments — those whose equations LaTeX numbers and
+/// that therefore support a `\label`/`\eqref` (LTXDOC03 S7). This is exactly [`is_display_math_env`]
+/// minus the starred forms (`equation*`, `align*`, `gather*`, `multline*`, `eqnarray*`, and the always
+/// unnumbered `displaymath`). Only these lift their `\label` onto the [`Block::DisplayMath`]; the
+/// starred forms keep `label: None` (matching LaTeX, where a starred equation is unnumbered so a
+/// `\label` inside it has no number to point at).
+fn is_numbered_display_math_env(name: &str) -> bool {
+    matches!(name, "equation" | "align" | "gather" | "multline" | "eqnarray")
+}
+
+/// Lift the **first** `\label{key}` out of a numbered display-math environment's body (LTXDOC03 S7),
+/// returning `(Some(key), body-without-that-label)` — or `(None, body)` when there is no `\label`.
+///
+/// A `\label{key}` inside a text-mode `\begin{equation}` wrapper parses (at the LTX01 node level) as a
+/// [`NodeKind::CrossRef`] with `command == "label"` sitting in the body node list — the parser already
+/// recognises `\label`/`\ref`/`\eqref` as cross-reference constructs (see [`NodeKind::CrossRef`]). The
+/// display-math body is never lowered to blocks/inlines (it is rendered straight back to a source
+/// string), so we scan the *raw* nodes here, remove the first such `label` cross-ref, and recover its
+/// key by rendering the `target` node list with [`document_to_latex`] — the same faithful round-trip
+/// the S1 ref pass uses for a cross-ref target, so an awkward key survives verbatim. **Total &
+/// panic-free**: no `unwrap`/`expect`, no unchecked indexing; a construct that is not a `label`
+/// cross-ref is left in the body untouched (nothing is lifted, nothing is dropped).
+fn extract_display_math_label(body: Vec<Node>) -> (Option<String>, Vec<Node>) {
+    let mut key: Option<String> = None;
+    let mut remaining: Vec<Node> = Vec::with_capacity(body.len());
+    for node in body {
+        if key.is_none() {
+            if let NodeKind::CrossRef { command, target, .. } = &node.kind {
+                if command == "label" {
+                    // Recover the key verbatim (no braces), then drop this `\label` node.
+                    key = Some(document_to_latex(target));
+                    continue;
+                }
+            }
+        }
+        remaining.push(node);
+    }
+    (key, remaining)
+}
+
 /// Classify a `\begin{name}…\end{name}` environment into its D5 [`Block`], recursing the body
 /// through the same bounded [`lower_blocks`] fold every other block-list uses (so nesting and
 /// sectioning work uniformly inside floats/quotes). **Total & panic-free**: no `unwrap`/`expect`,
@@ -1218,7 +1269,7 @@ fn is_display_math_env(name: &str) -> bool {
 /// | `figure`, `figure*` | [`Block::Figure`] (body minus `\caption`/`\label`) |
 /// | `table`, `table*` | the inner [`Block::Table`] with the float's `\caption`/`\label` attached (or [`Block::Figure`] if no tabular inside) |
 /// | `quote`, `quotation` | [`Block::Quote`] |
-/// | display-math envs (see [`is_display_math_env`]) | [`Block::DisplayMath`] (source kept, unparsed) |
+/// | display-math envs (see [`is_display_math_env`]) | [`Block::DisplayMath`] (source kept, unparsed; a non-starred env's `\label` lifted onto the block — S7) |
 /// | `lstlisting` | [`Block::CodeBlock`] (body rendered back to source text) |
 /// | any other | [`Block::Environment`] (recursed) — unchanged from D2 |
 fn lower_environment(name: String, body: Vec<Node>, env_span: Span) -> Block {
@@ -1232,7 +1283,19 @@ fn lower_environment(name: String, body: Vec<Node>, env_span: Span) -> Block {
     // nodes back to source (the parser accepted the math tokens as ordinary nodes, since these
     // are *text-mode* `\begin{equation}` wrappers) and trim the outer whitespace the wrapper adds.
     if is_display_math_env(&name) {
-        return Block::DisplayMath { source: render_nodes(&body).trim().to_string(), span: env_span };
+        // LTXDOC03 S7 — lift a `\label{…}` out of a **non-starred** display-math environment's body
+        // onto the block, so it becomes a real, resolvable equation label. Starred forms
+        // (`equation*`, …) are unnumbered in LaTeX, so we never lift their labels (a `\label` in a
+        // starred body is meaningless in LaTeX too). `render_nodes` runs over the body **with the
+        // `\label` node removed**, so the lifted key is not left duplicated in `source`.
+        let label = if is_numbered_display_math_env(&name) {
+            let (key, remaining) = extract_display_math_label(body);
+            let source = render_nodes(&remaining).trim().to_string();
+            return Block::DisplayMath { source, label: key, span: env_span };
+        } else {
+            None
+        };
+        return Block::DisplayMath { source: render_nodes(&body).trim().to_string(), label, span: env_span };
     }
     // `lstlisting` is *not* lexed raw (only `verbatim`/`verbatim*` are), so its body parsed as
     // ordinary nodes; render it back to source to recover the listing text. (A perfectly faithful
@@ -1695,11 +1758,27 @@ impl Block {
                 out.push_str(verbatim);
                 out.push_str("\\end{verbatim}");
             }
-            Block::DisplayMath { source, .. } => {
-                out.push_str("$$");
-                out.push_str(source);
-                out.push_str("$$");
-            }
+            Block::DisplayMath { source, label, .. } => match label {
+                // A lifted-label equation must re-emit as `\begin{equation}…\label{key}\end{equation}`
+                // (not `$$…$$`), so re-parsing re-lifts the `\label` and the AST is a fixed point
+                // (LTXDOC03 S7). The `$$…$$` form goes through `NodeKind::Math` → `label: None`, so it
+                // would silently drop the label — hence the split. A space separates the body from the
+                // `\label` so the re-lift's `render_nodes(...).trim()` reproduces the same `source`.
+                Some(key) => {
+                    out.push_str("\\begin{equation}");
+                    out.push_str(source);
+                    out.push_str(" \\label{");
+                    out.push_str(key);
+                    out.push('}');
+                    out.push_str("\\end{equation}");
+                }
+                // A label-free display island round-trips through `$$…$$` as before.
+                None => {
+                    out.push_str("$$");
+                    out.push_str(source);
+                    out.push_str("$$");
+                }
+            },
             Block::Quote(body, _) => {
                 out.push_str("\\begin{quote}");
                 write_blocks(body, out);
@@ -1760,7 +1839,9 @@ impl Block {
             },
             Block::CodeBlock { verbatim, .. } => Block::CodeBlock { verbatim: verbatim.clone(), span: z },
             Block::Quote(body, _) => Block::Quote(body.iter().map(|b| b.strip_spans(z)).collect(), z),
-            Block::DisplayMath { source, .. } => Block::DisplayMath { source: source.clone(), span: z },
+            Block::DisplayMath { source, label, .. } => {
+                Block::DisplayMath { source: source.clone(), label: label.clone(), span: z }
+            }
             Block::Environment { name, body, .. } => Block::Environment {
                 name: name.clone(),
                 body: body.iter().map(|b| b.strip_spans(z)).collect(),
@@ -2655,6 +2736,60 @@ mod tests {
         let al = parse_document(r"\begin{document}\begin{align}a &= b \\ c &= d\end{align}\end{document}")
             .expect("parse");
         assert!(al.body.iter().any(|b| matches!(b, Block::DisplayMath { .. })));
+    }
+
+    #[test]
+    fn s7_equation_label_is_lifted_onto_display_math() {
+        // LTXDOC03 S7: a `\label` inside a non-starred `equation` env is lifted onto the block and
+        // REMOVED from the source string (not left duplicated).
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let dm = doc.body.iter().find(|b| matches!(b, Block::DisplayMath { .. })).expect("display math");
+        if let Block::DisplayMath { source, label, .. } = dm {
+            assert_eq!(label.as_deref(), Some("eq:e"), "the label is lifted onto the block");
+            assert_eq!(source, "E = mc^2", "the source is the math body WITHOUT the \\label");
+        } else {
+            panic!("expected DisplayMath");
+        }
+    }
+
+    #[test]
+    fn s7_starred_equation_does_not_lift_a_label() {
+        // Starred display-math envs are unnumbered, so their `\label` stays inside the source string
+        // and `label` is None — no equation label def is created.
+        let src = r"\begin{document}\begin{equation*} E = mc^2 \label{eq:e} \end{equation*}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let dm = doc.body.iter().find(|b| matches!(b, Block::DisplayMath { .. })).expect("display math");
+        if let Block::DisplayMath { source, label, .. } = dm {
+            assert_eq!(*label, None, "a starred env lifts no label");
+            assert_eq!(source, r"E = mc^2 \label{eq:e}", "starred body keeps the \\label verbatim");
+        } else {
+            panic!("expected DisplayMath");
+        }
+    }
+
+    #[test]
+    fn s7_display_island_dollar_dollar_has_no_label() {
+        // A `$$…$$` / `\[…\]` island never lifts a label (label: None), unchanged from before S7.
+        let src = r"\begin{document}$$ x = y $$\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let dm = doc.body.iter().find(|b| matches!(b, Block::DisplayMath { .. })).expect("display math");
+        assert!(matches!(dm, Block::DisplayMath { label: None, .. }), "island has label: None");
+    }
+
+    #[test]
+    fn s7_labelled_equation_round_trips_through_to_latex() {
+        // A lifted-label equation must be a to_latex fixed point: re-parsing re-lifts an EQUAL label
+        // and source (it re-emits as `\begin{equation}…\label{…}\end{equation}`, not `$$…$$`).
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let rendered = doc.to_latex();
+        assert!(
+            rendered.contains(r"\begin{equation}") && rendered.contains(r"\label{eq:e}"),
+            "re-emits equation with its label: {rendered:?}"
+        );
+        let redoc = parse_document(&rendered).expect("re-parse");
+        assert_eq!(doc.strip_spans(), redoc.strip_spans(), "S7 lifted-label round-trip fixed point");
     }
 
     #[test]

--- a/code/packages/rust/latex/src/lib.rs
+++ b/code/packages/rust/latex/src/lib.rs
@@ -102,7 +102,8 @@ pub use document::{
 pub use references::{
     BibEntry, CiteEntry, CitationResolution, CrossReferenceReport, Duplicate, DuplicateBib,
     LabelDef, LabelKind, NumberedLabel, Numbering, RefEntry, ReferenceResolution, ResolvedCite,
-    ResolvedRef, UnresolvedCite, UnresolvedRef, CITE_COMMAND, REF_COMMANDS,
+    ResolvedRef, UnresolvedCite, UnresolvedRef, CITE_COMMAND, EQUATION_NUMBER_PLACEHOLDER,
+    REF_COMMANDS,
 };
 pub use catcode::{catcode, Catcode};
 pub use error::{LexError, ParseError};

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -94,6 +94,12 @@ fn is_ref_command(command: &str) -> bool {
     REF_COMMANDS.contains(&command)
 }
 
+/// The placeholder number an equation label carries in the S6 report while equation **numbering** is
+/// deferred to LTXDOC03 S8. It is `"?"` — echoing LaTeX's `??` for an as-yet-unresolved number — so a
+/// resolved `\eqref` renders a stable, greppable line (`\ref{eq:e} -> Equation ?`) instead of being
+/// omitted. S8 will replace this with the real `\theequation` counter value.
+pub const EQUATION_NUMBER_PLACEHOLDER: &str = "?";
+
 // -------------------------------------------------------------------------------------------------
 // What a label defines: the owner "kind" tag.
 // -------------------------------------------------------------------------------------------------
@@ -108,6 +114,7 @@ fn is_ref_command(command: &str) -> bool {
 /// | [`Section`](LabelKind::Section) | a `\section`…`\label` hoisted onto [`Block::Section`] | `\ref{sec:intro}` → a heading |
 /// | [`Table`](LabelKind::Table)     | a `table` float's `\label` hoisted onto [`Block::Table`] | `\ref{tab:data}` → a table |
 /// | [`Figure`](LabelKind::Figure)   | a `figure` float's `\label` hoisted onto [`Block::Figure`] | `\ref{fig:plot}` → a figure |
+/// | [`Equation`](LabelKind::Equation) | a **non-starred** display-math env's `\label` lifted onto [`Block::DisplayMath`] | `\eqref{eq:e}` → an equation |
 /// | [`Inline`](LabelKind::Inline)   | a non-hoisted inline `\label{…}` ([`Inline::CrossRef`]) | `\eqref{eq:x}` → an equation's label |
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LabelKind {
@@ -117,6 +124,13 @@ pub enum LabelKind {
     Table,
     /// A `\label` hoisted onto a [`Block::Figure`] float.
     Figure,
+    /// A `\label` lifted out of a **non-starred** display-math environment (`equation`, `align`,
+    /// `gather`, `multline`, `eqnarray`) onto its [`Block::DisplayMath`] (LTXDOC03 S7). Starred forms
+    /// (`equation*`, …) are unnumbered and never carry this kind. The equation **number** is deferred
+    /// to S8, so an `Equation` label carries a placeholder number in the S6 report (see
+    /// [`Document::number_labels`]); it is still a real definition, so an `\eqref` to it **resolves**
+    /// and is no longer omitted from the cross-reference report.
+    Equation,
     /// A bare inline `\label{…}` that was not hoisted onto any float/section — an
     /// [`Inline::CrossRef`] with `command == "label"` (e.g. a label after an `equation`).
     Inline,
@@ -131,6 +145,7 @@ impl LabelKind {
             LabelKind::Section => "section",
             LabelKind::Table => "table",
             LabelKind::Figure => "figure",
+            LabelKind::Equation => "equation",
             LabelKind::Inline => "inline",
         }
     }
@@ -323,6 +338,12 @@ fn block_label(block: &Block) -> Option<(String, LabelKind, Span)> {
         }
         Block::Figure { label: Some(key), span, .. } => {
             Some((key.clone(), LabelKind::Figure, *span))
+        }
+        // LTXDOC03 S7: a `\label` lifted out of a **non-starred** display-math environment onto its
+        // `Block::DisplayMath`. Only the non-starred forms carry a `Some(label)` (the lowering sets
+        // `label: None` for `equation*`/`\[…\]`/`$$…$$`), so a `Some` here is always numbered.
+        Block::DisplayMath { label: Some(key), span, .. } => {
+            Some((key.clone(), LabelKind::Equation, *span))
         }
         _ => None,
     }
@@ -943,9 +964,11 @@ impl Document {
 // S4 numbers **sections** (hierarchical) and **figure/table floats** (flat) — the counters whose
 // values a `\ref` most commonly prints. It deliberately does **not** yet assign:
 //
-// - **Equation numbers** — `equation`/`align` bodies are kept as opaque [`Block::DisplayMath`]
-//   source strings (never parsed here), and `\label`s inside them are inline labels with no counter
-//   context. Numbering them needs an equation counter threaded through the math island — an S5 rung.
+// - **Equation numbers** — as of S7 a **non-starred** display-math env's `\label` is *lifted* onto
+//   its [`Block::DisplayMath`] and recorded here as a [`LabelKind::Equation`] row, so an `\eqref` to
+//   it **resolves** and is no longer omitted from the S6 report. But the equation **counter**
+//   (`\theequation`) is still deferred: the row carries the [`EQUATION_NUMBER_PLACEHOLDER`] (`"?"`)
+//   rather than a real number. Assigning the true equation number is S8.
 // - **Citation `[1]` numbers** — the order-of-first-appearance number `\cite` prints in a numeric
 //   bibliography style. That is a *citation-order* traversal over S2's resolution, a separate rung.
 // - **Other `\label`-able counters** — `enumerate` item numbers, theorem/footnote counters, etc.
@@ -1215,6 +1238,17 @@ impl Document {
                         record(key, LabelKind::Table, n.to_string());
                     }
                 }
+                // LTXDOC03 S7: a **non-starred** display-math env's lifted `\label` is a real,
+                // resolvable equation label. The equation **counter** (`\theequation`) is deferred to
+                // S8, so we record the row with the placeholder number `EQUATION_NUMBER_PLACEHOLDER`
+                // (`"?"`, echoing LaTeX's `??` for an as-yet-unnumbered target). Recording the row —
+                // rather than skipping it as we do for `LabelKind::Inline` — is the whole point of S7:
+                // it makes `number_for(key)` return `Some`, so the S6 report *includes* an `\eqref` to
+                // this equation instead of omitting it. Starred forms set `label: None` (see the D5
+                // lowering), so they never reach here.
+                Block::DisplayMath { label: Some(key), .. } => {
+                    record(key, LabelKind::Equation, EQUATION_NUMBER_PLACEHOLDER.to_string());
+                }
                 // Any other block carries no counter S4 assigns.
                 _ => {}
             }
@@ -1281,12 +1315,10 @@ impl Document {
 // S5 numbers **in-document `thebibliography` citations only**, in the default numeric/unsorted style.
 // It deliberately does **not** yet assign:
 //
-// - **Equation numbers** — the other candidate for this rung, but the AST does not model them: an
-//   equation body is kept as an opaque [`Block::DisplayMath`] *raw source string* with **no** `label`
-//   field (an equation's `\label` is buried inside that string, not a resolvable label def), so
-//   per-equation numbering would need fuzzy string heuristics. Citation numbering is well-defined on
-//   S2's clean owned data, so S5 does citations; equation numbering stays a documented future rung
-//   (blocked on the `DisplayMath` AST shape carrying no label field).
+// - **Equation numbers** — as of S7 the AST *does* model an equation label: a non-starred
+//   display-math env's `\label` is lifted onto [`Block::DisplayMath::label`], and it resolves and is
+//   reported (with the [`EQUATION_NUMBER_PLACEHOLDER`]). What remains deferred is the equation
+//   **counter** (`\theequation`) that would replace that placeholder with a real number — an S8 rung.
 // - **Author-year / natbib sorted styles.** `plainnat`/`abbrvnat`/`alpha` renumber or re-*label*
 //   entries (`[Smith2020]`, `[Smi20]`) and often **sort** the list, changing the number a key prints.
 //   S5 models only the *listing-order numeric* style; sorted/author-year styles are a later rung.
@@ -1476,23 +1508,23 @@ impl Document {
 // ## The one subtlety: a *resolved* `\ref` whose target is not *numbered*
 //
 // Every entry in S1's `resolved` has a matching `\label` — but not every `\label` is *numbered*. S4
-// numbers sections and figure/table floats; an **inline `\label`** (typically an equation label) is
-// deliberately left unnumbered (deferred to a future equation-numbering rung — see S4/S5). So a
-// `\ref{eq:x}` to an inline `\label{eq:x}` *resolves* (it is in S1's `resolved`) yet has **no** S4
-// number. S6's rule for such an entry: **omit it from `refs`**. The report's `refs` therefore lists
-// exactly the `\ref`s that both resolve *and* carry a printable number — the ones a consumer can
-// render as "see Section 1.2". (An unnumbered-but-resolved `\ref` is neither a *dangling* reference —
-// its label exists — nor a *renderable* one, so it belongs in neither `refs` nor `dangling_refs`; it
-// is simply below S4's numbering horizon and reappears once equation numbering ships. Documenting this
-// keeps the report honest: every row in `refs` has a real number, no placeholder.) Citations have no
-// analogous gap — every *resolved* `\cite` names a winning `\bibitem`, which S5 always numbers — so
-// every S2-resolved cite becomes a [`CiteEntry`].
+// numbers sections, figure/table floats, and (as of S7) **non-starred display-math equation labels**.
+// A **bare inline `\label`** (a `\label` not lifted onto any block — [`LabelKind::Inline`]) is still
+// deliberately left unnumbered. So a `\ref{eq:x}` to a *bare inline* `\label{eq:x}` *resolves* (it is
+// in S1's `resolved`) yet has **no** S4 number, and S6's rule for such an entry is: **omit it from
+// `refs`**. An equation label lifted out of a `\begin{equation}` (S7), by contrast, *is* numbered — it
+// carries the [`EQUATION_NUMBER_PLACEHOLDER`] (`"?"`) until S8 assigns the real counter — so an
+// `\eqref` to it is **included** in `refs` (rendering `\ref{eq:e} -> Equation ?`) rather than omitted.
+// (A bare-inline unnumbered-but-resolved `\ref` is neither *dangling* — its label exists — nor
+// *renderable*, so it belongs in neither `refs` nor `dangling_refs`; it reappears once inline-label
+// numbering ships.) Citations have no analogous gap — every *resolved* `\cite` names a winning
+// `\bibitem`, which S5 always numbers — so every S2-resolved cite becomes a [`CiteEntry`].
 //
 // ## What stays OUT of S6 (inherited honest boundaries)
 //
-// - **Equation numbers** — deferred at S4/S5 (an equation body is an opaque [`Block::DisplayMath`]
-//   string with no label field); a `\ref` to an equation label is therefore *omitted* from `refs`
-//   (see above), not invented.
+// - **Equation counter values** — S7 lifts and *resolves* equation labels (they appear in `refs` with
+//   the [`EQUATION_NUMBER_PLACEHOLDER`]), but the true `\theequation` number is deferred to S8. A
+//   *bare inline* `\label` (not in a numbered display-math env) is still omitted from `refs`.
 // - **Author-year / natbib sorted citation styles** and **external `.bib`/`.bbl` databases** — out of
 //   scope at S2/S5, so out of scope here too (S6 reports only what those passes resolved).
 //
@@ -1516,6 +1548,7 @@ fn kind_display_name(kind: LabelKind) -> &'static str {
         LabelKind::Section => "Section",
         LabelKind::Table => "Table",
         LabelKind::Figure => "Figure",
+        LabelKind::Equation => "Equation",
         LabelKind::Inline => "Inline",
     }
 }
@@ -1532,12 +1565,13 @@ fn kind_display_name(kind: LabelKind) -> &'static str {
 /// - `key` — the referenced label key, verbatim (`"sec:intro"`), from S1's [`ResolvedRef::key`].
 /// - `command` — the reference command used (`"ref"`, `"eqref"`, or `"pageref"`), from
 ///   [`ResolvedRef::command`].
-/// - `kind` — the [`LabelKind`] of the node the reference points at (section / table / figure), from
-///   [`ResolvedRef::target_kind`]. (An [`LabelKind::Inline`] target is *not* numbered by S4, so it
-///   never becomes a `RefEntry` — see the S6 module docs — hence in practice `kind` is one of
-///   Section/Table/Figure.)
+/// - `kind` — the [`LabelKind`] of the node the reference points at (section / table / figure /
+///   equation), from [`ResolvedRef::target_kind`]. (A bare [`LabelKind::Inline`] target is *not*
+///   numbered by S4, so it never becomes a `RefEntry` — see the S6 module docs — hence in practice
+///   `kind` is one of Section/Table/Figure/Equation.)
 /// - `number` — the rendered number S4 assigns the target (`"1.2"`, `"3"`, …), from
-///   [`Numbering::number_for`].
+///   [`Numbering::number_for`]. For a [`LabelKind::Equation`] this is the
+///   [`EQUATION_NUMBER_PLACEHOLDER`] (`"?"`) until S8 wires the equation counter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefEntry {
     /// The referenced label key, verbatim, without braces (`"sec:intro"`).
@@ -1732,6 +1766,47 @@ mod tests {
         let doc = parse_document(src).expect("parse");
         let res = doc.resolve_references();
         (src.to_string(), res)
+    }
+
+    #[test]
+    fn s7_equation_label_is_registered_as_equation_kind() {
+        // LTXDOC03 S7: a `\label` in a non-starred `equation` env is a real label def tagged Equation.
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}\end{document}";
+        let (_src, res) = resolve(src);
+        assert_eq!(res.definitions.len(), 1, "one equation label defined");
+        let def = &res.definitions[0];
+        assert_eq!(def.key, "eq:e");
+        assert_eq!(def.kind, LabelKind::Equation);
+        assert_eq!(def.kind.as_str(), "equation");
+    }
+
+    #[test]
+    fn s7_starred_equation_registers_no_label() {
+        // A starred `equation*` lifts no label, so there is NO definition (and the ref dangles).
+        let src = r"\begin{document}\begin{equation*} E = mc^2 \label{eq:e} \end{equation*} \ref{eq:e}\end{document}";
+        let (_src, res) = resolve(src);
+        assert_eq!(res.definitions.len(), 0, "starred env defines no equation label");
+        assert_eq!(res.unresolved.len(), 1, "the ref has nothing to resolve against");
+        assert_eq!(res.unresolved[0].key, "eq:e");
+    }
+
+    #[test]
+    fn s7_eqref_to_equation_is_included_in_cross_reference_report() {
+        // The whole point of S7: a resolved `\eqref`/`\ref` to a lifted equation label is now INCLUDED
+        // in the S6 report (rendered `\ref{eq:e} -> Equation ?`), no longer omitted.
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation} See \eqref{eq:e} and \ref{eq:e}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        assert_eq!(report.refs.len(), 2, "both \\eqref and \\ref are included");
+        for entry in &report.refs {
+            assert_eq!(entry.key, "eq:e");
+            assert_eq!(entry.kind, LabelKind::Equation);
+            assert_eq!(entry.number, "?", "equation number is the S8-deferred placeholder");
+        }
+        assert!(report.dangling_refs.is_empty(), "nothing dangles");
+        // The rendered report lines name the binding as `Equation ?`.
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\ref{eq:e} -> Equation ?\n\\ref{eq:e} -> Equation ?");
     }
 
     #[test]

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -545,13 +545,15 @@ when called in a loop). No new parsing, no AST change, no new recursion.
    deliberate: two vectors make "resolved vs dangling" a *type-level* fact, rather than burying it in a
    `number: Option<String>` field the caller must remember to check.
 2. **A resolved `\ref` whose target is not numbered is omitted.** Every entry in S1's `resolved` has a
-   matching `\label`, but not every `\label` is *numbered*: S4 numbers sections and figure/table
-   floats, but an **inline `\label`** (typically an equation label) is deliberately unnumbered
-   (deferred to a future equation-numbering rung). So a `\ref{eq:x}` to an inline `\label{eq:x}`
-   *resolves* yet has **no** S4 number. S6 **omits** such an entry from `refs`, so every row in `refs`
-   carries a real number (no placeholder). It is neither *dangling* (its label exists) nor
-   *renderable*; it reappears once equation numbering ships. Citations have no analogous gap — a
-   winning `\bibitem` is always S5-numbered — so every resolved `\cite` becomes a `CiteEntry`.
+   matching `\label`, but not every `\label` is *numbered*: S4 numbers sections, figure/table floats,
+   and (as of S7, §13) **non-starred display-math equation labels**. A **bare-inline `\label`** (a
+   `\label` not lifted onto any block — `LabelKind::Inline`) is still deliberately unnumbered. So a
+   `\ref{eq:x}` to a *bare-inline* `\label{eq:x}` *resolves* yet has **no** S4 number, and S6 **omits**
+   it from `refs` (it is neither *dangling* — its label exists — nor *renderable*). An **equation**
+   label lifted out of a `\begin{equation}` (S7) *is* numbered — with the `EQUATION_NUMBER_PLACEHOLDER`
+   (`"?"`) until S8 — so an `\eqref` to it is **included** in `refs` (`\ref{eq:e} -> Equation ?`).
+   Citations have no analogous gap — a winning `\bibitem` is always S5-numbered — so every resolved
+   `\cite` becomes a `CiteEntry`.
 3. **Multi-key `\cite` yields one row per key.** S2 already split `\cite{a,b}` into per-key
    `ResolvedCite`s, so S6 emits one `CiteEntry` per key, each numbered independently (`a`→`[1]`,
    `b`→`[2]`).
@@ -626,3 +628,86 @@ numbered `[1]`/`[2]`; a resolved-but-unnumbered inline-label `\ref` is omitted f
 dangling); an empty document → an empty report with `to_plain_text()` == `"(no cross-references)"` (no
 panic); and a regression that building the report leaves the S1/S2/S3/S4/S5 outputs byte-for-byte
 unchanged (the tree is never mutated).
+
+## 13. S7 — equation-label lifting
+
+### 13.1 The gap S7 closes
+
+S1 *resolves* a `\ref`/`\eqref` to a `\label` that sits **inside** a display-math environment
+(`\begin{equation} E=mc^2 \label{eq:e} \end{equation}`), but that reference had **no** S4 number, so
+S6 (§12.2, rule 2) **omitted** it from `refs` — it was neither dangling nor renderable. The root cause
+is in the D5 lowering: `Block::DisplayMath` keeps its whole env body as one raw `source: String`, and
+`render_nodes(&body)` renders the `\label{eq:e}` **into** that string. The label is therefore swallowed
+— it never becomes a real label definition, so it has no `LabelKind`, no counter, and no report row.
+
+Empirically (the D5 lowering, before S7): `\begin{equation} E=mc^2 \label{eq:e} \end{equation}` →
+`DisplayMath { source: "E=mc^2 \\label{eq:e}" }`, and the label table has **no** entry for `eq:e`.
+
+### 13.2 What S7 does (and does not)
+
+S7 fixes exactly this one gap for a **non-starred** display-math environment — `equation`, `align`,
+`gather`, `multline`, `eqnarray` (the numbered forms). It does **not** touch the starred forms
+(`equation*`, `align*`, `gather*`, `multline*`, `eqnarray*`) or `displaymath`, which are **unnumbered**
+in LaTeX, nor the `\[…\]`/`$$…$$` islands (which lower via `NodeKind::Math`).
+
+- **Lift the `\label` out of the env body.** In `lower_environment`, a numbered display-math env's body
+  is scanned for the first `\label{key}` (a `NodeKind::CrossRef { command: "label", target }` at the
+  LTX01 node level); it is **removed** from the body, its key recovered verbatim via
+  `document_to_latex(target)`, and the remaining nodes are rendered to `source`. So the `\label` is
+  **not** left duplicated in `source`.
+- **`Block::DisplayMath` carries the lifted key.** A new field `label: Option<String>`, mirroring how
+  `Block::Figure`/`Block::Table` carry their lifted `\label`. It is `Some` **only** for the non-starred
+  named-env path; starred envs, `displaymath`, and `\[…\]`/`$$…$$` set `label: None` (no behaviour
+  change for them).
+- **A new numbered `LabelKind::Equation`.** `as_str()` → `"equation"`, `kind_display_name` → `"Equation"`.
+  The lifted label is registered as a real `LabelDef` in the **same** collection pass
+  (`block_label`/`collect_definitions`) that registers section/figure/table labels, so an
+  `\eqref{eq:e}`/`\ref{eq:e}` now **resolves** to it (S1) and reaches the S6 report.
+- **Included in the S6 report (no longer omitted).** `number_labels` records an `Equation` row so that
+  `Numbering::number_for(key)` returns `Some`, and `cross_reference_report()` therefore emits a
+  `RefEntry` (rendered `\ref{eq:e} -> Equation ?`) instead of dropping it.
+
+### 13.3 Numbering deferred to S8
+
+S7 is **just** the lifting + a resolvable `LabelKind::Equation`; it does **not** wire the equation
+counter (`\theequation`). Because a report row requires a number, the `Equation` row carries the
+placeholder `EQUATION_NUMBER_PLACEHOLDER` — the constant `"?"` (echoing LaTeX's `??` for an
+as-yet-unresolved number), exported from the crate root. S8 will replace this with the real per-equation
+counter value. This is consistent with S6's existing honesty rule: a *bare-inline* `\label` (a `\label`
+not lifted onto any block) is still `LabelKind::Inline`, still unnumbered, and still omitted from `refs`.
+
+### 13.4 Round-trip fixed point preserved
+
+`Document::to_latex()` previously re-emitted every `DisplayMath` as `$$source$$`. A lifted-label
+equation re-emitted that way would **drop** the label (the `$$…$$` form lowers via `NodeKind::Math` →
+`label: None`), breaking the round-trip. So `to_latex` now re-emits a *lifted-label* `DisplayMath` as
+`\begin{equation}<source> \label{<key>}\end{equation}`, and a label-free one as `$$source$$` (unchanged).
+Re-parsing then re-lifts to an equal AST, so `parse(doc.to_latex())` is a fixed point (modulo spans).
+
+### 13.5 Public API (added in S7)
+
+```rust
+// references.rs
+pub enum LabelKind { Section, Table, Figure, Equation /* new */, Inline }
+pub const EQUATION_NUMBER_PLACEHOLDER: &str = "?";
+
+// document.rs
+pub enum Block {
+    DisplayMath { source: String, label: Option<String> /* new */, span: Span },
+    // …
+}
+```
+
+Both are exported from the crate root. The change is **additive**: no S1–S6 result type is removed and
+no existing behaviour changes, except that a resolved equation-label reference stops being omitted.
+
+### 13.6 Verification (S7)
+
+`cargo test -p latex` green (4 new S7 tests: an `equation` env lifts `\label` onto the block with the
+exact `source` `"E = mc^2"` and `label: Some("eq:e")`; a starred `equation*` yields `label: None` and
+registers **no** equation label; a lifted equation label is a `LabelKind::Equation` def whose
+`as_str()` is `"equation"`; an `\eqref`/`\ref` to it is **included** in `cross_reference_report()` with
+number `"?"`, rendering `\ref{eq:e} -> Equation ?`; and a `to_latex()` round-trip re-lifts to an equal
+AST). `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
+-p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S7 — equation-label lifting (numbered `LabelKind::Equation`)

First rung of the equation sub-arc, and the fix for **S6's one documented gap**. Bumps the `latex` crate `0.42.0 → 0.43.0`.

### The gap S7 closes
A `\label` inside a display-math environment (`\begin{equation} E=mc^2 \label{eq:e} \end{equation}`) was swallowed into `Block::DisplayMath`'s raw `source: String` — the parser rendered the whole body back to one string, so `\label{eq:e}` never became a real label **definition**. Consequently a `\ref`/`\eqref{eq:e}` resolved to nothing, and the S6 `cross_reference_report()` **OMITTED** it (neither dangling nor renderable — the gap documented in S6's memo).

*Investigation (throwaway test, since removed) confirmed the exact pre-S7 behavior:* `DisplayMath.source == "E=mc^2 \label{eq:e}"` and `res.definitions == []` (key `eq:e` unregistered → the ref dangled).

### What S7 does (small, additive)
- **New numbered `LabelKind::Equation`** variant (`as_str() == "equation"`, `kind_display_name == "Equation"`).
- **`Block::DisplayMath` gains `label: Option<String>`** (mirroring how `Block::Figure`/`Block::Table` carry a lifted `label`). For a **non-starred** display-math env (`equation`/`align`/`gather`/`multline`/`eqnarray`), the `\label` is **lifted out of the body** into a real label definition tagged `Equation`, and its key stored on the block; `source` is the math body with the `\label{…}` **removed** (not duplicated).
- A resolved `\ref`/`\eqref` to an equation label is now **INCLUDED** in `cross_reference_report()`, rendered `\ref{k} -> Equation ?`.
- **Starred envs** (`equation*`, `align*`, …) and `\[…\]`/`$$…$$` islands keep `label: None` (unnumbered) — unchanged behavior.
- **Numbering is deferred to S8**: a `"?"` placeholder (`EQUATION_NUMBER_PLACEHOLDER`, exported from `lib.rs`) stands in for the equation number. S7 only stops the omission; S8 assigns the counter so `\eqref` → `(3)`.
- **`to_latex()` round-trip preserved**: a lifted-label equation re-emits as `\begin{equation}…\label{…}\end{equation}` (not `$$…$$`), so `parse(to_latex(doc))` re-lifts to an equal AST — a fixed point.

Additive to S1–S6: the lift happens during D5 lowering (tree construction), not by mutating already-built S1–S6 pass outputs; the numbering/report passes still read the tree without mutation.

### Tests (7 new, exact-assertion)
- `s7_equation_label_is_lifted_onto_display_math` — `label == Some("eq:e")`, `source == "E = mc^2"` (exact).
- `s7_starred_equation_does_not_lift_a_label` — `label == None`, `source == r"E = mc^2 \label{eq:e}"` (verbatim).
- `s7_display_island_dollar_dollar_has_no_label` — `$$…$$` → `label: None`.
- `s7_labelled_equation_round_trips_through_to_latex` — re-emits `\begin{equation}` + `\label{eq:e}`; `strip_spans()` equality fixed point.
- `s7_equation_label_is_registered_as_equation_kind` — one def, key `eq:e`, `kind == LabelKind::Equation`.
- `s7_starred_equation_registers_no_label` — 0 defs, 1 unresolved (`eq:e`).
- `s7_eqref_to_equation_is_included_in_cross_reference_report` — 2 `RefEntry`s (kind `Equation`, number `"?"`), nothing dangles, `to_plain_text() == "\ref{eq:e} -> Equation ?\n\ref{eq:e} -> Equation ?"`.

### Verification
- `cargo test -p latex` → **352 passed** (+7) + doctest.
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → downstream green.
- `cargo build -p latex --no-default-features` → builds.
- No `cargo fmt`, no grammar regen, no new deps, no file I/O, no `unsafe`, no new public-path panics (security-reviewed against the real diff).

7 files: `src/document.rs`, `src/references.rs`, `src/lib.rs`, `Cargo.toml` (0.43.0), `CHANGELOG.md`, `README.md`, `code/specs/LTXDOC03-cross-reference-resolution.md` (new S7 §13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
