### PR TITLE
feat(adj-ladder): rung-89 allergy skin-test-wheal (product of two binomials, (a+b)*(c-d))

### DIFF
--- a/code/specs/data/adj-ladder/rung89_skin_test_wheal/gen_items.py
+++ b/code/specs/data/adj-ladder/rung89_skin_test_wheal/gen_items.py
@@ -1,0 +1,239 @@
+"""Generate rung-89 (allergy skin-test-wheal reactivity index) items.json for the ADJ-LADDER.
+
+Rung 89 opens the **allergy / skin-test-wheal** panel on the quantitative band — the arithmetic of a skin-test
+reactivity index. A `wheal_diameter` and a `flare_rim` are ADDED into a total span, that span is multiplied by a net
+reaction — a `peak_reaction` minus a `trough_reaction` — and the result is the reactivity index. A **sum times a
+difference** introduces a genuinely NEW arithmetic shape on the ladder: a **product of two binomials** — `(a+b)*(c-d)`,
+i.e. `((a+b) * (c-d))`.
+
+This is genuinely new: no shipped shape ever multiplied a SUM by a DIFFERENCE — every prior shape that used a
+parenthesised binomial multiplied it by a single observed factor or divided by one (rung-67 `(a-b)*c/d`, rung-68
+`(a+b)*c/d`, rung-75 `(a-b)/c*d`, rung-76 `(a+b)/c*d`, rung-81 `(a+b)/c-d`, rung-82 `(a-b)/c+d`, rung-84 `(a+b)*c-d`) —
+never a binomial times ANOTHER binomial. `(a+b)*(c-d)` is the ladder's first **product of two binomials**. The operator
+order matters: `(a+b)*(c-d)` is `((a+b)*(c-d))` (each parenthesised group evaluates first, then the two groups
+multiply), NOT `(a+b)*c-d` (subtracting `d` OUTSIDE the product instead of inside the second factor) and NOT
+`(a-b)*(c+d)` (swapping which pair is summed and which is differenced) — the two distractors exploit exactly those
+confusions.
+
+The setup: a `wheal_diameter`, a `flare_rim`, a `peak_reaction`, and a `trough_reaction`. The reactivity index is:
+
+  REACTIVITY INDEX  (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)  [ sum times a difference ]
+  SPAN SUM          wheal_diameter + flare_rim                                         [ the total span, before scaling ]
+  NET REACTION      peak_reaction - trough_reaction                                    [ the net reaction, before scaling ]
+
+The **reactivity index** is what makes this rung distinctive — it is the ladder's first **product of two binomials**.
+(The span sum `a+b` and the net reaction `c-d` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 47-88 shipped their component sums/products/differences/ratios beside the headline
+figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the addition of the wheal diameter and the flare rim into a span, the subtraction of the trough
+reaction from the peak reaction into a net reaction, then the multiplication of the two (each binomial group before the
+multiply) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine
+change, exactly as rungs 8/16/.../87/88. This rung exercises the engine across **a product of two binomials** — the fact
+that `(a+b)*(c-d)` is `((a+b)*(c-d))` and NOT `(a+b)*c-d` and NOT `(a-b)*(c+d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `*`
+— **no structural constants** — so no numeric literal appears in any program, and neither the span sum, the net
+reaction, nor any reactivity figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`wheal_diameter`, `flare_rim`, `peak_reaction`, `trough_reaction`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (wheal_diameter + flare_rim) * peak_reaction - trough_reaction    subtract the trough reaction OUTSIDE the
+                                                                               product instead of inside the second
+                                                                               factor (the classic `(a+b)*(c-d)` vs
+                                                                               `(a+b)*c-d` error), and
+  SWAPPED    (wheal_diameter - flare_rim) * (peak_reaction + trough_reaction)  swap which pair is summed and which is
+                                                                               differenced — sum the reactions and take
+                                                                               the difference of the spans (`(a-b)*(c+d)`
+                                                                               instead of `(a+b)*(c-d)`),
+
+which are exactly the mistakes a student makes (dropping the parenthesis on the difference, or mispairing which group
+gets the sum and which gets the difference). Gold rotates A-E by index. QUERIED (used as gold) = the three real
+readouts; all five always appear as options.
+
+Distinctness and positivity: the tables keep the guards — `wheal_diameter > flare_rim >= 2` (so the span difference in
+the swapped slip stays positive) and `peak_reaction > trough_reaction >= 2` (so the net reaction is positive) — so every
+family member, including the headline reactivity index `(a+b)*(c-d)`, is strictly positive (a positive span times a
+positive net reaction, and likewise for the slips); the five family values are pairwise distinct with a comfortable
+margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (WHEAL_DIAMETER, FLARE_RIM, PEAK_REACTION, TROUGH_REACTION) — a wheal diameter and a flare rim to add into a total
+# span, and a peak reaction and a trough reaction whose difference is the net reaction, all plain positive numbers >= 2.
+# The tables satisfy the guards: wheal_diameter > flare_rim >= 2 (so the swapped slip's (a-b) stays positive) and
+# peak_reaction > trough_reaction >= 2 (so the net reaction (c-d) is positive). The five family values are asserted
+# pairwise-distinct below.
+TABLES = [
+    (3, 2, 5, 2),
+    (4, 2, 5, 2),
+    (4, 3, 6, 3),
+    (5, 2, 4, 2),
+    (5, 3, 4, 2),
+    (5, 4, 4, 2),
+    (6, 2, 4, 2),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, -, and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "reactivity_index",
+        "reactivity index (the total span times the net reaction)",
+        "(wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)",
+    ),
+    (
+        "span_sum",
+        "the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)",
+        "wheal_diameter + flare_rim",
+    ),
+    (
+        "net_reaction",
+        "the net reaction (the peak reaction minus the trough reaction, before scaling by the span)",
+        "peak_reaction - trough_reaction",
+    ),
+    (
+        "crossed",
+        "the total span times the peak reaction, MINUS the trough reaction, with the trough subtracted outside the product instead of inside the second factor (a wrong grouping)",
+        "(wheal_diameter + flare_rim) * peak_reaction - trough_reaction",
+    ),
+    (
+        "swapped",
+        "the wheal diameter MINUS the flare rim, times the peak reaction PLUS the trough reaction, swapping which pair is summed and which is differenced (a wrong pairing)",
+        "(wheal_diameter - flare_rim) * (peak_reaction + trough_reaction)",
+    ),
+]
+QUERIED = ["reactivity_index", "span_sum", "net_reaction"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(wheal_diameter, flare_rim, peak_reaction, trough_reaction):
+    # Operation order mirrors the ADJ programs exactly (each parenthesised binomial evaluates first, then the two groups
+    # multiply, so (a+b)*(c-d) evaluates as ((a+b)*(c-d))), so the Python option value and the engine result are the
+    # same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "reactivity_index": (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction),
+        "span_sum": wheal_diameter + flare_rim,
+        "net_reaction": peak_reaction - trough_reaction,
+        "crossed": (wheal_diameter + flare_rim) * peak_reaction - trough_reaction,
+        "swapped": (wheal_diameter - flare_rim) * (peak_reaction + trough_reaction),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for wheal_diameter, flare_rim, peak_reaction, trough_reaction in TABLES:
+        assert (
+            wheal_diameter > 0
+            and flare_rim > 0
+            and peak_reaction > 0
+            and trough_reaction > 0
+        ), (wheal_diameter, flare_rim, peak_reaction, trough_reaction)
+        fv = family_values(wheal_diameter, flare_rim, peak_reaction, trough_reaction)
+        # The tables satisfy the guards, so every family member is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, wheal_diameter, flare_rim, peak_reaction, trough_reaction, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    wheal_diameter,
+                    flare_rim,
+                    peak_reaction,
+                    trough_reaction,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                wheal_diameter,
+                flare_rim,
+                peak_reaction,
+                trough_reaction,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r89stw-{idx + 1:02d}",
+                "qtype": "skin_test_wheal_index",
+                "stem": (
+                    f"A skin test reads a wheal diameter of {num(wheal_diameter)} plus a flare rim of "
+                    f"{num(flare_rim)}, all scaled by a peak reaction of {num(peak_reaction)} minus a trough reaction "
+                    f"of {num(trough_reaction)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe wheal_diameter({num(wheal_diameter)})\n"
+                    f"observe flare_rim({num(flare_rim)})\n"
+                    f"observe peak_reaction({num(peak_reaction)})\n"
+                    f"observe trough_reaction({num(trough_reaction)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 89 — allergy skin-test-wheal reactivity index from four stated quantities (a NEW panel: "
+            "allergy / skin-test-wheal). From a wheal diameter and a flare rim to add into a total span and a peak "
+            "reaction and a trough reaction whose difference is the net reaction, compute the reactivity index "
+            "((wheal_diameter+flare_rim)*(peak_reaction-trough_reaction)), the span sum (wheal_diameter+flare_rim), or "
+            "the net reaction (peak_reaction-trough_reaction). Each item is a compute_dimensioned program (observe the "
+            "four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, PRODUCT OF TWO "
+            "BINOMIALS (a+b)*(c-d) (add a and b, subtract d from c, multiply the two groups, so (a+b)*(c-d) = "
+            "((a+b)*(c-d)); no prior shape multiplied a SUM by a DIFFERENCE — every earlier binomial shape, e.g. rung-67 "
+            "(a-b)*c/d, rung-68 (a+b)*c/d, and rung-84 (a+b)*c-d, multiplied or divided a binomial by a single observed "
+            "factor, never by another binomial) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via +, -, and * — no "
+            "constant leaks, and neither the span sum, the net reaction, nor any reactivity figure ever appears as a "
+            "literal (each is computed) — and the observed quantities carry digit-free identifiers so no numeral hides "
+            "inside a variable name. The five options are a family over the same four quantities, so the distractors are "
+            "exactly the slips students make: subtracting the trough reaction outside the product instead of inside the "
+            "second factor ((a+b)*c-d, a wrong grouping) and swapping which pair is summed and which is differenced "
+            "((a-b)*(c+d), a wrong pairing). The core confusion tested is that (a+b)*(c-d) is ((a+b)*(c-d)), not "
+            "(a+b)*c-d and not (a-b)*(c+d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung89_skin_test_wheal/items.json
+++ b/code/specs/data/adj-ladder/rung89_skin_test_wheal/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 89 \u2014 allergy skin-test-wheal reactivity index from four stated quantities (a NEW panel: allergy / skin-test-wheal). From a wheal diameter and a flare rim to add into a total span and a peak reaction and a trough reaction whose difference is the net reaction, compute the reactivity index ((wheal_diameter+flare_rim)*(peak_reaction-trough_reaction)), the span sum (wheal_diameter+flare_rim), or the net reaction (peak_reaction-trough_reaction). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OF TWO BINOMIALS (a+b)*(c-d) (add a and b, subtract d from c, multiply the two groups, so (a+b)*(c-d) = ((a+b)*(c-d)); no prior shape multiplied a SUM by a DIFFERENCE \u2014 every earlier binomial shape, e.g. rung-67 (a-b)*c/d, rung-68 (a+b)*c/d, and rung-84 (a+b)*c-d, multiplied or divided a binomial by a single observed factor, never by another binomial) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, -, and * \u2014 no constant leaks, and neither the span sum, the net reaction, nor any reactivity figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: subtracting the trough reaction outside the product instead of inside the second factor ((a+b)*c-d, a wrong grouping) and swapping which pair is summed and which is differenced ((a-b)*(c+d), a wrong pairing). The core confusion tested is that (a+b)*(c-d) is ((a+b)*(c-d)), not (a+b)*c-d and not (a-b)*(c+d).",
+  "items": [
+    {
+      "id": "r89stw-01",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 3 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(3)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-02",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 3 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(3)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-03",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 3 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(3)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-04",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-05",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-06",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-07",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 3, all scaled by a peak reaction of 6 minus a trough reaction of 3. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(3)\nobserve peak_reaction(6)\nobserve trough_reaction(3)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-08",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 3, all scaled by a peak reaction of 6 minus a trough reaction of 3. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(3)\nobserve peak_reaction(6)\nobserve trough_reaction(3)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-09",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 3, all scaled by a peak reaction of 6 minus a trough reaction of 3. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(3)\nobserve peak_reaction(6)\nobserve trough_reaction(3)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-10",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-11",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-12",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-13",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 3, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(3)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-14",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 3, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(3)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-15",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 3, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(3)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-16",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 4, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(4)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-17",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 4, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(4)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-18",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 4, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(4)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-19",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 6 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(6)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-20",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 6 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(6)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-21",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 6 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(6)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -126,6 +126,7 @@ SELF_CONTAINED_RUNGS = (
     "rung86_joint_fluid",
     "rung87_complement_titer",
     "rung88_nerve_conduction",
+    "rung89_skin_test_wheal",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-89 — allergy skin-test-wheal reactivity index (product of two binomials, `(a+b)*(c-d)`)

Next quantitative rung on the ADJ-LADDER. Opens a **NEW clinical panel — allergy / skin-test-wheal** and introduces a **genuinely new arithmetic shape**: a **product of two binomials** — a sum times a difference, `(a+b)*(c-d)` = `((a+b) * (c-d))` (each parenthesised group evaluates first, then the two groups multiply).

### The shape (new on the ladder) — the first sum-times-a-difference
Shapes shipped through rung-88: 67 `(a-b)*c/d`, 68 `(a+b)*c/d`, 69 `a*b/c+d`, 70 `a*b/c-d`, 71 `a/b*c+d`, 72 `a/b*c-d`, 73 `a-b/c*d`, 74 `a+b/c*d`, 75 `(a-b)/c*d`, 76 `(a+b)/c*d`, 77 `a/b+c*d`, 78 `a/b-c*d`, 79 `a*b+c/d`, 80 `a*b-c/d`, 81 `(a+b)/c-d`, 82 `(a-b)/c+d`, 83 `a-b*c/d`, 84 `(a+b)*c-d`, 85 `a*b-c-d`, 86 `a*b*c-d`, 87 `a*b*c/d`, 88 `a*b*c+d`. Rung-89 = **`(a+b)*(c-d)`**, genuinely new: it is the ladder's **first product of two binomials**. Every prior shape that used a parenthesised binomial multiplied it (or divided it) by a **single** observed factor — rung-67 `(a-b)*c/d`, rung-68 `(a+b)*c/d`, rung-75 `(a-b)/c*d`, rung-76 `(a+b)/c*d`, rung-81 `(a+b)/c-d`, rung-82 `(a-b)/c+d`, rung-84 `(a+b)*c-d`. None ever multiplied a **sum** by a **difference** — a binomial times *another* binomial.

### The panel
Four observed quantities: `wheal_diameter`, `flare_rim`, `peak_reaction`, `trough_reaction`. A total span is the sum of the wheal diameter and the flare rim; a net reaction is the peak minus the trough; the reactivity index is their product:

| readout | formula | |
|---|---|---|
| **reactivity index** (headline) | `(wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)` | sum times a difference |
| span sum | `wheal_diameter + flare_rim` | the total span, before scaling |
| net reaction | `peak_reaction - trough_reaction` | the net reaction, before scaling |

Each item is a constant-free `compute_dimensioned` program (`observe` four quantities + `let answer = formula`); the ADJ engine carries the arithmetic (a sum, a difference, then a multiply) and the harness reads the scalar via the existing `compute_dimensioned` extractor. **No harness/engine change** — exactly as rungs 8/16/…/87/88.

### 5-member mutually-confusable family (over the SAME four quantities)
3 real readouts (queried as gold) + 2 classic student slips:
- **crossed** `(wheal_diameter + flare_rim) * peak_reaction - trough_reaction` — subtract the trough reaction OUTSIDE the product instead of inside the second factor (`(a+b)*(c-d)` vs `(a+b)*c-d`, dropping the parenthesis on the difference).
- **swapped** `(wheal_diameter - flare_rim) * (peak_reaction + trough_reaction)` — swap which pair is summed and which is differenced (`(a+b)*(c-d)` vs `(a-b)*(c+d)`, a wrong pairing).

Gold rotates A–E via `gold_pos = idx % 5`; 7 tables × 3 queried = **21 items**. The tables keep the guards — `wheal_diameter > flare_rim >= 2` (so the swapped slip's `(a-b)` stays positive) and `peak_reaction > trough_reaction >= 2` (so the net reaction `(c-d)` is positive) — so every family member, including the headline `(a+b)*(c-d)`, is strictly positive; the five values are pairwise-distinct (>1e-6, global min margin 2 across all tables) asserted at build. **Contamination-safe**: no numeric constant in any program; every figure computed from the observed quantities; DIGIT-FREE identifiers.

### Verification
- `python3 gen_items.py` from the rung subdir → `wrote items.json: 21 items`.
- `python3 -m pytest test_ladder_eval.py -k rung89 -q` → **3 passed** (the 3 self-contained-rung parametrized gates; adj-lang-cli built first so the compute test runs, not skips).
- `rung89_skin_test_wheal` registered in the `SELF_CONTAINED_RUNGS` tuple.

3 files: `rung89_skin_test_wheal/gen_items.py`, `rung89_skin_test_wheal/items.json`, `test_ladder_eval.py` (one tuple line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
