### PR TITLE
feat(sir-typescript): display convention — Ruby booleans true/false

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.8.0 — source-language display convention: Ruby booleans (`true`/`false`)
+
+Emits the display-convention selection (SIR display-convention spec) for the
+TypeScript backend — the **last** of the five backends, completing the boolean
+convention across the whole stack. A **Ruby**-sourced module now emits
+`__Sir.setDisplayConvention("ruby");` once after the runtime import, so a
+translated `puts true` prints `true` instead of the Twig/Lisp `#t`. Requires
+`@coding-adventures/sir-runtime-core` ≥ 0.1.10 (which adds
+`setDisplayConvention`).
+
+Non-Ruby modules emit **nothing extra** (the setter uses the already
+namespace-imported `__Sir`, so there is no new import either) — existing Twig
+output is byte-for-byte unchanged. The emitted argument is a hardcoded `"ruby"`
+literal chosen by an exact `source_language == "ruby"` check (never
+source-derived → no injection).
+
+Scope: booleans only (the flagship divergence); `nil`, symbols, string
+`inspect` quoting, and the Ruby hash `=>` form remain follow-ups per the spec.
+Verified: the core lib's `setDisplayConvention`/`toDisplay` under `vitest`, and
+an emitter unit test asserting a Ruby module emits the setter while a Twig
+module does not.
+
 ## 0.7.0 — Ruby mixins: `include` / `extend` emit arms (MX3)
 
 Part of the `sir-mixins` cascade (spec `code/specs/sir-mixins.md`). Adds the

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -459,6 +459,19 @@ pub fn emit_module(m: &Module) -> String {
     let mut out = String::new();
     emit_banner(&mut out, m);
     out.push_str(RUNTIME);
+    // Source-language display convention (SIR display-convention spec): a
+    // Ruby-sourced module selects the Ruby boolean form (`true`/`false`) once
+    // at startup via the namespace-imported `__Sir`; every other source
+    // language keeps the default Lisp `#t`/`#f`, so existing Twig output is
+    // unchanged.
+    //
+    // SECURITY: the emitted argument is a hardcoded `"ruby"` literal chosen by
+    // an exact `== "ruby"` comparison — never text derived from
+    // `source_language` or any other source-controlled field — so this can
+    // never inject into the emitted TypeScript.
+    if m.metadata.source_language.as_deref() == Some("ruby") {
+        out.push_str("__Sir.setDisplayConvention(\"ruby\");\n");
+    }
     // Only OOP-using modules import the OOP runtime, so a pure
     // arithmetic module gains no dependency on it.
     if uses_oop(m) {
@@ -2630,6 +2643,47 @@ mod tests {
         assert!(out.contains(r#"import * as __Sir from "@coding-adventures/sir-runtime-core";"#));
         assert!(out.contains("function main()"));
         assert!(out.contains("const __sir_result: __Sir.Val = main();"));
+        // A non-Ruby module must NOT emit the display-convention setter.
+        assert!(
+            !out.contains("setDisplayConvention"),
+            "twig module must keep the default Lisp display; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn emit_display_convention_ruby_selects_ruby_booleans() {
+        // A Ruby-sourced module emits the display-convention setter once so
+        // `puts true` renders `true`; a non-Ruby module (above) does not.
+        let m = Module {
+            name: "demo".into(),
+            manifest: FeatureManifest::new(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![Function {
+                name: "main".into(),
+                params: vec![],
+                return_type: None,
+                captures: vec![],
+                body: Block {
+                    stmts: vec![],
+                    value: Expr::NilLit { span: s() },
+                    span: s(),
+                },
+                effects: EffectSet::PURE,
+                metadata: Metadata::new(),
+                span: s(),
+            }],
+            globals: vec![],
+            metadata: Metadata::new()
+                .with_source_language("ruby")
+                .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+            span: s(),
+        };
+        let out = emit_module(&m);
+        assert!(
+            out.contains(r#"__Sir.setDisplayConvention("ruby");"#),
+            "ruby module must select the Ruby display convention; got:\n{out}"
+        );
     }
 
     #[test]

--- a/code/packages/typescript/sir-runtime-core/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-core/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `@coding-adventures/sir-runtime-core` are documented here.
 
+## [0.1.10] - 2026-07-07
+
+### Added — source-language display convention (SIR display-convention spec)
+
+- `setDisplayConvention(name)` selects the value-display convention: `"ruby"`
+  renders booleans as `true`/`false`; any other name (the default) keeps the
+  Lisp `#t`/`#f`. `toDisplay`'s boolean arm now branches on the active
+  convention. Module-level state — an emitted Ruby program calls the setter
+  once at startup (each program is its own process). The default is unchanged,
+  so all existing behaviour and callers are byte-for-byte identical until the
+  setter is invoked. Mirrors the Rust/Go/JS/Python backends' boolean
+  display-convention increment. `nil`, symbol, and pair forms are unaffected
+  (convention-independent for now; follow-ups per the spec rollout).
+
 ## [0.1.9] - 2026-07-01
 
 ### Added — typed `ZeroDivisionError` on division by zero (T2)

--- a/code/packages/typescript/sir-runtime-core/package.json
+++ b/code/packages/typescript/sir-runtime-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Core runtime for Semantic-IR-emitted TypeScript/JavaScript — SIR truthiness, symbols, pairs, equality, display, arithmetic, closures, globals",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-core/src/index.ts
+++ b/code/packages/typescript/sir-runtime-core/src/index.ts
@@ -19,7 +19,15 @@
 
 export { Sym, intern } from "./symbols.js";
 export { Pair, cons, car, cdr, isPair } from "./pairs.js";
-export { truthy, isNull, isNumber, isSymbol, eq, toDisplay } from "./values.js";
+export {
+  truthy,
+  isNull,
+  isNumber,
+  isSymbol,
+  eq,
+  toDisplay,
+  setDisplayConvention,
+} from "./values.js";
 export type { Val, ClosureLike } from "./values.js";
 export { add, sub, mul, div, lt, gt } from "./arithmetic.js";
 export {

--- a/code/packages/typescript/sir-runtime-core/src/values.ts
+++ b/code/packages/typescript/sir-runtime-core/src/values.ts
@@ -66,20 +66,40 @@ export function eq(a: Val, b: Val): boolean {
   return a === b;
 }
 
+// ── source-language display convention (SIR display-convention spec) ──
+//
+// The default convention is "lisp" (Twig/Scheme: booleans as `#t`/`#f`),
+// matching this library's original behaviour. A Ruby-sourced emitted program
+// calls `setDisplayConvention("ruby")` once at startup so `puts true` prints
+// `true`. Module-level state (each emitted program is its own process) keeps
+// `toDisplay` convention-aware without threading a parameter through the whole
+// display path.
+let _displayConvention: "ruby" | "lisp" = "lisp";
+
 /**
- * SIR display form. Distinct from JSON: `nil` prints as `nil`, booleans
- * as `#t`/`#f`, a symbol as its bare name, a pair as a Lisp list.
- * Everything else falls back to `String(v)`.
+ * Select the value-display convention: `"ruby"` or `"lisp"` (default).
+ * An unrecognised name falls back to the `"lisp"` default rather than
+ * throwing, so a forward-compatible emitter can never crash an older runtime.
+ */
+export function setDisplayConvention(name: string): void {
+  _displayConvention = name === "ruby" ? "ruby" : "lisp";
+}
+
+/**
+ * SIR display form. Distinct from JSON: `nil` prints as `nil`, a symbol as its
+ * bare name, a pair as a Lisp list. Booleans follow the active display
+ * convention (see `setDisplayConvention`): `true`/`false` under `"ruby"`, else
+ * the default Lisp `#t`/`#f`. Everything else falls back to `String(v)`.
  */
 export function toDisplay(v: Val): string {
   if (v === null) {
     return "nil";
   }
   if (v === true) {
-    return "#t";
+    return _displayConvention === "ruby" ? "true" : "#t";
   }
   if (v === false) {
-    return "#f";
+    return _displayConvention === "ruby" ? "false" : "#f";
   }
   if (v instanceof Sym) {
     return v.name;

--- a/code/packages/typescript/sir-runtime-core/tests/core.test.ts
+++ b/code/packages/typescript/sir-runtime-core/tests/core.test.ts
@@ -69,6 +69,25 @@ describe("predicates and display", () => {
     expect(sir.toDisplay("hi")).toBe("hi");
   });
 
+  it("display convention: Ruby booleans", () => {
+    // Default is Lisp (`#t`/`#f`); a Ruby-sourced program selects
+    // `true`/`false`. Restore the default so module state does not leak.
+    try {
+      sir.setDisplayConvention("ruby");
+      expect(sir.toDisplay(true)).toBe("true");
+      expect(sir.toDisplay(false)).toBe("false");
+      // Non-boolean forms are convention-independent.
+      expect(sir.toDisplay(null)).toBe("nil");
+      expect(sir.toDisplay(sir.intern("sym"))).toBe("sym");
+      // An unrecognised convention falls back to the Lisp default.
+      sir.setDisplayConvention("klingon");
+      expect(sir.toDisplay(true)).toBe("#t");
+    } finally {
+      sir.setDisplayConvention("lisp");
+    }
+    expect(sir.toDisplay(true)).toBe("#t");
+  });
+
   it("print returns null and writes display form", () => {
     const lines: string[] = [];
     const spy = vi.spyOn(console, "log").mockImplementation((s: string) => {


### PR DESCRIPTION
**Completes the boolean display convention across ALL FIVE backends** (SIR display-convention spec) — TS is the last, after Rust (#7724) + Go (#7726) merged and JS (#7729) + Python (#7736) in flight.

A translated **Ruby** `puts true` prints `true` instead of the Twig/Lisp `#t`.

## Two crates (one logical change)
**`@coding-adventures/sir-runtime-core` 0.1.9 → 0.1.10** (TS lib): adds `setDisplayConvention(name)` (module-level state) + convention-aware `toDisplay` boolean arm (`true`/`false` under `"ruby"`, else default `#t`/`#f`). Unknown name → lisp (forward-compatible, never throws). **Default unchanged.**

**`semantic-ir-to-typescript` 0.7.0 → 0.8.0** (Rust emitter): a Ruby-sourced module emits `__Sir.setDisplayConvention("ruby");` once after the runtime import — via the already namespace-imported `__Sir`, so **no extra import**. Non-Ruby modules emit nothing extra → Twig output unchanged.

## Safety
Security review passed. Emitted arg is a hardcoded `"ruby"` literal chosen by an exact `source_language == "ruby"` check — no source-derived interpolation, no injection. Lib setter is pure string comparison (no eval/Function/indexing).

## Verification
- Lib: `vitest` — **50 passed**, incl. a new Ruby-convention test.
- Emitter: unit tests — ruby emits the setter, twig does not.

Follow-ups per spec: nil/symbol/`inspect`/hash-`=>` display aspects across all backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)