### PR TITLE
feat(latex): LTXDOC03 S9 \eqref parenthesisation + re-land S7/S8 dropped by #7682

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.45.0] — 2026-07-06
+
+### Added — cross-reference resolution: `\eqref` parenthesisation (LTXDOC03 S9)
+
+Closes the surface-form gap S8's "Deferred to S9" note flagged. amsmath's `\eqref{eq:e}` typesets the
+equation number **parenthesised** — `(1)` — whereas a plain `\ref{eq:e}` typesets a bare `1`. Through
+S8 the cross-reference report ignored the surface command and rendered every reference with the
+canonical `\ref` prefix and a bare number. S9 makes the report mirror amsmath for the one case that
+matters:
+
+- **`\eqref` to an equation parenthesises.** In `CrossReferenceReport::to_plain_text`, a resolved
+  reference whose `command == "eqref"` **and** whose `kind == LabelKind::Equation` now renders
+  `\eqref{eq:e} -> Equation (1)` — the `\eqref` spelling is kept and the number is wrapped in
+  parentheses.
+- **Everything else is byte-for-byte unchanged.** All `\ref`, all `\pageref`, and any `\eqref` to a
+  **non-equation** kind still render with the canonical `\ref` prefix and a bare number
+  (`\ref{sec:intro} -> Section 1.2`), exactly as through S8.
+- **Additive, no AST/struct/numbering change.** `RefEntry.command` (the surface spelling) was already
+  retained by S1 and populated by `cross_reference_report`, so S9 is a pure rendering split in one
+  `format!`. No AST change, no new field, no re-numbering; `to_latex()` remains a fixed point.
+
+## [0.44.0] — 2026-07-06
+
+### Added — cross-reference resolution: equation numbering (LTXDOC03 S8)
+
+Closes the numbering gap S7 left open. S7 made a `\ref`/`\eqref` to a display-math `\label` *resolve*
+and appear in the S6 cross-reference report, but the number it carried was the placeholder
+`EQUATION_NUMBER_PLACEHOLDER` (`"?"`) — the report printed `Equation ?`. S8 wires the real
+`\theequation` counter so the report prints `Equation 1`, `Equation 2`, … in document order.
+
+- **New flat equation counter.** `Counters` gains an `equation: u32` field (initialised to `0` in
+  `new()`) and a `step_equation(&mut self) -> u32` method that pre-increments (saturating) and returns
+  the new value — mirroring `step_figure`/`step_table` exactly. Equations are numbered on a single
+  monotonic run, **independent** of the section/figure/table counters (the `article` default, where
+  `\theequation` is not reset per section).
+- **Labelled equations get a real number.** In the `Block::DisplayMath { label: Some(key), .. }` arm of
+  `Document::number_labels`, the placeholder is replaced with `counters.step_equation().to_string()`.
+  A single labelled equation numbers `1`; two in document order number `1` then `2`; a `\section`,
+  figure, or table between/around them does not perturb the equation sequence (each counter is its own
+  run).
+- **S6 report now prints the number.** A resolved `\ref`/`\eqref` to an equation label renders
+  `\ref{eq:e} -> Equation 1` (was `-> Equation ?` in S7).
+- **`EQUATION_NUMBER_PLACEHOLDER` retained.** The constant stays `pub`/re-exported (still referenced by
+  the module's intra-doc links and available to S9+ `\eqref` parenthesisation); only its former
+  code use in the numbering arm is replaced.
+
+### Known limitation — unlabelled numbered equations
+
+In real LaTeX *every* non-starred display equation consumes the equation counter, `\label` or not
+(like figures/tables). Our AST only marks the **labelled** non-starred case: `Block::DisplayMath`
+carries no `numbered` flag, and the D5 lowering sets `label: None` for *both* starred envs and
+unlabelled islands (`\[…\]`, `$$…$$`), so an unlabelled-but-numbered `equation` env is
+indistinguishable from an unnumbered island. S8 therefore steps the counter **only** for labelled
+equations. Consequence: an unlabelled numbered equation sitting between two labelled ones leaves the
+second labelled one's number one lower than a full LaTeX run would assign. Closing this gap needs a
+`numbered: bool` on `Block::DisplayMath` (an AST change) and is deferred to a later slice.
+
+### Deferred to S9 — `\eqref` parenthesisation
+
+The S6 report renders every reference as `\ref{key} -> Kind number` (canonical `\ref` spelling,
+bare number), so `\eqref` does **not** yet parenthesise to `(1)`. That surface distinction is a
+later slice; S8 is counter-only.
+
 ## [0.43.0] — 2026-07-06
 
 ### Added — cross-reference resolution: equation-label lifting (LTXDOC03 S7)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.43.0"
+version = "0.45.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -55,6 +55,8 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S5 — citation numbering (bracketed bibliography numbers)** | `Document::number_citations() -> CitationNumbering` — the bracketed number a `\cite` *prints* (`[2]`), the citation-family analogue of S4's `ref_number`. In the default numeric/unsorted style each `\bibitem` is numbered by its **listing position**, so S5 numbers S2's already-ordered winning `entries` by index: `entries[0]` → `[1]`, `entries[1]` → `[2]`, …. A first-`\bibitem`-wins **duplicate** is in `duplicate_entries`, not `entries`, so it consumes **no** number and the entries after it are unshifted (`a, b, c` + a later dup `\bibitem{a}` keeps `c` at `[3]`). A **dangling** `\cite` is in S2's `unresolved`, so it has no entry and `number_for` returns `None` (LaTeX's `[?]`). Returns one owned `NumberedCitation { key, ordinal, number }` per numbered entry, with `number_for(key) -> Option<&str>`; `cite_number(&ResolvedCite) -> Option<String>` ties S2 resolution to S5 numbering (`\cite{foo}` → `"[2]"`). Bracket style single-sourced in one helper. Equation numbers (blocked on `DisplayMath` carrying no label field), author-year/natbib sorted styles, and external `.bib` remain future rungs. Pure, additive, tree-unchanged. Total & panic-free. | ✅ |
 | **LTXDOC03 S6 — the cross-reference report (consumer composing S1/S2/S4/S5)** | `Document::cross_reference_report() -> CrossReferenceReport` — the consumer rung that proves the passes **compose**: it walks S1's resolved `\ref`s and S2's resolved `\cite`s and assembles an owned, plain-data report where each entry carries its rendered **number** (S4/S5) alongside key/command/kind. **No new AST walk** — it numbers each family **once** (`number_labels`/`number_citations`) then looks each key up (never per-item re-numbering). Produces `refs: Vec<RefEntry { key, command, kind, number }>` (one per resolved **and numbered** `\ref`, in S1 order — a resolved `\ref` to an *unnumbered bare-inline* label is still **omitted**; an S7 equation label is included), `cites: Vec<CiteEntry { key, number }>` (one per resolved `\cite` key, in S2 order), and `dangling_refs`/`dangling_cites: Vec<String>` (S1/S2 `unresolved` keys — LaTeX's `??`/`[?]`, surfaced **separately**). `CrossReferenceReport::to_plain_text() -> String` renders a stable, pinned string (`\ref{k} -> Section 1.2` / `\cite{k} -> [2]` lines, optional `Dangling …:` footers, joined by `\n`, no trailing newline; empty → `(no cross-references)`). Pure composition, reads S1–S5 unchanged, tree untouched. Total & panic-free. | ✅ |
 | **LTXDOC03 S7 — equation-label lifting** | `Block::DisplayMath` gains a `label: Option<String>` and `LabelKind` gains an `Equation` variant. For a **non-starred** display-math environment (`equation`/`align`/`gather`/`multline`/`eqnarray` — not the starred forms), the D5 lowering now **lifts** the `\label{key}` out of the env body onto the block (removing it from `source`, no duplication) and registers it as a real `LabelKind::Equation` definition in the same pass as section/figure/table labels. So an `\eqref{eq:e}`/`\ref{eq:e}` to an in-equation label now **resolves** and is **included** in the S6 report (`\ref{eq:e} -> Equation ?`) instead of being omitted. The equation **number** (`\theequation`) is deferred to S8: the report carries the placeholder `EQUATION_NUMBER_PLACEHOLDER` (`"?"`). `to_latex()` re-emits a lifted-label equation as `\begin{equation}…\label{…}\end{equation}` so the round-trip fixed point holds. Starred forms and `\[…\]`/`$$…$$` keep `label: None`. Pure, additive; total & panic-free. | ✅ |
+| **LTXDOC03 S8 — equation numbering** | `Counters` gains a flat `equation: u32` field and a `step_equation()` method (mirroring `step_figure`/`step_table` — pre-increment, saturating, one monotonic run **independent** of section/figure/table). In the `Block::DisplayMath { label: Some(key), .. }` arm of `number_labels`, S7's placeholder is replaced with `counters.step_equation().to_string()`, so a lifted equation label now carries a **real** sequential number in document order (`1`, `2`, …). The S6 report prints `\ref{eq:e} -> Equation 1` (was `Equation ?`). Equation numbering is independent of the section/figure/table counters. **Limitation:** because `Block::DisplayMath` carries no `numbered` flag (the D5 lowering sets `label: None` for both starred envs and `\[…\]`/`$$…$$` islands), only **labelled** equations step the counter — an unlabelled numbered equation between two labelled ones is not yet counted (needs an AST change, deferred). `\eqref` parenthesisation (`(1)` vs `1`) is also deferred to a later slice; S8 is counter-only. Pure, additive, tree-unchanged; total & panic-free. | ✅ |
+| **LTXDOC03 S9 — `\eqref` parenthesisation** | `CrossReferenceReport::to_plain_text` now mirrors amsmath's `\eqref` for the one case that matters: a resolved reference whose `command == "eqref"` **and** `kind == LabelKind::Equation` renders `\eqref{eq:e} -> Equation (1)` — the `\eqref` spelling is kept and the number is **parenthesised**. Every other reference — all `\ref`, all `\pageref`, and any `\eqref` to a **non-equation** kind — is byte-for-byte unchanged from S8: canonical `\ref` prefix, bare number (`\ref{sec:intro} -> Section 1.2`). `RefEntry.command` (the surface spelling) was already retained by S1, so S9 is a pure rendering split in one `format!` — no AST change, no new field, no re-numbering; `to_latex()` stays a fixed point. Pure, additive; total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -98,9 +100,13 @@ Section 1.2`, `\cite{smith} -> [2]`), dangling refs/cites surfaced separately, p
 `to_plain_text()` rendering — adding no new AST walk (each family numbered once, then looked up).
 **S7 lifts equation labels**: a non-starred display-math env's `\label` is now pulled onto its
 `Block::DisplayMath { label }` and registered as a `LabelKind::Equation` definition, so an `\eqref`
-to it resolves and is included in the S6 report (`\ref{eq:e} -> Equation ?`) instead of omitted — the
-equation **number** carries the placeholder `EQUATION_NUMBER_PLACEHOLDER` (`"?"`) until S8 wires the
-`\theequation` counter. Author-year/natbib sorted styles and external `.bib` remain future rungs.
+to it resolves and is included in the S6 report instead of omitted. **S8 numbers equations**: a flat
+`step_equation()` counter (independent of section/figure/table, mirroring `step_figure`) assigns each
+lifted equation label a real sequential number in document order, so the S6 report prints
+`\ref{eq:e} -> Equation 1` (was `Equation ?`). Only **labelled** equations step the counter (the AST
+carries no `numbered` flag for unlabelled numbered equations — deferred), and `\eqref`
+parenthesisation is deferred to a later slice. Author-year/natbib sorted styles and external `.bib`
+remain future rungs.
 
 ## The Document layer (LTXDOC01)
 
@@ -371,8 +377,9 @@ assert_eq!(doc.ref_number(r), Some("1.1".to_string())); // \ref{sec:scope} → "
 `number_labels()` returns a `Numbering` of one `NumberedLabel { key, kind, number }` per defined,
 numberable label (section/figure/table). A document that starts deep applies the documented
 missing-parent rule (a lone leading `\subsection` numbers `0.1`). Bare-inline labels and other
-counters (enumerate/theorem/…) are deferred to S5+; a lifted **equation** label (S7) is numbered with
-the `EQUATION_NUMBER_PLACEHOLDER` (`"?"`) until S8. Numbering is pure, additive analysis — it never
+counters (enumerate/theorem/…) are deferred to S5+; a lifted **equation** label (S7) is numbered by a
+flat `step_equation()` counter (S8), independent of section/figure/table, so it prints a real
+sequential number (`1`, `2`, …). Numbering is pure, additive analysis — it never
 mutates the tree, so the S1/S2/S3 outputs are unchanged.
 
 ### Citation numbering (LTXDOC03 S5)
@@ -461,7 +468,7 @@ assert_eq!(
 `cross_reference_report()` returns a `CrossReferenceReport { refs, cites, dangling_refs,
 dangling_cites }` with `RefEntry { key, command, kind, number }` and `CiteEntry { key, number }`. A
 resolved `\ref` to an *unnumbered bare-inline* label is omitted from `refs` (it has no S4 number —
-deferred); an **equation** label (S7) is included with the placeholder number `"?"`. Like S1–S5, S6 is
+deferred); an **equation** label (S7) is included with its real number (S8), e.g. `Equation 1`. Like S1–S5, S6 is
 pure, additive analysis — it reads the prior passes and mutates nothing, so their outputs are unchanged.
 
 ### Equation-label lifting (LTXDOC03 S7)
@@ -475,7 +482,7 @@ definition, so the reference is now resolvable and reported:
 use latex::{parse_document, Block, LabelKind};
 
 let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}
-See \eqref{eq:e}.\end{document}";
+See \ref{eq:e}.\end{document}";
 let doc = parse_document(src).unwrap();
 
 // The `\label` is lifted onto the block; `source` no longer contains it.
@@ -483,18 +490,45 @@ let dm = doc.body.iter().find(|b| matches!(b, Block::DisplayMath { .. })).unwrap
 assert!(matches!(dm, Block::DisplayMath { source, label: Some(k), .. }
     if source == "E = mc^2" && k == "eq:e"));
 
-// It is a real Equation-kind definition, so the `\eqref` resolves and is REPORTED.
+// It is a real Equation-kind definition, so the `\ref` resolves and is REPORTED.
 let rep = doc.cross_reference_report();
 assert_eq!(rep.refs.len(), 1);
 assert_eq!(rep.refs[0].kind, LabelKind::Equation);
-assert_eq!(rep.refs[0].number, "?"); // EQUATION_NUMBER_PLACEHOLDER — real number is S8
-assert_eq!(rep.to_plain_text(), "\\ref{eq:e} -> Equation ?");
+assert_eq!(rep.refs[0].number, "1"); // real `\theequation` value (S8)
+assert_eq!(rep.to_plain_text(), "\\ref{eq:e} -> Equation 1");
 ```
 
 Starred forms (`equation*`, …) and `\[…\]`/`$$…$$` islands keep `label: None` (unnumbered in LaTeX,
-so unchanged). The equation **number** (`\theequation`) is deferred to S8; until then the label carries
-`EQUATION_NUMBER_PLACEHOLDER` (`"?"`). `to_latex()` re-emits a lifted-label equation as
+so unchanged). The equation **number** (`\theequation`) arrives in S8 (a real `1`, `2`, …), and its
+amsmath parenthesisation in S9 (below). `to_latex()` re-emits a lifted-label equation as
 `\begin{equation}…\label{…}\end{equation}`, so the round-trip fixed point holds.
+
+### `\eqref` parenthesisation (LTXDOC03 S9)
+
+amsmath's `\eqref{eq:e}` typesets the equation number **parenthesised** — `(1)` — where a plain
+`\ref{eq:e}` typesets a bare `1`. S9 makes the S6 report mirror that surface distinction for the one
+case that matters: an `\eqref` to an **equation** keeps its `\eqref` spelling and parenthesises the
+number; everything else is byte-for-byte the S8 line.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}
+See \eqref{eq:e} and \ref{eq:e}.\end{document}";
+let doc = parse_document(src).unwrap();
+
+// The `\eqref` parenthesises; the sibling `\ref` to the same equation stays bare.
+assert_eq!(
+    doc.cross_reference_report().to_plain_text(),
+    "\\eqref{eq:e} -> Equation (1)\n\
+     \\ref{eq:e} -> Equation 1",
+);
+```
+
+Only `command == "eqref"` **and** `kind == LabelKind::Equation` diverges: all `\ref`, all `\pageref`,
+and any `\eqref` to a non-equation kind still render with the canonical `\ref` prefix and a bare number
+(`\ref{sec:intro} -> Section 1.2`). `RefEntry.command` (the surface spelling) was already retained by
+S1, so S9 is a pure rendering split — no AST change, no re-numbering, `to_latex()` still a fixed point.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1086,13 +1086,20 @@ struct Counters {
     figure: u32,
     /// The flat `table` counter — only ever increments (one global run), independent of `figure`.
     table: u32,
+    /// The flat `equation` counter (`\theequation`) — only ever increments (one global run),
+    /// independent of `section`/`figure`/`table`. LaTeX numbers display equations in pure document
+    /// order, so — exactly like `figure`/`table` — this is a single monotonic run rather than a
+    /// section-scoped or hierarchical value. (Real LaTeX *can* reset `\theequation` per section under
+    /// classes/packages that redefine it, but the `article` default is a flat run, which is what S8
+    /// models.)
+    equation: u32,
 }
 
 impl Counters {
-    /// Fresh counters — every section depth, the figure counter, and the table counter at `0` (no
-    /// heading/float seen yet).
+    /// Fresh counters — every section depth, the figure counter, the table counter, and the equation
+    /// counter at `0` (no heading/float/equation seen yet).
     fn new() -> Self {
-        Counters { section: [0; SECTION_DEPTHS], figure: 0, table: 0 }
+        Counters { section: [0; SECTION_DEPTHS], figure: 0, table: 0, equation: 0 }
     }
 
     /// Advance the section counters for a numbered heading at `rank`, and render its dotted number.
@@ -1127,6 +1134,15 @@ impl Counters {
     fn step_table(&mut self) -> u32 {
         self.table = self.table.saturating_add(1);
         self.table
+    }
+
+    /// Advance and return the flat `equation` counter (`\theequation`), independent of the
+    /// section/figure/table counters — the S8 payoff. Mirrors [`step_figure`](Counters::step_figure)
+    /// exactly: pre-increment (saturating, so a pathological run can never wrap/panic) and return the
+    /// new value, so the first equation numbers `1`, the next `2`, in pure document order.
+    fn step_equation(&mut self) -> u32 {
+        self.equation = self.equation.saturating_add(1);
+        self.equation
     }
 }
 
@@ -1238,16 +1254,28 @@ impl Document {
                         record(key, LabelKind::Table, n.to_string());
                     }
                 }
-                // LTXDOC03 S7: a **non-starred** display-math env's lifted `\label` is a real,
-                // resolvable equation label. The equation **counter** (`\theequation`) is deferred to
-                // S8, so we record the row with the placeholder number `EQUATION_NUMBER_PLACEHOLDER`
-                // (`"?"`, echoing LaTeX's `??` for an as-yet-unnumbered target). Recording the row —
-                // rather than skipping it as we do for `LabelKind::Inline` — is the whole point of S7:
-                // it makes `number_for(key)` return `Some`, so the S6 report *includes* an `\eqref` to
-                // this equation instead of omitting it. Starred forms set `label: None` (see the D5
-                // lowering), so they never reach here.
+                // LTXDOC03 S8: a **non-starred** display-math env's lifted `\label` is a real,
+                // resolvable equation label — and now a **numbered** one. We step the flat equation
+                // counter (`\theequation`) and record the row with the real sequential number, so the
+                // S6 report prints `Equation 3` rather than the S7 placeholder `Equation ?`. Recording
+                // the row — rather than skipping it as we do for `LabelKind::Inline` — is what makes
+                // `number_for(key)` return `Some`, so the S6 report *includes* an `\eqref` to this
+                // equation. Starred forms set `label: None` (see the D5 lowering), so they never reach
+                // here.
+                //
+                // LaTeX-fidelity limitation: in real LaTeX *every* non-starred display equation
+                // consumes the equation counter whether or not it carries a `\label` (like figures and
+                // tables — the `\label` only *captures* an already-stepped value). Our AST, however,
+                // only marks the **labelled** non-starred case: [`Block::DisplayMath`] carries no
+                // `numbered` flag, and the D5 lowering sets `label: None` for *both* starred envs and
+                // unlabelled islands (`\[…\]`, `$$…$$`), so an unlabelled-but-numbered `equation` env
+                // is indistinguishable from an unnumbered island here. We therefore step the counter
+                // **only** for labelled equations. Consequence: if an unlabelled numbered equation
+                // sits between two labelled ones, the second labelled equation's number will be one
+                // lower than a full LaTeX run would assign. Closing this gap needs a `numbered: bool`
+                // on `Block::DisplayMath` (an AST change) and is left to a later slice.
                 Block::DisplayMath { label: Some(key), .. } => {
-                    record(key, LabelKind::Equation, EQUATION_NUMBER_PLACEHOLDER.to_string());
+                    record(key, LabelKind::Equation, counters.step_equation().to_string());
                 }
                 // Any other block carries no counter S4 assigns.
                 _ => {}
@@ -1630,11 +1658,18 @@ impl CrossReferenceReport {
     /// Render this report to a **stable, deterministic, human-readable** plain-text string (LTXDOC03
     /// S6). The exact format — pinned so tests and consumers can rely on it byte-for-byte:
     ///
-    /// - One line per resolved reference, in `refs` order:
-    ///   `` \ref{<key>} -> <Kind> <number> `` — e.g. `` \ref{sec:intro} -> Section 1.2 ``. The
-    ///   command shown is always `\ref` (the canonical reference form) regardless of the actual
-    ///   `\eqref`/`\pageref` spelling, so the line names the *binding*, not the surface command;
-    ///   `<Kind>` is the capitalised kind name ([`kind_display_name`]).
+    /// - One line per resolved reference, in `refs` order. There are two renderings (LTXDOC03 S9):
+    ///   - An `\eqref` whose target is an **equation** renders amsmath-style, keeping the `\eqref`
+    ///     spelling and **parenthesising** the number:
+    ///     `` \eqref{<key>} -> <Kind> (<number>) `` — e.g. `` \eqref{eq:e} -> Equation (1) ``. This
+    ///     mirrors how amsmath's `\eqref` typesets the equation number as `(1)`.
+    ///   - Every **other** resolved reference — all `\ref`, all `\pageref`, and any `\eqref` to a
+    ///     **non-equation** kind — renders with the canonical `\ref` prefix and a **bare** number:
+    ///     `` \ref{<key>} -> <Kind> <number> `` — e.g. `` \ref{sec:intro} -> Section 1.2 ``. The
+    ///     `\ref` prefix here names the *binding*, not the surface command (a `\pageref` still shows
+    ///     as `\ref`), unchanged from S8.
+    ///
+    ///   In both renderings `<Kind>` is the capitalised kind name ([`kind_display_name`]).
     /// - One line per resolved citation, in `cites` order:
     ///   `` \cite{<key>} -> <number> `` — e.g. `` \cite{smith} -> [2] ``.
     /// - **Only if** `dangling_refs` is non-empty, a footer line:
@@ -1653,9 +1688,35 @@ impl CrossReferenceReport {
     pub fn to_plain_text(&self) -> String {
         let mut lines: Vec<String> = Vec::new();
 
-        // Resolved references: `\ref{key} -> Kind number`.
+        // Resolved references.
+        //
+        // Two renderings, keyed off the *surface command* + *target kind* (LTXDOC03 S9):
+        //
+        //   * An `\eqref` whose target is an **equation** renders amsmath-style — the `\eqref`
+        //     spelling is kept and the number is **parenthesised**:
+        //     `\eqref{eq:e} -> Equation (1)`.  (`\eqref` on `article`'s equation counter typesets
+        //     "(1)", so the report mirrors that surface form.)
+        //   * Every other resolved reference — all `\ref`, all `\pageref`, and any `\eqref` to a
+        //     **non-equation** kind — renders exactly as it did through S8: the canonical `\ref`
+        //     prefix and a **bare** number, `\ref{sec:intro} -> Section 1.2`.
+        //
+        // Only the one amsmath case diverges; the else-branch is byte-for-byte the S8 line.
         for r in &self.refs {
-            lines.push(format!(r"\ref{{{}}} -> {} {}", r.key, kind_display_name(r.kind), r.number));
+            if r.command == "eqref" && r.kind == LabelKind::Equation {
+                lines.push(format!(
+                    r"\eqref{{{}}} -> {} ({})",
+                    r.key,
+                    kind_display_name(r.kind),
+                    r.number
+                ));
+            } else {
+                lines.push(format!(
+                    r"\ref{{{}}} -> {} {}",
+                    r.key,
+                    kind_display_name(r.kind),
+                    r.number
+                ));
+            }
         }
         // Resolved citations: `\cite{key} -> number`.
         for c in &self.cites {
@@ -1792,8 +1853,9 @@ mod tests {
 
     #[test]
     fn s7_eqref_to_equation_is_included_in_cross_reference_report() {
-        // The whole point of S7: a resolved `\eqref`/`\ref` to a lifted equation label is now INCLUDED
-        // in the S6 report (rendered `\ref{eq:e} -> Equation ?`), no longer omitted.
+        // The whole point of S7: a resolved `\eqref`/`\ref` to a lifted equation label is INCLUDED in
+        // the S6 report, no longer omitted. S8 upgrade: the number it renders is now the real
+        // sequential equation number (`Equation 1`), not the S7 placeholder (`Equation ?`).
         let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation} See \eqref{eq:e} and \ref{eq:e}.\end{document}";
         let doc = parse_document(src).expect("parse");
         let report = doc.cross_reference_report();
@@ -1801,12 +1863,100 @@ mod tests {
         for entry in &report.refs {
             assert_eq!(entry.key, "eq:e");
             assert_eq!(entry.kind, LabelKind::Equation);
-            assert_eq!(entry.number, "?", "equation number is the S8-deferred placeholder");
+            assert_eq!(entry.number, "1", "S8: the equation carries the real counter value");
         }
         assert!(report.dangling_refs.is_empty(), "nothing dangles");
-        // The rendered report lines name the binding as `Equation ?`.
+        // The rendered report lines name the binding. Under S9 the `\eqref` (first, in source order)
+        // parenthesises its number and keeps the `\eqref` spelling; the plain `\ref` stays bare.
         let text = report.to_plain_text();
-        assert_eq!(text, "\\ref{eq:e} -> Equation ?\n\\ref{eq:e} -> Equation ?");
+        assert_eq!(text, "\\eqref{eq:e} -> Equation (1)\n\\ref{eq:e} -> Equation 1");
+    }
+
+    #[test]
+    fn s9_eqref_to_equation_parenthesises_its_number() {
+        // LTXDOC03 S9: an `\eqref` to an equation renders amsmath-style — `\eqref` spelling kept and
+        // the number parenthesised — while a sibling `\ref` to the same equation stays a bare number.
+        // The source lists `\eqref` BEFORE `\ref`, so that is the report's `refs` (S1 pre-order) order.
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation} See \eqref{eq:e} and \ref{eq:e}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\eqref{eq:e} -> Equation (1)\n\\ref{eq:e} -> Equation 1");
+    }
+
+    #[test]
+    fn s9_ref_to_equation_is_a_bare_number() {
+        // A plain `\ref` (not `\eqref`) to an equation is UNCHANGED from S8: `\ref` prefix, bare
+        // number, no parentheses. S9 only touches the `\eqref`-to-equation case.
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation} See \ref{eq:e}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\ref{eq:e} -> Equation 1");
+    }
+
+    #[test]
+    fn s9_two_eqrefs_number_sequentially_and_each_parenthesises() {
+        // Two labelled equations number 1 then 2 (S8 sequential counter); each `\eqref` to them
+        // parenthesises its own number, so the report reads `(1)` then `(2)`.
+        let src = r"\begin{document}\begin{equation} a = 1 \label{eq:a} \end{equation}\begin{equation} b = 2 \label{eq:b} \end{equation} See \eqref{eq:a} and \eqref{eq:b}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\eqref{eq:a} -> Equation (1)\n\\eqref{eq:b} -> Equation (2)");
+    }
+
+    #[test]
+    fn s8_single_equation_numbers_as_one() {
+        // A single lifted equation label numbers as "1" — the S8 counter's first value.
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let numbering = doc.number_labels();
+        assert_eq!(numbering.number_for("eq:e"), Some("1"));
+    }
+
+    #[test]
+    fn s8_two_equations_number_sequentially_in_document_order() {
+        // Two lifted equation labels, in document order, number "1" then "2" — a pure monotonic run.
+        let src = r"\begin{document}\begin{equation} a = 1 \label{eq:a} \end{equation}\begin{equation} b = 2 \label{eq:b} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let numbering = doc.number_labels();
+        assert_eq!(numbering.number_for("eq:a"), Some("1"), "first equation is 1");
+        assert_eq!(numbering.number_for("eq:b"), Some("2"), "second equation is 2");
+    }
+
+    #[test]
+    fn s8_equation_counter_is_independent_of_section_counter() {
+        // A `\section` before the equation numbers as "1" (section counter), but the equation still
+        // numbers "1" — the equation counter is independent of the section counter.
+        let src = r"\begin{document}\section{Intro}\label{sec:i} \begin{equation} E = mc^2 \label{eq:e} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let numbering = doc.number_labels();
+        assert_eq!(numbering.number_for("sec:i"), Some("1"), "the section is 1");
+        assert_eq!(numbering.number_for("eq:e"), Some("1"), "the equation is still 1, not perturbed");
+    }
+
+    #[test]
+    fn s8_equation_counter_is_independent_of_figure_counter() {
+        // A figure BETWEEN two equations must not perturb the equation sequence: eq:a=1, eq:b=2, with
+        // the figure numbering "1" on its own independent (flat figure) counter.
+        let src = r"\begin{document}\begin{equation} a = 1 \label{eq:a} \end{equation}\begin{figure}\caption{F}\label{fig:f}\end{figure}\begin{equation} b = 2 \label{eq:b} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let numbering = doc.number_labels();
+        assert_eq!(numbering.number_for("eq:a"), Some("1"), "first equation is 1");
+        assert_eq!(numbering.number_for("fig:f"), Some("1"), "the figure is 1 on its own counter");
+        assert_eq!(numbering.number_for("eq:b"), Some("2"), "second equation is 2, figure did not perturb it");
+    }
+
+    #[test]
+    fn s8_labelled_equation_to_latex_round_trip_is_a_fixed_point() {
+        // S8 is pure analysis (numbering), leaving the tree unchanged: a labelled equation still
+        // round-trips through `to_latex()` byte-for-byte (unchanged from S7).
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let once = doc.to_latex();
+        let twice = parse_document(&once).expect("re-parse").to_latex();
+        assert_eq!(once, twice, "to_latex() is a fixed point for a labelled equation");
     }
 
     #[test]

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -711,3 +711,142 @@ number `"?"`, rendering `\ref{eq:e} -> Equation ?`; and a `to_latex()` round-tri
 AST). `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
 -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 14. S8 — equation numbering
+
+### 14.1 The gap S8 closes
+
+S7 (§13) made a `\ref`/`\eqref` to a display-math `\label` *resolve* and appear in the S6 report, but
+it left the equation **number** unwired: the `Equation` row carried the placeholder
+`EQUATION_NUMBER_PLACEHOLDER` (`"?"`, §13.3), so `cross_reference_report()` rendered
+`\ref{eq:e} -> Equation ?`. S8 wires the real `\theequation` counter so the report prints
+`\ref{eq:e} -> Equation 1`.
+
+### 14.2 What S8 does — a flat equation counter
+
+The numbering walk (`Document::number_labels`) already threads a single `Counters` state through the
+pre-order `walk`, with a **hierarchical** section counter (`step_section`, deeper-reset) and two
+**flat** float counters (`step_figure`/`step_table`, one monotonic run each, incremented for *every*
+float in document order). S8 adds a third flat counter of exactly the same shape for equations:
+
+- **New `Counters` field.** `equation: u32`, initialised to `0` in `Counters::new()` alongside
+  `figure`/`table`.
+- **New `step_equation(&mut self) -> u32`.** Mirrors `step_figure`/`step_table` **exactly**:
+  pre-increment (saturating, so a pathological run never wraps or panics) and return the new value. So
+  the first equation numbers `1`, the next `2`, in pure document order — **independent** of the
+  section/figure/table counters (the `article` default, where `\theequation` is a flat run and is not
+  reset per section).
+- **The `Block::DisplayMath { label: Some(key), .. }` arm.** The single line
+  `record(key, LabelKind::Equation, EQUATION_NUMBER_PLACEHOLDER.to_string())` becomes
+  `record(key, LabelKind::Equation, counters.step_equation().to_string())`. Nothing else in the walk
+  changes; the `Equation` row now carries a real sequential number, so `Numbering::number_for(key)`
+  returns `Some("1")` and the S6 report renders `\ref{eq:e} -> Equation 1`.
+
+### 14.3 LaTeX-fidelity limitation — unlabelled numbered equations
+
+In real LaTeX **every** non-starred display equation consumes the equation counter whether or not it
+carries a `\label` — exactly like figures/tables, where the `\label` only *captures* an
+already-stepped value. Our AST, however, only marks the **labelled** non-starred case:
+`Block::DisplayMath` carries **no** `numbered: bool` flag, and the D5 lowering (§13.2) sets
+`label: None` for *both* starred envs (`equation*`, …) **and** unlabelled islands (`\[…\]`, `$$…$$`).
+So an unlabelled-but-numbered `equation` env is, at the numbering walk, indistinguishable from an
+unnumbered island — there is no state to key a step on. S8 therefore steps the counter **only** for
+labelled equations, in keeping with the "don't invent AST fields" constraint.
+
+**Consequence:** if an unlabelled numbered equation sits between two labelled ones, the second
+labelled equation's number is one lower than a full LaTeX run would assign. Closing this gap requires
+adding `numbered: bool` to `Block::DisplayMath` (an AST change) so the numbering walk can step for
+unlabelled numbered equations too, mirroring the figure/table "every float advances the counter"
+rule; that is deferred to a later slice.
+
+### 14.4 `\eqref` parenthesisation — deferred
+
+S8 is **counter-only**. The S6 report (§12.4) renders every reference as `\ref{key} -> Kind number`
+(canonical `\ref` spelling, bare number), so `\eqref` does **not** yet parenthesise to `(1)`. That
+surface distinction — amsmath's `\eqref` wrapping the number in parentheses — is a later slice and is
+out of scope for S8.
+
+### 14.5 `EQUATION_NUMBER_PLACEHOLDER` retained
+
+The constant stays defined and re-exported from the crate root (§13.5). Although its former **code**
+use in the numbering arm is replaced by the real counter, it is still referenced by the module's
+intra-doc links and remains available to the deferred `\eqref` work. It is a `pub` item, so removing
+its sole code use does not make it dead code.
+
+### 14.6 Public API (added in S8)
+
+No public type or signature changes: `Counters`/`step_equation` are private to `references.rs`, and
+`number_labels`/`Numbering`/`cross_reference_report` keep their existing signatures. The only
+observable change is that an `Equation` row's `number` is now a real sequential value (`"1"`, `"2"`,
+…) instead of the placeholder `"?"`. The change is **additive** and byte-for-byte compatible with
+S1–S7 except for that number.
+
+### 14.7 Verification (S8)
+
+`cargo test -p latex` green (5 new/updated tests: a single lifted equation label numbers `"1"`; two in
+document order number `"1"` then `"2"`; the equation counter is independent of the section counter (a
+`\section` before the equation leaves it `"1"`); the equation counter is independent of the figure
+counter (a figure between two equations leaves them `"1"`/`"2"` while the figure is its own `"1"`); the
+`to_latex()` round-trip for a labelled equation is still a fixed point; and the updated S7 report test
+now asserts `\ref{eq:e} -> Equation 1`). `cargo clippy -p latex --all-targets -- -D warnings` clean;
+downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features`
+builds. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 15. S9 — `\eqref` parenthesisation
+
+### 15.1 The gap S9 closes
+
+S8 (§14) gave a lifted equation label a real number, so the S6 report prints `Equation 1`. But it
+rendered **every** reference identically — `\ref{key} -> Kind number` (canonical `\ref` spelling, bare
+number) — regardless of the surface command (§14.4). amsmath's `\eqref{eq:e}`, however, typesets the
+equation number **parenthesised** as `(1)`, whereas a plain `\ref{eq:e}` typesets a bare `1`. Through
+S8 that surface distinction was lost in the report. S9 closes it for the one case that matters.
+
+### 15.2 What S9 does — an amsmath-faithful rendering split
+
+S9 is a **rendering-only** change confined to `CrossReferenceReport::to_plain_text` (§12.4). The
+single resolved-refs `format!` becomes a two-branch split, keyed on the *surface command* + *target
+kind* already carried by `RefEntry`:
+
+- **`\eqref` to an equation** — a `RefEntry` with `command == "eqref"` **and**
+  `kind == LabelKind::Equation` renders `\eqref{eq:e} -> Equation (1)`: the `\eqref` spelling is kept
+  and the number is **parenthesised**, mirroring how amsmath's `\eqref` typesets `(1)`.
+- **Everything else** — all `\ref`, all `\pageref`, and any `\eqref` to a **non-equation** kind —
+  renders exactly as through S8: the canonical `\ref` prefix and a **bare** number,
+  `\ref{sec:intro} -> Section 1.2`. The `\ref` prefix names the *binding*, not the surface command (a
+  `\pageref` still shows as `\ref`), unchanged.
+
+Only the one amsmath case diverges; the else-branch is byte-for-byte the S8 line. The `\cite`,
+dangling-ref, dangling-cite, and empty-report branches of `to_plain_text` are untouched.
+
+### 15.3 `RefEntry.command` was already retained by S1
+
+No struct or AST change is needed. `RefEntry` has carried `pub command: String` (the surface spelling
+`"ref"` / `"eqref"` / `"pageref"`) since S1, and `cross_reference_report` (§12) has always populated it
+via `command: r.command.clone()`. S9 simply *reads* that field it had been ignoring, so it is a pure
+rendering split in one `format!` — no new field, no numbering change, no AST walk.
+
+### 15.4 Additive, and `to_latex()` unchanged
+
+S9 touches only report rendering, not the tree: `to_latex()` remains a fixed point (S9 does not touch
+the AST at all). Every S1–S8 output byte is unchanged **except** the one thing S9 is about — the
+report line for an `\eqref`-to-equation reference, which gains its `\eqref` prefix and parentheses.
+
+### 15.5 Public API (added in S9)
+
+No public type or signature changes: `RefEntry`, `CrossReferenceReport`, `cross_reference_report`, and
+`to_plain_text` keep their existing shapes. The only observable change is the rendered text of an
+`\eqref`-to-equation line (now `\eqref{eq:e} -> Equation (1)`). The change is **additive** and
+byte-for-byte compatible with S1–S8 except for that one line.
+
+### 15.6 Verification (S9)
+
+`cargo test -p latex` green (3 new S9 tests: an `\eqref` to an equation parenthesises its number while
+a sibling `\ref` to the same equation stays bare (`\eqref{eq:e} -> Equation (1)` then
+`\ref{eq:e} -> Equation 1`); a lone `\ref` to an equation is a bare number (`\ref{eq:e} -> Equation 1`,
+unchanged from S8); two `\eqref`s to two equations number sequentially and each parenthesises
+(`\eqref{eq:a} -> Equation (1)` then `\eqref{eq:b} -> Equation (2)`) — plus the updated S7 report test,
+whose first (`\eqref`) line now asserts `\eqref{eq:e} -> Equation (1)`).
+`cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
+`cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
+`cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S9 — `\eqref` parenthesisation **+ re-land of S7 / S8 (dropped by #7682)**

### Why this PR grew
This PR opened as **S9** only. While babysitting it green it went `CONFLICTING`: origin/main's `latex` crate had regressed to **0.43.0** with no `step_equation` — i.e. **S7 (#7678, equation-label lifting) and S8 (#7696, equation counter) were both gone from main's tree**, even though both are MERGED and their feat commits (`baac0e72`=S7, `f332f0cd`=S8) sit right below the offending merge in history.

**Root cause:** the most recent commit touching `latex/src/references.rs` on main is **#7682** (`feat(sir): feat/sir-hashmethods-go … (rebased onto main, v0.17.0)`), a SIR-Go PR **merged from a stale base** that reverted the latex crate (and, separately, the ADJ-ladder — see #7708) back to their pre-merge states. Same class of incident as the earlier "step-therapy lost in a squash → re-landed" (L1).

### What this PR now does
- **S9**: an `\eqref` to an equation renders its number **parenthesised** — `\eqref{eq:e} -> Equation (1)` — while `\ref`/`\pageref` stay bare (`-> Equation 1`), matching amsmath. The only production edit is the resolved-refs branch of `CrossReferenceReport::to_plain_text()` (`RefEntry.command` was already retained by S1). Additive; `to_latex()` fixed point.
- **Re-lands S7 + S8**: the five latex files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, LTXDOC03 spec) are restored from the S9-tip tree, which contains S7+S8+S9 cumulatively. **No other latex file changed**, so this compiles cleanly onto the reverted main and brings the crate `0.43.0 → 0.45.0`.

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → **360 passed** (+doctest): `s7_` 7, `s8_` 5, `s9_` 3.
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green. `cargo build -p latex --no-default-features` → compiles.
- No new deps, no `unsafe`, no I/O. Single-parent; scoped diff = the 5 latex/spec files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
