### PR TITLE
feat(sir-rust): Ruby Symbol methods — capitalize/inspect/empty?/to_proc parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.16.0 — Ruby `Symbol` method catalog (to_s / upcase / capitalize / inspect / to_proc / …)
+
+Completes the Rust backend's **`Symbol` method catalog** for parity with the
+Python and TypeScript `sir-runtime-oop` reference. Runtime-only change (no core
+semantic-IR, no frontend, no emitter change): a `Value::Sym` receiver already
+routed to `symbol_method`; this release fills in the missing methods.
+
+- **Added to `symbol_method`** (previously only `to_s`, `to_sym`,
+  `length`/`size`, `upcase`, `downcase`):
+  - **`capitalize`** — returns a **new interned `Symbol`** whose name is the
+    first char upper-cased and the rest lower-cased (`:hELLo.capitalize` →
+    `:Hello`), matching Ruby (a helper `capitalize_str` implements the fold).
+  - **`inspect`** — the `":name"` display form (leading colon), e.g.
+    `:x.inspect == ":x"`.
+  - **`empty?`** — whether the symbol's name is the empty string.
+  - **`to_proc`** — builds the SAME dispatching `Closure` that a `&:sym`
+    block-pass lowers to, by re-using the free `sym_to_proc` helper. So
+    `:to_s.to_proc` and `&:to_s` are byte-for-byte the same proc.
+- Like the reference, `upcase`/`downcase`/`capitalize` return a **Symbol**
+  (not a String). Since a bare `Value::Sym` prints as its name with no `:`,
+  the exec-proof test chains `.inspect` to observe the returned type.
+- **`respond_to?`** on a `Symbol` now reports the new names
+  (`capitalize`/`inspect`/`empty?`/`to_proc`) so the honesty invariant holds:
+  a name it reports `true` for is exactly one a real call runs.
+- **SECURITY ([[dynamic-dispatch-rce]]):** `to_proc`'s closure re-enters the
+  runtime through the SAME explicit, closed `call_method` — an unknown method
+  raises `NoMethodError`; there is no reflection on the source-derived name.
+- **`&:sym` is runtime-reachable:** the frontend lowers `&:to_s` to
+  `block_pass(SymLit("to_s"))`, which the emitter turns into
+  `sym_to_proc(intern("to_s"))`, so `Symbol#to_proc` is load-bearing (it is
+  NOT a frontend block-expansion). Proved end-to-end by
+  `[1,2,3].map(&:to_s).join(",") == "1,2,3"`.
+- **Test:** new exec-proof `tests/compile_and_run_symbol_methods.rs`
+  (`symbol_methods_compile_and_run`) — emits Rust, compiles with `rustc`, runs
+  the binary, and diffs stdout against the reference:
+  `:hello.to_s → "hello"`, `:hi.length → 2`, `:abc.upcase.inspect → ":ABC"`,
+  `:x.inspect → ":x"`, `:hELLo.capitalize.inspect → ":Hello"`,
+  `[1,2,3].map(&:to_s).join(",") → "1,2,3"`.
+
 ## 0.15.0 — Array aggregate / reshape parity (min / max / sum / uniq / flatten / compact / to_a / each_with_index)
 
 Ports the remaining `Array`/`Enumerable` aggregate and reshape methods —

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1455,6 +1455,7 @@ pub const RUNTIME: &str = r##"mod __sir {
             Value::Sym(_) => matches!(
                 name,
                 "to_s" | "to_sym" | "length" | "size" | "upcase" | "downcase"
+                    | "capitalize" | "inspect" | "empty?" | "to_proc"
             ),
             Value::Bool(_) => matches!(name, "&" | "|" | "^"),
             Value::Int(_) | Value::Float(_) => {
@@ -1990,13 +1991,47 @@ pub const RUNTIME: &str = r##"mod __sir {
             _ => return unknown_method(&recv, name),
         };
         match name {
+            // `:hello.to_s` → the bare name as a `String` (`"hello"`).
             "to_s" => Value::Str(Rc::from(&*s)),
+            // `:hi.to_sym` → self (a Symbol is already its own symbol).
             "to_sym" => recv,
+            // `:hi.length` / `.size` → the name's character count (`2`).
             "length" | "size" => Value::Int(s.chars().count() as i64),
+            // Ruby's `Symbol#upcase`/`downcase`/`capitalize` return a *new
+            // Symbol* (NOT a String) — the case-folded name, re-interned so
+            // it shares identity with any equal symbol.  Proving this at
+            // runtime needs `.inspect` (`:ABC`), since a bare Symbol prints
+            // as its name (`ABC`) with no `:` prefix.
             "upcase" => intern(&s.to_uppercase()),
             "downcase" => intern(&s.to_lowercase()),
+            "capitalize" => intern(&capitalize_str(&s)),
+            // `:x.inspect` → the `":name"` display form (leading colon).
+            "inspect" => Value::Str(Rc::from(format!(":{s}").as_str())),
+            // `:"".empty?` → whether the name is the empty string.
+            "empty?" => Value::Bool(s.is_empty()),
+            // `:m.to_proc` → the same dispatching `Closure` that `&:m` lowers
+            // to at a call site (Ruby's `Symbol#to_proc`).  Re-uses the free
+            // `sym_to_proc` helper so an explicit `.to_proc` and an implicit
+            // `&:m` block-pass are byte-for-byte the same closure.
+            "to_proc" => sym_to_proc(recv),
             _ => no_method_error(&recv, name),
         }
+    }
+
+    // Ruby `String#capitalize` / `Symbol#capitalize`: the first character is
+    // upper-cased and every subsequent character lower-cased (`"hELLo"` →
+    // `"Hello"`).  A byte-honest, allocation-light port of the String catalog's
+    // capitalize so the Symbol catalog need not depend on it.
+    fn capitalize_str(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        for (i, ch) in s.chars().enumerate() {
+            if i == 0 {
+                out.extend(ch.to_uppercase());
+            } else {
+                out.extend(ch.to_lowercase());
+            }
+        }
+        out
     }
 
     // `sym_to_proc(:m)` builds a `Closure` equivalent to Ruby's

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_symbol_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_symbol_methods.rs
@@ -1,0 +1,228 @@
+//! End-to-end proof for the **Ruby `Symbol` method catalog** in the Rust
+//! backend (parity with the Python/TypeScript `sir-runtime-oop` reference).
+//!
+//! A Ruby `Symbol` reaches this backend as a `Value::Sym` (an interned
+//! `Rc<str>`), and a call `:sym.meth(…)` arrives as the narrow-waist
+//! envelope `BuiltinCall("__method__", [recv, StrLit("meth"), …])`, which the
+//! emitter turns into `__sir::call_method(recv, "meth", vec![…])`.  The
+//! inline `__sir` runtime routes a `Value::Sym` receiver to `symbol_method`,
+//! an EXPLICIT `(name)` match — never reflection — ported from the reference.
+//!
+//! This test hand-builds SIR modules exercising the catalog, emits Rust,
+//! compiles it with `rustc`, runs the binary, and diffs stdout against the
+//! values Ruby (and the Python/TS reference) produce for the SAME module:
+//!
+//!   * `:hello.to_s`                     → `"hello"`  (a String)
+//!   * `:hi.length`                      → `2`
+//!   * `:abc.upcase.inspect`             → `":ABC"`   (upcase returns a Symbol)
+//!   * `:x.inspect`                      → `":x"`
+//!   * `:hELLo.capitalize.inspect`       → `":Hello"` (capitalize → Symbol)
+//!   * `[1,2,3].map(&:to_s).join(",")`   → `"1,2,3"`  (`Symbol#to_proc`)
+//!
+//! Note on the `upcase`/`capitalize` assertions: a bare `Value::Sym` prints
+//! as its *name* (`ABC`), with no leading `:`, so those results are chained
+//! through `.inspect` (which prefixes `:`) to prove the method returned a
+//! **Symbol** and not a String.  The `map(&:to_s)` line proves `to_proc` is
+//! runtime-reachable: the frontend lowers `&:to_s` to
+//! `block_pass(SymLit("to_s"))`, which the emitter turns into
+//! `sym_to_proc(intern("to_s"))` — the same closure `:to_s.to_proc` builds —
+//! re-entering `call_method(x, "to_s", [])` through explicit dispatch.
+//!
+//! If `rustc` (or a usable linker) is unavailable the test logs a skip rather
+//! than failing; a missing host tool must never redden a build.  The host can
+//! point the test at a working linker via `SIR_TEST_RUSTC_LINKER`.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn symlit(v: &str) -> Expr {
+    Expr::SymLit { name: v.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn call(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, slit(name)];
+    all.append(&mut args);
+    Expr::BuiltinCall {
+        name: "__method__".into(),
+        args: all,
+        effects: EffectSet::PURE,
+        span: s(),
+    }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn demo_module(main_stmts: Vec<Stmt>) -> Module {
+    let functions = vec![Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }];
+
+    Module {
+        name: "symbol_methods_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Symbols,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn full_demo() -> Module {
+    let main_stmts = vec![
+        // 1. :hello.to_s  → "hello"
+        print_stmt(method(symlit("hello"), "to_s", vec![])),
+        // 2. :hi.length  → 2
+        print_stmt(method(symlit("hi"), "length", vec![])),
+        // 3. :abc.upcase.inspect  → ":ABC"  (upcase returns a Symbol)
+        print_stmt(method(method(symlit("abc"), "upcase", vec![]), "inspect", vec![])),
+        // 4. :x.inspect  → ":x"
+        print_stmt(method(symlit("x"), "inspect", vec![])),
+        // 5. :hELLo.capitalize.inspect  → ":Hello"  (capitalize returns a Symbol)
+        print_stmt(method(method(symlit("hELLo"), "capitalize", vec![]), "inspect", vec![])),
+        // 6. [1,2,3].map(&:to_s).join(",")  → "1,2,3"  (Symbol#to_proc reachable)
+        print_stmt(method(
+            method(
+                seq(vec![ilit(1), ilit(2), ilit(3)]),
+                "map",
+                vec![call("block_pass", vec![symlit("to_s")])],
+            ),
+            "join",
+            vec![slit(",")],
+        )),
+    ];
+
+    demo_module(main_stmts)
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn symbol_methods_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&full_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_symbol_methods_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_symbol_methods_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "hello",  // :hello.to_s
+            "2",      // :hi.length
+            ":ABC",   // :abc.upcase.inspect
+            ":x",     // :x.inspect
+            ":Hello", // :hELLo.capitalize.inspect
+            "1,2,3",  // [1,2,3].map(&:to_s).join(",")
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Runtime-only stdlib-breadth (Symbol family) for the **Rust** backend, parity with Python/TS. Sibling to the Array-methods PR #7673.

`symbol_method` already had `to_s`/`to_sym`/`length`/`size`/`upcase`/`downcase`; this adds `capitalize` (→ a Symbol), `inspect` (`":name"`), `empty?`, and **`to_proc`**.

**`to_proc` is load-bearing:** the Ruby frontend lowers `&:to_s` → `BuiltinCall("block_pass",[SymLit])` → `__sir::sym_to_proc(intern("to_s"))`, so `[1,2,3].map(&:to_s)` exercises `Symbol#to_proc` at runtime. The `.to_proc` method reuses the same `sym_to_proc`, so `:m.to_proc` and `&:m` build byte-identical closures.

**Security ([[dynamic-dispatch-rce]]) — review PASSED:** `to_proc`'s closure captures an **owned String** and re-enters the same explicit `match`-based `call_method` — never reflection; a gadget-ish name (`&:constructor…`) bottoms out at `NoMethodError`, can't reach a host callable. Empty-args guard prevents OOB. `capitalize`/`inspect` operate on `chars()`/`format!` (no byte-slicing → no multibyte panic). No self-driving recursion; no `unsafe`.

Execution-proofed via rustc: `:hello.to_s`, `:hi.length`, `:abc.upcase`, `:x.inspect`, `:hELLo.capitalize`, `[1,2,3].map(&:to_s).join(",")`. 123 unit + all exec suites green, 0 warnings.

Note: version lands at 0.15.0 (same as #7673 off main); whichever merges first, I'll rebase the other's version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)