### PR TITLE
fix: restore JSON codec reverted by a stale-branch merge (main is broken)

### DIFF
--- a/code/packages/rust/json-lexer/CHANGELOG.md
+++ b/code/packages/rust/json-lexer/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-07-06
+
+### Added
+
+- `try_tokenize_json()` — like `tokenize_json()` but returns `Result<Vec<Token>, String>`
+  instead of panicking on a malformed input. Use it on **untrusted** bytes (a
+  file, a network payload) where malformed JSON is an ordinary error to handle,
+  not a reason to abort the process. The panicking `tokenize_json()` remains for
+  pre-validated input.
+- 2 tests: valid input returns `Ok`; a character the grammar cannot lex returns
+  `Err` (never panics).
+
 ## [0.1.0] - 2026-03-20
 
 ### Added

--- a/code/packages/rust/json-lexer/Cargo.toml
+++ b/code/packages/rust/json-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-json-lexer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "JSON lexer — tokenizes JSON source text using the grammar-driven lexer and the json.tokens grammar file"
 

--- a/code/packages/rust/json-lexer/src/lib.rs
+++ b/code/packages/rust/json-lexer/src/lib.rs
@@ -17,6 +17,18 @@ pub fn tokenize_json(source: &str) -> Vec<Token> {
         .unwrap_or_else(|e| panic!("JSON tokenization failed: {e}"))
 }
 
+/// Like [`tokenize_json`], but returns the lexer error instead of panicking.
+///
+/// Use this on **untrusted** input (a file, a network payload): malformed JSON
+/// is an ordinary error to handle, not a reason to abort the process. The
+/// panicking [`tokenize_json`] remains for callers that have already validated
+/// their input or want a hard failure.
+pub fn try_tokenize_json(source: &str) -> Result<Vec<Token>, String> {
+    create_json_lexer(source)
+        .tokenize()
+        .map_err(|e| e.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -364,6 +376,27 @@ mod tests {
         assert_eq!(pairs_arr.len(), 2);
         assert_eq!(pairs_arr[0].0, TokenType::LBracket);
         assert_eq!(pairs_arr[1].0, TokenType::RBracket);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 18: panic-free tokenization of untrusted input
+    // -----------------------------------------------------------------------
+
+    /// `try_tokenize_json` returns `Ok` for valid input, matching the panicking
+    /// `tokenize_json`.
+    #[test]
+    fn test_try_tokenize_ok() {
+        let tokens = try_tokenize_json("[1, true, null]").expect("valid JSON should tokenize");
+        assert!(tokens.iter().any(|t| t.type_ == TokenType::LBracket));
+    }
+
+    /// `try_tokenize_json` returns `Err` — never panics — on a character the
+    /// JSON grammar cannot lex. This is the property that makes it safe on
+    /// untrusted bytes.
+    #[test]
+    fn test_try_tokenize_bad_char_is_err() {
+        // `@` is not part of any JSON token, so lexing must fail cleanly.
+        assert!(try_tokenize_json("@").is_err());
     }
 }
 

--- a/code/packages/rust/json-parser/CHANGELOG.md
+++ b/code/packages/rust/json-parser/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-07-06
+
+### Added
+
+- `try_parse_json()` — like `parse_json()` but returns `Result<GrammarASTNode, String>`
+  instead of panicking. Both the tokenize and parse steps are fallible here (via
+  `json-lexer`'s new `try_tokenize_json`), so a malformed **untrusted** document
+  (a file, a request body) is an error to handle rather than a crash. The
+  panicking `parse_json()` remains for pre-validated input.
+- 3 tests: valid input returns `Ok`; unterminated / stray-token / empty inputs
+  return `Err` (never panic); a 100 000-deep `[[[…]]]` returns `Err` instead of
+  overflowing the stack.
+
+### Fixed
+
+- **DoS: deeply-nested JSON overflowed the native stack.** Both `parse_json` and
+  `try_parse_json` constructed the parser via `GrammarParser::new`, which
+  defaults to *no* recursion cap (`usize::MAX`). The recursive-descent parser
+  recurses once per nesting level, so an adversarial `[[[…]]]` a few hundred
+  levels deep aborted the whole process with an uncatchable stack overflow —
+  fatal for untrusted input. Both entry points now apply
+  `.with_max_depth(DEFAULT_MAX_RULE_DEPTH)` (128, the repo-standard cap the SIR
+  frontends use), so over-deep input is refused as an ordinary error. This also
+  protects every other `parse_json`/`create_json_parser` consumer.
+
 ## [0.1.0] - 2026-03-20
 
 ### Added

--- a/code/packages/rust/json-parser/Cargo.toml
+++ b/code/packages/rust/json-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-json-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "JSON parser — parses JSON source text into an AST using the grammar-driven parser and the json.grammar file"
 

--- a/code/packages/rust/json-parser/src/lib.rs
+++ b/code/packages/rust/json-parser/src/lib.rs
@@ -1,14 +1,21 @@
 //! JSON parser backed by compiled parser grammar.
 
-use coding_adventures_json_lexer::tokenize_json;
-use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+use coding_adventures_json_lexer::{tokenize_json, try_tokenize_json};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
 mod _grammar;
 
 pub fn create_json_parser(source: &str) -> GrammarParser {
     let tokens = tokenize_json(source);
     let grammar = _grammar::parser_grammar();
-    GrammarParser::new(tokens, grammar)
+    // Cap recursion depth. `GrammarParser::new` defaults to *no* cap
+    // (`usize::MAX`), and `parse_rule` recurses once per nesting level, so a
+    // deeply-nested document like `[[[…]]]` would otherwise overflow the native
+    // thread stack — an **uncatchable** SIGSEGV that kills the process before
+    // any `Result` could report it. At 128 the parser instead returns a clean
+    // depth-limit error (surfaced here as a catchable `panic!`); beyond ~200 in
+    // a debug build the stack overflows, so the cap sits safely below that.
+    GrammarParser::new(tokens, grammar).with_max_depth(DEFAULT_MAX_RULE_DEPTH)
 }
 
 pub fn parse_json(source: &str) -> GrammarASTNode {
@@ -16,6 +23,26 @@ pub fn parse_json(source: &str) -> GrammarASTNode {
     parser
         .parse()
         .unwrap_or_else(|e| panic!("JSON parse failed: {e}"))
+}
+
+/// Like [`parse_json`], but returns any lexer/parser error instead of panicking.
+///
+/// Use this on **untrusted** JSON (a file, a request body): malformed input is
+/// an error to handle, not a crash. Both the tokenise and parse steps are
+/// fallible here (the panicking [`parse_json`]/`tokenize_json` remain for
+/// pre-validated input).
+///
+/// The parser is depth-capped at [`DEFAULT_MAX_RULE_DEPTH`], so an adversarial
+/// deeply-nested document (`[[[…]]]`) is refused with an ordinary `Err` rather
+/// than overflowing the native stack — the property that makes this genuinely
+/// safe on untrusted bytes.
+pub fn try_parse_json(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_json(source)?;
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar)
+        .with_max_depth(DEFAULT_MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -254,6 +281,37 @@ mod tests {
     // -----------------------------------------------------------------------
     // Test 14: Whitespace handling
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Test: panic-free parsing of untrusted input
+    // -----------------------------------------------------------------------
+
+    /// `try_parse_json` returns `Ok` for valid input, matching `parse_json`.
+    #[test]
+    fn test_try_parse_ok() {
+        let ast = try_parse_json("{\"key\": 42}").expect("valid JSON should parse");
+        assert_eq!(ast.rule_name, "value");
+    }
+
+    /// `try_parse_json` returns `Err` — never panics — on malformed input. This
+    /// is the property that makes it safe on untrusted bytes (files, uploads).
+    #[test]
+    fn test_try_parse_malformed_is_err() {
+        // Unterminated object, stray tokens, and empty input must all be errors.
+        assert!(try_parse_json("{not json").is_err());
+        assert!(try_parse_json("[1, 2,").is_err());
+        assert!(try_parse_json("").is_err());
+    }
+
+    /// A deeply-nested document must be REFUSED with an `Err`, not overflow the
+    /// native stack. The recursive-descent parser recurses once per nesting
+    /// level, so without the `DEFAULT_MAX_RULE_DEPTH` cap this input would
+    /// SIGSEGV the whole process (uncatchable). With the cap it returns cleanly.
+    #[test]
+    fn test_try_parse_deep_nesting_is_err_not_crash() {
+        let deep = "[".repeat(100_000) + &"]".repeat(100_000);
+        assert!(try_parse_json(&deep).is_err());
+    }
 
     /// JSON allows arbitrary whitespace between tokens. The parser should
     /// handle prettified JSON the same as minified JSON.

--- a/code/packages/rust/spreadsheet-io/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-io/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to `spreadsheet-io` are documented here.
 
+## [0.4.0] — SSIO-JSON: JSON (array-of-objects records) load & save
+
+### Added
+- `load_json(&[u8]) -> Result<Workbook, IoError>` — read JSON into a one-sheet
+  `Workbook`. The canonical shape is a top-level **array of objects** ("records"):
+  keys become row 1 (the union of keys across records, in first-seen order), each
+  object becomes a data row, a missing key is a blank cell. Also accepts array of
+  arrays (positional grid), array of scalars (single column), a single object
+  (header + one row), and a top-level scalar (single cell). A nested object/array
+  inside a value is stored as its compact JSON text.
+- `save_json(&wb) -> Vec<u8>` — serialize the **first** sheet as a JSON array of
+  record objects (row 1 = keys, each row below = one `{key: value}` object). The
+  inverse of the records load, so a records file round-trips. Formulas export as
+  their computed value; other sheets are dropped; empty/sheetless → `[]`. Walks
+  `populated_cells` **sparsely**, so a far-flung cell does not blow up.
+- `IoError::Json` variant.
+- 15 tests: header+rows load, records round-trip, value-kind mapping, ragged
+  union header, nested→JSON-text, array-of-arrays grid, array-of-scalars column,
+  single-object, top-level scalar, formula→value, sparse far-corner save, empty
+  array, malformed-input rejection (panic-free), invalid-UTF-8 rejection, and a
+  **JSON → .xlsx bridge**.
+
+### Depends on
+- `json-parser`'s new `try_parse_json` (and `json-lexer`'s `try_tokenize_json`):
+  panic-free parsing, because JSON here is untrusted input — malformed bytes must
+  be an `IoError`, never a crash.
+
+### Security
+- **DoS guard (depth):** a deeply-nested document (`[[[…]]]`) fed to `load_json`
+  would have overflowed the native stack via the recursive parser — an
+  uncatchable process abort. Fixed in `json-parser` (recursion now capped at
+  `DEFAULT_MAX_RULE_DEPTH`); pinned here by `tests/deep_nesting_dos.rs`, which
+  proves a 100 000-deep array resolves to `IoError::Json` in milliseconds.
+
 ## [0.3.0] — SSIO-CSV: delimited text (CSV / TSV) load & save
 
 ### Added

--- a/code/packages/rust/spreadsheet-io/Cargo.toml
+++ b/code/packages/rust/spreadsheet-io/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "spreadsheet-io"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
-description = "The adapter layer that unifies every spreadsheet/tabular file format onto a single in-memory model: load/save .xlsx, legacy .xls, and CSV/TSV straight to and from the spreadsheet-core engine VisiCalc computes on (SSIO01-03)"
+description = "The adapter layer that unifies every spreadsheet/tabular file format onto a single in-memory model: load/save .xlsx, legacy .xls, CSV/TSV, and JSON straight to and from the spreadsheet-core engine VisiCalc computes on (SSIO01-03)"
 license = "MIT"
 
 [dependencies]
@@ -12,3 +12,6 @@ coding-adventures-xlsx-writer = { path = "../xlsx-writer" }
 xls = { path = "../xls" }
 xls-writer = { path = "../xls-writer" }
 coding-adventures-csv-parser = { path = "../csv-parser" }
+coding-adventures-json-parser = { path = "../json-parser" }
+coding-adventures-json-value = { path = "../json-value" }
+coding-adventures-json-serializer = { path = "../json-serializer" }

--- a/code/packages/rust/spreadsheet-io/README.md
+++ b/code/packages/rust/spreadsheet-io/README.md
@@ -14,16 +14,18 @@ live workbook:
 
 ```text
   .xlsx ──load_xlsx────┐                              ┌────save_xlsx──▶ .xlsx
-  .xls  ──load_xls─────┤─▶  spreadsheet-core::Workbook ─┤────save_xls───▶ .xls
-  .csv/.tsv ─load_csv──┘        (THE model)             └────save_csv───▶ .csv/.tsv
+  .xls  ──load_xls─────┤                              ├────save_xls───▶ .xls
+  .csv/.tsv ─load_csv──┤─▶ spreadsheet-core::Workbook ─┤────save_csv───▶ .csv/.tsv
+  .json ──load_json────┘        (THE model)            └────save_json──▶ .json
 ```
 
-Modern `.xlsx` (SSIO01), legacy `.xls`/BIFF8 (SSIO02), and delimited `.csv`/`.tsv`
-(SSIOCSV01) are supported. `.xlsx` preserves live formulas; `.xls` and CSV are
-lower-fidelity (values only — see below). Because everything lands in the one
-`Workbook`, any format loads and any format saves: `load_csv` then `save_xlsx`
-converts a CSV to Excel, and a loaded sheet is queryable with SQL via
-`sql-spreadsheet-source`.
+Modern `.xlsx` (SSIO01), legacy `.xls`/BIFF8 (SSIO02), delimited `.csv`/`.tsv`
+(SSIOCSV01), and `.json` records (SSIOJSON01) are supported. `.xlsx` preserves
+live formulas; `.xls`, CSV, and JSON are lower-fidelity (values only — see below).
+Because everything lands in the one `Workbook`, any format loads and any format
+saves: `load_csv` then `save_xlsx` converts a CSV to Excel, `load_json` then
+`save_csv` flattens an API payload to a spreadsheet, and a loaded sheet is
+queryable with SQL via `sql-spreadsheet-source`.
 
 It is the *only* crate that depends on both the engine and the file-format
 codecs, so the engine never learns what a `.xlsx` is and each codec stays small.
@@ -74,12 +76,35 @@ cache one), booleans become `1`/`0`, and errors become their display text.
 Numbers and text round-trip exactly. Prefer `.xlsx` when formulas matter. See
 `code/specs/SSIO02-spreadsheet-io-xls.md`.
 
+## JSON (records) — SSIOJSON01
+
+JSON has no single canonical spreadsheet shape, so `load_json`/`save_json`
+standardize on the one nearly every data API emits: a top-level **array of
+objects** ("records"). Keys become the header row (the union of keys across
+records, in first-seen order); each object becomes a data row; a missing key is
+a blank cell:
+
+```text
+  [ {"region":"East","sales":200},        region | sales
+    {"region":"West","sales":340} ]  ──▶    East  |  200
+                                            West  |  340
+```
+
+`save_json` is the inverse (row 1 = keys, rows below = objects), so a records
+file round-trips. `load_json` also accepts an array of arrays (positional grid),
+an array of scalars (single column), a single object (header + one row), and a
+top-level scalar (single cell); a nested object/array inside a value is stored as
+its compact JSON text. Formulas export as their computed value and, like CSV,
+only the first sheet is written. `load_json` parses **panic-free** (malformed
+bytes are an `IoError::Json`, never a crash), since JSON is untrusted input. See
+`code/specs/SSIOJSON01-spreadsheet-io-json.md`.
+
 ## Where it sits
 
 ```
-spreadsheetml + xlsx-eval / xls   (read)  ─┐
-                                           ├─▶ spreadsheet-io ◀─▶ spreadsheet-core
-xlsx-writer / xls-writer          (write) ─┘                        (the engine)
+spreadsheetml + xlsx-eval / xls / csv-parser / json-parser  (read)  ─┐
+                                                                     ├─▶ spreadsheet-io ◀─▶ spreadsheet-core
+xlsx-writer / xls-writer / json-serializer                  (write) ─┘                        (the engine)
 ```
 
 Later milestones wire load/save into the `SpreadsheetSession` facade and surface

--- a/code/packages/rust/spreadsheet-io/src/lib.rs
+++ b/code/packages/rust/spreadsheet-io/src/lib.rs
@@ -81,6 +81,9 @@ pub enum IoError {
     /// The delimited-text (CSV/TSV) bytes could not be read — not valid UTF-8,
     /// or malformed CSV structure. Carries the underlying message.
     Csv(String),
+    /// The JSON bytes could not be read — not valid UTF-8, malformed JSON, or a
+    /// top-level shape that isn't tabular. Carries the underlying message.
+    Json(String),
 }
 
 impl std::fmt::Display for IoError {
@@ -89,6 +92,7 @@ impl std::fmt::Display for IoError {
             IoError::Xlsx(msg) => write!(f, "failed to load .xlsx: {msg}"),
             IoError::Xls(msg) => write!(f, "failed to load .xls: {msg}"),
             IoError::Csv(msg) => write!(f, "failed to load CSV/TSV: {msg}"),
+            IoError::Json(msg) => write!(f, "failed to load JSON: {msg}"),
         }
     }
 }
@@ -492,6 +496,244 @@ pub fn save_csv(wb: &Workbook) -> Vec<u8> {
 /// Serialize the first sheet to `.tsv` (tab-delimited). See [`save_delimited`].
 pub fn save_tsv(wb: &Workbook) -> Vec<u8> {
     save_delimited(wb, '\t')
+}
+
+// ===========================================================================
+// JSON (array-of-objects "records") — load & save
+// ===========================================================================
+//
+// JSON has no single canonical spreadsheet shape, so we standardize on the one
+// almost every data API emits: a top-level ARRAY OF OBJECTS ("records"). Each
+// object is a row; each key is a column. That maps cleanly to a one-sheet grid:
+//
+//     [ {"region":"East","sales":200},        region | sales
+//       {"region":"West","sales":340} ]  -->   East   |  200
+//                                              West   |  340
+//
+// Row 1 is the header (the union of keys, in first-seen order); each later row
+// is one record, with a field placed under its key's column (a missing key is a
+// blank cell — records need not be uniform). We also accept the other natural
+// shapes so a hand-written file still round-trips somewhere sensible:
+//
+//   - array of ARRAYS   -> a positional grid (row r, col c), no header
+//   - array of SCALARS  -> a single column
+//   - a single OBJECT   -> header + exactly one record row
+//   - a top-level SCALAR -> a single cell
+//
+// A value that is itself an object or array (a nested structure inside a cell)
+// has no flat spreadsheet meaning, so it is stored as its compact JSON *text* —
+// lossy for editing but faithful for display and re-export.
+//
+// `load_json` uses the panic-free `try_parse_json`: JSON here is UNTRUSTED input
+// (a file, a paste, eventually a browser upload), so malformed bytes must be an
+// `IoError` to handle, never a crash.
+
+use coding_adventures_json_value::{from_ast, JsonNumber, JsonValue};
+use spreadsheet_core::SheetId;
+
+/// Place a value at a 1-based (row, col), skipping blanks and any coordinate
+/// past the u32 address space — a >4-billion-row/col document can't be placed
+/// and is dropped rather than wrapping to a wrong, colliding address.
+fn set_at(wb: &mut Workbook, sheet: SheetId, row: usize, col: usize, value: CellValue) {
+    if value == CellValue::Empty {
+        return;
+    }
+    if let (Ok(r), Ok(c)) = (u32::try_from(row), u32::try_from(col)) {
+        wb.set_value(sheet, CellAddress::new(r, c), value);
+    }
+}
+
+/// Map one JSON value to a cell. Scalars map directly; a nested object/array is
+/// serialized back to compact JSON text (there is no flat cell for a subtree).
+fn json_to_cell(v: &JsonValue) -> CellValue {
+    match v {
+        JsonValue::Null => CellValue::Empty,
+        JsonValue::Bool(b) => CellValue::Boolean(*b),
+        JsonValue::Number(JsonNumber::Integer(i)) => CellValue::Number(*i as f64),
+        JsonValue::Number(JsonNumber::Float(f)) => CellValue::Number(*f),
+        JsonValue::String(s) => CellValue::Text(s.clone()),
+        nested @ (JsonValue::Object(_) | JsonValue::Array(_)) => CellValue::Text(
+            coding_adventures_json_serializer::serialize(nested).unwrap_or_default(),
+        ),
+    }
+}
+
+/// Map one cell's computed value back to a JSON value. A whole-number `Number`
+/// becomes a JSON integer (so `200` re-exports as `200`, not `200.0`); a
+/// fractional or non-finite one stays a float. Errors export as their display
+/// text (there is no JSON error literal).
+fn cell_to_json(v: CellValue) -> JsonValue {
+    match v {
+        CellValue::Empty => JsonValue::Null,
+        CellValue::Boolean(b) => JsonValue::Bool(b),
+        CellValue::Number(n) => {
+            if n.fract() == 0.0 && n.is_finite() && n >= i64::MIN as f64 && n <= i64::MAX as f64 {
+                JsonValue::Number(JsonNumber::Integer(n as i64))
+            } else {
+                JsonValue::Number(JsonNumber::Float(n))
+            }
+        }
+        CellValue::Text(s) => JsonValue::String(s),
+        CellValue::Error(e) => JsonValue::String(e.display().to_string()),
+    }
+}
+
+/// Load JSON bytes into a one-sheet [`Workbook`] named `Sheet1`, interpreting a
+/// top-level array of objects as records (see the module-level shape table).
+///
+/// # Errors
+///
+/// [`IoError::Json`] if the bytes are not valid UTF-8, are malformed JSON, or
+/// the AST cannot be lowered to a value.
+pub fn load_json(bytes: &[u8]) -> Result<Workbook, IoError> {
+    let text = std::str::from_utf8(bytes).map_err(|e| IoError::Json(e.to_string()))?;
+    let ast = coding_adventures_json_parser::try_parse_json(text).map_err(IoError::Json)?;
+    let value = from_ast(&ast).map_err(|e| IoError::Json(e.message))?;
+
+    let mut wb = Workbook::new();
+    let sheet = wb.add_sheet("Sheet1");
+
+    match &value {
+        // Array of objects — the canonical "records" table.
+        JsonValue::Array(items)
+            if !items.is_empty() && items.iter().all(|it| matches!(it, JsonValue::Object(_))) =>
+        {
+            // Header = union of keys across all records, in first-seen order, so
+            // a later record introducing a new key still gets a column.
+            let mut headers: Vec<String> = Vec::new();
+            for it in items {
+                if let JsonValue::Object(pairs) = it {
+                    for (k, _) in pairs {
+                        if !headers.contains(k) {
+                            headers.push(k.clone());
+                        }
+                    }
+                }
+            }
+            for (c, h) in headers.iter().enumerate() {
+                set_at(&mut wb, sheet, 1, c + 1, CellValue::Text(h.clone()));
+            }
+            for (r, it) in items.iter().enumerate() {
+                if let JsonValue::Object(pairs) = it {
+                    for (k, v) in pairs {
+                        if let Some(c) = headers.iter().position(|h| h == k) {
+                            set_at(&mut wb, sheet, r + 2, c + 1, json_to_cell(v));
+                        }
+                    }
+                }
+            }
+        }
+        // Array of arrays — a positional grid, no header row.
+        JsonValue::Array(rows) if rows.iter().all(|it| matches!(it, JsonValue::Array(_))) => {
+            for (r, row) in rows.iter().enumerate() {
+                if let JsonValue::Array(cells) = row {
+                    for (c, v) in cells.iter().enumerate() {
+                        set_at(&mut wb, sheet, r + 1, c + 1, json_to_cell(v));
+                    }
+                }
+            }
+        }
+        // Array of scalars (or a mix) — a single column.
+        JsonValue::Array(items) => {
+            for (r, v) in items.iter().enumerate() {
+                set_at(&mut wb, sheet, r + 1, 1, json_to_cell(v));
+            }
+        }
+        // A single object — header plus exactly one record row.
+        JsonValue::Object(pairs) => {
+            for (c, (k, v)) in pairs.iter().enumerate() {
+                set_at(&mut wb, sheet, 1, c + 1, CellValue::Text(k.clone()));
+                set_at(&mut wb, sheet, 2, c + 1, json_to_cell(v));
+            }
+        }
+        // A top-level scalar — a single cell.
+        scalar => set_at(&mut wb, sheet, 1, 1, json_to_cell(scalar)),
+    }
+
+    wb.recalc_all();
+    Ok(wb)
+}
+
+/// Read the header key for a column from a header cell — text verbatim, other
+/// value kinds rendered so a numeric or boolean header still names its column.
+fn header_key(v: CellValue, col: u32) -> String {
+    match v {
+        CellValue::Text(s) => s,
+        CellValue::Empty => format!("col{col}"),
+        other => match cell_to_json(other) {
+            JsonValue::String(s) => s,
+            JsonValue::Number(JsonNumber::Integer(i)) => i.to_string(),
+            JsonValue::Number(JsonNumber::Float(f)) => format!("{f}"),
+            JsonValue::Bool(b) => b.to_string(),
+            _ => format!("col{col}"),
+        },
+    }
+}
+
+/// Serialize the workbook's **first sheet** to a JSON array of record objects:
+/// row 1 supplies the keys, each row below becomes one `{key: value}` object.
+///
+/// This is the inverse of [`load_json`]'s records shape, so a records file
+/// round-trips. Like the CSV writer, other sheets are dropped and formulas
+/// export as their computed value. An empty or sheetless workbook yields `[]`.
+///
+/// Unlike the dense CSV writer, this walks `populated_cells` **sparsely**, so a
+/// sheet with one far-flung cell does not blow up — cost is proportional to the
+/// number of non-empty cells, not the used-range area.
+pub fn save_json(wb: &Workbook) -> Vec<u8> {
+    let empty = || b"[]".to_vec();
+    let Some(first) = wb.sheet_names().first().and_then(|n| wb.sheet_id(n)) else {
+        return empty();
+    };
+    let Some(ur) = wb.used_range(first) else {
+        return empty();
+    };
+
+    let populated = wb.populated_cells(first);
+    let header_row = ur.min_row;
+
+    // Columns: each populated header-row cell → (col, key), left to right.
+    let mut cols: Vec<(u32, String)> = populated
+        .iter()
+        .filter(|a| a.row == header_row)
+        .map(|a| {
+            let key = header_key(
+                wb.get_value(first, *a).unwrap_or(CellValue::Empty),
+                a.col,
+            );
+            (a.col, key)
+        })
+        .collect();
+    cols.sort_by_key(|(c, _)| *c);
+
+    // Data rows: every populated row below the header, ascending, de-duplicated.
+    let mut rows: Vec<u32> = populated
+        .iter()
+        .map(|a| a.row)
+        .filter(|&r| r > header_row)
+        .collect();
+    rows.sort_unstable();
+    rows.dedup();
+
+    let records: Vec<JsonValue> = rows
+        .into_iter()
+        .map(|row| {
+            let pairs: Vec<(String, JsonValue)> = cols
+                .iter()
+                .map(|(col, key)| {
+                    let v = wb
+                        .get_value(first, CellAddress::new(row, *col))
+                        .unwrap_or(CellValue::Empty);
+                    (key.clone(), cell_to_json(v))
+                })
+                .collect();
+            JsonValue::Object(pairs)
+        })
+        .collect();
+
+    coding_adventures_json_serializer::serialize(&JsonValue::Array(records))
+        .unwrap_or_else(|_| "[]".to_string())
+        .into_bytes()
 }
 
 #[cfg(test)]

--- a/code/packages/rust/spreadsheet-io/src/tests.rs
+++ b/code/packages/rust/spreadsheet-io/src/tests.rs
@@ -6,7 +6,8 @@
 //! workbook is byte-identical) and cover the documented edge cases.
 
 use super::{
-    load_csv, load_tsv, load_xls, load_xlsx, save_csv, save_tsv, save_xls, save_xlsx,
+    load_csv, load_json, load_tsv, load_xls, load_xlsx, save_csv, save_json, save_tsv, save_xls,
+    save_xlsx,
 };
 use spreadsheet_core::{CellAddress, CellValue, SheetId, Workbook};
 
@@ -564,6 +565,168 @@ fn csv_to_xlsx_bridge() {
     // A CSV loaded into the engine can be saved right back out as a real .xlsx —
     // the whole point of a single hub: any format in, any format out.
     let wb = load_csv(b"h1,h2\n1,two\n").unwrap();
+    let xlsx = save_xlsx(&wb);
+    assert_eq!(&xlsx[..2], b"PK");
+    let reopened = load_xlsx(&xlsx).unwrap();
+    let s = reopened.sheet_id("Sheet1").unwrap();
+    assert_eq!(reopened.get_value(s, CellAddress::new(2, 1)), Some(CellValue::Number(1.0)));
+    assert_eq!(reopened.get_value(s, CellAddress::new(2, 2)), Some(CellValue::Text("two".into())));
+}
+
+// =========================================================================
+// JSON (array-of-objects records) — SSIO-JSON
+// =========================================================================
+
+#[test]
+fn json_records_load_header_and_rows() {
+    // The canonical shape: a top-level array of objects. Keys become the header
+    // row (in first-seen order); each object becomes a data row.
+    let wb =
+        load_json(br#"[{"region":"East","sales":200},{"region":"West","sales":340}]"#).unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Text("region".into()));
+    assert_eq!(cell(&wb, "B1"), CellValue::Text("sales".into()));
+    assert_eq!(cell(&wb, "A2"), CellValue::Text("East".into()));
+    assert_eq!(cell(&wb, "B2"), CellValue::Number(200.0)); // JSON integer → Number
+    assert_eq!(cell(&wb, "A3"), CellValue::Text("West".into()));
+    assert_eq!(cell(&wb, "B3"), CellValue::Number(340.0));
+}
+
+#[test]
+fn json_records_round_trip() {
+    // records → workbook → records is byte-stable for a uniform table.
+    let src = br#"[{"region":"East","sales":200},{"region":"West","sales":340}]"#;
+    let wb = load_json(src).unwrap();
+    let out = save_json(&wb);
+    assert_eq!(
+        String::from_utf8(out.clone()).unwrap(),
+        r#"[{"region":"East","sales":200},{"region":"West","sales":340}]"#,
+        "got {}",
+        String::from_utf8_lossy(&out)
+    );
+    // Reloading yields the same values.
+    let wb2 = load_json(&out).unwrap();
+    assert_eq!(cell(&wb2, "B3"), CellValue::Number(340.0));
+}
+
+#[test]
+fn json_value_kinds_map_to_cell_kinds() {
+    // Each JSON scalar maps to its matching cell kind; null → blank.
+    let wb = load_json(br#"[{"n":3.5,"s":"hi","b":true,"z":null}]"#).unwrap();
+    assert_eq!(cell(&wb, "A2"), CellValue::Number(3.5)); // float stays float
+    assert_eq!(cell(&wb, "B2"), CellValue::Text("hi".into()));
+    assert_eq!(cell(&wb, "C2"), CellValue::Boolean(true));
+    assert_eq!(cell(&wb, "D2"), CellValue::Empty); // null → blank cell
+}
+
+#[test]
+fn json_ragged_records_get_union_header() {
+    // A later record introducing a new key still gets a column; a record missing
+    // a key leaves that cell blank.
+    let wb = load_json(br#"[{"a":1},{"a":2,"b":9}]"#).unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Text("a".into()));
+    assert_eq!(cell(&wb, "B1"), CellValue::Text("b".into()));
+    assert_eq!(cell(&wb, "B2"), CellValue::Empty); // first record had no "b"
+    assert_eq!(cell(&wb, "B3"), CellValue::Number(9.0));
+}
+
+#[test]
+fn json_nested_value_becomes_json_text() {
+    // A nested object/array has no flat cell, so it is stored as compact JSON.
+    let wb = load_json(br#"[{"tags":[1,2],"meta":{"k":"v"}}]"#).unwrap();
+    assert_eq!(cell(&wb, "A2"), CellValue::Text("[1,2]".into()));
+    assert_eq!(cell(&wb, "B2"), CellValue::Text(r#"{"k":"v"}"#.into()));
+}
+
+#[test]
+fn json_array_of_arrays_is_a_grid() {
+    // A positional grid, no header row.
+    let wb = load_json(br#"[[1,2],[3,4]]"#).unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Number(1.0));
+    assert_eq!(cell(&wb, "B1"), CellValue::Number(2.0));
+    assert_eq!(cell(&wb, "A2"), CellValue::Number(3.0));
+    assert_eq!(cell(&wb, "B2"), CellValue::Number(4.0));
+}
+
+#[test]
+fn json_array_of_scalars_is_a_column() {
+    let wb = load_json(br#"[10,20,30]"#).unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Number(10.0));
+    assert_eq!(cell(&wb, "A2"), CellValue::Number(20.0));
+    assert_eq!(cell(&wb, "A3"), CellValue::Number(30.0));
+}
+
+#[test]
+fn json_single_object_is_header_plus_one_row() {
+    let wb = load_json(br#"{"x":1,"y":2}"#).unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Text("x".into()));
+    assert_eq!(cell(&wb, "B1"), CellValue::Text("y".into()));
+    assert_eq!(cell(&wb, "A2"), CellValue::Number(1.0));
+    assert_eq!(cell(&wb, "B2"), CellValue::Number(2.0));
+}
+
+#[test]
+fn json_top_level_scalar_is_one_cell() {
+    let wb = load_json(br#"42"#).unwrap();
+    assert_eq!(cell(&wb, "A1"), CellValue::Number(42.0));
+}
+
+#[test]
+fn json_save_flattens_formula_to_value() {
+    // Like the other flat writers, a formula exports as its computed value.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("Sheet1");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Text("total".into()));
+    wb.set_value(s, CellAddress::new(2, 1), CellValue::Number(0.0));
+    wb.set_formula(s, CellAddress::new(2, 1), "=6*7").unwrap();
+    wb.recalc_all();
+    assert_eq!(String::from_utf8(save_json(&wb)).unwrap(), r#"[{"total":42}]"#);
+}
+
+#[test]
+fn json_save_far_corner_is_sparse() {
+    // A header plus one far-flung cell must not blow up: the writer walks
+    // populated cells, not the used-range area.
+    let mut wb = Workbook::new();
+    let s = wb.add_sheet("Sheet1");
+    wb.set_value(s, CellAddress::new(1, 1), CellValue::Text("k".into()));
+    wb.set_value(s, CellAddress::new(1_048_576, 1), CellValue::Number(9.0));
+    wb.recalc_all();
+    // One data row (the far one); header key "k".
+    assert_eq!(String::from_utf8(save_json(&wb)).unwrap(), r#"[{"k":9}]"#);
+}
+
+#[test]
+fn json_empty_array_is_empty_workbook() {
+    let wb = load_json(b"[]").unwrap();
+    let s = wb.sheet_id("Sheet1").unwrap();
+    assert!(wb.used_range(s).is_none());
+    assert_eq!(save_json(&wb), b"[]");
+}
+
+#[test]
+fn json_load_rejects_malformed_input() {
+    // Untrusted input: a malformed document is an error, never a panic.
+    match load_json(b"{not json") {
+        Ok(_) => panic!("malformed JSON must not load"),
+        Err(e) => {
+            assert!(matches!(e, super::IoError::Json(_)));
+            assert!(e.to_string().contains("failed to load JSON"));
+        }
+    }
+}
+
+#[test]
+fn json_load_rejects_invalid_utf8() {
+    match load_json(&[0xff, 0xfe, 0x00]) {
+        Ok(_) => panic!("invalid UTF-8 must not load as JSON"),
+        Err(e) => assert!(matches!(e, super::IoError::Json(_))),
+    }
+}
+
+#[test]
+fn json_to_xlsx_bridge() {
+    // JSON records in, a real .xlsx out — the single-hub promise across formats.
+    let wb = load_json(br#"[{"h1":1,"h2":"two"}]"#).unwrap();
     let xlsx = save_xlsx(&wb);
     assert_eq!(&xlsx[..2], b"PK");
     let reopened = load_xlsx(&xlsx).unwrap();

--- a/code/packages/rust/spreadsheet-io/tests/deep_nesting_dos.rs
+++ b/code/packages/rust/spreadsheet-io/tests/deep_nesting_dos.rs
@@ -1,0 +1,26 @@
+//! DoS guard: a deeply-nested JSON document (adversarial untrusted input) must
+//! return an error, never overflow the native thread stack.
+//!
+//! `load_json` feeds untrusted bytes into the recursive-descent grammar parser,
+//! which recurses once per nesting level. Without a depth cap, an input like
+//! `[[[…]]]` a few hundred levels deep overflows the stack — an *uncatchable*
+//! SIGSEGV that aborts the whole process, defeating the panic-free contract.
+//! `json-parser` caps recursion at `DEFAULT_MAX_RULE_DEPTH` (128), so such input
+//! is refused as an ordinary `IoError::Json`. This test pins that at the codec
+//! level: 100 000 levels deep resolves to an error in milliseconds, no crash.
+
+#[test]
+fn deeply_nested_json_is_rejected_not_crash() {
+    let depth = 100_000;
+    let mut s = String::with_capacity(depth * 2);
+    for _ in 0..depth {
+        s.push('[');
+    }
+    for _ in 0..depth {
+        s.push(']');
+    }
+    match spreadsheet_io::load_json(s.as_bytes()) {
+        Ok(_) => panic!("a 100k-deep array must not parse as a valid workbook"),
+        Err(e) => assert!(matches!(e, spreadsheet_io::IoError::Json(_))),
+    }
+}

--- a/code/specs/SSIOJSON01-spreadsheet-io-json.md
+++ b/code/specs/SSIOJSON01-spreadsheet-io-json.md
@@ -1,0 +1,84 @@
+# SSIOJSON01 — `spreadsheet-io`: JSON (array-of-objects records) load & save
+
+Extends `spreadsheet-io` (which unified `.xlsx`/`.xls`/CSV/TSV onto
+`spreadsheet-core`) with **JSON**, so the same engine reads and writes the shape
+almost every web API and data tool emits — a top-level array of record objects.
+A JSON payload loaded this way is editable in VisiCalc, queryable with SQL
+(`sql-spreadsheet-source`), and re-exportable as `.xlsx`/CSV. This continues
+"read and process any tabular format, export any tabular format" onto the one
+core.
+
+## API (added)
+
+```rust
+pub fn load_json(bytes: &[u8]) -> Result<Workbook, IoError>;
+pub fn save_json(wb: &Workbook) -> Vec<u8>;
+```
+
+`IoError` gains a `Json(String)` variant (invalid UTF-8 / malformed JSON / an
+AST that can't be lowered to a value).
+
+## Model: JSON has no single spreadsheet shape, so pick the common one
+
+The canonical, round-tripping shape is a top-level **array of objects**
+("records") — one object per row, one key per column:
+
+```text
+  [ {"region":"East","sales":200},        region | sales
+    {"region":"West","sales":340} ]  ──▶    East  |  200
+                                            West  |  340
+```
+
+- **Load** parses the bytes (panic-free — see below), then interprets the value:
+  - **array of objects** → records: row 1 is the header (the **union** of keys
+    across all records, in first-seen order, so a later record's new key still
+    gets a column); each object is a data row, a field placed under its key's
+    column; a missing key is a blank cell (records need not be uniform).
+  - **array of arrays** → a positional grid `(r+1, c+1)`, no header row.
+  - **array of scalars** → a single column.
+  - **single object** → header + exactly one record row.
+  - **top-level scalar** → a single cell.
+  - A value that is itself an **object or array** (a nested subtree) has no flat
+    cell, so it is stored as its **compact JSON text** — lossy for editing but
+    faithful for display and re-export.
+  - Scalar → cell mapping: JSON integer/float → `Number`, string → `Text`,
+    `true`/`false` → `Boolean`, `null` → empty cell.
+- **Save** is the inverse of the records shape: the **first** sheet's header row
+  (`used_range.min_row`) supplies the keys, and each populated row below becomes
+  one `{key: value}` object. Cell → JSON mapping: a whole-number `Number` → JSON
+  integer (`200`, not `200.0`), a fractional/non-finite `Number` → float, `Text`
+  → string, `Boolean` → `true`/`false`, empty → `null`, error → its display text
+  (there is no JSON error literal). An empty or sheetless workbook yields `[]`.
+
+## Panic-free parsing (untrusted input)
+
+JSON here is **untrusted** (a file, a paste, eventually a browser upload), so
+`load_json` uses `json-parser`'s new `try_parse_json` (which uses `json-lexer`'s
+new `try_tokenize_json`): malformed bytes return `IoError::Json`, never a panic.
+The pre-existing `parse_json`/`tokenize_json` (which panic) remain for callers
+with pre-validated input.
+
+## Sparse save (DoS-safe)
+
+Unlike the dense CSV writer, `save_json` walks `populated_cells` **sparsely**, so
+a sheet with one far-flung cell costs one record, not a used-range-area blow-up.
+
+## Round-trip & interop
+
+A records file round-trips (`load_json(save_json(wb))` preserves the table). The
+output is standard JSON any parser accepts, and a `JSON → .xlsx` bridge test
+proves any-format-in / any-format-out.
+
+## Limitations (documented + tested)
+
+- **One sheet.** A JSON records array is a single table; `save_json` writes the
+  first sheet and drops the rest — use `.xlsx` for multi-sheet.
+- **No formulas/types-as-such.** Formulas save as their computed value; a
+  nested object/array in a cell round-trips as JSON *text*, not as structure.
+- **Records shape on save.** `save_json` always emits the array-of-objects
+  records shape; it does not attempt to reproduce a grid/scalar input shape.
+
+## Non-goals
+
+- JSON Lines / NDJSON, streaming, or schema inference beyond the header row.
+- Header-aware column typing (that lives in `sql-spreadsheet-source`).

--- a/lessons.md
+++ b/lessons.md
@@ -1256,3 +1256,44 @@ The split is exactly what SIR21 §E3 prescribes precisely to avoid one overloade
 `/` that different sources read differently.
 
 Discovered: 2026-07-04, SIR21 division frontier (sir-conformance 0.10.0).
+
+## A stale-branch merge can silently REVERT already-merged work → red main from two green PRs
+
+**Symptom:** `main` stopped compiling. `spreadsheet-core-wasm` 0.15 (SSIO PR4
+#7701) called `spreadsheet_io::load_json`, but `spreadsheet-io` on `main` was
+back at 0.3.0 with the whole JSON codec gone. `cargo build -p spreadsheet-wasm
+--target wasm32-unknown-unknown --release` failed with `cannot find function
+load_json in crate spreadsheet_io`.
+
+**Root cause:** PR #7682 ("feat(sir): sir-hashmethods-go … **rebased onto
+main**") was rebased on a **stale, pre-#7693 main**. Its merge silently reverted
+the ENTIRE #7693 changeset (13 files across spreadsheet-io + json-parser +
+json-lexer) as collateral — #7682 was the only post-#7693 commit touching any of
+them, and it dragged them back to their old state. #7682's CI was green (its
+snapshot compiled); #7701's CI was green (its base still had `load_json`).
+Neither CI saw the other, so **two individually-green PRs merged into a red
+main**. This also re-opened a CRITICAL DoS (the json-parser recursion depth cap
+went with the revert).
+
+**How to detect fast:** when a symbol "vanishes" that you know was merged,
+`git log --oneline <good-merge>..origin/main -- <file>` shows the culprit, and
+`git show origin/main:<file> | grep <symbol>` confirms it's gone. A reverted
+crate's **version number rolls backward** (0.4.0 → 0.3.0) — a dead giveaway.
+
+**Fix:** restore only the affected files to their last-good commit —
+`git checkout <good-sha> -- <the exact file list>` — never a broad revert (that
+would clobber the stale PR's *legitimate* work). Verify the previously-failing
+build command actually passes now. The restore is byte-identical to
+already-reviewed code, so no fresh security review is needed.
+
+**Prevention / takeaways:**
+- **"Rebased onto main" in a PR title is a smell** — verify its file list is only
+  what it claims. A SIR/Go PR touching `spreadsheet-io`/`json-*` is a red flag.
+- Green CI on *both* PRs does NOT mean their *combination* is green. A shared
+  crate that one PR removes and another PR starts calling is invisible to both
+  pre-merge checks. (See also: "Diff branch full file list vs origin/main before
+  push; stale worktrees revert files.")
+- When you inherit a broken main mid-loop, **fixing main is the priority** — a
+  focused hotfix PR unblocks the whole repo, not just your feature.
+
+Discovered: 2026-07-06, SSIO PR5 setup (found `main` non-compiling; hotfix #7709).


### PR DESCRIPTION
## 🔴 `main` currently does not compile — this restores it

`spreadsheet-core-wasm` 0.15 (from [SSIO PR4 #7701](https://github.com/adhithyan15/coding-adventures/pull/7701)) calls `spreadsheet_io::load_json` / `save_json`, but `spreadsheet-io` on `main` is back at **0.3.0 with the JSON codec removed** — so `spreadsheet-core-wasm` (and the `wasm32` release build) **fails to compile**.

### Root cause
[#7682](https://github.com/adhithyan15/coding-adventures/pull/7682) ("feat(sir): sir-hashmethods-go … **rebased onto main**") was rebased on a **stale, pre-#7693 `main`**, so its merge silently **reverted the entire [#7693](https://github.com/adhithyan15/coding-adventures/pull/7693) changeset** as collateral — it is the only post-#7693 commit touching any of these 13 files. Two individually-green PRs (#7682 removing the codec, #7701 adding a caller) raced into a red `main`; neither's CI saw the other. Classic "green ≠ mergeable".

### What was lost and is restored (to the exact #7693 state, `35d975de`)
- **spreadsheet-io** 0.3.0 → 0.4.0: `load_json`/`save_json`, `IoError::Json`, tests, `tests/deep_nesting_dos.rs`, README, CHANGELOG, spec `SSIOJSON01`.
- **json-parser** 0.1.0 → 0.2.0: `try_parse_json` **+ the stack-overflow DoS depth cap** (`.with_max_depth(DEFAULT_MAX_RULE_DEPTH)`) — the revert also **re-opened that CRITICAL DoS**.
- **json-lexer** 0.1.0 → 0.2.0: `try_tokenize_json`.

### Scope & safety
Only #7693's 13 files are touched, restored via `git checkout 35d975de -- …`, so **#7682's legitimate SIR/Go work is untouched**. The diff is **byte-identical to #7693**, which already passed a full security review (incl. independent confirmation of the DoS fix).

### Verification
`spreadsheet-io` 51 · `json-parser` 19 · `json-lexer` 19 · `spreadsheet-core-wasm` 47 · `spreadsheet-wasm` 13 tests pass, and `cargo build -p spreadsheet-wasm --target wasm32-unknown-unknown --release` (broken on `main`) now compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)