### PR TITLE
feat(sir-go): Ruby Symbol methods — capitalize/inspect/to_proc parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.16.0
+
+### Added — Ruby Symbol method catalog completion (`capitalize` / `inspect` / `to_proc`)
+
+Parity-fill: the Python + TypeScript `sir-runtime-oop` Symbol catalogs already
+expose `inspect`; this ports it into the Go runtime's `_sir_symbol_method`
+switch and adds the two task-mandated Ruby Symbol methods `capitalize` and
+`to_proc`, so a translated Ruby program's Symbol calls execute on the Go
+backend instead of hitting the `NoMethodError` floor.
+
+- **`inspect`** — returns the source form `":name"` (a String). Matches the
+  Python/TS reference semantics.
+- **`capitalize`** — returns a NEW interned `*Symbol` whose name has an
+  uppercase first char and a lowercase remainder (rune-aware, mirroring the
+  existing `upcase`/`downcase` arms).
+- **`to_proc`** — an explicit `sym.to_proc` call returns a `*Closure` built by
+  the SAME `_sir_sym_to_proc` helper the `&:sym` block-pass form uses. The
+  resulting proc routes each application through the explicit
+  `_sir_call_method` switch — NEVER Go `reflect` ([[dynamic-dispatch-rce]]); an
+  out-of-catalog method surfaces the ordinary `NoMethodError`. Note: the
+  `&:sym` block-pass form is FRONTEND-lowered straight to `_sir_sym_to_proc`
+  (see `try_emit_block_pass` in `emit.rs`) and never reaches this catalog arm;
+  `to_proc` is added for the explicit-call path and full correctness.
+- `_sir_symbol_responds` (`respond_to?`) updated to include `capitalize`,
+  `inspect`, and `to_proc`.
+
+Exec-proof: `tests/compile_and_run_symbol_methods.rs` runs the emitted Go under
+a real `go run` toolchain and asserts `:hello.to_s`→"hello", `:hi.length`→"2",
+`:abc.upcase`→"ABC", `:ABC.downcase`→"abc", `:hELLO.capitalize`→"Hello",
+`:x.inspect`→":x", `[1,2,3].map(&:to_s).join`→"123" (block-pass form), and
+`[4,5,6].map(:to_s.to_proc).join`→"456" (explicit catalog `to_proc`).
+
 ## 0.15.0
 
 ### Added — Array collection-method parity (min / max / sum / uniq / flatten / compact / each_with_index)

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -2955,6 +2955,19 @@ mod tests {
         assert!(RUNTIME.contains("func _sir_string_method("));
         assert!(RUNTIME.contains("func _sir_numeric_method("));
         assert!(RUNTIME.contains("func _sir_symbol_method("));
+        // Ruby Symbol catalog arms (parity with Python/TS + task-mandated
+        // `capitalize`/`to_proc`).
+        for arm in &[
+            "case \"to_s\":",
+            "case \"to_sym\":",
+            "case \"upcase\":",
+            "case \"downcase\":",
+            "case \"capitalize\":",
+            "case \"inspect\":",
+            "case \"to_proc\":",
+        ] {
+            assert!(RUNTIME.contains(arm), "symbol catalog missing `{}`", arm);
+        }
         assert!(RUNTIME.contains("undefined method"));
     }
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1650,7 +1650,8 @@ func _sir_string_responds(name string) bool {
 
 func _sir_symbol_responds(name string) bool {
 	switch name {
-	case "to_s", "to_sym", "length", "size", "upcase", "downcase", "empty?":
+	case "to_s", "to_sym", "length", "size", "upcase", "downcase",
+		"capitalize", "inspect", "to_proc", "empty?":
 		return true
 	}
 	return false
@@ -2318,6 +2319,28 @@ func _sir_symbol_method(recv *Symbol, name string, args []Value) (Value, bool) {
 		return _sir_intern(strings.ToUpper(recv.Name)), true
 	case "downcase":
 		return _sir_intern(strings.ToLower(recv.Name)), true
+	case "capitalize":
+		// Ruby `Symbol#capitalize`: first char upper, the rest lower, as a
+		// NEW interned Symbol (mirrors `upcase`/`downcase`).  Operate on runes
+		// so a multi-byte leading char is not split.
+		rs := []rune(recv.Name)
+		if len(rs) == 0 {
+			return recv, true
+		}
+		head := strings.ToUpper(string(rs[0]))
+		tail := strings.ToLower(string(rs[1:]))
+		return _sir_intern(head + tail), true
+	case "inspect":
+		// Ruby `Symbol#inspect` → the source form `":name"` (a String).
+		return ":" + recv.Name, true
+	case "to_proc":
+		// Ruby `Symbol#to_proc` — an explicit `sym.to_proc` call (the `&:sym`
+		// block-pass form is FRONTEND-lowered straight to `_sir_sym_to_proc`
+		// and never reaches this catalog).  Reuse the SAME helper so the
+		// resulting `*Closure` routes through the explicit `_sir_call_method`
+		// switch — never Go `reflect` ([[dynamic-dispatch-rce]]); an
+		// out-of-catalog method surfaces the ordinary NoMethodError floor.
+		return _sir_sym_to_proc(recv), true
 	case "empty?":
 		return len(recv.Name) == 0, true
 	}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_symbol_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_symbol_methods.rs
@@ -1,0 +1,187 @@
+//! End-to-end proof for the **Ruby Symbol method catalog** in the Go backend
+//! (`_sir_symbol_method`) — parity-fill with the Python + TypeScript
+//! `sir-runtime-oop` Symbol catalogs plus the task-mandated `capitalize` /
+//! `to_proc`.
+//!
+//! Unit tests assert the emitted *shape*; this test goes the whole way: it
+//! hand-builds a SIR module that exercises the Symbol methods on a symbol
+//! literal receiver, emits Go, writes it to a temp `.go` file, runs it with
+//! `go run`, and checks stdout — proving the emitted Go actually compiles and
+//! behaves under a real Go toolchain (mirrors `compile_and_run_seq_maps.rs`).
+//!
+//! Note on formatting: a `*Symbol` is printed by its BARE name (see
+//! `_sir_format_d`), so `:abc.upcase` (a `*Symbol` `:ABC`) renders as `ABC`,
+//! and `:x.inspect` (a String `":x"`) renders as `:x`.
+//!
+//! Gates on `go` being available; logs a skip instead of failing when the Go
+//! toolchain is absent (a missing tool must never redden an unrelated build).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn symlit(name: &str) -> Expr {
+    Expr::SymLit { name: name.into(), span: s() }
+}
+
+fn seq(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
+fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
+    let mut args = vec![recv, slit(name)];
+    args.extend(extra);
+    builtin("__method__", args)
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// Build a module whose `main` prints, one per line:
+///   1. `:hello.to_s`                 → "hello"  (String)
+///   2. `:hi.length`                  → "2"
+///   3. `:abc.upcase`                 → "ABC"    (Symbol, bare-name print)
+///   4. `:ABC.downcase`               → "abc"    (Symbol)
+///   5. `:hELLO.capitalize`           → "Hello"  (Symbol)
+///   6. `:x.inspect`                  → ":x"     (String)
+///   7. `[1,2,3].map(&:to_s).join`    → "123"    (Symbol#to_proc via block-pass)
+///   8. `[10,20].map(&(:to_s.to_proc)).join` — but simpler: prove explicit
+///      `.to_proc` yields a usable proc by mapping with it. We instead exercise
+///      the explicit-catalog `to_proc` through `[4,5].map(sym.to_proc)` where
+///      the proc is passed as a trailing block arg (a `*Closure`).
+fn demo_module() -> Module {
+    let stmts = vec![
+        print_stmt(method(symlit("hello"), "to_s", vec![])),
+        print_stmt(method(symlit("hi"), "length", vec![])),
+        print_stmt(method(symlit("abc"), "upcase", vec![])),
+        print_stmt(method(symlit("ABC"), "downcase", vec![])),
+        print_stmt(method(symlit("hELLO"), "capitalize", vec![])),
+        print_stmt(method(symlit("x"), "inspect", vec![])),
+        // `&:to_s` block-pass form (frontend-lowered to `_sir_sym_to_proc`).
+        print_stmt(method(
+            method(
+                seq(vec![ilit(1), ilit(2), ilit(3)]),
+                "map",
+                vec![builtin("block_pass", vec![symlit("to_s")])],
+            ),
+            "join",
+            vec![],
+        )),
+        // Explicit `Symbol#to_proc` from the catalog: `:to_s.to_proc` returns a
+        // `*Closure` that, passed as the trailing block arg to `map`, drives the
+        // same per-element dispatch. Proves the catalog `to_proc` arm works.
+        print_stmt(method(
+            method(
+                seq(vec![ilit(4), ilit(5), ilit(6)]),
+                "map",
+                vec![method(symlit("to_s"), "to_proc", vec![])],
+            ),
+            "join",
+            vec![],
+        )),
+    ];
+
+    Module {
+        name: "symbol_methods_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Symbols,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn symbol_methods_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+
+    let artifact = compile(&demo_module()).expect("module should compile to Go source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_symbol_methods_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["hello", "2", "ABC", "abc", "Hello", ":x", "123", "456"],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+}


### PR DESCRIPTION
Runtime-only stdlib-breadth (Symbol family) for the **Go** backend. Sibling to Rust #7679 + the Array PRs.

`_sir_symbol_method` already had `to_s`/`to_sym`/`length`/`size`/`upcase`/`downcase`/`empty?`; this adds `inspect` (parity-fill — Python/TS have it), `capitalize` (→ Symbol, rune-aware), and `to_proc`. `respond_to?` catalog updated.

`&:sym` is emit-lowered directly to `_sir_sym_to_proc` (proven by pre-existing coll-methods tests), so the catalog `to_proc` arm is reached by explicit `:m.to_proc` calls; it reuses the same helper for identical behavior.

**Security ([[dynamic-dispatch-rce]]) — review PASSED:** `to_proc`'s closure re-enters the explicit `_sir_call_method` type-switch/catalogs (`reflect` not imported; gadget-ish `&:sym` names floor to `NoMethodError`, can't reach a host callable). Zero-arg proc application guarded (no OOB). `capitalize` operates on `[]rune` with an empty guard (no multibyte-split/empty panic); `inspect` pure concat; no nil-deref.

Execution-proofed via `go run`: `to_s`/`length`/`upcase`/`downcase`/`capitalize`/`inspect` + `&:to_s` block-pass + explicit `:to_s.to_proc` map. All tests green (Scope warning pre-existing/untouched).

Note: version 0.15.0 (same as #7674 off main); I'll rebase the 2nd-merged one's bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)