### PR TITLE
feat(sir-js): Ruby Hash method-catalog parity (v0.15.0, stacked on #7716)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.15.0 — Ruby Hash method-catalog parity
+
+Adds a hand-implemented Ruby Hash catalog (`hashMethod`) to the emitted JS
+runtime for `Map` receivers, dispatched by an **explicit `switch` on the
+source-derived name** (never `recv[name]`) ahead of the native allowlist. This
+also fixes a latent bug: `keys`/`values` previously mis-routed to the native
+`Map.prototype.keys()`/`values()`, which return lazy iterators rather than the
+Ruby Arrays a translated program expects.
+
+Methods: `keys`, `values`, `size`/`length`, `empty?`, `has_key?`/`key?`/
+`include?`/`member?`, `has_value?`/`value?`, `to_a` (Array of `[k, v]` pairs),
+`merge` (non-mutating), `dig` (nested, nil on miss), `invert`, `delete`
+(mutating, returns removed value), `store`, and block-taking `each`/`each_pair`,
+`map`, `select`/`filter`/`reject`. Value comparison uses `===` (exact for
+primitives / strings / interned symbols — deep-equal is a follow-up).
+`respond_to?` kept honest via `HASH_METHODS`. `fetch` (raising) is unchanged.
+
+Verified end-to-end under Node (`run_with_node`): keys/values/to_a as real
+Arrays, `dig`, a `merge`-chain, and `delete` mutation all Ruby-faithful.
+
+(Stacked on the v0.14.0 String-catalog change.)
+
 ## 0.14.0 — Ruby String method-catalog parity
 
 Adds a hand-implemented Ruby String catalog (`stringMethod`) to the emitted JS

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -526,6 +526,9 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     // A string resolves the hand-implemented Ruby String catalog (in lockstep
     // with `stringMethod`'s case labels), ahead of the native gate.
     if (typeof recv === "string" && STRING_METHODS.has(name)) { return true; }
+    // A Hash (`Map`) resolves the hand-implemented Ruby Hash catalog (in
+    // lockstep with `hashMethod`'s case labels), ahead of the native gate.
+    if (recv instanceof Map && HASH_METHODS.has(name)) { return true; }
     // A primitive resolves a name iff it (or its Ruby→native alias) is on the
     // method allowlist AND the native member is actually a function on `recv`.
     if (!(recv instanceof SirInstance)) {
@@ -747,6 +750,102 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return STR_MISS;
   }
 
+  // ── Ruby Hash catalog (`Map` receiver) ─────────────────────────
+  // A Ruby Hash is a JS `Map` (insertion-ordered).  Hand-implemented by an
+  // EXPLICIT `switch` on the source-derived `name` (never `recv[name]`) ahead of
+  // the native allowlist — Ruby's `keys`/`values`/`to_a` must return real
+  // Arrays (native `Map.keys()` yields a lazy iterator, not a Ruby Array), and
+  // `each`/`merge`/`dig`/`invert`/… have no faithful native equivalent.  Value
+  // comparison (`has_value?`/`invert`) uses `===`: exact for primitives,
+  // strings, and interned symbols — the v0 floor (deep-equal of nested values
+  // is a follow-up).  `HASH_METHODS` mirrors these labels for `respond_to?`.
+  const HASH_MISS = Symbol("hash-miss");
+  const HASH_METHODS = new Set([
+    "keys", "values", "size", "length", "empty?", "has_key?", "key?",
+    "include?", "member?", "has_value?", "value?", "to_a", "merge", "dig",
+    "invert", "delete", "store", "each", "each_pair", "map", "select",
+    "filter", "reject",
+  ]);
+  function hashMethod(recv, name, args) {
+    switch (name) {
+      case "keys": return [...recv.keys()];
+      case "values": return [...recv.values()];
+      case "size": case "length": return recv.size;
+      case "empty?": return recv.size === 0;
+      case "has_key?": case "key?": case "include?": case "member?":
+        return recv.has(args[0]);
+      case "has_value?": case "value?": {
+        for (const v of recv.values()) { if (v === args[0]) { return true; } }
+        return false;
+      }
+      case "to_a": {
+        // Array of `[key, value]` two-element Arrays, in insertion order.
+        const out = [];
+        for (const [k, v] of recv) { out.push([k, v]); }
+        return out;
+      }
+      case "merge": {
+        // Non-mutating: a fresh Map with `other`'s entries overlaid (last wins).
+        const out = new Map(recv);
+        if (args[0] instanceof Map) { for (const [k, v] of args[0]) { out.set(k, v); } }
+        return out;
+      }
+      case "dig": {
+        // Walk one key per argument, nil the moment a level is missing; a
+        // non-diggable intermediate stops the walk.
+        let cur = recv;
+        for (const k of args) {
+          if (cur instanceof Map) { cur = cur.has(k) ? cur.get(k) : null; }
+          else if (Array.isArray(cur) && typeof k === "number") { cur = cur[k] ?? null; }
+          else { return null; }
+          if (cur === null) { return null; }
+        }
+        return cur;
+      }
+      case "invert": {
+        const out = new Map();
+        for (const [k, v] of recv) { out.set(v, k); }
+        return out;
+      }
+      case "delete": {
+        // Ruby `delete` MUTATES and returns the removed value (nil if absent).
+        if (recv.has(args[0])) { const v = recv.get(args[0]); recv.delete(args[0]); return v; }
+        return null;
+      }
+      case "store": {
+        // Ruby `store(k, v)` (alias `[]=`): mutates, returns the value.
+        recv.set(args[0], args[1]);
+        return args[1];
+      }
+      case "each": case "each_pair": {
+        // Yields (key, value); returns the receiver.
+        const blk = args[args.length - 1];
+        if (typeof blk === "function") { for (const [k, v] of recv) { blk(k, v); } }
+        return recv;
+      }
+      case "map": {
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return []; }
+        const out = [];
+        for (const [k, v] of recv) { out.push(blk(k, v)); }
+        return out;
+      }
+      case "select": case "filter": case "reject": {
+        // Ruby `select`/`reject` return a new Hash of the kept pairs.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return new Map(recv); }
+        const keepWhenTruthy = name !== "reject";
+        const out = new Map();
+        for (const [k, v] of recv) {
+          const t = truthy(blk(k, v));
+          if (keepWhenTruthy ? t : !t) { out.set(k, v); }
+        }
+        return out;
+      }
+    }
+    return HASH_MISS;
+  }
+
   // Dispatch the universal M6 surface on ANY receiver.  Returns `M6_MISS` when
   // `name` is not an M6 method, so `callMethod` continues to its type-specific
   // paths.  `rawArgs` is the UN-unwrapped argument list — a trailing block is
@@ -832,6 +931,13 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     if (typeof recv === "string") {
       const sm = stringMethod(recv, name, args);
       if (sm !== STR_MISS) { return sm; }
+    }
+    // Ruby Hash catalog on a `Map` receiver — explicit-switch dispatch (no
+    // `recv[name]`) ahead of the native allowlist, so `keys`/`values`/`to_a`
+    // return real Arrays and `each`/`merge`/`dig`/… resolve faithfully.
+    if (recv instanceof Map) {
+      const hm = hashMethod(recv, name, args);
+      if (hm !== HASH_MISS) { return hm; }
     }
     // `length` as a nullary method mirrors the property.  Kept special-cased
     // ahead of the allowlist: it is a property read, not a method call.

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2282,3 +2282,40 @@ fn string_catalog_methods() {
         assert_eq!(stdout, "Hello\ncba\nheLlo\nheLLo\n42\nhi\n6\n[a, b, c]");
     }
 }
+
+// ── Ruby Hash method catalog (hand-implemented, explicit dispatch) ──
+//
+// Exercises the `hashMethod` catalog end-to-end under Node: `keys`/`values`/
+// `to_a` must return real Arrays (not native Map iterators), `dig`/`merge`
+// resolve faithfully, and `delete` mutates the receiver — all routed through
+// the explicit Map switch (never `recv[name]`).
+#[test]
+fn hash_catalog_methods() {
+    let mk = |pairs: Vec<(&str, Expr)>| Expr::MapLit {
+        entries: pairs
+            .into_iter()
+            .map(|(k, v)| MapEntry { key: str_(k), value: v })
+            .collect(),
+        span: sp(),
+    };
+    let stmts = vec![
+        let_("m", mk(vec![("a", int(1)), ("b", int(2))])),
+        print(method(local("m"), "keys", vec![])),   // [a, b]
+        print(method(local("m"), "values", vec![])), // [1, 2]
+        print(method(local("m"), "size", vec![])),   // 2
+        print(method(local("m"), "to_a", vec![])),   // [[a, 1], [b, 2]]
+        print(method(local("m"), "dig", vec![str_("b")])), // 2
+        print(method(
+            method(local("m"), "merge", vec![mk(vec![("c", int(3))])]),
+            "keys",
+            vec![],
+        )), // [a, b, c]
+        print(method(local("m"), "delete", vec![str_("a")])), // 1 (mutates m)
+        print(method(local("m"), "keys", vec![])),            // [b]
+    ];
+    let module =
+        module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Maps, Feature::Strings]);
+    if let Some(stdout) = run_module(&module, "hashcatalog") {
+        assert_eq!(stdout, "[a, b]\n[1, 2]\n2\n[[a, 1], [b, 2]]\n2\n[a, b, c]\n1\n[b]");
+    }
+}


### PR DESCRIPTION
**Stacked on #7716** (JS String) → #7714 (JS Numeric). Review/merge those first; this branch's net-new change is the Hash catalog.

Adds a hand-implemented Ruby **Hash** catalog to the emitted JS runtime for `Map` receivers — the last of JS's core-collection gaps vs. Go/Rust/Python.

## What
`hashMethod` on a `Map` receiver, dispatched by an **explicit `switch` on the source-derived name** (never `recv[name]`) ahead of the native allowlist. Also fixes a latent bug: `keys`/`values` previously mis-routed to native `Map.prototype.keys()`/`values()`, returning lazy iterators instead of Ruby Arrays.

Methods: `keys`, `values`, `size`/`length`, `empty?`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `to_a`, `merge` (non-mutating), `dig`, `invert`, `delete` (mutating), `store`, and block-taking `each`/`each_pair`/`map`/`select`/`filter`/`reject`. `fetch` (raising) unchanged.

## Safety
- Explicit-switch dispatch only — no reflection/`recv[name]`. **No prototype pollution**: every write goes through `Map.prototype.set`/`.delete` (never `obj[key]=`), so a source-controlled `__proto__`/`constructor` key is inert Map data. Block args guarded `typeof === "function"`; `dig` bounded + numeric-guarded. Security review passed.

## Verification
Full crate suite green (172). New `run_with_node` test executes the emitted JS under Node and asserts Ruby-faithful output for keys/values/to_a (real Arrays), `dig`, a `merge`-chain, and `delete` mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)