### PR TITLE
feat(latex): LTXDOC03 S15 — group resolved citations by their source \cite

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.51.0] — 2026-07-07
+
+### Added — resolved citations grouped by their source `\cite` (LTXDOC03 S15)
+
+A **new** public method `Document::citations_by_source(&self) -> String` that renders the resolved
+citations **grouped by the source `\cite` construct they came from** — the citation-family parallel
+of S11's `to_plain_text_by_kind` (which groups resolved *references*) and S13's `resolve_namerefs`
+(one rendered line per target). It reads only `resolve_citations().resolved` and re-assembles the
+per-key rows that S2 flattened out of each multi-key `\cite`. Every S1–S14 output is left
+**byte-for-byte unchanged**; S15 is purely additive and leaves the `to_latex()` round-trip fixed
+point intact.
+
+- **Groups by `cite_span`, in source order.** S2 emits one `ResolvedCite` per key, every key of a
+  `\cite{a,b}` sharing that one `\cite`'s `cite_span`. S15 groups the `resolved` rows back by
+  `cite_span`, preserving the **first-appearance order** of the cite_spans (source order of the
+  `\cite`s, since `resolved` is already in body pre-order) and keeping keys within a group in their
+  original left-to-right order.
+- **One line per source `\cite`, reconstructed from its resolved keys.** Each line is
+  `\cite{` + the group's resolved keys joined by `", "` + `}`. A **dangling** key (one no `\bibitem`
+  defines) never entered `resolved`, so it is **excluded** by construction: a `\cite{a,ghost}` where
+  only `a` resolves renders `\cite{a}`, not `\cite{a,ghost}`. We reconstruct rather than slice the
+  raw `&src[cite_span]` precisely because the source text would still contain the dangling `ghost`;
+  reconstruction shows exactly what *bound*. Lines are joined by `\n` with **no** trailing newline
+  (matching S11 `to_plain_text_by_kind`, S12 `list_of_floats`, S13 `resolve_namerefs`, S14
+  `list_summary`).
+- **Empty marker.** A document with **no** resolved citations — none present, or every cited key
+  dangling — returns the fixed marker `"(no resolved citations)"`, so the output is never the empty
+  string (the same stable-marker discipline S12/S13/S14 use).
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+  keys are already owned `String`s); a single pass over the already-bounded `resolved` list. Borrows
+  `self` immutably, returns owned `String`.
+
+Four `s15_*` tests pin the exact rendered strings: a doc grouping a multi-key `\cite{a,b}` and a
+separate `\cite{c}` (`\cite{a, b}\n\cite{c}`), a partial `\cite{a,ghost}` rendering only the
+resolved key (`\cite{a}`), an all-dangling doc returning the `(no resolved citations)` marker, and
+an additivity check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`,
+`resolve_namerefs`, and `list_summary` all still produce their exact prior strings.
+
 ## [0.50.0] — 2026-07-07
 
 ### Added — per-kind census of the numbered-label table (LTXDOC03 S14)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -62,6 +62,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S12 — List of Figures / List of Tables index** | `Document::list_of_floats() -> String` — a **new** method that renders the document's **List of Figures** and **List of Tables** (LaTeX's `\listoffigures` / `\listoftables`, as plain text) directly from the floats. A single document-order walk threads the **same** `Counters` float counters as `number_labels`, so each float's line number equals its S4 flat figure/table number (a labeled float's List-of number and its `\ref` number agree; figures numbered `1, 2, …`, tables independently from `1`). Each line is `<n>. <caption text>`, where the caption text is the plain rendering of the float's `\caption{…}` inlines (text/code verbatim, space as a single space, font-wrapper content recursively, trimmed — the same descent the caption-reaching test proves), via a private `caption_text(&Option<Caption>)` helper; a float with **no** `\caption` renders the fixed placeholder `(no caption)` so every float still gets a numbered line. The `List of Figures` heading is emitted only when there is ≥1 figure, `List of Tables` only when ≥1 table; a document with no floats → the fixed marker `(no floats)`. Lines joined by `\n`, no trailing newline. Real LaTeX gates these on `\listoffigures` / `\listoftables` commands (not parser-recognised here), so — like S11 — S12 is a method the caller invokes; every S1–S11 output is byte-for-byte unchanged. Pure assembly over existing blocks + the existing float walk — no AST/grammar/counter change, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S13 — `\nameref` resolution to a target's name** | `Document::resolve_namerefs() -> String` — a **new** method that resolves every `\nameref{key}` to the **name** (title/caption text) of its target — the name-valued sibling of `\ref` (number) and `\pageref` (page). `\nameref` is **not** a `REF_COMMAND`, so it appears in neither the resolved nor unresolved ref table (an AST probe confirms it lowers to `Inline::CrossRef { command: "nameref", .. }`); S13 reads the same S1 `\label` table but answers "*what is it called?*", so it is purely additive. One document-order walk collects each `nameref` cross-ref; the key is resolved against the winning label table and the name read from its defining node via the S3 `label_def_node` accessor — a `Section` → its title inlines flattened, a `Figure`/`Table` → its `\caption` via the shared `caption_text` helper (S12's flatten factored into a module-level `flatten_inlines_to_text`, reused by both so they can never drift). An `Equation`/`Inline` target (a number, not a title) → `(no name)`; an undefined key → `(undefined nameref: <key>)`; no `\nameref` at all → `(no namerefs)`. Each line is `\nameref{<key>} -> <name>`, joined by `\n`, no trailing newline. Every S1–S12 output is byte-for-byte unchanged. Total & panic-free. | ✅ |
 | **LTXDOC03 S14 — per-kind census of the numbered-label table** | `Document::list_summary() -> String` — a **new**, read-only method that renders a compact per-kind **count** of the document's numbered labels: how many sections, figures, tables, and equations carry a `\label`. It is a pure tally of the rows `number_labels()` returns, grouped by `LabelKind`, so it can never drift from the S4 numbering it summarises. Only the four numberable kinds reach that table — a bare inline `\label{…}` (`LabelKind::Inline`) is not numbered and is counted nowhere. One line per non-zero kind in the **fixed order** `Sections`, `Figures`, `Tables`, `Equations` (deterministic, not source order), formatted `<Kind>: <count>` with a **fixed plural** label regardless of count (a single section still prints `Sections: 1`); a kind with count 0 is **omitted** (mirroring S11). Lines joined by `\n`, no trailing newline. A document with **no** numbered label at all → the fixed marker `(no labels)`. E.g. two labeled sections + a figure + a table + an equation → `Sections: 2\nFigures: 1\nTables: 1\nEquations: 1`. Every S1–S13 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S15 — resolved citations grouped by their source `\cite`** | `Document::citations_by_source() -> String` — a **new**, read-only method that renders the resolved citations **grouped by the source `\cite` they came from** — the citation-family parallel of S11's `to_plain_text_by_kind` and S13's `resolve_namerefs`. It reads only `resolve_citations().resolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping them back by `cite_span` in **first-appearance order** (source order of the `\cite`s) with keys kept in their left-to-right order. One line per source `\cite`: `\cite{` + the group's **resolved** keys joined by `", "` + `}`. A **dangling** key never entered `resolved`, so it is excluded — `\cite{a,ghost}` where only `a` resolves renders `\cite{a}` (we reconstruct from resolved keys rather than slice `&src[cite_span]`, which would still show `ghost`). Lines joined by `\n`, no trailing newline. A document with **no** resolved citations (none present, or every key dangling) → the fixed marker `(no resolved citations)`. E.g. `\cite{a,b}` (both defined) then `\cite{c}` → `\cite{a, b}\n\cite{c}`. Every S1–S14 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -668,6 +669,36 @@ A bare inline `\label{…}` is not numbered, so it never appears in this census;
 label is such an inline label renders the `(no labels)` marker. Purely additive — reuses
 `number_labels`, mutates nothing, leaves every S1–S13 output and the `to_latex()` fixed point
 unchanged.
+
+### resolved citations grouped by their source `\cite` (LTXDOC03 S15)
+
+S2's `resolve_citations` flattens a multi-key `\cite{a,b}` into *several* `ResolvedCite` rows (one per
+key, all sharing that `\cite`'s `cite_span`). `citations_by_source` reads only that `resolved` list and
+re-assembles it: it groups the rows back by `cite_span` — in first-appearance order, i.e. source order
+of the `\cite`s — and emits one line per `\cite`, reconstructed as `\cite{` + the group's resolved keys
+joined by `", "` + `}`. A dangling key never entered `resolved`, so it is excluded by construction.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}
+See \cite{a,b} and \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\end{thebibliography}
+\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.citations_by_source(),
+    "\\cite{a, b}\n\\cite{c}",   // both of {a,b} resolve; only `c` of {c,ghost} does
+);
+```
+
+A document with no resolved citations — none present, or every cited key dangling — renders the fixed
+`(no resolved citations)` marker. Purely additive — reuses `resolve_citations`, mutates nothing, leaves
+every S1–S14 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1590,6 +1590,87 @@ impl Document {
         }
         lines.join("\n")
     }
+
+    /// The resolved citations **grouped by the source `\cite` they came from** (LTXDOC03 S15) — the
+    /// citation-family parallel of S11's `to_plain_text_by_kind` (which groups resolved *references*)
+    /// and S13's `resolve_namerefs` (one rendered line per target).
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] flattens a multi-key `\cite{a,b}` into *several*
+    /// [`ResolvedCite`] rows — one per key — every one carrying that single `\cite`'s
+    /// [`cite_span`](ResolvedCite::cite_span). This method reads only that `resolved` list and
+    /// re-assembles it: it groups the rows back by `cite_span` (so all keys of one `\cite` reunite)
+    /// and emits **one line per source `\cite`** that resolved at least one key.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Each line is the citing command **reconstructed from its resolved keys**:
+    /// `\cite{` + the group's keys joined by `", "` + `}`. The keys are **only the resolved ones**,
+    /// in their original left-to-right order — a *dangling* key (one no `\bibitem` defines) is
+    /// **excluded**, so a `\cite{a,ghost}` where only `a` resolves renders `\cite{a}`, not
+    /// `\cite{a,ghost}`. (We reconstruct rather than slice `&src[cite_span]` precisely because the
+    /// source text would still contain the dangling `ghost`; reconstruction shows exactly what
+    /// *bound*.)
+    ///
+    /// The groups appear in **first-appearance order of their `cite_span`** — i.e. the source order of
+    /// the `\cite`s (S2's `resolved` is already in body pre-order, so the first time each distinct
+    /// `cite_span` is seen fixes that group's position). Lines are joined by `\n` with **no** trailing
+    /// newline (matching S11's `to_plain_text_by_kind`, S12's `list_of_floats`, S13's
+    /// `resolve_namerefs`, and S14's `list_summary`).
+    ///
+    /// A document with **no** resolved citations — none present, or every cited key dangling — returns
+    /// the fixed marker `(no resolved citations)`, never the empty string (the same stable-marker
+    /// discipline S12/S13/S14 use).
+    ///
+    /// Concretely, for a body `\cite{smith2020, jones2019}` (both defined) then `\cite{a, ghost}`
+    /// (only `a` defined), against a bibliography defining `smith2020`, `jones2019`, `a`:
+    ///
+    /// ```text
+    /// \cite{smith2020, jones2019}
+    /// \cite{a}
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S15 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1-S14 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single pass over the already-bounded `resolved` list.
+    /// Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow of
+    /// the source.
+    pub fn citations_by_source(&self) -> String {
+        // S2 already flattened every `\cite` into per-key `ResolvedCite` rows in body pre-order, each
+        // tagged with its source `\cite`'s span. We only read that list.
+        let resolution = self.resolve_citations();
+
+        // Group the resolved keys by their shared `cite_span`, preserving the FIRST-APPEARANCE order
+        // of the cite_spans (source order of the `\cite`s). A `Vec` of `(cite_span, keys)` — not a
+        // hash map — keeps that order deterministic and the code allocation-light (the number of
+        // distinct `\cite`s is small). Keys within a group stay in their existing left-to-right order.
+        let mut groups: Vec<(Span, Vec<&str>)> = Vec::new();
+        for cite in &resolution.resolved {
+            match groups.iter_mut().find(|(span, _)| *span == cite.cite_span) {
+                Some((_, keys)) => keys.push(&cite.key),
+                None => groups.push((cite.cite_span, vec![&cite.key])),
+            }
+        }
+
+        if groups.is_empty() {
+            // No `\cite` resolved a single key → the fixed marker, never the empty string.
+            return "(no resolved citations)".to_string();
+        }
+
+        // One line per source `\cite`: `\cite{` + resolved keys joined by `", "` + `}`. Dangling keys
+        // never entered `resolved`, so they are excluded here by construction.
+        groups
+            .iter()
+            .map(|(_, keys)| format!("\\cite{{{}}}", keys.join(", ")))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -3963,5 +4044,99 @@ See Section~\ref{sec:intro}, \nameref{sec:intro}, and \nameref{fig:p}.\end{docum
 
         // And S14 itself produces the per-kind census (one section, one figure, one equation).
         assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S15 — resolved citations grouped by their source `\cite` (`citations_by_source`).
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s15_groups_by_cite() {
+        // A multi-key `\cite{a,b}` (both resolving) and a separate `\cite{c}`. The report reunites the
+        // two keys of the first `\cite` on ONE line and emits the second `\cite` on its own line, in
+        // source order.
+        let src = r"\begin{document}
+See \cite{a,b} and \cite{c}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+    }
+
+    #[test]
+    fn s15_multikey_partial() {
+        // A `\cite{a,ghost}` where `a` resolves and `ghost` is dangling → the line shows ONLY the
+        // resolved key (`\cite{a}`). We reconstruct from resolved keys, so the dangling `ghost` — which
+        // the raw source `\cite{a,ghost}` still contains — is excluded by construction.
+        let src = r"\begin{document}
+See \cite{a,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citations_by_source(), "\\cite{a}");
+    }
+
+    #[test]
+    fn s15_empty_returns_marker() {
+        // A document whose only `\cite` is entirely dangling (no `\bibitem` defines its key) has NO
+        // resolved citations → the fixed `(no resolved citations)` marker, never the empty string.
+        let src = r"\begin{document}
+See \cite{nope}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citations_by_source(), "(no resolved citations)");
+    }
+
+    #[test]
+    fn s15_is_additive_leaves_s1_s14_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a `\ref`, a `\nameref`,
+        // and two `\cite`s (one multi-key, one dangling key), S15 changes NONE of the S1-S14 outputs —
+        // it only reads `resolve_citations`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+See Section~\ref{sec:intro}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — the resolved `\ref` and the three resolved `\cite`s with their `[n]`
+        // markers, plus the dangling `ghost` footer, all unchanged by S15.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — the single ref under its `Sections:` group, unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — one figure line, unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — both namerefs render their names, unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — one section, one figure, one equation, unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+
+        // And S15 itself groups the resolved cites: `{a,b}` fully resolves; `{c,ghost}` keeps only `c`.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1231,3 +1231,72 @@ still produce their exact prior strings). All prior S1–S13 tests pass unchange
 latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green;
 `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new
 dependencies.
+
+## 21. S15 — resolved citations grouped by their source `\cite` (`citations_by_source`)
+
+### 21.1 Motivation
+
+S2's `resolve_citations` returns `resolved: Vec<ResolvedCite>` **flattened per key** — a multi-key
+`\cite{a,b}` yields one row for `a` and one for `b`, each carrying that single `\cite`'s `cite_span`.
+That per-key shape is right for a resolver but loses, at a glance, *which keys travelled together in
+one `\cite`*. S15 answers the citation-family analogue of the question S11's `to_plain_text_by_kind`
+answers for references: *"grouped by the construct they came from, what resolved?"* — it re-assembles
+the per-key rows back into one line per source `\cite`.
+
+### 21.2 Why a new method — additive by construction
+
+S15 adds a **new public method** `Document::citations_by_source(&self) -> String`. It is a pure,
+read-only re-assembly of `resolve_citations().resolved` — grouping the rows by `cite_span`. It reuses
+that table verbatim (never re-walking the body or re-resolving keys), so the grouping can never drift
+from the S2 resolution it summarises. It mutates nothing and changes no S1–S14 output — including
+`to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S14 it is a method the caller invokes
+directly.
+
+### 21.3 The grouping and ordering rule
+
+Every `ResolvedCite` from one `\cite` shares that `\cite`'s `cite_span`, so grouping `resolved` by
+`cite_span` reconstructs "which resolved keys came from which `\cite`". Because `resolved` is already
+in body pre-order (and within one multi-key `\cite` in left-to-right key order), the **first
+appearance** of each distinct `cite_span` fixes that group's position — so the groups come out in
+source order of the `\cite`s, and keys within a group keep their left-to-right order. The
+implementation uses a `Vec<(Span, Vec<&str>)>` (not a hash map) precisely to keep that first-appearance
+order deterministic.
+
+### 21.4 The exact rendering contract — `Document::citations_by_source(&self) -> String`
+
+- One line per source `\cite` that resolved **≥ 1** key, in first-appearance (source) order of the
+  `\cite`s.
+- Each line is the citing command **reconstructed from its resolved keys**: `\cite{` + the group's
+  resolved keys joined by `", "` + `}`.
+- The keys are **only the resolved ones**, in their original left-to-right order. A **dangling** key
+  (one no `\bibitem` defines) never entered `resolved`, so it is **excluded**: a `\cite{a,ghost}`
+  where only `a` resolves renders `\cite{a}`, not `\cite{a,ghost}`. We reconstruct from resolved keys
+  rather than slice the raw `&src[cite_span]` precisely because the source text would still contain the
+  dangling `ghost`; the reconstruction shows exactly what *bound*.
+- Lines are joined by `\n` with **no** trailing newline (matching S11 `to_plain_text_by_kind`, S12
+  `list_of_floats`, S13 `resolve_namerefs`, S14 `list_summary`).
+- If there are **no** resolved citations (none present, or every cited key dangling), the fixed marker
+  `(no resolved citations)` is returned, so the output is never the empty string.
+
+Example (`\cite{smith2020, jones2019}` both defined, then `\cite{a, ghost}` with only `a` defined):
+
+```text
+\cite{smith2020, jones2019}
+\cite{a}
+```
+
+### 21.5 Public API (added in S15)
+
+One new method: `Document::citations_by_source(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_citations` and every S1–S14 method are unchanged; no AST or grammar
+change; no new dependency, no `unsafe`, no I/O.
+
+### 21.6 Verification (S15)
+
+`cargo test -p latex` green (4 new S15 tests: a doc grouping a multi-key `\cite{a,b}` and a separate
+`\cite{c}` into `\cite{a, b}\n\cite{c}`; a partial `\cite{a,ghost}` rendering only `\cite{a}`; an
+all-dangling doc returning the `(no resolved citations)` marker; and an additivity check that
+`to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, and `list_summary` all
+still produce their exact prior strings). All prior S1–S14 tests pass unchanged. `cargo clippy -p latex
+--all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo
+build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S15 — group resolved citations by their source `\cite`

Adds a new read-only method `Document::citations_by_source(&self) -> String` to the `latex` crate — the **citation-family parallel** of S11 `to_plain_text_by_kind` (which groups resolved *references* by kind) and S13 `resolve_namerefs` (one rendered line per target). Bumps `latex` **0.50.0 → 0.51.0**.

### What it does

S2's `resolve_citations` flattens a multi-key `\cite{a,b}` into *several* `ResolvedCite` rows — one per key — each carrying that single `\cite`'s shared `cite_span`. S15 reads **only** that `.resolved` list and re-assembles it: it groups the rows back by `cite_span` (so all keys of one `\cite` reunite) and emits **one line per source `\cite`** that resolved at least one key.

| aspect | rule |
|---|---|
| line format | `\cite{` + the group's **resolved** keys joined by `", "` + `}` |
| grouping | by shared `cite_span`, in **first-appearance (source) order** |
| key order | original left-to-right within each `\cite` |
| dangling keys | **excluded** — `\cite{a,ghost}` (only `a` defined) → `\cite{a}` |
| empty | fixed marker `(no resolved citations)`, never `""` |
| joining | `\n`-joined, **no** trailing newline (matches S11–S14) |

We **reconstruct** the line from resolved keys rather than slice `&src[cite_span]` precisely because the raw source of `\cite{a,ghost}` still contains the dangling `ghost`; reconstruction shows exactly what *bound*.

Example — body `\cite{smith2020, jones2019}` then `\cite{a, ghost}`, with `smith2020`/`jones2019`/`a` defined:

```text
\cite{smith2020, jones2019}
\cite{a}
```

### Additive by construction

Brand-new, read-only method that reuses `resolve_citations` and mutates nothing. **Total & panic-free**: no source slicing/indexing, no `unwrap`/`expect`, no `unsafe`, a single pass over the already-bounded `resolved` list; a `Vec<(Span, Vec<&str>)>` (not a hash map) keeps first-appearance order deterministic. All **S1–S14 outputs stay byte-for-byte unchanged**, pinned by a dedicated additivity test. The `to_latex` round-trip fixed point is untouched.

### Tests (exact strings, real output)

- `s15_groups_by_cite` — `\cite{a,b}` + `\cite{c}` (all resolve) → `"\\cite{a, b}\n\\cite{c}"`
- `s15_multikey_partial` — `\cite{a,ghost}` (only `a` defined) → `"\\cite{a}"` (dangling excluded)
- `s15_empty_returns_marker` — only a dangling `\cite{nope}` → `"(no resolved citations)"`
- `s15_is_additive_leaves_s1_s14_outputs_unchanged` — pins `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, and `list_summary` to their exact prior strings on a representative doc

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → **384 passed; 0 failed** (was 380; +4 S15) + doc-tests ok
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → all green (140 + 38 + smaller suites; 0 failed)
- `cargo build -p latex --no-default-features` → builds
- Inline security review PASSED (returned `String`, no injection sink; total/panic-free; no DoS regression).
- Single-parent commit; scoped diff = 5 files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
