### PR TITLE
feat(latex): LTXDOC03 S13 — \nameref support (resolve to target's name text)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.49.0] — 2026-07-07
+
+### Added — `\nameref` resolution to a target's name text (LTXDOC03 S13)
+
+A **new** public method `Document::resolve_namerefs(&self) -> String` that resolves every
+`\nameref{key}` in the body to the **name** (title/caption text) of its target — the `nameref`
+package's name-valued sibling of `\ref` (number-valued) and `\pageref` (page-valued). A
+`\nameref{sec:intro}` yields the section's title (`Introduction`), not "Section 1"; a
+`\nameref{fig:p}` yields the figure's caption text. Every S1–S12 output is left **byte-for-byte
+unchanged**; S13 is purely additive.
+
+- **`\nameref` is not a `REF_COMMAND`.** The S1 resolver binds only `\ref`/`\eqref`/`\pageref`, so a
+  `\nameref` appears in *neither* the resolved *nor* the unresolved reference table. Confirmed by an
+  AST probe: `\nameref{sec:intro}` lowers to `Inline::CrossRef { command: "nameref", target:
+  "sec:intro", .. }`, and `resolve_references()` returns it in no table. That is *why* S13 is a brand
+  new method rather than a tweak to `REF_COMMANDS` — it reads the same `\label` table S1 builds but
+  answers a different question (*what is it called?*), touching no existing output.
+- **One line per `\nameref`, in body order, formatted `\nameref{<key>} -> <name>`** (mirroring the
+  S6 `\ref{k} -> …` arrow). A single document-order `walk()` collects every `nameref` cross-ref, then
+  each key is resolved against the winning label table (`ReferenceResolution::definition`, the same
+  first-wins table `\ref` uses) and the target's name read from its defining node via the S3
+  `label_def_node` accessor.
+- **Name text per kind.** A `Section` target → its `title` inlines flattened; a `Figure`/`Table`
+  target → its `\caption` via the S12 `caption_text` helper (so a `\nameref` and the List-of-Floats
+  entry read the *same* caption). An `Equation`/`Inline` target carries no name (a number, not a
+  title) → the fixed marker `(no name)`. An undefined key → `(undefined nameref: <key>)`. A document
+  with no `\nameref` at all → `(no namerefs)`.
+- **Shared flatten helper.** S12's caption-flattening descent (`Text`/`Code` verbatim, `Space` → one
+  space, `Strong`/`Emph`/`Styled` recursed, trimmed) is factored into a module-level
+  `flatten_inlines_to_text(&[Inline]) -> String`, reused by both `caption_text` (captions) and
+  `resolve_namerefs` (section titles) so the two name-rendering paths can never drift.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing; reuses the bounded `walk()`,
+  the S1 `resolve_references` table, and the S3 `label_def_node` accessor. Borrows `self` immutably,
+  returns owned `String`.
+
+Five `s13_*` tests pin the exact rendered strings: section+figure names, an undefined-key
+placeholder, equation/inline `(no name)`, the empty `(no namerefs)` marker, and an additivity
+check that `\namerefs` stay out of the resolved/unresolved ref tables and leave `list_of_floats`
+unchanged.
+
 ## [0.48.0] — 2026-07-07
 
 ### Added — List of Figures / List of Tables index (LTXDOC03 S12)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -60,6 +60,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S10 — distinct `\pageref` rendering** | `CrossReferenceReport::to_plain_text` gains a **third** rendering branch so a resolved `\pageref` no longer renders identically to a `\ref`. A `\pageref{key}` asks "what **page** is the target on" — a different question from `\ref`'s "what **number** is the target" — but the crate has **no page model**, so it cannot compute a real page number. A resolved reference whose `command == "pageref"` (to **any** target kind) now renders `\pageref{sec:i} -> page ?` — the `\pageref` spelling is kept and the kind/number are replaced by the fixed literal placeholder `page ?` (the `?` mirrors LaTeX's own `??` for an unresolved page reference; it means "page number not modelled", not the kind, not the number). Branch precedence: (1) `\eqref` to Equation → parenthesised (S9); (2) `\pageref` any kind → `page ?` (S10); (3) else → `\ref{key} -> Kind N` (S8). So `\ref` and `\eqref` outputs are byte-for-byte unchanged; only `\pageref` lines change. Pure rendering branch — no AST change, no re-numbering, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S11 — grouped-by-kind cross-reference report** | `CrossReferenceReport::to_plain_text_by_kind() -> String` — a **new, separate** method that renders the **same** resolved references as `to_plain_text` but **grouped under fixed-order kind subheadings** (Sections, Figures, Tables, Equations, Inline — regardless of source order), each subheading followed by two-space-indented ref lines in the report's existing pre-order. Kinds with zero resolved refs are omitted entirely. The per-line rendering is the **identical** S8/S9/S10 rule — factored into a shared private `render_resolved_ref(&RefEntry)` that **both** `to_plain_text` and `to_plain_text_by_kind` call, so the flat and grouped reports can never drift (`to_plain_text` output is byte-for-byte unchanged). Only resolved refs are grouped (no citations, no dangling footers); zero resolved refs → the fixed marker `(no resolved references)`. A `\pageref` groups under its **target kind**. Pure report-assembly over data the report already holds — no AST/struct/numbering change, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S12 — List of Figures / List of Tables index** | `Document::list_of_floats() -> String` — a **new** method that renders the document's **List of Figures** and **List of Tables** (LaTeX's `\listoffigures` / `\listoftables`, as plain text) directly from the floats. A single document-order walk threads the **same** `Counters` float counters as `number_labels`, so each float's line number equals its S4 flat figure/table number (a labeled float's List-of number and its `\ref` number agree; figures numbered `1, 2, …`, tables independently from `1`). Each line is `<n>. <caption text>`, where the caption text is the plain rendering of the float's `\caption{…}` inlines (text/code verbatim, space as a single space, font-wrapper content recursively, trimmed — the same descent the caption-reaching test proves), via a private `caption_text(&Option<Caption>)` helper; a float with **no** `\caption` renders the fixed placeholder `(no caption)` so every float still gets a numbered line. The `List of Figures` heading is emitted only when there is ≥1 figure, `List of Tables` only when ≥1 table; a document with no floats → the fixed marker `(no floats)`. Lines joined by `\n`, no trailing newline. Real LaTeX gates these on `\listoffigures` / `\listoftables` commands (not parser-recognised here), so — like S11 — S12 is a method the caller invokes; every S1–S11 output is byte-for-byte unchanged. Pure assembly over existing blocks + the existing float walk — no AST/grammar/counter change, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S13 — `\nameref` resolution to a target's name** | `Document::resolve_namerefs() -> String` — a **new** method that resolves every `\nameref{key}` to the **name** (title/caption text) of its target — the name-valued sibling of `\ref` (number) and `\pageref` (page). `\nameref` is **not** a `REF_COMMAND`, so it appears in neither the resolved nor unresolved ref table (an AST probe confirms it lowers to `Inline::CrossRef { command: "nameref", .. }`); S13 reads the same S1 `\label` table but answers "*what is it called?*", so it is purely additive. One document-order walk collects each `nameref` cross-ref; the key is resolved against the winning label table and the name read from its defining node via the S3 `label_def_node` accessor — a `Section` → its title inlines flattened, a `Figure`/`Table` → its `\caption` via the shared `caption_text` helper (S12's flatten factored into a module-level `flatten_inlines_to_text`, reused by both so they can never drift). An `Equation`/`Inline` target (a number, not a title) → `(no name)`; an undefined key → `(undefined nameref: <key>)`; no `\nameref` at all → `(no namerefs)`. Each line is `\nameref{<key>} -> <name>`, joined by `\n`, no trailing newline. Every S1–S12 output is byte-for-byte unchanged. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -604,6 +605,40 @@ to a section sits under `Sections:`). A report with zero resolved refs renders t
 `(no resolved references)` — the S11 analogue of `to_plain_text`'s `(no cross-references)`. Pure
 report-assembly over data the report already holds — no AST/struct/numbering change, `to_latex()`
 still a fixed point.
+
+### `\nameref` resolution to a target's name (LTXDOC03 S13)
+
+`\ref` prints a target's **number** ("Section 1"); `\pageref` prints its **page**. The `nameref`
+package's `\nameref` prints its **name** — a section's title, a float's caption text. `resolve_namerefs`
+is a **new** method that answers exactly that: it walks the body, finds every `\nameref{key}`, resolves
+the key against the same S1 `\label` table `\ref` uses, and renders the target's name. Because
+`\nameref` is **not** a `REF_COMMAND`, it appears in neither the resolved nor the unresolved reference
+table — S13 reads the same table but asks a different question, so it changes no S1–S12 output.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\caption{A plot}\label{fig:p}\end{figure}
+
+See \nameref{sec:intro}, \nameref{fig:p}, and \nameref{nope}.\end{document}";
+let doc = parse_document(src).unwrap();
+
+// One `\nameref{key} -> <name>` line per reference, in body order.
+assert_eq!(
+    doc.resolve_namerefs(),
+    "\\nameref{sec:intro} -> Introduction\n\
+     \\nameref{fig:p} -> A plot\n\
+     \\nameref{nope} -> (undefined nameref: nope)",
+);
+```
+
+A `Section` target resolves to its title text; a `Figure`/`Table` to its `\caption` text (via the
+**same** `caption_text` descent S12's List-of-Floats uses, so the two agree). An `Equation`/inline-label
+target has a number, not a name, so it renders `(no name)`; an undefined key renders
+`(undefined nameref: <key>)`; a document with no `\nameref` at all renders `(no namerefs)`. Pure
+assembly over existing blocks + the S1 label table — no AST/grammar change, `to_latex()` still a fixed
+point.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1379,6 +1379,121 @@ impl Document {
         }
         lines.join("\n")
     }
+
+    /// Resolve every `\nameref{key}` in the body to the **name** (title/caption text) of its target
+    /// (LTXDOC03 S13).
+    ///
+    /// ## What `\nameref` is, and why it needs its own pass
+    ///
+    /// The `nameref` package's `\nameref{key}` prints the *textual name* of a label's owner rather
+    /// than its number: a `\nameref{sec:intro}` typesets **"Introduction"** (the section's title), not
+    /// "Section 1"; a `\nameref{fig:p}` typesets the figure's **caption text**. It is the name-valued
+    /// sibling of `\ref` (number-valued) and `\pageref` (page-valued).
+    ///
+    /// Crucially, `"nameref"` is **not** in [`REF_COMMANDS`] — the S1 resolver deliberately binds only
+    /// `\ref`/`\eqref`/`\pageref`, so a `\nameref` appears in *neither*
+    /// [`ReferenceResolution::resolved`] nor [`ReferenceResolution::unresolved`]. (The scratch parse
+    /// confirmed this: `\nameref{sec:intro}` lowers to `Inline::CrossRef { command: "nameref", target:
+    /// "sec:intro", .. }`, and `resolve_references()` returns it in no table.) That is *why* S13 is a
+    /// brand-new method rather than a tweak to the resolver — it reads the same `\label` table S1
+    /// builds, but answers a different question (*what is it called?* not *what number is it?*), and
+    /// touches no S1–S12 output.
+    ///
+    /// ## The walk (mirrors S12's `list_of_floats` shape)
+    ///
+    /// One document-order [`Document::walk`], collecting every `Inline::CrossRef` whose `command` is
+    /// `"nameref"`. Each key is resolved against the winning label table
+    /// ([`ReferenceResolution::definition`], the same first-wins table `\ref` uses), then the target's
+    /// **name** is read from its defining node:
+    ///
+    /// - [`LabelKind::Section`] → the section's `title` inlines, flattened via
+    ///   [`flatten_inlines_to_text`] (the exact descent S12 uses for captions): `\nameref{sec:intro}`
+    ///   → `Introduction`.
+    /// - [`LabelKind::Figure`] / [`LabelKind::Table`] → the float's `\caption` text via the shared
+    ///   [`caption_text`] (so a `\nameref` and the List-of-Floats entry read the *same* caption). A
+    ///   float with no caption yields the same `(no caption)` marker `caption_text` returns.
+    /// - [`LabelKind::Equation`] / [`LabelKind::Inline`] → these carry **no** textual name (an
+    ///   equation/bare `\label` has a number, not a title), so they render the fixed marker
+    ///   `(no name)`. This is the honest boundary: `\nameref` to a nameless target is well-defined but
+    ///   has nothing to print.
+    /// - a key that **no** `\label` defines → the fixed placeholder `(undefined nameref: <key>)` (the
+    ///   name-valued analogue of LaTeX's `??`, echoing S1's honest "undefined" boundary).
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// One line per `\nameref`, in body pre-order, formatted `\nameref{<key>} -> <name>` (mirroring the
+    /// `\ref{k} -> …` arrow style of the S6 report). Lines are joined by `\n` with **no** trailing
+    /// newline. A document with **no** `\nameref` at all returns the fixed marker `(no namerefs)`.
+    ///
+    /// Concretely, for
+    /// `\section{Introduction}\label{sec:intro} … \nameref{sec:intro} … \nameref{fig:p} … \nameref{nope}`:
+    ///
+    /// ```text
+    /// \nameref{sec:intro} -> Introduction
+    /// \nameref{fig:p} -> A plot
+    /// \nameref{nope} -> (undefined nameref: nope)
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S13 is a brand-new method that reads existing blocks and the S1 label table; it mutates nothing
+    /// and changes no S1–S12 output (`\nameref` was already parsed into `Inline::CrossRef` and already
+    /// ignored by the resolver). Like S11/S12 it is a method the caller invokes directly (real LaTeX
+    /// gates `\nameref` on loading the `nameref` package, which is not modelled here).
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing; reuses the bounded
+    /// [`Document::walk`], the S1 [`Document::resolve_references`] table, and the S3
+    /// [`Document::label_def_node`] accessor. Borrows `self` immutably and returns owned `String` data.
+    pub fn resolve_namerefs(&self) -> String {
+        // The winning label table `\ref` resolves against — first definition of each key wins. We
+        // build it once and share it across every `\nameref` lookup below.
+        let refs = self.resolve_references();
+
+        let mut lines: Vec<String> = Vec::new();
+        for node in self.walk() {
+            // Only an inline `\nameref{key}` cross-ref carries a nameref key.
+            let NodeRef::Inline(Inline::CrossRef { command, target, .. }) = node else {
+                continue;
+            };
+            if command != "nameref" {
+                continue; // A `\ref`/`\eqref`/`\pageref`/`\cite`/`\label` is not a nameref.
+            }
+
+            // Resolve the key to its winning definition, then read that node's textual name.
+            let name = match refs.definition(target) {
+                None => format!("(undefined nameref: {target})"),
+                Some(def) => self.nameref_name(def),
+            };
+            lines.push(format!("\\nameref{{{target}}} -> {name}"));
+        }
+
+        if lines.is_empty() {
+            return "(no namerefs)".to_string();
+        }
+        lines.join("\n")
+    }
+
+    /// The **name text** a `\nameref` prints for a resolved label definition (LTXDOC03 S13 helper).
+    ///
+    /// Given the winning [`LabelDef`], reach its defining node via [`Document::label_def_node`] (the S3
+    /// span→node accessor) and read the target's name:
+    ///
+    /// - a [`Block::Section`] → its `title` inlines flattened by [`flatten_inlines_to_text`];
+    /// - a [`Block::Figure`]/[`Block::Table`] → its `\caption` via [`caption_text`];
+    /// - anything else (an equation/inline label, or the honest edge where the span is not a walked
+    ///   node) → the fixed `(no name)` marker.
+    ///
+    /// Kept separate so the walk in [`Document::resolve_namerefs`] stays a flat collect + render.
+    /// Pure and total: no panic, one owned `String` out.
+    fn nameref_name(&self, def: &LabelDef) -> String {
+        match self.label_def_node(def) {
+            Some(NodeRef::Block(Block::Section { title, .. })) => flatten_inlines_to_text(title),
+            Some(NodeRef::Block(Block::Figure { caption, .. }))
+            | Some(NodeRef::Block(Block::Table { caption, .. })) => caption_text(caption),
+            // An equation/inline label (or a non-walked span) has a number, not a name.
+            _ => "(no name)".to_string(),
+        }
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -1393,9 +1508,25 @@ fn caption_text(caption: &Option<crate::document::Caption>) -> String {
     let Some(cap) = caption else {
         return "(no caption)".to_string();
     };
-    // Flatten the caption inlines to visible text. Composite font inlines recurse into their
-    // wrapped content; math/cross-ref/accent/other inlines contribute no plain text (matching the
-    // caption-reaching test's text view).
+    flatten_inlines_to_text(&cap.content)
+}
+
+/// Flatten a run of inlines to their **visible plain text**, trimmed (LTXDOC03 S12/S13).
+///
+/// The single descent shared by [`caption_text`] (S12, float captions) and
+/// [`Document::resolve_namerefs`] (S13, section titles) so both name-rendering paths agree on
+/// exactly which inlines contribute text and how:
+///
+/// - [`Inline::Text`] / [`Inline::Code`] → their string verbatim;
+/// - [`Inline::Space`] → a single ASCII space;
+/// - [`Inline::Strong`] / [`Inline::Emph`] / [`Inline::Styled`] → **recurse** into the wrapped
+///   content (a `\textbf{Intro}` heading reads as `Intro`, dropping only the font wrapper);
+/// - every other inline (math, cross-ref, accent, raw) contributes **no** plain text.
+///
+/// Leading/trailing whitespace is trimmed, so `\caption{ x }` and `\section{ Intro }` both read as
+/// their tight text. Returns owned `String` data (one allocation for the accumulator), so the
+/// result outlives any borrow of the source.
+fn flatten_inlines_to_text(inlines: &[Inline]) -> String {
     fn flatten(inlines: &[Inline], out: &mut String) {
         for i in inlines {
             match i {
@@ -1409,7 +1540,7 @@ fn caption_text(caption: &Option<crate::document::Caption>) -> String {
         }
     }
     let mut s = String::new();
-    flatten(&cap.content, &mut s);
+    flatten(inlines, &mut s);
     s.trim().to_string()
 }
 
@@ -3574,5 +3705,90 @@ See Section~\ref{s:i} and \cite{b}.
 Body text with no floats.\end{document}";
         let doc = parse_document(src).expect("parse");
         assert_eq!(doc.list_of_floats(), "(no floats)");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S13 — `\nameref` resolution to a target's title/caption text.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s13_resolves_section_and_figure_names() {
+        // A `\nameref{sec:intro}` → the section's TITLE ("Introduction"); a `\nameref{fig:p}` → the
+        // figure's CAPTION text ("A plot"). Both render `\nameref{key} -> <name>`, in body order.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+See \nameref{sec:intro} and \nameref{fig:p}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+    }
+
+    #[test]
+    fn s13_undefined_key_renders_placeholder() {
+        // A `\nameref{nope}` whose key no `\label` defines renders the fixed `(undefined nameref: …)`
+        // placeholder — the name-valued analogue of LaTeX's `??`. A resolved section name precedes it,
+        // proving the two branches coexist in one deterministic report.
+        let src = r"\begin{document}\section{Methods}\label{sec:m}
+
+See \nameref{sec:m} and \nameref{nope}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:m} -> Methods\n\\nameref{nope} -> (undefined nameref: nope)"
+        );
+    }
+
+    #[test]
+    fn s13_equation_and_inline_targets_have_no_name() {
+        // A `\nameref` to an EQUATION label (a number, not a title) and to a bare inline `\label`
+        // (likewise nameless) both render the fixed `(no name)` marker — the honest boundary.
+        let src = r"\begin{document}\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+Text \label{marker}. See \nameref{eq:e} and \nameref{marker}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{eq:e} -> (no name)\n\\nameref{marker} -> (no name)"
+        );
+    }
+
+    #[test]
+    fn s13_no_namerefs_returns_marker() {
+        // A document with `\ref` but NO `\nameref` returns the fixed `(no namerefs)` marker — a plain
+        // `\ref` is not a nameref, so it never appears in this report.
+        let src = r"\begin{document}\section{Intro}\label{s:i}
+
+See Section~\ref{s:i}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolve_namerefs(), "(no namerefs)");
+    }
+
+    #[test]
+    fn s13_is_additive_leaves_s1_s12_outputs_unchanged() {
+        // S13 reads the document but changes nothing: `\nameref` is absent from BOTH resolved and
+        // unresolved ref tables (it is not a REF_COMMAND), and the S12 list_of_floats is unaffected.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+See Section~\ref{sec:intro}, \nameref{sec:intro}, and \nameref{fig:p}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        let refs = doc.resolve_references();
+        // Exactly ONE resolved ref (the `\ref{sec:intro}`); the two `\nameref`s are in neither table.
+        assert_eq!(refs.resolved.len(), 1, "only the \\ref resolves; \\namerefs are not REF_COMMANDS");
+        assert_eq!(refs.resolved[0].command, "ref");
+        assert!(refs.unresolved.is_empty(), "no undefined refs; \\namerefs are not tabled here either");
+
+        // S12 output is unchanged by S13's presence.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+
+        // And S13 itself renders both namerefs correctly.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1083,3 +1083,77 @@ float-free document returning `(no floats)`). All prior S1–S11 tests pass unch
 latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green;
 `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new
 dependencies.
+
+## 19. S13 — `\nameref` resolution to a target's name (`resolve_namerefs`)
+
+### 19.1 Motivation
+
+`\ref` prints a target's **number** ("Section 1"), `\pageref` prints its **page**. The `nameref`
+package's `\nameref{key}` prints its **name** — a section's *title*, a float's *caption text*. It is the
+name-valued sibling of the number- and page-valued references S1–S12 already model. S13 answers the
+question `\nameref` asks: *what is this label's target called?*
+
+### 19.2 Why a new method, not a change to `REF_COMMANDS`
+
+`"nameref"` is deliberately **not** in `REF_COMMANDS = ["ref", "eqref", "pageref"]`. An AST probe
+confirms `\nameref{sec:intro}` lowers to `Inline::CrossRef { command: "nameref", target: "sec:intro",
+note: None, span }` — the key is fully recoverable — and that `resolve_references()` returns it in
+**neither** the resolved **nor** the unresolved table (it is not a `REF_COMMAND`, so the S1 resolver
+skips it entirely). Adding `"nameref"` to `REF_COMMANDS` would change S1–S12 output (a `\nameref` would
+suddenly appear in the resolved/unresolved tables and the S6 report), violating additivity. So S13 is a
+**new public method** that reads the same S1 `\label` table but answers a *different* question, leaving
+every S1–S12 output — including `to_latex()`'s round-trip fixed point — byte-for-byte unchanged.
+
+### 19.3 What S13 does — `Document::resolve_namerefs(&self) -> String`
+
+A single document-order walk (`Document::walk`) collects every `Inline::CrossRef` whose `command` is
+`"nameref"`. Each key is resolved against the **winning** label table (`ReferenceResolution::definition`,
+the same first-definition-wins table `\ref` resolves against, built once via `resolve_references`), then
+the target's **name** is read from its defining node (reached by the S3 `label_def_node` accessor):
+
+- a `Block::Section` target → its `title` inlines flattened to visible text via a module-level
+  `flatten_inlines_to_text(&[Inline]) -> String` (`Text`/`Code` verbatim, `Space` → one space,
+  `Strong`/`Emph`/`Styled` recursed, trimmed);
+- a `Block::Figure`/`Block::Table` target → its `\caption` text via the **shared** `caption_text`
+  helper (so a `\nameref` and the S12 List-of-Floats entry read the *same* caption; an uncaptioned
+  float yields the `(no caption)` marker `caption_text` returns);
+- a `LabelKind::Equation`/`LabelKind::Inline` target → the fixed marker `(no name)` (an equation or a
+  bare `\label` has a *number*, not a title — the honest boundary);
+- a key that **no** `\label` defines → the fixed placeholder `(undefined nameref: <key>)` (the
+  name-valued analogue of LaTeX's `??`).
+
+To keep S12's caption descent and S13's title descent from ever diverging, the flatten logic previously
+nested inside `caption_text` is factored into the module-level `flatten_inlines_to_text`, which **both**
+`caption_text` and `resolve_namerefs` call.
+
+### 19.4 Assembly rules
+
+- One line per `\nameref`, in body pre-order, formatted `\nameref{<key>} -> <name>` (mirroring the S6
+  `\ref{k} -> …` arrow).
+- Lines are joined by `\n` with **no** trailing newline.
+- A document with **no** `\nameref` at all returns the fixed marker `(no namerefs)`.
+
+Example (a section, a captioned figure, and an undefined key):
+
+```text
+\nameref{sec:intro} -> Introduction
+\nameref{fig:p} -> A plot
+\nameref{nope} -> (undefined nameref: nope)
+```
+
+### 19.5 Public API (added in S13)
+
+One new method: `Document::resolve_namerefs(&self) -> String`, plus a private `nameref_name(&LabelDef)`
+helper and the module-level `flatten_inlines_to_text` (factored out of `caption_text`). No existing
+type, field, counter, or signature changes; `REF_COMMANDS` is **unchanged**; no AST or grammar change;
+no new dependency, no `unsafe`, no I/O.
+
+### 19.6 Verification (S13)
+
+`cargo test -p latex` green (5 new S13 tests: a section+figure resolving to `Introduction` / `A plot`;
+an undefined key rendering `(undefined nameref: nope)`; an equation + inline label both rendering
+`(no name)`; a `\ref`-only document returning `(no namerefs)`; and an additivity check that the two
+`\namerefs` stay out of the resolved/unresolved ref tables and `list_of_floats` is unchanged). All prior
+S1–S12 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
+`cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
+`cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S13 — `\nameref` support (resolve to the target's *name text*)

S1–S12 are done (cross-reference resolution; per-command `\eqref`/`\pageref` rendering; grouped-by-kind report; List of Figures/Tables index). S13 adds **`\nameref` resolution** — a `\nameref{key}` yields the **target's title/caption text**, not its number.

### What S13 adds
A **new method** that walks the parsed body and names every `\nameref`:

```
\nameref{sec:intro} -> Introduction
\nameref{fig:p} -> A plot
\nameref{nope} -> (undefined nameref: nope)
```

```rust
pub fn resolve_namerefs(&self) -> String
```

- One line per `\nameref` in body pre-order, formatted `\nameref{<key>} -> <name>`, joined by `\n`, no trailing newline.
- `<name>` is the resolved target's **name text**: a **section title** (flattened inlines) for section labels, or the **caption text** for figures/tables — reusing S12's caption extraction, now factored into a shared `flatten_inlines_to_text` helper (`caption_text` calls it too, so S12 output is unchanged).
- Equation and inline-marker labels have no name → `(no name)`; an unresolved key → `(undefined nameref: <key>)`; a document with **no** `\nameref` → the fixed marker `(no namerefs)`.

### Additive by construction
`\nameref` is **not** in `REF_COMMANDS` (`= ["ref","eqref","pageref"]`), so it never entered the S1 resolution tables — investigation confirmed `\nameref{key}` lowers to `Inline::CrossRef { command: "nameref", target: key, .. }`, appearing in **neither** the resolved nor the unresolved sets. S13 is therefore a **new read-only method** that scans for these nodes independently; `REF_COMMANDS` is untouched and every S1–S12 output (resolution, numbering, `list_of_floats`, `to_plain_text_by_kind`, `cross_reference_report`, `to_latex` fixed point) is **byte-for-byte unchanged**. No AST/grammar/counter change, no new deps, no `unsafe`, no I/O. latex `0.48.0 → 0.49.0`.

### Verification (from `code/packages/rust/`)
- `cargo test -p latex` → **376 passed** (371 prior + 5 new `s13_*`; assert exact strings: section+figure names, the `(undefined nameref: …)` placeholder, `(no name)` for equation/inline targets, the empty `(no namerefs)` marker, and an **additivity test** pinning `list_of_floats()` and `resolve_references()` counts to their S12 values).
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green. `cargo build -p latex --no-default-features` → builds.
- Single-parent; scoped diff = latex crate source + Cargo.toml + CHANGELOG.md + README.md + the LTXDOC03 spec. Inline security review PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
