### PR TITLE
feat(latex): LTXDOC03 S10 — distinct \pageref rendering (-> page ?)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.46.0] — 2026-07-07
+
+### Added — cross-reference resolution: distinct `\pageref` rendering (LTXDOC03 S10)
+
+Closes the surface-form gap S8/S9 left for the *page* reference family. A `\pageref{key}` asks "what
+**page** is the target on", a fundamentally different question from `\ref`'s "what **number** is the
+target". Through S9 the report conflated the two: a resolved `\pageref` rendered **identically** to a
+`\ref` — `\ref{key} -> Kind N`. The crate has no page model, so it cannot compute a real page number,
+but it can at least render the page family *honestly and distinctly*:
+
+- **`\pageref` renders `page ?`.** In `CrossReferenceReport::to_plain_text`, a resolved reference
+  whose `command == "pageref"` (to **any** target kind — Section/Table/Figure/Equation/Inline) now
+  renders `\pageref{sec:i} -> page ?` — the `\pageref` spelling is kept and the number/kind are
+  replaced by the fixed literal placeholder `page ?`. The `?` mirrors LaTeX's own `??` for an
+  unresolved page reference (and the S7 number-placeholder pattern): it means "page number not
+  modelled", NOT the kind and NOT the number.
+- **A `\pageref` ignores kind entirely.** Because a page reference is about location, not identity,
+  the `\pageref` branch takes precedence over the S8 else-branch and is orthogonal to the S9 amsmath
+  branch: a `\pageref` to an equation still renders `page ?`, never `Equation (1)` or `Equation 1`.
+- **`\ref` and `\eqref` are byte-for-byte unchanged.** Branch precedence is (1) `\eqref` to Equation →
+  parenthesised (S9); (2) `\pageref` any kind → `page ?` (S10, NEW); (3) else → `\ref{key} -> Kind N`
+  (S8). Only `\pageref` lines change.
+- **Additive, no AST/struct/numbering change.** `RefEntry.command` (the surface spelling) was already
+  retained by S1, so S10 is a pure rendering branch in one loop. No AST change, no new field, no
+  re-numbering; `to_latex()` remains a fixed point.
+
 ## [0.45.0] — 2026-07-06
 
 ### Added — cross-reference resolution: `\eqref` parenthesisation (LTXDOC03 S9)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -57,6 +57,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S7 — equation-label lifting** | `Block::DisplayMath` gains a `label: Option<String>` and `LabelKind` gains an `Equation` variant. For a **non-starred** display-math environment (`equation`/`align`/`gather`/`multline`/`eqnarray` — not the starred forms), the D5 lowering now **lifts** the `\label{key}` out of the env body onto the block (removing it from `source`, no duplication) and registers it as a real `LabelKind::Equation` definition in the same pass as section/figure/table labels. So an `\eqref{eq:e}`/`\ref{eq:e}` to an in-equation label now **resolves** and is **included** in the S6 report (`\ref{eq:e} -> Equation ?`) instead of being omitted. The equation **number** (`\theequation`) is deferred to S8: the report carries the placeholder `EQUATION_NUMBER_PLACEHOLDER` (`"?"`). `to_latex()` re-emits a lifted-label equation as `\begin{equation}…\label{…}\end{equation}` so the round-trip fixed point holds. Starred forms and `\[…\]`/`$$…$$` keep `label: None`. Pure, additive; total & panic-free. | ✅ |
 | **LTXDOC03 S8 — equation numbering** | `Counters` gains a flat `equation: u32` field and a `step_equation()` method (mirroring `step_figure`/`step_table` — pre-increment, saturating, one monotonic run **independent** of section/figure/table). In the `Block::DisplayMath { label: Some(key), .. }` arm of `number_labels`, S7's placeholder is replaced with `counters.step_equation().to_string()`, so a lifted equation label now carries a **real** sequential number in document order (`1`, `2`, …). The S6 report prints `\ref{eq:e} -> Equation 1` (was `Equation ?`). Equation numbering is independent of the section/figure/table counters. **Limitation:** because `Block::DisplayMath` carries no `numbered` flag (the D5 lowering sets `label: None` for both starred envs and `\[…\]`/`$$…$$` islands), only **labelled** equations step the counter — an unlabelled numbered equation between two labelled ones is not yet counted (needs an AST change, deferred). `\eqref` parenthesisation (`(1)` vs `1`) is also deferred to a later slice; S8 is counter-only. Pure, additive, tree-unchanged; total & panic-free. | ✅ |
 | **LTXDOC03 S9 — `\eqref` parenthesisation** | `CrossReferenceReport::to_plain_text` now mirrors amsmath's `\eqref` for the one case that matters: a resolved reference whose `command == "eqref"` **and** `kind == LabelKind::Equation` renders `\eqref{eq:e} -> Equation (1)` — the `\eqref` spelling is kept and the number is **parenthesised**. Every other reference — all `\ref`, all `\pageref`, and any `\eqref` to a **non-equation** kind — is byte-for-byte unchanged from S8: canonical `\ref` prefix, bare number (`\ref{sec:intro} -> Section 1.2`). `RefEntry.command` (the surface spelling) was already retained by S1, so S9 is a pure rendering split in one `format!` — no AST change, no new field, no re-numbering; `to_latex()` stays a fixed point. Pure, additive; total & panic-free. | ✅ |
+| **LTXDOC03 S10 — distinct `\pageref` rendering** | `CrossReferenceReport::to_plain_text` gains a **third** rendering branch so a resolved `\pageref` no longer renders identically to a `\ref`. A `\pageref{key}` asks "what **page** is the target on" — a different question from `\ref`'s "what **number** is the target" — but the crate has **no page model**, so it cannot compute a real page number. A resolved reference whose `command == "pageref"` (to **any** target kind) now renders `\pageref{sec:i} -> page ?` — the `\pageref` spelling is kept and the kind/number are replaced by the fixed literal placeholder `page ?` (the `?` mirrors LaTeX's own `??` for an unresolved page reference; it means "page number not modelled", not the kind, not the number). Branch precedence: (1) `\eqref` to Equation → parenthesised (S9); (2) `\pageref` any kind → `page ?` (S10); (3) else → `\ref{key} -> Kind N` (S8). So `\ref` and `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines change. Pure rendering branch — no AST change, no re-numbering, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -525,10 +526,41 @@ assert_eq!(
 );
 ```
 
-Only `command == "eqref"` **and** `kind == LabelKind::Equation` diverges: all `\ref`, all `\pageref`,
-and any `\eqref` to a non-equation kind still render with the canonical `\ref` prefix and a bare number
-(`\ref{sec:intro} -> Section 1.2`). `RefEntry.command` (the surface spelling) was already retained by
+Only `command == "eqref"` **and** `kind == LabelKind::Equation` diverges under S9: all `\ref` and any
+`\eqref` to a non-equation kind still render with the canonical `\ref` prefix and a bare number
+(`\ref{sec:intro} -> Section 1.2`). (`\pageref` diverges separately under S10, below.)
+`RefEntry.command` (the surface spelling) was already retained by
 S1, so S9 is a pure rendering split — no AST change, no re-numbering, `to_latex()` still a fixed point.
+
+### distinct `\pageref` rendering (LTXDOC03 S10)
+
+A `\pageref{key}` asks "what **page** is the target on" — a fundamentally different question from
+`\ref`'s "what **number** is the target". Through S9 the report conflated the two: a resolved
+`\pageref` rendered **identically** to a `\ref` (`\ref{sec:i} -> Section 1`). The crate has **no page
+model**, so it cannot compute a real page number, but S10 renders the page family *honestly and
+distinctly*: a resolved `\pageref` (to **any** target kind) keeps its `\pageref` spelling and prints
+the fixed literal placeholder `page ?` (the `?` mirrors LaTeX's own `??` for an unresolved page
+reference — it means "page number not modelled", not the kind, not the number).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:i} \ref{sec:i} \pageref{sec:i}\end{document}";
+let doc = parse_document(src).unwrap();
+
+// The `\ref` is unchanged (bare number); the `\pageref` now diverges to the honest placeholder.
+assert_eq!(
+    doc.cross_reference_report().to_plain_text(),
+    "\\ref{sec:i} -> Section 1\n\
+     \\pageref{sec:i} -> page ?",
+);
+```
+
+Branch precedence in the render loop is (1) `\eqref` to Equation → parenthesised (S9); (2) `\pageref`
+any kind → `page ?` (S10); (3) else → `\ref{key} -> Kind N` (S8). A `\pageref` ignores the
+eqref/Equation special-case entirely — a `\pageref` to an equation still renders `page ?`, never
+`Equation (1)`. So `\ref` and `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines
+change. Pure rendering branch — no AST change, no re-numbering, `to_latex()` still a fixed point.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1658,18 +1658,26 @@ impl CrossReferenceReport {
     /// Render this report to a **stable, deterministic, human-readable** plain-text string (LTXDOC03
     /// S6). The exact format — pinned so tests and consumers can rely on it byte-for-byte:
     ///
-    /// - One line per resolved reference, in `refs` order. There are two renderings (LTXDOC03 S9):
+    /// - One line per resolved reference, in `refs` order. There are **three** renderings, tried in
+    ///   this precedence order (LTXDOC03 S10):
     ///   - An `\eqref` whose target is an **equation** renders amsmath-style, keeping the `\eqref`
     ///     spelling and **parenthesising** the number:
     ///     `` \eqref{<key>} -> <Kind> (<number>) `` — e.g. `` \eqref{eq:e} -> Equation (1) ``. This
-    ///     mirrors how amsmath's `\eqref` typesets the equation number as `(1)`.
-    ///   - Every **other** resolved reference — all `\ref`, all `\pageref`, and any `\eqref` to a
-    ///     **non-equation** kind — renders with the canonical `\ref` prefix and a **bare** number:
+    ///     mirrors how amsmath's `\eqref` typesets the equation number as `(1)`. (S9, unchanged.)
+    ///   - Otherwise, a `\pageref` (to **any** kind — Section/Table/Figure/Equation/Inline) renders
+    ///     with the `\pageref` spelling and the literal placeholder `page ?`:
+    ///     `` \pageref{<key>} -> page ? `` — e.g. `` \pageref{sec:i} -> page ? ``. A `\pageref` asks
+    ///     *what page* its target is on, but the crate has **no page model**, so neither the target's
+    ///     kind nor its number is relevant; the honest, fixed placeholder is `page ?` (the `?` mirrors
+    ///     LaTeX's own `??` for an unresolved page reference, and the S7 number-placeholder pattern).
+    ///     (S10, NEW — previously a `\pageref` rendered identically to a `\ref`.)
+    ///   - Every **other** resolved reference — all `\ref` and any `\eqref` to a **non-equation**
+    ///     kind — renders with the canonical `\ref` prefix and a **bare** number:
     ///     `` \ref{<key>} -> <Kind> <number> `` — e.g. `` \ref{sec:intro} -> Section 1.2 ``. The
-    ///     `\ref` prefix here names the *binding*, not the surface command (a `\pageref` still shows
-    ///     as `\ref`), unchanged from S8.
+    ///     `\ref` prefix here names the *binding*, not the surface command, unchanged from S8.
     ///
-    ///   In both renderings `<Kind>` is the capitalised kind name ([`kind_display_name`]).
+    ///   In the first and third renderings `<Kind>` is the capitalised kind name
+    ///   ([`kind_display_name`]); the `\pageref` rendering carries no kind or number at all.
     /// - One line per resolved citation, in `cites` order:
     ///   `` \cite{<key>} -> <number> `` — e.g. `` \cite{smith} -> [2] ``.
     /// - **Only if** `dangling_refs` is non-empty, a footer line:
@@ -1690,17 +1698,25 @@ impl CrossReferenceReport {
 
         // Resolved references.
         //
-        // Two renderings, keyed off the *surface command* + *target kind* (LTXDOC03 S9):
+        // Three renderings, tried in this precedence order, keyed off the *surface command* +
+        // *target kind* (LTXDOC03 S10):
         //
-        //   * An `\eqref` whose target is an **equation** renders amsmath-style — the `\eqref`
-        //     spelling is kept and the number is **parenthesised**:
-        //     `\eqref{eq:e} -> Equation (1)`.  (`\eqref` on `article`'s equation counter typesets
-        //     "(1)", so the report mirrors that surface form.)
-        //   * Every other resolved reference — all `\ref`, all `\pageref`, and any `\eqref` to a
-        //     **non-equation** kind — renders exactly as it did through S8: the canonical `\ref`
-        //     prefix and a **bare** number, `\ref{sec:intro} -> Section 1.2`.
+        //   1. An `\eqref` whose target is an **equation** renders amsmath-style — the `\eqref`
+        //      spelling is kept and the number is **parenthesised**:
+        //      `\eqref{eq:e} -> Equation (1)`.  (`\eqref` on `article`'s equation counter typesets
+        //      "(1)", so the report mirrors that surface form.)  (S9, unchanged.)
+        //   2. Otherwise, a `\pageref` (to **any** kind) renders with the `\pageref` spelling and the
+        //      literal placeholder `page ?`: `\pageref{sec:i} -> page ?`.  A page reference asks
+        //      *what page* the target is on; the crate has NO page model, so the target's kind and
+        //      number are irrelevant — the honest fixed placeholder is `page ?` (the `?` mirrors
+        //      LaTeX's own `??` for an unresolved page ref).  (S10, NEW.)
+        //   3. Every other resolved reference — all `\ref` and any `\eqref` to a **non-equation**
+        //      kind — renders exactly as it did through S8: the canonical `\ref` prefix and a **bare**
+        //      number, `\ref{sec:intro} -> Section 1.2`.
         //
-        // Only the one amsmath case diverges; the else-branch is byte-for-byte the S8 line.
+        // Precedence matters: (1) before (2) is moot (an `\eqref` is never a `\pageref`), but (2)
+        // before (3) is what makes every `\pageref` diverge from the S8 `\ref` line.  `\ref` and
+        // `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines change.
         for r in &self.refs {
             if r.command == "eqref" && r.kind == LabelKind::Equation {
                 lines.push(format!(
@@ -1709,6 +1725,9 @@ impl CrossReferenceReport {
                     kind_display_name(r.kind),
                     r.number
                 ));
+            } else if r.command == "pageref" {
+                // No page model: a fixed, honest placeholder, independent of kind/number.
+                lines.push(format!(r"\pageref{{{}}} -> page ?", r.key));
             } else {
                 lines.push(format!(
                     r"\ref{{{}}} -> {} {}",
@@ -1904,6 +1923,43 @@ mod tests {
         let report = doc.cross_reference_report();
         let text = report.to_plain_text();
         assert_eq!(text, "\\eqref{eq:a} -> Equation (1)\n\\eqref{eq:b} -> Equation (2)");
+    }
+
+    #[test]
+    fn s10_pageref_renders_page_placeholder() {
+        // LTXDOC03 S10: a resolved `\pageref` to a labelled section renders with the `\pageref`
+        // spelling and the fixed `page ?` placeholder — NOT the S8 `\ref{...} -> Section 1` line.
+        // (The crate has no page model, so a page reference cannot report a real page number.)
+        let src = r"\begin{document}\section{Intro}\label{sec:i} \pageref{sec:i}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\pageref{sec:i} -> page ?");
+    }
+
+    #[test]
+    fn s10_ref_still_bare_and_pageref_distinct() {
+        // A doc with BOTH a `\ref` and a `\pageref` to the same section: the `\ref` is UNCHANGED from
+        // S8 (`\ref{sec:i} -> Section 1`) while the `\pageref` now diverges (`\pageref{sec:i} -> page
+        // ?`). `\ref` first in source order, so it is the report's first line (S1 pre-order).
+        let src = r"\begin{document}\section{Intro}\label{sec:i} \ref{sec:i} \pageref{sec:i}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\ref{sec:i} -> Section 1\n\\pageref{sec:i} -> page ?");
+    }
+
+    #[test]
+    fn s10_pageref_to_equation_is_still_page() {
+        // A `\pageref` to a labelled EQUATION ignores the `\eqref`-to-equation special-case entirely:
+        // it is a page reference, so it still renders `\pageref{eq:e} -> page ?` (no parentheses, no
+        // Equation kind, no number). This proves the `\pageref` branch takes precedence over the S8
+        // else-branch and is orthogonal to the S9 amsmath branch.
+        let src = r"\begin{document}\begin{equation} E = mc^2 \label{eq:e} \end{equation} \pageref{eq:e}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let report = doc.cross_reference_report();
+        let text = report.to_plain_text();
+        assert_eq!(text, "\\pageref{eq:e} -> page ?");
     }
 
     #[test]

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -811,10 +811,10 @@ kind* already carried by `RefEntry`:
 - **`\eqref` to an equation** — a `RefEntry` with `command == "eqref"` **and**
   `kind == LabelKind::Equation` renders `\eqref{eq:e} -> Equation (1)`: the `\eqref` spelling is kept
   and the number is **parenthesised**, mirroring how amsmath's `\eqref` typesets `(1)`.
-- **Everything else** — all `\ref`, all `\pageref`, and any `\eqref` to a **non-equation** kind —
-  renders exactly as through S8: the canonical `\ref` prefix and a **bare** number,
-  `\ref{sec:intro} -> Section 1.2`. The `\ref` prefix names the *binding*, not the surface command (a
-  `\pageref` still shows as `\ref`), unchanged.
+- **Everything else** — all `\ref`, all `\pageref` (superseded by S10, §16), and any `\eqref` to a
+  **non-equation** kind — renders exactly as through S8: the canonical `\ref` prefix and a **bare**
+  number, `\ref{sec:intro} -> Section 1.2`. The `\ref` prefix names the *binding*, not the surface
+  command, unchanged.
 
 Only the one amsmath case diverges; the else-branch is byte-for-byte the S8 line. The `\cite`,
 dangling-ref, dangling-cite, and empty-report branches of `to_plain_text` are untouched.
@@ -847,6 +847,83 @@ a sibling `\ref` to the same equation stays bare (`\eqref{eq:e} -> Equation (1)`
 unchanged from S8); two `\eqref`s to two equations number sequentially and each parenthesises
 (`\eqref{eq:a} -> Equation (1)` then `\eqref{eq:b} -> Equation (2)`) — plus the updated S7 report test,
 whose first (`\eqref`) line now asserts `\eqref{eq:e} -> Equation (1)`).
+`cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
+`cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
+`cargo fmt`, no grammar regen, no new dependencies.
+
+## 16. S10 — distinct `\pageref` rendering
+
+### 16.1 The gap S10 closes
+
+S9 (§15) split the report rendering so an `\eqref` to an equation parenthesises its number, but it
+left the **page** reference family conflated with the **number** reference family. A `\pageref{key}`
+asks a fundamentally different question from `\ref{key}`: `\ref` asks "what **number** is the target"
+(a section number, figure number, …), while `\pageref` asks "what **page** is the target printed on".
+LaTeX resolves these against two different values in the `.aux` `\newlabel` record. Through S9 the S6
+report ignored the distinction and rendered a resolved `\pageref` **identically** to a `\ref` —
+`\ref{key} -> Kind number` — so `\pageref{sec:i}` printed `\ref{sec:i} -> Section 1`, silently
+answering the *number* question for a command that asked the *page* question. S10 closes that gap.
+
+### 16.2 What S10 does — an honest page placeholder
+
+The crate has **no page model**: it parses and numbers *structure*, never lays out pages, so it cannot
+compute a real page number for any label. S10 therefore does not invent one — it renders the page
+family **distinctly and honestly** with a fixed placeholder. S10 is a **rendering-only** change
+confined to `CrossReferenceReport::to_plain_text` (§12.4), adding a **third** branch to the
+resolved-refs loop, tried in this precedence order:
+
+1. **`\eqref` to an equation** — `command == "eqref"` **and** `kind == LabelKind::Equation` renders
+   `\eqref{eq:e} -> Equation (1)` (S9, §15.2, unchanged).
+2. **`\pageref` to any kind** — a `RefEntry` with `command == "pageref"` (regardless of target kind —
+   Section/Table/Figure/Equation/Inline) renders `\pageref{sec:i} -> page ?`: the `\pageref` spelling
+   is kept and the kind/number are replaced by the fixed literal placeholder `page ?`. The `?` mirrors
+   LaTeX's own `??` for an unresolved page reference (and the S7 number-placeholder `"?"`): it means
+   "page number not modelled" — **not** the kind, **not** the number. Because a page reference is
+   about *location*, not *identity*, the target's kind and number are irrelevant to this rendering.
+3. **Everything else** — all `\ref` and any `\eqref` to a **non-equation** kind — renders exactly as
+   through S8: the canonical `\ref` prefix and a **bare** number, `\ref{sec:intro} -> Section 1.2`.
+
+Precedence matters. Branch (1) before (2) is moot (an `\eqref` is never a `\pageref`), but (2) before
+(3) is what makes **every** `\pageref` diverge from the S8 `\ref` line. So `\ref` and `\eqref` outputs
+are byte-for-byte unchanged from S9; **only** `\pageref` lines change (previously `\ref{key} -> Kind
+N`, now `\pageref{key} -> page ?`). The `\cite`, dangling-ref, dangling-cite, and empty-report
+branches of `to_plain_text` are untouched.
+
+### 16.3 `RefEntry.command` was already retained by S1
+
+As with S9, no struct or AST change is needed. `RefEntry` has carried `pub command: String` (the
+surface spelling `"ref"` / `"eqref"` / `"pageref"`) since S1, and `cross_reference_report` (§12) has
+always populated it. S10 simply reads `command == "pageref"` — a field it had been folding into the
+else-branch — so it is a pure rendering branch in one loop, no new field, no numbering change, no AST
+walk.
+
+### 16.4 Additive, and `to_latex()` unchanged
+
+S10 touches only report rendering, not the tree: `to_latex()` remains a fixed point (S10 does not
+touch the AST at all). Every S1–S9 output byte is unchanged **except** the one thing S10 is about — a
+resolved `\pageref` line, which now reads `\pageref{key} -> page ?` instead of `\ref{key} -> Kind N`.
+
+### 16.5 What is DEFERRED (honest boundary)
+
+A **real page number** is out of scope: it requires a page-layout model (line/page breaking, float
+placement, `\pagebreak`, class geometry) the crate does not have and does not intend to add at this
+rung. The `page ?` placeholder is the honest terminus for the page family until such a model exists,
+exactly as `Equation ?` was S7's honest terminus before S8 wired the equation counter.
+
+### 16.6 Public API (added in S10)
+
+No public type or signature changes: `RefEntry`, `CrossReferenceReport`, `cross_reference_report`, and
+`to_plain_text` keep their existing shapes. The only observable change is the rendered text of a
+resolved `\pageref` line (now `\pageref{key} -> page ?`). The change is **additive** and byte-for-byte
+compatible with S1–S9 except for that one line.
+
+### 16.7 Verification (S10)
+
+`cargo test -p latex` green (3 new S10 tests: a `\pageref` to a labelled section renders
+`\pageref{sec:i} -> page ?` (not `\ref{sec:i} -> Section 1`); a doc with both `\ref` and `\pageref` to
+the same section renders `\ref{sec:i} -> Section 1` then `\pageref{sec:i} -> page ?`, proving `\ref` is
+unchanged and `\pageref` now diverges; a `\pageref` to a labelled equation still renders
+`\pageref{eq:e} -> page ?`, proving `\pageref` ignores the S9 eqref/Equation special-case).
 `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
 `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
 `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S10 — distinct `\pageref` rendering (`-> page ?`)

The equation sub-arc **S7 (label lift) → S8 (counter) → S9 (`\eqref` parens)** is complete. S10 turns to the last conflated reference command: **`\pageref`**.

### The gap
`CrossReferenceReport::to_plain_text()` renders one line per resolved reference. Through S9 there were two branches:
- `\eqref` → Equation: `\eqref{eq:e} -> Equation (1)` (parenthesised, S9)
- everything else — including **every `\pageref`**: `\ref{key} -> Kind N` (bare, S8)

So a `\pageref{key}` rendered **identically to `\ref`**, conflating a *page* reference (asks "what **page** is the target on") with a *number* reference (asks "what **number** is the target"). The crate has **no page model**, so the bare `\ref{key} -> Kind N` line was actively misleading — it printed the label's *counter* number as if it answered a page query.

### S10
Adds a **third branch** to the same loop so a resolved `\pageref` renders distinctly and honestly:

```
\pageref{sec:i} -> page ?
```

- Keeps the `\pageref` spelling (exactly as S9 keeps `\eqref`).
- `page ?` is a fixed placeholder — the `?` mirrors the **established S7 pattern** (the equation number was `"?"` before S8 wired the real counter) and LaTeX's own `??` for an unresolved page ref. It is honest: "this is a page reference; the page number is not modelled."
- Applies to **every** resolved `\pageref` regardless of target kind — a page ref always asks for a page, so the target's kind/number are irrelevant.

Branch precedence: (1) `\eqref`→Equation parenthesised (S9, unchanged) → (2) **`\pageref` (any kind) → `-> page ?` (NEW)** → (3) else `\ref{key} -> Kind N` (S8, unchanged). So `\ref` and `\eqref` output is **byte-for-byte unchanged**; only `\pageref` lines change.

The only production edit is that one loop (+ its doc comment) in `references.rs` — pure string building, no AST/counter change, no `unwrap`/index/`unsafe`/I/O. `to_latex()` fixed point unaffected. latex `0.45.0 → 0.46.0`.

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → all pass (s7_/s8_/s9_ unchanged; new `s10_` tests assert exact strings: `\pageref{sec:i} -> page ?`, `\ref` stays bare beside a diverging `\pageref`, and a `\pageref` to an equation is still `-> page ?`).
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green. `cargo build -p latex --no-default-features` → builds.
- No new deps, no `unsafe`, no I/O, no fmt/grammar regen. Single-parent; scoped diff = references.rs + Cargo.toml + CHANGELOG.md + README.md + the LTXDOC03 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
