### PR TITLE
feat(latex): LTXDOC03 S14 — list_summary() per-kind label census

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.50.0] — 2026-07-07
+
+### Added — per-kind census of the numbered-label table (LTXDOC03 S14)
+
+A **new** public method `Document::list_summary(&self) -> String` that renders a compact per-kind
+count of the document's **numbered** labels — how many sections, figures, tables, and equations
+carry a `\label`. It is a pure tally of the rows `number_labels()` returns, grouped by `LabelKind`,
+so the census can never drift from the S4 numbering it summarises. Every S1–S13 output is left
+**byte-for-byte unchanged**; S14 is purely additive and leaves the `to_latex()` round-trip fixed
+point intact.
+
+- **Counts exactly the numberable kinds.** Only a numbered `\section`, a `figure`, a `table`, and a
+  non-starred display `equation` label reach `number_labels()`, so those are the only kinds counted.
+  A bare inline `\label{…}` (`LabelKind::Inline`) is **not** numbered — it never appears in
+  `number_labels()` — and is therefore counted nowhere. Confirmed by reading the numbering pass
+  (it records no `Inline` rows) and by an exploratory tally over a mixed fixture.
+- **One line per non-zero kind, in a fixed order.** The output emits `"Sections: n"`, `"Figures: n"`,
+  `"Tables: n"`, `"Equations: n"` — in that fixed order (deterministic, never document order) — with
+  a **fixed plural** label regardless of `n` (a single section still prints `Sections: 1`). A kind
+  whose count is 0 is **omitted** entirely, mirroring S11's "kinds with 0 refs are omitted"
+  convention. Lines are joined by `\n` with **no** trailing newline (matching S11
+  `to_plain_text_by_kind`, S12 `list_of_floats`, S13 `resolve_namerefs`).
+- **Empty marker.** A document with **no** numbered label at all → the fixed marker `"(no labels)"`,
+  so the output is never the empty string (the same stable-marker discipline S12/S13 use).
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing; a single pass over the
+  already-bounded numbering table. Borrows `self` immutably, returns owned `String`.
+
+Four `s14_*` tests pin the exact rendered strings: a doc counting all four kinds
+(`Sections: 2\nFigures: 1\nTables: 1\nEquations: 1`), a sections-only doc (`Sections: 3`, zero-count
+kinds omitted), an equation/inline-only doc returning the empty `(no labels)` marker, and an
+additivity check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, and
+`resolve_namerefs` all still produce their exact prior strings.
+
 ## [0.49.0] — 2026-07-07
 
 ### Added — `\nameref` resolution to a target's name text (LTXDOC03 S13)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -61,6 +61,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S11 — grouped-by-kind cross-reference report** | `CrossReferenceReport::to_plain_text_by_kind() -> String` — a **new, separate** method that renders the **same** resolved references as `to_plain_text` but **grouped under fixed-order kind subheadings** (Sections, Figures, Tables, Equations, Inline — regardless of source order), each subheading followed by two-space-indented ref lines in the report's existing pre-order. Kinds with zero resolved refs are omitted entirely. The per-line rendering is the **identical** S8/S9/S10 rule — factored into a shared private `render_resolved_ref(&RefEntry)` that **both** `to_plain_text` and `to_plain_text_by_kind` call, so the flat and grouped reports can never drift (`to_plain_text` output is byte-for-byte unchanged). Only resolved refs are grouped (no citations, no dangling footers); zero resolved refs → the fixed marker `(no resolved references)`. A `\pageref` groups under its **target kind**. Pure report-assembly over data the report already holds — no AST/struct/numbering change, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S12 — List of Figures / List of Tables index** | `Document::list_of_floats() -> String` — a **new** method that renders the document's **List of Figures** and **List of Tables** (LaTeX's `\listoffigures` / `\listoftables`, as plain text) directly from the floats. A single document-order walk threads the **same** `Counters` float counters as `number_labels`, so each float's line number equals its S4 flat figure/table number (a labeled float's List-of number and its `\ref` number agree; figures numbered `1, 2, …`, tables independently from `1`). Each line is `<n>. <caption text>`, where the caption text is the plain rendering of the float's `\caption{…}` inlines (text/code verbatim, space as a single space, font-wrapper content recursively, trimmed — the same descent the caption-reaching test proves), via a private `caption_text(&Option<Caption>)` helper; a float with **no** `\caption` renders the fixed placeholder `(no caption)` so every float still gets a numbered line. The `List of Figures` heading is emitted only when there is ≥1 figure, `List of Tables` only when ≥1 table; a document with no floats → the fixed marker `(no floats)`. Lines joined by `\n`, no trailing newline. Real LaTeX gates these on `\listoffigures` / `\listoftables` commands (not parser-recognised here), so — like S11 — S12 is a method the caller invokes; every S1–S11 output is byte-for-byte unchanged. Pure assembly over existing blocks + the existing float walk — no AST/grammar/counter change, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S13 — `\nameref` resolution to a target's name** | `Document::resolve_namerefs() -> String` — a **new** method that resolves every `\nameref{key}` to the **name** (title/caption text) of its target — the name-valued sibling of `\ref` (number) and `\pageref` (page). `\nameref` is **not** a `REF_COMMAND`, so it appears in neither the resolved nor unresolved ref table (an AST probe confirms it lowers to `Inline::CrossRef { command: "nameref", .. }`); S13 reads the same S1 `\label` table but answers "*what is it called?*", so it is purely additive. One document-order walk collects each `nameref` cross-ref; the key is resolved against the winning label table and the name read from its defining node via the S3 `label_def_node` accessor — a `Section` → its title inlines flattened, a `Figure`/`Table` → its `\caption` via the shared `caption_text` helper (S12's flatten factored into a module-level `flatten_inlines_to_text`, reused by both so they can never drift). An `Equation`/`Inline` target (a number, not a title) → `(no name)`; an undefined key → `(undefined nameref: <key>)`; no `\nameref` at all → `(no namerefs)`. Each line is `\nameref{<key>} -> <name>`, joined by `\n`, no trailing newline. Every S1–S12 output is byte-for-byte unchanged. Total & panic-free. | ✅ |
+| **LTXDOC03 S14 — per-kind census of the numbered-label table** | `Document::list_summary() -> String` — a **new**, read-only method that renders a compact per-kind **count** of the document's numbered labels: how many sections, figures, tables, and equations carry a `\label`. It is a pure tally of the rows `number_labels()` returns, grouped by `LabelKind`, so it can never drift from the S4 numbering it summarises. Only the four numberable kinds reach that table — a bare inline `\label{…}` (`LabelKind::Inline`) is not numbered and is counted nowhere. One line per non-zero kind in the **fixed order** `Sections`, `Figures`, `Tables`, `Equations` (deterministic, not source order), formatted `<Kind>: <count>` with a **fixed plural** label regardless of count (a single section still prints `Sections: 1`); a kind with count 0 is **omitted** (mirroring S11). Lines joined by `\n`, no trailing newline. A document with **no** numbered label at all → the fixed marker `(no labels)`. E.g. two labeled sections + a figure + a table + an equation → `Sections: 2\nFigures: 1\nTables: 1\nEquations: 1`. Every S1–S13 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -639,6 +640,34 @@ target has a number, not a name, so it renders `(no name)`; an undefined key ren
 `(undefined nameref: <key>)`; a document with no `\nameref` at all renders `(no namerefs)`. Pure
 assembly over existing blocks + the S1 label table — no AST/grammar change, `to_latex()` still a fixed
 point.
+
+### per-kind census of numbered labels (LTXDOC03 S14)
+
+`number_labels` assigns each numbered label a *number*; `list_summary` answers the coarser question
+*"how many of each kind are there?"*. It is a pure tally of that same table, grouped by kind — one
+line per non-zero kind in the fixed order `Sections`, `Figures`, `Tables`, `Equations` (never source
+order), each `<Kind>: <count>` with a fixed plural label; zero-count kinds are omitted; no numbered
+label at all → `(no labels)`.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{One}\label{sec:a}
+\section{Two}\label{sec:b}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+\begin{table}\begin{tabular}{lc}a & b\end{tabular}\caption{Data}\label{tab:d}\end{table}
+\begin{equation}\label{eq:e}E=mc^2\end{equation}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.list_summary(),
+    "Sections: 2\nFigures: 1\nTables: 1\nEquations: 1",
+);
+```
+
+A bare inline `\label{…}` is not numbered, so it never appears in this census; a document whose only
+label is such an inline label renders the `(no labels)` marker. Purely additive — reuses
+`number_labels`, mutates nothing, leaves every S1–S13 output and the `to_latex()` fixed point
+unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1494,6 +1494,102 @@ impl Document {
             _ => "(no name)".to_string(),
         }
     }
+
+    /// A **per-kind census** of the numbered-label table (LTXDOC03 S14) — how many labels of each
+    /// kind this document defines, as a compact plain-text summary.
+    ///
+    /// ## What it counts, and where the numbers come from
+    ///
+    /// This is a pure *tally* of the rows [`number_labels`](Document::number_labels) returns, grouped
+    /// by [`LabelKind`]. That table is the S4 numbering table — one row per **defined, numberable**
+    /// label key — so S14 counts exactly the labels a `\ref` could print a number for. It reuses the
+    /// same table (never re-deriving the counts), so the census can never drift from the numbering it
+    /// summarises.
+    ///
+    /// Only four kinds ever reach that table: a numbered `\section`, a `figure`, a `table`, and a
+    /// non-starred display `equation` label. A bare inline `\label{…}` ([`LabelKind::Inline`]) is
+    /// **not** numbered, so it never appears in `number_labels` and is therefore **not** counted here
+    /// (this is confirmed by reading the numbering pass — it records `Inline` rows nowhere).
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// One line per kind whose count is `>= 1`, in this **fixed order** (chosen once, so the output is
+    /// deterministic and greppable — it never follows document order): **Sections, Figures, Tables,
+    /// Equations**. Each line is exactly `"<Kind>: <count>"` with a **fixed plural** label regardless
+    /// of the count (so a single section still prints `Sections: 1`, never `Section: 1`):
+    ///
+    /// ```text
+    /// Sections: 2
+    /// Figures: 1
+    /// Tables: 1
+    /// Equations: 1
+    /// ```
+    ///
+    /// A kind whose count is **0 is omitted** entirely (mirroring S11's "kinds with 0 refs are
+    /// omitted" convention), so a document with only labeled sections renders just the one
+    /// `Sections: N` line. Lines are joined by `\n` with **no** trailing newline (matching S11's
+    /// `to_plain_text_by_kind`, S12's `list_of_floats`, and S13's `resolve_namerefs`).
+    ///
+    /// If **all** counts are 0 — the document defines no numbered label at all — the fixed marker
+    /// `"(no labels)"` is returned, so the output is never the empty string (the same stable-marker
+    /// discipline S12/S13 use).
+    ///
+    /// | document | `list_summary()` |
+    /// |----------|------------------|
+    /// | 2 `\section`+`\label`, 1 fig, 1 table, 1 eq (all labeled) | `Sections: 2`⏎`Figures: 1`⏎`Tables: 1`⏎`Equations: 1` |
+    /// | 3 labeled sections, nothing else | `Sections: 3` |
+    /// | only a bare inline `\label{marker}` (not numbered) | `(no labels)` |
+    ///
+    /// ## Additive by construction
+    ///
+    /// S14 is a brand-new, read-only method that reuses [`number_labels`](Document::number_labels)
+    /// and mutates nothing; it changes no S1-S13 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing; a single pass over the
+    /// already-bounded numbering table. Borrows `self` immutably and returns owned `String` data, so
+    /// the result outlives any borrow of the source.
+    pub fn list_summary(&self) -> String {
+        // Tally the numbering table by kind. Inline labels never reach this table (they are not
+        // numbered — see `number_labels`), so only the four numbered kinds can be non-zero.
+        let numbering = self.number_labels();
+        let mut sections = 0u32;
+        let mut figures = 0u32;
+        let mut tables = 0u32;
+        let mut equations = 0u32;
+        for label in &numbering.labels {
+            match label.kind {
+                LabelKind::Section => sections += 1,
+                LabelKind::Figure => figures += 1,
+                LabelKind::Table => tables += 1,
+                LabelKind::Equation => equations += 1,
+                // Not numbered, so never present here; counted nowhere.
+                LabelKind::Inline => {}
+            }
+        }
+
+        // Emit one line per non-zero kind in the FIXED order Sections, Figures, Tables, Equations
+        // (deterministic, not document order). The plural label is fixed regardless of count.
+        let mut lines: Vec<String> = Vec::new();
+        if sections >= 1 {
+            lines.push(format!("Sections: {sections}"));
+        }
+        if figures >= 1 {
+            lines.push(format!("Figures: {figures}"));
+        }
+        if tables >= 1 {
+            lines.push(format!("Tables: {tables}"));
+        }
+        if equations >= 1 {
+            lines.push(format!("Equations: {equations}"));
+        }
+
+        if lines.is_empty() {
+            // No numbered label at all → the fixed marker, never the empty string.
+            return "(no labels)".to_string();
+        }
+        lines.join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -3790,5 +3886,82 @@ See Section~\ref{sec:intro}, \nameref{sec:intro}, and \nameref{fig:p}.\end{docum
             doc.resolve_namerefs(),
             "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
         );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S14 — per-kind census of the numbered-label table (`list_summary`).
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s14_counts_each_kind() {
+        // Two labeled sections, one labeled figure, one labeled table, one labeled equation. The
+        // census emits ONE line per kind (count >= 1) in the fixed order Sections, Figures, Tables,
+        // Equations, with the fixed plural label regardless of count.
+        let src = r"\begin{document}\section{One}\label{sec:a}
+\section{Two}\label{sec:b}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+\begin{table}\begin{tabular}{lc}a & b\end{tabular}\caption{Data}\label{tab:d}\end{table}
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+Text \label{marker} inline.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.list_summary(), "Sections: 2\nFigures: 1\nTables: 1\nEquations: 1");
+    }
+
+    #[test]
+    fn s14_omits_zero_kinds() {
+        // Only sections are labeled → ONLY the `Sections:` line appears; the zero-count Figures,
+        // Tables, and Equations lines are omitted entirely. Note the fixed plural even though there
+        // are two — and that a single labeled section would still print `Sections: 1`.
+        let src = r"\begin{document}\section{Alpha}\label{s:a}
+\section{Beta}\label{s:b}
+\section{Gamma}\label{s:c}
+
+Body text with no floats or equations.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.list_summary(), "Sections: 3");
+    }
+
+    #[test]
+    fn s14_empty_returns_marker() {
+        // A document with NO numbered labels at all (a bare inline `\label` is NOT numbered, so it
+        // never appears in `number_labels`) → the fixed `(no labels)` marker, never the empty string.
+        let src = r"\begin{document}Text \label{marker} with only a bare inline label.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.list_summary(), "(no labels)");
+    }
+
+    #[test]
+    fn s14_is_additive_leaves_s1_s13_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a `\ref`, and a
+        // `\nameref`, S14 changes NONE of the S1-S13 outputs — it only reads `number_labels`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+See Section~\ref{sec:intro}, \nameref{sec:intro}, and \nameref{fig:p}.\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — the resolved `\ref` with its S4 number, nothing perturbed.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1"
+        );
+        // S11 grouped-by-kind report — the same single ref under its `Sections:` group.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — one figure line, unaffected.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — both namerefs render their names, unaffected.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+
+        // And S14 itself produces the per-kind census (one section, one figure, one equation).
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1157,3 +1157,77 @@ an undefined key rendering `(undefined nameref: nope)`; an equation + inline lab
 S1–S12 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream
 `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No
 `cargo fmt`, no grammar regen, no new dependencies.
+
+---
+
+## 20. S14 — per-kind census of the numbered-label table (`list_summary`)
+
+### 20.1 Motivation
+
+S1–S13 answer *"where does this reference point, what number/name is its target?"* — always per
+reference or per label. S14 asks the coarser, aggregate question a table-of-contents or a document
+overview needs: *"how many numbered labels of each kind does this document have?"* — a count of
+sections vs figures vs tables vs equations that carry a `\label`. It is the census over the table S4
+already built.
+
+### 20.2 Why a new method — additive by construction
+
+S14 adds a **new public method** `Document::list_summary(&self) -> String`. It is a pure, read-only
+tally of the rows `Document::number_labels()` returns, grouped by `LabelKind`. It reuses that table
+verbatim (never re-deriving counts from a fresh walk), so the census can never drift from the S4
+numbering it summarises. It mutates nothing and changes no S1–S13 output — including `to_latex()`'s
+round-trip fixed point — byte-for-byte.
+
+### 20.3 What S14 counts
+
+Only four kinds ever reach `number_labels()`: a numbered `\section` (`LabelKind::Section`), a
+`figure` (`Figure`), a `table` (`Table`), and a non-starred display `equation` label (`Equation`).
+A bare inline `\label{…}` (`LabelKind::Inline`) is **not** numbered — the numbering pass records no
+`Inline` rows — so it never appears in the table and is therefore **counted nowhere**. (Confirmed by
+reading the numbering pass and by an exploratory tally over a mixed fixture: a doc with two labeled
+sections, a figure, a table, an equation, and one bare inline `\label` yields exactly five numbered
+rows — Section, Section, Figure, Table, Equation — the inline label omitted.)
+
+### 20.4 The exact rendering contract — `Document::list_summary(&self) -> String`
+
+- One line per kind whose count is **≥ 1**, in this **fixed order** (deterministic, *not* document
+  order): **Sections, Figures, Tables, Equations**.
+- Each line is exactly `<Kind>: <count>` — `Sections: n`, `Figures: n`, `Tables: n`, `Equations: n`
+  — with a **fixed plural** label regardless of `n` (a single section still prints `Sections: 1`,
+  never `Section: 1`).
+- A kind whose count is **0 is omitted** entirely, mirroring S11's "kinds with 0 refs are omitted"
+  convention.
+- Lines are joined by `\n` with **no** trailing newline (matching S11 `to_plain_text_by_kind`, S12
+  `list_of_floats`, S13 `resolve_namerefs`).
+- If **all** counts are 0 (the document defines no numbered label at all), the fixed marker
+  `(no labels)` is returned, so the output is never the empty string.
+
+Example (two labeled sections, one labeled figure, one labeled table, one labeled equation):
+
+```text
+Sections: 2
+Figures: 1
+Tables: 1
+Equations: 1
+```
+
+A document whose only label is a bare inline `\label{marker}` renders `(no labels)` (that label is
+not numbered). A document with only three labeled sections renders just `Sections: 3` (the other
+three kinds are omitted).
+
+### 20.5 Public API (added in S14)
+
+One new method: `Document::list_summary(&self) -> String`. No existing type, field, counter, or
+signature changes; `number_labels` and every S1–S13 method are unchanged; no AST or grammar change;
+no new dependency, no `unsafe`, no I/O.
+
+### 20.6 Verification (S14)
+
+`cargo test -p latex` green (4 new S14 tests: a doc counting all four kinds
+`Sections: 2\nFigures: 1\nTables: 1\nEquations: 1`; a sections-only doc `Sections: 3` with zero-count
+kinds omitted; an equation/inline-only doc returning the `(no labels)` marker; and an additivity
+check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, and `resolve_namerefs` all
+still produce their exact prior strings). All prior S1–S13 tests pass unchanged. `cargo clippy -p
+latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green;
+`cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new
+dependencies.


### PR DESCRIPTION
## LTXDOC03 S14 — `list_summary()`: a per-kind census of numbered labels

Adds a new read-only method `Document::list_summary() -> String` that reports, per label kind, **how many numbered labels of that kind the document defines** — a one-line census built directly on top of S4's `number_labels()`.

### What it does
Counts the rows `number_labels()` returns, grouped by `LabelKind`, and emits one line per non-empty kind in a fixed order:

```
Sections: 2
Figures: 1
Tables: 1
Equations: 1
```

- **Fixed order**: Sections, Figures, Tables, Equations (the four kinds `number_labels()` ever emits — inline `\label`s are not numbered and never appear).
- **Zero-count kinds are omitted** (mirrors S11's grouped-report convention).
- **`"(no labels)"`** when the document has no numbered labels at all.
- Lines joined by `\n`, no trailing newline — same shape as S11 `to_plain_text_by_kind`, S12 `list_of_floats`, S13 `resolve_namerefs`.

### Why it's a clean, guaranteed-additive slice
`list_summary()` is a **brand-new method** that only *reads* `number_labels()`. No existing method body is touched — the `references.rs` diff is **174 lines added, 0 removed**. The counts can never drift from `\ref` numbering because they are literally derived from the same `number_labels()` rows that back the reference numbers. `\listsummary` is not a recognized LaTeX command, so (as with S11/S12/S13) there is nothing to gate on and the addition is additive by construction.

### Verification
- `cargo test -p latex` → **380 passed** (376 prior + 4 new `s14_*`), including `s14_is_additive_leaves_s1_s13_outputs_unchanged`, which pins the exact outputs of `to_plain_text()`, `to_plain_text_by_kind()`, `list_of_floats()`, and `resolve_namerefs()` so S1–S13 are provably unperturbed.
- `cargo clippy -p latex --all-targets -- -D warnings` → clean.
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected).
- `cargo build -p latex --no-default-features` → builds (zero-dep).
- No `cargo fmt`, no grammar regen, no new deps, no file I/O, no `unsafe`.

### Scope
5 files: `src/references.rs` (method + 4 tests), `Cargo.toml` (0.49.0 → 0.50.0), `CHANGELOG.md`, `README.md`, `code/specs/LTXDOC03-cross-reference-resolution.md` (new S14 section). Single-parent commit; inline security review PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
