### PR TITLE
feat(cloc12): CLOC12.168 PR2 — bridge import.meta → ImportMeta (closes gap-169)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.32.0] - 2026-07-07
+
+### Added — CLOC12.168 PR2: bridge `import.meta` → `Expression::ImportMeta` (closes gap-169)
+
+The bridge now converts the grammar's `import_meta` leaf into
+`Expression::ImportMeta` (the module meta-property, sibling of `new.target`).
+Previously the `import_meta` rule — whose children are the three bare tokens
+`[Token("import"), Token("."), Token("meta")]` with no Node child — fell through
+the expression dispatch to the `other =>` internal-error arm, dragging any file
+containing `import.meta` to WHITESPACE_ONLY. A new `convert_import_meta` lowers
+it to the atomic `ImportMeta` leaf (the `.meta` is part of the fixed spelling,
+not a member access; the `import` token's `cv` becomes the node's provenance),
+mirroring `new.target`. The dead `import_meta_expression` decline arm (a rule
+name the grammar never emits for this construct) is removed. 3 new bridge unit
+tests (`import.meta;` → `ImportMeta`; `import.meta.url;` → member access whose
+object is `ImportMeta`; `f(import.meta);` bridges in argument position). The
+closurec end-to-end diff fixture exercises the full SIMPLE pipeline. (gap-169)
+
+
 ## [0.31.0] - 2026-07-07
 
 ### Added — CLOC12.167 PR2: bridge `new.target` → `Expression::NewTarget` (closes gap-168)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -58,7 +58,7 @@ use coding_adventures_javascript_ast::{
         BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
         ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
         LogicalOperator,
-        MemberExpression, NewExpression, NewTarget, NullLiteral, NumericLiteral, ObjectExpression, Property,
+        ImportMeta, MemberExpression, NewExpression, NewTarget, NullLiteral, NumericLiteral, ObjectExpression, Property,
         PropertyKey, PropertyKind, SequenceExpression, SpreadElement, StringLiteral, TaggedTemplateExpression,
         TemplateElement, TemplateLiteral,
         UnaryExpression, UnaryOperator,
@@ -1347,6 +1347,15 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
         "member_expression" => convert_member_expression(node),
         "primary_expression" => convert_primary_expression(node),
 
+        // `import.meta` — the module meta-property (CLOC12.168 PR2, gap-169).
+        // The grammar emits a dedicated `import_meta` leaf whose children are the
+        // three bare tokens `[Token("import"), Token("."), Token("meta")]` (no
+        // Node child). It lowers to the atomic `Expression::ImportMeta` leaf, the
+        // sibling of `new.target`: the `.meta` is part of the fixed spelling, not
+        // a member access, so nothing is walked. Previously fell through to the
+        // `other =>` internal-error arm (dropping the file to WHITESPACE_ONLY).
+        "import_meta" => convert_import_meta(node),
+
         // Literals
         "array_literal" => convert_array_literal(node),
         "object_literal" => convert_object_literal(node),
@@ -1406,8 +1415,7 @@ fn convert_expression(node: &GrammarASTNode) -> Result<Expression, BridgeError> 
         | "async_generator_expression"
         | "class_expression"
         | "tagged_template_expression"
-        | "new_target_expression"
-        | "import_meta_expression" => Err(unsupported(node)),
+        | "new_target_expression" => Err(unsupported(node)),
 
         other => Err(BridgeError::InternalError {
             msg: format!("unknown expression rule '{other}'"),
@@ -2127,6 +2135,26 @@ fn convert_argument(node: &GrammarASTNode) -> Result<Expression, BridgeError> {
         node
     };
     convert_expression(target)
+}
+
+// -------------------------------------------------------------------------
+// import.meta (CLOC12.168 PR2, gap-169)
+// -------------------------------------------------------------------------
+
+/// `import.meta` — the module meta-property. The grammar emits a dedicated
+/// `import_meta` leaf whose children are the three bare tokens
+/// `[Token("import"), Token("."), Token("meta")]` (no Node child), so — exactly
+/// like `new.target` — there is no object / property to fold; the whole thing
+/// is one atomic primary. It lowers to the `Expression::ImportMeta` leaf: the
+/// `.meta` is part of the fixed spelling, NOT a member access. We take the
+/// `import` token's `cv` as the node's provenance (the meta-property is a single
+/// conceptual read).
+fn convert_import_meta(node: &GrammarASTNode) -> Result<Expression, BridgeError> {
+    let cv = match node.children.first() {
+        Some(ASTNodeOrToken::Token(t)) => t.cv.clone(),
+        _ => None,
+    };
+    Ok(Expression::ImportMeta(ImportMeta { cv }))
 }
 
 // -------------------------------------------------------------------------
@@ -3161,6 +3189,49 @@ mod tests {
             ),
             other => panic!("expected MemberExpression; got {:?}", other),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // import.meta (CLOC12.168 PR2, gap-169)
+    // -----------------------------------------------------------------------
+
+    /// `import.meta` — the module meta-property, the sibling of `new.target`.
+    /// The grammar emits a dedicated `import_meta` leaf (`[Token("import"),
+    /// Token("."), Token("meta")]`, no Node child); the bridge intercepts it as
+    /// an atomic `ImportMeta` leaf (the `.meta` is spelling, not member access).
+    /// A bare `import.meta;` parses standalone here. Previously the rule fell
+    /// through to the internal-error arm, dropping the file to WHITESPACE_ONLY.
+    #[test]
+    fn import_meta_meta_property() {
+        let p = bridge_ok("import.meta;");
+        assert!(
+            matches!(only_expr(&p), Expression::ImportMeta(_)),
+            "expected ImportMeta; got {:?}",
+            only_expr(&p)
+        );
+    }
+
+    /// `import.meta.url` — the canonical use, as the object of a member access.
+    /// The meta-property becomes the object of the outer member, pinning that
+    /// the leaf slots into the suffix-fold like any other base primary.
+    #[test]
+    fn import_meta_as_member_object() {
+        let p = bridge_ok("import.meta.url;");
+        match only_expr(&p) {
+            Expression::MemberExpression(m) => assert!(
+                matches!(&*m.object, Expression::ImportMeta(_)),
+                "expected ImportMeta object; got {:?}",
+                m.object
+            ),
+            other => panic!("expected MemberExpression; got {:?}", other),
+        }
+    }
+
+    /// `f(import.meta)` — the meta-property as a call argument bridges cleanly
+    /// (a plain primary operand), proving it is handled in nested position too.
+    #[test]
+    fn import_meta_as_call_argument() {
+        let _ = bridge_ok("f(import.meta);");
     }
 
     // -----------------------------------------------------------------------

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.7] - 2026-07-07
+
+### Added — CLOC12.168 PR2: `import.meta` flows through the SIMPLE pipeline (gap-169)
+
+With the `javascript-parser` bridge now converting `import.meta` →
+`Expression::ImportMeta` (v0.32.0), a file containing `import.meta` no longer
+falls back to WHITESPACE_ONLY — it flows through the full SIMPLE pipeline
+(parser → typed-AST bridge → passes → emitter). New end-to-end diff fixture
+`tests/diff/simple-importmeta/` (`f(import.meta, 1 + 2);` → `f(import.meta,3);`):
+`import.meta` round-trips as the first argument while the second argument
+`1 + 2` folds to `3`, proving the pipeline ran rather than re-emitting the
+source verbatim. Version bump only; no CLI-surface change. (gap-169)
+
+
 ## [0.234.6] - 2026-07-07
 
 ### Added — CLOC12.167 PR2: `new.target` end-to-end fixture

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.6"
+version = "0.234.7"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.6",
+  "version": "0.234.7",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.6
+Version: 0.234.7
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-importmeta/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-importmeta/expected.stdout
@@ -1,0 +1,1 @@
+f(import.meta,3);

--- a/code/programs/rust/closurec/tests/diff/simple-importmeta/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-importmeta/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-importmeta/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-importmeta/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-importmeta/input/a.js
@@ -1,0 +1,1 @@
+f(import.meta, 1 + 2);

--- a/code/programs/rust/closurec/tests/diff_simple_importmeta.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_importmeta.rs
@@ -1,0 +1,84 @@
+//! Integration test for the `tests/diff/simple-importmeta/` fixture.
+//!
+//! Exercises CLOC12.168 PR2 — the **`import.meta`** module meta-property
+//! (`ImportMeta`) now flows through the full SIMPLE pipeline (parser →
+//! typed-AST bridge → passes → emitter) instead of falling through the bridge's
+//! internal-error arm and dragging the whole file to WHITESPACE_ONLY
+//! (gap-169, now closed).
+//!
+//! The fixture is `f(import.meta, 1 + 2);` — a retained call (an unknown
+//! `f(...)` has side effects, so DCE keeps it) whose first argument is the
+//! `import.meta` meta-property and whose second argument is the foldable
+//! `1 + 2`. Two facts prove the pipeline ran end-to-end rather than falling
+//! back:
+//!   1. `import.meta` round-trips (the bridge produced a real `ImportMeta` node
+//!      rather than erroring / declining), and
+//!   2. the argument `1 + 2` folds to `3`.
+//! A WHITESPACE_ONLY fallback — which a bridge failure would force for the
+//! *whole file* — would instead re-emit the source verbatim, leaving `1 + 2`
+//! unfolded (`f(import.meta, 1 + 2)`).
+//!
+//! (`import.meta` is syntactically legal only inside a module; the shared
+//! grammar is permissive and parses the bare statement, and the bridge simply
+//! lowers whatever the parser produced. The point here is the *pipeline
+//! plumbing*, not JS semantic validation — see CLOC12.167's `simple-newtarget`
+//! fixture for the sibling `new.target` case.)
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-importmeta/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_importmeta_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-importmeta/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture. Strip spaces so the checks are
+    // insensitive to inter-token whitespace.
+    let a = actual.replace(' ', "");
+    // (1) the `import.meta` meta-property survived — proving the bridge
+    //     converted it to a real `ImportMeta` node rather than dropping the
+    //     file to WHITESPACE_ONLY.
+    assert!(
+        a.contains("import.meta"),
+        "`import.meta` did not round-trip: {actual}"
+    );
+    // (2) the argument folded — proving the SIMPLE pipeline ran over the call
+    //     (`1 + 2` → `3`), not a verbatim WHITESPACE_ONLY pass.
+    assert!(
+        a.contains("import.meta,3"),
+        "argument `1 + 2` did not fold to `3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded `1+2` present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2170,19 +2170,35 @@ references no ordinary identifier and has no sub-expression). Atomic node PR1:
 node + emit + all nine downstream pass arms land together so the workspace
 never breaks.
 
-### gap-169 — bridge declines `import.meta` (`ImportMeta`) — **OPEN (bridge slice pending, CLOC12.168 PR2)**
+### gap-169 — bridge declines `import.meta` (`ImportMeta`) — **RESOLVED (javascript-parser 0.32.0, CLOC12.168 PR2)**
 
-The `javascript-parser` bridge does not yet convert `import.meta` to
-`Expression::ImportMeta`, so any file containing it drops to WHITESPACE_ONLY.
-The atomic node PR (CLOC12.168 PR1) lands the node + emit + pass traversals so
-the typed AST and every downstream pass can already represent and print an
-`import.meta`; the **PR2 bridge slice** wires the grammar production through
-(the shape parallels `new.target` — a `member_expression` with an `import`
-token followed by `.` `meta`, distinguished from an ordinary member access by
-the reserved `import` token and the absence of a Node object). Whether any
-grammar work is required (as with `await`, gap-165) or the token is already
-produced and merely declined (as with `new.target`, gap-168) is determined
-during PR2. The **PR3** CodePrinter conformance port follows.
+The `javascript-parser` bridge previously did not convert `import.meta` to
+`Expression::ImportMeta`, so any file containing it dropped to WHITESPACE_ONLY.
+The atomic node PR (CLOC12.168 PR1) landed the node + emit + pass traversals so
+the typed AST and every downstream pass could already represent and print an
+`import.meta`.
+
+**Probe divergence from the recipe.** The grammar was expected (by analogy with
+`new.target`, gap-168) to fold `import.meta` into a `member_expression` with an
+`import` token base. A probe showed otherwise: the grammar emits a **dedicated
+`import_meta` leaf** whose children are the three bare tokens `[Token("import"),
+Token("."), Token("meta")]` with no Node child — and this rule was *not* listed
+in the bridge's expression dispatch, so it fell through to the `other =>`
+internal-error arm (worse than a graceful decline). Note the pre-existing
+`import_meta_expression` decline arm was a **different, never-emitted rule
+name** — dead code; PR2 removed it. **Like `new.target` and unlike `await`
+(gap-165), no grammar work was required** — the token was already produced.
+
+**Fix (CLOC12.168 PR2):** a new `convert_import_meta` and an `"import_meta"`
+dispatch arm lower the leaf to `Expression::ImportMeta` (the `import` token's
+`cv` becomes provenance; the `.meta` is spelling, not a member access). 3 new
+bridge unit tests (`import.meta;` → `ImportMeta`; `import.meta.url;` → member
+access whose object is `ImportMeta`; `f(import.meta);` in argument position)
+plus the closurec end-to-end diff fixture `tests/diff/simple-importmeta/`
+(`f(import.meta, 1 + 2);` → `f(import.meta,3);` at SIMPLE — `import.meta`
+round-trips and the argument folds, proving the pipeline ran rather than
+falling back to WHITESPACE_ONLY). The **PR3** CodePrinter conformance port is a
+separate slice.
 
 
 ## CLOC12.167 — `NewTarget` (`new.target`): atomic node + emit + passes (PR1)


### PR DESCRIPTION
## CLOC12.168 PR2 — bridge `import.meta` → `Expression::ImportMeta`

The `javascript-parser` bridge now converts the grammar's `import_meta` leaf
into `Expression::ImportMeta` (the module meta-property, sibling of
`new.target`, added in PR1 #7719). Previously the `import_meta` rule — children
`[Token("import"), Token("."), Token("meta")]`, no Node child — was **not** in
the expression dispatch and fell through to the `other =>` internal-error arm,
dragging any file containing `import.meta` to WHITESPACE_ONLY.

### Probe divergence from the recipe

By analogy with `new.target` (gap-168) the grammar was expected to fold
`import.meta` into a `member_expression` with an `import` token base. A probe
showed the grammar instead emits a **dedicated `import_meta` leaf**, and that
the pre-existing `import_meta_expression` decline arm was a *different,
never-emitted* rule name — dead code, removed here. **Like `new.target` and
unlike `await` (gap-165), no grammar work was required.**

### Fix

`convert_import_meta` + an `"import_meta"` dispatch arm lower the leaf to the
atomic `ImportMeta` (the `import` token's `cv` becomes provenance; the `.meta`
is fixed spelling, not a member access). `javascript-parser` MINOR
`0.31.0` → `0.32.0`.

- **3 bridge unit tests**: `import.meta;` → `ImportMeta`; `import.meta.url;` →
  member access whose object is `ImportMeta`; `f(import.meta);` in argument
  position.
- **closurec e2e diff fixture** `tests/diff/simple-importmeta/`
  (`f(import.meta, 1 + 2);` → `f(import.meta,3);` at SIMPLE): `import.meta`
  round-trips as the first argument while `1 + 2` folds to `3` — proving the
  full pipeline ran, not a verbatim WHITESPACE_ONLY fallback. closurec PATCH
  `0.234.6` → `0.234.7` (+ `cli.spec.json` + help-markdown `Version` sync).

Spec: gap-169 marked **RESOLVED** (with the probe-divergence note). PR3
CodePrinter conformance port is #7723.

## Verification

- `javascript-parser`: 150 tests pass (incl. 3 new import.meta bridge tests).
- `closurec`: `simple-importmeta` + `help-markdown` diff tests pass.
- security review: **PASSED** (mirrors the reviewed `new.target` bridge slice;
  bounded leaf conversion, safe `None`/malformed-child handling, no new panic /
  recursion / unsafe surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)