### PR TITLE
feat(cloc12): CLOC12.168 PR1 — ImportMeta (import.meta) atomic node + emit + 9 passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.32.0] - 2026-07-07
+
+### Added — CLOC12.168: `emit_import_meta` (`import.meta`)
+
+Added `emit_import_meta` + the `Expression::ImportMeta` dispatch arm + the `PREC_PRIMARY` classification for the new `import.meta` module meta-property (the leaf sibling of `new.target`, CLOC12.168 PR1). `import.meta` prints as its literal eleven-character spelling and binds at primary strength — never wrapped in any parent, never forcing a paren around an operand (it has none); the internal `.meta` is part of the spelling, not a member access. 4 hand-constructed-AST unit tests (`import.meta`, `import.meta.url`, `f(import.meta)`, `import.meta+1`). Part of the atomic node PR1 that lands the node + emit + all nine downstream pass arms together. (CLOC12.168)
+
+
 ## [0.31.1] - 2026-07-07
 
 ### Added — CLOC12.167 PR3: CodePrinter `new.target` conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.31.1"
+version = "0.32.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -79,7 +79,7 @@ use coding_adventures_javascript_ast::{
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
     TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
-    Super, NewTarget,
+    Super, NewTarget, ImportMeta,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1143,6 +1143,7 @@ impl<'a> Emitter<'a> {
             Expression::ThisExpression(t) => self.emit_this(t),
             Expression::Super(s) => self.emit_super(s),
             Expression::NewTarget(n) => self.emit_new_target(n),
+            Expression::ImportMeta(n) => self.emit_import_meta(n),
         }
         if needs_parens {
             self.write_str(")");
@@ -1662,6 +1663,17 @@ impl<'a> Emitter<'a> {
         self.write_str("new.target");
     }
 
+    /// `import.meta` — the module meta-property, a leaf like `new.target`. It is
+    /// spelled with three tokens plus a dot, so the emit is the literal eleven
+    /// characters `import.meta` (after recording the source-map anchor). As a
+    /// `PREC_PRIMARY` leaf it is only ever followed by a member/call token or a
+    /// punctuator, never by another word that would fuse; the internal `.` is
+    /// part of the spelling, not a member access, so no operand is walked.
+    fn emit_import_meta(&mut self, n: &ImportMeta) {
+        self.maybe_map(&n.cv);
+        self.write_str("import.meta");
+    }
+
     fn emit_member(&mut self, m: &MemberExpression) {
         self.maybe_map(&m.cv);
         // The object must bind at least as tightly as member access, or the
@@ -2048,7 +2060,12 @@ fn expr_prec(e: &Expression) -> u8 {
         // spelling that binds at the tightest level, like `this`. It never
         // needs wrapping and never forces a paren around an operand (it has
         // none). The internal `.` is part of the spelling, not member access.
-        | Expression::NewTarget(_) => PREC_PRIMARY,
+        | Expression::NewTarget(_)
+        // `import.meta` is the module meta-property, the sibling of
+        // `new.target`: an atomic three-token spelling that binds at the
+        // tightest level. Same primary treatment — never wrapped, never forces
+        // a paren; the internal `.meta` is part of the spelling, not access.
+        | Expression::ImportMeta(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
         // Update (`++x` / `x++`) binds a hair tighter than the pure unary
@@ -5213,5 +5230,40 @@ mod tests {
     fn new_target_under_binary_parent_is_bare() {
         let e = binary(BinaryOperator::Add, new_target_expr(), num(1.0));
         assert_eq!(emit_expr(e), "new.target+1;");
+    }
+
+    // =================================================================
+    // ImportMeta (`import.meta`) — CLOC12.168
+    // =================================================================
+
+    /// Build an `ImportMeta`.
+    fn import_meta_expr() -> Expression {
+        Expression::ImportMeta(ImportMeta { cv: None })
+    }
+
+    /// `import.meta` — the module meta-property, printed as its literal spelling.
+    #[test]
+    fn import_meta_emits_literal_spelling() {
+        assert_eq!(emit_expr(import_meta_expr()), "import.meta;");
+    }
+
+    /// `import.meta.url` — `import.meta` is a primary, so a member parent needs
+    /// no parens (the trailing `.url` is a real member access on top of it).
+    #[test]
+    fn import_meta_as_member_object_is_bare() {
+        assert_eq!(emit_expr(member(import_meta_expr(), "url", false)), "import.meta.url;");
+    }
+
+    /// `f(import.meta)` — as a call argument it is a plain primary operand.
+    #[test]
+    fn import_meta_as_call_argument_is_bare() {
+        assert_eq!(emit_expr(call(ident("f"), vec![import_meta_expr()])), "f(import.meta);");
+    }
+
+    /// `import.meta+1` — even a binary parent leaves the primary bare.
+    #[test]
+    fn import_meta_under_binary_parent_is_bare() {
+        let e = binary(BinaryOperator::Add, import_meta_expr(), num(1.0));
+        assert_eq!(emit_expr(e), "import.meta+1;");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.85.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.10"
+version = "0.85.11"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -505,6 +505,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => fold_binary(b, st),

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.20.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.10"
+version = "0.20.11"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -1168,6 +1168,7 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals (and returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.20.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.10"
+version = "0.20.11"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -282,6 +282,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         ThisExpression(t) => t.cv.clone(),
         Super(s) => s.cv.clone(),
         NewTarget(n) => n.cv.clone(),
+        ImportMeta(n) => n.cv.clone(),
         MemberExpression(e) => e.cv.clone(),
         ArrayExpression(e) => e.cv.clone(),
         ObjectExpression(e) => e.cv.clone(),
@@ -1366,6 +1367,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => expr.clone(),
 
         Expression::BinaryExpression(b) => Expression::BinaryExpression(BinaryExpression {

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.11.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.10"
+version = "0.11.11"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -733,6 +733,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             count_uses_expr(&be.left, name, count);
@@ -1037,6 +1038,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= propagate_in_expr(&mut be.left, cand);

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.25.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.10"
+version = "0.25.11"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -442,6 +442,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => 0,
         Expression::BinaryExpression(be) => expr_node_count(&be.left) + expr_node_count(&be.right),
         Expression::LogicalExpression(le) => expr_node_count(&le.left) + expr_node_count(&le.right),
@@ -761,6 +762,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_binding_idents_expr(&be.left, out);
@@ -1049,6 +1051,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             tally_expr(&be.left, cand, t);
@@ -1393,6 +1396,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             changed |= inline_in_expr(&mut be.left, cand);
@@ -1527,6 +1531,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             substitute(&mut be.left, map);
@@ -2049,6 +2054,7 @@ fn expr_collect_mutated_params(
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
     }
 }
@@ -3401,6 +3407,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_in_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.10.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.10"
+version = "0.10.11"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -638,6 +638,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -963,6 +964,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rename_apply_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.12.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1149,6 +1149,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             classify_expr(&be.left, cls);
@@ -1436,6 +1437,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_expr(&mut be.left, map);

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.14.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.10"
+version = "0.14.11"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -916,6 +916,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             collect_all_idents_expr(&be.left, out);
@@ -1227,6 +1228,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             rewrite_uses_expr(&mut be.left, map);

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.11] - 2026-07-07
+
+### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm
+
+Added an `Expression::ImportMeta` case so the pass stays exhaustive over the new `javascript-ast` leaf variant (part of the CLOC12.168 atomic node PR1). `import.meta` is a leaf meta-property with no sub-expression and is never itself a constant, so it clones through unchanged alongside the literals. No behaviour change to any existing node.
+
+
 ## [0.12.10] - 2026-07-04
 
 ### Changed — CLOC12.167: `NewTarget` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.10"
+version = "0.12.11"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -854,6 +854,7 @@ fn walk_expression(
         | Expression::ThisExpression(_)
         | Expression::Super(_)
         | Expression::NewTarget(_)
+        | Expression::ImportMeta(_)
         | Expression::UndefinedLiteral(_) => {}
         Expression::BinaryExpression(be) => {
             walk_expression(&be.left, ctx, analysis, pending);

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.27.0] - 2026-07-07
+
+### Added — CLOC12.168: `Expression::ImportMeta` (`import.meta`)
+
+Added `Expression::ImportMeta` variant + `ImportMeta { cv }` struct — the `import.meta` module meta-property, the `MetaProperty` **leaf** sibling of `NewTarget` (same shape, no operand). Spelled with three tokens (`import` `.` `meta`) in source but modelled as an atomic node rather than a member access — `import` is a reserved word with no accessible identifier — so the renaming passes never touch it. Re-exported from the crate root. Atomic node PR (PR1): the node + `closure-emitter` emit + all nine downstream pass match-arms land together so the workspace never breaks. (CLOC12.168)
+
+
 ## [0.26.0] - 2026-07-04
 
 ### Added — CLOC12.167: `Expression::NewTarget` (`new.target`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -142,6 +142,16 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   never touch it. It tags at `PREC_PRIMARY` and the emitter prints the literal
   spelling `new.target`. Node + `closure-emitter` + all pass traversals land in
   one atomic PR; the bridge-enable + conformance port follow.
+- `ImportMeta` (CLOC12.168) — the `import.meta` module meta-property (host
+  metadata about the current module, e.g. `import.meta.url`): the
+  `MetaProperty` sibling of `NewTarget`. `ImportMeta { cv }` — no operand, the
+  same leaf shape as `NewTarget`. Spelled with three tokens (`import` `.`
+  `meta`) in source, but the `.meta` is part of the fixed spelling (not a member
+  access — `import` is a reserved word with no accessible identifier), so it is
+  modelled as an atomic leaf rather than a `MemberExpression`; the renaming
+  passes never touch it. It tags at `PREC_PRIMARY` and the emitter prints the
+  literal spelling `import.meta`. Node + `closure-emitter` + all pass traversals
+  land in one atomic PR; the bridge-enable + conformance port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -67,6 +67,7 @@ pub enum Expression {
     ThisExpression(ThisExpression),
     Super(Super),
     NewTarget(NewTarget),
+    ImportMeta(ImportMeta),
 }
 
 // ---------------------------------------------------------------------
@@ -682,6 +683,40 @@ pub struct NewTarget {
     pub cv: Option<CvId>,
 }
 
+/// `import.meta` — the module meta-property exposing host-provided metadata
+/// about the current module (e.g. `import.meta.url`). It is the sibling of
+/// [`NewTarget`]: ESTree models both as `MetaProperty` nodes, so `import.meta`
+/// gets its own atomic variant here rather than being a member access of an
+/// `import` identifier (`import` is a reserved word — there is no such
+/// identifier to access).
+///
+/// # Shape
+///
+/// `import.meta` is a **leaf** — like [`ThisExpression`], [`Super`] and
+/// [`NewTarget`] it carries no operand and no payload beyond its `cv`. In
+/// source it is spelled with three tokens (`import` `.` `meta`), but
+/// semantically it is one atomic meta-property. Because `import` can never be a
+/// variable name, the renaming passes (`rename`, `rename-globals`,
+/// `rename-properties`) must never touch it — a dedicated variant lets those
+/// passes exclude it structurally instead of string-matching the spelling.
+///
+/// # Precedence
+///
+/// `import.meta` binds at **primary** strength — the tightest level, exactly
+/// like `this` / `super` / `new.target`. It never needs wrapping in any parent
+/// context (`import.meta.url`, `f(import.meta)`, `import.meta+1` all print
+/// bare), and no parent operand ever forces a paren around it. The emitter tags
+/// it `PREC_PRIMARY` and prints the literal three-token spelling `import.meta`.
+/// The `.meta` is part of the fixed spelling, NOT a member access — a genuine
+/// property read such as `import.meta.url` wraps this leaf in an outer
+/// [`MemberExpression`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportMeta {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+}
+
 /// `obj.prop` or `obj[key]`. `computed = false` ↔ `obj.prop` (the
 /// `property` is conventionally an [`Expression::Identifier`]);
 /// `computed = true` ↔ `obj[key]` (the `property` is any expression).
@@ -1154,6 +1189,21 @@ mod tests {
     #[test]
     fn new_target_untraced_omits_cv() {
         let n = Expression::NewTarget(NewTarget { cv: None });
+        let json = serde_json::to_string(&n).expect("serialize");
+        assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(n.clone(), roundtrip(n));
+    }
+
+    #[test]
+    fn import_meta_roundtrips_traced() {
+        let n = Expression::ImportMeta(ImportMeta { cv: Some("importMeta.1".to_string()) });
+        assert_eq!(n.clone(), roundtrip(n.clone()));
+        assert_eq!(type_tag(&n), "ImportMeta");
+    }
+
+    #[test]
+    fn import_meta_untraced_omits_cv() {
+        let n = Expression::ImportMeta(ImportMeta { cv: None });
         let json = serde_json::to_string(&n).expect("serialize");
         assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
         assert_eq!(n.clone(), roundtrip(n));

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
-    AwaitExpression, NewTarget, Super, ThisExpression, YieldExpression,
+    AwaitExpression, ImportMeta, NewTarget, Super, ThisExpression, YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2137,6 +2137,54 @@ shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
 
+## CLOC12.168 — `ImportMeta` (`import.meta`): atomic node + emit + passes (PR1)
+
+Adds `Expression::ImportMeta { cv }` to `javascript-ast` (0.27.0) — the
+`import.meta` module meta-property exposing host-provided metadata about the
+current module (canonically `import.meta.url`). It is the direct **sibling of
+`NewTarget`**: ESTree models both `new.target` and `import.meta` as
+`MetaProperty` nodes, so `import.meta` gets its own atomic leaf variant here
+rather than being a member access of an `import` identifier — `import` is a
+reserved word and there is no such identifier to access.
+
+It is modelled as its own variant (not `MemberExpression { object: Identifier
+"import", property: "meta" }`) for the same reason `NewTarget` / `Super` /
+`this` are: the spelling contains reserved words that can never be renamed, so
+the renaming passes (`rename`, `rename-globals`, `rename-properties`) must never
+touch it. A dedicated variant lets those passes exclude it structurally.
+
+**Emit (`closure-emitter` 0.32.0).** `emit_import_meta` writes the bare
+eleven-character spelling `import.meta`. It tags at `PREC_PRIMARY` — the
+tightest level, like `this` / `super` / `new.target` — so it never needs
+wrapping in any parent (`import.meta.url`, `f(import.meta)`, `import.meta+1` all
+print bare) and never forces a paren around an operand (it carries none). The
+internal `.meta` is part of the fixed spelling, NOT a member access; a genuine
+property read like `import.meta.url` wraps this leaf in an outer
+`MemberExpression`.
+
+**Passes (PATCH bumps).** The three rebuild passes (`constant-fold`, `dce`,
+`fold-control-flow`) clone the leaf through unchanged like the literals;
+`fold-control-flow` also gains an `ImportMeta` arm in its `expression_cv`
+accessor. The six traversal passes get a no-op arm (`import.meta` binds/
+references no ordinary identifier and has no sub-expression). Atomic node PR1:
+node + emit + all nine downstream pass arms land together so the workspace
+never breaks.
+
+### gap-169 — bridge declines `import.meta` (`ImportMeta`) — **OPEN (bridge slice pending, CLOC12.168 PR2)**
+
+The `javascript-parser` bridge does not yet convert `import.meta` to
+`Expression::ImportMeta`, so any file containing it drops to WHITESPACE_ONLY.
+The atomic node PR (CLOC12.168 PR1) lands the node + emit + pass traversals so
+the typed AST and every downstream pass can already represent and print an
+`import.meta`; the **PR2 bridge slice** wires the grammar production through
+(the shape parallels `new.target` — a `member_expression` with an `import`
+token followed by `.` `meta`, distinguished from an ordinary member access by
+the reserved `import` token and the absence of a Node object). Whether any
+grammar work is required (as with `await`, gap-165) or the token is already
+produced and merely declined (as with `new.target`, gap-168) is determined
+during PR2. The **PR3** CodePrinter conformance port follows.
+
+
 ## CLOC12.167 — `NewTarget` (`new.target`): atomic node + emit + passes (PR1)
 
 Adds `Expression::NewTarget { cv }` to `javascript-ast` (0.26.0) — the


### PR DESCRIPTION
## CLOC12.168 PR1 — `ImportMeta` (`import.meta`) atomic node

Adds `Expression::ImportMeta { cv }` — the `import.meta` module meta-property,
the ESTree `MetaProperty` **sibling of `NewTarget`** (`new.target`). Like
`this` / `super` / `new.target` it is a fixed-spelling reserved-word **leaf**
primary: no operand, no payload beyond `cv`. `import` is a reserved word with
no accessible identifier, so `import.meta` is its own atomic node rather than a
member access — the renaming passes must never touch it, and a dedicated
variant lets them exclude it structurally.

**Atomic node PR1** — node + emitter + all nine downstream pass match-arms land
in ONE commit so the workspace never breaks:

- **javascript-ast 0.27.0** (MINOR) — `ImportMeta` variant + struct, re-exported
  from the crate root; 2 roundtrip/serde tests.
- **closure-emitter 0.32.0** (MINOR) — `emit_import_meta` prints the literal
  `import.meta`; `Expression::ImportMeta` dispatch arm; `PREC_PRIMARY`
  classification (never wrapped, never forces a paren; the internal `.meta` is
  part of the spelling, not member access). 4 unit tests (`import.meta`,
  `import.meta.url`, `f(import.meta)`, `import.meta+1`).
- **nine downstream passes** (PATCH) — exhaustive `Expression::ImportMeta` arms.
  Rebuild passes (constant-fold / dce / fold-control-flow) clone the leaf
  through unchanged like the literals; fold-control-flow also gains an
  `ImportMeta` arm in its `expression_cv` accessor. Traversal passes (inline /
  inline-variables / rename / rename-globals / rename-properties /
  scope-analyzer) get a no-op arm. No behaviour change to any existing node.

Spec: adds the CLOC12.168 section + gap-169 (bridge slice pending, PR2) to
`CLOC12-gaps.md`. The **PR2** bridge-enable + **PR3** CodePrinter conformance
port follow.

## Verification

- javascript-ast (19 tests) + closure-emitter + all nine passes **build and
  test clean**, 0 failures across all 11 crates.
- security review: **PASSED** (mirrors the previously-reviewed `NewTarget` leaf;
  no new data flow from untrusted input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)