### PR TITLE
feat(sir-oop-py): more String methods — ljust / rjust / center / swapcase (v0.1.13)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.13] - 2026-07-07
+
+### Added — more String methods: `ljust` / `rjust` / `center` / `swapcase`
+
+Extends `_string_method` (and the `_STRING_METHODS` `respond_to?` catalog) with
+four more common non-block Ruby String methods, mirroring the Go/JS runtimes:
+
+- `ljust(width, pad=" ")` / `rjust(...)` / `center(...)` — pad to `width`
+  characters using `pad` cyclically; `width <= len` returns the string
+  unchanged; `center` puts an odd extra pad char on the **right** (Ruby's rule,
+  the opposite of Python's built-in `str.center`, which also rejects a
+  multi-char fill). An empty pad degrades to a single space (never-raise floor).
+  New helper `_str_pad` builds the exact-length cyclic padding.
+- `swapcase` — flips each ASCII letter (non-letters / non-ASCII untouched),
+  matching the Go/JS runtimes byte-for-byte.
+
 ## [0.1.12] - 2026-07-07
 
 ### Added — Array block-method breadth (sort_by / group_by / partition / …)

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.12"
+version = "0.1.13"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1271,7 +1271,9 @@ def _string_method(recv: str, name: str, args: list[Val]) -> Val:
         # single space rather than raising, holding the never-raise floor.
         width = int(args[0]) if args and isinstance(args[0], (int, float)) else 0
         pad = args[1] if len(args) > 1 and isinstance(args[1], str) and args[1] else " "
-        deficit = width - len(recv)
+        # Clamp the padding to `_MAX_REPEAT_LEN` — the same DoS bound `_str_repeat`
+        # uses — so a hostile width (e.g. ``"".ljust(10**12)``) cannot OOM the host.
+        deficit = min(width - len(recv), _MAX_REPEAT_LEN)
         if deficit <= 0:
             return recv
         if name == "ljust":

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -681,6 +681,10 @@ _STRING_METHODS = frozenset(
         "empty?",
         "*",
         "+",
+        "ljust",
+        "rjust",
+        "center",
+        "swapcase",
     }
 )
 
@@ -1258,7 +1262,49 @@ def _string_method(recv: str, name: str, args: list[Val]) -> Val:
         return _str_repeat(recv, args[0])
     if name == "+":
         return recv + args[0]
+    if name in ("ljust", "rjust", "center"):
+        # Ruby ``String#ljust``/``#rjust``/``#center(width, pad=" ")``: pad to
+        # ``width`` CHARACTERS using ``pad`` cyclically.  ``width <= len(recv)``
+        # returns the string unchanged; ``center`` puts any odd extra pad char on
+        # the RIGHT (Ruby's rule — the opposite of Python's ``str.center``, which
+        # also only accepts a single-char fill).  An empty pad degrades to a
+        # single space rather than raising, holding the never-raise floor.
+        width = int(args[0]) if args and isinstance(args[0], (int, float)) else 0
+        pad = args[1] if len(args) > 1 and isinstance(args[1], str) and args[1] else " "
+        deficit = width - len(recv)
+        if deficit <= 0:
+            return recv
+        if name == "ljust":
+            return recv + _str_pad(pad, deficit)
+        if name == "rjust":
+            return _str_pad(pad, deficit) + recv
+        left = deficit // 2
+        return _str_pad(pad, left) + recv + _str_pad(pad, deficit - left)
+    if name == "swapcase":
+        # Ruby ``String#swapcase``: flip the case of each ASCII letter (leaving
+        # non-letters and non-ASCII characters untouched), matching the Go/JS
+        # runtimes byte-for-byte.
+        out = []
+        for ch in recv:
+            code = ord(ch)
+            if 65 <= code <= 90:
+                out.append(chr(code + 32))
+            elif 97 <= code <= 122:
+                out.append(chr(code - 32))
+            else:
+                out.append(ch)
+        return "".join(out)
     return _MISS
+
+
+def _str_pad(pad: str, n: int) -> str:
+    """Build a padding string of exactly ``n`` characters by repeating ``pad``
+    cyclically (truncating the final repeat).  ``n <= 0`` or an empty ``pad``
+    yields ``""`` — callers guarantee a non-empty pad, so the guard is defensive."""
+    if n <= 0 or not pad:
+        return ""
+    repeats = (n // len(pad)) + 1
+    return (pad * repeats)[:n]
 
 
 def _string_block_method(recv: str, name: str, block: Closure) -> Val:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -486,6 +486,21 @@ def test_string_length_case_reverse() -> None:
     assert oop.call_method("abc", "reverse") == "cba"
 
 
+def test_string_justify_and_swapcase() -> None:
+    # ljust/rjust/center pad to `width` chars with a cyclic pad; center's odd
+    # extra pad goes on the RIGHT (Ruby's rule); width <= len is a no-op.
+    assert oop.call_method("hi", "ljust", 5) == "hi   "
+    assert oop.call_method("hi", "ljust", 5, "*") == "hi***"
+    assert oop.call_method("hi", "rjust", 5, "*") == "***hi"
+    assert oop.call_method("hi", "center", 6, "*") == "**hi**"
+    assert oop.call_method("hi", "center", 5, "*") == "*hi**"
+    assert oop.call_method("abc", "ljust", 1) == "abc"
+    assert oop.call_method("abcdef", "ljust", 10, "xy") == "abcdefxyxy"
+    # swapcase flips each ASCII letter, leaving other characters untouched.
+    assert oop.call_method("Hello World", "swapcase") == "hELLO wORLD"
+    assert oop.call_method("a1B!c", "swapcase") == "A1b!C"
+
+
 def test_string_strip_family_and_chomp() -> None:
     assert oop.call_method("  hi  ", "strip") == "hi"
     assert oop.call_method("  hi  ", "lstrip") == "hi  "


### PR DESCRIPTION
## What

Completes the String justify/swapcase parity sweep on the Python `sir-runtime-oop` library (Go #7760, JS #7761 already in flight). Extends `_string_method` (and the `_STRING_METHODS` `respond_to?` catalog):

- **`ljust(width, pad=" ")` / `rjust(...)` / `center(...)`** — pad to `width` characters using `pad` cyclically; `width <= len` returns the string unchanged; `center` puts any odd extra pad char on the **right** (Ruby's rule — the opposite of Python's built-in `str.center`, which also rejects a multi-char fill). New helper `_str_pad` builds the exact-length cyclic padding.
- **`swapcase`** — flips each ASCII letter (non-letters / non-ASCII untouched), matching the Go/JS runtimes byte-for-byte.

## Why

Cross-backend stdlib-breadth parity — these were missing on the Python runtime. Off the maintainers' active frontier.

## Safety

Dispatch stays explicit name-comparison — never `getattr(recv, name)`. Never-raise floor holds: every `args` access is `isinstance`/length-guarded; `_str_pad` guards `n <= 0`/empty-pad before `len(pad)`; `swapcase` bounds `ord`/`chr` to ASCII. A follow-up `fix(security)` commit **clamps `_str_pad` to `_MAX_REPEAT_LEN`** (the same DoS bound the sibling `_str_repeat` uses) so a hostile width can't OOM the host — resolving an asymmetry the security review flagged. Review passed (0 vulnerabilities).

## Verification

- `pytest tests/test_oop.py` — 114 passed, 96.6% coverage.
- `ruff check src/` clean.
- New `test_string_justify_and_swapcase` asserts all 9 cases against the Ruby reference (matching the Go/JS PR assertions byte-for-byte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)