### PR TITLE
feat(sir-go): Numeric + String method-catalog parity (consolidated, v0.18.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
+## 0.18.0 — Numeric + String method-catalog parity
 
+Expands the emitted Go runtime's `_sir_numeric_method` and
+`_sir_string_method` catalogs to Ruby parity, and grows the matching
+`_sir_numeric_responds` / `_sir_string_responds` predicates so
+`respond_to?` stays honest.
+
+**Numeric (`int64` / `float64`):** `to_int`, `positive?`, `negative?`,
+`succ` / `next`, `pred`, `floor`, `ceil`, `round` (`_sir_ruby_round`,
+round-half-up), `gcd` (`_sir_gcd`, overflow-safe), `pow` / `**`
+(`_sir_int_pow`, with a closed-form short-circuit for base ∈ {0, 1, −1}
+and a bit-width guard so a large exponent can't spin), `digits`
+(`_sir_digits`), and the block-taking walkers `upto` / `downto` / `step`
+(counter arithmetic guarded against `int64` boundary overflow).
+
+**String:** `capitalize`, `chomp`, `bytes`, `index`, `replace`, `sub`,
+`gsub` (literal, first/all-occurrence; no regex or back-reference
+expansion). All arity-guard their optional arguments (`len(args)` checks
+before any `args[0]`), returning `nil`/receiver rather than panicking.
+
+Dispatch stays receiver-type routed through explicit `switch` labels — no
+reflection on source-derived method names.
+
+(Consolidates the previously-separate Numeric and String catalog PRs into
+one crate change to avoid intra-crate version churn.)
 
 ## 0.16.0
 

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -2553,8 +2553,8 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 				limit := positional[0]
 				useFloat := _sir_is_float_val(recv) || _sir_is_float_val(limit) || _sir_is_float_val(stride)
 				if useFloat {
-					step := _sir_as_float(stride)
-					lim := _sir_as_float(limit)
+					step := _sir_as_float_lenient(stride)
+					lim := _sir_as_float_lenient(limit)
 					v := _sir_as_float(recv)
 					if step > 0 {
 						for v <= lim {
@@ -2574,17 +2574,23 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 						}
 					}
 				} else {
-					step := _sir_as_int(stride)
-					lim := _sir_as_int(limit)
+					step := _sir_as_int_trunc(stride)
+					lim := _sir_as_int_trunc(limit)
 					v := _sir_as_int(recv)
 					if step > 0 {
 						for v <= lim {
 							_sir_apply(block, []Value{v})
+							if v > math.MaxInt64-step {
+								break
+							}
 							v += step
 						}
 					} else if step < 0 {
 						for v >= lim {
 							_sir_apply(block, []Value{v})
+							if v < math.MinInt64-step {
+								break
+							}
 							v += step
 						}
 					}
@@ -2695,7 +2701,10 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 				return _sir_int_pow(_sir_as_int(recv), e), true
 			}
 		}
-		return math.Pow(_sir_as_float(recv), _sir_as_float(args[0])), true
+		// `recv` is numeric on this dispatch path; a non-numeric exponent
+		// degrades to 0.0 (→ result 1.0) via the lenient coercion rather than
+		// panicking on the dispatch surface.
+		return math.Pow(_sir_as_float(recv), _sir_as_float_lenient(args[0])), true
 	case "digits":
 		// Ruby `Integer#digits`: the base-10 digits, LEAST-significant first
 		// (`123.digits == [3, 2, 1]`).  A float receiver truncates first
@@ -2807,6 +2816,21 @@ func _sir_digits(n int64) *Seq {
 // `to_i`-style truncation that also accepts a float receiver (Ruby's
 // `3.7.to_i == 3`, `even?`/`odd?` truncate first).  A non-finite float
 // degrades to 0 rather than panicking (never-raise floor).
+// Lenient float coercion for the numeric OO surface: a non-numeric
+// receiver/argument degrades to 0.0 instead of panicking, upholding the
+// never-raise-on-the-dispatch-surface invariant (mirrors _sir_as_int_trunc).
+func _sir_as_float_lenient(v Value) float64 {
+	switch n := v.(type) {
+	case int64:
+		return float64(n)
+	case int:
+		return float64(n)
+	case float64:
+		return n
+	}
+	return 0
+}
+
 func _sir_as_int_trunc(v Value) int64 {
 	switch n := v.(type) {
 	case int64:

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -2562,7 +2562,12 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 							if v > math.MaxInt64-step {
 								break
 							}
+							prev := v
 							v += step
+							if v == prev {
+								// float stagnation (ulp >= step): the never-hang floor.
+								break
+							}
 						}
 					} else if step < 0 {
 						for v >= lim {
@@ -2570,7 +2575,12 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 							if v < math.MinInt64-step {
 								break
 							}
+							prev := v
 							v += step
+							if v == prev {
+								// float stagnation (ulp >= step): the never-hang floor.
+								break
+							}
 						}
 					}
 				} else {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1658,8 +1658,14 @@ func _sir_symbol_responds(name string) bool {
 
 func _sir_numeric_responds(name string) bool {
 	switch name {
-	case "times", "abs", "to_i", "to_f", "even?", "odd?", "zero?",
-		"positive?", "negative?", "succ", "next", "pred":
+	// Block-taking Integer iterators.
+	case "times", "upto", "downto", "step":
+		return true
+	// Non-block Integer/Float methods (kept in lockstep with the
+	// `_sir_numeric_method` switch above).
+	case "abs", "to_i", "to_int", "to_f", "even?", "odd?", "zero?",
+		"positive?", "negative?", "succ", "next", "pred",
+		"floor", "ceil", "round", "gcd", "pow", "**", "digits":
 		return true
 	}
 	return false
@@ -2294,6 +2300,18 @@ func _sir_string_method(recv string, name string, args []Value) (Value, bool) {
 		return strings.ToUpper(recv), true
 	case "downcase":
 		return strings.ToLower(recv), true
+	case "capitalize":
+		// Ruby `String#capitalize`: first character upcased, the rest
+		// downcased (e.g. `"hELLO".capitalize == "Hello"`).  We work on
+		// `[]rune` so a multibyte first character upcases correctly and we
+		// never split a UTF-8 sequence mid-codepoint.
+		r := []rune(recv)
+		if len(r) == 0 {
+			return "", true
+		}
+		head := strings.ToUpper(string(r[0]))
+		tail := strings.ToLower(string(r[1:]))
+		return head + tail, true
 	case "reverse":
 		r := []rune(recv)
 		for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
@@ -2306,6 +2324,26 @@ func _sir_string_method(recv string, name string, args []Value) (Value, bool) {
 		return strings.TrimLeft(recv, " \t\r\n\f\v"), true
 	case "rstrip":
 		return strings.TrimRight(recv, " \t\r\n\f\v"), true
+	case "chomp":
+		// Ruby `String#chomp`: with an explicit separator argument, drop
+		// exactly that trailing suffix (once); with no argument, drop one
+		// trailing "\r\n", "\n", or "\r" (Ruby's default record separator).
+		if len(args) > 0 {
+			if sep, ok := args[0].(string); ok {
+				if sep != "" && strings.HasSuffix(recv, sep) {
+					return recv[:len(recv)-len(sep)], true
+				}
+				return recv, true
+			}
+			return recv, true
+		}
+		if strings.HasSuffix(recv, "\r\n") {
+			return recv[:len(recv)-2], true
+		}
+		if strings.HasSuffix(recv, "\n") || strings.HasSuffix(recv, "\r") {
+			return recv[:len(recv)-1], true
+		}
+		return recv, true
 	case "empty?":
 		return len(recv) == 0, true
 	case "include?":
@@ -2346,6 +2384,63 @@ func _sir_string_method(recv string, name string, args []Value) (Value, bool) {
 			out[i] = string(c)
 		}
 		return &Seq{Items: out}, true
+	case "bytes":
+		// Ruby `String#bytes`: the raw UTF-8 byte values as integers.  A Go
+		// `string` is already UTF-8, so we iterate its bytes directly.
+		b := []byte(recv)
+		out := make([]Value, len(b))
+		for i, x := range b {
+			out[i] = int64(x)
+		}
+		return &Seq{Items: out}, true
+	case "index":
+		// Ruby `String#index`: the rune index of the first occurrence of the
+		// substring, or `nil` when absent.  `strings.Index` reports a *byte*
+		// offset, so we convert it to a rune count to match Ruby's character
+		// indexing on multibyte strings.
+		if len(args) > 0 {
+			if s, ok := args[0].(string); ok {
+				bi := strings.Index(recv, s)
+				if bi < 0 {
+					return nil, true
+				}
+				return int64(len([]rune(recv[:bi]))), true
+			}
+		}
+		return nil, true
+	case "replace":
+		// Ruby `String#replace` overwrites the entire content; for an
+		// immutable Go string that is simply the replacement value.
+		if len(args) > 0 {
+			if s, ok := args[0].(string); ok {
+				return s, true
+			}
+		}
+		return recv, true
+	case "sub":
+		// Ruby `String#sub` with string arguments: literal replacement of the
+		// FIRST occurrence only (n == 1).  `strings.Replace` inserts the
+		// replacement verbatim — no `$&`/`\1` back-reference expansion.
+		if len(args) >= 2 {
+			from, ok1 := args[0].(string)
+			to, ok2 := args[1].(string)
+			if ok1 && ok2 {
+				return strings.Replace(recv, from, to, 1), true
+			}
+		}
+		return recv, true
+	case "gsub":
+		// Ruby `String#gsub` with string arguments: literal replacement of
+		// ALL occurrences.  `strings.ReplaceAll` is verbatim (no regex, no
+		// back-reference expansion).
+		if len(args) >= 2 {
+			from, ok1 := args[0].(string)
+			to, ok2 := args[1].(string)
+			if ok1 && ok2 {
+				return strings.ReplaceAll(recv, from, to), true
+			}
+		}
+		return recv, true
 	case "to_i":
 		return _sir_str_to_i(recv), true
 	case "to_f":
@@ -2394,14 +2489,109 @@ func _sir_str_to_f(s string) Value {
 
 // ── Numeric (Integer/Float) catalog ────────────────────────────
 func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
-	// Block-taking `times` is dispatched when a trailing *Closure is present.
-	_, block := _sir_split_block(args)
-	if block != nil && name == "times" {
-		n := _sir_as_int(recv)
-		for i := int64(0); i < n; i++ {
-			_sir_apply(block, []Value{i})
+	// Block-taking methods are dispatched when a trailing *Closure is present:
+	// `times`/`upto`/`downto`/`step` each iterate a block and return the
+	// receiver (Ruby's Integer iterators).  Parity with the Python/TS
+	// `_numeric_block_method` catalog.  `positional` is the arg list with the
+	// trailing block stripped off (empty for `times`, one limit for
+	// `upto`/`downto`, limit + optional stride for `step`).
+	positional, block := _sir_split_block(args)
+	if block != nil {
+		switch name {
+		case "times":
+			// `n.times { |i| … }` yields 0,1,…,n-1.  A non-positive `n` yields
+			// nothing (the loop condition is immediately false).
+			n := _sir_as_int_trunc(recv)
+			for i := int64(0); i < n; i++ {
+				_sir_apply(block, []Value{i})
+			}
+			return recv, true
+		case "upto":
+			// `a.upto(b) { |i| … }` yields a,a+1,…,b (inclusive); no iterations
+			// when a > b.  Uses truncating int coercion so a float endpoint
+			// behaves like the reference (`3.upto(5.9)` stops at 5).
+			if len(positional) >= 1 {
+				lo := _sir_as_int_trunc(recv)
+				hi := _sir_as_int_trunc(positional[0])
+				// Guard the terminal `i++` so a finite `hi == MaxInt64` limit
+				// terminates instead of wrapping to MinInt64 and spinning.
+				for i := lo; i <= hi; {
+					_sir_apply(block, []Value{i})
+					if i == math.MaxInt64 {
+						break
+					}
+					i++
+				}
+				return recv, true
+			}
+		case "downto":
+			// `a.downto(b) { |i| … }` yields a,a-1,…,b (inclusive); no
+			// iterations when a < b.
+			if len(positional) >= 1 {
+				hi := _sir_as_int_trunc(recv)
+				lo := _sir_as_int_trunc(positional[0])
+				for i := hi; i >= lo; {
+					_sir_apply(block, []Value{i})
+					if i == math.MinInt64 {
+						break
+					}
+					i--
+				}
+				return recv, true
+			}
+		case "step":
+			// `a.step(limit, stride) { |v| … }` yields a, a+stride, … while
+			// `v <= limit` (positive stride) or `v >= limit` (negative stride).
+			// A float receiver/limit/stride runs the whole walk in float64;
+			// an all-integer walk stays exact.  A zero stride yields nothing
+			// (rather than spinning forever) — the never-hang floor.
+			if len(positional) >= 1 {
+				stride := Value(int64(1))
+				if len(positional) >= 2 {
+					stride = positional[1]
+				}
+				limit := positional[0]
+				useFloat := _sir_is_float_val(recv) || _sir_is_float_val(limit) || _sir_is_float_val(stride)
+				if useFloat {
+					step := _sir_as_float(stride)
+					lim := _sir_as_float(limit)
+					v := _sir_as_float(recv)
+					if step > 0 {
+						for v <= lim {
+							_sir_apply(block, []Value{v})
+							if v > math.MaxInt64-step {
+								break
+							}
+							v += step
+						}
+					} else if step < 0 {
+						for v >= lim {
+							_sir_apply(block, []Value{v})
+							if v < math.MinInt64-step {
+								break
+							}
+							v += step
+						}
+					}
+				} else {
+					step := _sir_as_int(stride)
+					lim := _sir_as_int(limit)
+					v := _sir_as_int(recv)
+					if step > 0 {
+						for v <= lim {
+							_sir_apply(block, []Value{v})
+							v += step
+						}
+					} else if step < 0 {
+						for v >= lim {
+							_sir_apply(block, []Value{v})
+							v += step
+						}
+					}
+				}
+				return recv, true
+			}
 		}
-		return recv, true
 	}
 	isInt := false
 	switch recv.(type) {
@@ -2418,7 +2608,9 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 			return n, true
 		}
 		return math.Abs(_sir_as_float(recv)), true
-	case "to_i":
+	case "to_i", "to_int":
+		// Ruby's `to_i`/`to_int` truncate a float toward zero (`3.7.to_i == 3`,
+		// `(-3.7).to_i == -3`); on an integer they are the identity.
 		return _sir_as_int_trunc(recv), true
 	case "to_f":
 		return _sir_as_float(recv), true
@@ -2442,8 +2634,174 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 			return _sir_as_int(recv) - 1, true
 		}
 		return _sir_as_float(recv) - 1, true
+	case "floor":
+		// `floor` returns the greatest integer ≤ self.  On an integer it is
+		// the identity; on a float it rounds toward −∞ and yields an integer
+		// (Ruby: `3.7.floor == 3`, `(-3.2).floor == -4`).  A non-finite float
+		// degrades to 0 via `_sir_as_int_trunc` (never-raise floor).
+		if isInt {
+			return _sir_as_int(recv), true
+		}
+		f := _sir_as_float(recv)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return int64(0), true
+		}
+		return int64(math.Floor(f)), true
+	case "ceil":
+		// `ceil` returns the least integer ≥ self.  Identity on an integer;
+		// rounds a float toward +∞ (`3.2.ceil == 4`, `(-3.7).ceil == -3`).
+		if isInt {
+			return _sir_as_int(recv), true
+		}
+		f := _sir_as_float(recv)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return int64(0), true
+		}
+		return int64(math.Ceil(f)), true
+	case "round":
+		// Ruby `Float#round` (no digits) rounds half AWAY from zero — unlike
+		// Go's `math.Round` which also rounds half away, but we route through
+		// the explicit helper to stay in lockstep with the Python/TS
+		// `_ruby_round` (`2.5.round == 3`, `(-2.5).round == -3`).  An integer
+		// receiver is the identity; a non-finite float degrades to 0.
+		if isInt {
+			return _sir_as_int(recv), true
+		}
+		f := _sir_as_float(recv)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return int64(0), true
+		}
+		return _sir_ruby_round(f), true
+	case "gcd":
+		// `a.gcd(b)` is the (non-negative) greatest common divisor, via
+		// Euclid on the truncated magnitudes (matching Python `math.gcd` and
+		// the TS `gcdInt`).  `0.gcd(0) == 0`.  Requires one argument; a
+		// missing arg is the controlled arity floor.
+		if len(args) < 1 {
+			return nil, false
+		}
+		return _sir_gcd(_sir_as_int_trunc(recv), _sir_as_int_trunc(args[0])), true
+	case "pow", "**":
+		// `base.pow(exp)` / `base ** exp`.  Requires one argument.  Integer
+		// base AND exponent stay in the exact integer tower (int64 wrapping,
+		// the SAME convention as `_sir_times`), guarded so a hostile exponent
+		// cannot spin an unbounded loop; any float operand promotes to
+		// float64 `math.Pow`.  See `_sir_int_pow`.
+		if len(args) < 1 {
+			return nil, false
+		}
+		if isInt {
+			if e, ok := _sir_int_val(args[0]); ok {
+				return _sir_int_pow(_sir_as_int(recv), e), true
+			}
+		}
+		return math.Pow(_sir_as_float(recv), _sir_as_float(args[0])), true
+	case "digits":
+		// Ruby `Integer#digits`: the base-10 digits, LEAST-significant first
+		// (`123.digits == [3, 2, 1]`).  A float receiver truncates first
+		// (parity with the reference, which coerces via `int(recv)`).  The
+		// magnitude is taken so a negative receiver produces its digits
+		// (Ruby raises `Math::DomainError` on a true negative, but the
+		// reference runtimes take the absolute value — we match them).
+		return _sir_digits(_sir_as_int_trunc(recv)), true
 	}
 	return nil, false
+}
+
+func _sir_int_val(v Value) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	}
+	return 0, false
+}
+
+func _sir_ruby_round(x float64) int64 {
+	if x >= 0 {
+		return int64(math.Floor(x + 0.5))
+	}
+	return int64(math.Ceil(x - 0.5))
+}
+
+func _sir_gcd(a, b int64) int64 {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
+}
+
+// The upper bound on a `pow` result's bit-length before we refuse it.
+// Mirrors the Python/TS `_MAX_POW_BITS` (1 << 20): a translated program asking
+// for an astronomically large integer power gets a controlled 0 rather than an
+// unbounded multiply loop.  int64 can only ever HOLD 63 significant bits, so
+// this really guards the LOOP COUNT (the exponent), not the result width.
+const _sir_max_pow_bits = 1 << 20
+
+func _sir_int_pow(base, exp int64) int64 {
+	if exp < 0 {
+		// Only ±1 have integer reciprocals; everything else collapses to 0.
+		switch base {
+		case 1:
+			return 1
+		case -1:
+			if exp%2 == 0 {
+				return 1
+			}
+			return -1
+		}
+		return 0
+	}
+	// Closed-form fast paths for base ∈ {0, 1, -1}: these are O(1) regardless
+	// of exponent.  This ALSO closes a DoS gap — the old code exempted them
+	// from the `exp > _sir_max_pow_bits` guard but still ran the `exp`-length
+	// loop, so `1 ** (1<<40)` spun ~10^12 trivial iterations.
+	switch base {
+	case 0:
+		if exp == 0 {
+			return 1 // 0**0 == 1, matching Ruby
+		}
+		return 0
+	case 1:
+		return 1
+	case -1:
+		if exp%2 == 0 {
+			return 1
+		}
+		return -1
+	}
+	// Refuse an exponent so large the multiply loop would never finish (the
+	// int64 result is meaningless past overflow anyway).
+	if exp > _sir_max_pow_bits {
+		return 0
+	}
+	var acc int64 = 1
+	for i := int64(0); i < exp; i++ {
+		acc *= base // int64 wraparound, matching `_sir_times`
+	}
+	return acc
+}
+
+func _sir_digits(n int64) *Seq {
+	if n < 0 {
+		n = -n
+	}
+	if n == 0 {
+		return &Seq{Items: []Value{int64(0)}}
+	}
+	out := []Value{}
+	for n > 0 {
+		out = append(out, n%10)
+		n /= 10
+	}
+	return &Seq{Items: out}
 }
 
 // `to_i`-style truncation that also accepts a float receiver (Ruby's

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
@@ -1,0 +1,245 @@
+//! Execution proof for the Ruby `Integer`/`Float` (Numeric) method catalog on
+//! the Go backend — parity-fill with the Python/TS `sir-runtime-oop` runtimes.
+//!
+//! Each program builds a SIR module that calls a numeric method (via the
+//! `__method__` builtin the frontend emits for `recv.meth(args…)`), emits Go,
+//! runs it with `go run`, and asserts the printed value equals what the
+//! reference runtimes yield for the identical operation.  Booleans print as the
+//! runtime's `#t`/`#f`, arrays as `[a, b, …]`.
+//!
+//! Covered here (the methods ADDED in this change, plus a couple of pre-existing
+//! ones as controls): `even?`, `odd?`, `abs`, `to_s`, `to_i`, `gcd`, `pow`,
+//! `**`, `digits`, `succ`, `floor`, `ceil`, `round`, and the block iterators
+//! `upto`/`downto`/`step`.
+//!
+//! A missing `go` toolchain logs a skip rather than reddening the build
+//! (mirrors `compile_and_run_coll_methods.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Param,
+    ParamKind, Scope, Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(n: i64) -> Expr {
+    Expr::IntLit { value: n, span: s() }
+}
+
+fn flit(x: f64) -> Expr {
+    Expr::FloatLit { value: x, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn var_p(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
+fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
+    let mut args = vec![recv, slit(name)];
+    args.extend(extra);
+    builtin("__method__", args)
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// One-parameter lambda `fn_name(x) -> body`, registered as a top-level
+/// function; the caller builds a `MakeClosure` referencing it.
+fn lambda_fn(fn_name: &str, param: &str, body: Expr) -> Function {
+    Function {
+        name: fn_name.into(),
+        params: vec![Param {
+            name: param.into(),
+            kind: ParamKind::Required,
+            sir_type: None,
+            default: None,
+            span: s(),
+        }],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn closure(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: vec![], span: s() }
+}
+
+fn manifest() -> FeatureManifest {
+    FeatureManifest::from_features(&[
+        Feature::Closures,
+        Feature::Sequences,
+        Feature::Strings,
+        Feature::Floats,
+        Feature::MutableBindings,
+        Feature::DynamicTyping,
+    ])
+}
+
+fn program(functions: Vec<Function>) -> Module {
+    Module {
+        name: "numeric_methods_demo".into(),
+        manifest: manifest(),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// The catalog demo `main`.  Each printed line's expected value is what the
+/// Python/TS reference runtime yields for the identical operation.
+fn catalog_module() -> Module {
+    // `puts`-style print lambda the block iterators drive (prints each yielded
+    // value on its own line).
+    let show = lambda_fn("__lam_show", "x", builtin("print", vec![var_p("x")]));
+
+    let stmts = vec![
+        // 4.even? → #t ; 3.odd? → #t
+        print_stmt(method(ilit(4), "even?", vec![])),
+        print_stmt(method(ilit(3), "odd?", vec![])),
+        // (-5).abs → 5
+        print_stmt(method(ilit(-5), "abs", vec![])),
+        // 7.to_s → "7"
+        print_stmt(method(ilit(7), "to_s", vec![])),
+        // 3.14.to_i → 3   (truncate toward zero)
+        print_stmt(method(flit(3.14), "to_i", vec![])),
+        // 10.gcd(15) → 5
+        print_stmt(method(ilit(10), "gcd", vec![ilit(15)])),
+        // 2.pow(10) → 1024
+        print_stmt(method(ilit(2), "pow", vec![ilit(10)])),
+        // 2 ** 8 → 256   (via the `**` method name)
+        print_stmt(method(ilit(2), "**", vec![ilit(8)])),
+        // 123.digits → [3, 2, 1]  (least-significant first)
+        print_stmt(method(ilit(123), "digits", vec![])),
+        // 5.succ → 6
+        print_stmt(method(ilit(5), "succ", vec![])),
+        // 3.7.floor → 3 ; 3.2.ceil → 4 ; 2.5.round → 3 (half away from zero)
+        print_stmt(method(flit(3.7), "floor", vec![])),
+        print_stmt(method(flit(3.2), "ceil", vec![])),
+        print_stmt(method(flit(2.5), "round", vec![])),
+        // 1.upto(3) { |i| print i } → 1,2,3 (three lines).  The block itself
+        // prints; the iterator's return value (the receiver) is discarded, so
+        // this is a bare ExprStmt, NOT wrapped in another print.
+        Stmt::ExprStmt {
+            expr: method(ilit(1), "upto", vec![ilit(3), closure("__lam_show")]),
+            span: s(),
+        },
+        // 3.downto(1) { |i| print i } → 3,2,1 (three lines)
+        Stmt::ExprStmt {
+            expr: method(ilit(3), "downto", vec![ilit(1), closure("__lam_show")]),
+            span: s(),
+        },
+        // 0.step(4, 2) { |i| print i } → 0,2,4 (three lines)
+        Stmt::ExprStmt {
+            expr: method(ilit(0), "step", vec![ilit(4), ilit(2), closure("__lam_show")]),
+            span: s(),
+        },
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![show, main])
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_go(source: &str, tag: &str) -> std::process::Output {
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_numeric_{tag}_{nonce}.go"));
+    std::fs::write(&src_path, source).expect("write temp source");
+    let out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    out
+}
+
+#[test]
+fn numeric_methods_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&catalog_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "catalog");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "#t",        // 4.even?
+            "#t",        // 3.odd?
+            "5",         // (-5).abs
+            "7",         // 7.to_s
+            "3",         // 3.14.to_i
+            "5",         // 10.gcd(15)
+            "1024",      // 2.pow(10)
+            "256",       // 2 ** 8
+            "[3, 2, 1]", // 123.digits
+            "6",         // 5.succ
+            "3",         // 3.7.floor
+            "4",         // 3.2.ceil
+            "3",         // 2.5.round
+            "1", "2", "3", // 1.upto(3)
+            "3", "2", "1", // 3.downto(1)
+            "0", "2", "4", // 0.step(4, 2)
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_string_methods.rs
@@ -1,0 +1,188 @@
+//! End-to-end proof for the Go backend's **String-method catalog** — the Go
+//! analogue of the Python/TS `sir-runtime-oop` `_string_method` dispatch.
+//!
+//! It hand-builds a SIR module exercising the newly-added String methods
+//! (`capitalize`, `chomp`, `bytes`, `index`, `replace`, `sub`, `gsub`) plus a
+//! few pre-existing ones for regression coverage (`chars`, `split`,
+//! `start_with?`, `reverse`), emits Go, runs it under a real `go run`, and
+//! diffs stdout against the values the Python/TS reference backends yield for
+//! the SAME operations.  `sub`/`gsub` are LITERAL (no regex / no `$&`), matching
+//! the reference runtimes exactly.
+//!
+//! Gated on `go version`: a missing toolchain logs a skip rather than
+//! reddening the build (mirrors `compile_and_run_coll_methods.rs`).
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span,
+    Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn builtin(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args, effects: EffectSet::PURE, span: s() }
+}
+
+/// `recv.meth(extra…)` → `BuiltinCall("__method__", [recv, "meth", …extra])`.
+fn method(recv: Expr, name: &str, extra: Vec<Expr>) -> Expr {
+    let mut args = vec![recv, slit(name)];
+    args.extend(extra);
+    builtin("__method__", args)
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn manifest() -> FeatureManifest {
+    FeatureManifest::from_features(&[
+        Feature::Strings,
+        Feature::Symbols,
+        Feature::Sequences,
+        Feature::DynamicTyping,
+    ])
+}
+
+fn program(functions: Vec<Function>) -> Module {
+    Module {
+        name: "string_methods_demo".into(),
+        manifest: manifest(),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// Each printed line's expected value is what the Python/TS reference runtime
+/// yields for the identical operation.
+fn catalog_module() -> Module {
+    let stmts = vec![
+        // "hello".capitalize → "Hello"
+        print_stmt(method(slit("hello"), "capitalize", vec![])),
+        // "hELLO".capitalize → "Hello"  (first up, rest DOWN)
+        print_stmt(method(slit("hELLO"), "capitalize", vec![])),
+        // "hi\n".chomp → "hi"
+        print_stmt(method(slit("hi\n"), "chomp", vec![])),
+        // "hi\r\n".chomp → "hi"  (one CRLF)
+        print_stmt(method(slit("hi\r\n"), "chomp", vec![])),
+        // "hello!".chomp("!") → "hello"  (explicit separator)
+        print_stmt(method(slit("hello!"), "chomp", vec![slit("!")])),
+        // "abc".chars → [a, b, c]
+        print_stmt(method(slit("abc"), "chars", vec![])),
+        // "hi".bytes → [104, 105]
+        print_stmt(method(slit("hi"), "bytes", vec![])),
+        // "a-b-c".split("-") → [a, b, c]
+        print_stmt(method(slit("a-b-c"), "split", vec![slit("-")])),
+        // "foobar".sub("o","0") → "f0obar"  (first only)
+        print_stmt(method(slit("foobar"), "sub", vec![slit("o"), slit("0")])),
+        // "foobar".gsub("o","0") → "f00bar"  (all)
+        print_stmt(method(slit("foobar"), "gsub", vec![slit("o"), slit("0")])),
+        // "hello".index("l") → 2
+        print_stmt(method(slit("hello"), "index", vec![slit("l")])),
+        // "hello".index("z") → nil
+        print_stmt(method(slit("hello"), "index", vec![slit("z")])),
+        // "old".replace("new") → "new"
+        print_stmt(method(slit("old"), "replace", vec![slit("new")])),
+        // "hi".start_with?("h") → #t
+        print_stmt(method(slit("hi"), "start_with?", vec![slit("h")])),
+        // "abc".reverse → "cba"
+        print_stmt(method(slit("abc"), "reverse", vec![])),
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![main])
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_go(source: &str, tag: &str) -> std::process::Output {
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_strm_{tag}_{nonce}.go"));
+    std::fs::write(&src_path, source).expect("write temp source");
+    let out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    let _ = std::fs::remove_file(&src_path);
+    out
+}
+
+#[test]
+fn string_methods_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&catalog_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "catalog");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "Hello",      // "hello".capitalize
+            "Hello",      // "hELLO".capitalize
+            "hi",         // "hi\n".chomp
+            "hi",         // "hi\r\n".chomp
+            "hello",      // "hello!".chomp("!")
+            "[a, b, c]",  // "abc".chars
+            "[104, 105]", // "hi".bytes
+            "[a, b, c]",  // "a-b-c".split("-")
+            "f0obar",     // "foobar".sub("o","0")
+            "f00bar",     // "foobar".gsub("o","0")
+            "2",          // "hello".index("l")
+            "nil",        // "hello".index("z")
+            "new",        // "old".replace("new")
+            "#t",         // "hi".start_with?("h")
+            "cba",        // "abc".reverse
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Runtime-only stdlib-breadth (String family) for the **Go** backend, parity with Python/TS. Sibling to the Rust String PR.

`_sir_string_method` already had `upcase`/`downcase`/`reverse`/`strip`/`chars`/`split`/`start_with?`/`end_with?`/`include?`/`to_i`/`to_f`/`to_sym`. **Added** (exact reference-missing set): `capitalize` (rune-aware), `chomp`, `bytes`, `index` (rune offset), `replace`, `sub`/`gsub` (literal). Correctly skipped `center`/`ljust`/`tr`/`count`/… which aren't in the Python/TS reference catalog.

**Security review: 1 Low finding fixed** — `index`/`replace` indexed `args[0]` without a length guard (zero-arg call → Go panic); now `len(args)>0`-guarded (graceful nil/passthrough), matching the sibling methods. Otherwise clean: `capitalize`/`index` char-boundary-safe (`[]rune` / byte-boundary from `strings.Index`), `sub`/`gsub` literal (no regex/backref injection), explicit `switch` dispatch (no reflection), `bytes` fresh Seq.

Execution-proofed via `go run`. Full suite green.

Note: version 0.15.0 (same as Go siblings off main); rebase on 2nd+ Go merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)