### PR TITLE
feat(engram): HTML tag-strip scanner — reduce regex use (Phase C2)

### DIFF
--- a/code/packages/rust/engram-core/CHANGELOG.md
+++ b/code/packages/rust/engram-core/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### HTML tag-strip no longer uses `regex` (zero-dep step)
+
+`rendered_search_text` (search) stripped HTML tags with the `regex` pattern
+`(?is)<[^>]+>`. That step is now the hand-written `html_scan::strip_tags`
+scanner, byte-for-byte verified against the live `regex` across 300k random
+strings. The `regex` dependency is **not yet removed** — the media-tag pattern
+and the search-match pipeline (glob/whole-word/`re:`) still use it and are
+scheduled for the zero-dep regex engine (Phase D). Part of the Engram
+zero-dependency program (`code/specs/engram-zero-dep-plan.md`, Phase C2).
+
 ### Removed third-party `unicode-normalization` — NFD/NFC is now zero-dep
 
 Accent-stripping and canonical de-duplication in `search.rs` and `template.rs`

--- a/code/packages/rust/engram-core/src/html_scan.rs
+++ b/code/packages/rust/engram-core/src/html_scan.rs
@@ -1,0 +1,155 @@
+//! # `html_scan` — a hand-written HTML-tag stripper for search-text rendering
+//!
+//! Anki stores flashcard fields as HTML. When searching, that HTML is reduced to
+//! plain text. One step of that reduction is stripping every tag — turning
+//! `Hello <b>world</b>` into `Hello world`. This used to be done with the
+//! `regex` pattern `(?is)<[^>]+>`; as part of the Engram zero-dependency program
+//! we replace it with an explicit scanner so the crate needs no regular-
+//! expression engine for this step.
+//!
+//! The pattern `<[^>]+>` is simple enough to reproduce exactly: from each `<`,
+//! find the next `>`; if there is at least one character between them, that whole
+//! `<…>` span is a tag and is removed. (`<>` — nothing between the brackets — is
+//! *not* a tag, because `[^>]+` requires at least one character, so it is left
+//! as-is.) The `(?is)` flags do not change anything here: `s` (dot-matches-
+//! newline) is irrelevant because `[^>]` already includes newlines, and there is
+//! no case-sensitive literal to fold. Verified byte-for-byte against the original
+//! `regex` across a large random corpus.
+//!
+//! The *media-tag* handling (extracting a filename from `<img src=…>` etc.) is
+//! deliberately **not** reimplemented here: its original regex relies on
+//! alternation and quoted values that can span `>`, whose exact backtracking is
+//! best reproduced by a general regex engine rather than a bespoke scanner. It
+//! is handled by the forthcoming zero-dependency regex engine (Phase D) together
+//! with the search-matching patterns.
+
+/// Strip every `<…>` tag — a `<`, at least one non-`>` character, then a `>` —
+/// leaving the text between tags untouched. Equivalent to the original
+/// `Regex::new(r"(?is)<[^>]+>").replace_all(value, "")`.
+///
+/// Between tags we copy validated `&str` slices of the input, so multi-byte
+/// UTF-8 passes through intact (`<` and `>` are ASCII, so every cut lands on a
+/// character boundary).
+pub(crate) fn strip_tags(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(value.len());
+    let mut i = 0;
+    let mut copied = 0; // start of the not-yet-copied region
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            // `<[^>]+>`: need ≥1 non-`>` char, then a `>`.
+            match bytes[i + 1..].iter().position(|&b| b == b'>') {
+                Some(rel) if rel >= 1 => {
+                    out.push_str(&value[copied..i]);
+                    i = i + 1 + rel + 1; // resume just past the `>`
+                    copied = i;
+                    continue;
+                }
+                // `<>` (rel == 0) is not a tag; skip just this `<`.
+                Some(_) => {
+                    i += 1;
+                    continue;
+                }
+                // No `>` in the remainder — and since every later position's tail
+                // is a suffix of this one, no `<` at or after `i` can find a `>`
+                // either. Stop scanning. (Without this, a run of `<` with no `>`
+                // would re-scan the tail per `<`, an O(n²) DoS on hostile input.)
+                None => break,
+            }
+        }
+        i += 1;
+    }
+    out.push_str(&value[copied..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_tags;
+    use regex::Regex;
+
+    fn tag_re() -> Regex {
+        Regex::new(r"(?is)<[^>]+>").unwrap()
+    }
+
+    #[test]
+    fn basics() {
+        assert_eq!(strip_tags("<b>hi</b> there"), "hi there");
+        assert_eq!(strip_tags("a<br>b"), "ab");
+        // `<>` is not a tag (`[^>]+` needs ≥1 char between the brackets).
+        assert_eq!(strip_tags("a<>b"), "a<>b");
+        // A `<` with no following `>` is left alone.
+        assert_eq!(strip_tags("a < b"), "a < b");
+        // Multi-byte content survives; only the tags are removed.
+        assert_eq!(strip_tags("café<i>x</i>"), "caféx");
+        // `[^>]` spans newlines (the `s` flag is a no-op here).
+        assert_eq!(strip_tags("a<b\nc>d"), "ad");
+    }
+
+    // Deterministic LCG — no rng dependency.
+    struct Lcg(u64);
+    impl Lcg {
+        fn n(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0 >> 16
+        }
+    }
+
+    #[test]
+    fn long_unterminated_angle_run_is_linear_and_correct() {
+        // Regression guard for the O(n²) DoS: a long run of `<` with no `>` must
+        // be returned unchanged (no tag) and must not re-scan the tail per `<`.
+        let s: String = std::iter::repeat_n('<', 200_000).collect();
+        let start = std::time::Instant::now();
+        let out = strip_tags(&s);
+        let dt = start.elapsed();
+        assert_eq!(out, s); // no `>` anywhere ⇒ nothing is a tag
+        assert!(dt.as_millis() < 200, "strip_tags not linear: {dt:?}");
+        // Mixed: many `<`, one `>` near the end forms exactly one tag.
+        let mut m = "<".repeat(100_000);
+        m.push_str(">tail");
+        assert_eq!(strip_tags(&m), "tail");
+    }
+
+    #[test]
+    fn matches_regex_across_random_corpus() {
+        let toks = [
+            "<",
+            ">",
+            "<b>",
+            "</b>",
+            "<br>",
+            "<>",
+            "a",
+            "b",
+            "café",
+            " ",
+            "\n",
+            "\t",
+            "<i",
+            "x>",
+            "hello",
+            "<img src=",
+            "\"y\"",
+            "z",
+            "<<",
+            ">>",
+            "</",
+            "/>",
+        ];
+        let re = tag_re();
+        let mut rng = Lcg(0x5CA1AB1E);
+        for _ in 0..300_000 {
+            let len = 1 + (rng.n() % 14) as usize;
+            let s: String = (0..len)
+                .map(|_| toks[(rng.n() as usize) % toks.len()])
+                .collect();
+            let mine = strip_tags(&s);
+            let re_out = re.replace_all(&s, "").into_owned();
+            assert_eq!(mine, re_out, "strip mismatch on {s:?}");
+        }
+    }
+}

--- a/code/packages/rust/engram-core/src/lib.rs
+++ b/code/packages/rust/engram-core/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod csv;
 mod history;
+mod html_scan;
 mod media;
 mod merge;
 mod model;

--- a/code/packages/rust/engram-core/src/search.rs
+++ b/code/packages/rust/engram-core/src/search.rs
@@ -23,8 +23,6 @@ static DUPLICATE_HTML_MEDIA_TAGS: LazyLock<Regex> = LazyLock::new(|| {
     .expect("duplicate media tag regex should compile")
 });
 
-static DUPLICATE_HTML_TAGS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?is)<[^>]+>").expect("html tag regex should compile"));
 const FSRS5_DEFAULT_DECAY: f64 = 0.5;
 const SECONDS_PER_DAY: i64 = 86_400;
 const ANKI_TYPE_NEW: i64 = 0;
@@ -2281,7 +2279,7 @@ fn rendered_search_text(value: &str) -> Cow<'_, str> {
             .map_or("", |capture| capture.as_str());
         format!(" {filename} ")
     });
-    let without_tags = DUPLICATE_HTML_TAGS.replace_all(&with_media, "");
+    let without_tags = crate::html_scan::strip_tags(&with_media);
     Cow::Owned(decode_search_html_entities(&without_tags))
 }
 

--- a/code/specs/engram-zero-dep-plan.md
+++ b/code/specs/engram-zero-dep-plan.md
@@ -90,16 +90,32 @@ Effort: S ≈ ½ day, M ≈ 1–2 days, L ≈ several days / multiple PRs.
   vs the live upstream crate across **every scalar value** (~1.1M code points) +
   200k random strings — zero mismatches. engram-core swapped (2 `use` lines +
   Cargo.toml); 167 tests pass; `unicode-normalization` gone.
-- **C2 — TODO (removes most of `regex`).** Hand-write the HTML-tag scanner
-  (`<[^>]+>` strip + the duplicate-media-tag `replace_all`) and the `*`/`_` glob
-  matcher for search patterns. Leaves only the true `re:` engine for Phase D.
+- **C2 — ✅ PARTIAL (tag-strip scanner only).** New `engram-core::html_scan`
+  reimplements the `<[^>]+>` tag-strip (`DUPLICATE_HTML_TAGS`) as an explicit
+  scanner, byte-verified vs the live `regex` across 300k random strings. The
+  `regex` **dep stays** (still used by the media pattern + the search-match
+  pipeline).
+  - **Scope correction:** the *media* pattern
+    (`DUPLICATE_HTML_MEDIA_TAGS`) and the `*`/`_` glob were originally slated as
+    hand-scanners here, but they rely on regex **backtracking** that is a rabbit
+    hole to hand-emulate (quoted values crossing `>`; alternation × trailing-`>`
+    backtracking; `\s*` overlapping `[^ >]`). The right mechanism is the general
+    engine below — so media/glob/whole-word/`re:` **all move to Phase D**, which
+    now removes `regex` in one coherent step.
 - Character classes (`\p{Alphabetic}`/`\p{Mark}`/`\p{Nd}`) to add if/when the
-  regex work needs them; `is_combining_mark` (Mark) already shipped in C1.
+  regex engine needs them; `is_combining_mark` (Mark) already shipped in C1.
 
-### Phase D — `re:` regex engine (removes `regex` entirely) — L
-- Mini backtracking/NFA engine for the subset Anki users type in `re:` search
-  (`. * + ? [] () | ^ $ \d \w`, case-insensitive) + whole-word Unicode boundary.
-- Consider feature-gating/deferring `re:` if it lets `regex` drop after Phase C.
+### Phase D — zero-dep regex engine (removes `regex` entirely) — L
+- Build a small zero-dep backtracking/NFA regex engine covering the exact subset
+  engram-core uses: literals, `.`, `* + ?`, `[]`/`[^]`, `()`, `|`, `^ $`,
+  `\d \w \s`, case-insensitive + dot-all flags, capture groups, and
+  `replace_all` — enough to execute **all** current patterns: the media tag
+  pattern, the glob-compiled search patterns, whole-word Unicode boundary, and
+  user `re:` search.
+- Cross-verify against the live `regex` on every current pattern + random
+  corpora, then swap all `Regex`/`RegexBuilder`/`regex::escape` uses and **drop
+  `regex`**. This subsumes the C2 media/glob work (byte-exactness by correct
+  engine semantics, not per-pattern hand-emulation).
 
 ### Phase E — sqlite-file reader (unblocks rusqlite-free **import**) — L (PRs A1–A5)
 Per `code/specs/storage-sqlite.md` + the Python `storage-sqlite` port:

--- a/lessons.md
+++ b/lessons.md
@@ -1298,3 +1298,35 @@ with a from-scratch zero-dep `code/packages/rust/unicode-normalize` (NFD/NFC +
   compose via the same arithmetic.
 
 Discovered: 2026-07-03, Engram zero-dep Phase C1 (drop `unicode-normalization`).
+
+---
+
+## Don't hand-emulate a specific regex's backtracking — reach for the engine
+
+Context: Phase C2 of the Engram zero-dep program aimed to hand-write scanners
+replacing the two HTML-tag regexes in `engram-core` search-text rendering.
+
+**Lessons:**
+- **A hand scanner can replace a *simple* regex, but not a backtracking one.**
+  The tag-strip `(?is)<[^>]+>` has no alternation/backreference/overlap, so a
+  two-pointer scanner reproduces it byte-for-byte (verified vs live `regex` on
+  300k random strings). But the media pattern
+  `<(?:img|…)[^>]*(?:src|data)\s*=\s*(?:"([^"]+)"|'([^']+)'|([^ >]+))[^>]*>`
+  hides layered backtracking that a fuzz cross-check exposed one corner at a
+  time: (1) a **quoted value `[^"]+` crosses `>`**, so the tag end isn't the
+  first `>`; (2) when the quoted alt yields no trailing `>`, the regex
+  **backtracks through the alternation** to the bare `[^ >]+`; (3) `\s*` and the
+  value class `[^ >]` **overlap** (tab ∈ both), so greedy `\s*` gives a tab back
+  to the value. Each fix surfaced the next corner — a sign you're reimplementing
+  a regex engine badly.
+- **When you catch yourself hand-emulating quantifier/alternation backtracking,
+  stop and build/adopt the general engine.** The right move was to descope: ship
+  only the trivially-exact tag-strip scanner now, and move the media pattern (plus
+  glob/whole-word/`re:`) to the planned zero-dep regex *engine*, where correct
+  semantics give byte-exactness for free instead of per-pattern emulation.
+- **The randomized cross-check earned its keep**: every divergence was a
+  malformed-HTML input a human would never think to unit-test. Fuzz vs the real
+  library before trusting a reimplementation — and read the *first* divergence
+  carefully; it usually reveals a structural misunderstanding, not an off-by-one.
+
+Discovered: 2026-07-03, Engram zero-dep Phase C2 (HTML tag scanners).


### PR DESCRIPTION
## Phase C2 of the Engram zero-dependency program

Replaces the `regex` pattern `(?is)<[^>]+>` (HTML tag stripping in search-text rendering) with an explicit zero-dep scanner, `engram-core::html_scan::strip_tags`. Follows C1 (drop `unicode-normalization`, #7694). Plan: `code/specs/engram-zero-dep-plan.md`.

### What
- New `html_scan` module — `strip_tags`: from each `<`, find the next `>`; if ≥1 char between, drop that `<…>` span. Copies validated `&str` slices between tags, so multi-byte UTF-8 is preserved. Literate docs.
- `search.rs` uses it for the tag-strip step (the media-tag `regex` is unchanged).

### Verification
- **Byte-for-byte** verified against the live `regex` across **300k random strings**.
- **Security review found + this fixes a HIGH DoS**: the initial scanner re-scanned the tail for every `<` when no `>` followed — O(n²) on hostile input like `<<<<…` (**82s at 800K chars**, a regression vs the linear RE2 `regex`). Fixed by breaking the scan when the remainder has no `>` (no later `<` can find one either): provably **byte-equivalent**, now **linear** (200K `<` in <1ms). Regression test added. No unsafe; all indexing/slicing proven panic-free and UTF-8-boundary-safe.
- All **170 `engram-core` tests** pass; clippy/fmt clean.

### Scope correction (honest note)
The *media* tag pattern and the `*`/`_` glob were originally slated as scanners here too, but a fuzz cross-check exposed layered regex **backtracking** (quoted values crossing `>`; alternation × trailing-`>`; `\s*` overlapping `[^ >]`) that is a rabbit hole to hand-emulate. They move to **Phase D's zero-dep regex engine**, which removes `regex` wholesale via correct semantics. So **`regex` stays a dependency this PR** — this is a surface-reduction step, not the dep removal. Spec + lessons.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)