### PR TITLE
feat(latex): LTXDOC03 S11 — grouped-by-kind cross-reference report

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.47.0] — 2026-07-07
+
+### Added — cross-reference report: grouped-by-kind rendering (LTXDOC03 S11)
+
+A **new, separate** public method `CrossReferenceReport::to_plain_text_by_kind(&self) -> String` that
+renders the **same** resolved references as `to_plain_text`, but **grouped under fixed-order kind
+subheadings** instead of flat source order — so a reader can see "which sections / figures / equations
+does this document cross-reference?" at a glance. `to_plain_text` is left **byte-for-byte unchanged**;
+S11 is purely additive.
+
+- **Fixed kind order, source-order within a group.** Groups are emitted **Sections, Figures, Tables,
+  Equations, Inline** regardless of source order (`S11_KIND_ORDER`). Within a group the refs keep the
+  report's existing pre-order (a filter of `refs` for that kind, preserving order).
+- **Subheading + two-space-indented lines.** Each kind with ≥1 resolved ref emits a pluralised
+  capitalised subheading (`Sections:`, `Figures:`, `Tables:`, `Equations:`, `Inline:`, from the new
+  `kind_group_heading` helper) followed by one two-space-indented line per ref. Kinds with zero
+  resolved refs are **omitted entirely** — no empty subheading.
+- **Same per-command rendering — factored into a shared helper.** The single-line rendering (S8/S9/S10
+  rules: `\eqref` to an equation → `\eqref{k} -> Equation (N)`; `\pageref` → `\pageref{k} -> page ?`;
+  else `\ref{k} -> Kind N`) is factored into a private `render_resolved_ref(&RefEntry) -> String` that
+  **both** `to_plain_text` and `to_plain_text_by_kind` call, so the flat and grouped renderings can
+  never drift. `to_plain_text` was refactored to call it with byte-for-byte identical output (the
+  existing S6–S10 tests pass unchanged). A `\pageref` groups under its **target kind** (e.g. a
+  `\pageref` to a section sits under `Sections:`).
+- **Resolved refs only; distinct empty marker.** Citations and dangling footers are **not** included
+  (the flat `to_plain_text` remains the full report). A report with **zero** resolved refs renders the
+  fixed string `"(no resolved references)"` — the S11 analogue of `to_plain_text`'s
+  `"(no cross-references)"`.
+- **Additive, no AST/struct/numbering change.** A pure report-assembly method over data the report
+  already holds (`refs` with their `kind`). No new field, no new dependency, no `unsafe`, no I/O;
+  `to_latex()` remains a fixed point. 5 new S11 tests; version bump 0.46.0 → 0.47.0.
+
 ## [0.46.0] — 2026-07-07
 
 ### Added — cross-reference resolution: distinct `\pageref` rendering (LTXDOC03 S10)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -58,6 +58,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S8 — equation numbering** | `Counters` gains a flat `equation: u32` field and a `step_equation()` method (mirroring `step_figure`/`step_table` — pre-increment, saturating, one monotonic run **independent** of section/figure/table). In the `Block::DisplayMath { label: Some(key), .. }` arm of `number_labels`, S7's placeholder is replaced with `counters.step_equation().to_string()`, so a lifted equation label now carries a **real** sequential number in document order (`1`, `2`, …). The S6 report prints `\ref{eq:e} -> Equation 1` (was `Equation ?`). Equation numbering is independent of the section/figure/table counters. **Limitation:** because `Block::DisplayMath` carries no `numbered` flag (the D5 lowering sets `label: None` for both starred envs and `\[…\]`/`$$…$$` islands), only **labelled** equations step the counter — an unlabelled numbered equation between two labelled ones is not yet counted (needs an AST change, deferred). `\eqref` parenthesisation (`(1)` vs `1`) is also deferred to a later slice; S8 is counter-only. Pure, additive, tree-unchanged; total & panic-free. | ✅ |
 | **LTXDOC03 S9 — `\eqref` parenthesisation** | `CrossReferenceReport::to_plain_text` now mirrors amsmath's `\eqref` for the one case that matters: a resolved reference whose `command == "eqref"` **and** `kind == LabelKind::Equation` renders `\eqref{eq:e} -> Equation (1)` — the `\eqref` spelling is kept and the number is **parenthesised**. Every other reference — all `\ref`, all `\pageref`, and any `\eqref` to a **non-equation** kind — is byte-for-byte unchanged from S8: canonical `\ref` prefix, bare number (`\ref{sec:intro} -> Section 1.2`). `RefEntry.command` (the surface spelling) was already retained by S1, so S9 is a pure rendering split in one `format!` — no AST change, no new field, no re-numbering; `to_latex()` stays a fixed point. Pure, additive; total & panic-free. | ✅ |
 | **LTXDOC03 S10 — distinct `\pageref` rendering** | `CrossReferenceReport::to_plain_text` gains a **third** rendering branch so a resolved `\pageref` no longer renders identically to a `\ref`. A `\pageref{key}` asks "what **page** is the target on" — a different question from `\ref`'s "what **number** is the target" — but the crate has **no page model**, so it cannot compute a real page number. A resolved reference whose `command == "pageref"` (to **any** target kind) now renders `\pageref{sec:i} -> page ?` — the `\pageref` spelling is kept and the kind/number are replaced by the fixed literal placeholder `page ?` (the `?` mirrors LaTeX's own `??` for an unresolved page reference; it means "page number not modelled", not the kind, not the number). Branch precedence: (1) `\eqref` to Equation → parenthesised (S9); (2) `\pageref` any kind → `page ?` (S10); (3) else → `\ref{key} -> Kind N` (S8). So `\ref` and `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines change. Pure rendering branch — no AST change, no re-numbering, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S11 — grouped-by-kind cross-reference report** | `CrossReferenceReport::to_plain_text_by_kind() -> String` — a **new, separate** method that renders the **same** resolved references as `to_plain_text` but **grouped under fixed-order kind subheadings** (Sections, Figures, Tables, Equations, Inline — regardless of source order), each subheading followed by two-space-indented ref lines in the report's existing pre-order. Kinds with zero resolved refs are omitted entirely. The per-line rendering is the **identical** S8/S9/S10 rule — factored into a shared private `render_resolved_ref(&RefEntry)` that **both** `to_plain_text` and `to_plain_text_by_kind` call, so the flat and grouped reports can never drift (`to_plain_text` output is byte-for-byte unchanged). Only resolved refs are grouped (no citations, no dangling footers); zero resolved refs → the fixed marker `(no resolved references)`. A `\pageref` groups under its **target kind**. Pure report-assembly over data the report already holds — no AST/struct/numbering change, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -561,6 +562,47 @@ any kind → `page ?` (S10); (3) else → `\ref{key} -> Kind N` (S8). A `\pagere
 eqref/Equation special-case entirely — a `\pageref` to an equation still renders `page ?`, never
 `Equation (1)`. So `\ref` and `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines
 change. Pure rendering branch — no AST change, no re-numbering, `to_latex()` still a fixed point.
+
+### grouped-by-kind cross-reference report (LTXDOC03 S11)
+
+`to_plain_text` renders resolved references in flat source order. `to_plain_text_by_kind` is a
+**separate, sibling** method that renders the **same** resolved-ref lines **grouped under fixed-order
+kind subheadings** — Sections, Figures, Tables, Equations, Inline — so a reader can answer "which
+sections / figures / equations does this document cross-reference?" at a glance. The kind order is
+fixed regardless of source order; within a kind group the refs keep their source (pre-order) order; a
+kind with zero resolved refs is omitted entirely (no empty subheading). The per-line rendering is the
+**identical** S8/S9/S10 rule — a shared `render_resolved_ref` helper backs **both** methods, so the
+flat and grouped reports can never drift.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\section{Methods}\label{sec:methods}
+\begin{figure}\caption{A plot}\label{fig:plot}\end{figure}
+\begin{equation} a = 1 \label{eq:e} \end{equation}
+See \ref{sec:intro}, \ref{sec:methods}, \ref{fig:plot}, \eqref{eq:e}.\end{document}";
+let doc = parse_document(src).unwrap();
+
+// Grouped under fixed-order kind subheadings, two-space-indented ref lines in pre-order.
+assert_eq!(
+    doc.cross_reference_report().to_plain_text_by_kind(),
+    "Sections:\n\
+     \x20 \\ref{sec:intro} -> Section 1\n\
+     \x20 \\ref{sec:methods} -> Section 2\n\
+     Figures:\n\
+     \x20 \\ref{fig:plot} -> Figure 1\n\
+     Equations:\n\
+     \x20 \\eqref{eq:e} -> Equation (1)",
+);
+```
+
+Only resolved references are grouped (citations and dangling footers are **not** included — the flat
+`to_plain_text` remains the full report); a `\pageref` groups under its **target kind** (a `\pageref`
+to a section sits under `Sections:`). A report with zero resolved refs renders the fixed marker
+`(no resolved references)` — the S11 analogue of `to_plain_text`'s `(no cross-references)`. Pure
+report-assembly over data the report already holds — no AST/struct/numbering change, `to_latex()`
+still a fixed point.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1581,6 +1581,68 @@ fn kind_display_name(kind: LabelKind) -> &'static str {
     }
 }
 
+/// Render **one** resolved-reference [`RefEntry`] to its single plain-text line — the shared
+/// per-command rendering used by **both** [`CrossReferenceReport::to_plain_text`] (S6, flat pre-order)
+/// and [`CrossReferenceReport::to_plain_text_by_kind`] (S11, grouped-by-kind). Factoring the three
+/// precedence-ordered renderings into this one place is what guarantees the flat and grouped reports
+/// can **never** drift — they call the identical code, so a `\ref`/`\eqref`/`\pageref` line is
+/// byte-for-byte the same wherever it appears.
+///
+/// Three renderings, tried in this precedence order, keyed off the *surface command* + *target kind*
+/// (LTXDOC03 S9/S10):
+///
+///   1. An `\eqref` whose target is an **equation** renders amsmath-style — the `\eqref` spelling is
+///      kept and the number is **parenthesised**: `\eqref{eq:e} -> Equation (1)`. (`\eqref` on
+///      `article`'s equation counter typesets "(1)", so the report mirrors that surface form.) (S9.)
+///   2. Otherwise, a `\pageref` (to **any** kind) renders with the `\pageref` spelling and the literal
+///      placeholder `page ?`: `\pageref{sec:i} -> page ?`. A page reference asks *what page* the target
+///      is on; the crate has NO page model, so the target's kind and number are irrelevant — the
+///      honest fixed placeholder is `page ?` (the `?` mirrors LaTeX's own `??` for an unresolved page
+///      ref). (S10.)
+///   3. Every other resolved reference — all `\ref` and any `\eqref` to a **non-equation** kind —
+///      renders with the canonical `\ref` prefix and a **bare** number: `\ref{sec:intro} -> Section
+///      1.2`.
+///
+/// Pure and total: string building only (no indexing, no `unwrap`), allocating just the returned line.
+fn render_resolved_ref(r: &RefEntry) -> String {
+    if r.command == "eqref" && r.kind == LabelKind::Equation {
+        format!(r"\eqref{{{}}} -> {} ({})", r.key, kind_display_name(r.kind), r.number)
+    } else if r.command == "pageref" {
+        // No page model: a fixed, honest placeholder, independent of kind/number.
+        format!(r"\pageref{{{}}} -> page ?", r.key)
+    } else {
+        format!(r"\ref{{{}}} -> {} {}", r.key, kind_display_name(r.kind), r.number)
+    }
+}
+
+/// The **pluralised** capitalised subheading a kind gets in the S11 grouped report: `"Sections"`,
+/// `"Figures"`, `"Tables"`, `"Equations"`, `"Inline"`. Distinct from [`kind_display_name`]'s singular
+/// per-line form (`"Section"`) because the S11 subheading names a *group* of references. `Inline` has
+/// no natural plural here (it is not a numbered display kind), so it is left as-is. Pure, total, one
+/// fixed match.
+fn kind_group_heading(kind: LabelKind) -> &'static str {
+    match kind {
+        LabelKind::Section => "Sections",
+        LabelKind::Table => "Tables",
+        LabelKind::Figure => "Figures",
+        LabelKind::Equation => "Equations",
+        LabelKind::Inline => "Inline",
+    }
+}
+
+/// The **fixed kind order** the S11 grouped report emits its subheadings in — Sections, then Figures,
+/// then Tables, then Equations, then Inline — *regardless* of the source order references appear in.
+/// A group is only emitted if it has ≥1 resolved ref (see
+/// [`to_plain_text_by_kind`](CrossReferenceReport::to_plain_text_by_kind)); within a group the refs
+/// keep their pre-order.
+const S11_KIND_ORDER: [LabelKind; 5] = [
+    LabelKind::Section,
+    LabelKind::Figure,
+    LabelKind::Table,
+    LabelKind::Equation,
+    LabelKind::Inline,
+];
+
 // -------------------------------------------------------------------------------------------------
 // The report record types (plain, Clone-able, owned data — mirroring S4/S5's owned-String rows).
 // -------------------------------------------------------------------------------------------------
@@ -1696,46 +1758,11 @@ impl CrossReferenceReport {
     pub fn to_plain_text(&self) -> String {
         let mut lines: Vec<String> = Vec::new();
 
-        // Resolved references.
-        //
-        // Three renderings, tried in this precedence order, keyed off the *surface command* +
-        // *target kind* (LTXDOC03 S10):
-        //
-        //   1. An `\eqref` whose target is an **equation** renders amsmath-style — the `\eqref`
-        //      spelling is kept and the number is **parenthesised**:
-        //      `\eqref{eq:e} -> Equation (1)`.  (`\eqref` on `article`'s equation counter typesets
-        //      "(1)", so the report mirrors that surface form.)  (S9, unchanged.)
-        //   2. Otherwise, a `\pageref` (to **any** kind) renders with the `\pageref` spelling and the
-        //      literal placeholder `page ?`: `\pageref{sec:i} -> page ?`.  A page reference asks
-        //      *what page* the target is on; the crate has NO page model, so the target's kind and
-        //      number are irrelevant — the honest fixed placeholder is `page ?` (the `?` mirrors
-        //      LaTeX's own `??` for an unresolved page ref).  (S10, NEW.)
-        //   3. Every other resolved reference — all `\ref` and any `\eqref` to a **non-equation**
-        //      kind — renders exactly as it did through S8: the canonical `\ref` prefix and a **bare**
-        //      number, `\ref{sec:intro} -> Section 1.2`.
-        //
-        // Precedence matters: (1) before (2) is moot (an `\eqref` is never a `\pageref`), but (2)
-        // before (3) is what makes every `\pageref` diverge from the S8 `\ref` line.  `\ref` and
-        // `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines change.
+        // Resolved references — each rendered by the shared per-command helper
+        // [`render_resolved_ref`], so this S6 rendering and the S11 grouped rendering
+        // ([`to_plain_text_by_kind`](CrossReferenceReport::to_plain_text_by_kind)) can never drift.
         for r in &self.refs {
-            if r.command == "eqref" && r.kind == LabelKind::Equation {
-                lines.push(format!(
-                    r"\eqref{{{}}} -> {} ({})",
-                    r.key,
-                    kind_display_name(r.kind),
-                    r.number
-                ));
-            } else if r.command == "pageref" {
-                // No page model: a fixed, honest placeholder, independent of kind/number.
-                lines.push(format!(r"\pageref{{{}}} -> page ?", r.key));
-            } else {
-                lines.push(format!(
-                    r"\ref{{{}}} -> {} {}",
-                    r.key,
-                    kind_display_name(r.kind),
-                    r.number
-                ));
-            }
+            lines.push(render_resolved_ref(r));
         }
         // Resolved citations: `\cite{key} -> number`.
         for c in &self.cites {
@@ -1752,6 +1779,71 @@ impl CrossReferenceReport {
         if lines.is_empty() {
             // A stable, greppable marker so the rendering is never the empty string.
             "(no cross-references)".to_string()
+        } else {
+            lines.join("\n")
+        }
+    }
+
+    /// Render the report's **resolved references only**, grouped under fixed-order kind subheadings
+    /// (LTXDOC03 S11). A *sibling* of [`to_plain_text`](CrossReferenceReport::to_plain_text) — it
+    /// leaves that flat rendering untouched — that re-organises the **same** resolved-ref lines from
+    /// source order into per-kind groups, so a reader can see "which sections / figures / equations
+    /// does this document cross-reference?" at a glance.
+    ///
+    /// The exact format, pinned so tests and consumers can rely on it byte-for-byte:
+    ///
+    /// - Kinds are emitted in a **fixed order** — **Sections, Figures, Tables, Equations, Inline** —
+    ///   *regardless* of the order references appear in the source (see [`S11_KIND_ORDER`]).
+    /// - For each kind with **≥1** resolved ref, a subheading line — the pluralised capitalised kind
+    ///   name plus a colon (`Sections:`, `Figures:`, `Tables:`, `Equations:`, `Inline:`, from
+    ///   [`kind_group_heading`]) — followed by **one line per ref**, each **indented by two spaces**
+    ///   then rendered by the **shared** [`render_resolved_ref`] helper — the *identical* per-command
+    ///   rule [`to_plain_text`](CrossReferenceReport::to_plain_text) uses, so an `\eqref` to an
+    ///   equation still reads `\eqref{eq:e} -> Equation (1)` and a `\pageref` still reads
+    ///   `\pageref{key} -> page ?`. Within a kind group the refs keep their existing pre-order (this
+    ///   filters [`refs`](CrossReferenceReport::refs) for that kind, preserving order).
+    ///
+    ///   ```text
+    ///   Sections:
+    ///     \ref{sec:intro} -> Section 1
+    ///     \ref{sec:methods} -> Section 2
+    ///   Figures:
+    ///     \ref{fig:plot} -> Figure 1
+    ///   ```
+    /// - A kind with **zero** resolved refs is **omitted entirely** — no empty subheading.
+    /// - Only resolved **references** are grouped; citations and the dangling footers are **not**
+    ///   included (this method stays focused on the kind-grouped resolved refs — the flat
+    ///   [`to_plain_text`](CrossReferenceReport::to_plain_text) remains the place for the full report).
+    /// - If there are **zero** resolved refs at all, the fixed string `"(no resolved references)"` is
+    ///   returned (a stable, greppable marker — the S11 analogue of `to_plain_text`'s
+    ///   `"(no cross-references)"`), so the output is never the empty string.
+    ///
+    /// Lines are joined by a single `\n` with **no trailing newline** and no trailing whitespace on any
+    /// line. The kind order is fixed and the within-group order is source-derived, so the whole
+    /// rendering is a pure function of the report.
+    ///
+    /// Total & panic-free: string building only (no indexing, no `unwrap`), allocating just the output
+    /// `String`.
+    pub fn to_plain_text_by_kind(&self) -> String {
+        let mut lines: Vec<String> = Vec::new();
+
+        // Walk the fixed kind order; for each kind, gather its refs in pre-order and, if any, emit a
+        // subheading followed by the two-space-indented per-ref lines (shared render helper).
+        for &kind in &S11_KIND_ORDER {
+            let group: Vec<&RefEntry> = self.refs.iter().filter(|r| r.kind == kind).collect();
+            if group.is_empty() {
+                continue; // omit empty kinds entirely — no bare subheading.
+            }
+            lines.push(format!("{}:", kind_group_heading(kind)));
+            for r in group {
+                // Two-space indent, then the SAME per-command line the flat report emits.
+                lines.push(format!("  {}", render_resolved_ref(r)));
+            }
+        }
+
+        if lines.is_empty() {
+            // A stable, greppable marker so the rendering is never the empty string.
+            "(no resolved references)".to_string()
         } else {
             lines.join("\n")
         }
@@ -3235,6 +3327,102 @@ See Section~\ref{sec:intro} and \cite{smith2020}.
         assert!(
             doc.ref_target_node(&refs_before.resolved[0]).is_some(),
             "S3 lookup still resolves after building the report"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S11 — the grouped-by-kind cross-reference report (`to_plain_text_by_kind`).
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s11_groups_refs_by_kind_in_fixed_order() {
+        // Sections + a figure + an equation, referenced by `\ref`/`\eqref`. The grouped rendering
+        // emits the FIXED kind order (Sections, Figures, Equations here — Tables/Inline absent, so
+        // omitted), each subheading followed by two-space-indented ref lines in pre-order, with the
+        // real S4 numbers (sec:intro→1, sec:methods→2, fig:plot→1, eq:e→(1)).
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+\section{Methods}\label{sec:methods}
+
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:plot}\end{figure}
+
+\begin{equation} a = 1 \label{eq:e} \end{equation}
+
+See \ref{sec:intro}, \ref{sec:methods}, \ref{fig:plot}, \eqref{eq:e}.\end{document}";
+        let rep = report(src);
+        assert_eq!(
+            rep.to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\n  \\ref{sec:methods} -> Section 2\n\
+             Figures:\n  \\ref{fig:plot} -> Figure 1\n\
+             Equations:\n  \\eqref{eq:e} -> Equation (1)",
+            "the pinned grouped-by-kind rendering (fixed kind order, two-space indent)"
+        );
+    }
+
+    #[test]
+    fn s11_eqref_and_pageref_render_rules_hold_in_groups() {
+        // The grouped lines reuse the SAME shared per-command helper as the flat report:
+        //   - an `\eqref` to an equation shows `\eqref{eq:e} -> Equation (1)` under `Equations:`;
+        //   - a `\pageref` shows `\pageref{...} -> page ?` under its TARGET kind's group — here the
+        //     `\pageref{sec:intro}` targets a Section, so it sits in the `Sections:` group.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+
+\begin{equation} a = 1 \label{eq:e} \end{equation}
+
+See \ref{sec:intro}, \pageref{sec:intro}, \eqref{eq:e}.\end{document}";
+        let rep = report(src);
+        assert_eq!(
+            rep.to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\n  \\pageref{sec:intro} -> page ?\n\
+             Equations:\n  \\eqref{eq:e} -> Equation (1)",
+            "grouped lines obey the S9 eqref-parenthesises and S10 pageref-placeholder rules"
+        );
+    }
+
+    #[test]
+    fn s11_empty_returns_marker() {
+        // A doc with no resolved refs → the fixed S11 empty marker (distinct from the flat report's
+        // "(no cross-references)").
+        let rep = report(r"\begin{document}\end{document}");
+        assert_eq!(
+            rep.to_plain_text_by_kind(),
+            "(no resolved references)",
+            "no resolved refs renders the stable S11 marker"
+        );
+    }
+
+    #[test]
+    fn s11_dangling_and_cites_do_not_appear_in_grouped_report() {
+        // A doc with a dangling `\ref{nope}` and a `\cite` but NO resolved refs → still the empty
+        // marker: the grouped method is focused on resolved refs only (no citations, no dangling
+        // footers).
+        let src = r"\begin{document}See \ref{nope} and \cite{ghost}.\end{document}";
+        let rep = report(src);
+        assert_eq!(
+            rep.to_plain_text_by_kind(),
+            "(no resolved references)",
+            "citations and dangling keys are not part of the grouped resolved-ref report"
+        );
+    }
+
+    #[test]
+    fn s11_to_plain_text_unchanged() {
+        // GUARD (additivity/refactor): a representative doc's flat `to_plain_text()` still returns its
+        // exact prior S6 string, byte-for-byte, after the shared-helper refactor and the new S11
+        // method. If this line ever changes, the refactor broke additivity.
+        let src = r"\begin{document}\section{Intro}\label{s:i}
+
+See Section~\ref{s:i} and \cite{b}.
+
+\begin{thebibliography}{9}
+\bibitem{a} A. First. 2001.
+\bibitem{b} B. Second. 2002.
+\end{thebibliography}\end{document}";
+        let rep = report(src);
+        assert_eq!(
+            rep.to_plain_text(),
+            "\\ref{s:i} -> Section 1\n\\cite{b} -> [2]",
+            "flat to_plain_text() output is byte-for-byte unchanged by S11"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -927,3 +927,91 @@ unchanged and `\pageref` now diverges; a `\pageref` to a labelled equation still
 `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
 `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
 `cargo fmt`, no grammar regen, no new dependencies.
+
+## 17. S11 — grouped-by-kind cross-reference report
+
+### 17.1 The gap S11 closes
+
+Through S10 the only rendering of the cross-reference report was `CrossReferenceReport::to_plain_text`
+(§12.4, S6): resolved references, one line each, in **flat source (pre-order)** order — the order the
+`\ref`s appear in the body. That is the right default for an audit trail, but it answers "in what order
+are things referenced?" rather than "**which sections / figures / equations** does this document
+cross-reference?". A reader who wants the latter must eyeball the flat list and mentally bucket it by
+kind. S11 closes that gap with a **new, separate** rendering that does the bucketing.
+
+### 17.2 What S11 does — a new sibling method, `to_plain_text_by_kind`
+
+S11 adds a **new public method** `CrossReferenceReport::to_plain_text_by_kind(&self) -> String`. It
+renders the **same** resolved references `to_plain_text` does, but **grouped under fixed-order kind
+subheadings** instead of flat source order. It does **not** touch `to_plain_text`: S11 is purely
+additive, a second lens on the same `refs` data.
+
+The exact format, pinned:
+
+1. **Fixed kind order.** Groups are emitted in the fixed order **Sections, Figures, Tables, Equations,
+   Inline** (`S11_KIND_ORDER`) — *regardless* of the order the references appear in the source.
+2. **Non-empty groups only.** For each kind with **≥1** resolved ref, a subheading line — the
+   **pluralised capitalised** kind name plus a colon (`Sections:`, `Figures:`, `Tables:`,
+   `Equations:`, `Inline:`, from the new `kind_group_heading` helper) — followed by **one line per
+   ref**. A kind with **zero** resolved refs is **omitted entirely** (no bare subheading).
+3. **Two-space-indented ref lines, shared rendering.** Each ref line is indented by **two spaces** then
+   rendered by the **shared** `render_resolved_ref(&RefEntry) -> String` helper — the *identical*
+   per-command rule `to_plain_text` uses (§16.2 S8/S9/S10): an `\eqref` to an equation →
+   `\eqref{eq:e} -> Equation (1)`; a `\pageref` (any kind) → `\pageref{key} -> page ?`; else
+   `\ref{key} -> Kind N`. Within a kind group the refs keep the report's existing **pre-order** (a
+   filter of `refs` for that kind, preserving order). A `\pageref` groups under its **target kind**
+   (e.g. a `\pageref` to a section appears in the `Sections:` group).
+4. **Resolved refs only.** Citations (`cites`) and the dangling footers (`dangling_refs`,
+   `dangling_cites`) are **not** included — this method stays focused on the kind-grouped resolved
+   refs; the flat `to_plain_text` remains the place for the full report.
+5. **Distinct empty marker.** If there are **zero** resolved refs at all, the method returns the fixed
+   string `"(no resolved references)"` — the S11 analogue of `to_plain_text`'s `"(no cross-references)"`
+   — so the output is never the empty string.
+
+Lines are joined by a single `\n` with **no trailing newline** and no trailing whitespace on any line.
+Example:
+
+```text
+Sections:
+  \ref{sec:intro} -> Section 1
+  \ref{sec:methods} -> Section 2
+Figures:
+  \ref{fig:plot} -> Figure 1
+Equations:
+  \eqref{eq:e} -> Equation (1)
+```
+
+### 17.3 The shared `render_resolved_ref` helper (no-drift guarantee)
+
+To guarantee the flat (S6) and grouped (S11) reports can never diverge on how a single ref line looks,
+the three precedence-ordered per-command renderings are **factored** out of `to_plain_text`'s loop into
+a private `render_resolved_ref(&RefEntry) -> String`. **Both** `to_plain_text` and
+`to_plain_text_by_kind` call it, so a `\ref`/`\eqref`/`\pageref` line is byte-for-byte the same wherever
+it appears. `to_plain_text` was refactored to call the helper **only** because its output stays
+byte-for-byte identical — the existing S6–S10 tests (`report_to_plain_text_renders_the_exact_pinned_string`,
+the `s9_`/`s10_` tests) pass unchanged, proving additivity.
+
+### 17.4 Additive, and `to_latex()` unchanged
+
+S11 is a pure report-assembly method over data the report already holds (`refs` with their `kind`
+`LabelKind`). No AST/grammar/counter change, no new struct or field, no new dependency, no `unsafe`, no
+I/O. `to_latex()` remains a fixed point (S11 does not touch the AST). Every S1–S10 output byte is
+unchanged — `to_plain_text` included.
+
+### 17.5 Public API (added in S11)
+
+One new method: `CrossReferenceReport::to_plain_text_by_kind(&self) -> String`. No existing type or
+signature changes; `RefEntry`, `CrossReferenceReport`, `cross_reference_report`, and `to_plain_text`
+keep their shapes and outputs.
+
+### 17.6 Verification (S11)
+
+`cargo test -p latex` green (5 new S11 tests: sections + a figure + an equation grouped in the fixed
+Sections/Figures/Equations order with two-space-indented lines and the real S4 numbers; the grouped
+lines obey the S9 `\eqref`-parenthesises and S10 `\pageref` → `page ?` rules, with a `\pageref` grouped
+under its target kind's group; a doc with no resolved refs → the `(no resolved references)` marker; a
+doc with only a dangling `\ref` and a `\cite` → still the marker, proving citations/dangling are
+excluded; and a guard that `to_plain_text()` still returns its exact prior pinned string). All prior
+S1–S10 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
+`cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
+`cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S11 — grouped-by-kind cross-reference report (new `to_plain_text_by_kind()`)

The equation sub-arc (S7–S9) and the per-command rendering (S9 `\eqref`, S10 `\pageref`) are complete. S11 adds a **richer report view** without disturbing any existing output.

### What S11 adds
A **new, separate** public method `CrossReferenceReport::to_plain_text_by_kind()` that renders the *same* resolved references **grouped by kind** under fixed-order subheadings:

```
Sections:
  \ref{sec:intro} -> Section 1
  \ref{sec:methods} -> Section 2
Figures:
  \ref{fig:plot} -> Figure 1
Equations:
  \eqref{eq:e} -> Equation (1)
```

- Kind order is fixed — **Sections, Figures, Tables, Equations, Inline** — regardless of source order; within each group, refs keep the report's pre-order. Kinds with zero resolved refs are omitted; an empty report returns a stable `(no resolved references)` marker.
- Each ref line reuses the **exact** S8/S9/S10 per-command rendering (`\eqref`→Equation parenthesised, `\pageref`→`page ?`, else bare `\ref{key} -> Kind N`), factored into a **shared private helper** that both `to_plain_text()` and `to_plain_text_by_kind()` call — so the two renderings can never drift.

### Additive by construction
`to_plain_text()` (S1–S10) is **byte-for-byte unchanged** — S11 is a *new method*, not a modification. The refactor to the shared helper is verified output-preserving by the unchanged s7/s8/s9/s10 tests plus a dedicated `s11_to_plain_text_unchanged` guard. Pure report-assembly over `self.refs` (which already carry `kind`) — no AST/grammar/counter change, no new deps, no `unsafe`, no I/O. `to_latex()` fixed point unaffected. latex `0.46.0 → 0.47.0`.

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → all pass (s7/s8/s9/s10 unchanged; new `s11_` tests assert exact grouped strings, including the `\eqref`/`\pageref` rules holding inside groups and the empty marker).
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green. `cargo build -p latex --no-default-features` → builds.
- Single-parent; scoped diff = references.rs + Cargo.toml + CHANGELOG.md + README.md + the LTXDOC03 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
