### PR TITLE
fix(sir-rust): no-panic string/symbol ordering in num_lt (v0.21.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.21.0 — string/symbol ordering: no-panic `num_lt` comparator
+
+Fixes a reachable panic on the OO surface: the runtime's ordering primitive
+`num_lt` (used by the `<`/`>` operators and by `sort`/`min`/`max`/`sort_by`/
+`min_by`/`max_by`) fell through to `as_f64` for any non-`Int` pair, which
+**panics** on a string, symbol, nil, etc. So a valid Ruby `["b", "a"].sort` or
+`"a" < "b"` crashed the emitted program.
+
+`num_lt` now compares strings and symbols **lexicographically**, numbers
+numerically, and returns `false` (a stable, defined order — never a panic) for
+a genuinely mixed/uncomparable pair. `sort`/`min`/`max`/`sort_by`/… therefore
+work on string/symbol arrays, and the `<`/`>` operators no longer crash on a
+non-numeric operand. (Ruby raises `ArgumentError` on a genuinely uncomparable
+`<`; that typed-error refinement is a separate follow-up — this change removes
+the uncontrolled panic.)
+
+Verified end-to-end under `rustc`: `["banana","apple","cherry"].sort` →
+`[apple, banana, cherry]`, string `min`/`max`, `"apple" < "banana"` → true, and
+a mixed `"apple" < 1` → false (no panic).
+
 ## 0.20.0 — Array block-method breadth (sort_by / group_by / partition / …)
 
 Extends the emitted runtime's `array_method` catalog with the common

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -479,7 +479,20 @@ pub const RUNTIME: &str = r##"mod __sir {
     fn num_lt(a: &Value, b: &Value) -> bool {
         match (a, b) {
             (Value::Int(x), Value::Int(y)) => x < y,
-            _ => as_f64(a) < as_f64(b),
+            // Strings and symbols compare lexicographically (Ruby `<`/`sort`).
+            (Value::Str(x), Value::Str(y)) => x < y,
+            (Value::Sym(x), Value::Sym(y)) => x < y,
+            (Value::Int(_) | Value::Float(_), Value::Int(_) | Value::Float(_)) => {
+                as_f64(a) < as_f64(b)
+            }
+            // Mixed / uncomparable types: no defined order.  We return `false`
+            // rather than feeding a non-number to `as_f64` (which panicked) —
+            // upholding the never-panic-on-the-OO-surface invariant.  `sort`/
+            // `min`/`max`/`sort_by` then keep a stable order; the `<`/`>`
+            // operators yield `false` (Ruby raises `ArgumentError` on a
+            // genuinely uncomparable `<` — the typed-error refinement is a
+            // separate follow-up).
+            _ => false,
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_collection_methods.rs
@@ -406,3 +406,61 @@ fn array_block_methods_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+/// String/symbol ordering: `sort`/`min`/`max`/`<` on non-numeric values must
+/// compare lexicographically and NEVER panic (the pre-fix `num_lt` fed strings
+/// to `as_f64`, which panicked — so a Ruby string sort crashed the program).
+fn string_ordering_demo() -> Module {
+    let strs = || seq(vec![slit("banana"), slit("apple"), slit("cherry")]);
+    let main_stmts = vec![
+        print_stmt(method(strs(), "sort", vec![])),         // [apple, banana, cherry]
+        print_stmt(method(strs(), "min", vec![])),          // apple
+        print_stmt(method(strs(), "max", vec![])),          // cherry
+        print_stmt(call("<", vec![slit("apple"), slit("banana")])), // #t
+        // Mixed, genuinely-uncomparable `<` must NOT panic — returns #f.
+        print_stmt(call("<", vec![slit("apple"), ilit(1)])), // #f
+    ];
+    demo_module(main_stmts, vec![])
+}
+
+#[test]
+fn string_ordering_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+    let artifact = compile(&string_ordering_demo()).expect("module should compile to Rust source");
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_strord_{nonce}.rs"));
+    let bin_path = dir.join(format!("sir_strord_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker") && (stderr.contains("not found") || stderr.contains("No such file")) {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!("emitted Rust failed to compile:\n{stderr}\n--- source ---\n{}", artifact.source);
+    }
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(run_out.status.success(), "binary exited non-zero (string sort must not panic):\n{}", String::from_utf8_lossy(&run_out.stderr));
+    let stdout = String::from_utf8_lossy(&run_out.stdout).replace("\r\n", "\n");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec!["[apple, banana, cherry]", "apple", "cherry", "#t", "#f"],
+        "unexpected output; full stdout:\n{stdout}"
+    );
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Fixes a **reachable panic** on the Rust backend's OO surface. `num_lt` — the ordering primitive behind the `<`/`>` operators **and** `sort`/`min`/`max`/`sort_by`/`min_by`/`max_by` — fell through to `as_f64(a) < as_f64(b)` for any non-`Int` pair, and `as_f64` **panics** on a non-number. So a perfectly valid Ruby `["b","a"].sort` or `"a" < "b"` **crashed the emitted program**.

## Fix
`num_lt` now:
- compares `Str`/`Str` and `Sym`/`Sym` **lexicographically** (`Rc<str>` `Ord`),
- numeric pairs numerically (unchanged),
- returns `false` (a stable, defined order — **never a panic**) for a genuinely mixed/uncomparable pair.

So string/symbol `sort`/`min`/`max` work, and `<`/`>` no longer crash on a non-numeric operand. (Ruby raises `ArgumentError` on a genuinely uncomparable `<`; that typed-error refinement is a separate follow-up — this removes the *uncontrolled panic*.)

## Safety
Security review passed: `as_f64` is now only reached for Int/Float pairs (panic removed, none introduced); numeric path byte-identical; Rust `sort` never panics on a non-total comparator (only unspecified order); no injection/reflection.

## Verification
Exec-proof under `rustc`: `["banana","apple","cherry"].sort` → `[apple, banana, cherry]`, string `min`/`max`, `"apple" < "banana"` → true, mixed `"apple" < 1` → false (no panic). Full crate suite green.

Note: Go's `_sir_value_lt` is already safe; Python/JS/TS use `<`/native (non-throwing for strings). This closes the Rust-specific gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)