### PR TITLE
feat(spreadsheet-android-jni,jni-bridge): file open/save over JNI — byte[] in/out (SSIO PR7)

### DIFF
--- a/code/packages/rust/jni-bridge/CHANGELOG.md
+++ b/code/packages/rust/jni-bridge/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — jni-bridge
 
+## [0.2.0] — 2026-07-07
+
+### Added
+
+Byte-array support, so file bytes (a spreadsheet a user opened, or a document to
+download) can cross the JNI boundary as a Java `byte[]`.
+
+- `jbyteArray` type alias (a `jarray` of `jbyte`).
+- Raw slot wrappers at their JNI-spec offsets (derived from the existing
+  `NewDoubleArray` = 182 / `SetDoubleArrayRegion` = 214 anchors): `GetArrayLength`
+  = 171, `NewByteArray` = 176, `GetByteArrayRegion` = 200, `SetByteArrayRegion` =
+  208 → `jni_get_array_length`, `jni_new_byte_array`, `jni_get_byte_array_region`,
+  `jni_set_byte_array_region`.
+- Convenience wrappers: `jni_get_byte_array(env, arr) -> Vec<u8>` (length query +
+  one region copy; `jbyte`/`u8` share a bit pattern) and
+  `jni_new_byte_array_from(env, &[u8]) -> jbyteArray`. Both null-safe.
+- 2 tests against a **mock JNIEnv function table** (a `[*const c_void; 232]` with
+  the byte-array slots pointing at Rust emulators; a `jbyteArray` modelled as a
+  `*mut Vec<u8>`): a bytes round-trip that keeps a high bit (`0xD0`, the `.xls`
+  magic), and empty/null-array safety.
+
 ## [0.1.0] — 2026-06-13
 
 ### Added

--- a/code/packages/rust/jni-bridge/Cargo.toml
+++ b/code/packages/rust/jni-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jni-bridge"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Zero-dependency Rust wrapper for the Java Native Interface (JNI)"
 publish = false

--- a/code/packages/rust/jni-bridge/README.md
+++ b/code/packages/rust/jni-bridge/README.md
@@ -67,3 +67,9 @@ pub unsafe extern "C" fn Java_com_example_Foo_greet(
 | `jni_set_object_field(env, obj, fid, val)` | 104 | Set object field |
 | `jni_new_double_array(env, len)` | 182 | Create `double[]` |
 | `jni_set_double_array_region(env, arr, s, l, buf)` | 214 | Fill `double[]` from buffer |
+| `jni_get_array_length(env, arr)` | 171 | Length of any array |
+| `jni_new_byte_array(env, len)` | 176 | Create `byte[]` |
+| `jni_get_byte_array_region(env, arr, s, l, buf)` | 200 | Copy `byte[]` → buffer |
+| `jni_set_byte_array_region(env, arr, s, l, buf)` | 208 | Fill `byte[]` from buffer |
+| `jni_get_byte_array(env, arr)` → `Vec<u8>` | — | `byte[]` → owned bytes (null-safe) |
+| `jni_new_byte_array_from(env, &[u8])` | — | owned bytes → `byte[]` |

--- a/code/packages/rust/jni-bridge/src/lib.rs
+++ b/code/packages/rust/jni-bridge/src/lib.rs
@@ -120,6 +120,8 @@ pub type jthrowable = jobject;
 pub type jstring   = jobject;
 /// JNI array reference.
 pub type jarray    = jobject;
+/// JNI `byte[]` reference (a `jarray` whose elements are `jbyte`).
+pub type jbyteArray = jarray;
 /// JNI method ID — identifies a Java method; not a GC root.
 pub type jmethodID = *mut c_void;
 /// JNI field ID — identifies a Java field; not a GC root.
@@ -214,7 +216,11 @@ const SET_DOUBLE_FIELD_OFFSET:        usize = 112; // void SetDoubleField(env, o
 const NEW_STRING_UTF_OFFSET:          usize = 167; // jstring NewStringUTF(env, utf8)
 const GET_STRING_UTF_CHARS_OFFSET:    usize = 169; // const char* GetStringUTFChars(env, str, isCopy)
 const RELEASE_STRING_UTF_CHARS_OFFSET:usize = 170; // void ReleaseStringUTFChars(env, str, chars)
+const GET_ARRAY_LENGTH_OFFSET:        usize = 171; // jsize GetArrayLength(env, array)
+const NEW_BYTE_ARRAY_OFFSET:          usize = 176; // jbyteArray NewByteArray(env, len)
 const NEW_DOUBLE_ARRAY_OFFSET:        usize = 182; // jarray NewDoubleArray(env, len)
+const GET_BYTE_ARRAY_REGION_OFFSET:   usize = 200; // void GetByteArrayRegion(env, arr, start, len, buf)
+const SET_BYTE_ARRAY_REGION_OFFSET:   usize = 208; // void SetByteArrayRegion(env, arr, start, len, buf)
 const SET_DOUBLE_ARRAY_REGION_OFFSET: usize = 214; // void SetDoubleArrayRegion(env, arr, start, len, buf)
 const GET_JAVA_VM_OFFSET:             usize = 219; // jint GetJavaVM(env, JavaVM**)
 const EXCEPTION_CHECK_OFFSET:         usize = 228; // jboolean ExceptionCheck(env)
@@ -505,6 +511,103 @@ pub unsafe fn jni_set_double_array_region(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Byte arrays (JNI spec §Array Operations) — for passing file bytes to/from Java
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// A Java `byte[]` is the natural carrier for a spreadsheet file's raw bytes
+// (an `.xlsx` a user opened, or a document to download). The two convenience
+// wrappers below hide the raw JNI dance: `jni_get_byte_array` copies a `byte[]`
+// into an owned `Vec<u8>` (length query + one region copy — `jbyte` is `i8`, the
+// same bit pattern as `u8`), and `jni_new_byte_array_from` allocates a fresh
+// `byte[]` and fills it from a `&[u8]`. Both are safe against a null array.
+
+/// `GetArrayLength` — the element count of any Java array.
+///
+/// # Safety
+/// `env` must be a valid JNIEnv; `arr` a valid array ref or null (→ 0).
+pub unsafe fn jni_get_array_length(env: *mut JNIEnv, arr: jarray) -> jsize {
+    if arr.is_null() {
+        return 0;
+    }
+    type F = unsafe extern "C" fn(*mut JNIEnv, jarray) -> jsize;
+    let f: F = table_fn(env, GET_ARRAY_LENGTH_OFFSET);
+    f(env, arr)
+}
+
+/// `NewByteArray` — allocate an empty Java `byte[]` of `len` bytes. Null on OOM.
+///
+/// # Safety
+/// `env` must be a valid JNIEnv.
+pub unsafe fn jni_new_byte_array(env: *mut JNIEnv, len: jsize) -> jbyteArray {
+    type F = unsafe extern "C" fn(*mut JNIEnv, jsize) -> jbyteArray;
+    let f: F = table_fn(env, NEW_BYTE_ARRAY_OFFSET);
+    f(env, len)
+}
+
+/// `GetByteArrayRegion` — copy `len` bytes from `arr` (starting at `start`) into
+/// `buf`. `jbyte` is `i8`; the caller reinterprets the identical bits as `u8`.
+///
+/// # Safety
+/// `env` valid; `arr` a valid `byte[]`; `buf` writable for `len` `jbyte`s.
+pub unsafe fn jni_get_byte_array_region(
+    env: *mut JNIEnv,
+    arr: jbyteArray,
+    start: jsize,
+    len: jsize,
+    buf: *mut jbyte,
+) {
+    type F = unsafe extern "C" fn(*mut JNIEnv, jbyteArray, jsize, jsize, *mut jbyte);
+    let f: F = table_fn(env, GET_BYTE_ARRAY_REGION_OFFSET);
+    f(env, arr, start, len, buf);
+}
+
+/// `SetByteArrayRegion` — copy `len` bytes from `buf` into `arr` at `start`.
+///
+/// # Safety
+/// `env` valid; `arr` a valid `byte[]`; `buf` readable for `len` `jbyte`s.
+pub unsafe fn jni_set_byte_array_region(
+    env: *mut JNIEnv,
+    arr: jbyteArray,
+    start: jsize,
+    len: jsize,
+    buf: *const jbyte,
+) {
+    type F = unsafe extern "C" fn(*mut JNIEnv, jbyteArray, jsize, jsize, *const jbyte);
+    let f: F = table_fn(env, SET_BYTE_ARRAY_REGION_OFFSET);
+    f(env, arr, start, len, buf);
+}
+
+/// Copy a Java `byte[]` into an owned `Vec<u8>`. A null array yields an empty
+/// vec. `jbyte` (`i8`) and `u8` share a bit pattern, so the region copies
+/// straight into a `u8` buffer.
+///
+/// # Safety
+/// `env` must be a valid JNIEnv; `arr` a valid `byte[]` ref or null.
+pub unsafe fn jni_get_byte_array(env: *mut JNIEnv, arr: jbyteArray) -> Vec<u8> {
+    let len = jni_get_array_length(env, arr);
+    if arr.is_null() || len <= 0 {
+        return Vec::new();
+    }
+    let mut buf = vec![0u8; len as usize];
+    jni_get_byte_array_region(env, arr, 0, len, buf.as_mut_ptr() as *mut jbyte);
+    buf
+}
+
+/// Allocate a fresh Java `byte[]` and fill it from a `&[u8]`. Returns null if
+/// the allocation fails (an `OutOfMemoryError` is then pending).
+///
+/// # Safety
+/// `env` must be a valid JNIEnv.
+pub unsafe fn jni_new_byte_array_from(env: *mut JNIEnv, bytes: &[u8]) -> jbyteArray {
+    let len = bytes.len() as jsize;
+    let arr = jni_new_byte_array(env, len);
+    if !arr.is_null() && len > 0 {
+        jni_set_byte_array_region(env, arr, 0, len, bytes.as_ptr() as *const jbyte);
+    }
+    arr
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Local reference frames (JNI spec §5.1.2)
 // ─────────────────────────────────────────────────────────────────────────────
 //
@@ -792,4 +895,97 @@ pub unsafe fn jni_detach_current_thread(vm: *mut JavaVM) {
     type F = unsafe extern "C" fn(*mut JavaVM) -> jint;
     let f: F = vm_table_fn(vm, VM_DETACH_CURRENT_THREAD_OFFSET);
     f(vm);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// A real JNIEnv comes only from a running JVM, so we verify the byte-array
+// helpers against a MOCK function table: a `[*const c_void; N]` with the four
+// byte-array slots (at the same offset constants the helpers use) pointing at
+// Rust functions that emulate the JVM's behaviour. A `jbyteArray` is modelled as
+// a `*mut Vec<u8>`. This exercises the offset dispatch AND the get/new wrappers'
+// length-query + region-copy logic end to end.
+#[cfg(test)]
+mod byte_array_tests {
+    use super::*;
+    use std::os::raw::c_void;
+
+    unsafe extern "C" fn mock_new_byte_array(_env: *mut JNIEnv, len: jsize) -> jbyteArray {
+        Box::into_raw(Box::new(vec![0u8; len.max(0) as usize])) as jbyteArray
+    }
+    unsafe extern "C" fn mock_get_array_length(_env: *mut JNIEnv, arr: jarray) -> jsize {
+        (*(arr as *mut Vec<u8>)).len() as jsize
+    }
+    unsafe extern "C" fn mock_get_byte_array_region(
+        _env: *mut JNIEnv,
+        arr: jbyteArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jbyte,
+    ) {
+        let v = &*(arr as *mut Vec<u8>);
+        for i in 0..len as usize {
+            *buf.add(i) = v[start as usize + i] as jbyte;
+        }
+    }
+    unsafe extern "C" fn mock_set_byte_array_region(
+        _env: *mut JNIEnv,
+        arr: jbyteArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jbyte,
+    ) {
+        let v = &mut *(arr as *mut Vec<u8>);
+        for i in 0..len as usize {
+            v[start as usize + i] = *buf.add(i) as u8;
+        }
+    }
+
+    /// Build a mock JNIEnv: a 232-slot table with the byte-array slots filled.
+    /// Returns the boxed table (which must outlive `env`) and the env pointer.
+    fn mock_env() -> (Box<[*const c_void; 232]>, Box<JNIEnv>) {
+        let mut table: Box<[*const c_void; 232]> = Box::new([std::ptr::null(); 232]);
+        table[GET_ARRAY_LENGTH_OFFSET] = mock_get_array_length as *const c_void;
+        table[NEW_BYTE_ARRAY_OFFSET] = mock_new_byte_array as *const c_void;
+        table[GET_BYTE_ARRAY_REGION_OFFSET] = mock_get_byte_array_region as *const c_void;
+        table[SET_BYTE_ARRAY_REGION_OFFSET] = mock_set_byte_array_region as *const c_void;
+        // JNIEnv is a pointer to the table base (`*const *const c_void`).
+        let env: Box<JNIEnv> = Box::new(table.as_ptr() as *const *const c_void);
+        (table, env)
+    }
+
+    #[test]
+    fn round_trips_bytes_through_a_java_byte_array() {
+        unsafe {
+            let (_table, mut env) = mock_env();
+            let envp: *mut JNIEnv = &mut *env;
+            // Rust bytes → new byte[] → read them back: identical, including a
+            // high bit (0xD0, the .xls magic) that i8/u8 reinterpretation covers.
+            let src = [0xD0u8, 0xCF, 0x00, 0x7F, 0xFFu8, 42];
+            let arr = jni_new_byte_array_from(envp, &src);
+            assert!(!arr.is_null());
+            assert_eq!(jni_get_array_length(envp, arr), src.len() as jsize);
+            assert_eq!(jni_get_byte_array(envp, arr), src);
+            drop(Box::from_raw(arr as *mut Vec<u8>)); // free the mock object
+        }
+    }
+
+    #[test]
+    fn empty_and_null_arrays_are_safe() {
+        unsafe {
+            let (_table, mut env) = mock_env();
+            let envp: *mut JNIEnv = &mut *env;
+            // Empty input → a real, zero-length array; reads back empty.
+            let arr = jni_new_byte_array_from(envp, &[]);
+            assert!(!arr.is_null());
+            assert_eq!(jni_get_array_length(envp, arr), 0);
+            assert!(jni_get_byte_array(envp, arr).is_empty());
+            drop(Box::from_raw(arr as *mut Vec<u8>));
+            // Null array → length 0 and an empty vec, never a deref crash.
+            assert_eq!(jni_get_array_length(envp, std::ptr::null_mut()), 0);
+            assert!(jni_get_byte_array(envp, std::ptr::null_mut()).is_empty());
+        }
+    }
 }

--- a/code/packages/rust/spreadsheet-android-jni/CHANGELOG.md
+++ b/code/packages/rust/spreadsheet-android-jni/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog — spreadsheet-android-jni
+
+## [0.2.0] — 2026-07-07
+
+### Added
+
+**File open / save over JNI — a Java `byte[]` in, a `byte[]` out (SSIO PR7).**
+The Android host can now open a real spreadsheet file the user picked and save
+the current document as one, over the one engine — the Android arm of the same
+open/save story as the WASM (`spreadsheet-wasm`) and C-ABI (`spreadsheet-capi`)
+facades.
+
+- `nativeLoadXlsx` / `nativeLoadXls` / `nativeLoadCsv` / `nativeLoadTsv` /
+  `nativeLoadJson` `(handle: jlong, data: byte[]) -> boolean` — read a file's
+  bytes and replace the current document; `true` = opened, `false` = not a
+  readable file of that format (or a dead handle). A failed open leaves the
+  document untouched.
+- `nativeSaveXlsx` / `nativeSaveXls` / `nativeSaveCsv` / `nativeSaveTsv` /
+  `nativeSaveJson` `(handle: jlong) -> byte[]` — serialize the current document
+  to that format's bytes.
+- Wraps `SpreadsheetSession`'s `*_bytes` methods; the `byte[]` marshalling uses
+  `jni-bridge` 0.2.0's new `jni_get_byte_array` / `jni_new_byte_array_from` (a
+  `byte[]` carries raw file bytes intact — an `.xlsx` is a ZIP, an `.xls` an OLE2
+  file — with no UTF-8 / NUL surprises).
+- `.xlsx` keeps live formulas; `.xls` / CSV / TSV / JSON are lower-fidelity
+  (values only) per `spreadsheet-io`. Verified: host build + Android
+  (`aarch64-linux-android`) compile; the byte marshalling is covered by
+  `jni-bridge`'s mock-JNIEnv tests.
+
+## [0.1.0]
+
+### Added
+
+Initial release. JNI bridge from the `com.example.visicalc` Android host to the
+shared Rust spreadsheet engine: `nativeNewSession` / `nativeFree`,
+`nativeSetCell`, `nativeGetDisplay` / `nativeGetRaw`, `nativeGetDisplayWindow`,
+`nativeColumnLetters` — all `Java_<package>_<Class>_<method>` exports over the
+zero-dependency `jni-bridge` crate.

--- a/code/packages/rust/spreadsheet-android-jni/Cargo.toml
+++ b/code/packages/rust/spreadsheet-android-jni/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spreadsheet-android-jni"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "JNI native library bridging the com.example.visicalc Android host to spreadsheet-core"
 publish = false

--- a/code/packages/rust/spreadsheet-android-jni/README.md
+++ b/code/packages/rust/spreadsheet-android-jni/README.md
@@ -1,0 +1,57 @@
+# spreadsheet-android-jni
+
+The **JNI bridge** from the `com.example.visicalc` Android host to the shared
+Rust spreadsheet engine — the Android arm of the cross-platform VisiCalc, over
+the same `spreadsheet-core-wasm::SpreadsheetSession` the C-ABI and WASM facades
+wrap.
+
+## Why JNI (and not the JVM FFM API)
+
+The Compose **Desktop** demo loads the engine through the Foreign Function &
+Memory API (JDK 21+). Android's ART runtime has no FFM, so a native library
+there is reached the classic way: `System.loadLibrary` + `native` methods whose
+symbols are `Java_<package>_<Class>_<method>`. We build those `extern "C"`
+exports directly on the **zero-dependency** [`jni-bridge`](../jni-bridge) crate
+(no `jni` / `jni-sys` / `bindgen`), cross-compile to a per-ABI `.so`, and drop it
+in the app's `jniLibs/`.
+
+```text
+  Android host (Kotlin/Compose)
+        │  System.loadLibrary("spreadsheet_android_jni")
+        │  external fun nativeSetCell(handle, "B6", "=SUM(B1:B5)")
+        ▼
+  spreadsheet-android-jni   ← this crate (Java_… exports, over jni-bridge)
+        ▼
+  spreadsheet-core-wasm     ← SpreadsheetSession (the shared facade)
+        ▼
+  spreadsheet-core          ← cells, dependency graph, recalc, formulas
+```
+
+## API
+
+A session lives on the native heap as a boxed `SpreadsheetSession`; Java holds it
+as an opaque `long` handle and must call `nativeFree` when done. All calls are
+expected on a single (UI) thread — the handle is not synchronised.
+
+- **Session:** `nativeNewSession() -> long`, `nativeFree(handle)`.
+- **Cells:** `nativeSetCell(handle, a1, raw) -> String` (JSON status),
+  `nativeGetDisplay` / `nativeGetRaw(handle, a1) -> String`,
+  `nativeGetDisplayWindow(handle, r0, c0, r1, c1) -> String` (grid JSON),
+  `nativeColumnLetters(handle, index) -> String`.
+- **File open / save (bytes in, bytes out):**
+  `nativeLoadXlsx` / `nativeLoadXls` / `nativeLoadCsv` / `nativeLoadTsv` /
+  `nativeLoadJson` `(handle, byte[]) -> boolean` open a real file the user
+  picked (`true` = opened, `false` = unreadable / dead handle; the document is
+  left untouched on failure); `nativeSaveXlsx` / … / `nativeSaveJson`
+  `(handle) -> byte[]` return the current document serialized to that format. A
+  `byte[]` carries the raw file bytes intact — an `.xlsx` is a ZIP, an `.xls` an
+  OLE2 file. `.xlsx` keeps live formulas; `.xls`/CSV/TSV/JSON are lower-fidelity
+  (values only) per [`spreadsheet-io`](../spreadsheet-io).
+
+## Build & test
+
+This crate builds and tests on the **host** with `cargo test` (no JVM needed for
+compilation). Cross-compile for Android with the installed NDK targets, e.g.
+`cargo build -p spreadsheet-android-jni --target aarch64-linux-android`. The
+`byte[]` marshalling is covered by [`jni-bridge`](../jni-bridge)'s mock-JNIEnv
+tests (a real JNIEnv comes only from a running JVM).

--- a/code/packages/rust/spreadsheet-android-jni/src/lib.rs
+++ b/code/packages/rust/spreadsheet-android-jni/src/lib.rs
@@ -14,7 +14,8 @@
 //! side holds it as an opaque `long` handle and must call `nativeFree` when done.
 //! All calls are expected on a single (UI) thread — the handle is not synchronised.
 
-use jni_bridge::{jint, jlong, jstring, JNIEnv, jclass};
+use jni_bridge::{jboolean, jbyteArray, jclass, jint, jlong, jstring, JNIEnv};
+use jni_bridge::{jni_get_byte_array, jni_new_byte_array_from};
 use jni_bridge::{jni_get_string_utf, jni_new_string_utf};
 use spreadsheet_core_wasm::SpreadsheetSession;
 
@@ -142,4 +143,165 @@ pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeColumnLetters(
 ) -> jstring {
     let session = session!(ptr, env, jni_new_string_utf(env, ""));
     jni_new_string_utf(env, &session.column_letters(index as u32))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File open / save — a Java `byte[]` in, a `byte[]` out.
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The Android host reads a file the user picked into a `byte[]` and passes it to
+// `nativeLoad<Fmt>` (returns a `boolean`); `nativeSave<Fmt>` returns a `byte[]`
+// the host writes back out. A `byte[]` carries the raw file bytes intact — an
+// `.xlsx` is a ZIP, an `.xls` an OLE2 file — with no UTF-8 / NUL surprises. This
+// is the Android arm of the same open/save story as the WASM and C-ABI facades,
+// over the one engine. `.xlsx` keeps live formulas; the others are
+// lower-fidelity per `spreadsheet-io`.
+
+/// Open `.xlsx` file bytes as the current document. Returns `true` if opened,
+/// `false` if the bytes are not a readable `.xlsx` (or the handle is dead); a
+/// failed open leaves the current document untouched.
+///
+/// # Safety
+/// `ptr` must be a live session handle; `data` a valid `byte[]` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeLoadXlsx(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    data: jbyteArray,
+) -> jboolean {
+    let session = session!(ptr, env, 0);
+    session.load_xlsx_bytes(&jni_get_byte_array(env, data)) as jboolean
+}
+
+/// Save the current document to `.xlsx` bytes (a fresh `byte[]`).
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeSaveXlsx(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+) -> jbyteArray {
+    let session = session!(ptr, env, jni_new_byte_array_from(env, &[]));
+    jni_new_byte_array_from(env, &session.save_xlsx_bytes())
+}
+
+/// Open legacy `.xls` (BIFF8) file bytes. Returns `true`/`false` like
+/// [`nativeLoadXlsx`](Java_com_example_visicalc_Engine_nativeLoadXlsx).
+///
+/// # Safety
+/// `ptr` must be a live session handle; `data` a valid `byte[]` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeLoadXls(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    data: jbyteArray,
+) -> jboolean {
+    let session = session!(ptr, env, 0);
+    session.load_xls_bytes(&jni_get_byte_array(env, data)) as jboolean
+}
+
+/// Save the current document to legacy `.xls` bytes.
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeSaveXls(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+) -> jbyteArray {
+    let session = session!(ptr, env, jni_new_byte_array_from(env, &[]));
+    jni_new_byte_array_from(env, &session.save_xls_bytes())
+}
+
+/// Open `.csv` file bytes. Returns `true`/`false` (`false` on invalid UTF-8).
+///
+/// # Safety
+/// `ptr` must be a live session handle; `data` a valid `byte[]` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeLoadCsv(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    data: jbyteArray,
+) -> jboolean {
+    let session = session!(ptr, env, 0);
+    session.load_csv_bytes(&jni_get_byte_array(env, data)) as jboolean
+}
+
+/// Save the current document's first sheet to `.csv` bytes.
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeSaveCsv(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+) -> jbyteArray {
+    let session = session!(ptr, env, jni_new_byte_array_from(env, &[]));
+    jni_new_byte_array_from(env, &session.save_csv_bytes())
+}
+
+/// Open `.tsv` file bytes. Returns `true`/`false` like `nativeLoadCsv`.
+///
+/// # Safety
+/// `ptr` must be a live session handle; `data` a valid `byte[]` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeLoadTsv(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    data: jbyteArray,
+) -> jboolean {
+    let session = session!(ptr, env, 0);
+    session.load_tsv_bytes(&jni_get_byte_array(env, data)) as jboolean
+}
+
+/// Save the current document's first sheet to `.tsv` bytes.
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeSaveTsv(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+) -> jbyteArray {
+    let session = session!(ptr, env, jni_new_byte_array_from(env, &[]));
+    jni_new_byte_array_from(env, &session.save_tsv_bytes())
+}
+
+/// Open `.json` file bytes (a top-level array of record objects → a table).
+/// Returns `true`/`false` (`false` on malformed JSON — parsing is panic-free).
+///
+/// # Safety
+/// `ptr` must be a live session handle; `data` a valid `byte[]` or null.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeLoadJson(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+    data: jbyteArray,
+) -> jboolean {
+    let session = session!(ptr, env, 0);
+    session.load_json_bytes(&jni_get_byte_array(env, data)) as jboolean
+}
+
+/// Save the current document's first sheet to `.json` bytes (array of records).
+///
+/// # Safety
+/// `ptr` must be a live session handle.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_example_visicalc_Engine_nativeSaveJson(
+    env: *mut JNIEnv,
+    _class: jclass,
+    ptr: jlong,
+) -> jbyteArray {
+    let session = session!(ptr, env, jni_new_byte_array_from(env, &[]));
+    jni_new_byte_array_from(env, &session.save_json_bytes())
 }


### PR DESCRIPTION
## What

Brings **file open/save to the Android front-end** over JNI — the Android arm of the same open/save story as the WASM ([spreadsheet-wasm](https://github.com/adhithyan15/coding-adventures/pull/7701)) and C-ABI ([spreadsheet-capi #7743](https://github.com/adhithyan15/coding-adventures/pull/7743)) facades, over the one engine. Two crates:

### `jni-bridge` 0.1 → 0.2
Byte-array support so file bytes cross the JNI boundary as a Java `byte[]`:
- `jbyteArray` type alias + four raw slot wrappers at their JNI-spec offsets — `GetArrayLength`=171, `NewByteArray`=176, `GetByteArrayRegion`=200, `SetByteArrayRegion`=208, **derived from the pre-existing `NewDoubleArray`=182 / `SetDoubleArrayRegion`=214 anchors**.
- Null-safe convenience wrappers: `jni_get_byte_array(env, arr) -> Vec<u8>` and `jni_new_byte_array_from(env, &[u8]) -> jbyteArray`. `jbyte`(i8) and `u8` share a bit pattern, so the region copies straight into a `u8` buffer.
- **2 tests against a mock JNIEnv function table** (a `[*const c_void; 232]` with the byte-array slots pointing at Rust emulators; a `jbyteArray` modelled as `*mut Vec<u8>`): a round-trip that keeps a high bit (`0xD0`, the `.xls` magic) + empty/null-array safety. (A real JNIEnv comes only from a running JVM.)

### `spreadsheet-android-jni` 0.1 → 0.2
- `nativeLoadXlsx`/`Xls`/`Csv`/`Tsv`/`Json` `(handle, byte[]) -> boolean` and `nativeSaveXlsx`/…/`Json` `(handle) -> byte[]`, over `SpreadsheetSession`'s `*_bytes` methods. A `byte[]` carries raw file bytes intact (an `.xlsx` is a ZIP, an `.xls` an OLE2 file). A failed open returns `false` and leaves the document untouched.
- Added the crate's **missing README + CHANGELOG** (CLAUDE.md compliance).

## Verification

- Host `cargo test` + `cargo check --target aarch64-linux-android` (the real Android target) both clean; the `byte[]` marshalling is covered by jni-bridge's mock-JNIEnv tests.
- jni-bridge's **other consumers** (`conduit-jni`, `irc-server-native-jni`, `silicon-rust-jni`) re-built — no regressions (the change is purely additive).
- **Security review passed**: a Rust/JNI-FFI subagent confirmed the offsets are correct, the marshalling is sound (null/negative-`jsize`/dead-handle all guarded, `u8↔i8` cast valid), and untrusted bytes stay behind `Result` boundaries. Two non-blocking LOW hardening notes (host-side file-size cap; optional `catch_unwind` wrappers) — the latter left out to stay consistent with the rest of the crate + the merged C-ABI.

`.xlsx` keeps live formulas; `.xls`/CSV/TSV/JSON are lower-fidelity (values only) per `spreadsheet-io`.

## Completes the arc

File open/save now spans **all front-end boundaries**: web (WASM) + native (C-ABI) + Android (JNI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)