### PR TITLE
feat(sir-js): display convention — Ruby booleans true/false (v0.16.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.16.0 — source-language display convention: Ruby booleans (`true`/`false`)
+
+Mirrors the Rust/Go backends' display-convention increment (SIR
+display-convention spec) to JavaScript. A **Ruby**-sourced module now renders
+booleans as `true`/`false` instead of the Twig/Lisp `#t`/`#f`, so a translated
+`puts true` prints `true`.
+
+Mechanism: the runtime carries a `const SIR_DISPLAY_RUBY` (a
+`__SIR_DISPLAY_RUBY__` placeholder); the emitter substitutes `true`/`false`
+from `Module.metadata.source_language` (`== "ruby"` → `true`, else `false`).
+`formatSeen` branches the boolean arm on it. The default is the Lisp form, so
+all existing non-Ruby (Twig) output is **byte-for-byte unchanged**.
+
+Scope: booleans only; `nil`, symbols, string `inspect` quoting, and the Ruby
+hash `=>` element form remain follow-ups per the spec's rollout. Verified
+end-to-end under Node: Ruby source → `true\nfalse`; Twig source → `#t\n#f`.
+
 ## 0.15.0 — Ruby Hash method-catalog parity
 
 Adds a hand-implemented Ruby Hash catalog (`hashMethod`) to the emitted JS

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -100,7 +100,17 @@ pub fn emit_module(m: &Module) -> String {
     // Strict mode goes first (after the banner comment) so the whole
     // file — including the inlined runtime — runs under strict semantics.
     out.push_str("\"use strict\";\n\n");
-    out.push_str(RUNTIME);
+    // Substitute the display-convention placeholder (SIR display-convention
+    // spec): a Ruby-sourced module renders booleans as `true`/`false`; every
+    // other source language keeps the default Lisp `#t`/`#f`, so existing Twig
+    // output is unchanged.
+    //
+    // SECURITY: the replacement value MUST remain a hardcoded literal selected
+    // by a boolean — never text derived from `source_language` or any other
+    // source-controlled field — so this substitution can never inject into the
+    // emitted JavaScript.
+    let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
+    out.push_str(&RUNTIME.replace("__SIR_DISPLAY_RUBY__", if display_ruby { "true" } else { "false" }));
     emit_ancestry_registration(&mut out, m);
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -45,6 +45,13 @@
 /// declarations start on their own line.
 pub const RUNTIME: &str = r##"const __Sir = (() => {
   "use strict";
+  // Source-language display convention (SIR display-convention spec).  The
+  // emitter substitutes `__SIR_DISPLAY_RUBY__` with `true` when the module's
+  // `source_language` is Ruby, else `false` (the default Twig/Lisp form).  The
+  // display path (`formatSeen`) reads this to render a boolean as Ruby
+  // `true`/`false` rather than the Lisp `#t`/`#f`; existing Twig output is
+  // unchanged.
+  const SIR_DISPLAY_RUBY = __SIR_DISPLAY_RUBY__;
   // ── value model ────────────────────────────────────────────────
   // A symbol is an interned name; `===` on two interned symbols with
   // the same name is therefore identity-equal.
@@ -107,8 +114,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   function format(v) { return formatSeen(v, new Set()); }
   function formatSeen(v, seen) {
     if (v === null || v === undefined) { return "nil"; }
-    if (v === true) { return "#t"; }
-    if (v === false) { return "#f"; }
+    if (v === true) { return SIR_DISPLAY_RUBY ? "true" : "#t"; }
+    if (v === false) { return SIR_DISPLAY_RUBY ? "false" : "#f"; }
     if (typeof v === "string") { return v; }
     if (typeof v === "number") { return String(v); }
     if (v instanceof Sym) { return v.name; }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2319,3 +2319,50 @@ fn hash_catalog_methods() {
         assert_eq!(stdout, "[a, b]\n[1, 2]\n2\n[[a, 1], [b, 2]]\n2\n[a, b, c]\n1\n[b]");
     }
 }
+
+// ── source-language display convention: Ruby booleans (SIR spec) ──
+//
+// A Ruby-sourced module renders booleans as `true`/`false`; every other
+// source language keeps the default Lisp `#t`/`#f`.  Proven end-to-end under
+// Node for both conventions.
+fn bool_display_module(source_language: &str) -> Module {
+    let stmts = vec![
+        print(Expr::BoolLit { value: true, span: sp() }),
+        print(Expr::BoolLit { value: false, span: sp() }),
+    ];
+    Module {
+        name: "dispbool".into(),
+        manifest: FeatureManifest::from_features(&[]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language(source_language)
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+#[test]
+fn ruby_source_prints_true_false() {
+    if let Some(stdout) = run_module(&bool_display_module("ruby"), "dispruby") {
+        assert_eq!(stdout, "true\nfalse", "Ruby source must render booleans as true/false");
+    }
+}
+
+#[test]
+fn twig_source_keeps_lisp_booleans() {
+    if let Some(stdout) = run_module(&bool_display_module("twig"), "disptwig") {
+        assert_eq!(stdout, "#t\n#f", "non-Ruby source keeps the default Lisp #t/#f");
+    }
+}


### PR DESCRIPTION
**Completes the boolean display convention across all three inlined-runtime backends** (Rust #7724 + Go #7726 merged; this is JS), per the merged [sir-display-convention spec](code/specs/sir-display-convention.md).

A translated **Ruby** `puts true` now prints `true` (not the Twig/Lisp `#t`). JS backend, booleans only.

## Mechanism (identical to Rust/Go)
- Runtime carries a `const SIR_DISPLAY_RUBY` (inside the `__Sir` IIFE) via a `__SIR_DISPLAY_RUBY__` placeholder; `formatSeen`'s boolean arm branches on it.
- Emitter substitutes `true`/`false` from `Module.metadata.source_language` (`== "ruby"` → `true`, else `false`).
- **Default is the Lisp form** → existing non-Ruby (Twig) output byte-for-byte unchanged (full suite green). `formatSeen` uses strict `===`, so only genuine boolean primitives take the arm.

## Safety
Security review passed. Replacement is a hardcoded literal chosen by an exact `== "ruby"` boolean — no source-controlled text reaches emitted JS (comment-guarded). Single unique placeholder token in the fixed `RUNTIME` constant.

## Verification
Exec-proof under Node: `source_language=ruby` → `true\nfalse`; `source_language=twig` → `#t\n#f`.

Remaining per spec rollout: Python+TS bool mirrors (runtime-lib `set_display_convention`), then nil/symbol/inspect/hash-`=>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)