### PR TITLE
feat(sir-go): slice-selection Array methods — take / drop / values_at (v0.23.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.23.0 — slice-selection Array methods: `take` / `drop` / `values_at`
+
+Extends the emitted Go runtime's non-block `Array` catalog (and the
+`respond_to?` table):
+
+- `take(n)` — a fresh Array of the first `n` elements; `n` is clamped to
+  `[0, len]` (`n <= 0` → `[]`, `n > len` → a full copy). A negative `n` raises
+  `ArgumentError` in Ruby; the never-raise floor treats it as `0`.
+- `drop(n)` — a fresh Array with the first `n` elements removed (same clamp;
+  `n >= len` → `[]`).
+- `values_at(*idxs)` — a fresh Array of the element at each index, folding a
+  negative index from the end; an out-of-range index yields `nil` (never
+  panics).
+
+Verified end-to-end under `go run`.
+
 ## 0.22.0 — more String methods: `ljust` / `rjust` / `center` / `swapcase`
 
 Extends the emitted Go runtime's `_sir_string_method` catalog (and its

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1694,7 +1694,7 @@ func _sir_array_responds(name string) bool {
 	case "length", "size", "count", "first", "last", "empty?", "include?",
 		"index", "push", "append", "<<", "pop", "shift", "reverse", "sort",
 		"min", "max", "sum", "uniq", "flatten", "compact", "zip", "rotate",
-		"to_h", "tally",
+		"to_h", "tally", "take", "drop", "values_at",
 		"join", "fetch", "to_a":
 		return true
 	// Block-taking Array/Enumerable methods.
@@ -1989,6 +1989,57 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 			_sir_map_set(acc, x, n+1)
 		}
 		return acc, true
+	case "take":
+		// `a.take(n)` -> a fresh Array of the first n elements. Ruby clamps: n<=0
+		// yields [], n>len yields a full copy. A negative n raises ArgumentError in
+		// Ruby; the never-raise floor treats it as 0.
+		n := int64(0)
+		if len(args) > 0 {
+			n = _sir_as_int_trunc(args[0])
+		}
+		if n < 0 {
+			n = 0
+		}
+		if n > int64(len(recv.Items)) {
+			n = int64(len(recv.Items))
+		}
+		out := make([]Value, int(n))
+		copy(out, recv.Items[:int(n)])
+		return &Seq{Items: out}, true
+	case "drop":
+		// `a.drop(n)` -> a fresh Array with the first n elements removed (n<=0 -> a
+		// full copy, n>=len -> []). A negative n is treated as 0 (never-raise floor).
+		n := int64(0)
+		if len(args) > 0 {
+			n = _sir_as_int_trunc(args[0])
+		}
+		if n < 0 {
+			n = 0
+		}
+		if n > int64(len(recv.Items)) {
+			n = int64(len(recv.Items))
+		}
+		out := make([]Value, len(recv.Items)-int(n))
+		copy(out, recv.Items[int(n):])
+		return &Seq{Items: out}, true
+	case "values_at":
+		// `a.values_at(i, j, ...)` -> a fresh Array of the element at each index,
+		// folding a negative index from the end; an out-of-range index yields nil
+		// (Ruby's behaviour), never panicking.
+		length := int64(len(recv.Items))
+		out := make([]Value, 0, len(args))
+		for _, a := range args {
+			idx := _sir_as_int_trunc(a)
+			if idx < 0 {
+				idx += length
+			}
+			if idx >= 0 && idx < length {
+				out = append(out, recv.Items[idx])
+			} else {
+				out = append(out, nil)
+			}
+		}
+		return &Seq{Items: out}, true
 	case "to_a":
 		return recv, true
 	}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_coll_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_coll_methods.rs
@@ -509,3 +509,66 @@ fn array_more_methods_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+/// v0.23.0 slice-selection Array methods: `take`, `drop`, `values_at`.  All are
+/// index-clamped and never panic (`take`/`drop` clamp n to `[0, len]`;
+/// `values_at` folds negatives and yields nil out of range).
+fn take_drop_module() -> Module {
+    let stmts = vec![
+        // [1,2,3,4,5].take(2) -> [1, 2]
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]), "take", vec![ilit(2)])),
+        // [1,2,3].take(9) -> [1, 2, 3]  (n>len clamps to a full copy)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "take", vec![ilit(9)])),
+        // [1,2,3,4,5].drop(2) -> [3, 4, 5]
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]), "drop", vec![ilit(2)])),
+        // [1,2,3].drop(9) -> []  (n>=len yields empty)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "drop", vec![ilit(9)])),
+        // [10,20,30].values_at(0, 2, -1) -> [10, 30, 30]  (negative folds from end)
+        print_stmt(method(
+            seq(vec![ilit(10), ilit(20), ilit(30)]),
+            "values_at",
+            vec![ilit(0), ilit(2), ilit(-1)],
+        )),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+    program(vec![main])
+}
+
+#[test]
+fn take_drop_values_at_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&take_drop_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "takedrop");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "[1, 2]",       // take(2)
+            "[1, 2, 3]",    // take(9) clamps
+            "[3, 4, 5]",    // drop(2)
+            "[]",           // drop(9) -> empty
+            "[10, 30, 30]", // values_at(0, 2, -1)
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## What

Extends `semantic-ir-to-go`'s emitted-runtime `_sir_array_method` catalog (and its `respond_to?` table) with three common non-block Ruby Array methods:

- **`take(n)`** — a fresh Array of the first `n` elements; `n` clamped to `[0, len]` (`n <= 0` → `[]`, `n > len` → a full copy). A negative `n` raises `ArgumentError` in Ruby; the never-raise floor treats it as `0`.
- **`drop(n)`** — a fresh Array with the first `n` elements removed (same clamp; `n >= len` → `[]`).
- **`values_at(*idxs)`** — a fresh Array of the element at each index, folding a negative index from the end; an out-of-range index yields `nil` (never panics).

## Why

Continues the cross-backend Array stdlib-breadth lane. Pure runtime-library breadth — off the maintainers' active frontier.

## Safety

Dispatch stays a receiver-type `switch` on literal method names — no reflection. Never-panic invariant holds: `take`/`drop` clamp `n` to `[0, len]` before any `make`/slice (so `len - n` is never negative and no slice bound is out of range); `values_at` folds a negative index once then bounds-guards `idx >= 0 && idx < length` before indexing (a doubly-negative index falls to the `nil` branch). Allocations are bounded by the receiver / arg count — no amplification. Security review passed (0 findings).

## Verification

- `cargo test -p semantic-ir-to-go` green (97 unit + integration suites, no new warnings).
- New `take_drop_values_at_compile_and_run` emits Go, runs it under `go run`, and diffs stdout for all 5 cases (take(2), take(9) clamp, drop(2), drop(9)→[], values_at(0,2,-1)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)