### PR TITLE
feat(sir-go): display convention — Ruby booleans true/false (v0.19.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.19.0 — source-language display convention: Ruby booleans (`true`/`false`)
+
+Mirrors the Rust backend's first increment of the SIR display-convention spec
+(`code/specs/sir-display-convention.md`) to Go. A **Ruby**-sourced module now
+renders booleans as `true`/`false` instead of the Twig/Lisp `#t`/`#f`, so a
+translated `puts true` prints `true`.
+
+Mechanism: the runtime carries a compile-time `const _sir_display_ruby` (a
+`__SIR_DISPLAY_RUBY__` placeholder); the emitter substitutes `true`/`false`
+from `Module.metadata.source_language` (`== "ruby"` → `true`, else `false`).
+`_sir_format` branches the boolean arm on it. The default is the Lisp form, so
+all existing non-Ruby (Twig) output is **byte-for-byte unchanged**. The Go
+compiler folds the `const` branch — zero per-call cost.
+
+Scope: booleans only (the flagship divergence); `nil`, symbols, string
+`inspect` quoting, and the Ruby hash `=>` element form remain follow-ups per
+the spec's rollout. Verified end-to-end under `go run`: Ruby source →
+`true\nfalse\n`; Twig source → `#t\n#f\n`.
+
 ## 0.18.0 — Numeric + String method-catalog parity
 
 Expands the emitted Go runtime's `_sir_numeric_method` and

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -70,7 +70,17 @@ pub fn emit_module(m: &Module) -> String {
     // case future minimal runtimes drop them).  Actually no:
     // blank-imports would have side effects; just rely on the
     // runtime.
-    out.push_str(RUNTIME);
+    // Substitute the display-convention placeholder (SIR display-convention
+    // spec): a Ruby-sourced module renders booleans as `true`/`false`; every
+    // other source language keeps the default Lisp `#t`/`#f`, so existing Twig
+    // output is unchanged.
+    //
+    // SECURITY: the replacement value MUST remain a hardcoded literal selected
+    // by a boolean — never text derived from `source_language` or any other
+    // source-controlled field — so this substitution can never inject into the
+    // emitted Go.
+    let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
+    out.push_str(&RUNTIME.replace("__SIR_DISPLAY_RUBY__", if display_ruby { "true" } else { "false" }));
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
         out.push('\n');

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -7,6 +7,15 @@
 //! "unused import" rule is satisfied for every generated file.
 
 pub const RUNTIME: &str = r##"// ── inlined SIR runtime ────────────────────────────────────────
+
+// Source-language display convention (SIR display-convention spec).  The
+// emitter substitutes `__SIR_DISPLAY_RUBY__` with `true` when the module's
+// `source_language` is Ruby, else `false` (the default Twig/Lisp form).  The
+// display path (`_sir_format`) reads this to render a boolean as Ruby
+// `true`/`false` rather than the Lisp `#t`/`#f`.  A compile-time `const` → the
+// Go compiler folds the branch away; existing Twig output is unchanged.
+const _sir_display_ruby = __SIR_DISPLAY_RUBY__
+
 type Value interface{}
 
 type Symbol struct {
@@ -772,7 +781,13 @@ func _sir_format_d(v Value, visited map[Value]bool) string {
 	}
 	if b, ok := v.(bool); ok {
 		if b {
+			if _sir_display_ruby {
+				return "true"
+			}
 			return "#t"
+		}
+		if _sir_display_ruby {
+			return "false"
 		}
 		return "#f"
 	}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_display_convention.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_display_convention.rs
@@ -1,0 +1,119 @@
+//! End-to-end proof for the source-language display convention (SIR
+//! display-convention spec) in the Go backend.
+//!
+//! A translated **Ruby** program's `puts true` must print `true` — not the
+//! Twig/Lisp `#t`.  The emitter selects the convention from the module's
+//! `source_language` metadata and substitutes it into the runtime's
+//! `_sir_display_ruby` constant; `_sir_format` then renders booleans
+//! accordingly.
+//!
+//! Builds the program `puts true; puts false` twice — once tagged
+//! `source_language = "ruby"`, once `"twig"` — runs it with `go run`, and
+//! asserts:
+//!   * Ruby → `true\nfalse\n`   (Ruby-faithful)
+//!   * Twig → `#t\n#f\n`        (Lisp default, unchanged)
+//!
+//! Gates on `go` being available; logs a skip when the toolchain is absent.
+
+use std::process::Command;
+
+use semantic_ir::{
+    Block, Effect, EffectSet, Expr, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use semantic_ir_to_go::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn blit(v: bool) -> Expr {
+    Expr::BoolLit { value: v, span: s() }
+}
+
+fn puts_stmt(args: Vec<Expr>) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args,
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn bool_module(source_language: &str) -> Module {
+    let stmts = vec![puts_stmt(vec![blit(true)]), puts_stmt(vec![blit(false)])];
+    Module {
+        name: "display_bool".into(),
+        manifest: FeatureManifest::from_features(&[]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            metadata: Metadata::new(),
+            span: s(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language(source_language)
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+fn go_available() -> bool {
+    Command::new("go")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("module should compile to Go source");
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_go_disp_{tag}_{nonce}.go"));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let run_out = Command::new("go")
+        .arg("run")
+        .arg(&src_path)
+        .output()
+        .expect("invoke go run");
+    if !run_out.status.success() {
+        let stderr = String::from_utf8_lossy(&run_out.stderr);
+        let _ = std::fs::remove_file(&src_path);
+        panic!(
+            "emitted Go failed to compile/run:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+    let _ = std::fs::remove_file(&src_path);
+    Some(String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n"))
+}
+
+#[test]
+fn ruby_source_prints_true_false() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let Some(out) = run(&bool_module("ruby"), "ruby") else { return };
+    assert_eq!(out, "true\nfalse\n", "Ruby source must render booleans as true/false");
+}
+
+#[test]
+fn twig_source_keeps_lisp_booleans() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let Some(out) = run(&bool_module("twig"), "twig") else { return };
+    assert_eq!(out, "#t\n#f\n", "non-Ruby source keeps the default Lisp #t/#f");
+}


### PR DESCRIPTION
**Mirrors the Rust-backend display-convention increment (#7724) to Go**, per the merged [sir-display-convention spec](code/specs/sir-display-convention.md).

A translated **Ruby** `puts true` now prints `true` (not the Twig/Lisp `#t`). Go backend, booleans only.

## Mechanism (identical to Rust increment)
- Runtime carries a compile-time `const _sir_display_ruby` via a `__SIR_DISPLAY_RUBY__` placeholder; `_sir_format`'s boolean arm branches on it.
- Emitter substitutes `true`/`false` from `Module.metadata.source_language` (`== "ruby"` → `true`, else `false`).
- **Default is the Lisp form** → existing non-Ruby (Twig) output byte-for-byte unchanged (full suite green). Go compiler folds the `const` branch → zero per-call cost.

## Safety
Security review passed. Replacement is a hardcoded literal chosen by an exact `== "ruby"` boolean — no source-controlled text reaches emitted Go (comment-guarded invariant). `str::replace` on the fixed `RUNTIME` constant, single unique token.

## Verification
Exec-proof under `go run`: `source_language=ruby` → `true\nfalse\n`; `source_language=twig` → `#t\n#f\n`.

Follow-ups per spec rollout: JS/Python/TS bool mirrors, then nil/symbol/inspect/hash-`=>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)