### PR TITLE
feat(spreadsheet-wasm): file open/save over the WASM ABI — bytes in/out (SSIO PR4)

### DIFF
--- a/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-core-wasm/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.15.0
+
+**Open & save CSV / TSV / JSON through the session (SSIOJSON01 wiring).** Extends
+the `.xlsx`/`.xls` file methods added in 0.14.0 with the delimited-text and JSON
+formats, so every front-end can open and save those too through the one facade.
+
+- `load_csv_bytes` / `load_tsv_bytes` / `load_json_bytes` `(&[u8]) -> bool` — open a
+  `.csv` / `.tsv` / `.json` file as the current document, reusing the same
+  snapshot path as the `.xlsx` methods (parse via `spreadsheet-io` into a fresh
+  engine workbook, serialize to canonical JSON, `deserialize`) — so the open is
+  undoable and rebuilds the formula-bar echo. Returns `false` on invalid UTF-8 /
+  malformed JSON (panic-free); a failed open leaves the document untouched.
+- `save_csv_bytes` / `save_tsv_bytes` / `save_json_bytes` `(&self) -> Vec<u8>` —
+  serialize the current document's first sheet to that format's bytes (RFC-4180
+  CSV; JSON array-of-record-objects). Pure computation.
+- Lower-fidelity than `.xlsx` in the ways `spreadsheet-io` documents (one sheet;
+  formulas flatten to their computed value), inherent to the formats.
+- 4 tests: CSV+TSV round-trip through the session, JSON records round-trip, and a
+  bad-bytes-preserves-document guard.
+
 ## 0.14.0
 
 **Open & save real spreadsheet files (SSIO03).** The session can now open and

--- a/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-core-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spreadsheet-core-wasm"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
-description = "Browser/WASM-facing string-in / JSON-out facade over spreadsheet-core, including real spreadsheet file open/save (.xlsx/.xls) via spreadsheet-io"
+description = "Browser/WASM-facing string-in / JSON-out facade over spreadsheet-core, including real spreadsheet file open/save (.xlsx/.xls/.csv/.tsv/.json) via spreadsheet-io"
 license = "MIT"
 
 [dependencies]

--- a/code/packages/rust/spreadsheet-core-wasm/README.md
+++ b/code/packages/rust/spreadsheet-core-wasm/README.md
@@ -50,6 +50,22 @@ A cell has two faces — what you *typed* (`=SUM(B1:B5)`) and what it *shows*
 (`46`). The engine owns the computed value; this facade keeps a small per-cell
 `raw` map so the formula bar can be repopulated with the source.
 
+### File open / save
+
+The session also opens and saves real files, not just its own JSON snapshot —
+via [`spreadsheet-io`](../spreadsheet-io):
+
+| method | in | out |
+|---|---|---|
+| `load_xlsx_bytes` / `load_xls_bytes` / `load_csv_bytes` / `load_tsv_bytes` / `load_json_bytes` | file bytes | `bool` (opened?) |
+| `save_xlsx_bytes` / `save_xls_bytes` / `save_csv_bytes` / `save_tsv_bytes` / `save_json_bytes` | — | file bytes |
+
+An open reuses the snapshot path (load → serialize → `deserialize`), so it is
+**undoable** and rebuilds the formula bar; a failed open (bad bytes / malformed
+JSON) returns `false` and leaves the document untouched. `.xlsx` keeps live
+formulas; `.xls`/CSV/TSV/JSON are lower-fidelity (one sheet, formulas flatten to
+their value) per `spreadsheet-io`.
+
 ## Safety
 
 - Text values are JSON-escaped (via `serde_json`), so a label like `a"b<c>`

--- a/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-core-wasm/src/lib.rs
@@ -895,6 +895,61 @@ impl SpreadsheetSession {
         spreadsheet_io::save_xls(&self.wb)
     }
 
+    // The delimited-text and JSON formats mirror the `.xlsx`/`.xls` pair above
+    // exactly: a load parses the bytes into a fresh engine workbook, serializes
+    // it to the engine's canonical JSON, and feeds that to `deserialize` (so the
+    // open is undoable and the formula-bar echo is rebuilt); a save is pure
+    // computation over the current workbook. They are lower-fidelity than
+    // `.xlsx` in the same ways `spreadsheet-io` documents (one sheet, formulas
+    // flatten to their computed value), which is inherent to the formats.
+
+    /// Open a `.csv` (comma-delimited) file as the current document. Each field
+    /// lands at its grid position; a numeric-looking field becomes a number,
+    /// else text. Returns `false` if the bytes are not valid UTF-8 / CSV.
+    pub fn load_csv_bytes(&mut self, bytes: &[u8]) -> bool {
+        match spreadsheet_io::load_csv(bytes) {
+            Ok(loaded) => self.deserialize(&loaded.serialize()),
+            Err(_) => false,
+        }
+    }
+
+    /// Serialize the current document's **first sheet** to `.csv` bytes (RFC
+    /// 4180 quoting; formulas as their computed value). Pure computation.
+    pub fn save_csv_bytes(&self) -> Vec<u8> {
+        spreadsheet_io::save_csv(&self.wb)
+    }
+
+    /// Open a `.tsv` (tab-delimited) file. Same semantics as
+    /// [`load_csv_bytes`](Self::load_csv_bytes) with a tab delimiter.
+    pub fn load_tsv_bytes(&mut self, bytes: &[u8]) -> bool {
+        match spreadsheet_io::load_tsv(bytes) {
+            Ok(loaded) => self.deserialize(&loaded.serialize()),
+            Err(_) => false,
+        }
+    }
+
+    /// Serialize the current document's first sheet to `.tsv` bytes.
+    pub fn save_tsv_bytes(&self) -> Vec<u8> {
+        spreadsheet_io::save_tsv(&self.wb)
+    }
+
+    /// Open a `.json` file as the current document. A top-level array of objects
+    /// is read as records (keys → header row, each object → a data row); other
+    /// shapes map as `spreadsheet-io` documents. Parsing is panic-free: returns
+    /// `false` on malformed JSON / invalid UTF-8. See [`load_csv_bytes`].
+    pub fn load_json_bytes(&mut self, bytes: &[u8]) -> bool {
+        match spreadsheet_io::load_json(bytes) {
+            Ok(loaded) => self.deserialize(&loaded.serialize()),
+            Err(_) => false,
+        }
+    }
+
+    /// Serialize the current document's first sheet to `.json` bytes — an array
+    /// of record objects (row 1 supplies the keys). Pure computation.
+    pub fn save_json_bytes(&self) -> Vec<u8> {
+        spreadsheet_io::save_json(&self.wb)
+    }
+
     /// Get a cell's *computed* value as a JSON object (see [`value_to_json`] for
     /// the shape). A malformed address yields an `#REF!`-style error object
     /// rather than failing.
@@ -1346,6 +1401,62 @@ mod tests {
         assert!(s2.load_xls_bytes(&bytes), "our own .xls must open");
         assert_eq!(s2.get_value("A1"), r#"{"kind":"number","value":42.0}"#);
         assert_eq!(s2.get_value("A2"), r#"{"kind":"text","value":"world"}"#);
+    }
+
+    #[test]
+    fn csv_and_tsv_open_save_round_trip_through_session() {
+        // A CSV is a positional grid: numbers stay numeric, text stays text, and
+        // a formula flattens to its computed value on save.
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "region");
+        s.set_cell("B1", "sales");
+        s.set_cell("A2", "East");
+        s.set_cell("B2", "200");
+        s.set_cell("A3", "=A2"); // flattens to "East" text on save
+        let csv = s.save_csv_bytes();
+        assert_eq!(
+            String::from_utf8(csv.clone()).unwrap(),
+            "region,sales\nEast,200\nEast,"
+        );
+
+        let mut s2 = SpreadsheetSession::new();
+        assert!(s2.load_csv_bytes(&csv), "our own .csv must open");
+        assert_eq!(s2.get_value("A1"), r#"{"kind":"text","value":"region"}"#);
+        assert_eq!(s2.get_value("B2"), r#"{"kind":"number","value":200.0}"#);
+
+        // TSV is the same grid with tabs.
+        let tsv = s2.save_tsv_bytes();
+        assert_eq!(String::from_utf8(tsv.clone()).unwrap(), "region\tsales\nEast\t200\nEast\t");
+        let mut s3 = SpreadsheetSession::new();
+        assert!(s3.load_tsv_bytes(&tsv));
+        assert_eq!(s3.get_value("B2"), r#"{"kind":"number","value":200.0}"#);
+    }
+
+    #[test]
+    fn json_open_save_round_trip_through_session() {
+        // A records array round-trips: keys become the header row, each object a
+        // data row; save re-emits the array-of-objects shape.
+        let mut s = SpreadsheetSession::new();
+        assert!(s.load_json_bytes(br#"[{"region":"East","sales":200},{"region":"West","sales":340}]"#));
+        assert_eq!(s.get_value("A1"), r#"{"kind":"text","value":"region"}"#);
+        assert_eq!(s.get_value("B2"), r#"{"kind":"number","value":200.0}"#);
+        assert_eq!(s.get_value("B3"), r#"{"kind":"number","value":340.0}"#);
+        let json = s.save_json_bytes();
+        assert_eq!(
+            String::from_utf8(json).unwrap(),
+            r#"[{"region":"East","sales":200},{"region":"West","sales":340}]"#
+        );
+    }
+
+    #[test]
+    fn load_bad_text_formats_return_false_and_preserve_document() {
+        // A failed open must not clobber the open document. CSV accepts any
+        // UTF-8 as a grid, so only invalid UTF-8 / malformed JSON fail here.
+        let mut s = SpreadsheetSession::new();
+        s.set_cell("A1", "keepme");
+        assert!(!s.load_csv_bytes(&[0xff, 0xfe])); // invalid UTF-8
+        assert!(!s.load_json_bytes(b"{not json")); // malformed, panic-free
+        assert_eq!(s.get_value("A1"), r#"{"kind":"text","value":"keepme"}"#);
     }
 
     #[test]

--- a/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-wasm/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.14.0
+
+**File open / save over the ABI — bytes in, bytes out (SSIO PR4).** New
+`extern "C"` exports let the JS host open a real spreadsheet file the user picked
+and download the current document as one, routing every format through the one
+engine:
+
+- `load_xlsx` / `load_xls` / `load_csv` / `load_tsv` / `load_json` `(ptr, len) -> u32`
+  — read the file's raw bytes from linear memory and replace the current
+  document; return `1` on success or `0` if the bytes aren't a readable file of
+  that format (a failed open leaves the document untouched).
+- `save_xlsx` / `save_xls` / `save_csv` / `save_tsv` / `save_json` `() -> *mut u8`
+  — serialize the current document to that format's bytes, returned packed as
+  `[len: u32 LE][bytes]` (freed with `dealloc(ptr, 4 + len)`), exactly like a
+  string result.
+- New binary-safe marshalling primitives: `read_input_bytes` reads a `(ptr, len)`
+  input as **raw bytes** (not lossy UTF-8 — critical, since `.xlsx`/`.xls` are
+  binary and lossy decoding would corrupt them), and `pack_bytes` packs raw bytes
+  with the length prefix. `pack(String)` is now a thin UTF-8 wrapper over it.
+- 5 host-target tests drive the `(ptr, len)` protocol by hand: xlsx save→load
+  round-trip (formula stays live), an xls binary-safety proof (0xD0 0xCF magic
+  survives), CSV+TSV and JSON round-trips, and a bad-file → `0` guard that leaves
+  the document intact.
+
+Thin wrappers over `spreadsheet-core-wasm` 0.15.0's `*_bytes` session methods.
+`.xlsx` keeps live formulas; the others are lower-fidelity per `spreadsheet-io`.
+
 ## 0.13.0
 
 **Column widths & row heights (wasm linear-mem exports).** `column_width(col)` /

--- a/code/packages/rust/spreadsheet-wasm/Cargo.toml
+++ b/code/packages/rust/spreadsheet-wasm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spreadsheet-wasm"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
-description = "extern \"C\" + linear-memory WASM ABI over the spreadsheet-core-wasm JSON facade"
+description = "extern \"C\" + linear-memory WASM ABI over the spreadsheet-core-wasm JSON facade, including file open/save (.xlsx/.xls/.csv/.tsv/.json) bytes in/out"
 license = "MIT"
 
 [lib]

--- a/code/packages/rust/spreadsheet-wasm/README.md
+++ b/code/packages/rust/spreadsheet-wasm/README.md
@@ -29,6 +29,10 @@ Linear memory is a flat byte array shared with JS; strings cross it as
   `[len: u32 LE][utf8 bytes]` buffer; JS reads the length, then the bytes, then
   frees the whole thing with `dealloc(ptr, 4 + len)`.
 
+The **file** exports (below) use the *same* `[len][bytes]` layout but with raw
+bytes, not UTF-8 — a `.xlsx`/`.xls` is binary, so `read_input_bytes`/`pack_bytes`
+never run the payload through lossy UTF-8 (which would corrupt it).
+
 Every allocation uses an explicit `Layout` with `align = 1`, and `dealloc`
 rebuilds the *same* layout from the `len` JS passes back — so allocation and
 free can never disagree on size (the classic source of unsoundness in
@@ -41,6 +45,16 @@ documented inline.
 — one per [`SpreadsheetSession`](../spreadsheet-core-wasm) method. A single
 global session lives in thread-local storage (WASM is single-threaded);
 `reset` starts a fresh sheet.
+
+**File open / save (bytes in, bytes out).** `load_xlsx` / `load_xls` /
+`load_csv` / `load_tsv` / `load_json` `(ptr, len) -> u32` read a file's raw bytes
+and replace the current document (`1` = opened, `0` = not a readable file of that
+format — the document is left untouched on failure). `save_xlsx` / `save_xls` /
+`save_csv` / `save_tsv` / `save_json` `() -> *mut u8` serialize the current
+document to that format's bytes, packed `[len][bytes]`. So a host can open the
+file a user picked and download the sheet as any format — every format routed
+through the one engine. `.xlsx` keeps live formulas; the others are
+lower-fidelity per [`spreadsheet-io`](../spreadsheet-io).
 
 ## Building & using
 

--- a/code/packages/rust/spreadsheet-wasm/src/lib.rs
+++ b/code/packages/rust/spreadsheet-wasm/src/lib.rs
@@ -105,11 +105,26 @@ unsafe fn read_input(ptr: *const u8, len: usize) -> String {
     String::from_utf8_lossy(slice).into_owned()
 }
 
-/// Pack a result string into a freshly allocated `[len: u32 LE][bytes]` buffer
-/// and return its pointer. The caller (JS) frees it with `dealloc(ptr, 4 +
-/// len)`.
-fn pack(s: String) -> *mut u8 {
-    let bytes = s.into_bytes();
+/// Read a `(ptr, len)` input as **raw bytes** (a copy). Unlike [`read_input`],
+/// this does *not* run the bytes through lossy UTF-8 — a file like `.xlsx` or
+/// `.xls` is binary, and lossy decoding would replace every non-UTF-8 byte with
+/// U+FFFD and destroy the file. Use this for file bytes; use `read_input` for
+/// the text-string ABI (addresses, formulas).
+///
+/// # Safety
+/// `ptr` must point to `len` readable bytes (or be null with `len == 0`).
+unsafe fn read_input_bytes(ptr: *const u8, len: usize) -> Vec<u8> {
+    if ptr.is_null() || len == 0 {
+        return Vec::new();
+    }
+    std::slice::from_raw_parts(ptr, len).to_vec()
+}
+
+/// Pack raw bytes into a freshly allocated `[len: u32 LE][bytes]` buffer and
+/// return its pointer. The caller (JS) frees it with `dealloc(ptr, 4 + len)`.
+/// This is the byte-level primitive behind [`pack`]; it is also what the file
+/// exports return, since a saved `.xlsx`/`.xls` is binary, not a `String`.
+fn pack_bytes(bytes: Vec<u8>) -> *mut u8 {
     let payload_len = bytes.len();
     // Guard the length prefix add and the layout the same way `alloc` does:
     // return null on overflow / invalid layout rather than panicking (a panic
@@ -136,6 +151,12 @@ fn pack(s: String) -> *mut u8 {
         std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr.add(4), payload_len);
         ptr
     }
+}
+
+/// Pack a result string into a `[len: u32 LE][bytes]` buffer — a thin UTF-8
+/// wrapper over [`pack_bytes`]. The caller frees it with `dealloc(ptr, 4 + len)`.
+fn pack(s: String) -> *mut u8 {
+    pack_bytes(s.into_bytes())
 }
 
 // ---------------------------------------------------------------------------
@@ -659,6 +680,112 @@ pub extern "C" fn changed_since(since: u64) -> *mut u8 {
 }
 
 // ---------------------------------------------------------------------------
+// File open / save exports — bytes in, bytes out.
+// ---------------------------------------------------------------------------
+//
+// These are the byte-oriented cousins of the string exports above. They let the
+// JS host open a real spreadsheet file the user picked and download the current
+// document as one — the whole point of routing every format through the one
+// engine. The wiring is uniform across all five formats:
+//
+//   - **load_<fmt>(ptr, len) -> u32**: the host `alloc`s a buffer, writes the
+//     file's raw bytes, and passes `(ptr, len)`. We read them as raw bytes
+//     (NOT lossy UTF-8 — `.xlsx`/`.xls` are binary), hand them to the session,
+//     and return `1` on success or `0` if the bytes aren't a readable file of
+//     that format. A failed open leaves the current document untouched.
+//   - **save_<fmt>() -> *mut u8**: serialize the current document to that
+//     format's bytes and return them packed as `[len: u32 LE][bytes]` (freed by
+//     the host with `dealloc(ptr, 4 + len)`), exactly like a string result —
+//     `pack_bytes` is binary-safe, so a ZIP or OLE2 file survives the trip.
+//
+// `.xlsx` keeps live formulas; the others are lower-fidelity per `spreadsheet-io`.
+
+/// Open `.xlsx` file bytes as the current document. Returns `1` on success, `0`
+/// if the bytes are not a readable `.xlsx`. See [`SpreadsheetSession::load_xlsx_bytes`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range (or `ptr` null with `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn load_xlsx(ptr: *const u8, len: usize) -> u32 {
+    let bytes = read_input_bytes(ptr, len);
+    SESSION.with(|s| s.borrow_mut().load_xlsx_bytes(&bytes)) as u32
+}
+
+/// Save the current document to `.xlsx` file bytes, packed `[len][bytes]`.
+#[no_mangle]
+pub extern "C" fn save_xlsx() -> *mut u8 {
+    pack_bytes(SESSION.with(|s| s.borrow().save_xlsx_bytes()))
+}
+
+/// Open legacy `.xls` (BIFF8) file bytes. Returns `1`/`0` like [`load_xlsx`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range (or `ptr` null with `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn load_xls(ptr: *const u8, len: usize) -> u32 {
+    let bytes = read_input_bytes(ptr, len);
+    SESSION.with(|s| s.borrow_mut().load_xls_bytes(&bytes)) as u32
+}
+
+/// Save the current document to legacy `.xls` bytes, packed `[len][bytes]`.
+#[no_mangle]
+pub extern "C" fn save_xls() -> *mut u8 {
+    pack_bytes(SESSION.with(|s| s.borrow().save_xls_bytes()))
+}
+
+/// Open `.csv` file bytes. Returns `1`/`0` (`0` on invalid UTF-8). See
+/// [`SpreadsheetSession::load_csv_bytes`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range (or `ptr` null with `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn load_csv(ptr: *const u8, len: usize) -> u32 {
+    let bytes = read_input_bytes(ptr, len);
+    SESSION.with(|s| s.borrow_mut().load_csv_bytes(&bytes)) as u32
+}
+
+/// Save the current document's first sheet to `.csv` bytes, packed `[len][bytes]`.
+#[no_mangle]
+pub extern "C" fn save_csv() -> *mut u8 {
+    pack_bytes(SESSION.with(|s| s.borrow().save_csv_bytes()))
+}
+
+/// Open `.tsv` file bytes. Returns `1`/`0` like [`load_csv`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range (or `ptr` null with `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn load_tsv(ptr: *const u8, len: usize) -> u32 {
+    let bytes = read_input_bytes(ptr, len);
+    SESSION.with(|s| s.borrow_mut().load_tsv_bytes(&bytes)) as u32
+}
+
+/// Save the current document's first sheet to `.tsv` bytes, packed `[len][bytes]`.
+#[no_mangle]
+pub extern "C" fn save_tsv() -> *mut u8 {
+    pack_bytes(SESSION.with(|s| s.borrow().save_tsv_bytes()))
+}
+
+/// Open `.json` file bytes (a top-level array of record objects → a table).
+/// Returns `1`/`0` (`0` on malformed JSON — parsing is panic-free). See
+/// [`SpreadsheetSession::load_json_bytes`].
+///
+/// # Safety
+/// `(ptr, len)` must describe a readable byte range (or `ptr` null with `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn load_json(ptr: *const u8, len: usize) -> u32 {
+    let bytes = read_input_bytes(ptr, len);
+    SESSION.with(|s| s.borrow_mut().load_json_bytes(&bytes)) as u32
+}
+
+/// Save the current document's first sheet to `.json` bytes (array of record
+/// objects), packed `[len][bytes]`.
+#[no_mangle]
+pub extern "C" fn save_json() -> *mut u8 {
+    pack_bytes(SESSION.with(|s| s.borrow().save_json_bytes()))
+}
+
+// ---------------------------------------------------------------------------
 // Host-target tests: exercise the ABI exactly as the JS loader would, but in
 // Rust (so they run under `cargo test` with no WASM toolchain). We drive the
 // `(ptr, len)` protocol by hand to prove the marshalling and the alloc/dealloc
@@ -873,5 +1000,117 @@ mod tests {
 
         // A bad window surfaces an error object — never a panic/trap.
         assert_eq!(take(get_window(0, 0, 5, 5)), r##"{"error":"#REF!"}"##);
+    }
+
+    // -----------------------------------------------------------------------
+    // File open / save over the ABI (bytes in, bytes out).
+    // -----------------------------------------------------------------------
+
+    /// Copy raw bytes into module memory via `alloc` — the binary `put`, used
+    /// for file bytes (which are not necessarily UTF-8).
+    fn put_bytes(data: &[u8]) -> (*mut u8, usize) {
+        let ptr = alloc(data.len());
+        // SAFETY: `alloc` reserved `data.len()` writable bytes at `ptr`.
+        unsafe { std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, data.len()) };
+        (ptr, data.len())
+    }
+
+    /// Read a `[len][bytes]` result buffer as raw bytes and free it — the binary
+    /// `take`, used for saved file bytes.
+    fn take_bytes(ptr: *mut u8) -> Vec<u8> {
+        // SAFETY: `ptr` points at a buffer produced by `pack_bytes`.
+        unsafe {
+            let len = u32::from_le_bytes([*ptr, *ptr.add(1), *ptr.add(2), *ptr.add(3)]) as usize;
+            let bytes = std::slice::from_raw_parts(ptr.add(4), len).to_vec();
+            dealloc(ptr, 4 + len);
+            bytes
+        }
+    }
+
+    #[test]
+    fn abi_xlsx_save_then_load_round_trips() {
+        reset();
+        set("A1", "10");
+        set("A2", "20");
+        set("A3", "=SUM(A1:A2)");
+        // Save over the ABI → real .xlsx bytes (a ZIP: "PK").
+        let bytes = take_bytes(save_xlsx());
+        assert_eq!(&bytes[..2], b"PK");
+        // Open them back through the ABI into a fresh document.
+        reset();
+        let (p, l) = put_bytes(&bytes);
+        let ok = unsafe { load_xlsx(p, l) };
+        unsafe { dealloc(p, l) };
+        assert_eq!(ok, 1, "our own .xlsx must load");
+        assert_eq!(value("A3"), r#"{"kind":"number","value":30.0}"#);
+        assert_eq!(raw("A3"), "=SUM(A1:A2)"); // still a live formula
+    }
+
+    #[test]
+    fn abi_xls_bytes_are_binary_safe() {
+        // The .xls magic starts with 0xD0 0xCF — a byte that lossy-UTF-8 reading
+        // would corrupt. This proves the file path uses raw bytes, not `pack`.
+        reset();
+        set("A1", "42");
+        let bytes = take_bytes(save_xls());
+        assert_eq!(&bytes[..4], &[0xD0, 0xCF, 0x11, 0xE0]);
+        reset();
+        let (p, l) = put_bytes(&bytes);
+        let ok = unsafe { load_xls(p, l) };
+        unsafe { dealloc(p, l) };
+        assert_eq!(ok, 1);
+        assert_eq!(value("A1"), r#"{"kind":"number","value":42.0}"#);
+    }
+
+    #[test]
+    fn abi_csv_and_tsv_round_trip() {
+        reset();
+        set("A1", "region");
+        set("B1", "sales");
+        set("A2", "East");
+        set("B2", "200");
+        let csv = take_bytes(save_csv());
+        assert_eq!(csv, b"region,sales\nEast,200");
+        reset();
+        let (p, l) = put_bytes(&csv);
+        assert_eq!(unsafe { load_csv(p, l) }, 1);
+        unsafe { dealloc(p, l) };
+        assert_eq!(value("B2"), r#"{"kind":"number","value":200.0}"#);
+
+        let tsv = take_bytes(save_tsv());
+        assert_eq!(tsv, b"region\tsales\nEast\t200");
+        reset();
+        let (p, l) = put_bytes(&tsv);
+        assert_eq!(unsafe { load_tsv(p, l) }, 1);
+        unsafe { dealloc(p, l) };
+        assert_eq!(value("A1"), r#"{"kind":"text","value":"region"}"#);
+    }
+
+    #[test]
+    fn abi_json_round_trips() {
+        reset();
+        let doc = br#"[{"region":"East","sales":200},{"region":"West","sales":340}]"#;
+        let (p, l) = put_bytes(doc);
+        assert_eq!(unsafe { load_json(p, l) }, 1);
+        unsafe { dealloc(p, l) };
+        assert_eq!(value("B3"), r#"{"kind":"number","value":340.0}"#);
+        let out = take_bytes(save_json());
+        assert_eq!(out, doc);
+    }
+
+    #[test]
+    fn abi_load_bad_file_returns_zero_and_preserves_document() {
+        // A failed open returns 0 and must not clobber the open document.
+        reset();
+        set("A1", "keepme");
+        let (p, l) = put_bytes(b"not a real file");
+        assert_eq!(unsafe { load_xlsx(p, l) }, 0);
+        assert_eq!(unsafe { load_xls(p, l) }, 0);
+        unsafe { dealloc(p, l) };
+        // Malformed JSON is panic-free → 0.
+        let (jp, jl) = put_bytes(b"{not json");
+        assert_eq!(unsafe { load_json(jp, jl) }, 0);
+        unsafe { dealloc(jp, jl) };
+        assert_eq!(value("A1"), r#"{"kind":"text","value":"keepme"}"#);
     }
 }


### PR DESCRIPTION
## What

Exposes real **file open/save across the hand-written `extern \"C\"` + linear-memory WASM ABI** (no wasm-bindgen), so a browser host can open a spreadsheet file the user picked and download the current document as any format — every format routed through the one engine. Builds directly on the [JSON codec (SSIOJSON01, #7693)](https://github.com/adhithyan15/coding-adventures/pull/7693).

Two layers:

### `spreadsheet-core-wasm` 0.14 → 0.15
Adds CSV/TSV/JSON byte methods to `SpreadsheetSession`, mirroring the `.xlsx`/`.xls` pair from PR3 exactly:
- `load_csv_bytes` / `load_tsv_bytes` / `load_json_bytes` `(&[u8]) -> bool`
- `save_csv_bytes` / `save_tsv_bytes` / `save_json_bytes` `(&self) -> Vec<u8>`

A load reuses the snapshot path (parse via `spreadsheet-io` → serialize to canonical JSON → `deserialize`), so the open is **undoable** and rebuilds the formula-bar echo; it returns `false` on invalid UTF-8 / malformed JSON (panic-free) and leaves the document untouched on failure.

### `spreadsheet-wasm` 0.13 → 0.14
Adds `extern \"C\"` file exports for all five formats:
- `load_xlsx` / `load_xls` / `load_csv` / `load_tsv` / `load_json` `(ptr, len) -> u32` (`1` = opened, `0` = unreadable)
- `save_xlsx` / `save_xls` / `save_csv` / `save_tsv` / `save_json` `() -> *mut u8`, packed `[len: u32 LE][bytes]`

**Binary-safe marshalling:** new `read_input_bytes` reads a `(ptr, len)` input as **raw bytes** — not lossy UTF-8, which would corrupt a binary `.xlsx`/`.xls` — and `pack_bytes` packs raw bytes with the length prefix. `pack(String)` is now a thin wrapper over `pack_bytes`, so the existing string ABI is byte-identical.

## Fidelity

`.xlsx` keeps live formulas; `.xls`/CSV/TSV/JSON are lower-fidelity (one sheet, formulas flatten to their computed value) per `spreadsheet-io`.

## Tests

- **core-wasm +4** (CSV+TSV round-trip, JSON records round-trip, bad-bytes-preserves-document) → **47** total.
- **spreadsheet-wasm +5** host-target tests driving the `(ptr, len)` protocol by hand: xlsx save→load keeps the formula live, an **xls binary-safety proof** (the `0xD0 0xCF` OLE2 magic survives the byte path), CSV+TSV and JSON round-trips, and a bad-file → `0` guard → **13** total.
- Compiles clean for **`wasm32-unknown-unknown`**. Downstream `spreadsheet-capi` / `spreadsheet-android-jni` re-tested — no regressions.
- **Security review passed**: a Rust/WASM-FFI subagent confirmed the new code mirrors the accepted `pack`/`read_input` patterns, all exports are total over adversarial input (Result-matched loads, pure saves) so nothing unwinds across the boundary, and the `pack_bytes` overflow guards are intact.

## Out of scope (→ SSIO PR5)

The committed `pkg/*.wasm` rebuild, the JS loader `open`/`save` wrappers, the web VisiCalc open/save UI buttons, and preview-harness round-trip verification land in PR5 (where they're verified end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)