### PR TITLE
feat(sir-rust): slice-selection Array methods — take / drop / values_at (v0.23.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.23.0 — slice-selection Array methods: `take` / `drop` / `values_at`
+
+Extends the emitted Rust runtime's `array_method` catalog (and the `Value::Seq`
+`respond_to?` table), mirroring the Go backend:
+
+- `take(n)` / `drop(n)` — a fresh Array of the first / all-but-first `n`
+  elements; `n` is clamped to `[0, len]` (`n <= 0` and `n > len` both saturate),
+  so the slice bounds are always valid. A negative `n` raises `ArgumentError` in
+  Ruby; the never-raise floor treats it as `0`.
+- `values_at(*idxs)` — a fresh Array of the element at each index, folding a
+  negative index from the end once; an out-of-range index yields `nil` (never
+  panics).
+
+Verified end-to-end: emitted Rust compiled with `rustc` and executed, output
+diffed against the reference.
+
 ## 0.22.0 — more Array methods: `zip` / `rotate` / `to_h` / `tally`
 
 Extends the emitted Rust runtime's `array_method` catalog (and the `Value::Seq`

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1467,8 +1467,9 @@ pub const RUNTIME: &str = r##"mod __sir {
                     // aggregate / reshape non-block methods (all dispatch in
                     // `array_method` above; previously under-reported here)
                     | "min" | "max" | "sum" | "uniq" | "flatten" | "compact" | "to_a"
-                    // this PR: more non-block Array methods
+                    // more non-block Array methods
                     | "zip" | "rotate" | "to_h" | "tally"
+                    | "take" | "drop" | "values_at"
             ),
             Value::Map(_) => matches!(
                 name,
@@ -2095,6 +2096,51 @@ pub const RUNTIME: &str = r##"mod __sir {
                     map_set(&acc, item, Value::Int(n + 1));
                 }
                 acc
+            }
+            // `take(n)` / `drop(n)` — a fresh Array of the first / all-but-first
+            // `n` elements.  `n` is clamped to `[0, len]` (`n <= 0` and `n > len`
+            // both saturate), so the slice bounds are always valid.  Ruby raises
+            // `ArgumentError` on a negative `n`; the never-raise floor treats it
+            // as `0`.  The snapshot is taken up front so no `RefCell` borrow is
+            // held across the allocation.
+            "take" | "drop" => {
+                let snapshot = items_rc.borrow().clone();
+                let len = snapshot.len() as i64;
+                let mut n = pos.first().map(as_i64).unwrap_or(0);
+                if n < 0 {
+                    n = 0;
+                }
+                if n > len {
+                    n = len;
+                }
+                let n = n as usize;
+                if name == "take" {
+                    seq_lit(snapshot[..n].to_vec())
+                } else {
+                    seq_lit(snapshot[n..].to_vec())
+                }
+            }
+            // `values_at(*idxs)` — a fresh Array of the element at each index,
+            // folding a negative index from the end once; an out-of-range index
+            // (including a doubly-negative one) yields `nil` rather than panicking.
+            "values_at" => {
+                let snapshot = items_rc.borrow().clone();
+                let len = snapshot.len() as i64;
+                let out: Vec<Value> = pos
+                    .iter()
+                    .map(|a| {
+                        let mut idx = as_i64(a);
+                        if idx < 0 {
+                            idx += len;
+                        }
+                        if idx >= 0 && idx < len {
+                            snapshot[idx as usize].clone()
+                        } else {
+                            Value::Nil
+                        }
+                    })
+                    .collect();
+                seq_lit(out)
             }
             _ => no_method_error(&recv, name),
         }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -408,3 +408,98 @@ fn array_more_methods_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+/// The v0.23.0 **slice-selection Array methods**: `take`, `drop`, `values_at`.
+/// All index-clamped / bounds-guarded and never panic.  Assertions stay
+/// integer-valued and never print a `nil` element, so the proof is independent
+/// of the display convention (this module's `source_language` is `"test"`).
+fn take_drop_demo() -> Module {
+    let main_stmts = vec![
+        // take(2) of a 5-element array
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]), "take", vec![ilit(2)])),
+        // take(9) clamps to a full copy (n > len)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "take", vec![ilit(9)])),
+        // drop(2)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]), "drop", vec![ilit(2)])),
+        // drop(9) -> [] (n >= len)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "drop", vec![ilit(9)])),
+        // values_at(0, 2, -1) -> [10, 30, 30] (negative folds from the end)
+        print_stmt(method(
+            seq(vec![ilit(10), ilit(20), ilit(30)]),
+            "values_at",
+            vec![ilit(0), ilit(2), ilit(-1)],
+        )),
+    ];
+    demo_module(main_stmts, vec![])
+}
+
+#[test]
+fn take_drop_values_at_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&take_drop_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_take_drop_{nonce}.rs"));
+    let bin_path = dir.join(format!(
+        "sir_take_drop_{nonce}{}",
+        if cfg!(windows) { ".exe" } else { "" }
+    ));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&bin_path)
+        .output()
+        .expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "[1, 2]",       // take(2)
+            "[1, 2, 3]",    // take(9) clamps
+            "[3, 4, 5]",    // drop(2)
+            "[]",           // drop(9) -> empty
+            "[10, 30, 30]", // values_at(0, 2, -1)
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## What

Mirrors the Go `take`/`drop`/`values_at` work (#7765) onto the Rust backend. Extends `semantic-ir-to-rust`'s emitted-runtime `array_method` catalog (and the `Value::Seq` `respond_to?` table):

- **`take(n)` / `drop(n)`** — a fresh Array of the first / all-but-first `n` elements; `n` is clamped to `[0, len]` (`n <= 0` and `n > len` both saturate), so the slice bounds are always valid. A negative `n` raises `ArgumentError` in Ruby; the never-raise floor treats it as `0`.
- **`values_at(*idxs)`** — a fresh Array of the element at each index, folding a negative index from the end once; an out-of-range index yields `nil` (never panics).

## Why

Continues the cross-backend Array stdlib-breadth sweep (Go landed in #7765). Pure runtime-library breadth — off the maintainers' active frontier.

## Safety

Dispatch stays an explicit `(type, name)` match — no reflection. Never-panic invariant holds: `take`/`drop` clamp `n` to `[0, len]` before slicing (`snapshot[..n]`/`snapshot[n..]` always in range, incl. `len == 0`); `values_at` folds a negative index once then bounds-guards `idx >= 0 && idx < len` (a doubly-negative or `i64::MIN` index cannot overflow — the `+= len` addend is non-negative and moves toward zero — and falls to the `nil` branch). Snapshots are taken via `.borrow().clone()` so no `RefCell` borrow is held across allocation. Allocations bounded by receiver/arg count. Security review passed (0 findings).

## Verification

- `cargo test -p semantic-ir-to-rust` green (123 + integration suites, 0 warnings).
- New `take_drop_values_at_compile_and_run` emits Rust, compiles with `rustc`, runs, and diffs stdout for all 5 cases (byte-for-byte matching the Go PR's assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)