### PR TITLE
feat(cloc12): CLOC12.169 PR1 — ImportExpression (dynamic import(x)) atomic node + emit + 9 passes

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.33.0] - 2026-07-07
+
+### Added — CLOC12.169: `emit_import_expression` (dynamic `import(x)`)
+
+Added `emit_import_expression` + the `Expression::ImportExpression` dispatch arm + the `PREC_PRIMARY` classification for the new dynamic `import(specifier)` node (CLOC12.169 PR1). It prints the `import` keyword directly followed by a *literal* parenthesised argument — a call-like primary — with the `source` emitted at `PREC_ASSIGNMENT` (a call-argument level): a looser *sequence* specifier wraps (`import((a,b))`), everything else prints bare (`import("m")`, `import(a+b)`, `import(f())`). As a `PREC_PRIMARY` node the whole import is atomic, so a member/call parent composes without extra parens (`import(x).then(f)`). 5 hand-constructed-AST unit tests. Part of the atomic node PR1 that lands the node + emit + all nine downstream pass arms together. (CLOC12.169)
+
+
 ## [0.32.1] - 2026-07-07
 
 ### Added — CLOC12.168 PR3: CodePrinter `import.meta` conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.32.1"
+version = "0.33.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -79,7 +79,7 @@ use coding_adventures_javascript_ast::{
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
     TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
-    Super, NewTarget, ImportMeta,
+    Super, NewTarget, ImportMeta, ImportExpression,
 };
 use coding_adventures_type_sidecar::Sidecar;
 use std::fmt;
@@ -1140,6 +1140,7 @@ impl<'a> Emitter<'a> {
             Expression::SpreadElement(s) => self.emit_spread(s),
             Expression::YieldExpression(y) => self.emit_yield(y),
             Expression::AwaitExpression(a) => self.emit_await(a),
+            Expression::ImportExpression(e) => self.emit_import_expression(e),
             Expression::ThisExpression(t) => self.emit_this(t),
             Expression::Super(s) => self.emit_super(s),
             Expression::NewTarget(n) => self.emit_new_target(n),
@@ -1631,6 +1632,26 @@ impl<'a> Emitter<'a> {
         self.emit_expression_inner(&a.argument, PREC_UNARY);
     }
 
+    /// Emit an `ImportExpression` — a dynamic `import(specifier)`.
+    ///
+    /// This is the `import` keyword immediately followed by a *literal*
+    /// parenthesised argument — syntactically a call-like primary. Unlike
+    /// `await` (a word-shaped unary), no separator is needed after the keyword:
+    /// the `(` follows `import` directly (`import(x)`, never `import (x)`). The
+    /// `source` sits inside the literal parens, so it is emitted at
+    /// `PREC_ASSIGNMENT` (the same level as a call argument): a looser *sequence*
+    /// specifier wraps (`import((a,b))`), everything else prints bare
+    /// (`import("m")`, `import(a.b)`, `import(f())`). The wrapping of the *whole*
+    /// import in a tighter parent is a non-issue — as a `PREC_PRIMARY` node it
+    /// is already atomic, so `import(x).then(f)` and `(await import(x))` compose
+    /// without extra parens.
+    fn emit_import_expression(&mut self, e: &ImportExpression) {
+        self.maybe_map(&e.cv);
+        self.write_str("import(");
+        self.emit_expression_inner(&e.source, PREC_ASSIGNMENT);
+        self.write_str(")");
+    }
+
     /// `this` — a bare reserved-word keyword. It carries no operand, so the
     /// emit is simply the four characters `this` (after recording the source
     /// map anchor). No trailing separator is needed: as a `PREC_PRIMARY`
@@ -2065,7 +2086,12 @@ fn expr_prec(e: &Expression) -> u8 {
         // `new.target`: an atomic three-token spelling that binds at the
         // tightest level. Same primary treatment — never wrapped, never forces
         // a paren; the internal `.meta` is part of the spelling, not access.
-        | Expression::ImportMeta(_) => PREC_PRIMARY,
+        | Expression::ImportMeta(_)
+        // A dynamic `import(x)` is the `import` keyword plus a *literal*
+        // parenthesised argument — a call-like primary. The parens make it
+        // atomic from the outside, so it binds at the tightest level like a
+        // `CallExpression`: `import(x).then(f)` composes without extra parens.
+        | Expression::ImportExpression(_) => PREC_PRIMARY,
 
         Expression::UnaryExpression(_) => PREC_UNARY,
         // Update (`++x` / `x++`) binds a hair tighter than the pure unary
@@ -5265,5 +5291,54 @@ mod tests {
     fn import_meta_under_binary_parent_is_bare() {
         let e = binary(BinaryOperator::Add, import_meta_expr(), num(1.0));
         assert_eq!(emit_expr(e), "import.meta+1;");
+    }
+
+    // =================================================================
+    // ImportExpression (dynamic `import(x)`) — CLOC12.169
+    // =================================================================
+
+    /// Build a dynamic `import(source)`.
+    fn import_expr(source: Expression) -> Expression {
+        Expression::ImportExpression(ImportExpression { cv: None, source: Box::new(source) })
+    }
+
+    /// `import("m")` — a string-literal specifier prints inside the literal
+    /// parens with no surrounding space.
+    #[test]
+    fn import_expression_string_specifier() {
+        assert_eq!(emit_expr(import_expr(string("m"))), "import(\"m\");");
+    }
+
+    /// `import(x)` — an identifier specifier.
+    #[test]
+    fn import_expression_identifier_specifier() {
+        assert_eq!(emit_expr(import_expr(ident("x"))), "import(x);");
+    }
+
+    /// `import(a+b)` — a binary specifier prints bare inside the parens (it is
+    /// tighter than a sequence, so it needs no inner wrapping).
+    #[test]
+    fn import_expression_binary_specifier_is_bare() {
+        let e = import_expr(binary(BinaryOperator::Add, ident("a"), ident("b")));
+        assert_eq!(emit_expr(e), "import(a+b);");
+    }
+
+    /// `import((a,b))` — a *sequence* specifier is looser than assignment, so it
+    /// wraps in its own parens inside the import argument.
+    #[test]
+    fn import_expression_sequence_specifier_wraps() {
+        let seq = Expression::SequenceExpression(SequenceExpression {
+            cv: None,
+            expressions: vec![ident("a"), ident("b")],
+        });
+        assert_eq!(emit_expr(import_expr(seq)), "import((a,b));");
+    }
+
+    /// `import(x).then(f)` — the whole import is a `PREC_PRIMARY` call-like
+    /// primary, so a member/call parent composes without wrapping it.
+    #[test]
+    fn import_expression_as_member_object_is_bare() {
+        let e = call(member(import_expr(ident("x")), "then", false), vec![ident("f")]);
+        assert_eq!(emit_expr(e), "import(x).then(f);");
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.85.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.11"
+version = "0.85.12"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -91,7 +91,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BinaryExpression,
-    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression,
+    BinaryOperator, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression, ImportExpression,
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
@@ -582,6 +582,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::AwaitExpression(a) => Expression::AwaitExpression(AwaitExpression {
             cv: a.cv.clone(),
             argument: Box::new(fold_expression(&a.argument, st)),
+        }),
+        Expression::ImportExpression(e) => Expression::ImportExpression(ImportExpression {
+            cv: e.cv.clone(),
+            source: Box::new(fold_expression(&e.source, st)),
         }),
         Expression::MemberExpression(m) => fold_member(m, st),
         Expression::ArrayExpression(a) => Expression::ArrayExpression(ArrayExpression {

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.20.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.11"
+version = "0.20.12"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -71,7 +71,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, BigIntLiteral,
-    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression,
+    BinaryExpression, BlockStatement, BooleanLiteral, CallExpression, ConditionalExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression, ImportExpression,
     Declaration, EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit,
     ForOfStatement,
     ForStatement,
@@ -1264,6 +1264,10 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         Expression::AwaitExpression(a) => Expression::AwaitExpression(AwaitExpression {
             cv: a.cv.clone(),
             argument: Box::new(dce_expression(&a.argument, st)),
+        }),
+        Expression::ImportExpression(e) => Expression::ImportExpression(ImportExpression {
+            cv: e.cv.clone(),
+            source: Box::new(dce_expression(&e.source, st)),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm (and returns its own `cv` from the `expression_cv` accessor). No behaviour change to any existing node.
+
+
 ## [0.20.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.11"
+version = "0.20.12"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -56,7 +56,7 @@ use coding_adventures_closure_pass_pipeline::{
 use coding_adventures_correlation_vector::{CVLog, Contribution};
 use coding_adventures_javascript_ast::{
     statement::TaggedStatement, ArrayExpression, AssignmentExpression, AssignmentOperator,
-    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression,
+    AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression, ImportExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
@@ -279,6 +279,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         SpreadElement(e) => e.cv.clone(),
         YieldExpression(y) => y.cv.clone(),
         AwaitExpression(a) => a.cv.clone(),
+        ImportExpression(e) => e.cv.clone(),
         ThisExpression(t) => t.cv.clone(),
         Super(s) => s.cv.clone(),
         NewTarget(n) => n.cv.clone(),
@@ -1450,6 +1451,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::AwaitExpression(a) => Expression::AwaitExpression(AwaitExpression {
             cv: a.cv.clone(),
             argument: Box::new(fold_expression(&a.argument, st)),
+        }),
+        Expression::ImportExpression(e) => Expression::ImportExpression(ImportExpression {
+            cv: e.cv.clone(),
+            source: Box::new(fold_expression(&e.source, st)),
         }),
         Expression::MemberExpression(m) => Expression::MemberExpression(MemberExpression {
             cv: m.cv.clone(),

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.11.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.11"
+version = "0.11.12"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -834,6 +834,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         Expression::SpreadElement(s) => count_uses_expr(&s.argument, name, count),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { count_uses_expr(a, name, count); } }
         Expression::AwaitExpression(a) => count_uses_expr(&a.argument, name, count),
+        Expression::ImportExpression(e) => count_uses_expr(&e.source, name, count),
     }
 }
 
@@ -1137,6 +1138,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         Expression::SpreadElement(s) => changed |= propagate_in_expr(&mut s.argument, cand),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { changed |= propagate_in_expr(a, cand); } }
         Expression::AwaitExpression(a) => changed |= propagate_in_expr(&mut a.argument, cand),
+        Expression::ImportExpression(e) => changed |= propagate_in_expr(&mut e.source, cand),
     }
     changed
 }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.25.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.11"
+version = "0.25.12"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -516,6 +516,7 @@ fn expr_node_count(expr: &Expression) -> usize {
         Expression::SpreadElement(s) => expr_node_count(&s.argument),
         Expression::YieldExpression(y) => y.argument.as_ref().map_or(0, |a| expr_node_count(a)),
         Expression::AwaitExpression(a) => expr_node_count(&a.argument),
+        Expression::ImportExpression(e) => expr_node_count(&e.source),
     }
 }
 
@@ -861,6 +862,7 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         Expression::SpreadElement(s) => collect_binding_idents_expr(&s.argument, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_binding_idents_expr(a, out); } }
         Expression::AwaitExpression(a) => collect_binding_idents_expr(&a.argument, out),
+        Expression::ImportExpression(e) => collect_binding_idents_expr(&e.source, out),
     }
 }
 
@@ -1172,6 +1174,7 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         Expression::SpreadElement(s) => tally_expr(&s.argument, cand, t),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { tally_expr(a, cand, t); } }
         Expression::AwaitExpression(a) => tally_expr(&a.argument, cand, t),
+        Expression::ImportExpression(e) => tally_expr(&e.source, cand, t),
     }
 }
 
@@ -1489,6 +1492,7 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         Expression::SpreadElement(s) => changed |= inline_in_expr(&mut s.argument, cand),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { changed |= inline_in_expr(a, cand); } }
         Expression::AwaitExpression(a) => changed |= inline_in_expr(&mut a.argument, cand),
+        Expression::ImportExpression(e) => changed |= inline_in_expr(&mut e.source, cand),
     }
     changed
 }
@@ -1657,6 +1661,7 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         Expression::SpreadElement(s) => substitute(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { substitute(a, map); } }
         Expression::AwaitExpression(a) => substitute(&mut a.argument, map),
+        Expression::ImportExpression(e) => substitute(&mut e.source, map),
     }
 }
 
@@ -2040,6 +2045,7 @@ fn expr_collect_mutated_params(
         Expression::SpreadElement(s) => expr_collect_mutated_params(&s.argument, params, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { expr_collect_mutated_params(a, params, out); } }
         Expression::AwaitExpression(a) => expr_collect_mutated_params(&a.argument, params, out),
+        Expression::ImportExpression(e) => expr_collect_mutated_params(&e.source, params, out),
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
@@ -3532,6 +3538,7 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::SpreadElement(s) => rename_in_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rename_in_expr(a, map); } }
         Expression::AwaitExpression(a) => rename_in_expr(&mut a.argument, map),
+        Expression::ImportExpression(e) => rename_in_expr(&mut e.source, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.10.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.11"
+version = "0.10.12"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -754,6 +754,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_all_idents_expr(a, out); } }
         Expression::AwaitExpression(a) => collect_all_idents_expr(&a.argument, out),
+        Expression::ImportExpression(e) => collect_all_idents_expr(&e.source, out),
     }
 }
 
@@ -1093,6 +1094,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::SpreadElement(s) => rename_apply_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rename_apply_expr(a, map); } }
         Expression::AwaitExpression(a) => rename_apply_expr(&mut a.argument, map),
+        Expression::ImportExpression(e) => rename_apply_expr(&mut e.source, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.12.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.11"
+version = "0.12.12"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1263,6 +1263,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         Expression::SpreadElement(s) => classify_expr(&s.argument, cls),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { classify_expr(a, cls); } }
         Expression::AwaitExpression(a) => classify_expr(&a.argument, cls),
+        Expression::ImportExpression(e) => classify_expr(&e.source, cls),
     }
 }
 
@@ -1537,6 +1538,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::SpreadElement(s) => rewrite_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rewrite_expr(a, map); } }
         Expression::AwaitExpression(a) => rewrite_expr(&mut a.argument, map),
+        Expression::ImportExpression(e) => rewrite_expr(&mut e.source, map),
     }
 }
 

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.14.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.11"
+version = "0.14.12"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -1035,6 +1035,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         Expression::SpreadElement(s) => collect_all_idents_expr(&s.argument, out),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { collect_all_idents_expr(a, out); } }
         Expression::AwaitExpression(a) => collect_all_idents_expr(&a.argument, out),
+        Expression::ImportExpression(e) => collect_all_idents_expr(&e.source, out),
     }
 }
 
@@ -1355,6 +1356,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         Expression::SpreadElement(s) => rewrite_uses_expr(&mut s.argument, map),
         Expression::YieldExpression(y) => { if let Some(a) = &mut y.argument { rewrite_uses_expr(a, map); } }
         Expression::AwaitExpression(a) => rewrite_uses_expr(&mut a.argument, map),
+        Expression::ImportExpression(e) => rewrite_uses_expr(&mut e.source, map),
     }
 }
 

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.12] - 2026-07-07
+
+### Changed — CLOC12.169: `ImportExpression` exhaustive-match arm
+
+Added an `Expression::ImportExpression` case so the pass stays exhaustive over the new `javascript-ast` single-operand variant (part of the CLOC12.169 atomic node PR1). A dynamic `import(source)` carries one sub-expression (the module specifier), so the pass recurses into `source` exactly like the sibling `AwaitExpression` arm. No behaviour change to any existing node.
+
+
 ## [0.12.11] - 2026-07-07
 
 ### Changed — CLOC12.168: `ImportMeta` exhaustive-match arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.11"
+version = "0.12.12"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -951,6 +951,7 @@ fn walk_expression(
         Expression::SpreadElement(s) => walk_expression(&s.argument, ctx, analysis, pending),
         Expression::YieldExpression(y) => { if let Some(a) = &y.argument { walk_expression(a, ctx, analysis, pending); } }
         Expression::AwaitExpression(a) => walk_expression(&a.argument, ctx, analysis, pending),
+        Expression::ImportExpression(e) => walk_expression(&e.source, ctx, analysis, pending),
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.28.0] - 2026-07-07
+
+### Added — CLOC12.169: `Expression::ImportExpression` (dynamic `import(x)`)
+
+Added `Expression::ImportExpression` variant + `ImportExpression { cv, source }` struct — a **dynamic `import(specifier)`**, the runtime module-loading form (distinct from a static `import` declaration and from the `ImportMeta` meta-property). A single-operand node (`source: Box<Expression>`, the module specifier), the same shape as `AwaitExpression`; `import()` with no argument is a syntax error, so `source` is non-optional. It is a call-like primary (`import` keyword + parenthesised argument), tagging at `PREC_PRIMARY`. Re-exported from the crate root; 2 roundtrip/serde tests. Atomic node PR (PR1): the node + `closure-emitter` emit + all nine downstream pass arms (which recurse into `source`) land together so the workspace never breaks. (CLOC12.169)
+
+
 ## [0.27.0] - 2026-07-07
 
 ### Added — CLOC12.168: `Expression::ImportMeta` (`import.meta`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/README.md
+++ b/code/packages/rust/javascript-ast/README.md
@@ -152,6 +152,17 @@ emitter grow a need for them — each behind its own `CLOC12.NN` slice:
   passes never touch it. It tags at `PREC_PRIMARY` and the emitter prints the
   literal spelling `import.meta`. Node + `closure-emitter` + all pass traversals
   land in one atomic PR; the bridge-enable + conformance port follow.
+- `ImportExpression` (CLOC12.169) — a **dynamic `import(specifier)`**: the
+  runtime module-loading form that returns a promise (distinct from a static
+  `import` declaration and from the `ImportMeta` meta-property). `ImportExpression
+  { cv, source }` — a single-operand node (`source: Box<Expression>`, the module
+  specifier), the same shape as `AwaitExpression`. It is spelled as the `import`
+  keyword immediately followed by a parenthesised argument — a call-like primary
+  — so it tags at `PREC_PRIMARY` (atomic from the outside, like a call) and the
+  emitter prints `import(` + source + `)` with the source at assignment
+  precedence (inside literal parens). The nine passes recurse into `source` like
+  any other single-operand node. Node + `closure-emitter` + all pass arms land in
+  one atomic PR; the bridge-enable + conformance port follow.
 
 ## What's coming (follow-up PRs)
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -68,6 +68,7 @@ pub enum Expression {
     Super(Super),
     NewTarget(NewTarget),
     ImportMeta(ImportMeta),
+    ImportExpression(ImportExpression),
 }
 
 // ---------------------------------------------------------------------
@@ -582,6 +583,41 @@ pub struct AwaitExpression {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
     pub argument: Box<Expression>,
+}
+
+/// A **dynamic `import()`** — `import(specifier)`, the runtime module-loading
+/// form that returns a promise for the module namespace (distinct from a static
+/// `import` *declaration*, and distinct from the [`ImportMeta`] meta-property).
+/// ESTree calls this node `ImportExpression`, with a single `source` operand.
+///
+/// # Shape
+///
+/// Unlike the reserved-word leaf primaries ([`ThisExpression`], [`Super`],
+/// [`NewTarget`], [`ImportMeta`]), a dynamic import **always** has exactly one
+/// operand — the module specifier — so `source` is a plain (non-optional)
+/// `Box<Expression>`. `import()` with no argument is a syntax error. There is no
+/// second axis (options-bag / attributes are a later proposal not modelled
+/// here).
+///
+/// # Precedence
+///
+/// `import(x)` is spelled as the `import` keyword immediately followed by a
+/// parenthesised argument — syntactically a **call-like primary**. The literal
+/// parens make the whole node atomic from the outside (it binds at
+/// `PREC_PRIMARY`, like a `CallExpression`: `import(x).then(f)`,
+/// `(await import(x))` compose without extra parens around the import itself).
+/// The `source` sits *inside* those literal parens, so it is emitted at the
+/// lowest (assignment) precedence and never needs its own wrapping — the parens
+/// are part of the `import(...)` spelling, not a precedence artifact.
+///
+/// Like the other operand-carrying nodes `source` is a `Box` so the
+/// `Expression` enum stays a fixed size regardless of nesting depth.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportExpression {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub source: Box<Expression>,
 }
 
 /// The `this` keyword — a primary expression that reads the current
@@ -1206,6 +1242,40 @@ mod tests {
         let n = Expression::ImportMeta(ImportMeta { cv: None });
         let json = serde_json::to_string(&n).expect("serialize");
         assert!(!json.contains("\"cv\""), "expected no cv key; got {}", json);
+        assert_eq!(n.clone(), roundtrip(n));
+    }
+
+    #[test]
+    fn import_expression_roundtrips_traced() {
+        // import("m") — a dynamic import with a string-literal specifier.
+        let n = Expression::ImportExpression(ImportExpression {
+            cv: Some("importExpr.1".to_string()),
+            source: Box::new(Expression::StringLiteral(StringLiteral {
+                cv: None,
+                value: "m".to_string(),
+                raw: "\"m\"".to_string(),
+            })),
+        });
+        assert_eq!(n.clone(), roundtrip(n.clone()));
+        assert_eq!(type_tag(&n), "ImportExpression");
+    }
+
+    #[test]
+    fn import_expression_untraced_omits_cv() {
+        let n = Expression::ImportExpression(ImportExpression {
+            cv: None,
+            source: Box::new(Expression::Identifier(Identifier {
+                cv: None,
+                name: "spec".to_string(),
+            })),
+        });
+        let json = serde_json::to_string(&n).expect("serialize");
+        // The node's own `cv` is omitted; the `source` operand is still present.
+        assert!(
+            json.starts_with("{\"type\":\"ImportExpression\",\"source\""),
+            "expected no node cv key; got {}",
+            json
+        );
         assert_eq!(n.clone(), roundtrip(n));
     }
 

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -142,7 +142,7 @@ pub use expression::{
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,
-    AwaitExpression, ImportMeta, NewTarget, Super, ThisExpression, YieldExpression,
+    AwaitExpression, ImportExpression, ImportMeta, NewTarget, Super, ThisExpression, YieldExpression,
 };
 pub use statement::{
     BlockStatement, BreakStatement, CatchClause, ContinueStatement, DebuggerStatement,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2137,6 +2137,56 @@ shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
 
+## CLOC12.169 — `ImportExpression` (dynamic `import(x)`): atomic node + emit + passes (PR1)
+
+Adds `Expression::ImportExpression { cv, source }` to `javascript-ast` (0.28.0)
+— a **dynamic `import(specifier)`**, the runtime module-loading form that
+returns a promise for the module namespace. It is distinct from a static
+`import` *declaration* (a statement) and from the `import.meta` meta-property
+(the `ImportMeta` leaf, CLOC12.168). ESTree names this node `ImportExpression`
+with a single `source` operand.
+
+This is the first **compound** Expression node in the recent run of reserved-word
+leaf primaries (`this` / `super` / `new.target` / `import.meta`): it carries one
+sub-expression, the module specifier, so `source` is a non-optional
+`Box<Expression>` — the same single-operand shape as `AwaitExpression`
+(`import()` with no argument is a syntax error). There is no second axis
+(the import-attributes / options-bag proposal is not modelled).
+
+**Emit (`closure-emitter` 0.33.0).** `emit_import_expression` prints the
+`import` keyword immediately followed by a *literal* parenthesised argument — a
+call-like primary. Unlike the word-shaped unary `await`, no separator follows
+the keyword (`import(x)`, never `import (x)`). The `source` sits inside the
+literal parens, emitted at `PREC_ASSIGNMENT` (the call-argument level): a looser
+*sequence* specifier wraps (`import((a,b))`), everything else prints bare
+(`import("m")`, `import(a.b)`, `import(f())`). The whole node tags at
+`PREC_PRIMARY` — atomic from the outside, like a `CallExpression` — so a
+member/call parent composes without extra parens (`import(x).then(f)`).
+
+**Passes (PATCH bumps).** Unlike the leaf primaries (whose pass arms are no-ops),
+a dynamic import has a child, so every pass **recurses into `source`** exactly
+like the sibling `AwaitExpression` arm: the three rebuild passes
+(`constant-fold`, `dce`, `fold-control-flow`) rebuild `ImportExpression` with a
+folded `source` (and `fold-control-flow` returns its `cv` from the
+`expression_cv` accessor); the six traversal passes (`inline`,
+`inline-variables`, `rename`, `rename-globals`, `rename-properties`,
+`scope-analyzer`) visit / rewrite the `source` sub-expression. Atomic node PR1:
+node + emit + all nine downstream pass arms land together so the workspace never
+breaks.
+
+### gap-170 — bridge declines dynamic `import(x)` (`ImportExpression`) — **OPEN (bridge slice pending, CLOC12.169 PR2)**
+
+The `javascript-parser` bridge does not yet convert a dynamic `import(x)` to
+`Expression::ImportExpression`, so any file containing one drops to
+WHITESPACE_ONLY. The atomic node PR (CLOC12.169 PR1) lands the node + emit + pass
+recursion so the typed AST and every downstream pass can already represent,
+optimise-through, and print a dynamic import; the **PR2 bridge slice** wires the
+grammar production through. Whether grammar work is required (as with `await`,
+gap-165) or the rule is already produced and merely declined / mis-dispatched
+(as with `import.meta`, gap-169) is determined by a PR2 probe. The **PR3**
+CodePrinter conformance port follows.
+
+
 ## CLOC12.168 — `ImportMeta` (`import.meta`): atomic node + emit + passes (PR1)
 
 Adds `Expression::ImportMeta { cv }` to `javascript-ast` (0.27.0) — the


### PR DESCRIPTION
## CLOC12.169 PR1 — `ImportExpression` (dynamic `import(x)`) atomic node

Adds `Expression::ImportExpression { cv, source }` — a **dynamic
`import(specifier)`**, the runtime module-loading form (distinct from a static
`import` declaration and from the `import.meta` meta-property). This is the
**first compound node** after the run of reserved-word leaf primaries
(`this`/`super`/`new.target`/`import.meta`): it carries one sub-expression (the
module specifier), so `source` is a non-optional `Box<Expression>` — the same
single-operand shape as `AwaitExpression`.

**Atomic node PR1** — node + emitter + all nine downstream pass match-arms in
ONE commit so the workspace never breaks:

- **javascript-ast 0.28.0** (MINOR) — `ImportExpression` variant + struct,
  re-exported; 2 roundtrip/serde tests.
- **closure-emitter 0.33.0** (MINOR) — `emit_import_expression`: `import` +
  literal parenthesised argument (call-like primary), `source` at
  `PREC_ASSIGNMENT` (a looser sequence wraps: `import((a,b))`; else bare:
  `import("m")`, `import(a+b)`, `import(f())`); the whole node tags
  `PREC_PRIMARY` so `import(x).then(f)` composes without parens. Dispatch + PREC
  arm + import + 5 unit tests.
- **nine downstream passes** (PATCH) — unlike the leaf primaries (no-op arms), a
  dynamic import has a child, so every pass **recurses into `source`** exactly
  like the sibling `AwaitExpression` arm (rebuild passes clone-with-folded-
  source; fold-control-flow also returns its `cv` from `expression_cv`; the six
  traversal passes visit/rewrite `source`).

Spec: adds CLOC12.169 section + gap-170 (bridge slice pending, PR2). The **PR2**
bridge-enable + **PR3** CodePrinter conformance port follow.

## Verification

- javascript-ast (94) + closure-emitter + all nine passes **build and test
  clean** — 0 failures across 53 test binaries.
- security review: **PASSED** (single-operand node mirroring the shipped
  `AwaitExpression`; no new recursion class, no unsafe / injection / untrusted
  surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)