### PR TITLE
feat(adj-ladder): rung-91 protein-delivery (a+b+c*d) + re-land rung-89/90 dropped by #7682

### DIFF
--- a/code/specs/data/adj-ladder/rung89_skin_test_wheal/gen_items.py
+++ b/code/specs/data/adj-ladder/rung89_skin_test_wheal/gen_items.py
@@ -1,0 +1,239 @@
+"""Generate rung-89 (allergy skin-test-wheal reactivity index) items.json for the ADJ-LADDER.
+
+Rung 89 opens the **allergy / skin-test-wheal** panel on the quantitative band — the arithmetic of a skin-test
+reactivity index. A `wheal_diameter` and a `flare_rim` are ADDED into a total span, that span is multiplied by a net
+reaction — a `peak_reaction` minus a `trough_reaction` — and the result is the reactivity index. A **sum times a
+difference** introduces a genuinely NEW arithmetic shape on the ladder: a **product of two binomials** — `(a+b)*(c-d)`,
+i.e. `((a+b) * (c-d))`.
+
+This is genuinely new: no shipped shape ever multiplied a SUM by a DIFFERENCE — every prior shape that used a
+parenthesised binomial multiplied it by a single observed factor or divided by one (rung-67 `(a-b)*c/d`, rung-68
+`(a+b)*c/d`, rung-75 `(a-b)/c*d`, rung-76 `(a+b)/c*d`, rung-81 `(a+b)/c-d`, rung-82 `(a-b)/c+d`, rung-84 `(a+b)*c-d`) —
+never a binomial times ANOTHER binomial. `(a+b)*(c-d)` is the ladder's first **product of two binomials**. The operator
+order matters: `(a+b)*(c-d)` is `((a+b)*(c-d))` (each parenthesised group evaluates first, then the two groups
+multiply), NOT `(a+b)*c-d` (subtracting `d` OUTSIDE the product instead of inside the second factor) and NOT
+`(a-b)*(c+d)` (swapping which pair is summed and which is differenced) — the two distractors exploit exactly those
+confusions.
+
+The setup: a `wheal_diameter`, a `flare_rim`, a `peak_reaction`, and a `trough_reaction`. The reactivity index is:
+
+  REACTIVITY INDEX  (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)  [ sum times a difference ]
+  SPAN SUM          wheal_diameter + flare_rim                                         [ the total span, before scaling ]
+  NET REACTION      peak_reaction - trough_reaction                                    [ the net reaction, before scaling ]
+
+The **reactivity index** is what makes this rung distinctive — it is the ladder's first **product of two binomials**.
+(The span sum `a+b` and the net reaction `c-d` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 47-88 shipped their component sums/products/differences/ratios beside the headline
+figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the addition of the wheal diameter and the flare rim into a span, the subtraction of the trough
+reaction from the peak reaction into a net reaction, then the multiplication of the two (each binomial group before the
+multiply) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine
+change, exactly as rungs 8/16/.../87/88. This rung exercises the engine across **a product of two binomials** — the fact
+that `(a+b)*(c-d)` is `((a+b)*(c-d))` and NOT `(a+b)*c-d` and NOT `(a-b)*(c+d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `*`
+— **no structural constants** — so no numeric literal appears in any program, and neither the span sum, the net
+reaction, nor any reactivity figure is ever a literal (each is computed from the observed quantities). The observed
+quantities carry **digit-free identifiers** (`wheal_diameter`, `flare_rim`, `peak_reaction`, `trough_reaction`) so no
+numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (wheal_diameter + flare_rim) * peak_reaction - trough_reaction    subtract the trough reaction OUTSIDE the
+                                                                               product instead of inside the second
+                                                                               factor (the classic `(a+b)*(c-d)` vs
+                                                                               `(a+b)*c-d` error), and
+  SWAPPED    (wheal_diameter - flare_rim) * (peak_reaction + trough_reaction)  swap which pair is summed and which is
+                                                                               differenced — sum the reactions and take
+                                                                               the difference of the spans (`(a-b)*(c+d)`
+                                                                               instead of `(a+b)*(c-d)`),
+
+which are exactly the mistakes a student makes (dropping the parenthesis on the difference, or mispairing which group
+gets the sum and which gets the difference). Gold rotates A-E by index. QUERIED (used as gold) = the three real
+readouts; all five always appear as options.
+
+Distinctness and positivity: the tables keep the guards — `wheal_diameter > flare_rim >= 2` (so the span difference in
+the swapped slip stays positive) and `peak_reaction > trough_reaction >= 2` (so the net reaction is positive) — so every
+family member, including the headline reactivity index `(a+b)*(c-d)`, is strictly positive (a positive span times a
+positive net reaction, and likewise for the slips); the five family values are pairwise distinct with a comfortable
+margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (WHEAL_DIAMETER, FLARE_RIM, PEAK_REACTION, TROUGH_REACTION) — a wheal diameter and a flare rim to add into a total
+# span, and a peak reaction and a trough reaction whose difference is the net reaction, all plain positive numbers >= 2.
+# The tables satisfy the guards: wheal_diameter > flare_rim >= 2 (so the swapped slip's (a-b) stays positive) and
+# peak_reaction > trough_reaction >= 2 (so the net reaction (c-d) is positive). The five family values are asserted
+# pairwise-distinct below.
+TABLES = [
+    (3, 2, 5, 2),
+    (4, 2, 5, 2),
+    (4, 3, 6, 3),
+    (5, 2, 4, 2),
+    (5, 3, 4, 2),
+    (5, 4, 4, 2),
+    (6, 2, 4, 2),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, -, and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "reactivity_index",
+        "reactivity index (the total span times the net reaction)",
+        "(wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)",
+    ),
+    (
+        "span_sum",
+        "the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)",
+        "wheal_diameter + flare_rim",
+    ),
+    (
+        "net_reaction",
+        "the net reaction (the peak reaction minus the trough reaction, before scaling by the span)",
+        "peak_reaction - trough_reaction",
+    ),
+    (
+        "crossed",
+        "the total span times the peak reaction, MINUS the trough reaction, with the trough subtracted outside the product instead of inside the second factor (a wrong grouping)",
+        "(wheal_diameter + flare_rim) * peak_reaction - trough_reaction",
+    ),
+    (
+        "swapped",
+        "the wheal diameter MINUS the flare rim, times the peak reaction PLUS the trough reaction, swapping which pair is summed and which is differenced (a wrong pairing)",
+        "(wheal_diameter - flare_rim) * (peak_reaction + trough_reaction)",
+    ),
+]
+QUERIED = ["reactivity_index", "span_sum", "net_reaction"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(wheal_diameter, flare_rim, peak_reaction, trough_reaction):
+    # Operation order mirrors the ADJ programs exactly (each parenthesised binomial evaluates first, then the two groups
+    # multiply, so (a+b)*(c-d) evaluates as ((a+b)*(c-d))), so the Python option value and the engine result are the
+    # same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "reactivity_index": (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction),
+        "span_sum": wheal_diameter + flare_rim,
+        "net_reaction": peak_reaction - trough_reaction,
+        "crossed": (wheal_diameter + flare_rim) * peak_reaction - trough_reaction,
+        "swapped": (wheal_diameter - flare_rim) * (peak_reaction + trough_reaction),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for wheal_diameter, flare_rim, peak_reaction, trough_reaction in TABLES:
+        assert (
+            wheal_diameter > 0
+            and flare_rim > 0
+            and peak_reaction > 0
+            and trough_reaction > 0
+        ), (wheal_diameter, flare_rim, peak_reaction, trough_reaction)
+        fv = family_values(wheal_diameter, flare_rim, peak_reaction, trough_reaction)
+        # The tables satisfy the guards, so every family member is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, wheal_diameter, flare_rim, peak_reaction, trough_reaction, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    wheal_diameter,
+                    flare_rim,
+                    peak_reaction,
+                    trough_reaction,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                wheal_diameter,
+                flare_rim,
+                peak_reaction,
+                trough_reaction,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r89stw-{idx + 1:02d}",
+                "qtype": "skin_test_wheal_index",
+                "stem": (
+                    f"A skin test reads a wheal diameter of {num(wheal_diameter)} plus a flare rim of "
+                    f"{num(flare_rim)}, all scaled by a peak reaction of {num(peak_reaction)} minus a trough reaction "
+                    f"of {num(trough_reaction)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe wheal_diameter({num(wheal_diameter)})\n"
+                    f"observe flare_rim({num(flare_rim)})\n"
+                    f"observe peak_reaction({num(peak_reaction)})\n"
+                    f"observe trough_reaction({num(trough_reaction)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 89 — allergy skin-test-wheal reactivity index from four stated quantities (a NEW panel: "
+            "allergy / skin-test-wheal). From a wheal diameter and a flare rim to add into a total span and a peak "
+            "reaction and a trough reaction whose difference is the net reaction, compute the reactivity index "
+            "((wheal_diameter+flare_rim)*(peak_reaction-trough_reaction)), the span sum (wheal_diameter+flare_rim), or "
+            "the net reaction (peak_reaction-trough_reaction). Each item is a compute_dimensioned program (observe the "
+            "four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW shape, PRODUCT OF TWO "
+            "BINOMIALS (a+b)*(c-d) (add a and b, subtract d from c, multiply the two groups, so (a+b)*(c-d) = "
+            "((a+b)*(c-d)); no prior shape multiplied a SUM by a DIFFERENCE — every earlier binomial shape, e.g. rung-67 "
+            "(a-b)*c/d, rung-68 (a+b)*c/d, and rung-84 (a+b)*c-d, multiplied or divided a binomial by a single observed "
+            "factor, never by another binomial) — and the harness matches the scalar to the printed options. "
+            "Contamination-safe: every index is built only from the four observed quantities via +, -, and * — no "
+            "constant leaks, and neither the span sum, the net reaction, nor any reactivity figure ever appears as a "
+            "literal (each is computed) — and the observed quantities carry digit-free identifiers so no numeral hides "
+            "inside a variable name. The five options are a family over the same four quantities, so the distractors are "
+            "exactly the slips students make: subtracting the trough reaction outside the product instead of inside the "
+            "second factor ((a+b)*c-d, a wrong grouping) and swapping which pair is summed and which is differenced "
+            "((a-b)*(c+d), a wrong pairing). The core confusion tested is that (a+b)*(c-d) is ((a+b)*(c-d)), not "
+            "(a+b)*c-d and not (a-b)*(c+d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung89_skin_test_wheal/items.json
+++ b/code/specs/data/adj-ladder/rung89_skin_test_wheal/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 89 \u2014 allergy skin-test-wheal reactivity index from four stated quantities (a NEW panel: allergy / skin-test-wheal). From a wheal diameter and a flare rim to add into a total span and a peak reaction and a trough reaction whose difference is the net reaction, compute the reactivity index ((wheal_diameter+flare_rim)*(peak_reaction-trough_reaction)), the span sum (wheal_diameter+flare_rim), or the net reaction (peak_reaction-trough_reaction). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OF TWO BINOMIALS (a+b)*(c-d) (add a and b, subtract d from c, multiply the two groups, so (a+b)*(c-d) = ((a+b)*(c-d)); no prior shape multiplied a SUM by a DIFFERENCE \u2014 every earlier binomial shape, e.g. rung-67 (a-b)*c/d, rung-68 (a+b)*c/d, and rung-84 (a+b)*c-d, multiplied or divided a binomial by a single observed factor, never by another binomial) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, -, and * \u2014 no constant leaks, and neither the span sum, the net reaction, nor any reactivity figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: subtracting the trough reaction outside the product instead of inside the second factor ((a+b)*c-d, a wrong grouping) and swapping which pair is summed and which is differenced ((a-b)*(c+d), a wrong pairing). The core confusion tested is that (a+b)*(c-d) is ((a+b)*(c-d)), not (a+b)*c-d and not (a-b)*(c+d).",
+  "items": [
+    {
+      "id": "r89stw-01",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 3 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(3)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-02",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 3 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(3)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-03",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 3 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(3)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-04",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-05",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-06",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 2, all scaled by a peak reaction of 5 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(2)\nobserve peak_reaction(5)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 28,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-07",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 3, all scaled by a peak reaction of 6 minus a trough reaction of 3. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(3)\nobserve peak_reaction(6)\nobserve trough_reaction(3)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-08",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 3, all scaled by a peak reaction of 6 minus a trough reaction of 3. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(3)\nobserve peak_reaction(6)\nobserve trough_reaction(3)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-09",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 4 plus a flare rim of 3, all scaled by a peak reaction of 6 minus a trough reaction of 3. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(4)\nobserve flare_rim(3)\nobserve peak_reaction(6)\nobserve trough_reaction(3)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 39,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-10",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 14,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-11",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-12",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-13",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 3, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(3)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-14",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 3, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(3)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-15",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 3, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(3)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-16",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 4, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(4)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r89stw-17",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 4, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(4)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r89stw-18",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 5 plus a flare rim of 4, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(5)\nobserve flare_rim(4)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r89stw-19",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 6 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the reactivity index (the total span times the net reaction)?",
+      "program": "observe wheal_diameter(6)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = (wheal_diameter + flare_rim) * (peak_reaction - trough_reaction)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r89stw-20",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 6 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the span sum (the wheal diameter plus the flare rim, before scaling by the net reaction)?",
+      "program": "observe wheal_diameter(6)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = wheal_diameter + flare_rim\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r89stw-21",
+      "qtype": "skin_test_wheal_index",
+      "stem": "A skin test reads a wheal diameter of 6 plus a flare rim of 2, all scaled by a peak reaction of 4 minus a trough reaction of 2. What is the the net reaction (the peak reaction minus the trough reaction, before scaling by the span)?",
+      "program": "observe wheal_diameter(6)\nobserve flare_rim(2)\nobserve peak_reaction(4)\nobserve trough_reaction(2)\nlet answer = peak_reaction - trough_reaction\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/rung90_spirometry_reserve/gen_items.py
+++ b/code/specs/data/adj-ladder/rung90_spirometry_reserve/gen_items.py
@@ -1,0 +1,239 @@
+"""Generate rung-90 (pulmonary-function / spirometry ventilatory reserve index) items.json for the ADJ-LADDER.
+
+Rung 90 opens the **pulmonary-function / spirometry** panel on the quantitative band — the arithmetic of a ventilatory
+reserve index. A `forced_volume` minus a `residual_volume` gives a usable capacity span, a `peak_flow` minus a
+`trough_flow` gives a flow span, and the two spans MULTIPLY into the reserve index. A **difference times a difference**
+introduces a genuinely NEW arithmetic shape on the ladder: the **product of two DIFFERENCES** — `(a-b)*(c-d)`, i.e.
+`((a-b)*(c-d))`.
+
+This is genuinely new and completes the binomial-product family opened at rung-89. Rung-89 shipped the ladder's first
+product of two binomials as a SUM times a DIFFERENCE (`(a+b)*(c-d)`); rung-90 ships the DIFFERENCE times a DIFFERENCE
+(`(a-b)*(c-d)`) — no shipped shape ever multiplied a difference by ANOTHER difference. Every earlier shape that used a
+parenthesised binomial either multiplied/divided it by a single observed factor (rung-67 `(a-b)*c/d`, rung-68
+`(a+b)*c/d`, rung-75 `(a-b)/c*d`, rung-76 `(a+b)/c*d`, rung-81 `(a+b)/c-d`, rung-82 `(a-b)/c+d`, rung-84 `(a+b)*c-d`) or,
+at rung-89, multiplied a SUM by a difference (`(a+b)*(c-d)`) — never a difference by another difference. `(a-b)*(c-d)` is
+the ladder's first **product of two differences**. The operator order matters: `(a-b)*(c-d)` is `((a-b)*(c-d))` (each
+parenthesised group evaluates first, then the two groups multiply), NOT `(a-b)*c-d` (subtracting `d` OUTSIDE the product
+instead of inside the second factor) and NOT `(a+b)*(c-d)` (summing the first pair instead of differencing it) — the two
+distractors exploit exactly those confusions.
+
+The setup: a `forced_volume`, a `residual_volume`, a `peak_flow`, and a `trough_flow`. The reserve index is:
+
+  RESERVE INDEX   (forced_volume - residual_volume) * (peak_flow - trough_flow)  [ capacity span times flow span ]
+  CAPACITY SPAN   forced_volume - residual_volume                                [ the usable capacity, before scaling ]
+  FLOW SPAN       peak_flow - trough_flow                                        [ the flow span, before scaling ]
+
+The **reserve index** is what makes this rung distinctive — it is the ladder's first **product of two differences**.
+(The capacity span `a-b` and the flow span `c-d` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 47-89 shipped their component sums/products/differences/ratios beside the headline
+figure.)
+
+Each index is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the subtraction of the residual volume from the forced volume into a capacity span, the
+subtraction of the trough flow from the peak flow into a flow span, then the multiplication of the two (each difference
+group before the multiply) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No
+harness/engine change, exactly as rungs 8/16/.../88/89. This rung exercises the engine across **a product of two
+differences** — the fact that `(a-b)*(c-d)` is `((a-b)*(c-d))` and NOT `(a-b)*c-d` and NOT `(a+b)*(c-d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `*`
+— **no structural constants** — so no numeric literal appears in any program, and neither the capacity span, the flow
+span, nor any reserve figure is ever a literal (each is computed from the observed quantities). The observed quantities
+carry **digit-free identifiers** (`forced_volume`, `residual_volume`, `peak_flow`, `trough_flow`) so no numeral hides
+inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (forced_volume - residual_volume) * peak_flow - trough_flow    subtract the trough flow OUTSIDE the product
+                                                                            instead of inside the second factor (the
+                                                                            classic `(a-b)*(c-d)` vs `(a-b)*c-d` error),
+                                                                            and
+  SWAPPED    (forced_volume + residual_volume) * (peak_flow - trough_flow)  sum the first pair instead of differencing
+                                                                            it — add the volumes rather than subtract
+                                                                            (`(a+b)*(c-d)` instead of `(a-b)*(c-d)`),
+
+which are exactly the mistakes a student makes (dropping the parenthesis on the second difference, or summing the first
+pair when it should be differenced). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all
+five always appear as options.
+
+Distinctness and positivity: the tables keep the guards — `forced_volume > residual_volume >= 2` (so the capacity span
+is positive) and `peak_flow > trough_flow >= 2` (so the flow span is positive) — so every family member, including the
+headline reserve index `(a-b)*(c-d)`, is strictly positive (a positive capacity span times a positive flow span, and
+likewise for the slips); the five family values are pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (FORCED_VOLUME, RESIDUAL_VOLUME, PEAK_FLOW, TROUGH_FLOW) — a forced volume and a residual volume whose difference is
+# the usable capacity span, and a peak flow and a trough flow whose difference is the flow span, all plain positive
+# numbers >= 2. The tables satisfy the guards: forced_volume > residual_volume >= 2 (so the capacity span (a-b) stays
+# positive) and peak_flow > trough_flow >= 2 (so the flow span (c-d) is positive). The five family values are asserted
+# pairwise-distinct below.
+TABLES = [
+    (4, 2, 6, 2),
+    (5, 2, 7, 2),
+    (5, 3, 7, 3),
+    (6, 2, 4, 2),
+    (6, 3, 8, 2),
+    (6, 4, 8, 3),
+    (7, 2, 5, 2),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, -, and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "reserve_index",
+        "ventilatory reserve index (the capacity span times the flow span)",
+        "(forced_volume - residual_volume) * (peak_flow - trough_flow)",
+    ),
+    (
+        "capacity_span",
+        "the capacity span (the forced volume minus the residual volume, before scaling by the flow span)",
+        "forced_volume - residual_volume",
+    ),
+    (
+        "flow_span",
+        "the flow span (the peak flow minus the trough flow, before scaling by the capacity span)",
+        "peak_flow - trough_flow",
+    ),
+    (
+        "crossed",
+        "the capacity span times the peak flow, MINUS the trough flow, with the trough subtracted outside the product instead of inside the second factor (a wrong grouping)",
+        "(forced_volume - residual_volume) * peak_flow - trough_flow",
+    ),
+    (
+        "swapped",
+        "the forced volume PLUS the residual volume, times the peak flow minus the trough flow, summing the first pair instead of differencing it (a wrong pairing)",
+        "(forced_volume + residual_volume) * (peak_flow - trough_flow)",
+    ),
+]
+QUERIED = ["reserve_index", "capacity_span", "flow_span"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(forced_volume, residual_volume, peak_flow, trough_flow):
+    # Operation order mirrors the ADJ programs exactly (each parenthesised difference evaluates first, then the two
+    # groups multiply, so (a-b)*(c-d) evaluates as ((a-b)*(c-d))), so the Python option value and the engine result are
+    # the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "reserve_index": (forced_volume - residual_volume) * (peak_flow - trough_flow),
+        "capacity_span": forced_volume - residual_volume,
+        "flow_span": peak_flow - trough_flow,
+        "crossed": (forced_volume - residual_volume) * peak_flow - trough_flow,
+        "swapped": (forced_volume + residual_volume) * (peak_flow - trough_flow),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for forced_volume, residual_volume, peak_flow, trough_flow in TABLES:
+        assert (
+            forced_volume > 0
+            and residual_volume > 0
+            and peak_flow > 0
+            and trough_flow > 0
+        ), (forced_volume, residual_volume, peak_flow, trough_flow)
+        fv = family_values(forced_volume, residual_volume, peak_flow, trough_flow)
+        # The tables satisfy the guards, so every family member is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, forced_volume, residual_volume, peak_flow, trough_flow, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    forced_volume,
+                    residual_volume,
+                    peak_flow,
+                    trough_flow,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                forced_volume,
+                residual_volume,
+                peak_flow,
+                trough_flow,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r90spr-{idx + 1:02d}",
+                "qtype": "spirometry_reserve_index",
+                "stem": (
+                    f"A spirometry study reads a forced volume of {num(forced_volume)} minus a residual volume of "
+                    f"{num(residual_volume)}, all scaled by a peak flow of {num(peak_flow)} minus a trough flow "
+                    f"of {num(trough_flow)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe forced_volume({num(forced_volume)})\n"
+                    f"observe residual_volume({num(residual_volume)})\n"
+                    f"observe peak_flow({num(peak_flow)})\n"
+                    f"observe trough_flow({num(trough_flow)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 90 — pulmonary-function spirometry ventilatory reserve index from four stated quantities (a "
+            "NEW panel: pulmonary-function / spirometry). From a forced volume and a residual volume whose difference is "
+            "the usable capacity span and a peak flow and a trough flow whose difference is the flow span, compute the "
+            "reserve index ((forced_volume-residual_volume)*(peak_flow-trough_flow)), the capacity span "
+            "(forced_volume-residual_volume), or the flow span (peak_flow-trough_flow). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW shape, PRODUCT OF TWO DIFFERENCES (a-b)*(c-d) (subtract b from a, subtract d from c, "
+            "multiply the two groups, so (a-b)*(c-d) = ((a-b)*(c-d)); no prior shape multiplied a DIFFERENCE by another "
+            "DIFFERENCE — every earlier binomial shape multiplied or divided a binomial by a single observed factor, and "
+            "rung-89 (a+b)*(c-d) multiplied a SUM by a difference, never a difference by another difference) — and the "
+            "harness matches the scalar to the printed options. Contamination-safe: every index is built only from the "
+            "four observed quantities via +, -, and * — no constant leaks, and neither the capacity span, the flow span, "
+            "nor any reserve figure ever appears as a literal (each is computed) — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the "
+            "same four quantities, so the distractors are exactly the slips students make: subtracting the trough flow "
+            "outside the product instead of inside the second factor ((a-b)*c-d, a wrong grouping) and summing the first "
+            "pair instead of differencing it ((a+b)*(c-d), a wrong pairing). The core confusion tested is that "
+            "(a-b)*(c-d) is ((a-b)*(c-d)), not (a-b)*c-d and not (a+b)*(c-d)."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung90_spirometry_reserve/items.json
+++ b/code/specs/data/adj-ladder/rung90_spirometry_reserve/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 90 \u2014 pulmonary-function spirometry ventilatory reserve index from four stated quantities (a NEW panel: pulmonary-function / spirometry). From a forced volume and a residual volume whose difference is the usable capacity span and a peak flow and a trough flow whose difference is the flow span, compute the reserve index ((forced_volume-residual_volume)*(peak_flow-trough_flow)), the capacity span (forced_volume-residual_volume), or the flow span (peak_flow-trough_flow). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW shape, PRODUCT OF TWO DIFFERENCES (a-b)*(c-d) (subtract b from a, subtract d from c, multiply the two groups, so (a-b)*(c-d) = ((a-b)*(c-d)); no prior shape multiplied a DIFFERENCE by another DIFFERENCE \u2014 every earlier binomial shape multiplied or divided a binomial by a single observed factor, and rung-89 (a+b)*(c-d) multiplied a SUM by a difference, never a difference by another difference) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every index is built only from the four observed quantities via +, -, and * \u2014 no constant leaks, and neither the capacity span, the flow span, nor any reserve figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: subtracting the trough flow outside the product instead of inside the second factor ((a-b)*c-d, a wrong grouping) and summing the first pair instead of differencing it ((a+b)*(c-d), a wrong pairing). The core confusion tested is that (a-b)*(c-d) is ((a-b)*(c-d)), not (a-b)*c-d and not (a+b)*(c-d).",
+  "items": [
+    {
+      "id": "r90spr-01",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 4 minus a residual volume of 2, all scaled by a peak flow of 6 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(4)\nobserve residual_volume(2)\nobserve peak_flow(6)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-02",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 4 minus a residual volume of 2, all scaled by a peak flow of 6 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(4)\nobserve residual_volume(2)\nobserve peak_flow(6)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-03",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 4 minus a residual volume of 2, all scaled by a peak flow of 6 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(4)\nobserve residual_volume(2)\nobserve peak_flow(6)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 24,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-04",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 2, all scaled by a peak flow of 7 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(2)\nobserve peak_flow(7)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 35,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-05",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 2, all scaled by a peak flow of 7 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(2)\nobserve peak_flow(7)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-06",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 2, all scaled by a peak flow of 7 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(2)\nobserve peak_flow(7)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 35,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-07",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 3, all scaled by a peak flow of 7 minus a trough flow of 3. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(3)\nobserve peak_flow(7)\nobserve trough_flow(3)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-08",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 3, all scaled by a peak flow of 7 minus a trough flow of 3. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(3)\nobserve peak_flow(7)\nobserve trough_flow(3)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-09",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 5 minus a residual volume of 3, all scaled by a peak flow of 7 minus a trough flow of 3. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(5)\nobserve residual_volume(3)\nobserve peak_flow(7)\nobserve trough_flow(3)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 32,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-10",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 2, all scaled by a peak flow of 4 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(2)\nobserve peak_flow(4)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-11",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 2, all scaled by a peak flow of 4 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(2)\nobserve peak_flow(4)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-12",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 2, all scaled by a peak flow of 4 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(2)\nobserve peak_flow(4)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-13",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 3, all scaled by a peak flow of 8 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(3)\nobserve peak_flow(8)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 54,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-14",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 3, all scaled by a peak flow of 8 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(3)\nobserve peak_flow(8)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 54,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-15",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 3, all scaled by a peak flow of 8 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(3)\nobserve peak_flow(8)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-16",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 4, all scaled by a peak flow of 8 minus a trough flow of 3. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(4)\nobserve peak_flow(8)\nobserve trough_flow(3)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r90spr-17",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 4, all scaled by a peak flow of 8 minus a trough flow of 3. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(4)\nobserve peak_flow(8)\nobserve trough_flow(3)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r90spr-18",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 6 minus a residual volume of 4, all scaled by a peak flow of 8 minus a trough flow of 3. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(6)\nobserve residual_volume(4)\nobserve peak_flow(8)\nobserve trough_flow(3)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r90spr-19",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 7 minus a residual volume of 2, all scaled by a peak flow of 5 minus a trough flow of 2. What is the ventilatory reserve index (the capacity span times the flow span)?",
+      "program": "observe forced_volume(7)\nobserve residual_volume(2)\nobserve peak_flow(5)\nobserve trough_flow(2)\nlet answer = (forced_volume - residual_volume) * (peak_flow - trough_flow)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 27,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r90spr-20",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 7 minus a residual volume of 2, all scaled by a peak flow of 5 minus a trough flow of 2. What is the the capacity span (the forced volume minus the residual volume, before scaling by the flow span)?",
+      "program": "observe forced_volume(7)\nobserve residual_volume(2)\nobserve peak_flow(5)\nobserve trough_flow(2)\nlet answer = forced_volume - residual_volume\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r90spr-21",
+      "qtype": "spirometry_reserve_index",
+      "stem": "A spirometry study reads a forced volume of 7 minus a residual volume of 2, all scaled by a peak flow of 5 minus a trough flow of 2. What is the the flow span (the peak flow minus the trough flow, before scaling by the capacity span)?",
+      "program": "observe forced_volume(7)\nobserve residual_volume(2)\nobserve peak_flow(5)\nobserve trough_flow(2)\nlet answer = peak_flow - trough_flow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 27,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/rung91_protein_delivery/gen_items.py
+++ b/code/specs/data/adj-ladder/rung91_protein_delivery/gen_items.py
@@ -1,0 +1,234 @@
+"""Generate rung-91 (nutrition / protein-delivery total) items.json for the ADJ-LADDER.
+
+Rung 91 opens the **nutrition / protein-delivery** panel on the quantitative band — the arithmetic of a total protein
+delivered. An `oral_protein` and an `enteral_protein` are ADDED as two base terms, an `infusion_rate` times
+`infusion_hours` gives the parenteral load, and all three ADD into the total. **Two added terms plus a product**
+introduces a genuinely NEW arithmetic family on the ladder: `a+b+c*d`, i.e. `((a+b)+(c*d))`.
+
+This is genuinely new and opens a NEW family. The **binomial-product family** — rung-89's `(a+b)*(c-d)` and rung-90's
+`(a-b)*(c-d)` — is now COMPLETE. Rung 91 moves to an **additive-chain-plus-product**: a three-way sum whose last term
+is itself a product. No shipped shape ever summed TWO independent added terms and a product in one flat chain — the
+earlier add/sub shapes attached at most one product or quotient to a single leading term (rung-79 `a*b+c/d`, rung-80
+`a*b-c/d`, rung-83 `a-b*c/d`, rung-85 `a*b-c-d` subtracted two bare terms from ONE product). `a+b+c*d` is the ladder's
+first **two-added-terms-plus-a-product**. The operator order matters: `a+b+c*d` is `((a+b)+(c*d))` (the product forms
+first by precedence, then the flat sum), NOT `a+(b+c)*d` (folding the middle sum into the product) and NOT `a+b*c+d`
+(multiplying the wrong pair and adding the last term bare) — the two distractors exploit exactly those confusions.
+
+The setup: an `oral_protein`, an `enteral_protein`, an `infusion_rate`, and an `infusion_hours`. The total is:
+
+  TOTAL PROTEIN     oral_protein + enteral_protein + infusion_rate * infusion_hours  [ two added terms plus a product ]
+  ORAL-ENTERAL SUM  oral_protein + enteral_protein                                   [ the two base terms, before the product ]
+  PARENTERAL LOAD   infusion_rate * infusion_hours                                   [ the infusion product, before the sum ]
+
+The **total protein** is what makes this rung distinctive — it is the ladder's first **two-added-terms-plus-a-product**.
+(The oral-enteral sum `a+b` and the parenteral load `c*d` ride alongside as component readouts, so the panel teaches the
+whole calculation — exactly as rungs 47-90 shipped their component sums/products/differences/ratios beside the headline
+figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the addition of the oral and enteral protein into a base sum, the multiplication of the
+infusion rate by the infusion hours into a parenteral load, then the flat addition of the three (the product forming
+before the sum, so a+b+c*d evaluates as ((a+b)+(c*d))) — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../89/90. This rung exercises the engine
+across a **two-added-terms-plus-a-product** — the fact that `a+b+c*d` is `((a+b)+(c*d))` and NOT `a+(b+c)*d` and NOT
+`a+b*c+d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+` and `*` — **no
+structural constants** — so no numeric literal appears in any program, and neither the oral-enteral sum, the parenteral
+load, nor any total figure is ever a literal (each is computed from the observed quantities). The observed quantities
+carry **digit-free identifiers** (`oral_protein`, `enteral_protein`, `infusion_rate`, `infusion_hours`) so no numeral
+hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    oral_protein + (enteral_protein + infusion_rate) * infusion_hours  fold the middle sum (enteral + rate)
+                                                                                INTO the product instead of leaving the
+                                                                                two terms added (the classic `a+b+c*d`
+                                                                                vs `a+(b+c)*d` error), and
+  SWAPPED    oral_protein + enteral_protein * infusion_rate + infusion_hours    multiply the WRONG pair (enteral × rate)
+                                                                                and add the infusion hours bare
+                                                                                (`a+b*c+d` instead of `a+b+c*d`),
+
+which are exactly the mistakes a student makes (folding a neighbouring term into the product, or multiplying the wrong
+adjacent pair). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness and positivity: every quantity is a plain positive number >= 2, so every family member — a sum of positive
+terms and positive products — is automatically strictly positive; the tables are chosen so the five family values are
+pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (ORAL_PROTEIN, ENTERAL_PROTEIN, INFUSION_RATE, INFUSION_HOURS) — an oral protein and an enteral protein to add as two
+# base terms, and an infusion rate times infusion hours to add as a parenteral load, all plain positive numbers >= 2.
+# Every family member is a sum of positive terms / positive products, so positivity is automatic; the five family values
+# are asserted pairwise-distinct below.
+TABLES = [
+    (2, 2, 2, 4),
+    (2, 3, 2, 5),
+    (2, 4, 2, 2),
+    (2, 5, 2, 7),
+    (2, 6, 2, 3),
+    (2, 7, 3, 2),
+    (3, 2, 3, 3),
+]
+
+# The option family (5 members), all built from the four observed quantities via + and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "total_protein",
+        "total protein delivered (the oral and enteral protein plus the parenteral load)",
+        "oral_protein + enteral_protein + infusion_rate * infusion_hours",
+    ),
+    (
+        "oral_enteral_sum",
+        "the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)",
+        "oral_protein + enteral_protein",
+    ),
+    (
+        "parenteral_load",
+        "the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)",
+        "infusion_rate * infusion_hours",
+    ),
+    (
+        "crossed",
+        "the oral protein plus the enteral protein and infusion rate together times the infusion hours, folding the middle sum into the product instead of leaving the two terms added (a wrong grouping)",
+        "oral_protein + (enteral_protein + infusion_rate) * infusion_hours",
+    ),
+    (
+        "swapped",
+        "the oral protein plus the enteral protein times the infusion rate, plus the infusion hours added bare, multiplying the wrong pair (a wrong pairing)",
+        "oral_protein + enteral_protein * infusion_rate + infusion_hours",
+    ),
+]
+QUERIED = ["total_protein", "oral_enteral_sum", "parenteral_load"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(oral_protein, enteral_protein, infusion_rate, infusion_hours):
+    # Operation order mirrors the ADJ programs exactly (the product forms first by precedence, then the flat sum, so
+    # a+b+c*d evaluates as ((a+b)+(c*d))), so the Python option value and the engine result are the same IEEE-double
+    # (well within the harness's 1e-9 match tolerance).
+    return {
+        "total_protein": oral_protein + enteral_protein + infusion_rate * infusion_hours,
+        "oral_enteral_sum": oral_protein + enteral_protein,
+        "parenteral_load": infusion_rate * infusion_hours,
+        "crossed": oral_protein + (enteral_protein + infusion_rate) * infusion_hours,
+        "swapped": oral_protein + enteral_protein * infusion_rate + infusion_hours,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for oral_protein, enteral_protein, infusion_rate, infusion_hours in TABLES:
+        assert (
+            oral_protein > 0
+            and enteral_protein > 0
+            and infusion_rate > 0
+            and infusion_hours > 0
+        ), (oral_protein, enteral_protein, infusion_rate, infusion_hours)
+        fv = family_values(oral_protein, enteral_protein, infusion_rate, infusion_hours)
+        # Every family member is a sum of positive terms / positive products, so every value is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, oral_protein, enteral_protein, infusion_rate, infusion_hours, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    oral_protein,
+                    enteral_protein,
+                    infusion_rate,
+                    infusion_hours,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                oral_protein,
+                enteral_protein,
+                infusion_rate,
+                infusion_hours,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r91prot-{idx + 1:02d}",
+                "qtype": "protein_delivery_total",
+                "stem": (
+                    f"A nutrition order records an oral protein of {num(oral_protein)} plus an enteral protein of "
+                    f"{num(enteral_protein)}, plus an infusion rate of {num(infusion_rate)} times infusion hours "
+                    f"of {num(infusion_hours)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe oral_protein({num(oral_protein)})\n"
+                    f"observe enteral_protein({num(enteral_protein)})\n"
+                    f"observe infusion_rate({num(infusion_rate)})\n"
+                    f"observe infusion_hours({num(infusion_hours)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 91 — nutrition protein-delivery total from four stated quantities (a NEW panel: nutrition / "
+            "protein-delivery). From an oral protein and an enteral protein to add as two base terms and an infusion rate "
+            "times infusion hours to add as a parenteral load, compute the total protein "
+            "(oral_protein+enteral_protein+infusion_rate*infusion_hours), the oral-enteral sum "
+            "(oral_protein+enteral_protein), or the parenteral load (infusion_rate*infusion_hours). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW family, TWO ADDED TERMS PLUS A PRODUCT a+b+c*d (add a and b, multiply c by d, add the "
+            "three, so a+b+c*d = ((a+b)+(c*d)); the binomial-product family (rung-89 (a+b)*(c-d), rung-90 (a-b)*(c-d)) is "
+            "COMPLETE, and no prior add/sub shape summed TWO independent added terms and a product in one flat chain — "
+            "e.g. rung-79 a*b+c/d, rung-83 a-b*c/d attached one term to a single product) — and the harness matches the "
+            "scalar to the printed options. Contamination-safe: every figure is built only from the four observed "
+            "quantities via + and * — no constant leaks, and neither the oral-enteral sum, the parenteral load, nor any "
+            "total figure ever appears as a literal (each is computed) — and the observed quantities carry digit-free "
+            "identifiers so no numeral hides inside a variable name. The five options are a family over the same four "
+            "quantities, so the distractors are exactly the slips students make: folding the middle sum into the product "
+            "(a+(b+c)*d, a wrong grouping) and multiplying the wrong pair with the last term added bare (a+b*c+d, a wrong "
+            "pairing). The core confusion tested is that a+b+c*d is ((a+b)+(c*d)), not a+(b+c)*d and not a+b*c+d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung91_protein_delivery/items.json
+++ b/code/specs/data/adj-ladder/rung91_protein_delivery/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 91 \u2014 nutrition protein-delivery total from four stated quantities (a NEW panel: nutrition / protein-delivery). From an oral protein and an enteral protein to add as two base terms and an infusion rate times infusion hours to add as a parenteral load, compute the total protein (oral_protein+enteral_protein+infusion_rate*infusion_hours), the oral-enteral sum (oral_protein+enteral_protein), or the parenteral load (infusion_rate*infusion_hours). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, TWO ADDED TERMS PLUS A PRODUCT a+b+c*d (add a and b, multiply c by d, add the three, so a+b+c*d = ((a+b)+(c*d)); the binomial-product family (rung-89 (a+b)*(c-d), rung-90 (a-b)*(c-d)) is COMPLETE, and no prior add/sub shape summed TWO independent added terms and a product in one flat chain \u2014 e.g. rung-79 a*b+c/d, rung-83 a-b*c/d attached one term to a single product) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every figure is built only from the four observed quantities via + and * \u2014 no constant leaks, and neither the oral-enteral sum, the parenteral load, nor any total figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: folding the middle sum into the product (a+(b+c)*d, a wrong grouping) and multiplying the wrong pair with the last term added bare (a+b*c+d, a wrong pairing). The core confusion tested is that a+b+c*d is ((a+b)+(c*d)), not a+(b+c)*d and not a+b*c+d.",
+  "items": [
+    {
+      "id": "r91prot-01",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 2, plus an infusion rate of 2 times infusion hours of 4. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(2)\nobserve infusion_rate(2)\nobserve infusion_hours(4)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r91prot-02",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 2, plus an infusion rate of 2 times infusion hours of 4. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(2)\nobserve infusion_rate(2)\nobserve infusion_hours(4)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r91prot-03",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 2, plus an infusion rate of 2 times infusion hours of 4. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(2)\nobserve infusion_rate(2)\nobserve infusion_hours(4)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r91prot-04",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 3, plus an infusion rate of 2 times infusion hours of 5. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(3)\nobserve infusion_rate(2)\nobserve infusion_hours(5)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r91prot-05",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 3, plus an infusion rate of 2 times infusion hours of 5. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(3)\nobserve infusion_rate(2)\nobserve infusion_hours(5)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r91prot-06",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 3, plus an infusion rate of 2 times infusion hours of 5. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(3)\nobserve infusion_rate(2)\nobserve infusion_hours(5)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 27,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r91prot-07",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 4, plus an infusion rate of 2 times infusion hours of 2. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(4)\nobserve infusion_rate(2)\nobserve infusion_hours(2)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r91prot-08",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 4, plus an infusion rate of 2 times infusion hours of 2. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(4)\nobserve infusion_rate(2)\nobserve infusion_hours(2)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r91prot-09",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 4, plus an infusion rate of 2 times infusion hours of 2. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(4)\nobserve infusion_rate(2)\nobserve infusion_hours(2)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r91prot-10",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 5, plus an infusion rate of 2 times infusion hours of 7. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(5)\nobserve infusion_rate(2)\nobserve infusion_hours(7)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 51,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 21,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r91prot-11",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 5, plus an infusion rate of 2 times infusion hours of 7. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(5)\nobserve infusion_rate(2)\nobserve infusion_hours(7)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 51,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 19,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r91prot-12",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 5, plus an infusion rate of 2 times infusion hours of 7. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(5)\nobserve infusion_rate(2)\nobserve infusion_hours(7)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 51,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 19,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r91prot-13",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 6, plus an infusion rate of 2 times infusion hours of 3. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(6)\nobserve infusion_rate(2)\nobserve infusion_hours(3)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r91prot-14",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 6, plus an infusion rate of 2 times infusion hours of 3. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(6)\nobserve infusion_rate(2)\nobserve infusion_hours(3)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r91prot-15",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 6, plus an infusion rate of 2 times infusion hours of 3. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(6)\nobserve infusion_rate(2)\nobserve infusion_hours(3)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 26,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r91prot-16",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 7, plus an infusion rate of 3 times infusion hours of 2. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(7)\nobserve infusion_rate(3)\nobserve infusion_hours(2)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r91prot-17",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 7, plus an infusion rate of 3 times infusion hours of 2. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(7)\nobserve infusion_rate(3)\nobserve infusion_hours(2)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r91prot-18",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 2 plus an enteral protein of 7, plus an infusion rate of 3 times infusion hours of 2. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(2)\nobserve enteral_protein(7)\nobserve infusion_rate(3)\nobserve infusion_hours(2)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r91prot-19",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 3 plus an enteral protein of 2, plus an infusion rate of 3 times infusion hours of 3. What is the total protein delivered (the oral and enteral protein plus the parenteral load)?",
+      "program": "observe oral_protein(3)\nobserve enteral_protein(2)\nobserve infusion_rate(3)\nobserve infusion_hours(3)\nlet answer = oral_protein + enteral_protein + infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r91prot-20",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 3 plus an enteral protein of 2, plus an infusion rate of 3 times infusion hours of 3. What is the the oral-enteral sum (the oral protein plus the enteral protein, before adding the parenteral load)?",
+      "program": "observe oral_protein(3)\nobserve enteral_protein(2)\nobserve infusion_rate(3)\nobserve infusion_hours(3)\nlet answer = oral_protein + enteral_protein\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r91prot-21",
+      "qtype": "protein_delivery_total",
+      "stem": "A nutrition order records an oral protein of 3 plus an enteral protein of 2, plus an infusion rate of 3 times infusion hours of 3. What is the the parenteral load (the infusion rate times the infusion hours, before adding the oral and enteral protein)?",
+      "program": "observe oral_protein(3)\nobserve enteral_protein(2)\nobserve infusion_rate(3)\nobserve infusion_hours(3)\nlet answer = infusion_rate * infusion_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -126,6 +126,9 @@ SELF_CONTAINED_RUNGS = (
     "rung86_joint_fluid",
     "rung87_complement_titer",
     "rung88_nerve_conduction",
+    "rung89_skin_test_wheal",
+    "rung90_spirometry_reserve",
+    "rung91_protein_delivery",
 )
 
 


### PR DESCRIPTION
## rung-91 protein-delivery (`a+b+c*d`) + re-land of rung-89 / rung-90 (dropped by #7682)

### Why this PR grew
This PR opened as **rung-91** only. While babysitting it green, it went `CONFLICTING`: origin/main's ladder tuple had regressed to end at **rung-88**, and the `rung89_skin_test_wheal` / `rung90_spirometry_reserve` directories were **gone from main's tree** — even though #7691 (rung-89) and #7699 (rung-90) are both **MERGED** and their feat commits are still in history.

**Root cause:** the most recent commit touching `test_ladder_eval.py` on main is **#7682** (`feat(sir): feat/sir-hashmethods-go … (rebased onto main, v0.17.0)`), a SIR-Go PR that was **merged from a stale base** and, as a side effect, reverted the ladder test file and the two rung directories back to the pre-89/90 state. Same class of incident as the earlier "step-therapy lost in a squash → re-landed" (repo history L1).

### What this PR now does
1. **Re-lands rung-89** (allergy skin-test-wheal, `(a+b)*(c-d)`) and **rung-90** (pulmonary-function spirometry, `(a-b)*(c-d)`) — directories restored **byte-for-byte from commit `5049e610`** (the pre-#7682 tip) + their `SELF_CONTAINED_RUNGS` entries.
2. **Adds rung-91** (nutrition / protein-delivery) — a **new arithmetic family `a+b+c*d`** (two added terms plus a product; the binomial-product family is complete, so this opens the additive-chain-plus-product family). `total_protein = oral_protein + enteral_protein + infusion_rate*infusion_hours`; components `oral_enteral_sum` (a+b) and `parenteral_load` (c*d) queried as gold; distractors `crossed` a+(b+c)*d and `swapped` a+b*c+d. 7 tables × 3 = 21 items, gold rotates A–E; constant-free, digit-free ids; 5 family members all positive + pairwise-distinct.

Net effect: the ladder runs **0..91 contiguously** again.

### Verification
- `pytest test_ladder_eval.py -k "rung89 or rung90 or rung91"` → **9 passed** (with `adj-lang-cli` built).
- Single-parent commit; scoped diff = 7 files (rung89 ×2, rung90 ×2, rung91 ×2, `test_ladder_eval.py`).
- rung-91 inline security review PASSED (data-only); rung-89/90 are byte-for-byte the already-reviewed merged versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
