### PR TITLE
feat(sir-go): more Array methods — zip / rotate / to_h / tally (v0.21.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.21.0 — more Array methods: `zip` / `rotate` / `to_h` / `tally`
+
+Extends the emitted Go runtime's non-block `Array` catalog and the
+`respond_to?` table:
+
+- `zip(*others)` — Array of tuples `[a[i], b[i], …]`, length = the receiver's;
+  a shorter operand pads with nil; a non-array operand is treated as empty.
+- `rotate(n = 1)` — elements rotated left by `n` (a negative `n` rotates
+  right); the modulo wraps so any `n` terminates without panicking.
+- `to_h` — `[[k, v], …]` → a Hash (2-element-array elements only; others
+  skipped, matching the never-raise floor).
+- `tally` — a Hash of element → occurrence count, first-seen order, keyed by
+  structural value-equality.
+
+Verified end-to-end under `go run`.
+
 ## 0.20.0 — Array block-method breadth (sort_by / group_by / partition / …)
 
 Mirrors the Rust backend's array block-method batch to Go: extends

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1691,7 +1691,8 @@ func _sir_array_responds(name string) bool {
 	// Non-block Array methods.
 	case "length", "size", "count", "first", "last", "empty?", "include?",
 		"index", "push", "append", "<<", "pop", "shift", "reverse", "sort",
-		"min", "max", "sum", "uniq", "flatten", "compact",
+		"min", "max", "sum", "uniq", "flatten", "compact", "zip", "rotate",
+		"to_h", "tally",
 		"join", "fetch", "to_a":
 		return true
 	// Block-taking Array/Enumerable methods.
@@ -1919,6 +1920,73 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 			}
 		}
 		return &Seq{Items: out}, true
+	case "zip":
+		// `a.zip(b, c, ...)` -> an Array of tuples `[a[i], b[i], ...]`, length =
+		// `len(a)`; a shorter operand pads with nil. Non-array operands are
+		// treated as empty (pad-only), never raising.
+		others := make([]*Seq, 0, len(args))
+		for _, o := range args {
+			if zs, ok := o.(*Seq); ok {
+				others = append(others, zs)
+			} else {
+				others = append(others, &Seq{Items: nil})
+			}
+		}
+		zipped := make([]Value, len(recv.Items))
+		for i, x := range recv.Items {
+			tuple := make([]Value, 0, len(others)+1)
+			tuple = append(tuple, x)
+			for _, o := range others {
+				if i < len(o.Items) {
+					tuple = append(tuple, o.Items[i])
+				} else {
+					tuple = append(tuple, nil)
+				}
+			}
+			zipped[i] = &Seq{Items: tuple}
+		}
+		return &Seq{Items: zipped}, true
+	case "rotate":
+		// `a.rotate(n=1)` -> elements rotated left by n (negative rotates right);
+		// the modulo wraps so any n terminates without panicking.
+		n := int64(1)
+		if len(args) > 0 {
+			n = _sir_as_int_trunc(args[0])
+		}
+		length := int64(len(recv.Items))
+		if length == 0 {
+			return &Seq{Items: []Value{}}, true
+		}
+		shift := ((n % length) + length) % length
+		rot := make([]Value, 0, length)
+		rot = append(rot, recv.Items[shift:]...)
+		rot = append(rot, recv.Items[:shift]...)
+		return &Seq{Items: rot}, true
+	case "to_h":
+		// `[[k, v], ...].to_h` -> a Hash. Each 2-element Array contributes a pair;
+		// anything else is skipped (Ruby raises TypeError - deferred to the typed-
+		// error cascade; the never-raise floor keeps a controlled result here).
+		keys := []Value{}
+		vals := []Value{}
+		for _, x := range recv.Items {
+			if pair, ok := x.(*Seq); ok && len(pair.Items) == 2 {
+				keys = append(keys, pair.Items[0])
+				vals = append(vals, pair.Items[1])
+			}
+		}
+		return _sir_map_lit(keys, vals), true
+	case "tally":
+		// `a.tally` -> a Hash of element -> occurrence count, in first-seen order.
+		// Keys use structural value-equality (via `_sir_map_get`).
+		acc := _sir_map_lit([]Value{}, []Value{})
+		for _, x := range recv.Items {
+			n := int64(0)
+			if c, ok := _sir_map_get(acc, x).(int64); ok {
+				n = c
+			}
+			_sir_map_set(acc, x, n+1)
+		}
+		return acc, true
 	case "to_a":
 		return recv, true
 	}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_coll_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_coll_methods.rs
@@ -429,3 +429,83 @@ fn array_block_methods_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+/// More non-block Array methods: `zip`, `rotate`, `to_h`, `tally`.
+fn array_more_module() -> Module {
+    let stmts = vec![
+        // [1,2,3].zip([4,5,6]) -> [[1, 4], [2, 5], [3, 6]]
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(3)]),
+            "zip",
+            vec![seq(vec![ilit(4), ilit(5), ilit(6)])],
+        )),
+        // [1,2,3,4,5].rotate(2) -> [3, 4, 5, 1, 2]
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]), "rotate", vec![ilit(2)])),
+        // [1,2,3].rotate -> [2, 3, 1]
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "rotate", vec![])),
+        // [["a",1],["b",2]].to_h -> {a=>1, b=>2}  (keys via Hash#keys)
+        print_stmt(method(
+            method(
+                seq(vec![
+                    seq(vec![slit("a"), ilit(1)]),
+                    seq(vec![slit("b"), ilit(2)]),
+                ]),
+                "to_h",
+                vec![],
+            ),
+            "keys",
+            vec![],
+        )), // [a, b]
+        // [1,1,2,3,3,3].tally -> {1=>2, 2=>1, 3=>3}  (values via Hash#values)
+        print_stmt(method(
+            method(
+                seq(vec![ilit(1), ilit(1), ilit(2), ilit(3), ilit(3), ilit(3)]),
+                "tally",
+                vec![],
+            ),
+            "values",
+            vec![],
+        )), // [2, 1, 3]
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    program(vec![main])
+}
+
+#[test]
+fn array_more_methods_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&array_more_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "arrmore");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "[[1, 4], [2, 5], [3, 6]]", // zip
+            "[3, 4, 5, 1, 2]",          // rotate(2)
+            "[2, 3, 1]",                // rotate
+            "[a, b]",                   // to_h -> keys
+            "[2, 1, 3]",                // tally -> values
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## What

Extends the emitted Go runtime's non-block `Array` catalog (in `semantic-ir-to-go`) with four more common Ruby methods, plus their `respond_to?` entries:

- **`zip(*others)`** — array of tuples `[a[i], b[i], …]`, length = the receiver's; shorter operands pad with `nil`; a non-array operand is treated as empty.
- **`rotate(n = 1)`** — elements rotated left by `n` (negative `n` rotates right); modulo-wrapped so any `n` terminates without panicking.
- **`to_h`** — `[[k, v], …]` → Hash (only 2-element-array elements; others skipped, per the never-raise floor).
- **`tally`** — Hash of element → occurrence count, first-seen order, structural value-equality keys.

## Why

Continues the cross-backend Array stdlib-breadth lane (Rust/Python/JS already have these; Go was missing them). Stays out of the maintainers' active frontier — pure runtime-library breadth.

## Safety

Dispatch stays receiver-type routed via explicit `switch` cases — no reflection on source-derived names. Never-panic invariant holds: all type assertions use the two-value `, ok` form; `rotate`'s modulo lands in `[0, length)` for any `int64` (early-return on empty guarantees a positive divisor, so `MinInt64 % -1` is unreachable); `zip`/`to_h` bounds-guard every index. Security review passed (0 findings).

## Verification

- `cargo test -p semantic-ir-to-go` green; new `array_more_methods_compile_and_run` executes emitted Go under `go run` and matches expected stdout for all five assertions.
- Lisp/Twig default path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)