### PR TITLE
feat(sir-js): slice-selection Array methods — take / drop / values_at (v0.20.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.20.0 — slice-selection Array methods: `take` / `drop` / `values_at`
+
+Extends the inlined JS runtime's `arrayMethod` switch (and the `ARRAY_METHODS`
+`respond_to?` set), mirroring the Go/Rust backends:
+
+- `take(n)` / `drop(n)` — the first / all-but-first `n` elements; `n` is clamped
+  to `[0, len]` (`n <= 0` → `[]`/full copy, `n > len` → full copy/`[]`), so
+  `recv.slice` never throws. A negative `n` raises `ArgumentError` in Ruby; the
+  never-raise floor treats it as `0`.
+- `values_at(*idxs)` — the element at each index, folding a negative index from
+  the end once; an out-of-range index yields `null` (never throws).
+
+Dispatch stays an explicit `switch (name)` — never `recv[name]`. Verified
+end-to-end under Node.
+
 ## 0.19.0 — more String methods: `ljust` / `rjust` / `center` / `swapcase`
 
 Extends the inlined JS runtime's `stringMethod` switch (and the `STRING_METHODS`

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -955,6 +955,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "sort", "sort_by", "min", "max", "min_by", "max_by", "group_by",
     "partition", "flat_map", "collect_concat", "take_while", "drop_while",
     "each_with_object", "sum", "uniq", "first", "last", "empty?", "to_a",
+    "take", "drop", "values_at",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
@@ -1089,6 +1090,27 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           ? recv.slice(Math.max(0, recv.length - args[0]))
           : (recv.length ? recv[recv.length - 1] : null);
       case "empty?": return recv.length === 0;
+      case "take": case "drop": {
+        // `take(n)` / `drop(n)` — the first / all-but-first `n` elements.  `n`
+        // is clamped to `[0, len]` (`n <= 0` -> 0, `n > len` -> len).  Ruby
+        // raises `ArgumentError` on a negative `n`; the never-raise floor
+        // treats it as 0.  `recv.slice` never throws for in-range bounds.
+        let n = typeof args[0] === "number" ? Math.trunc(args[0]) : 0;
+        if (n < 0) { n = 0; }
+        if (n > recv.length) { n = recv.length; }
+        return name === "take" ? recv.slice(0, n) : recv.slice(n);
+      }
+      case "values_at": {
+        // `values_at(*idxs)` — the element at each index, folding a negative
+        // index from the end once; an out-of-range index yields `null`.
+        const out = [];
+        for (const a of args) {
+          let idx = typeof a === "number" ? Math.trunc(a) : 0;
+          if (idx < 0) { idx += recv.length; }
+          out.push(idx >= 0 && idx < recv.length ? recv[idx] : null);
+        }
+        return out;
+      }
       case "to_a": return recv;
     }
     return ARR_MISS;

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2308,6 +2308,29 @@ fn string_justify_swapcase_methods() {
     }
 }
 
+// v0.20.0 slice-selection Array methods: `take`, `drop`, `values_at`.  All are
+// index-clamped / bounds-guarded and route through the explicit `arrayMethod`
+// switch (never `recv[name]`).
+#[test]
+fn array_take_drop_values_at_methods() {
+    let stmts = vec![
+        print(method(seq(vec![int(1), int(2), int(3), int(4), int(5)]), "take", vec![int(2)])), // [1, 2]
+        print(method(seq(vec![int(1), int(2), int(3)]), "take", vec![int(9)])), // [1, 2, 3] (clamp)
+        print(method(seq(vec![int(1), int(2), int(3), int(4), int(5)]), "drop", vec![int(2)])), // [3, 4, 5]
+        print(method(seq(vec![int(1), int(2), int(3)]), "drop", vec![int(9)])), // [] (n >= len)
+        print(method(
+            seq(vec![int(10), int(20), int(30)]),
+            "values_at",
+            vec![int(0), int(2), int(-1)],
+        )), // [10, 30, 30]
+    ];
+    let module =
+        module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Sequences, Feature::Strings]);
+    if let Some(stdout) = run_module(&module, "arrtakedrop") {
+        assert_eq!(stdout, "[1, 2]\n[1, 2, 3]\n[3, 4, 5]\n[]\n[10, 30, 30]");
+    }
+}
+
 // ── Ruby Hash method catalog (hand-implemented, explicit dispatch) ──
 //
 // Exercises the `hashMethod` catalog end-to-end under Node: `keys`/`values`/


### PR DESCRIPTION
## What

Continues the cross-backend Array slice-selection sweep (Go #7765, Rust #7769) on the JS backend. Extends the inlined JS runtime's `arrayMethod` switch (and the `ARRAY_METHODS` `respond_to?` set):

- **`take(n)` / `drop(n)`** — the first / all-but-first `n` elements; `n` is clamped to `[0, len]` (`n <= 0` → `[]`/full copy, `n > len` → full copy/`[]`), so `recv.slice` never misbehaves. A negative `n` raises `ArgumentError` in Ruby; the never-raise floor treats it as `0`.
- **`values_at(*idxs)`** — the element at each index, folding a negative index from the end once; an out-of-range index yields `null` (never throws).

## Safety

Dispatch stays an explicit `switch (name)` — never `recv[name]`, no reflection. Never-throw floor holds: `Math.trunc` + the `[0, len]` clamp keep `n` a safe slice bound (NaN/Infinity args degrade to `[]`/full-copy/clamp, never throw); `values_at` reads only numeric indices guarded by `idx >= 0 && idx < len` (out-of-range → `null`, no unguarded `recv[idx]`, no prototype access). Allocations bounded by `recv.length` / `args.length`. Security review passed (0 findings).

## Verification

- `cargo test -p semantic-ir-to-javascript` green (109 unit + 68 node, 0 warnings).
- New `array_take_drop_values_at_methods` emits JS, runs it under Node, and diffs stdout for all 5 cases (take(2), take(9) clamp, drop(2), drop(9)→[], values_at(0,2,-1)) — byte-for-byte matching the Go/Rust PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)