### PR TITLE
feat(cloc12): CLOC12.170 PR1 — object spread {...o} via ObjectMember (structural node + emit + 9 passes)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.34.0] - 2026-07-07
+
+### Added — CLOC12.170: emit object spread `{...o}` (`emit_object_spread`)
+
+`emit_object` now iterates `Vec<ObjectMember>` (the object-literal member type
+gained an object-spread arm in `javascript-ast` 0.29.0) and prints an
+`ObjectMember::Spread` via the new `emit_object_spread`: the three literal `.`
+characters then the `argument` at `PREC_ASSIGNMENT` with no interior space —
+identical in shape to the call/array `emit_spread`. The assignment precedence is
+the crux: an object-member position is an `AssignmentExpression`, so everything
+at or above assignment strength prints bare (`{...a}`, `{...a.b}`, `{...f()}`),
+while the one looser form — a **sequence** — must wrap (`{...(a,b)}`) because a
+bare `...a,b` would spread only `a` and leave `,b` as a second (invalid) member
+slot. 5 hand-constructed-AST unit tests (`{...a}`, `{...a,b:1}`, `{a:1,...b}`,
+`{...f()}`, and the sequence wrap `{...(a,b)}`). MINOR because the public
+`ObjectExpression` member type changed; no behaviour change for existing inputs.
+
 ## [0.33.1] - 2026-07-07
 
 ### Added — CLOC12.169 PR3: CodePrinter dynamic `import()` conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.33.1"
+version = "0.34.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -75,7 +75,7 @@ use coding_adventures_javascript_ast::{
     FunctionDeclaration, FunctionExpression,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem, SequenceExpression,
-    Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
+    ObjectMember, Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
     TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
@@ -1749,19 +1749,38 @@ impl<'a> Emitter<'a> {
     fn emit_object(&mut self, o: &ObjectExpression) {
         self.maybe_map(&o.cv);
         self.write_str("{");
-        for (i, p) in o.properties.iter().enumerate() {
+        for (i, member) in o.properties.iter().enumerate() {
             if i > 0 {
                 self.write_str(",");
                 self.pretty_ws();
             } else {
                 self.pretty_ws();
             }
-            self.emit_property(p);
+            match member {
+                ObjectMember::Property(p) => self.emit_property(p),
+                ObjectMember::Spread(s) => self.emit_object_spread(s),
+            }
         }
         if !o.properties.is_empty() {
             self.pretty_ws();
         }
         self.write_str("}");
+    }
+
+    /// Emit an object-spread member `...expr` inside an object literal.
+    ///
+    /// Identical in shape to the call/array [`emit_spread`](Self::emit_spread):
+    /// the three literal `.` characters then the `argument` at
+    /// `PREC_ASSIGNMENT` with no interior space (`...o`, never `... o`). The
+    /// assignment precedence is the crux — an object-literal member position is
+    /// an `AssignmentExpression`, so everything at or above assignment strength
+    /// prints bare (`...o`, `...o.p`, `...f()`, `...a?b:c`), while the one looser
+    /// form, a **sequence**, must wrap (`...(a,b)`): a bare `...a,b` would spread
+    /// only `a` and leave `,b` as a second (empty-keyed, invalid) member slot.
+    fn emit_object_spread(&mut self, s: &SpreadElement) {
+        self.maybe_map(&s.cv);
+        self.write_str("...");
+        self.emit_expression_inner(&s.argument, PREC_ASSIGNMENT);
     }
 
     fn emit_property(&mut self, p: &Property) {
@@ -3419,7 +3438,7 @@ mod tests {
         let o = Expression::ObjectExpression(ObjectExpression {
             cv: None,
             properties: vec![
-                Property {
+                ObjectMember::Property(Property {
                     cv: None,
                     kind: PropertyKind::Init,
                     key: PropertyKey::Identifier(Identifier {
@@ -3430,8 +3449,8 @@ mod tests {
                     computed: false,
                     shorthand: false,
                     method: false,
-                },
-                Property {
+                }),
+                ObjectMember::Property(Property {
                     cv: None,
                     kind: PropertyKind::Init,
                     key: PropertyKey::Identifier(Identifier {
@@ -3442,12 +3461,90 @@ mod tests {
                     computed: false,
                     shorthand: false,
                     method: false,
-                },
+                }),
             ],
         });
         let prog = program().with_body(vec![stmt(o)]);
         let out = emit_default(prog);
         assert_eq!(out.code, "({a:1,b:2});");
+    }
+
+    // ---- object spread `{...o}` (CLOC12.170) ----
+    //
+    // A spread member prints `...` then its argument at `PREC_ASSIGNMENT` with
+    // no interior space, exactly like a call/array spread. The object body is
+    // wrapped in `(...)` here only because an object at statement-start needs it
+    // (tested above) — the `...` printing is what these assert.
+
+    /// Build a spread member `...arg`.
+    fn spread_member(arg: Expression) -> ObjectMember {
+        ObjectMember::Spread(SpreadElement { cv: None, argument: Box::new(arg) })
+    }
+
+    /// Build a plain `name: value` init member.
+    fn init_member(name: &str, value: Expression) -> ObjectMember {
+        ObjectMember::Property(Property {
+            cv: None,
+            kind: PropertyKind::Init,
+            key: PropertyKey::Identifier(Identifier { cv: None, name: name.to_string() }),
+            value: Box::new(value),
+            computed: false,
+            shorthand: false,
+            method: false,
+        })
+    }
+
+    /// Emit an object literal (as a parenthesised statement) from its members.
+    fn emit_object_members(members: Vec<ObjectMember>) -> String {
+        let o = Expression::ObjectExpression(ObjectExpression { cv: None, properties: members });
+        emit_default(program().with_body(vec![stmt(o)])).code
+    }
+
+    #[test]
+    fn object_spread_sole_member_is_bare() {
+        // `{...a}` — the spread argument prints bare.
+        assert_eq!(emit_object_members(vec![spread_member(ident("a"))]), "({...a});");
+    }
+
+    #[test]
+    fn object_spread_before_property() {
+        // `{...a, b: 1}` — spread then a normal member, source order preserved.
+        assert_eq!(
+            emit_object_members(vec![spread_member(ident("a")), init_member("b", num(1.0))]),
+            "({...a,b:1});"
+        );
+    }
+
+    #[test]
+    fn object_spread_after_property() {
+        // `{a: 1, ...b}` — a normal member then a spread.
+        assert_eq!(
+            emit_object_members(vec![init_member("a", num(1.0)), spread_member(ident("b"))]),
+            "({a:1,...b});"
+        );
+    }
+
+    #[test]
+    fn object_spread_call_argument_is_bare() {
+        // `{...f()}` — a call binds tighter than assignment, so no wrap.
+        let call = Expression::CallExpression(CallExpression {
+            cv: None,
+            callee: Box::new(ident("f")),
+            arguments: vec![],
+        });
+        assert_eq!(emit_object_members(vec![spread_member(call)]), "({...f()});");
+    }
+
+    #[test]
+    fn object_spread_sequence_argument_wraps() {
+        // `{...(a, b)}` — a sequence is looser than the member comma, so it must
+        // wrap; a bare `...a,b` would spread only `a` and leave `,b` as a second
+        // (invalid) member slot.
+        let seq = Expression::SequenceExpression(SequenceExpression {
+            cv: None,
+            expressions: vec![ident("a"), ident("b")],
+        });
+        assert_eq!(emit_object_members(vec![spread_member(seq)]), "({...(a,b)});");
     }
 
     // ---- property-key quote stripping (emit_property_key) ----
@@ -3462,7 +3559,7 @@ mod tests {
     fn obj_one_string_key(value: &str) -> Expression {
         Expression::ObjectExpression(ObjectExpression {
             cv: None,
-            properties: vec![Property {
+            properties: vec![ObjectMember::Property(Property {
                 cv: None,
                 kind: PropertyKind::Init,
                 key: PropertyKey::StringLiteral(StringLiteral {
@@ -3476,7 +3573,7 @@ mod tests {
                 computed: false,
                 shorthand: false,
                 method: false,
-            }],
+            })],
         })
     }
 

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_object_literal_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_object_literal_test.rs
@@ -43,8 +43,8 @@
 use coding_adventures_closure_emitter::{emit, EmitOptions};
 use coding_adventures_correlation_vector::CVLog;
 use coding_adventures_javascript_ast::{
-    Expression, ExpressionStatement, Identifier, NumericLiteral, ObjectExpression, Program,
-    ProgramItem, Property, PropertyKey, PropertyKind, SourceType, Statement, StringLiteral,
+    Expression, ExpressionStatement, Identifier, NumericLiteral, ObjectExpression, ObjectMember,
+    Program, ProgramItem, Property, PropertyKey, PropertyKind, SourceType, Statement, StringLiteral,
 };
 use coding_adventures_javascript_tokens::EsVersion;
 use coding_adventures_type_sidecar::Sidecar;
@@ -109,7 +109,7 @@ fn numeric_key(v: f64) -> PropertyKey {
 fn object(properties: Vec<Property>) -> Expression {
     Expression::ObjectExpression(ObjectExpression {
         cv: None,
-        properties,
+        properties: properties.into_iter().map(ObjectMember::Property).collect(),
     })
 }
 

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_trailing_comma_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_trailing_comma_test.rs
@@ -53,8 +53,8 @@ use coding_adventures_closure_emitter::{emit, EmitOptions};
 use coding_adventures_correlation_vector::CVLog;
 use coding_adventures_javascript_ast::{
     ArrayExpression, BindingTarget, Declaration, Expression, Identifier, NumericLiteral,
-    ObjectExpression, Program, ProgramItem, Property, PropertyKey, PropertyKind, SourceType,
-    Statement, VarKind, VariableDeclaration, VariableDeclarator,
+    ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey, PropertyKind,
+    SourceType, Statement, VarKind, VariableDeclaration, VariableDeclarator,
 };
 use coding_adventures_javascript_tokens::EsVersion;
 use coding_adventures_type_sidecar::Sidecar;
@@ -94,14 +94,16 @@ fn obj(props: Vec<(&str, Expression)>) -> Expression {
         cv: None,
         properties: props
             .into_iter()
-            .map(|(k, v)| Property {
-                cv: None,
-                kind: PropertyKind::Init,
-                key: PropertyKey::Identifier(ident_name(k)),
-                value: Box::new(v),
-                computed: false,
-                shorthand: false,
-                method: false,
+            .map(|(k, v)| {
+                ObjectMember::Property(Property {
+                    cv: None,
+                    kind: PropertyKind::Init,
+                    key: PropertyKey::Identifier(ident_name(k)),
+                    value: Box::new(v),
+                    computed: false,
+                    shorthand: false,
+                    method: false,
+                })
             })
             .collect(),
     })

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -97,7 +97,7 @@ use coding_adventures_javascript_ast::{
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     FunctionDeclaration, FunctionExpression, Identifier,
     IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral,
-    ObjectExpression, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
+    ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
     StringLiteral, UnaryExpression, UnaryOperator, UndefinedLiteral, UpdateExpression, VariableDeclaration,
     DoWhileStatement, VariableDeclarator, WhileStatement,
 };
@@ -601,22 +601,31 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             properties: o
                 .properties
                 .iter()
-                .map(|p| Property {
-                    cv: p.cv.clone(),
-                    kind: p.kind,
-                    key: match &p.key {
-                        // Identifier / literal keys: pass through.
-                        PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
-                        PropertyKey::StringLiteral(s) => PropertyKey::StringLiteral(s.clone()),
-                        PropertyKey::NumericLiteral(n) => PropertyKey::NumericLiteral(n.clone()),
-                        PropertyKey::Expression(e) => {
-                            PropertyKey::Expression(Box::new(fold_expression(e, st)))
-                        }
-                    },
-                    value: Box::new(fold_expression(&p.value, st)),
-                    computed: p.computed,
-                    shorthand: p.shorthand,
-                    method: p.method,
+                .map(|member| match member {
+                    ObjectMember::Property(p) => ObjectMember::Property(Property {
+                        cv: p.cv.clone(),
+                        kind: p.kind,
+                        key: match &p.key {
+                            // Identifier / literal keys: pass through.
+                            PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
+                            PropertyKey::StringLiteral(s) => PropertyKey::StringLiteral(s.clone()),
+                            PropertyKey::NumericLiteral(n) => PropertyKey::NumericLiteral(n.clone()),
+                            PropertyKey::Expression(e) => {
+                                PropertyKey::Expression(Box::new(fold_expression(e, st)))
+                            }
+                        },
+                        value: Box::new(fold_expression(&p.value, st)),
+                        computed: p.computed,
+                        shorthand: p.shorthand,
+                        method: p.method,
+                    }),
+                    // Object spread `...expr` — fold through the spread argument
+                    // (`{...(1+2 && o)}` is not foldable here, but a foldable
+                    // sub-expression inside still simplifies).
+                    ObjectMember::Spread(s) => ObjectMember::Spread(SpreadElement {
+                        cv: s.cv.clone(),
+                        argument: Box::new(fold_expression(&s.argument, st)),
+                    }),
                 })
                 .collect(),
         }),
@@ -4919,13 +4928,19 @@ fn js_math_min(values: &[f64]) -> f64 {
 /// instant any property fails the static-shape conditions documented at the call
 /// site. On success the pairs are in source order with duplicate keys collapsed
 /// (first position, last value).
-fn fold_object_entries_pairs(properties: &[Property]) -> Option<Vec<Expression>> {
+fn fold_object_entries_pairs(properties: &[ObjectMember]) -> Option<Vec<Expression>> {
     // Parallel vectors in first-occurrence order; `keys` finds a duplicate so its
     // value can be overwritten in place (the object the literal builds keeps only
     // the last value under a repeated key).
     let mut keys: Vec<String> = Vec::new();
     let mut pairs: Vec<Expression> = Vec::new();
-    for p in properties {
+    for member in properties {
+        // An object spread `...o` injects keys we cannot know statically, so any
+        // spread makes the whole `Object.entries` result indeterminate — decline.
+        let p = match member {
+            ObjectMember::Property(p) => p,
+            ObjectMember::Spread(_) => return None,
+        };
         // Only plain data properties `k: v`. Getters/setters execute code,
         // methods are functions, and a computed key `[expr]: v` is unknown.
         if p.kind != PropertyKind::Init || p.method || p.computed {
@@ -4991,13 +5006,18 @@ fn fold_object_entries_pairs(properties: &[Property]) -> Option<Vec<Expression>>
 /// for why dropping the value does NOT loosen them: the value expression is still
 /// evaluated when the source literal is built, so it must be a side-effect-free
 /// primitive literal even though `Object.keys` never emits it.
-fn fold_object_keys_names(properties: &[Property]) -> Option<Vec<Expression>> {
+fn fold_object_keys_names(properties: &[ObjectMember]) -> Option<Vec<Expression>> {
     // First-occurrence order; a duplicate key is found and ignored (the object the
     // literal builds keeps a single own property under a repeated key, and its
     // position is the first occurrence).
     let mut keys: Vec<String> = Vec::new();
     let mut names: Vec<Expression> = Vec::new();
-    for p in properties {
+    for member in properties {
+        // A spread `...o` injects statically-unknown keys — decline the fold.
+        let p = match member {
+            ObjectMember::Property(p) => p,
+            ObjectMember::Spread(_) => return None,
+        };
         // Only plain data properties `k: v`. Getters/setters execute code,
         // methods are functions, and a computed key `[expr]: v` is unknown.
         if p.kind != PropertyKind::Init || p.method || p.computed {
@@ -5114,11 +5134,11 @@ fn stamp_literal_cv(v: FoldedLiteral, cv: Option<String>) -> Expression {
 /// `None` (decline the fold) the instant any element fails the static-shape
 /// conditions documented at the call site. On success the returned properties
 /// honour the spec's duplicate-key rule: first-occurrence POSITION, last VALUE.
-fn fold_from_entries_pairs(elements: &[Option<Expression>]) -> Option<Vec<Property>> {
+fn fold_from_entries_pairs(elements: &[Option<Expression>]) -> Option<Vec<ObjectMember>> {
     // Parallel vectors in first-occurrence order; `keys` lets us find a
     // duplicate so its value can be overwritten in place (spec behaviour).
     let mut keys: Vec<String> = Vec::new();
-    let mut props: Vec<Property> = Vec::new();
+    let mut props: Vec<ObjectMember> = Vec::new();
     for element in elements {
         // No outer hole — `[ , ["a", 1]]` is declined.
         let pair = element.as_ref()?;
@@ -5159,7 +5179,7 @@ fn fold_from_entries_pairs(elements: &[Option<Expression>]) -> Option<Vec<Proper
             | Expression::NullLiteral(_) => value_expr.clone(),
             _ => return None,
         };
-        let property = Property {
+        let property = ObjectMember::Property(Property {
             cv: None,
             kind: PropertyKind::Init,
             key: property_key_for(&key_string),
@@ -5167,7 +5187,7 @@ fn fold_from_entries_pairs(elements: &[Option<Expression>]) -> Option<Vec<Proper
             computed: false,
             shorthand: false,
             method: false,
-        };
+        });
         // Duplicate key → keep first POSITION, take last VALUE.
         if let Some(pos) = keys.iter().position(|k| k == &key_string) {
             props[pos] = property;
@@ -8847,7 +8867,7 @@ mod tests {
         // dedicated tests cover that.)
         let obj = Expression::ObjectExpression(ObjectExpression {
             cv: None,
-            properties: vec![Property {
+            properties: vec![ObjectMember::Property(Property {
                 cv: None,
                 kind: coding_adventures_javascript_ast::PropertyKind::Init,
                 key: PropertyKey::Identifier(coding_adventures_javascript_ast::Identifier {
@@ -8858,7 +8878,7 @@ mod tests {
                 shorthand: false,
                 computed: false,
                 method: false,
-            }],
+            })],
         });
         let c = object_static_call("values", obj);
         let (out, _, changed, _) = run_pass(program_with_expr(c, true));
@@ -8934,8 +8954,18 @@ mod tests {
     fn object_lit(props: Vec<Property>) -> Expression {
         Expression::ObjectExpression(ObjectExpression {
             cv: None,
-            properties: props,
+            properties: props.into_iter().map(ObjectMember::Property).collect(),
         })
+    }
+
+    /// Extract the `&Property` from an `&ObjectMember` in test assertions.
+    /// The fold outputs asserted on here never synthesize object spreads, so
+    /// a `Spread` arm here indicates a broken fold, not a missing case.
+    fn prop_of(member: &ObjectMember) -> &Property {
+        match member {
+            ObjectMember::Property(p) => p,
+            ObjectMember::Spread(_) => unreachable!("folded object has no spreads"),
+        }
     }
 
     /// Assert that `pair` is `["<key>", <expected-value-matcher>]`.
@@ -10049,13 +10079,13 @@ mod tests {
         match extract_expr(&out) {
             Expression::ObjectExpression(o) => {
                 assert_eq!(o.properties.len(), 2, "two properties");
-                let p0 = &o.properties[0];
+                let p0 = prop_of(&o.properties[0]);
                 match &p0.key {
                     PropertyKey::Identifier(id) => assert_eq!(id.name, "a"),
                     other => panic!("expected identifier key `a`; got {:?}", other),
                 }
                 assert!(matches!(&*p0.value, Expression::NumericLiteral(n) if n.value == 1.0));
-                let p1 = &o.properties[1];
+                let p1 = prop_of(&o.properties[1]);
                 match &p1.key {
                     PropertyKey::Identifier(id) => assert_eq!(id.name, "b"),
                     other => panic!("expected identifier key `b`; got {:?}", other),
@@ -10077,11 +10107,11 @@ mod tests {
         match extract_expr(&out) {
             Expression::ObjectExpression(o) => {
                 assert_eq!(o.properties.len(), 1, "one property");
-                match &o.properties[0].key {
+                match &prop_of(&o.properties[0]).key {
                     PropertyKey::StringLiteral(s) => assert_eq!(s.value, "1", "key ToString → \"1\""),
                     other => panic!("expected string key \"1\"; got {:?}", other),
                 }
-                assert!(matches!(&*o.properties[0].value, Expression::StringLiteral(s) if s.value == "x"));
+                assert!(matches!(&*prop_of(&o.properties[0]).value, Expression::StringLiteral(s) if s.value == "x"));
             }
             other => panic!("expected object literal; got {:?}", other),
         }
@@ -10102,15 +10132,15 @@ mod tests {
             Expression::ObjectExpression(o) => {
                 assert_eq!(o.properties.len(), 2, "deduped to two properties");
                 // position 0 is still `a`, but its value is the LAST one (3).
-                match &o.properties[0].key {
+                match &prop_of(&o.properties[0]).key {
                     PropertyKey::Identifier(id) => assert_eq!(id.name, "a", "a keeps first position"),
                     other => panic!("expected identifier key `a`; got {:?}", other),
                 }
                 assert!(
-                    matches!(&*o.properties[0].value, Expression::NumericLiteral(n) if n.value == 3.0),
+                    matches!(&*prop_of(&o.properties[0]).value, Expression::NumericLiteral(n) if n.value == 3.0),
                     "a takes the LAST value (3)"
                 );
-                match &o.properties[1].key {
+                match &prop_of(&o.properties[1]).key {
                     PropertyKey::Identifier(id) => assert_eq!(id.name, "b"),
                     other => panic!("expected identifier key `b`; got {:?}", other),
                 }
@@ -10145,10 +10175,10 @@ mod tests {
         match extract_expr(&out) {
             Expression::ObjectExpression(o) => {
                 assert_eq!(o.properties.len(), 4);
-                assert!(matches!(&*o.properties[0].value, Expression::StringLiteral(_)));
-                assert!(matches!(&*o.properties[1].value, Expression::NumericLiteral(_)));
-                assert!(matches!(&*o.properties[2].value, Expression::BooleanLiteral(_)));
-                assert!(matches!(&*o.properties[3].value, Expression::NullLiteral(_)));
+                assert!(matches!(&*prop_of(&o.properties[0]).value, Expression::StringLiteral(_)));
+                assert!(matches!(&*prop_of(&o.properties[1]).value, Expression::NumericLiteral(_)));
+                assert!(matches!(&*prop_of(&o.properties[2]).value, Expression::BooleanLiteral(_)));
+                assert!(matches!(&*prop_of(&o.properties[3]).value, Expression::NullLiteral(_)));
             }
             other => panic!("expected object literal; got {:?}", other),
         }

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -77,7 +77,7 @@ use coding_adventures_javascript_ast::{
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
     FunctionDeclaration, FunctionExpression, IfStatement, LogicalExpression, MemberExpression, NullLiteral,
-    NumericLiteral, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
+    NumericLiteral, ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, UpdateExpression, VarKind,
     DoWhileStatement, VariableDeclaration, VariableDeclarator, WhileStatement,
 };
@@ -1288,25 +1288,32 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
             properties: o
                 .properties
                 .iter()
-                .map(|p| Property {
-                    cv: p.cv.clone(),
-                    kind: p.kind,
-                    key: match &p.key {
-                        PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
-                        PropertyKey::StringLiteral(s) => {
-                            PropertyKey::StringLiteral(s.clone())
-                        }
-                        PropertyKey::NumericLiteral(n) => {
-                            PropertyKey::NumericLiteral(n.clone())
-                        }
-                        PropertyKey::Expression(e) => {
-                            PropertyKey::Expression(Box::new(dce_expression(e, st)))
-                        }
-                    },
-                    value: Box::new(dce_expression(&p.value, st)),
-                    computed: p.computed,
-                    shorthand: p.shorthand,
-                    method: p.method,
+                .map(|member| match member {
+                    ObjectMember::Property(p) => ObjectMember::Property(Property {
+                        cv: p.cv.clone(),
+                        kind: p.kind,
+                        key: match &p.key {
+                            PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
+                            PropertyKey::StringLiteral(s) => {
+                                PropertyKey::StringLiteral(s.clone())
+                            }
+                            PropertyKey::NumericLiteral(n) => {
+                                PropertyKey::NumericLiteral(n.clone())
+                            }
+                            PropertyKey::Expression(e) => {
+                                PropertyKey::Expression(Box::new(dce_expression(e, st)))
+                            }
+                        },
+                        value: Box::new(dce_expression(&p.value, st)),
+                        computed: p.computed,
+                        shorthand: p.shorthand,
+                        method: p.method,
+                    }),
+                    // Object spread `...expr` — recurse into the spread argument.
+                    ObjectMember::Spread(s) => ObjectMember::Spread(SpreadElement {
+                        cv: s.cv.clone(),
+                        argument: Box::new(dce_expression(&s.argument, st)),
+                    }),
                 })
                 .collect(),
         }),

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -62,7 +62,7 @@ use coding_adventures_javascript_ast::{
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
     LogicalExpression,
     LogicalOperator,
-    MemberExpression, ObjectExpression, Program, ProgramItem, Property, PropertyKey,
+    MemberExpression, ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, UnaryExpression, UnaryOperator, UpdateExpression, VarKind, VariableDeclaration,
     DoWhileStatement, VariableDeclarator, WhileStatement,
 };
@@ -1475,25 +1475,32 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
             properties: o
                 .properties
                 .iter()
-                .map(|p| Property {
-                    cv: p.cv.clone(),
-                    kind: p.kind,
-                    key: match &p.key {
-                        PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
-                        PropertyKey::StringLiteral(s) => {
-                            PropertyKey::StringLiteral(s.clone())
-                        }
-                        PropertyKey::NumericLiteral(n) => {
-                            PropertyKey::NumericLiteral(n.clone())
-                        }
-                        PropertyKey::Expression(e) => {
-                            PropertyKey::Expression(Box::new(fold_expression(e, st)))
-                        }
-                    },
-                    value: Box::new(fold_expression(&p.value, st)),
-                    computed: p.computed,
-                    shorthand: p.shorthand,
-                    method: p.method,
+                .map(|member| match member {
+                    ObjectMember::Property(p) => ObjectMember::Property(Property {
+                        cv: p.cv.clone(),
+                        kind: p.kind,
+                        key: match &p.key {
+                            PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
+                            PropertyKey::StringLiteral(s) => {
+                                PropertyKey::StringLiteral(s.clone())
+                            }
+                            PropertyKey::NumericLiteral(n) => {
+                                PropertyKey::NumericLiteral(n.clone())
+                            }
+                            PropertyKey::Expression(e) => {
+                                PropertyKey::Expression(Box::new(fold_expression(e, st)))
+                            }
+                        },
+                        value: Box::new(fold_expression(&p.value, st)),
+                        computed: p.computed,
+                        shorthand: p.shorthand,
+                        method: p.method,
+                    }),
+                    // Object spread `...expr` — recurse into the spread argument.
+                    ObjectMember::Spread(s) => ObjectMember::Spread(SpreadElement {
+                        cv: s.cv.clone(),
+                        argument: Box::new(fold_expression(&s.argument, st)),
+                    }),
                 })
                 .collect(),
         }),

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -108,7 +108,7 @@ use serde_json::json;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     ArrowBody, AssignmentTarget, BindingTarget, Declaration, Expression, ForInit, FunctionParam,
-    Program, ProgramItem, PropertyKey, Statement, VarKind, VariableDeclaration,
+    Program, ProgramItem, ObjectMember, PropertyKey, Statement, VarKind, VariableDeclaration,
 };
 
 /// `Pass::depends_on` value — constant-fold first, so a folded
@@ -786,13 +786,23 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &prop.key {
-                        count_uses_expr(e, name, count);
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &prop.key {
+                                count_uses_expr(e, name, count);
+                            }
+                        }
+                        count_uses_expr(&prop.value, name, count);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        count_uses_expr(&s.argument, name, count);
                     }
                 }
-                count_uses_expr(&prop.value, name, count);
             }
         }
         // Count uses of `name` inside a function *value*'s body, exactly
@@ -1089,15 +1099,25 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                // A computed key `[expr]` is a use position; a plain
-                // identifier / string / number key is a property name.
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        changed |= propagate_in_expr(e, cand);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        // A computed key `[expr]` is a use position; a plain
+                        // identifier / string / number key is a property name.
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                changed |= propagate_in_expr(e, cand);
+                            }
+                        }
+                        changed |= propagate_in_expr(&mut prop.value, cand);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        changed |= propagate_in_expr(&mut s.argument, cand);
                     }
                 }
-                changed |= propagate_in_expr(&mut prop.value, cand);
             }
         }
         // Propagate the candidate into a function *value*'s body,

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -130,7 +130,7 @@ use coding_adventures_javascript_ast::{
     ArrowBody, AssignmentExpression, AssignmentOperator, AssignmentTarget, BindingTarget,
     BlockStatement,
     CallExpression, Declaration, Expression, ExpressionStatement, ForInit, FunctionDeclaration,
-    FunctionParam, Identifier, IfStatement, NullLiteral, Program, ProgramItem, PropertyKey,
+    FunctionParam, Identifier, IfStatement, NullLiteral, Program, ProgramItem, ObjectMember, PropertyKey,
     Statement, VarKind, VariableDeclaration, VariableDeclarator,
 };
 
@@ -476,12 +476,17 @@ fn expr_node_count(expr: &Expression) -> usize {
         Expression::ObjectExpression(oe) => oe
             .properties
             .iter()
-            .map(|p| {
-                let key = match &p.key {
-                    PropertyKey::Expression(e) => expr_node_count(e),
-                    _ => 1,
-                };
-                key + expr_node_count(&p.value)
+            .map(|member| match member {
+                ObjectMember::Property(p) => {
+                    let key = match &p.key {
+                        PropertyKey::Expression(e) => expr_node_count(e),
+                        _ => 1,
+                    };
+                    key + expr_node_count(&p.value)
+                }
+                // A spread `...expr` has no key — count one node for the
+                // spread itself plus the node count of its argument.
+                ObjectMember::Spread(s) => 1 + expr_node_count(&s.argument),
             })
             .sum(),
         // A function *value* is heavy: count its params and one unit per
@@ -817,16 +822,26 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                // Only a *computed* key `[expr]` is a binding use; a
-                // plain identifier / string / number key is a property
-                // name.
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &prop.key {
-                        collect_binding_idents_expr(e, out);
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        // Only a *computed* key `[expr]` is a binding use; a
+                        // plain identifier / string / number key is a property
+                        // name.
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &prop.key {
+                                collect_binding_idents_expr(e, out);
+                            }
+                        }
+                        collect_binding_idents_expr(&prop.value, out);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        collect_binding_idents_expr(&s.argument, out);
                     }
                 }
-                collect_binding_idents_expr(&prop.value, out);
             }
         }
         // A function *value* binds its own name (if named) and its params
@@ -1127,13 +1142,23 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &prop.key {
-                        tally_expr(e, cand, t);
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &prop.key {
+                                tally_expr(e, cand, t);
+                            }
+                        }
+                        tally_expr(&prop.value, cand, t);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        tally_expr(&s.argument, cand, t);
                     }
                 }
-                tally_expr(&prop.value, cand, t);
             }
         }
         // Count uses of the candidate inside a function *value*'s body —
@@ -1444,16 +1469,26 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                // A computed key `[expr]` is a sub-expression to walk; a
-                // plain identifier / string / number key is a property
-                // name.
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        changed |= inline_in_expr(e, cand);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        // A computed key `[expr]` is a sub-expression to walk; a
+                        // plain identifier / string / number key is a property
+                        // name.
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                changed |= inline_in_expr(e, cand);
+                            }
+                        }
+                        changed |= inline_in_expr(&mut prop.value, cand);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        changed |= inline_in_expr(&mut s.argument, cand);
                     }
                 }
-                changed |= inline_in_expr(&mut prop.value, cand);
             }
         }
         // Inline candidate calls that appear inside a function *value*'s
@@ -1597,13 +1632,23 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        substitute(e, map);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                substitute(e, map);
+                            }
+                        }
+                        substitute(&mut prop.value, map);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        substitute(&mut s.argument, map);
                     }
                 }
-                substitute(&mut prop.value, map);
             }
         }
         // Substitute param→arg inside a function *value*'s body, but a
@@ -1998,13 +2043,23 @@ fn expr_collect_mutated_params(
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &prop.key {
-                        expr_collect_mutated_params(e, params, out);
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &prop.key {
+                                expr_collect_mutated_params(e, params, out);
+                            }
+                        }
+                        expr_collect_mutated_params(&prop.value, params, out);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        expr_collect_mutated_params(&s.argument, params, out);
                     }
                 }
-                expr_collect_mutated_params(&prop.value, params, out);
             }
         }
         // An assignment to an outer param INSIDE a function value's body
@@ -3475,13 +3530,23 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        rename_in_expr(e, map);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                rename_in_expr(e, map);
+                            }
+                        }
+                        rename_in_expr(&mut prop.value, map);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        rename_in_expr(&mut s.argument, map);
                     }
                 }
-                rename_in_expr(&mut prop.value, map);
             }
         }
         // Alpha-rename uses inside a function *value*'s body, but its own

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -73,7 +73,7 @@ use coding_adventures_javascript_ast::statement::TaggedStatement;
 use serde_json::json;
 use coding_adventures_javascript_ast::{
     ArrowBody, AssignmentTarget, BindingTarget, Declaration, Expression, ForInit, FunctionParam,
-    Program, ProgramItem, PropertyKey, Statement, VariableDeclaration,
+    ObjectMember, Program, ProgramItem, PropertyKey, Statement, VariableDeclaration,
 };
 
 /// `Pass::depends_on` value — empty. Global renaming is correct on its
@@ -692,15 +692,25 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                match &prop.key {
-                    PropertyKey::Identifier(id) => {
-                        out.insert(id.name.clone());
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        match &prop.key {
+                            PropertyKey::Identifier(id) => {
+                                out.insert(id.name.clone());
+                            }
+                            PropertyKey::Expression(e) => collect_all_idents_expr(e, out),
+                            _ => {}
+                        }
+                        collect_all_idents_expr(&prop.value, out);
                     }
-                    PropertyKey::Expression(e) => collect_all_idents_expr(e, out),
-                    _ => {}
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        collect_all_idents_expr(&s.argument, out);
+                    }
                 }
-                collect_all_idents_expr(&prop.value, out);
             }
         }
         // A function *value* introduces its own name (if any) and params
@@ -1023,15 +1033,25 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                // Only a *computed* key `[expr]` is a use position; a plain
-                // identifier / string / number key is a property name.
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        rename_apply_expr(e, map);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        // Only a *computed* key `[expr]` is a use position; a plain
+                        // identifier / string / number key is a property name.
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                rename_apply_expr(e, map);
+                            }
+                        }
+                        rename_apply_expr(&mut prop.value, map);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        rename_apply_expr(&mut s.argument, map);
                     }
                 }
-                rename_apply_expr(&mut prop.value, map);
             }
         }
         // A function *value*'s own name (if named) and its params are

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -83,7 +83,7 @@ use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use serde_json::json;
 use coding_adventures_javascript_ast::{
-    ArrowBody, AssignmentTarget, Declaration, Expression, ForInit, Program, ProgramItem,
+    ArrowBody, AssignmentTarget, Declaration, Expression, ForInit, ObjectMember, Program, ProgramItem,
     PropertyKey, Statement,
 };
 
@@ -1196,24 +1196,35 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                if prop.computed {
-                    // `{ [expr]: v }` — Phase-1 rejects this at the bridge,
-                    // but be defensive: recurse the key, record nothing.
-                    if let PropertyKey::Expression(e) = &prop.key {
-                        classify_expr(e, cls);
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            // `{ [expr]: v }` — Phase-1 rejects this at the bridge,
+                            // but be defensive: recurse the key, record nothing.
+                            if let PropertyKey::Expression(e) = &prop.key {
+                                classify_expr(e, cls);
+                            }
+                        } else {
+                            match &prop.key {
+                                // `{ x: v }` — a renameable dotted key.
+                                PropertyKey::Identifier(id) => cls.see_dotted(&id.name),
+                                // `{ "x": v }` — a quoted key disables `x`.
+                                PropertyKey::StringLiteral(s) => cls.see_quoted(&s.value),
+                                // Numeric keys / others — not renameable identifiers.
+                                _ => {}
+                            }
+                        }
+                        classify_expr(&prop.value, cls);
                     }
-                } else {
-                    match &prop.key {
-                        // `{ x: v }` — a renameable dotted key.
-                        PropertyKey::Identifier(id) => cls.see_dotted(&id.name),
-                        // `{ "x": v }` — a quoted key disables `x`.
-                        PropertyKey::StringLiteral(s) => cls.see_quoted(&s.value),
-                        // Numeric keys / others — not renameable identifiers.
-                        _ => {}
+                    // `{ ...expr }` — a spread has no property NAME, so it
+                    // touches no property namespace. Only walk its argument
+                    // sub-expression so a quoted access inside it still
+                    // disables the affected name.
+                    ObjectMember::Spread(s) => {
+                        classify_expr(&s.argument, cls);
                     }
                 }
-                classify_expr(&prop.value, cls);
             }
         }
         // Classify property accesses inside a function *value*'s body — a
@@ -1487,19 +1498,28 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        rewrite_expr(e, map);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                rewrite_expr(e, map);
+                            }
+                        } else if let PropertyKey::Identifier(id) = &mut prop.key {
+                            // Rewrite a renameable unquoted key; a `StringLiteral`
+                            // (quoted) key is never in `map`, so it is left alone.
+                            if let Some(new) = map.get(&id.name) {
+                                id.name = new.clone();
+                            }
+                        }
+                        rewrite_expr(&mut prop.value, map);
                     }
-                } else if let PropertyKey::Identifier(id) = &mut prop.key {
-                    // Rewrite a renameable unquoted key; a `StringLiteral`
-                    // (quoted) key is never in `map`, so it is left alone.
-                    if let Some(new) = map.get(&id.name) {
-                        id.name = new.clone();
+                    // `{ ...expr }` — a spread has no property NAME to rewrite;
+                    // only walk its argument sub-expression.
+                    ObjectMember::Spread(s) => {
+                        rewrite_expr(&mut s.argument, map);
                     }
                 }
-                rewrite_expr(&mut prop.value, map);
             }
         }
         // Rewrite property accesses inside a function *value*'s body, the

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -92,7 +92,7 @@ use serde_json::json;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     ArrowBody, AssignmentTarget, BindingTarget, BlockStatement, Declaration, Expression, ForInit,
-    FunctionDeclaration, FunctionParam, Program, ProgramItem, PropertyKey, Statement, VarKind,
+    FunctionDeclaration, FunctionParam, ObjectMember, Program, ProgramItem, PropertyKey, Statement, VarKind,
     VariableDeclaration,
 };
 
@@ -970,15 +970,25 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                match &prop.key {
-                    PropertyKey::Identifier(id) => {
-                        out.insert(id.name.clone());
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        match &prop.key {
+                            PropertyKey::Identifier(id) => {
+                                out.insert(id.name.clone());
+                            }
+                            PropertyKey::Expression(e) => collect_all_idents_expr(e, out),
+                            _ => {}
+                        }
+                        collect_all_idents_expr(&prop.value, out);
                     }
-                    PropertyKey::Expression(e) => collect_all_idents_expr(e, out),
-                    _ => {}
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        collect_all_idents_expr(&s.argument, out);
+                    }
                 }
-                collect_all_idents_expr(&prop.value, out);
             }
         }
         // A function *value* introduces its own name (if any), its params,
@@ -1285,16 +1295,26 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &mut oe.properties {
-                // Only a *computed* key `[expr]` is a use position; a
-                // plain identifier / string / number key is a property
-                // name, never rewritten.
-                if prop.computed {
-                    if let PropertyKey::Expression(e) = &mut prop.key {
-                        rewrite_uses_expr(e, map);
+            for member in &mut oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        // Only a *computed* key `[expr]` is a use position; a
+                        // plain identifier / string / number key is a property
+                        // name, never rewritten.
+                        if prop.computed {
+                            if let PropertyKey::Expression(e) = &mut prop.key {
+                                rewrite_uses_expr(e, map);
+                            }
+                        }
+                        rewrite_uses_expr(&mut prop.value, map);
+                    }
+                    // Object spread `...expr` — recurse into the spread
+                    // argument the same way the property arm recurses into
+                    // prop.value.
+                    ObjectMember::Spread(s) => {
+                        rewrite_uses_expr(&mut s.argument, map);
                     }
                 }
-                rewrite_uses_expr(&mut prop.value, map);
             }
         }
         // A nested function *value* closes over the enclosing function's

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -69,7 +69,7 @@ use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     ArrowBody, ArrowFunctionExpression,
     AssignmentTarget, BindingTarget, BlockStatement, CvId, Declaration, Expression, ForInit,
-    FunctionDeclaration, FunctionExpression, FunctionParam, Program, ProgramItem, Property, PropertyKey, Statement,
+    FunctionDeclaration, FunctionExpression, FunctionParam, ObjectMember, Program, ProgramItem, Property, PropertyKey, Statement,
     VarKind, VariableDeclaration,
 };
 use serde::{Deserialize, Serialize};
@@ -921,8 +921,18 @@ fn walk_expression(
             }
         }
         Expression::ObjectExpression(oe) => {
-            for prop in &oe.properties {
-                walk_property(prop, ctx, analysis, pending);
+            for member in &oe.properties {
+                match member {
+                    ObjectMember::Property(prop) => {
+                        walk_property(prop, ctx, analysis, pending);
+                    }
+                    // An object spread `...expr` reads `expr` in the current
+                    // scope (it binds nothing), so walk its argument like any
+                    // other sub-expression.
+                    ObjectMember::Spread(s) => {
+                        walk_expression(&s.argument, ctx, analysis, pending);
+                    }
+                }
             }
         }
         Expression::FunctionExpression(fe) => {

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.29.0] - 2026-07-07
+
+### Added — CLOC12.170: object spread `{...o}` via `ObjectMember` (gap-SpreadProperty)
+
+Object literals now model **object spread** `{...o}` (ES2018). This is the
+first *structural* change to an existing node: `ObjectExpression.properties`
+changes from `Vec<Property>` to `Vec<ObjectMember>`, where
+
+```rust
+pub enum ObjectMember { Property(Property), Spread(SpreadElement) }
+```
+
+reusing the existing `SpreadElement { cv, argument }` for the spread arm (the
+same node the call/array spread uses — ESTree names both `SpreadElement`). The
+enum keeps `Property` and `Spread` members in ONE ordered vector because the
+order is observable (`{a: 1, ...o, b: 2}` — a later member overrides an earlier
+key, and a spread may sit before, between, or after plain properties); a side
+channel would lose the interleaving and miscompile override semantics.
+Serialised `#[serde(untagged)]`: the `Property` arm carries its own
+`"type": "Property"` tag and the `Spread` arm carries `SpreadElement`'s
+`argument`, so a member round-trips unambiguously (new
+`object_member_spread_round_trips` test). This is the **node-only** PR1 — the
+`javascript-parser` bridge still declines `{...o}` (gap-SpreadProperty), and the
+emitter + all nine downstream passes gain their `ObjectMember` match arms in the
+same atomic change so the workspace never has a broken `match`.
+
 ## [0.28.0] - 2026-07-07
 
 ### Added — CLOC12.169: `Expression::ImportExpression` (dynamic `import(x)`)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -796,16 +796,59 @@ pub struct ArrayExpression {
     pub elements: Vec<Option<Expression>>,
 }
 
-/// `{ key1: value1, key2: value2 }`. Property insertion order is
-/// preserved per ES2015+ — `Object.keys` is observable. Phase 1
-/// supports `Init` properties (`{k: v}`), getters, setters, shorthand
-/// `{k}`, and methods `{k() {}}`. Spread (`{...x}`) is Phase 2.
+/// `{ key1: value1, key2: value2 }`. Member insertion order is
+/// preserved per ES2015+ — `Object.keys` is observable. Supports
+/// `Init` properties (`{k: v}`), getters, setters, shorthand
+/// `{k}`, methods `{k() {}}`, and **object spread** `{...x}` (ES2018) —
+/// see [`ObjectMember`] for how the two member shapes intermix.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectExpression {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub cv: Option<CvId>,
-    pub properties: Vec<Property>,
+    pub properties: Vec<ObjectMember>,
+}
+
+/// One entry in an [`ObjectExpression`]'s `properties` list — either a normal
+/// key/value [`Property`] or an object **spread** `...expr` (ES2018) that copies
+/// another object's own enumerable properties in.
+///
+/// # Why an enum rather than two parallel vectors
+///
+/// ESTree intermixes `Property` and `SpreadElement` nodes in the *same*
+/// `properties` array, and the order is **observable**: a later member's key
+/// overrides an earlier one, and a spread may sit before, between, or after
+/// plain properties (`{a: 1, ...o, b: 2}`). Modelling the list as a single
+/// `Vec<ObjectMember>` preserves that source order for every walker for free —
+/// splitting spreads into a side channel would lose the interleaving and
+/// silently miscompile override semantics.
+///
+/// # Why the spread reuses [`SpreadElement`]
+///
+/// The object-spread carries exactly what the call/array spread carries — a
+/// single `argument` expression and its provenance `cv` — and prints the same
+/// way (`...expr`). Reusing the existing node keeps one spread shape and one
+/// emit path (`emit_object_spread` mirrors `emit_spread`), rather than a
+/// near-duplicate struct. ESTree names both `SpreadElement`, so this matches
+/// the reference tree too.
+///
+/// ```text
+///   {a: 1}          → Property        a normal key/value member
+///   {...o}          → Spread          copy o's own enumerable props
+///   {a: 1, ...o}    → [Property, Spread]   order is observable
+/// ```
+///
+/// Serialised `#[serde(untagged)]`: the `Property` arm carries its own
+/// `"type": "Property"` tag and the `Spread` arm carries `SpreadElement`'s
+/// `argument` field, so a member deserialises unambiguously (only a spread has
+/// `argument`; only a property has `kind`/`key`/`value`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ObjectMember {
+    /// A normal `k: v` / shorthand / getter / setter / method property.
+    Property(Property),
+    /// An object spread `...expr`. Reuses [`SpreadElement`] (`{ cv, argument }`).
+    Spread(SpreadElement),
 }
 
 /// One entry of an [`ObjectExpression`]. ESTree calls this `Property`;
@@ -1601,7 +1644,7 @@ mod tests {
         // `{ foo: 1 }`.
         let e = Expression::ObjectExpression(ObjectExpression {
             cv: None,
-            properties: vec![Property {
+            properties: vec![ObjectMember::Property(Property {
                 cv: None,
                 kind: PropertyKind::Init,
                 key: PropertyKey::Identifier(Identifier {
@@ -1616,10 +1659,28 @@ mod tests {
                 computed: false,
                 shorthand: false,
                 method: false,
-            }],
+            })],
         });
         assert_eq!(e.clone(), roundtrip(e.clone()));
         assert_eq!(type_tag(&e), "ObjectExpression");
+    }
+
+    #[test]
+    fn object_member_spread_round_trips() {
+        // `{...o}` — an `ObjectMember::Spread` survives serialise→deserialise
+        // under the `#[serde(untagged)]` representation (only a spread carries
+        // `argument`; only a property carries `kind`/`key`/`value`).
+        let e = Expression::ObjectExpression(ObjectExpression {
+            cv: None,
+            properties: vec![ObjectMember::Spread(SpreadElement {
+                cv: None,
+                argument: Box::new(Expression::Identifier(Identifier {
+                    cv: None,
+                    name: "o".to_string(),
+                })),
+            })],
+        });
+        assert_eq!(e.clone(), roundtrip(e.clone()));
     }
 
     #[test]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -138,7 +138,7 @@ pub use expression::{
     ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
     LogicalOperator, MemberExpression,
     NewExpression,
-    NullLiteral, NumericLiteral, ObjectExpression, Property, PropertyKey, PropertyKind,
+    NullLiteral, NumericLiteral, ObjectExpression, ObjectMember, Property, PropertyKey, PropertyKind,
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -58,7 +58,7 @@ use coding_adventures_javascript_ast::{
         BigIntLiteral, BinaryExpression, BinaryOperator, BooleanLiteral, CallExpression,
         ConditionalExpression, Expression, FunctionExpression, Identifier, LogicalExpression,
         LogicalOperator,
-        ImportExpression, ImportMeta, MemberExpression, NewExpression, NewTarget, NullLiteral, NumericLiteral, ObjectExpression, Property,
+        ImportExpression, ImportMeta, MemberExpression, NewExpression, NewTarget, NullLiteral, NumericLiteral, ObjectExpression, ObjectMember, Property,
         PropertyKey, PropertyKind, SequenceExpression, SpreadElement, StringLiteral, TaggedTemplateExpression,
         TemplateElement, TemplateLiteral,
         UnaryExpression, UnaryOperator,
@@ -2654,7 +2654,12 @@ fn convert_object_literal(node: &GrammarASTNode) -> Result<Expression, BridgeErr
     for n in nodes {
         match n.rule_name.as_str() {
             "property_definition" => {
-                properties.push(convert_property_definition(n)?);
+                // PR1 (node-only): normal key/value / shorthand / getter / setter
+                // properties convert to `ObjectMember::Property`. Object spread
+                // `{...o}` is still declined inside `convert_property_definition`
+                // (gap-SpreadProperty) — the `ObjectMember::Spread` bridge lands
+                // in CLOC12.170 PR2.
+                properties.push(ObjectMember::Property(convert_property_definition(n)?));
             }
             _ => {}
         }
@@ -4332,7 +4337,12 @@ mod tests {
     /// The first property's key of an object-literal expression statement.
     fn first_object_key(src: &str) -> PropertyKey {
         match first_expr(&bridge_ok(src)) {
-            Expression::ObjectExpression(o) => o.properties[0].key.clone(),
+            Expression::ObjectExpression(o) => match &o.properties[0] {
+                ObjectMember::Property(p) => p.key.clone(),
+                ObjectMember::Spread(_) => {
+                    unreachable!("first_object_key fixtures build no object spreads")
+                }
+            },
             other => panic!("expected ObjectExpression, got {other:?}"),
         }
     }

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -1951,8 +1951,9 @@ closurec e2e diff fixture (`tests/diff/simple-spread/`) proving
 WHITESPACE_ONLY.
 
 **Scope:** object-spread `{...o}` in an object literal (`convert_property_definition`,
-gap tracked as `SpreadProperty`) remains declined — it is a *property*, a
-separate later slice; this PR is the call/array/`new` spread only.
+gap tracked as `SpreadProperty`) is a separate *property*-position slice, taken up
+in **CLOC12.170** (its node + emit landed in PR1; bridge in PR2). This PR is the
+call/array/`new` spread only.
 
 ## CLOC12.163 — `YieldExpression` (`yield` / `yield*`): atomic node + emit + passes (PR1)
 
@@ -2136,6 +2137,56 @@ the same staging used for the substitution-template slice (gap-157), which also
 shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
+
+## CLOC12.170 — object spread `{...o}` via `ObjectMember`: structural node + emit + passes (PR1)
+
+Object literals now model **object spread** `{...o}` (ES2018) — the `...expr`
+member that copies another object's own enumerable properties in. This is the
+FIRST *structural* node in the CLOC12 arc: rather than adding an `Expression`
+variant, it changes the shape of an existing node. `ObjectExpression.properties`
+goes from `Vec<Property>` to `Vec<ObjectMember>` (`javascript-ast` 0.29.0):
+
+```rust
+pub enum ObjectMember { Property(Property), Spread(SpreadElement) }
+```
+
+The spread arm **reuses** the existing `SpreadElement { cv, argument }` — the
+same node the call/array spread (CLOC12.162) uses, which ESTree also names
+`SpreadElement` — so there is one spread shape and one emit path. `Property` and
+`Spread` members share ONE ordered vector because the order is observable: in
+`{a: 1, ...o, b: 2}` a later member overrides an earlier key, and a spread may
+sit before, between, or after plain properties. A side channel would lose the
+interleaving and silently miscompile override semantics.
+
+`closure-emitter` (0.34.0) `emit_object` iterates the members and prints a
+spread via `emit_object_spread` — `...` then the argument at `PREC_ASSIGNMENT`
+with no interior space, mirroring the call/array `emit_spread`. The assignment
+precedence is the crux: an object-member position is an `AssignmentExpression`,
+so everything at or above assignment prints bare (`{...a}`, `{...a.b}`,
+`{...f()}`) while the one looser form — a **sequence** — wraps (`{...(a,b)}`),
+because a bare `...a,b` would spread only `a` and leave `,b` as a second
+(invalid) member slot. 5 emitter unit tests.
+
+All nine downstream pass/analysis crates gain their `ObjectMember` match arms —
+transform passes (`constant-fold`, `dce`, `fold-control-flow`) rebuild both
+member kinds and recurse into the spread `argument`; visitor passes (`inline`,
+`inline-variables`, `rename`, `rename-globals`, `rename-properties`,
+`scope-analyzer`) walk the spread `argument` like any read sub-expression
+(a spread has no property name, so the name-renaming passes never rename it).
+`Object.keys`/`Object.entries` constant-folds decline (return `None`) when any
+member is a spread, since a spread injects statically-unknown keys. All in ONE
+atomic commit so the workspace never has a broken `match`.
+
+### gap-SpreadProperty — bridge declines object spread `{...o}` — **OPEN (bridge slice pending, CLOC12.170 PR2)**
+
+The `javascript-parser` bridge's `convert_property_definition` still returns
+`UnsupportedSyntax` for a `...` spread property (the `has_token(node, "...")`
+guard), so a file containing `{...o}` drops to WHITESPACE_ONLY. PR1 lands the
+`ObjectMember` node + emit + pass recursion so the typed AST and every pass can
+already represent and print an object spread. **PR2** wires
+`convert_property_definition`'s spread branch to `ObjectMember::Spread` and adds
+a closurec e2e diff fixture; **PR3** ports the upstream CodePrinter object-spread
+conformance cases.
 
 ## CLOC12.169 — `ImportExpression` (dynamic `import(x)`): atomic node + emit + passes (PR1)
 


### PR DESCRIPTION
## CLOC12.170 PR1 — object spread `{...o}` (first *structural* node)

Object literals now model **object spread** `{...o}` (ES2018). Unlike prior CLOC12 nodes (additive `Expression` variants), this changes the shape of an existing node.

### javascript-ast 0.28.0 → 0.29.0 (MINOR)
- `ObjectExpression.properties`: `Vec<Property>` → `Vec<ObjectMember>` where
  ```rust
  pub enum ObjectMember { Property(Property), Spread(SpreadElement) }
  ```
  The spread arm **reuses** the existing `SpreadElement { cv, argument }` (the same node the call/array spread uses — ESTree names both `SpreadElement`), so there's one spread shape and one emit path.
- One ordered vector because member order is **observable**: `{a: 1, ...o, b: 2}` — a later member overrides an earlier key, and a spread may sit before/between/after plain properties. A side channel would lose the interleaving and miscompile override semantics.
- `#[serde(untagged)]`: `Property` self-tags `"type":"Property"`, `Spread` carries `argument` → members round-trip unambiguously (new `object_member_spread_round_trips` test).

### closure-emitter 0.33.1 → 0.34.0 (MINOR)
- `emit_object` iterates members; new `emit_object_spread` prints `...` then the argument at `PREC_ASSIGNMENT` with no interior space (mirrors `emit_spread`): a **sequence** wraps (`{...(a,b)}`), everything ≥ assignment prints bare (`{...a}`, `{...a.b}`, `{...f()}`). 5 unit tests.

### All 9 downstream passes — one atomic commit (workspace never has a broken match)
- **Transform** passes (constant-fold, dce, fold-control-flow) rebuild both member kinds and recurse the spread `argument`. `Object.keys`/`Object.entries` folds **decline** when any member is a spread (statically-unknown keys); `Object.fromEntries` builds `Vec<ObjectMember>`.
- **Visitor** passes (inline, inline-variables, rename, rename-globals, rename-properties, scope-analyzer) walk the spread `argument` as a read sub-expression; name-renaming passes never rename a spread (it has no key).

### Bridge — spread still declined (→ PR2)
`convert_object_literal` wraps normal members in `ObjectMember::Property`; `convert_property_definition`'s `...` branch still returns `UnsupportedSyntax` (gap-SpreadProperty). The `ObjectMember::Spread` bridge + closurec e2e fixture land in **PR2**; the upstream CodePrinter object-spread conformance port in **PR3**.

### Verification
- 56 `test result: ok` suites across the 12 affected crates + closurec green.
- Inline security review: **PASSED** (0 findings; both new `unreachable!` are `#[cfg(test)]` test-helper extractors, unreachable from input).
- spec: `CLOC12-gaps.md` gains the CLOC12.170 section + gap-SpreadProperty (OPEN→PR2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)