### PR TITLE
feat(sir-oop-ts): more String methods — ljust / rjust / center / swapcase (v0.1.13)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.13] - 2026-07-07
+
+### Added — more String methods: `ljust` / `rjust` / `center` / `swapcase`
+
+Extends `stringMethod` (and the `STRING_METHODS` `respond_to?` set) with four
+more common non-block Ruby String methods, completing the cross-backend parity
+sweep (Go / JS / Rust / Python already have these):
+
+- `ljust(width, pad = " ")` / `rjust(...)` / `center(...)` — pad to `width`
+  code points using `pad` cyclically; `width <= length` returns the string
+  unchanged; `center` puts an odd extra pad rune on the **right** (Ruby's rule).
+  An empty pad degrades to a single space, and the padding length is clamped to
+  `MAX_REPEAT_LEN` (like `strRepeat`) to bound a DoS.
+- `swapcase` — flips each ASCII letter (non-letters / non-ASCII untouched),
+  iterating whole code points so astral runes are never split.
+
 ## [0.1.12] - 2026-07-07
 
 ### Added — Array block-method breadth (sort_by / group_by / partition / …)

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -651,6 +651,10 @@ const STRING_METHODS = new Set<string>([
   "empty?",
   "*",
   "+",
+  "ljust",
+  "rjust",
+  "center",
+  "swapcase",
 ]);
 
 // Block-taking `String` methods (M1c); `each_char` yields one character.
@@ -1289,6 +1293,42 @@ function stringMethod(recv: string, name: string, args: Val[]): Val | typeof MIS
       return strRepeat(recv, args[0]);
     case "+":
       return recv + args[0];
+    case "ljust":
+    case "rjust":
+    case "center": {
+      // Ruby `String#ljust`/`#rjust`/`#center(width, pad = " ")`: pad to `width`
+      // CODE POINTS using `pad` cyclically; `width <= length` returns the string
+      // unchanged; `center` puts an odd extra pad rune on the RIGHT (Ruby's rule).
+      // An empty pad degrades to a single space (never-raise floor); the padding
+      // length is clamped to `MAX_REPEAT_LEN` (like `strRepeat`) to bound a DoS.
+      const width = typeof args[0] === "number" ? Math.trunc(args[0]) : 0;
+      const pad = typeof args[1] === "string" && args[1] !== "" ? args[1] : " ";
+      const cps = [...recv];
+      const deficit = Math.min(width - cps.length, MAX_REPEAT_LEN);
+      if (deficit <= 0) return recv;
+      const pr = [...pad];
+      const buildPad = (n: number): string => {
+        let out = "";
+        for (let i = 0; i < n; i++) out += pr[i % pr.length];
+        return out;
+      };
+      if (name === "ljust") return recv + buildPad(deficit);
+      if (name === "rjust") return buildPad(deficit) + recv;
+      const left = Math.floor(deficit / 2);
+      return buildPad(left) + recv + buildPad(deficit - left);
+    }
+    case "swapcase": {
+      // Flip the case of each ASCII letter (non-letters / non-ASCII untouched),
+      // iterating whole code points so astral runes are never split.
+      let out = "";
+      for (const ch of recv) {
+        const c = ch.codePointAt(0) as number;
+        if (c >= 65 && c <= 90) out += String.fromCodePoint(c + 32);
+        else if (c >= 97 && c <= 122) out += String.fromCodePoint(c - 32);
+        else out += ch;
+      }
+      return out;
+    }
     default:
       return MISS;
   }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -520,6 +520,21 @@ describe("built-in method catalog: String (M1c)", () => {
     expect(callMethod("abc", "reverse")).toBe("cba");
   });
 
+  it("justify (ljust / rjust / center) and swapcase", () => {
+    // pad to `width` runes with a cyclic pad; center's odd extra pad on the
+    // RIGHT; width <= length is a no-op.
+    expect(callMethod("hi", "ljust", 5)).toBe("hi   ");
+    expect(callMethod("hi", "ljust", 5, "*")).toBe("hi***");
+    expect(callMethod("hi", "rjust", 5, "*")).toBe("***hi");
+    expect(callMethod("hi", "center", 6, "*")).toBe("**hi**");
+    expect(callMethod("hi", "center", 5, "*")).toBe("*hi**");
+    expect(callMethod("abc", "ljust", 1)).toBe("abc");
+    expect(callMethod("abcdef", "ljust", 10, "xy")).toBe("abcdefxyxy");
+    // swapcase flips each ASCII letter, leaving other characters untouched.
+    expect(callMethod("Hello World", "swapcase")).toBe("hELLO wORLD");
+    expect(callMethod("a1B!c", "swapcase")).toBe("A1b!C");
+  });
+
   it("strip family and chomp", () => {
     expect(callMethod("  hi  ", "strip")).toBe("hi");
     expect(callMethod("  hi  ", "lstrip")).toBe("hi  ");


### PR DESCRIPTION
## What

**Completes the cross-backend String justify/swapcase parity sweep** — Go (#7760), JS (#7761), Rust (#7758), Python (#7762) already in flight; this is the TS `sir-runtime-oop` piece. Extends `stringMethod` (and the `STRING_METHODS` `respond_to?` set):

- **`ljust(width, pad = " ")` / `rjust(...)` / `center(...)`** — pad to `width` code points using `pad` cyclically; `width <= length` returns the string unchanged; `center` puts any odd extra pad rune on the **right** (Ruby's rule). Empty pad → single space; the padding deficit is clamped to `MAX_REPEAT_LEN` (matching the sibling `strRepeat`) to bound a DoS.
- **`swapcase`** — flips each ASCII letter (non-letters / non-ASCII untouched), iterating whole code points so astral runes are never split.

## Safety

Dispatch stays an explicit `switch(name)` — never `recv[name]`, no reflection. Never-throw floor holds: `width` non-number → 0 (no-op); `NaN`/`Infinity` widths degrade safely (loop skips / clamp bounds); the `pad !== ""` guard prevents `i % 0` → NaN index; `deficit` clamped to `MAX_REPEAT_LEN`; `swapcase` bounds `codePointAt`/`fromCodePoint` to ASCII and never splits surrogate pairs. Security review passed (0 findings).

## Verification

- `vitest run` — **107 passed** (includes new `justify … and swapcase` test asserting all 9 cases against the Ruby reference, byte-for-byte matching the Go/JS/Rust/Python PRs).
- Pre-existing `tsc` gaps (`@types/node` on `sir-runtime-core`, a `min_by` strict-null) are unrelated to this diff and unchanged (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)