### PR TITLE
feat(sir-rust): display convention — Ruby booleans true/false (v0.19.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.19.0 — source-language display convention: Ruby booleans (`true`/`false`)
+
+First increment of the SIR display-convention spec (`code/specs/sir-display-convention.md`).
+A **Ruby**-sourced module now renders booleans as `true`/`false` instead of the
+Twig/Lisp `#t`/`#f`, so a translated `puts true` prints `true`.
+
+Mechanism: the runtime carries a compile-time `const SIR_DISPLAY_RUBY` (a
+`__SIR_DISPLAY_RUBY__` placeholder); the emitter substitutes `true`/`false`
+from `Module.metadata.source_language` (`== "ruby"` → `true`, else `false`).
+`format` branches the boolean arm on it. The default is the Lisp form, so all
+existing non-Ruby (Twig) output is **byte-for-byte unchanged** (every prior
+golden still passes). The branch is a `const`, so it folds at compile time —
+zero per-call cost.
+
+Scope: booleans only (the flagship divergence). `nil`, symbols, string
+`inspect` quoting, and the Ruby hash `=>` element form remain follow-ups per
+the spec's rollout. Verified end-to-end under `rustc`: Ruby source →
+`true\nfalse\n`; Twig source → `#t\n#f\n`.
+
 ## 0.18.0 — Numeric + String method-catalog parity
 
 Expands the emitted Rust runtime's `numeric_method` and `string_method`

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -54,7 +54,17 @@ pub fn emit_module(m: &Module) -> String {
     let mut out = String::new();
     emit_banner(&mut out, m);
     emit_allows(&mut out);
-    out.push_str(RUNTIME);
+    // Substitute the display-convention placeholder (SIR display-convention
+    // spec): a Ruby-sourced module renders booleans as `true`/`false`; every
+    // other source language keeps the default Lisp `#t`/`#f` form, so existing
+    // Twig output is unchanged.
+    //
+    // SECURITY: the replacement value MUST remain a hardcoded literal selected
+    // by a boolean — never text derived from `source_language` or any other
+    // source-controlled field — so this substitution can never inject into the
+    // emitted Rust.
+    let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
+    out.push_str(&RUNTIME.replace("__SIR_DISPLAY_RUBY__", if display_ruby { "true" } else { "false" }));
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
         out.push('\n');

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -19,6 +19,15 @@
 /// The full inlined runtime.  Always emitted verbatim.
 pub const RUNTIME: &str = r##"mod __sir {
     //! Runtime support — value model, builtins, helpers.
+
+    // Source-language display convention (SIR display-convention spec).  The
+    // emitter substitutes `__SIR_DISPLAY_RUBY__` with `true` when the module's
+    // `source_language` is Ruby, else `false` (the default Twig/Lisp form).
+    // `format` reads this to render a boolean as Ruby `true`/`false` rather
+    // than the Lisp `#t`/`#f`.  Kept a compile-time `const` so the branch folds
+    // away — zero per-call cost — and existing Twig output is byte-for-byte
+    // unchanged (the default is the Lisp form).
+    pub const SIR_DISPLAY_RUBY: bool = __SIR_DISPLAY_RUBY__;
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -641,8 +650,8 @@ pub const RUNTIME: &str = r##"mod __sir {
             // matching how Python/Ruby render `3.0`.  Non-finite values
             // print as `NaN` / `inf` / `-inf`.
             Value::Float(x) => format_float(*x),
-            Value::Bool(true) => "#t".to_string(),
-            Value::Bool(false) => "#f".to_string(),
+            Value::Bool(true) => if SIR_DISPLAY_RUBY { "true" } else { "#t" }.to_string(),
+            Value::Bool(false) => if SIR_DISPLAY_RUBY { "false" } else { "#f" }.to_string(),
             Value::Nil => "nil".to_string(),
             // Defensive: a `Missing` sentinel should be consumed by a
             // defaulted param's prologue before any value is printed, so

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_display_convention.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_display_convention.rs
@@ -1,0 +1,147 @@
+//! End-to-end proof for the source-language display convention (SIR
+//! display-convention spec) in the Rust backend.
+//!
+//! A translated **Ruby** program's `puts true` must print `true` — not the
+//! Twig/Lisp `#t`.  The emitter selects the convention from the module's
+//! `source_language` metadata and substitutes it into the runtime's
+//! `SIR_DISPLAY_RUBY` constant; `format` then renders booleans accordingly.
+//!
+//! This test hand-builds the program
+//!
+//!     puts true
+//!     puts false
+//!
+//! twice — once tagged `source_language = "ruby"`, once `"twig"` — emits Rust,
+//! compiles it with `rustc`, runs it, and asserts:
+//!   * Ruby  → `true\nfalse\n`   (Ruby-faithful)
+//!   * Twig  → `#t\n#f\n`        (Lisp default, unchanged)
+//!
+//! Gates on `rustc` and degrades gracefully when the host linker is missing.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, Function, FeatureManifest, Metadata, Module, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn blit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args,
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// `puts true; puts false`, tagged with the given `source_language`.
+fn bool_module(source_language: &str) -> Module {
+    let stmts = vec![puts_stmt(vec![blit(true)]), puts_stmt(vec![blit(false)])];
+    Module {
+        name: "display_bool".into(),
+        manifest: FeatureManifest::from_features(&[]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language(source_language)
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn compile_run(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("module should compile to Rust source");
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_disp_{tag}_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_disp_{tag}_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return None;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run_out.stdout).into_owned();
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+    assert!(run_out.status.success(), "compiled binary exited non-zero");
+    Some(stdout.replace("\r\n", "\n"))
+}
+
+#[test]
+fn ruby_source_prints_true_false() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let Some(out) = compile_run(&bool_module("ruby"), "ruby") else { return };
+    assert_eq!(out, "true\nfalse\n", "Ruby source must render booleans as true/false");
+}
+
+#[test]
+fn twig_source_keeps_lisp_booleans() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let Some(out) = compile_run(&bool_module("twig"), "twig") else { return };
+    assert_eq!(out, "#t\n#f\n", "non-Ruby source keeps the default Lisp #t/#f");
+}


### PR DESCRIPTION
**First implementation increment of the merged [sir-display-convention spec](code/specs/sir-display-convention.md).**

A translated **Ruby** program's `puts true` now prints `true` (not the Twig/Lisp `#t`). Rust backend only, booleans only — the flagship divergence.

## Mechanism (per spec — no new IR/manifest field)
- Runtime carries a compile-time `const SIR_DISPLAY_RUBY: bool` via a `__SIR_DISPLAY_RUBY__` placeholder; `format`'s boolean arm branches on it.
- Emitter substitutes `true`/`false` from the existing `Module.metadata.source_language` (`== "ruby"` → `true`, else `false`).
- **Default is the Lisp form**, so every existing non-Ruby (Twig) golden is **byte-for-byte unchanged** (full suite green). The branch is a `const` → folds at compile time, zero per-call cost.

## Safety
Security review passed. The replacement value is a hardcoded literal chosen by an exact `== "ruby"` boolean — no source-controlled text reaches emitted code (a comment now guards this invariant). `str::replace` on the fixed `RUNTIME` constant, single unique token.

## Scope / follow-ups (per spec rollout)
Booleans only. `nil`, symbols, string `inspect` quoting, and Ruby hash `=>` are follow-ups; Go/JS/Python/TS backends mirror this in subsequent PRs.

## Verification
Exec-proof under `rustc`: `source_language=ruby` → `true\nfalse\n`; `source_language=twig` → `#t\n#f\n`. Full crate suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)