### PR TITLE
feat(sir-js): Ruby Array methods (sum/min/max/uniq/flatten/compact/each_with_index) parity

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.13.0
+
+### Added — Ruby `Array` collection methods (`sum`/`min`/`max`/`uniq`/`flatten`/`compact`/`each_with_index`/`to_a`)
+
+Parity fill for the JS backend's array dispatch. The JS backend dispatches
+array methods through a `METHOD_ALLOWLIST` of NATIVE JS method names plus a
+`RUBY_METHOD_ALIASES` table (calling `recv[name]` only for allowlisted native
+methods). The everyday Ruby `Array` methods below are NOT native JS array
+methods, so a translated `[1,2,3].sum` previously missed the allowlist and
+raised `NoMethodError`. They are now handled as **explicit Ruby-semantic
+special cases in `callMethod`** — a fixed `name ===` dispatch block guarded by
+`Array.isArray(recv)`, placed AHEAD of the native-method allowlist (mirroring
+how `.fetch` / the typed-error methods are special-cased). Dispatch is never
+`recv[name]` / `eval` / reflection on the source-derived name, so the
+RCE-hardened allowlist gate is completely untouched (a name like `constructor`
+still falls through to it and is rejected).
+
+- **`sum`** — numeric sum folded through the runtime's polymorphic `plus`
+  helper (so int/float promotion matches `+` everywhere else); empty array →
+  `0`; an optional seed arg (`sum(s)`) is the starting accumulator.
+- **`min` / `max`** — element-wise extreme by the SIR `<` order (native `<` on
+  numbers/strings, the same comparison the `"<"` builtin uses); an empty array
+  → `nil` (matching Ruby, not JS `Math.min([])` = `Infinity`).
+- **`uniq`** — first-occurrence dedup into a FRESH array by SIR VALUE equality
+  (a new `sirEqual` helper: `===` for primitives, STRUCTURAL for arrays/maps —
+  so two equal-but-distinct arrays count as one, matching Ruby, unlike JS
+  `===` on references). Cycle-guarded.
+- **`flatten`** — DEEP recursive flatten into a FRESH array (Ruby's `flatten`
+  is deep; JS `.flat()` is shallow). Cycle-guarded: a self-referential array
+  raises a typed, rescuable `ArgumentError: tried to flatten recursive array`
+  (matching Ruby) rather than infinite-looping (CWE-674).
+- **`compact`** — a new array with `nil` (null/undefined) elements removed.
+- **`each_with_index`** — applies the trailing block `Closure` with
+  `(element, index)` for each element, in order, and returns the receiver.
+- **`to_a`** — identity on an array (returns self).
+
+New runtime helpers: `sirEqual` (structural, cycle-guarded value equality) and
+`flattenDeep` (cycle-guarded deep flatten). Both reuse the `seen`-Set discipline
+`format` / `putsOne` already use for cyclic-structure safety.
+
 ## 0.12.0
 
 ### Added — M6 universal Object metaprogramming surface (send/tap/then/respond_to?)

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -159,10 +159,19 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     }
     if (a instanceof Map && b instanceof Map) {
       if (a.size !== b.size) { return false; }
+      // Same cycle guard as the array branch: two DISTINCT but structurally
+      // equal self-referential hashes (`a={}; a[:k]=a; b={}; b[:k]=b`) would
+      // otherwise recurse forever through their values (the `===` fast-path
+      // only covers the reference-identical case).  Record the LEFT map on
+      // the active compare path and short-circuit on re-encounter.
+      if (seen.has(a)) { return true; }
+      seen.add(a);
+      let ok = true;
       for (const [k, v] of a) {
-        if (!b.has(k) || !sirEqualSeen(v, b.get(k), seen)) { return false; }
+        if (!b.has(k) || !sirEqualSeen(v, b.get(k), seen)) { ok = false; break; }
       }
-      return true;
+      seen.delete(a);
+      return ok;
     }
     return false;
   }

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -126,6 +126,68 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return String(v);
   }
 
+  // ── SIR value equality (structural, for `uniq`) ────────────────
+  // Ruby's `Array#uniq` dedups by `eql?`/`hash`, i.e. VALUE equality: two
+  // equal-but-distinct arrays (`[1,2]` and a separate `[1,2]`) count as one.
+  // Primitives compare with `===` — the same op the `"="`/`case_eq` builtins
+  // use, so `uniq` agrees with `==` everywhere else.  Arrays and Maps compare
+  // STRUCTURALLY (element-/entry-wise), matching Ruby, since JS `===` on two
+  // distinct-but-equal arrays is `false`.  Cycle safety: a program can build a
+  // self-referential array (`a = []; a << a`), so the recursive array walk is
+  // guarded by a `seen` set of the (a, b) pairs already on the compare path —
+  // a re-encountered pair is treated as equal (the cycle has matched so far),
+  // which terminates instead of recursing forever (CWE-674).  `Sym`/`Pair`/
+  // `Closure` fall back to reference identity (`===`), matching how the rest
+  // of the runtime treats them as opaque.
+  function sirEqual(a, b) { return sirEqualSeen(a, b, new Set()); }
+  function sirEqualSeen(a, b, seen) {
+    if (a === b) { return true; }
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) { return false; }
+      // Cycle guard: record the LEFT array reference on the active compare
+      // path.  Re-encountering it means we are inside a self-referential
+      // structure whose elements have matched so far — treat as equal and
+      // stop recursing, so a cyclic array terminates instead of looping.
+      if (seen.has(a)) { return true; }
+      seen.add(a);
+      let ok = true;
+      for (let i = 0; i < a.length; i++) {
+        if (!sirEqualSeen(a[i], b[i], seen)) { ok = false; break; }
+      }
+      seen.delete(a);
+      return ok;
+    }
+    if (a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) { return false; }
+      for (const [k, v] of a) {
+        if (!b.has(k) || !sirEqualSeen(v, b.get(k), seen)) { return false; }
+      }
+      return true;
+    }
+    return false;
+  }
+
+  // ── deep flatten (Ruby `Array#flatten`) ────────────────────────
+  // Ruby's `flatten` recursively splices EVERY nested array into a single
+  // flat array, into a FRESH result (no aliasing / mutation of any input).
+  // Cycle safety mirrors `putsOne`/`format`: a self-referential array must
+  // not infinite-loop (CWE-674).  `seen` holds the array references on the
+  // active flatten path; an array already on the path is a cycle — real Ruby
+  // raises `ArgumentError: tried to flatten recursive array`, so we do too
+  // (a typed, rescuable error), rather than hanging or emitting a placeholder.
+  function flattenDeep(arr, out, seen) {
+    if (seen.has(arr)) {
+      raiseError("ArgumentError", "tried to flatten recursive array");
+    }
+    seen.add(arr);
+    for (const el of arr) {
+      if (Array.isArray(el)) { flattenDeep(el, out, seen); }
+      else { out.push(el); }
+    }
+    seen.delete(arr);
+    return out;
+  }
+
   // ── builtins dispatch table ────────────────────────────────────
   // Reached only for builtins the emitter did not specialise inline
   // (e.g. a variadic `+`, or a builtin referenced as a value via
@@ -665,6 +727,79 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       }
       // A `.fetch` on any other receiver has no Ruby-collection meaning
       // here; fall through to the unknown-method NoMethodError below.
+    }
+    // ── Ruby Array collection methods NOT native to JS arrays ─────
+    // `sum`/`min`/`max`/`uniq`/`flatten`/`compact`/`each_with_index`/`to_a`
+    // are everyday Ruby `Array` methods with NO 1:1 native JS equivalent (JS
+    // has `Math.min`/`.flat`/… but their semantics diverge — `flat` is
+    // shallow-by-default, `Math.min([])` is `Infinity` not `nil`, there is no
+    // native `uniq`/`compact`/`sum`/`each_with_index`).  So — exactly like
+    // `.fetch` above — they are handled HERE, ahead of the native-method
+    // allowlist, as EXPLICIT Ruby-semantic special cases.  Dispatch is a
+    // fixed `name ===` test on an `Array.isArray(recv)` receiver: never
+    // `recv[name]`, `eval`, or reflection on the source-derived name, so the
+    // RCE-hardened allowlist gate below is completely untouched (a name like
+    // `constructor` still falls through to it and is rejected).
+    if (Array.isArray(recv)) {
+      // `sum` — numeric sum; empty → 0 (or the seed).  A seed arg (`sum(s)`)
+      // is the starting accumulator, matching Ruby.  We fold through the
+      // runtime's polymorphic `plus`, so int/float promotion (and, per Ruby,
+      // string/array concat when a matching seed is given) is consistent with
+      // `+` everywhere else.
+      if (name === "sum") {
+        let acc = args.length >= 1 ? args[0] : 0;
+        for (const el of recv) { acc = plus(acc, el); }
+        return acc;
+      }
+      // `min` / `max` — element-wise extreme by the SIR `<` order (the same
+      // comparison the `"<"` builtin uses: native `<` on numbers/strings).
+      // An EMPTY array has no extreme → `nil` (null), matching Ruby.
+      if (name === "min" || name === "max") {
+        if (recv.length === 0) { return null; }
+        let best = recv[0];
+        for (let i = 1; i < recv.length; i++) {
+          const el = recv[i];
+          // `max` keeps the larger, `min` the smaller.  Strict `<` so an
+          // equal element does not displace the earlier one (stable).
+          if (name === "max" ? best < el : el < best) { best = el; }
+        }
+        return best;
+      }
+      // `uniq` — first-occurrence dedup by SIR VALUE equality (`sirEqual`),
+      // into a FRESH array (no mutation / aliasing of the receiver).  A later
+      // element equal to one already kept is dropped.
+      if (name === "uniq") {
+        const out = [];
+        for (const el of recv) {
+          if (!out.some((k) => sirEqual(k, el))) { out.push(el); }
+        }
+        return out;
+      }
+      // `flatten` — DEEP recursive flatten into a FRESH array, cycle-guarded
+      // (a self-referential array raises ArgumentError rather than looping).
+      if (name === "flatten") {
+        return flattenDeep(recv, [], new Set());
+      }
+      // `compact` — a NEW array with the nils (null / undefined) removed.
+      if (name === "compact") {
+        return recv.filter((el) => el !== null && el !== undefined);
+      }
+      // `each_with_index` — apply the trailing block Closure with
+      // `(element, index)` for each element, in order, and return the
+      // RECEIVER (Ruby returns self).  A block-less call returns the receiver
+      // too (Ruby returns an Enumerator; v0 floor).  The block arrives as the
+      // last RAW arg (an un-unwrapped `Closure`), invoked via `applyClosure`.
+      if (name === "each_with_index") {
+        const block = rawArgs[rawArgs.length - 1];
+        if (block instanceof Closure) {
+          for (let i = 0; i < recv.length; i++) {
+            applyClosure(block, [recv[i], i]);
+          }
+        }
+        return recv;
+      }
+      // `to_a` on an array is the identity (returns self), matching Ruby.
+      if (name === "to_a") { return recv; }
     }
     // Normalise a differently-spelled Ruby method name to its JS-native
     // equivalent (`upcase` → `toUpperCase`).  Unknown names pass through
@@ -1324,6 +1459,44 @@ mod tests {
         // SirInstance, the allowlist for a primitive) — not a probe of recv[name].
         assert!(RUNTIME.contains("resolveMethod(methodTable, recv.sirClass, name, includedModules) !== undefined"));
         assert!(RUNTIME.contains("METHOD_ALLOWLIST.has(native)"));
+    }
+
+    #[test]
+    fn runtime_defines_ruby_array_collection_methods() {
+        // Parity fill: the Ruby Array methods with NO 1:1 native JS equivalent
+        // (`sum`/`min`/`max`/`uniq`/`flatten`/`compact`/`each_with_index`/`to_a`)
+        // are special-cased in `callMethod`, ahead of the native allowlist, on
+        // an `Array.isArray(recv)` receiver.  Each name must be recognised.
+        assert!(RUNTIME.contains(r#"if (name === "sum")"#));
+        assert!(RUNTIME.contains(r#"if (name === "min" || name === "max")"#));
+        assert!(RUNTIME.contains(r#"if (name === "uniq")"#));
+        assert!(RUNTIME.contains(r#"if (name === "flatten")"#));
+        assert!(RUNTIME.contains(r#"if (name === "compact")"#));
+        assert!(RUNTIME.contains(r#"if (name === "each_with_index")"#));
+        assert!(RUNTIME.contains(r#"if (name === "to_a")"#));
+
+        // The helpers the special-cases reuse.
+        assert!(RUNTIME.contains("function sirEqual("));
+        assert!(RUNTIME.contains("function flattenDeep("));
+
+        // SECURITY: dispatch is a fixed `name ===` test on `Array.isArray`,
+        // NEVER a reflective `recv[name]` / eval on the source-derived name —
+        // the RCE-hardened allowlist gate is untouched.
+        assert!(!RUNTIME.contains("new Function("));
+        assert!(!RUNTIME.contains("eval("));
+
+        // `sum` folds through the polymorphic `plus` (int/float promotion).
+        assert!(RUNTIME.contains("acc = plus(acc, el);"));
+        // `min`/`max` floor an empty array to `nil` (null), matching Ruby.
+        assert!(RUNTIME.contains("if (recv.length === 0) { return null; }"));
+        // `uniq` dedups by SIR VALUE equality, not JS `===` on references.
+        assert!(RUNTIME.contains("!out.some((k) => sirEqual(k, el))"));
+        // `flatten` is cycle-guarded: a self-referential array raises a typed,
+        // rescuable ArgumentError rather than looping forever (CWE-674).
+        assert!(RUNTIME.contains(r#"raiseError("ArgumentError", "tried to flatten recursive array")"#));
+        // `each_with_index` invokes the trailing Closure block with (el, i) and
+        // returns the receiver.
+        assert!(RUNTIME.contains("applyClosure(block, [recv[i], i]);"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2214,3 +2214,247 @@ fn m6_boolean_operators() {
         assert_eq!(stdout, "#f\n#t\n#f\n#t");
     }
 }
+
+// ── Ruby Array collection methods (sum/min/max/uniq/flatten/compact/
+//    each_with_index) — execution-proof under `node` ────────────────────
+//
+// These Ruby `Array` methods have NO 1:1 native JS equivalent, so the JS
+// backend now special-cases them in `callMethod` ahead of the native-method
+// allowlist.  Each hand-built module builds a literal array, calls the method
+// via the `__method__` dispatch envelope, prints the result, and runs the
+// self-contained `.js` under Node.
+
+/// `[3,1,2].max` → 3 and `[3,1,2].min` → 1 (element-wise SIR order).
+#[test]
+fn array_min_max() {
+    let seq = || Expr::SeqLit { items: vec![int(3), int(1), int(2)], span: sp() };
+    let max = bc("__method__", vec![seq(), str_("max")]);
+    let min = bc("__method__", vec![seq(), str_("min")]);
+    let module = module_with_main(
+        vec![print(max), print(min)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "arr_min_max") {
+        assert_eq!(stdout, "3\n1");
+    }
+}
+
+/// `[].min` / `[].max` → nil (an empty array has no extreme).
+#[test]
+fn array_min_max_empty_is_nil() {
+    let min = bc("__method__", vec![Expr::SeqLit { items: vec![], span: sp() }, str_("min")]);
+    let max = bc("__method__", vec![Expr::SeqLit { items: vec![], span: sp() }, str_("max")]);
+    let module = module_with_main(
+        vec![print(min), print(max)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "arr_min_max_empty") {
+        assert_eq!(stdout, "nil\nnil");
+    }
+}
+
+/// `[1,2,3].sum` → 6, and a seeded `[1,2,3].sum(10)` → 16; `[].sum` → 0.
+#[test]
+fn array_sum() {
+    let plain = bc(
+        "__method__",
+        vec![Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: sp() }, str_("sum")],
+    );
+    let seeded = bc(
+        "__method__",
+        vec![Expr::SeqLit { items: vec![int(1), int(2), int(3)], span: sp() }, str_("sum"), int(10)],
+    );
+    let empty = bc("__method__", vec![Expr::SeqLit { items: vec![], span: sp() }, str_("sum")]);
+    let module = module_with_main(
+        vec![print(plain), print(seeded), print(empty)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "arr_sum") {
+        assert_eq!(stdout, "6\n16\n0");
+    }
+}
+
+/// `[1,2,2,3].uniq` → [1, 2, 3] (first-occurrence dedup by value equality).
+/// Also proves STRUCTURAL dedup: `[[1],[1],[2]].uniq` → [[1], [2]].
+#[test]
+fn array_uniq() {
+    let flat = bc(
+        "__method__",
+        vec![
+            Expr::SeqLit { items: vec![int(1), int(2), int(2), int(3)], span: sp() },
+            str_("uniq"),
+        ],
+    );
+    let seq1 = || Expr::SeqLit { items: vec![int(1)], span: sp() };
+    let nested = bc(
+        "__method__",
+        vec![
+            Expr::SeqLit {
+                items: vec![seq1(), seq1(), Expr::SeqLit { items: vec![int(2)], span: sp() }],
+                span: sp(),
+            },
+            str_("uniq"),
+        ],
+    );
+    let module = module_with_main(
+        vec![print(flat), print(nested)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "arr_uniq") {
+        assert_eq!(stdout, "[1, 2, 3]\n[[1], [2]]");
+    }
+}
+
+/// `[[1,[2]],3].flatten` → [1, 2, 3] (DEEP recursive flatten).
+#[test]
+fn array_flatten_deep() {
+    let inner = Expr::SeqLit {
+        items: vec![int(1), Expr::SeqLit { items: vec![int(2)], span: sp() }],
+        span: sp(),
+    };
+    let outer = Expr::SeqLit { items: vec![inner, int(3)], span: sp() };
+    let flat = bc("__method__", vec![outer, str_("flatten")]);
+    let module = module_with_main(
+        vec![print(flat)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "arr_flatten") {
+        assert_eq!(stdout, "[1, 2, 3]");
+    }
+}
+
+/// A self-referential array `.flatten` must TERMINATE (not infinite-loop):
+/// the cycle guard raises a typed ArgumentError, so node exits non-zero.
+#[test]
+fn array_flatten_cyclic_terminates() {
+    // let a = [1]; a[1] = a; a.flatten   → cycle → ArgumentError (non-zero).
+    let stmts = vec![
+        let_("a", Expr::SeqLit { items: vec![int(1)], span: sp() }),
+        // Push `a` into itself: a[1] = a.
+        Stmt::SeqSet { seq: local("a"), index: int(1), value: local("a"), span: sp() },
+        Stmt::ExprStmt {
+            expr: bc("__method__", vec![local("a"), str_("flatten")]),
+            span: sp(),
+        },
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping, Feature::MutableBindings],
+    );
+    if let Some(stderr) = run_module_expecting_failure(&module, "arr_flatten_cycle") {
+        // Termination is the load-bearing property: the guard raised our typed
+        // ArgumentError rather than hanging with a stack overflow.
+        assert!(
+            stderr.contains("ArgumentError") || stderr.contains("recursive array"),
+            "expected the cycle-guard ArgumentError, got stderr:\n{stderr}"
+        );
+    }
+}
+
+/// `[1,nil,2].compact` → [1, 2] (a new array without nils).
+#[test]
+fn array_compact() {
+    let seq = Expr::SeqLit {
+        items: vec![int(1), Expr::NilLit { span: sp() }, int(2)],
+        span: sp(),
+    };
+    let compact = bc("__method__", vec![seq, str_("compact")]);
+    let module = module_with_main(
+        vec![print(compact)],
+        Expr::NilLit { span: sp() },
+        &[Feature::Sequences, Feature::Strings, Feature::DynamicTyping],
+    );
+    if let Some(stdout) = run_module(&module, "arr_compact") {
+        assert_eq!(stdout, "[1, 2]");
+    }
+}
+
+/// `[10,20].each_with_index { |x, i| print(x); print(i) }` prints each element
+/// paired with its index (10,0,20,1) and returns the receiver.  We build the
+/// block as a top-level function passed via `MakeClosure` — exactly how the
+/// frontend lowers a `{ |x,i| … }` block to the trailing argument of
+/// `__method__`.
+#[test]
+fn array_each_with_index() {
+    // The block body: print(x); print(i).  `x`/`i` are the closure's params.
+    let block_fn = Function {
+        name: "ewi_block".into(),
+        params: vec![
+            semantic_ir::Param {
+                name: "x".into(),
+                sir_type: None,
+                kind: semantic_ir::ParamKind::Required,
+                default: None,
+                span: sp(),
+            },
+            semantic_ir::Param {
+                name: "i".into(),
+                sir_type: None,
+                kind: semantic_ir::ParamKind::Required,
+                default: None,
+                span: sp(),
+            },
+        ],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                print(Expr::VarRef { name: "x".into(), scope: Scope::Param, span: sp() }),
+                print(Expr::VarRef { name: "i".into(), scope: Scope::Param, span: sp() }),
+            ],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let block = Expr::MakeClosure { fn_name: "ewi_block".into(), captures: vec![], span: sp() };
+    let seq = Expr::SeqLit { items: vec![int(10), int(20)], span: sp() };
+    // `each_with_index` returns the receiver; we don't print it (it would add
+    // array output), we only observe the block's side effects.
+    let call = bc("__method__", vec![seq, str_("each_with_index"), block]);
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![Stmt::ExprStmt { expr: call, span: sp() }],
+            value: Expr::NilLit { span: sp() },
+            span: sp(),
+        },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+
+    let module = Module {
+        name: "eachwithindex".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Closures,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![block_fn, main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "arr_each_with_index") {
+        assert_eq!(stdout, "10\n0\n20\n1");
+    }
+}


### PR DESCRIPTION
Runtime-only stdlib-breadth for the **JavaScript** backend — brings JS to Array-method parity with Python/TS/Go/Rust. Separate crate from the Go/Rust PRs.

The JS backend dispatches array methods via a native-JS `METHOD_ALLOWLIST` (the RCE hardening), so Ruby methods that aren't native (`sum`/`min`/`max`/`uniq`/`flatten`/`compact`/`each_with_index`) all raised `NoMethodError`. All 8 (incl. `to_a`) are **newly added** as explicit Ruby-semantic special-cases in `callMethod`, placed **ahead of** the allowlist gate (same position as `.fetch`) — dispatch is fixed `name ===` comparisons + `Array.isArray`, never `recv[name]`, so the allowlist/RCE hardening is untouched (`constructor`/`__proto__` still fall through and are rejected).

Semantics match the reference: `sum` via `plus` (empty→0), `min`/`max` element-wise (empty→nil), `uniq` first-occurrence dedup via structural cycle-guarded `sirEqual`, `flatten` deep into a fresh array (cycle → Ruby's `ArgumentError: tried to flatten recursive array`), `compact` drops nil, `each_with_index` yields `(el,i)` returns self.

**Security review: 1 finding fixed** — the review found `sirEqual`'s **Map branch** lacked the cycle guard its array branch has (distinct self-referential hashes in `uniq` → stack-overflow DoS, CWE-674). Applied the same `seen`-Set guard to the Map branch (second commit). Everything else clean: RCE gate not weakened, flatten cycle-guarded, no prototype pollution, block application `Closure`-checked.

Execution-proofed under node (incl. `array_flatten_cyclic_terminates`). 110 unit + 66 integration green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)