### PR TITLE
feat(adj-ladder): rung-90 spirometry ventilatory reserve (product of two differences (a-b)*(c-d))

### DIFF
--- a/code/specs/data/adj-ladder/rung90_spirometry_reserve/gen_items.py
+++ b/code/specs/data/adj-ladder/rung90_spirometry_reserve/gen_items.py
@@ -1,0 +1,239 @@
+"""Generate rung-90 (pulmonary-function / spirometry ventilatory reserve index) items.json for the ADJ-LADDER.
+
+Rung 90 opens the **pulmonary-function / spirometry** panel on the quantitative band — the arithmetic of a ventilatory
+reserve index. A `forced_volume` minus a `residual_volume` gives a usable capacity span, a `peak_flow` minus a
+`trough_flow` gives a flow span, and the two spans MULTIPLY into the reserve index. A **difference times a difference**
+introduces a genuinely NEW arithmetic shape on the ladder: the **product of two DIFFERENCES** — `(a-b)*(c-d)`, i.e.
+`((a-b)*(c-d))`.
+
+This is genuinely new and completes the binomial-product family opened at rung-89. Rung-89 shipped the ladder's first
+product of two binomials as a SUM times a DIFFERENCE (`(a+b)*(c-d)`); rung-90 ships the DIFFERENCE times a DIFFERENCE
+(`(a-b)*(c-d)`) — no shipped shape ever multiplied a difference by ANOTHER difference. Every earlier shape that used a
+parenthesised binomial either multiplied/divided it by a single observed factor (rung-67 `(a-b)*c/d`, rung-68
+`(a+b)*c/d`, rung-75 `(a-b)/c*d`, rung-76 `(a+b)/c*d`, rung-81 `(a+b)/c-d`, rung-82 `(a-b)/c+d`, rung-84 `(a+b)*c-d`) or,
+at rung-89, multiplied a SUM by a difference (`(a+b)*(c-d)`) — never a difference by another difference. `(a-b)*(c-d)` is
+the ladder's first **product of two differences**. The operator order matters: `(a-b)*(c-d)` is `((a-b)*(c-d))` (each
+parenthesised group evaluates first, then the two groups multiply), NOT `(a-b)*c-d` (subtracting `d` OUTSIDE the product
+instead of inside the second factor) and NOT `(a+b)*(c-d)` (summing the first pair instead of differencing it) — the two
+distractors exploit exactly those confusions.
+
+The setup: a `forced_volume`, a `residual_volume`, a `peak_flow`, and a `trough_flow`. The reserve index is:
+
+  RESERVE INDEX   (forced_volume - residual_volume) * (peak_flow - trough_flow)  [ capacity span times flow span ]
+  CAPACITY SPAN   forced_volume - residual_volume                                [ the usable capacity, before scaling ]
+  FLOW SPAN       peak_flow - trough_flow                                        [ the flow span, before scaling ]
+
+The **reserve index** is what makes this rung distinctive — it is the ladder's first **product of two differences**.
+(The capacity span `a-b` and the flow span `c-d` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 47-89 shipped their component sums/products/differences/ratios beside the headline
+figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the subtraction of the residual volume from the forced volume into a capacity span, the
+subtraction of the trough flow from the peak flow into a flow span, then the multiplication of the two (each difference
+group before the multiply) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No
+harness/engine change, exactly as rungs 8/16/.../88/89. This rung exercises the engine across **a product of two
+differences** — the fact that `(a-b)*(c-d)` is `((a-b)*(c-d))` and NOT `(a-b)*c-d` and NOT `(a+b)*(c-d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `*`
+— **no structural constants** — so no numeric literal appears in any program, and neither the capacity span, the flow
+span, nor any reserve figure is ever a literal (each is computed from the observed quantities). The observed quantities
+carry **digit-free identifiers** (`forced_volume`, `residual_volume`, `peak_flow`, `trough_flow`) so no numeral hides
+inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (forced_volume - residual_volume) * peak_flow - trough_flow    subtract the trough flow OUTSIDE the product
+                                                                            instead of inside the second factor (the
+                                                                            classic `(a-b)*(c-d)` vs `(a-b)*c-d` error),
+                                                                            and
+  SWAPPED    (forced_volume + residual_volume) * (peak_flow - trough_flow)  sum the first pair instead of differencing
+                                                                            it — add the volumes rather than subtract
+                                                                            (`(a+b)*(c-d)` instead of `(a-b)*(c-d)`),
+
+which are exactly the mistakes a student makes (dropping the parenthesis on the second difference, or summing the first
+pair when it should be differenced). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all
+five always appear as options.
+
+Distinctness and positivity: the tables keep the guards — `forced_volume > residual_volume >= 2` (so the capacity span
+is positive) and `peak_flow > trough_flow >= 2` (so the flow span is positive) — so every family member, including the
+headline reserve index `(a-b)*(c-d)`, is strictly positive (a positive capacity span times a positive flow span, and
+likewise for the slips); the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (FORCED_VOLUME, RESIDUAL_VOLUME, PEAK_FLOW, TROUGH_FLOW) — a forced volume and a residual volume whose difference is
+# the usable capacity span, and a peak flow and a trough flow whose difference is the flow span, all plain positive
+# numbers >= 2. The tables satisfy the guards: forced_volume > residual_volume >= 2 (so the capacity span (a-b) stays
+# positive) and peak_flow > trough_flow >= 2 (so the flow span (c-d) is positive). The five family values are asserted
+# pairwise-distinct below.
+TABLES = [
+    (4, 2, 6, 2),
+    (5, 2, 7, 2),
+    (5, 3, 7, 3),
+    (6, 2, 4, 2),
+    (6, 3, 8, 2),
+    (6, 4, 8, 3),
+    (7, 2, 5, 2),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, -, and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "reserve_index",
+        "ventilatory reserve index (the capacity span times the flow span)",
+        "(forced_volume - residual_volume) * (peak_flow - trough_flow)",
+    ),
+    (
+        "capacity_span",
+        "the capacity span (the forced volume minus the residual volume, before scaling by the flow span)",
+        "forced_volume - residual_volume",
+    ),
+    (
+        "flow_span",
+        "the flow span (the peak flow minus the trough flow, before scaling by the capacity span)",
+        "peak_flow - trough_flow",
+    ),
+    (
+        "crossed",
+        "the capacity span times the peak flow, MINUS the trough flow, with the trough subtracted outside the product instead of inside the second factor (a wrong grouping)",
+        "(forced_volume - residual_volume) * peak_flow - trough_flow",
+    ),
+    (
+        "swapped",
+        "the forced volume PLUS the residual volume, times the peak flow minus the trough flow, summing the first pair instead of differencing it (a wrong pairing)",
+        "(forced_volume + residual_volume) * (peak_flow - trough_flow)",
+    ),
+]
+QUERIED = ["reserve_index", "capacity_span", "flow_span"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(forced_volume, residual_volume, peak_flow, trough_flow):
+    # Operation order mirrors the ADJ programs exactly (each parenthesised difference evaluates first, then the two
+    # groups multiply, so (a-b)*(c-d) evaluates as ((a-b)*(c-d))), so the Python option value and the engine result are
+    # the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "reserve_index": (forced_volume - residual_volume) * (peak_flow - trough_flow),
+        "capacity_span": forced_volume - residual_volume,
+        "flow_span": peak_flow - trough_flow,
+        "crossed": (forced_volume - residual_volume) * peak_flow - trough_flow,
+        "swapped": (forced_volume + residual_volume) * (peak_flow - trough_flow),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for forced_volume, residual_volume, peak_flow, trough_flow in TABLES:
+        assert (
+            forced_volume > 0
+            and residual_volume > 0
+            and peak_flow > 0
+            and trough_flow > 0
+        ), (forced_volume, residual_volume, peak_flow, trough_flow)
+        fv = family_values(forced_volume, residual_volume, peak_flow, trough_flow)
+        # The tables satisfy the guards, so every family member is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, forced_volume, residual_volume, peak_flow, trough_flow, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    forced_volume,
+                    residual_volume,
+                    peak_flow,
+                    trough_flow,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                forced_volume,
+                residual_volume,
+                peak_flow,
+                trough_flow,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r90spr-{idx + 1:02d}",
+                "qtype": "spirometry_reserve_index",
+                "stem": (
+                    f"A spirometry study reads a forced volume of {num(forced_volume)} minus a residual volume of "
+                    f"{num(residual_volume)}, all scaled by a peak flow of {num(peak_flow)} minus a trough flow "
+                    f"of {num(trough_flow)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe forced_volume({num(forced_volume)})\n"
+                    f"observe residual_volume({num(residual_volume)})\n"
+                    f"observe peak_flow({num(peak_flow)})\n"
+                    f"observe trough_flow({num(trough_flow)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 90 — pulmonary-function spirometry ventilatory reserve index from four stated quantities (a "
+            "NEW panel: pulmonary-function / spirometry). From a forced volume and a residual volume whose difference is "
+            "the usable capacity span and a peak flow and a trough flow whose difference is the flow span, compute the "
+            "reserve index ((forced_volume-residual_volume)*(peak_flow-trough_flow)), the capacity span "
+            "(forced_volume-residual_volume), or the flow span (peak_flow-trough_flow). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW shape, PRODUCT OF TWO DIFFERENCES (a-b)*(c-d) (subtract b from a, subtract d from c, "
+            "multiply the two groups, so (a-b)*(c-d) = ((a-b)*(c-d)); no prior shape multiplied a DIFFERENCE by another "
+            "DIFFERENCE — every earlier binomial shape multiplied or divided a binomial by a single observed factor, and "
+            "rung-89 (a+b)*(c-d) multiplied a SUM by a difference, never a difference by another difference) — and the "
+            "harness matches the scalar to the printed options. Contamination-safe: every index is built only from the "
+            "four observed quantities via +, -, and * — no constant leaks, and neither the capacity span, the flow span, "
+            "nor any reserve figure ever appears as a literal (each is computed) — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the "
+            "same four quantities, so the distractors are exactly the slips students make: subtracting the trough flow "
+            "outside the product instead of inside the second factor ((a-b)*c-d, a wrong grouping) and summing the first "
+            "pair instead of differencing it ((a+b)*(c-d), a wrong pairing). The core confusion tested is that "
+            "(a-b)*(c-d) is ((a-b)*(c-d)), not (a-b)*c-d and not (a+b)*(c-d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung90_spirometry_reserve/items.json
+++ b/code/specs/data/adj-ladder/rung90_spirometry_reserve/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 90 \u2014 pulmonary-function spirometry ventilatory reserve index from four stated quantities (a NEW panel: pulmonary-function / spirometry). From a forced volume and a residual volume whose difference is the usable capacity span and a peak flow and a trough flow whose difference is the flow span, compute the reserve index ((forced_volume-residual_volume)*(peak_flow-trough_flow)), the capacity span (forced_volume-residual_volume), or the flow span (peak_flow-trough_flow). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OF TWO DIFFERENCES (a-b)*(c-d) (subtract b from a, subtract d from c, multiply the two groups, so (a-b)*(c-d) = ((a-b)*(c-d)); no prior shape multiplied a DIFFERENCE by another DIFFERENCE \u2014 every earlier binomial shape multiplied or divided a binomial by a single observed factor, and rung-89 (a+b)*(c-d) multiplied a SUM by a difference, never a difference by another difference) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, -, and * \u2014 no constant leaks, and neither the capacity span, the flow span, nor any reserve figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: subtracting the trough flow outside the product instead of inside the second factor ((a-b)*c-d, a wrong grouping) and summing the first pair instead of differencing it ((a+b)*(c-d), a wrong pairing). The core confusion tested is that (a-b)*(c-d) is ((a-b)*(c-d)), not (a-b)*c-d and not (a+b)*(c-d).",
+  "items": [
+    {
+      "id": "r90spr-01",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 4 minus a residual volume of 2, all scaled by a peak flow of 6 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(4)\nobserve residual_volume(2)\nobserve peak_flow(6)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-02",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 4 minus a residual volume of 2, all scaled by a peak flow of 6 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(4)\nobserve residual_volume(2)\nobserve peak_flow(6)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-03",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 4 minus a residual volume of 2, all scaled by a peak flow of 6 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(4)\nobserve residual_volume(2)\nobserve peak_flow(6)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-04",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 2, all scaled by a peak flow of 7 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(2)\nobserve peak_flow(7)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 35,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-05",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 2, all scaled by a peak flow of 7 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(2)\nobserve peak_flow(7)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-06",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 2, all scaled by a peak flow of 7 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(2)\nobserve peak_flow(7)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 35,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-07",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 3, all scaled by a peak flow of 7 minus a trough flow of 3. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(3)\nobserve peak_flow(7)\nobserve trough_flow(3)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-08",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 3, all scaled by a peak flow of 7 minus a trough flow of 3. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(3)\nobserve peak_flow(7)\nobserve trough_flow(3)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-09",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 3, all scaled by a peak flow of 7 minus a trough flow of 3. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(3)\nobserve peak_flow(7)\nobserve trough_flow(3)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-10",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 2, all scaled by a peak flow of 4 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(2)\nobserve peak_flow(4)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-11",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 2, all scaled by a peak flow of 4 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(2)\nobserve peak_flow(4)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-12",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 2, all scaled by a peak flow of 4 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(2)\nobserve peak_flow(4)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-13",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 3, all scaled by a peak flow of 8 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(3)\nobserve peak_flow(8)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 54,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-14",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 3, all scaled by a peak flow of 8 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(3)\nobserve peak_flow(8)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 54,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-15",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 3, all scaled by a peak flow of 8 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(3)\nobserve peak_flow(8)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-16",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 4, all scaled by a peak flow of 8 minus a trough flow of 3. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(4)\nobserve peak_flow(8)\nobserve trough_flow(3)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-17",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 4, all scaled by a peak flow of 8 minus a trough flow of 3. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(4)\nobserve peak_flow(8)\nobserve trough_flow(3)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-18",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 4, all scaled by a peak flow of 8 minus a trough flow of 3. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(4)\nobserve peak_flow(8)\nobserve trough_flow(3)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-19",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 7 minus a residual volume of 2, all scaled by a peak flow of 5 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(7)\nobserve residual_volume(2)\nobserve peak_flow(5)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 27,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-20",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 7 minus a residual volume of 2, all scaled by a peak flow of 5 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(7)\nobserve residual_volume(2)\nobserve peak_flow(5)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-21",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 7 minus a residual volume of 2, all scaled by a peak flow of 5 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(7)\nobserve residual_volume(2)\nobserve peak_flow(5)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 27,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -127,6 +127,7 @@ SELF_CONTAINED_RUNGS = (
     "rung87_complement_titer",
     "rung88_nerve_conduction",
     "rung89_skin_test_wheal",
+    "rung90_spirometry_reserve",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-90 — pulmonary-function / spirometry ventilatory reserve index (product of two differences `(a-b)*(c-d)`)

Rung 90 opens a **new clinical panel — pulmonary-function / spirometry** — on the quantitative band, and ships a **genuinely new arithmetic shape: the product of two DIFFERENCES, `(a-b)*(c-d)`**.

### The new shape
This **completes the binomial-product family** opened at rung-89. Rung-89 shipped the ladder's first product of two binomials as a SUM times a DIFFERENCE (`(a+b)*(c-d)`); rung-90 ships the **DIFFERENCE times a DIFFERENCE** (`(a-b)*(c-d)`). No shipped shape ever multiplied a difference by *another* difference — every earlier binomial shape either multiplied/divided a binomial by a single observed factor (rung-67 `(a-b)*c/d`, rung-68 `(a+b)*c/d`, rung-75 `(a-b)/c*d`, rung-76 `(a+b)/c*d`, rung-81 `(a+b)/c-d`, rung-82 `(a-b)/c+d`, rung-84 `(a+b)*c-d`) or, at rung-89, multiplied a sum by a difference. `(a-b)*(c-d)` is `((a-b)*(c-d))` — each parenthesised difference evaluates first, then the two groups multiply.

### The panel
A `forced_volume` minus a `residual_volume` is a usable **capacity span**; a `peak_flow` minus a `trough_flow` is a **flow span**; the two spans multiply into the **ventilatory reserve index**.

| readout | formula |
|---|---|
| reserve index (headline) | `(forced_volume - residual_volume) * (peak_flow - trough_flow)` |
| capacity span (component) | `forced_volume - residual_volume` |
| flow span (component) | `peak_flow - trough_flow` |

All three real readouts are QUERIED as gold. Two classic student-slip distractors ride alongside:
- **crossed** `(forced_volume - residual_volume) * peak_flow - trough_flow` — subtract the trough flow *outside* the product instead of inside the second factor (the `(a-b)*(c-d)` vs `(a-b)*c-d` error).
- **swapped** `(forced_volume + residual_volume) * (peak_flow - trough_flow)` — *sum* the first pair instead of differencing it (`(a+b)*(c-d)` instead of `(a-b)*(c-d)`).

### Construction (mirrors rungs 8/16/…/88/89 exactly)
- Each item is a `compute_dimensioned` program: `observe` the four quantities + `let answer = formula` + `? answer`. The ADJ engine carries all arithmetic; the harness reads the scalar via the existing `compute_dimensioned` extractor. **No harness/engine change.**
- 7 tables × 3 queried readouts = **21 items**; gold rotates A–E by index.
- **Contamination-safe:** every formula is built only from the four observed quantities via `+`, `-`, `*` — no numeric constants leak into any program, and no readout is ever a literal (each is computed). Identifiers are **digit-free** (`forced_volume`, `residual_volume`, `peak_flow`, `trough_flow`) so no numeral hides inside a name.
- Build-time guards (`forced_volume > residual_volume >= 2`, `peak_flow > trough_flow >= 2`) make every one of the 5 family members strictly positive and pairwise-distinct with a comfortable margin.

### Verification
- `mise exec -- python3 gen_items.py` → `wrote items.json: 21 items`
- Registered `rung90_spirometry_reserve` in `SELF_CONTAINED_RUNGS` (after `rung89_skin_test_wheal`).
- `python3 -m pytest test_ladder_eval.py -k rung90 -q` → **3 passed** (with `adj-lang-cli` built, so the compute test runs rather than skipping).
- Inline security review: PASS (data-only fixture generator).

3 files: `rung90_spirometry_reserve/gen_items.py`, `rung90_spirometry_reserve/items.json`, `test_ladder_eval.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
