### PR TITLE
feat(adj-ladder): rung-93 insulin dosing (a*b+c+d — leading product plus two added terms)

### DIFF
--- a/code/specs/data/adj-ladder/rung93_insulin_dosing/gen_items.py
+++ b/code/specs/data/adj-ladder/rung93_insulin_dosing/gen_items.py
@@ -1,0 +1,238 @@
+"""Generate rung-93 (endocrinology / insulin-dosing total) items.json for the ADJ-LADDER.
+
+Rung 93 opens the **endocrinology / insulin-dosing** panel on the quantitative band — the arithmetic of a total insulin
+dose. A `basal_rate` times `active_hours` gives the basal infusion load, and a `correction_units` and a `carb_units` are
+ADDED as two bolus terms, all three ADDing into the total. A **product at the FRONT of two added terms** introduces a
+genuinely NEW arithmetic family on the ladder: `a*b+c+d`, i.e. `(((a*b)+c)+d)`.
+
+This is genuinely new and COMPLETES the additive-chain-plus-one-product family. Rung 91 shipped `a+b+c*d` (product
+LAST) and rung 92 shipped `a+b*c+d` (product in the MIDDLE). Rung 93 puts the single product at the **FRONT**:
+`a*b+c+d` — the product forms first, then two bare terms are added to its right. Together the three rungs exhaust the
+three positions a lone product can take in a flat four-term add-chain (last / middle / first). No prior shape led with a
+product and then added TWO independent bare terms in one flat chain — rung-79 `a*b+c/d`/rung-80 `a*b-c/d` attached ONE
+quotient to the leading product, rung-85 `a*b-c-d` SUBTRACTED two bare terms from it. `a*b+c+d` is the ladder's first
+**leading-product-plus-two-added-terms**. The operator order matters: `a*b+c+d` is `(((a*b)+c)+d)` (the product forms
+first by precedence, then the flat sum), NOT `a*(b+c)+d` (folding the first added term into the product) and NOT
+`a+b*c+d` (multiplying the WRONG pair and adding the basal rate bare) — the two distractors exploit exactly those
+confusions.
+
+The setup: a `basal_rate`, `active_hours`, `correction_units`, and `carb_units`. The total is:
+
+  TOTAL INSULIN     basal_rate * active_hours + correction_units + carb_units  [ a product at the front plus two added terms ]
+  INFUSION LOAD     basal_rate * active_hours                                  [ the basal product, before the boluses ]
+  BOLUS SUM         correction_units + carb_units                             [ the two bolus terms, before the product ]
+
+The **total insulin** is what makes this rung distinctive — it is the ladder's first
+**leading-product-plus-two-added-terms**. (The infusion load `a*b` and the bolus sum `c+d` ride alongside as component
+readouts, so the panel teaches the whole calculation — exactly as rungs 47-92 shipped their component
+sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the multiplication of the basal rate by the active hours into the infusion load, then the flat
+addition of that product, the correction units, and the carb units (the product forming before the sum, so a*b+c+d
+evaluates as (((a*b)+c)+d)) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No
+harness/engine change, exactly as rungs 8/16/.../91/92. This rung exercises the engine across a
+**leading-product-plus-two-added-terms** — the fact that `a*b+c+d` is `(((a*b)+c)+d)` and NOT `a*(b+c)+d` and NOT
+`a+b*c+d` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `*` and `+` — **no
+structural constants** — so no numeric literal appears in any program, and neither the infusion load, the bolus sum, nor
+any total figure is ever a literal (each is computed from the observed quantities). The observed quantities carry
+**digit-free identifiers** (`basal_rate`, `active_hours`, `correction_units`, `carb_units`) so no numeral hides inside a
+variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    basal_rate * (active_hours + correction_units) + carb_units  fold the FIRST added term (correction) into the
+                                                                          product instead of leaving it added (the classic
+                                                                          `a*b+c+d` vs `a*(b+c)+d` error), and
+  SWAPPED    basal_rate + active_hours * correction_units + carb_units    multiply the WRONG pair (active_hours × correction)
+                                                                          and add the basal rate bare (`a+b*c+d` instead of
+                                                                          `a*b+c+d`),
+
+which are exactly the mistakes a student makes (folding a neighbouring term into the product, or multiplying the wrong
+adjacent pair). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness and positivity: every quantity is a plain positive number >= 2, so every family member — a sum of positive
+terms and positive products — is automatically strictly positive; the tables are chosen so the five family values are
+pairwise distinct with a comfortable margin, asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (BASAL_RATE, ACTIVE_HOURS, CORRECTION_UNITS, CARB_UNITS) — a basal rate times active hours for the infusion load, and a
+# correction units and a carb units to add as two bolus terms, all plain positive numbers >= 2. Every family member is a
+# sum of positive terms / positive products, so positivity is automatic; the five family values are asserted
+# pairwise-distinct below (the tables avoid basal_rate == correction_units, which would collide the total with the
+# swapped slip, and basal_rate*active_hours == correction_units+carb_units, which would collide the infusion load with
+# the bolus sum).
+TABLES = [
+    (3, 2, 5, 4),
+    (2, 5, 3, 4),
+    (3, 3, 2, 4),
+    (2, 4, 6, 3),
+    (3, 4, 2, 5),
+    (5, 2, 3, 4),
+    (2, 6, 3, 2),
+]
+
+# The option family (5 members), all built from the four observed quantities via * and +. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "total_insulin",
+        "total insulin delivered (the basal infusion load plus the correction and carb boluses)",
+        "basal_rate * active_hours + correction_units + carb_units",
+    ),
+    (
+        "infusion_load",
+        "the basal infusion load (the basal rate times the active hours, before adding the boluses)",
+        "basal_rate * active_hours",
+    ),
+    (
+        "bolus_sum",
+        "the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)",
+        "correction_units + carb_units",
+    ),
+    (
+        "crossed",
+        "the basal rate times the active hours and correction units together, plus the carb units, folding the first bolus into the product instead of leaving it added (a wrong grouping)",
+        "basal_rate * (active_hours + correction_units) + carb_units",
+    ),
+    (
+        "swapped",
+        "the basal rate plus the active hours times the correction units, plus the carb units, multiplying the wrong pair (a wrong pairing)",
+        "basal_rate + active_hours * correction_units + carb_units",
+    ),
+]
+QUERIED = ["total_insulin", "infusion_load", "bolus_sum"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(basal_rate, active_hours, correction_units, carb_units):
+    # Operation order mirrors the ADJ programs exactly (the product forms first by precedence, then the flat sum, so
+    # a*b+c+d evaluates as (((a*b)+c)+d)), so the Python option value and the engine result are the same IEEE-double
+    # (well within the harness's 1e-9 match tolerance).
+    return {
+        "total_insulin": basal_rate * active_hours + correction_units + carb_units,
+        "infusion_load": basal_rate * active_hours,
+        "bolus_sum": correction_units + carb_units,
+        "crossed": basal_rate * (active_hours + correction_units) + carb_units,
+        "swapped": basal_rate + active_hours * correction_units + carb_units,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for basal_rate, active_hours, correction_units, carb_units in TABLES:
+        assert (
+            basal_rate > 0
+            and active_hours > 0
+            and correction_units > 0
+            and carb_units > 0
+        ), (basal_rate, active_hours, correction_units, carb_units)
+        fv = family_values(basal_rate, active_hours, correction_units, carb_units)
+        # Every family member is a sum of positive terms / positive products, so every value is strictly positive.
+        for key, v in fv.items():
+            assert v > 0, (key, basal_rate, active_hours, correction_units, carb_units, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    basal_rate,
+                    active_hours,
+                    correction_units,
+                    carb_units,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                basal_rate,
+                active_hours,
+                correction_units,
+                carb_units,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r93insulin-{idx + 1:02d}",
+                "qtype": "insulin_dosing_total",
+                "stem": (
+                    f"An insulin order records a basal rate of {num(basal_rate)} times active hours of "
+                    f"{num(active_hours)}, plus correction units of {num(correction_units)} plus carb units of "
+                    f"{num(carb_units)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe basal_rate({num(basal_rate)})\n"
+                    f"observe active_hours({num(active_hours)})\n"
+                    f"observe correction_units({num(correction_units)})\n"
+                    f"observe carb_units({num(carb_units)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 93 — insulin-dosing total from four stated quantities (a NEW panel: endocrinology / "
+            "insulin-dosing). From a basal rate times active hours for the infusion load and a correction units and a "
+            "carb units to add as two bolus terms, compute the total insulin "
+            "(basal_rate*active_hours+correction_units+carb_units), the infusion load (basal_rate*active_hours), or the "
+            "bolus sum (correction_units+carb_units). Each item is a compute_dimensioned program (observe the four "
+            "quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, A LEADING PRODUCT "
+            "PLUS TWO ADDED TERMS a*b+c+d (multiply a by b, then add c and d, so a*b+c+d = (((a*b)+c)+d); this COMPLETES "
+            "the additive-chain-plus-one-product family — rung-91 a+b+c*d put the product LAST, rung-92 a+b*c+d put it in "
+            "the MIDDLE, rung-93 puts it at the FRONT — and no prior shape led with a product and then added TWO "
+            "independent bare terms in one flat chain, e.g. rung-79 a*b+c/d attached one quotient, rung-85 a*b-c-d "
+            "subtracted two bare terms) — and the harness matches the scalar to the printed options. Contamination-safe: "
+            "every figure is built only from the four observed quantities via * and + — no constant leaks, and neither the "
+            "infusion load, the bolus sum, nor any total figure ever appears as a literal (each is computed) — and the "
+            "observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options "
+            "are a family over the same four quantities, so the distractors are exactly the slips students make: folding "
+            "the first bolus into the product (a*(b+c)+d, a wrong grouping) and multiplying the wrong pair with the basal "
+            "rate added bare (a+b*c+d, a wrong pairing). The core confusion tested is that a*b+c+d is (((a*b)+c)+d), not "
+            "a*(b+c)+d and not a+b*c+d."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung93_insulin_dosing/items.json
+++ b/code/specs/data/adj-ladder/rung93_insulin_dosing/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 93 \u2014 insulin-dosing total from four stated quantities (a NEW panel: endocrinology / insulin-dosing). From a basal rate times active hours for the infusion load and a correction units and a carb units to add as two bolus terms, compute the total insulin (basal_rate*active_hours+correction_units+carb_units), the infusion load (basal_rate*active_hours), or the bolus sum (correction_units+carb_units). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, A LEADING PRODUCT PLUS TWO ADDED TERMS a*b+c+d (multiply a by b, then add c and d, so a*b+c+d = (((a*b)+c)+d); this COMPLETES the additive-chain-plus-one-product family \u2014 rung-91 a+b+c*d put the product LAST, rung-92 a+b*c+d put it in the MIDDLE, rung-93 puts it at the FRONT \u2014 and no prior shape led with a product and then added TWO independent bare terms in one flat chain, e.g. rung-79 a*b+c/d attached one quotient, rung-85 a*b-c-d subtracted two bare terms) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every figure is built only from the four observed quantities via * and + \u2014 no constant leaks, and neither the infusion load, the bolus sum, nor any total figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: folding the first bolus into the product (a*(b+c)+d, a wrong grouping) and multiplying the wrong pair with the basal rate added bare (a+b*c+d, a wrong pairing). The core confusion tested is that a*b+c+d is (((a*b)+c)+d), not a*(b+c)+d and not a+b*c+d.",
+  "items": [
+    {
+      "id": "r93insulin-01",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 2, plus correction units of 5 plus carb units of 4. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(2)\nobserve correction_units(5)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r93insulin-02",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 2, plus correction units of 5 plus carb units of 4. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(2)\nobserve correction_units(5)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r93insulin-03",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 2, plus correction units of 5 plus carb units of 4. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(2)\nobserve correction_units(5)\nobserve carb_units(4)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r93insulin-04",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 5, plus correction units of 3 plus carb units of 4. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(5)\nobserve correction_units(3)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 21,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r93insulin-05",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 5, plus correction units of 3 plus carb units of 4. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(5)\nobserve correction_units(3)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r93insulin-06",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 5, plus correction units of 3 plus carb units of 4. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(5)\nobserve correction_units(3)\nobserve carb_units(4)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 21,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r93insulin-07",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 3, plus correction units of 2 plus carb units of 4. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(3)\nobserve correction_units(2)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r93insulin-08",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 3, plus correction units of 2 plus carb units of 4. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(3)\nobserve correction_units(2)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r93insulin-09",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 3, plus correction units of 2 plus carb units of 4. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(3)\nobserve correction_units(2)\nobserve carb_units(4)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r93insulin-10",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 4, plus correction units of 6 plus carb units of 3. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(4)\nobserve correction_units(6)\nobserve carb_units(3)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 17,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r93insulin-11",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 4, plus correction units of 6 plus carb units of 3. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(4)\nobserve correction_units(6)\nobserve carb_units(3)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 29,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r93insulin-12",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 4, plus correction units of 6 plus carb units of 3. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(4)\nobserve correction_units(6)\nobserve carb_units(3)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 29,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r93insulin-13",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 4, plus correction units of 2 plus carb units of 5. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(4)\nobserve correction_units(2)\nobserve carb_units(5)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r93insulin-14",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 4, plus correction units of 2 plus carb units of 5. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(4)\nobserve correction_units(2)\nobserve carb_units(5)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r93insulin-15",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 3 times active hours of 4, plus correction units of 2 plus carb units of 5. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(3)\nobserve active_hours(4)\nobserve correction_units(2)\nobserve carb_units(5)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r93insulin-16",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 5 times active hours of 2, plus correction units of 3 plus carb units of 4. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(5)\nobserve active_hours(2)\nobserve correction_units(3)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r93insulin-17",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 5 times active hours of 2, plus correction units of 3 plus carb units of 4. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(5)\nobserve active_hours(2)\nobserve correction_units(3)\nobserve carb_units(4)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r93insulin-18",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 5 times active hours of 2, plus correction units of 3 plus carb units of 4. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(5)\nobserve active_hours(2)\nobserve correction_units(3)\nobserve carb_units(4)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 29,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r93insulin-19",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 6, plus correction units of 3 plus carb units of 2. What is the total insulin delivered (the basal infusion load plus the correction and carb boluses)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(6)\nobserve correction_units(3)\nobserve carb_units(2)\nlet answer = basal_rate * active_hours + correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 22,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r93insulin-20",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 6, plus correction units of 3 plus carb units of 2. What is the the basal infusion load (the basal rate times the active hours, before adding the boluses)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(6)\nobserve correction_units(3)\nobserve carb_units(2)\nlet answer = basal_rate * active_hours\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 22,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r93insulin-21",
+      "qtype": "insulin_dosing_total",
+      "stem": "An insulin order records a basal rate of 2 times active hours of 6, plus correction units of 3 plus carb units of 2. What is the the bolus sum (the correction units plus the carb units, the two boluses before adding the infusion load)?",
+      "program": "observe basal_rate(2)\nobserve active_hours(6)\nobserve correction_units(3)\nobserve carb_units(2)\nlet answer = correction_units + carb_units\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 17,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 22,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -130,6 +130,7 @@ SELF_CONTAINED_RUNGS = (
     "rung90_spirometry_reserve",
     "rung91_protein_delivery",
     "rung92_gi_absorption",
+    "rung93_insulin_dosing",
 )
 
 


### PR DESCRIPTION
## rung-93 insulin dosing (`a*b+c+d` — leading product plus two added terms)

Opens the **endocrinology / insulin-dosing** panel on the ADJ-LADDER quantitative band, and **completes** the additive-chain-plus-one-product family: `a*b+c+d` — a lone product at the **front**, then two bare terms added to its right (`(((a*b)+c)+d)`).

### Why this shape completes the family
| rung | shape | product position |
|---|---|---|
| 91 | `a+b+c*d` | last |
| 92 | `a+b*c+d` | middle |
| **93** | **`a*b+c+d`** | **front** |

Together these three exhaust the positions a single product can take in a flat four-term add-chain. No prior shape led with a product and then added *two* independent bare terms in one flat chain — rung-79 `a*b+c/d` attached one quotient to the leading product, rung-85 `a*b-c-d` subtracted two bare terms from it.

### The panel
Four observed quantities — `basal_rate`, `active_hours`, `correction_units`, `carb_units`:

| readout | formula | shape |
|---|---|---|
| **total insulin** (headline) | `basal_rate*active_hours + correction_units + carb_units` | `a*b+c+d` |
| infusion load (queried) | `basal_rate*active_hours` | `a*b` (leading product) |
| bolus sum (queried) | `correction_units + carb_units` | `c+d` (the two added terms) |
| crossed *(distractor)* | `basal_rate*(active_hours+correction_units) + carb_units` | `a*(b+c)+d` (fold first bolus into the product) |
| swapped *(distractor)* | `basal_rate + active_hours*correction_units + carb_units` | `a+b*c+d` (multiply the wrong pair) |

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness matches the scalar to the printed options. No harness/engine change. 7 tables × 3 queried readouts = **21 items**, gold rotates A–E by index.

### Contamination-safe by construction
Every figure is built ONLY from the four observed quantities via `*` and `+` — **no numeric constants** in any program, no readout ever appears as a literal (each is computed), and identifiers are **digit-free** so no numeral hides in a variable name. Tables are chosen to avoid the two structural collisions (`basal_rate==correction_units` would collide total with the swapped slip; `basal_rate*active_hours==correction_units+carb_units` would collide the infusion load with the bolus sum) and the build asserts all 5 family members strictly positive and pairwise-distinct (>1e-6) for every table.

### Verification
- `pytest test_ladder_eval.py -k rung93` → **3 passed** (with `adj-lang-cli` built).
- Single-parent commit; scoped diff = 3 files (`rung93_insulin_dosing/gen_items.py`, `rung93_insulin_dosing/items.json`, `test_ladder_eval.py`).
- Inline security review PASSED (data-only generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
