### PR TITLE
fix(cloc12): restore CLOC12.167 NewTarget node reverted by #7682's stale rebase

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.31.0] - 2026-07-04
+
+### Added — CLOC12.167: emit `NewTarget` (`new.target`)
+
+Added `emit_new_target` (prints the literal two-token spelling `new.target` after recording its source-map anchor) and classified `Expression::NewTarget` at `PREC_PRIMARY` in `expr_prec` — a meta-property primary like `this` / `super`. As a primary leaf it never needs wrapping and never forces a paren around an operand; the internal `.` is part of the spelling, not a member access. Four unit tests. (CLOC12.167)
+
+
 ## [0.30.1] - 2026-07-04
 
 ### Added — CLOC12.166 PR3: CodePrinter `super` conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.30.1"
+version = "0.31.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -79,7 +79,7 @@ use coding_adventures_javascript_ast::{
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
     TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
-    Super,
+    Super, NewTarget,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1142,6 +1142,7 @@ impl<'a> Emitter<'a> {
             Expression::AwaitExpression(a) => self.emit_await(a),
             Expression::ThisExpression(t) => self.emit_this(t),
             Expression::Super(s) => self.emit_super(s),
+            Expression::NewTarget(n) => self.emit_new_target(n),
         }
         if needs_parens {
             self.write_str(")");
@@ -1650,6 +1651,17 @@ impl<'a> Emitter<'a> {
         self.write_str("super");
     }
 
+    /// `new.target` — the meta-property, a leaf like `this` / `super`. It is
+    /// spelled with two tokens plus a dot, so the emit is the literal ten
+    /// characters `new.target` (after recording the source-map anchor). As a
+    /// `PREC_PRIMARY` leaf it is only ever followed by a member/call token or a
+    /// punctuator, never by another word that would fuse; the internal `.` is
+    /// part of the spelling, not a member access, so no operand is walked.
+    fn emit_new_target(&mut self, n: &NewTarget) {
+        self.maybe_map(&n.cv);
+        self.write_str("new.target");
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -2031,7 +2043,12 @@ fn expr_prec(e: &Expression) -> u8 {
         // keyword that binds at the tightest level. It is only ever the object
         // of a member access or a call callee (`super.m()`, `super[k]`,
         // `super()`) — all of which compose paren-free at primary strength.
-        | Expression::Super(_) => PREC_PRIMARY,
+        | Expression::Super(_)
+        // `new.target` is a meta-property primary — an atomic two-token
+        // spelling that binds at the tightest level, like `this`. It never
+        // needs wrapping and never forces a paren around an operand (it has
+        // none). The internal `.` is part of the spelling, not member access.
+        | Expression::NewTarget(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
         // Update (`++x` / `x++`) binds a hair tighter than the pure unary
@@ -5161,5 +5178,40 @@ mod tests {
     fn super_under_binary_parent_is_bare() {
         let e = binary(BinaryOperator::Add, super_expr(), num(1.0));
         assert_eq!(emit_expr(e), "super+1;");
+    }
+
+    // =================================================================
+    // NewTarget (`new.target`) — CLOC12.167
+    // =================================================================
+
+    /// Build a `NewTarget`.
+    fn new_target_expr() -> Expression {
+        Expression::NewTarget(NewTarget { cv: None })
+    }
+
+    /// `new.target` — the meta-property, printed as its literal spelling.
+    #[test]
+    fn new_target_emits_literal_spelling() {
+        assert_eq!(emit_expr(new_target_expr()), "new.target;");
+    }
+
+    /// `new.target.x` — `new.target` is a primary, so a member parent needs no
+    /// parens (the trailing `.x` is a real member access on top of it).
+    #[test]
+    fn new_target_as_member_object_is_bare() {
+        assert_eq!(emit_expr(member(new_target_expr(), "x", false)), "new.target.x;");
+    }
+
+    /// `f(new.target)` — as a call argument it is a plain primary operand.
+    #[test]
+    fn new_target_as_call_argument_is_bare() {
+        assert_eq!(emit_expr(call(ident("f"), vec![new_target_expr()])), "f(new.target);");
+    }
+
+    /// `new.target+1` — even a binary parent leaves the primary bare.
+    #[test]
+    fn new_target_under_binary_parent_is_bare() {
+        let e = binary(BinaryOperator::Add, new_target_expr(), num(1.0));
+        assert_eq!(emit_expr(e), "new.target+1;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.85.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.9"
+version = "0.85.10"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -504,6 +504,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         // itself a constant, so it passes through unchanged like the literals.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => fold_binary(b, st),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.20.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.9"
+version = "0.20.10"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -1167,6 +1167,7 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         // its own, so it clones through like the literals.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.20.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.9"
+version = "0.20.10"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -281,6 +281,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         AwaitExpression(a) => a.cv.clone(),
         ThisExpression(t) => t.cv.clone(),
         Super(s) => s.cv.clone(),
+        NewTarget(n) => n.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1364,6 +1365,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         // through like the literals.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.11.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.9"
+version = "0.11.10"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -732,6 +732,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         // `this` binds no variable name — nothing to count or propagate into.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             count_uses_expr(&be.left, name, count);
@@ -1035,6 +1036,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         // `this` binds no variable name — nothing to count or propagate into.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= propagate_in_expr(&mut be.left, cand);

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.25.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.9"
+version = "0.25.10"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -441,6 +441,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         // other leaves (which this arm counts as 0 sub-nodes).
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => 0,
         Expression::BinaryExpression(be) => expr_node_count(&be.left) + expr_node_count(&be.right),
         Expression::LogicalExpression(le) => expr_node_count(&le.left) + expr_node_count(&le.right),
@@ -759,6 +760,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_binding_idents_expr(&be.left, out);
@@ -1046,6 +1048,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             tally_expr(&be.left, cand, t);
@@ -1389,6 +1392,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= inline_in_expr(&mut be.left, cand);
@@ -1522,6 +1526,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             substitute(&mut be.left, map);
@@ -2043,6 +2048,7 @@ fn expr_collect_mutated_params(
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
     }
 }
@@ -3394,6 +3400,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // predicates leave it conservative.)
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_in_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.10.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.9"
+version = "0.10.10"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -637,6 +637,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // `this` binds no global name — nothing to collect or rename.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -961,6 +962,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `this` binds no global name — nothing to collect or rename.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_apply_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.12.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.9"
+version = "0.12.10"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1148,6 +1148,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         // `this` holds no property name to classify or rewrite.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             classify_expr(&be.left, cls);
@@ -1434,6 +1435,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `this` holds no property name to classify or rewrite.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.14.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.9"
+version = "0.14.10"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -915,6 +915,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         // `this` is a reserved-word leaf — never a renameable identifier.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -1225,6 +1226,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `this` is a reserved-word leaf — never a renameable identifier.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_uses_expr(&mut be.left, map);

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.10] - 2026-07-04
+
+### Changed — CLOC12.167: `NewTarget` exhaustive-match arm
+
+Added an `Expression::NewTarget` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.167 atomic node PR1). `new.target` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and, in fold-control-flow, returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.12.9] - 2026-07-04
 
 ### Changed — CLOC12.166: `Super` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.9"
+version = "0.12.10"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -853,6 +853,7 @@ fn walk_expression(
         // scope analysis — so it introduces and references nothing.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
+        | Expression::NewTarget(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             walk_expression(&be.left, ctx, analysis, pending);

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.26.0] - 2026-07-04
+
+### Added — CLOC12.167: `Expression::NewTarget` (`new.target`)
+
+Added `Expression::NewTarget` variant + `NewTarget { cv }` struct — the `new.target` meta-property, a reserved-word **leaf** primary (same shape as `Super` / `ThisExpression`, no operand). Spelled with two tokens (`new` `.` `target`) in source but modelled as an atomic node rather than a member access, so the renaming passes never touch it. Re-exported from the crate root. Atomic node PR (PR1): the node + `closure-emitter` emit + all nine downstream pass match-arms land together so the workspace never breaks. (CLOC12.167)
+
+
 ## [0.25.0] - 2026-07-04
 
 ### Added — CLOC12.166: `Expression::Super` (`super`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -133,6 +133,15 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   `PREC_PRIMARY` and prints as the bare keyword. Node + `closure-emitter` +
   all pass traversals land in one atomic PR; the bridge-enable + conformance
   port follow.
+- `NewTarget` (CLOC12.167) — the `new.target` meta-property: the reserved-word
+  **leaf** sibling of `this` / `super`, reading the constructor a function was
+  invoked with (`undefined` for a plain call). `NewTarget { cv }` — no operand,
+  the same shape as `Super`. Spelled with two tokens plus a dot in source, but
+  the `.` is part of the spelling (not a member access), so it is modelled as
+  an atomic leaf node rather than a `MemberExpression`; the renaming passes
+  never touch it. It tags at `PREC_PRIMARY` and the emitter prints the literal
+  spelling `new.target`. Node + `closure-emitter` + all pass traversals land in
+  one atomic PR; the bridge-enable + conformance port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -66,6 +66,7 @@ pub enum Expression {
     AwaitExpression(AwaitExpression),
     ThisExpression(ThisExpression),
     Super(Super),
+    NewTarget(NewTarget),
 }
 
 // ---------------------------------------------------------------------
@@ -649,6 +650,38 @@ pub struct Super {
     pub cv: Option<CvId>,
 }
 
+/// The `new.target` meta-property — a primary that reads the constructor a
+/// function was invoked with (`undefined` for a plain call, the constructor
+/// for a `new` call):
+///
+/// ```text
+///   function F() { if (new.target) { … } }   // was F called with `new`?
+///   class C { constructor() { new.target } } // the actual (sub)class
+/// ```
+///
+/// # Shape
+///
+/// `new.target` is a **leaf** — like [`ThisExpression`] and [`Super`], it
+/// carries no operand and no payload beyond its `cv`. In source it is spelled
+/// with two tokens (`new` `.` `target`), but semantically it is an atomic
+/// meta-property, so ESTree models it as its own `MetaProperty`-style node
+/// (here `NewTarget`) rather than a member access. It can never be a variable
+/// name, so the renaming passes must never touch it — a dedicated variant lets
+/// those passes exclude it structurally.
+///
+/// # Precedence
+///
+/// `new.target` binds at **primary** strength — the tightest level, like
+/// `this` / `super`. It never needs wrapping in any parent context, and no
+/// parent operand ever forces a paren around it. The emitter tags it
+/// `PREC_PRIMARY` and prints the literal two-token spelling `new.target`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewTarget {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+}
+
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the
 /// `property` is conventionally an [`Expression::Identifier`]);
 /// `computed = true` ↔ `obj[key]` (the `property` is any expression).
@@ -1109,6 +1142,21 @@ mod tests {
         let json = serde_json::to_string(&s).expect("serialize");
         assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
         assert_eq!(s.clone(), roundtrip(s));
+    }
+
+    #[test]
+    fn new_target_roundtrips_traced() {
+        let n = Expression::NewTarget(NewTarget { cv: Some("newTarget.1".to_string()) });
+        assert_eq!(n.clone(), roundtrip(n.clone()));
+        assert_eq!(type_tag(&n), "NewTarget");
+    }
+
+    #[test]
+    fn new_target_untraced_omits_cv() {
+        let n = Expression::NewTarget(NewTarget { cv: None });
+        let json = serde_json::to_string(&n).expect("serialize");
+        assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(n.clone(), roundtrip(n));
     }
 
     #[test]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
-    AwaitExpression, Super, ThisExpression, YieldExpression,
+    AwaitExpression, NewTarget, Super, ThisExpression, YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2137,6 +2137,49 @@ shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
 
+## CLOC12.167 — `NewTarget` (`new.target`): atomic node + emit + passes (PR1)
+
+Adds `Expression::NewTarget { cv }` to `javascript-ast` (0.26.0) — the
+`new.target` meta-property, the reserved-word **leaf** sibling of `this` /
+`super`. It reads the constructor a function was invoked with (`undefined` for
+a plain call; the constructor for a `new` call). Like `this` / `super` it is
+the simplest possible node: no operand, no axis, the same shape as `Super` /
+`ThisExpression`.
+
+Although `new.target` is spelled with **two tokens plus a dot** in source, it
+is semantically an *atomic* meta-property — the `.` is part of the spelling,
+not a member access — so it is modelled as its own leaf variant rather than a
+`MemberExpression`. It can never be a variable name, so the renaming passes
+must exclude it structurally.
+
+**Emit (`closure-emitter` 0.31.0).** `emit_new_target` writes the literal
+ten-character spelling `new.target`. `new.target` tags at `PREC_PRIMARY` — the
+tightest level, like `this` — so it never needs wrapping in any parent
+(`new.target.x`, `f(new.target)`, `new.target+1` all print bare) and never
+forces a paren around an operand (it has none).
+
+**Passes (PATCH bumps).** The three rebuild passes (`constant-fold`, `dce`,
+`fold-control-flow`) clone the leaf through unchanged like the literals;
+`fold-control-flow` also gains a `NewTarget` arm in its `expression_cv`
+accessor. The six traversal passes get a no-op arm (`new.target` binds/
+references no ordinary identifier and has no sub-expression). Atomic node PR1:
+node + emit + all nine downstream pass arms land together so the workspace
+never breaks.
+
+### gap-168 — bridge declines `new.target` (`NewTarget`) — pending (CLOC12.167 PR2)
+
+The `javascript-parser` bridge returns `UnsupportedSyntax { rule: "NewTarget" }`
+in `convert_member_expression` (the `new`-token region: `has_token(node, "new")`
+&& a child token whose value is `"target"`), so any file containing
+`new.target` currently drops to WHITESPACE_ONLY. Like `this` (gap-166) and
+`super` (gap-167) — and **unlike `await` (gap-165)** — `new.target` is already
+parseable: there is a dedicated `new_target_expression` grammar rule and the
+bridge *reaches* and explicitly declines it, so PR2 is a pure bridge slice with
+**no grammar work required**: swap the decline for
+`Ok(Expression::NewTarget(NewTarget { cv: … }))`, mirroring the `super` fix.
+Tracked for CLOC12.167 PR2.
+
+
 ## CLOC12.166 — `Super` (`super`): atomic node + emit + passes (PR1)
 
 Adds `Expression::Super { cv }` to `javascript-ast` (0.25.0) — the `super`


### PR DESCRIPTION
## Regression being fixed

CLOC12.167 PR1 (#7689, commit `93fd45d`) added the `Expression::NewTarget` AST node
(the `new.target` meta-property) to `javascript-ast`, `emit_new_target` to
`closure-emitter`, and the nine downstream pass match-arms — and **merged to main**.

A later PR, #7682 (`feat(sir): … rebased onto main, v0.17.0`, commit `a8846cb`), was
rebased onto a **stale** main (pre-#7689). Its rebase clobbered all 36 of #7689's files
back out, silently reverting a merged PR. After #7682, `origin/main` had **zero**
references to `NewTarget` in `javascript-ast` / `closure-emitter` / the nine passes / the
CLOC12-gaps spec.

That break took out the two in-flight CLOC12.167 follow-ups, both of which depend on the
node existing:
- #7702 (PR2 — bridge-enable `new.target` → `Expression::NewTarget`)
- #7706 (PR3 — CodePrinter `new.target` conformance port)

## The fix

This re-applies #7689's exact diff via `git cherry-pick 93fd45d`. The cherry-pick applied
with **zero conflicts**, confirming no legitimate PR touched these 36 files between #7689
and now — only #7682's stale-rebase clobber. Nothing from #7682's actual SIR work is
affected (a SIR PR has no business editing `closure-*` / `javascript-ast/expression.rs`;
those edits were purely the rebase artifact).

## Restores

- `javascript-ast` 0.26.0 — `NewTarget` variant + struct + roundtrip tests
- `closure-emitter` 0.31.0 — `emit_new_target` + `PREC_PRIMARY` classification + dispatch + unit tests
- nine downstream passes (constant-fold / dce / fold-control-flow / inline / inline-variables / rename / rename-globals / rename-properties / scope-analyzer) — PATCH bumps + match arms
- CLOC12-gaps §CLOC12.167 spec section

## Verification

- `javascript-ast`: 19 tests pass
- `closure-emitter`: 7 tests pass
- all nine downstream passes build cleanly
- security review: PASSED (restores previously-reviewed #7689 code; leaf node, no new data flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)