### PR TITLE
feat(sir-python): display convention — Ruby booleans true/false

### DIFF
--- a/code/packages/python/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `coding-adventures-sir-runtime-core` are documented here.
 
+## [0.1.9] - 2026-07-07
+
+### Added — source-language display convention (SIR display-convention spec)
+
+- `set_display_convention(name)` selects the value-display convention:
+  `"ruby"` renders booleans as `true`/`false`; any other name (the default)
+  keeps the Lisp `#t`/`#f`. `to_display` now branches its boolean arm on the
+  active convention. Module-level state — an emitted Ruby program calls the
+  setter once at startup (each program is its own process). The default is
+  unchanged, so all existing behaviour and callers are byte-for-byte identical
+  until the setter is invoked. Mirrors the Rust/Go/JS backends' boolean
+  display-convention increment. `nil`, symbol, and pair forms are unaffected
+  (convention-independent for now; follow-ups per the spec rollout).
+
 ## [0.1.8] - 2026-07-01
 
 ### Added — typed division-by-zero (T1 of sir-typed-runtime-errors)

--- a/code/packages/python/sir-runtime-core/pyproject.toml
+++ b/code/packages/python/sir-runtime-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-core"
-version = "0.1.8"
+version = "0.1.9"
 description = "Core runtime for Semantic-IR-emitted Python — SIR truthiness, symbols, equality, display, arithmetic, closures, globals"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/__init__.py
@@ -35,7 +35,15 @@ from .runtime import (
     sir_puts,
 )
 from .symbols import Symbol, intern
-from .values import eq, is_null, is_number, is_symbol, to_display, truthy
+from .values import (
+    eq,
+    is_null,
+    is_number,
+    is_symbol,
+    set_display_convention,
+    to_display,
+    truthy,
+)
 
 # Inject core's richer ``to_display`` into the (dependency-free) pairs package
 # so a ``Pair`` renders as a Lisp list (``(1 2 3)``, ``#t``/``nil``/symbols)
@@ -52,6 +60,7 @@ __all__ = [
     "truthy",
     "eq",
     "to_display",
+    "set_display_convention",
     "is_null",
     "is_number",
     "is_symbol",

--- a/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/values.py
+++ b/code/packages/python/sir-runtime-core/src/coding_adventures_sir_runtime_core/values.py
@@ -52,16 +52,40 @@ def eq(a: Any, b: Any) -> bool:
     return bool(a == b)
 
 
+# ── source-language display convention (SIR display-convention spec) ──
+#
+# The default convention is ``"lisp"`` (Twig/Scheme: booleans as ``#t`` / ``#f``),
+# matching this library's original behaviour.  A Ruby-sourced emitted program
+# calls :func:`set_display_convention` with ``"ruby"`` once at startup so
+# ``puts true`` prints ``true``.  Module-level state (each emitted program is its
+# own process) keeps ``to_display`` and every call site convention-aware without
+# threading a parameter through the whole display path.
+_DISPLAY_CONVENTION = "lisp"
+
+
+def set_display_convention(name: str) -> None:
+    """Select the value-display convention: ``"ruby"`` or ``"lisp"`` (default).
+
+    An unrecognised name falls back to the ``"lisp"`` default rather than
+    raising, so a forward-compatible emitter can never crash an older runtime."""
+    global _DISPLAY_CONVENTION
+    _DISPLAY_CONVENTION = "ruby" if name == "ruby" else "lisp"
+
+
 def to_display(v: Any) -> str:
     """SIR display form of a value.
 
-    Distinct from ``repr``: ``nil`` prints as ``nil``, booleans as
-    ``#t`` / ``#f``, a symbol as its bare name, a pair as a Lisp list.
-    Everything else falls back to ``str`` (which renders ints/floats/
-    sequences/maps natively, and pairs via :meth:`Pair.__repr__`)."""
+    Distinct from ``repr``: ``nil`` prints as ``nil``, a symbol as its bare
+    name, a pair as a Lisp list.  Booleans follow the active display convention
+    (see :func:`set_display_convention`): ``true`` / ``false`` under ``"ruby"``,
+    else the default Lisp ``#t`` / ``#f``.  Everything else falls back to
+    ``str`` (which renders ints/floats/sequences/maps natively, and pairs via
+    :meth:`Pair.__repr__`)."""
     if v is None:
         return "nil"
     if isinstance(v, bool):
+        if _DISPLAY_CONVENTION == "ruby":
+            return "true" if v else "false"
         return "#t" if v else "#f"
     if isinstance(v, Symbol):
         return v.name

--- a/code/packages/python/sir-runtime-core/tests/test_core.py
+++ b/code/packages/python/sir-runtime-core/tests/test_core.py
@@ -94,6 +94,25 @@ def test_to_display_forms() -> None:
     assert sir.to_display("hi") == "hi"
 
 
+def test_display_convention_ruby_booleans() -> None:
+    # The default convention is Lisp (`#t`/`#f`); a Ruby-sourced program
+    # selects `true`/`false`.  Restore the default afterwards so the module
+    # state does not leak into other tests.
+    try:
+        sir.set_display_convention("ruby")
+        assert sir.to_display(True) == "true"
+        assert sir.to_display(False) == "false"
+        # Non-boolean forms are convention-independent.
+        assert sir.to_display(None) == "nil"
+        assert sir.to_display(sir.intern("sym")) == "sym"
+        # An unrecognised convention falls back to the Lisp default.
+        sir.set_display_convention("klingon")
+        assert sir.to_display(True) == "#t"
+    finally:
+        sir.set_display_convention("lisp")
+    assert sir.to_display(True) == "#t"
+
+
 def test_print_uses_display(capsys: pytest.CaptureFixture[str]) -> None:
     assert sir.print(None) is None
     out = capsys.readouterr().out

--- a/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-python/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.9.0 — source-language display convention: Ruby booleans (`true`/`false`)
+
+Emits the display-convention selection (SIR display-convention spec) for the
+Python backend. A **Ruby**-sourced module now emits, once after the core
+runtime import, `_sir_set_display_convention("ruby")`, so a translated
+`puts true` prints `true` instead of the Twig/Lisp `#t`. Requires
+`coding-adventures-sir-runtime-core` ≥ 0.1.9 (which adds
+`set_display_convention`).
+
+Non-Ruby modules emit **nothing extra** — no setter call, no additional import
+— so existing Twig output is byte-for-byte unchanged. The emitted argument is a
+hardcoded `"ruby"` literal chosen by an exact `source_language == "ruby"` check
+(never source-derived → no injection).
+
+Scope: booleans only (the flagship divergence); `nil`, symbols, string
+`inspect` quoting, and the Ruby hash `=>` form remain follow-ups per the spec.
+Verified end-to-end under `python` against the real runtime library: Ruby
+convention → `true`/`false`; default → `#t`/`#f`.
+
 ## 0.8.0 — mixin emit arms: `include` / `extend` (MX2 of sir-mixins)
 
 ### Added

--- a/code/packages/rust/semantic-ir-to-python/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-python"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Semantic IR → self-contained Python 3 source code (SIR14). Third backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -451,6 +451,23 @@ pub fn emit_module(m: &Module) -> String {
     let mut out = String::new();
     emit_banner(&mut out, m);
     out.push_str(RUNTIME);
+    // Source-language display convention (SIR display-convention spec): a
+    // Ruby-sourced module selects the Ruby boolean form (`true`/`false`) once
+    // at startup; every other source language keeps the default Lisp `#t`/`#f`,
+    // so existing Twig output is unchanged and non-Ruby modules gain no extra
+    // import.
+    //
+    // SECURITY: the emitted argument is a hardcoded `"ruby"` literal chosen by
+    // an exact `== "ruby"` comparison — never text derived from
+    // `source_language` or any other source-controlled field — so this can
+    // never inject into the emitted Python.
+    if m.metadata.source_language.as_deref() == Some("ruby") {
+        out.push_str(
+            "from coding_adventures_sir_runtime_core import \
+             set_display_convention as _sir_set_display_convention\n\
+             _sir_set_display_convention(\"ruby\")\n",
+        );
+    }
     // Only OOP-using modules import the OOP runtime, so a pure arithmetic
     // module gains no dependency on it.
     if uses_oop(m) {
@@ -2350,6 +2367,47 @@ mod tests {
         assert!(out.contains("def _sir_user_main():"));
         assert!(out.contains("return 42"));
         assert!(out.contains("_sir_user_main()"));
+        // A non-Ruby module must NOT emit the display-convention setter.
+        assert!(
+            !out.contains("_sir_set_display_convention"),
+            "twig module must keep the default Lisp display; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn emit_display_convention_ruby_selects_ruby_booleans() {
+        // A Ruby-sourced module emits the display-convention setter once so
+        // `puts true` renders `true`; a non-Ruby module (above) does not.
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("ruby")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module(&m);
+        assert!(
+            out.contains("_sir_set_display_convention(\"ruby\")"),
+            "ruby module must select the Ruby display convention; got:\n{out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
**Brings the boolean display convention to the Python reference backend** (SIR display-convention spec), mirroring the merged Rust (#7724) + Go (#7726) increments. Now 4 of 5 backends (JS in flight, TS remaining).

A translated **Ruby** `puts true` prints `true` instead of the Twig/Lisp `#t`.

## Two crates (one logical change)
**`coding-adventures-sir-runtime-core` 0.1.8 → 0.1.9** (Python lib): adds `set_display_convention(name)` (module-level state) and makes `to_display`'s boolean arm convention-aware — `true`/`false` under `"ruby"`, else the default `#t`/`#f`. Unknown name falls back to lisp (forward-compatible, never raises). **Default unchanged** → all existing callers/tests byte-for-byte identical until the setter is called.

**`semantic-ir-to-python` 0.8.0 → 0.9.0** (Rust emitter): a Ruby-sourced module emits `_sir_set_display_convention("ruby")` once after the core import. Non-Ruby modules emit **nothing extra** (no setter, no import) → Twig output unchanged.

## Safety
Security review passed. Emitted arg is a hardcoded `"ruby"` literal chosen by an exact `source_language == "ruby"` check — no source-derived interpolation, no injection. Lib setter does pure string comparison (no eval/exec/getattr).

## Verification
- Lib: `pytest` (66 passed, 99% cov) + `ruff` clean.
- Emitter: unit tests (100), incl. a test asserting ruby emits the setter & twig does not.
- **Exec-proof** under `python` against the real runtime library: ruby → `true`/`false`; default → `#t`/`#f`.

Follow-ups per spec: TS bool mirror, then nil/symbol/inspect/hash-`=>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)