### PR TITLE
feat(sir-ts-oop): Array block-method breadth — sort_by/group_by/partition/… (v0.1.12)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.12] - 2026-07-07
+
+### Added — Array block-method breadth (sort_by / group_by / partition / …)
+
+Extends `arrayBlockMethod` with the common block-taking Ruby
+`Enumerable`/`Array` methods that were missing (map/select/reduce/find/flat_map
+were already present), and adds them to the `ARRAY_BLOCK_METHODS` catalog so
+`respond_to?` stays honest. Mirrors the Rust/Go/Python backends' array-block
+batch — TS is the fourth backend to reach this parity.
+
+- `sort_by { |x| key }` — key-sorted (stable, `<`/`>` keeps numbers numeric).
+- `min_by` / `max_by { |x| key }` — extremal block key (`null` on empty).
+- `group_by { |x| key }` — a Hash (`Map`) of key → array of elements.
+- `partition { |x| pred }` — `[matching, non_matching]`.
+- `collect_concat` — alias of `flat_map`.
+- `take_while` / `drop_while { |x| pred }` — leading truthy run / remainder.
+- `count { |x| pred }` — truthy count (arg/bare forms unchanged in
+  `arrayMethod`).
+- `each_with_object(memo) { |x, memo| … }` — folds into and returns the memo.
+
+Predicate results route through SIR `truthy`; a block-less call keeps the nil
+Enumerator floor. Ordering uses `<`/`>` (never throws on mixed types),
+consistent with the existing `sort`/`min`/`max` arms.
+
 ## [0.1.11] - 2026-07-02
 
 ### Added — Ruby mixins: `include` / `extend` + module-aware MRO (MX3)

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -567,9 +567,19 @@ const ARRAY_BLOCK_METHODS = new Set<string>([
   "find",
   "detect",
   "flat_map",
+  "collect_concat",
   "any?",
   "all?",
   "none?",
+  "sort_by",
+  "min_by",
+  "max_by",
+  "group_by",
+  "partition",
+  "take_while",
+  "drop_while",
+  "count",
+  "each_with_object",
 ]);
 
 // Non-block `Hash` methods (M1c). Hash is a JS `Map`.
@@ -984,7 +994,8 @@ function arrayBlockMethod(
         if (truthy(apply(block, [item]))) return item;
       }
       return null;
-    case "flat_map": {
+    case "flat_map":
+    case "collect_concat": {
       const out: Val[] = [];
       for (const item of recv) {
         const mapped = apply(block, [item]);
@@ -999,6 +1010,80 @@ function arrayBlockMethod(
       return recv.every((item: Val) => truthy(apply(block, [item])));
     case "none?":
       return !recv.some((item: Val) => truthy(apply(block, [item])));
+    case "sort_by": {
+      // Sort by the block-computed key (Ruby `sort_by`); `<`/`>` keeps numbers
+      // numeric, matching the plain `sort` arm. Keys computed once (Schwartzian).
+      const keyed = recv.map((item: Val): [Val, Val] => [apply(block, [item]), item]);
+      keyed.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+      return keyed.map((pair) => pair[1]);
+    }
+    case "min_by":
+    case "max_by": {
+      if (recv.length === 0) return null;
+      const wantMin = name === "min_by";
+      let bestItem = recv[0];
+      let bestKey = apply(block, [recv[0]]);
+      for (let i = 1; i < recv.length; i++) {
+        const key = apply(block, [recv[i]]);
+        if (wantMin ? key < bestKey : key > bestKey) {
+          bestItem = recv[i];
+          bestKey = key;
+        }
+      }
+      return bestItem;
+    }
+    case "group_by": {
+      // A Hash (`Map`) of block key -> list of elements, in first-seen order.
+      const groups = new Map<Val, Val>();
+      for (const item of recv) {
+        const key = apply(block, [item]);
+        const bucket = groups.get(key);
+        if (Array.isArray(bucket)) bucket.push(item);
+        else groups.set(key, [item]);
+      }
+      return groups;
+    }
+    case "partition": {
+      const yes: Val[] = [];
+      const no: Val[] = [];
+      for (const item of recv) {
+        if (truthy(apply(block, [item]))) yes.push(item);
+        else no.push(item);
+      }
+      return [yes, no];
+    }
+    case "take_while": {
+      const out: Val[] = [];
+      for (const item of recv) {
+        if (truthy(apply(block, [item]))) out.push(item);
+        else break;
+      }
+      return out;
+    }
+    case "drop_while": {
+      const out: Val[] = [];
+      let dropping = true;
+      for (const item of recv) {
+        if (dropping && truthy(apply(block, [item]))) continue;
+        dropping = false;
+        out.push(item);
+      }
+      return out;
+    }
+    case "count":
+      // `count { |x| pred }` — number of truthy results (arg/bare forms are in
+      // the non-block `arrayMethod`).
+      return recv.reduce(
+        (n: number, item: Val) => (truthy(apply(block, [item])) ? n + 1 : n),
+        0,
+      );
+    case "each_with_object": {
+      // `each_with_object(memo) { |x, memo| … }` — folds into and returns memo.
+      if (args.length === 0) return recv;
+      const memo = args[0];
+      for (const item of recv) apply(block, [item, memo]);
+      return memo;
+    }
     default:
       return MISS;
   }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -350,6 +350,40 @@ describe("built-in method catalog: block-taking Array/Enumerable (M1b)", () => {
     expect(callMethod([], "reduce", new Closure((a: Val, b: Val) => a + b))).toBeNull();
   });
 
+  it("array block-method breadth: sort_by/min_by/max_by/group_by/partition/…", () => {
+    const id = new Closure((x: Val) => x);
+    const even = new Closure((x: Val) => x % 2 === 0);
+    expect(callMethod([3, 1, 2], "sort_by", id)).toEqual([1, 2, 3]);
+    expect(callMethod(["aaa", "a", "aa"], "sort_by", new Closure((s: Val) => s.length))).toEqual([
+      "a",
+      "aa",
+      "aaa",
+    ]);
+    expect(callMethod([3, 1, 2], "min_by", id)).toBe(1);
+    expect(callMethod([3, 1, 2], "max_by", id)).toBe(3);
+    expect(callMethod([], "min_by", id)).toBeNull();
+    // group_by returns a Hash (Map).
+    expect(callMethod([1, 2, 3, 4], "group_by", even)).toEqual(
+      new Map<Val, Val>([
+        [false, [1, 3]],
+        [true, [2, 4]],
+      ]),
+    );
+    expect(callMethod([1, 2, 3, 4], "partition", even)).toEqual([
+      [2, 4],
+      [1, 3],
+    ]);
+    expect(callMethod([1, 2], "collect_concat", new Closure((x: Val) => [x, x]))).toEqual([
+      1, 1, 2, 2,
+    ]);
+    expect(callMethod([1, 2, 3, 4], "take_while", new Closure((x: Val) => x < 3))).toEqual([1, 2]);
+    expect(callMethod([1, 2, 3, 4], "drop_while", new Closure((x: Val) => x < 3))).toEqual([3, 4]);
+    expect(callMethod([1, 2, 3, 4], "count", even)).toBe(2);
+    expect(
+      callMethod([1, 2, 3], "each_with_object", [], new Closure((x: Val, o: Val) => o.push(x * 10))),
+    ).toEqual([10, 20, 30]);
+  });
+
   it("find/detect and flat_map", () => {
     expect(callMethod([1, 2, 3, 4], "find", new Closure((x: Val) => x > 2))).toBe(3);
     expect(callMethod([1, 2], "detect", new Closure((x: Val) => x > 9))).toBeNull();


### PR DESCRIPTION
Brings the **TypeScript** backend to Array block-method parity with Rust (#7738), Go (#7739), and Python (#7740) — all merged. TS is the 4th backend; **JS is the last remaining**.

## Methods (in `arrayBlockMethod`)
`sort_by`, `min_by`/`max_by`, `group_by` (→ Hash/`Map`), `partition` (→ `[yes, no]`), `collect_concat` (`flat_map` alias), `take_while`/`drop_while`, `count` (block form), `each_with_object`. Plus `ARRAY_BLOCK_METHODS` catalog entries for honest `respond_to?`.

**Library-only** — the TS backend already dispatches `arr.method(block)` through `arrayBlockMethod`.

## Safety
Security review passed. Dispatch is a literal `switch (name)` — no `recv[name]`/`eval` ([[dynamic-dispatch-rce]]); block invoked only via `apply`. `min_by`/`max_by` guard empty; `each_with_object` guards missing memo. Ordering uses `<`/`>` (**never throws** on mixed types, consistent with the existing `sort`/`min`/`max`). `group_by` builds a `Map` via `.get`/`.set` — **no prototype pollution**.

## Verification
`vitest` **106 passed**, incl. a new `array block-method breadth` test. (Exec-proof runs the real lib; chain-installed the sibling `file:` deps leaf-to-root to resolve the monorepo imports.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)