### PR TITLE
feat(sir-python-oop): Array block-method breadth — sort_by/group_by/partition/… (v0.1.12)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.12] - 2026-07-07
+
+### Added — Array block-method breadth (sort_by / group_by / partition / …)
+
+Extends `_array_block_method` with the common block-taking Ruby
+`Enumerable`/`Array` methods that were missing (map/select/reduce/find/flat_map
+were already present), and adds them to the `_ARRAY_BLOCK_METHODS` catalog so
+`respond_to?` stays honest. Mirrors the Rust/Go backends' array-block batch.
+
+- `sort_by { |x| key }` — key-sorted (stable, like Ruby).
+- `min_by` / `max_by { |x| key }` — extremal block key (`nil` on empty).
+- `group_by { |x| key }` — a Hash (dict) of key → list of elements.
+- `partition { |x| pred }` — `[matching, non_matching]`.
+- `collect_concat` — alias of `flat_map`.
+- `take_while` / `drop_while { |x| pred }` — leading truthy run / remainder.
+- `count { |x| pred }` — truthy count (arg/bare forms unchanged in
+  `_array_method`).
+- `each_with_object(memo) { |x, memo| … }` — folds into and returns the memo.
+
+Predicate results route through SIR `truthy`; a block-less call keeps the nil
+Enumerator floor. Ordering uses Python's native comparison (a non-mutually-
+comparable key raises `TypeError`, identical to the existing `sort` arm).
+
 ## [0.1.11] - 2026-07-02
 
 ### Added — mixins: `include` / `extend` + Ruby MRO (MX2 of sir-mixins)

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.11"
+version = "0.1.12"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -591,9 +591,19 @@ _ARRAY_BLOCK_METHODS = frozenset(
         "find",
         "detect",
         "flat_map",
+        "collect_concat",
         "any?",
         "all?",
         "none?",
+        "sort_by",
+        "min_by",
+        "max_by",
+        "group_by",
+        "partition",
+        "take_while",
+        "drop_while",
+        "count",
+        "each_with_object",
     }
 )
 
@@ -984,7 +994,7 @@ def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Clos
             if truthy(apply(block, [item])):
                 return item
         return None
-    if name == "flat_map":
+    if name in ("flat_map", "collect_concat"):
         out: list[Val] = []
         for item in recv:
             mapped = apply(block, [item])
@@ -999,6 +1009,60 @@ def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Clos
         return all(truthy(apply(block, [item])) for item in recv)
     if name == "none?":
         return not any(truthy(apply(block, [item])) for item in recv)
+    if name == "sort_by":
+        # Sort by the block-computed key (Ruby ``sort_by``).  Python's sort is
+        # stable, matching Ruby.  A key that is not mutually comparable raises
+        # ``TypeError`` — identical to the plain ``sort`` arm above.
+        return sorted(recv, key=lambda item: apply(block, [item]))
+    if name in ("min_by", "max_by"):
+        if not recv:
+            return None
+        chooser = min if name == "min_by" else max
+        return chooser(recv, key=lambda item: apply(block, [item]))
+    if name == "group_by":
+        # A Hash (Python ``dict``) of block key -> list of elements, in
+        # first-seen key order.  Keys must be hashable, consistent with the
+        # backend's dict-based Hash model.
+        groups: dict[Val, list[Val]] = {}
+        for item in recv:
+            groups.setdefault(apply(block, [item]), []).append(item)
+        return groups
+    if name == "partition":
+        yes: list[Val] = []
+        no: list[Val] = []
+        for item in recv:
+            (yes if truthy(apply(block, [item])) else no).append(item)
+        return [yes, no]
+    if name == "take_while":
+        out2: list[Val] = []
+        for item in recv:
+            if truthy(apply(block, [item])):
+                out2.append(item)
+            else:
+                break
+        return out2
+    if name == "drop_while":
+        out3: list[Val] = []
+        dropping = True
+        for item in recv:
+            if dropping and truthy(apply(block, [item])):
+                continue
+            dropping = False
+            out3.append(item)
+        return out3
+    if name == "count":
+        # ``count { |x| pred }`` — number of truthy results.  (The argument and
+        # bare forms are handled by the non-block ``_array_method``.)
+        return sum(1 for item in recv if truthy(apply(block, [item])))
+    if name == "each_with_object":
+        # ``each_with_object(memo) { |x, memo| … }`` — yields each element with
+        # the memo and returns the (mutated) memo.
+        if not args:
+            return recv
+        memo = args[0]
+        for item in recv:
+            apply(block, [item, memo])
+        return memo
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -342,6 +342,36 @@ def test_find_detect_and_flat_map() -> None:
     ]
 
 
+def test_array_block_breadth() -> None:
+    # sort_by / min_by / max_by — keyed by the block result.
+    assert oop.call_method([3, 1, 2], "sort_by", Closure(lambda x: x)) == [1, 2, 3]
+    assert oop.call_method(["aaa", "a", "aa"], "sort_by", Closure(len)) == ["a", "aa", "aaa"]
+    assert oop.call_method([3, 1, 2], "min_by", Closure(lambda x: x)) == 1
+    assert oop.call_method([3, 1, 2], "max_by", Closure(lambda x: x)) == 3
+    assert oop.call_method([], "min_by", Closure(lambda x: x)) is None
+    # group_by — a Hash of key -> matching elements.
+    assert oop.call_method([1, 2, 3, 4], "group_by", Closure(lambda x: x % 2 == 0)) == {
+        False: [1, 3],
+        True: [2, 4],
+    }
+    # partition — [matching, non_matching].
+    assert oop.call_method([1, 2, 3, 4], "partition", Closure(lambda x: x % 2 == 0)) == [
+        [2, 4],
+        [1, 3],
+    ]
+    # collect_concat is an alias of flat_map.
+    assert oop.call_method([1, 2], "collect_concat", Closure(lambda x: [x, x])) == [1, 1, 2, 2]
+    # take_while / drop_while — leading truthy run and the remainder.
+    assert oop.call_method([1, 2, 3, 4], "take_while", Closure(lambda x: x < 3)) == [1, 2]
+    assert oop.call_method([1, 2, 3, 4], "drop_while", Closure(lambda x: x < 3)) == [3, 4]
+    # count { block } — number of truthy results.
+    assert oop.call_method([1, 2, 3, 4], "count", Closure(lambda x: x % 2 == 0)) == 2
+    # each_with_object — folds into and returns the memo.
+    assert oop.call_method(
+        [1, 2, 3], "each_with_object", [], Closure(lambda x, o: o.append(x * 10))
+    ) == [10, 20, 30]
+
+
 def test_any_all_none_use_sir_truthiness() -> None:
     assert oop.call_method([1, 2, 3], "any?", Closure(lambda x: x > 2)) is True
     assert oop.call_method([1, 2, 3], "any?", Closure(lambda x: x > 9)) is False


### PR DESCRIPTION
Brings the **Python reference backend** to Array block-method parity with Rust (#7738) + Go (#7739). Turns out the reference wasn't complete — `sir-runtime-oop` had map/select/reduce/find/flat_map but was **missing** the rest.

## Methods (in `_array_block_method`)
`sort_by`, `min_by`/`max_by`, `group_by` (→ Hash/dict), `partition` (→ `[yes, no]`), `collect_concat` (`flat_map` alias), `take_while`/`drop_while`, `count` (block form), `each_with_object`. Plus `_ARRAY_BLOCK_METHODS` catalog entries for honest `respond_to?`.

**Library-only change** — the Python backend already dispatches `arr.method(block)` through `_array_block_method`, so no emitter change.

## Safety
Security review passed. Dispatch is literal `if name == …` comparisons — no `getattr`/`eval` on source-derived names ([[dynamic-dispatch-rce]]); block invoked only via `apply`. Predicates route through SIR `truthy`. `min_by`/`max_by` guard empty; `each_with_object` guards missing memo. `sorted(key=)`/`min(key=)` raise `TypeError` on uncomparable keys — **identical to the pre-existing `sort`/`min`/`max` arms**, not a new crash vector (a uniform lenient-comparator pass across all ordering arms is a tracked cross-backend follow-up).

## Verification
`pytest` **113 passed (97% cov)** incl. a new `test_array_block_breadth`; `ruff` clean. This is the exec-proof (pytest runs the real lib).

TS reference likely needs the same next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)