### PR TITLE
feat(sir-runtime-oop): slice-selection Array methods — take / drop / values_at (TS, v0.1.14)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.14] - 2026-07-07
+
+### Added — Array slice-selection methods: `take` / `drop` / `values_at`
+
+Extends `arrayMethod` (and the `ARRAY_METHODS` `respond_to?` catalog) with three
+more non-block Ruby Array methods, mirroring the Go/Rust/Python/JS runtimes:
+
+- `take(n)` / `drop(n)` — the first `n` elements, or all elements *after* the
+  first `n`. `n` is clamped to `[0, len]`: Ruby raises `ArgumentError` on a
+  negative `n`, but the never-raise floor folds it to `0`, and `slice` saturates
+  `n > len`. A non-numeric argument degrades to `0`.
+- `values_at(*idxs)` — one element per index, with a negative index folded from
+  the end **once**; an out-of-range index yields `nil` (`null`) rather than
+  raising, matching the sibling backends.
+
 ## [0.1.13] - 2026-07-07
 
 ### Added — more String methods: `ljust` / `rjust` / `center` / `swapcase`

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -62,7 +62,8 @@ through `@coding-adventures/sir-runtime-exceptions`' explicit-string `raiseError
 The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md`)
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
-`min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a` — and the
+`min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
+`take`/`drop`/`values_at` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a` (`include?`/`index`/`==` use
 deep value equality), plus the **Kernel flow-control** group

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -550,6 +550,9 @@ const ARRAY_METHODS = new Set<string>([
   "to_a",
   "join",
   "fetch",
+  "take",
+  "drop",
+  "values_at",
 ]);
 
 // Block-taking `Array`/`Enumerable` methods (M1b); each invokes a trailing
@@ -946,6 +949,31 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
         `index ${raw} outside of array bounds: ${-recv.length}...${recv.length}`,
       );
       return MISS; // unreachable: raiseError returns `never`
+    }
+    case "take":
+    case "drop": {
+      // Ruby `Array#take(n)` / `#drop(n)`: the first `n` elements, or all
+      // elements *after* the first `n`.  `n` is clamped to `[0, len]` — Ruby
+      // raises `ArgumentError` on a negative `n`, but the never-raise floor
+      // (mirroring the Go/Rust/Python runtimes) folds a negative count to 0,
+      // and `slice` already saturates `n > len`.  A non-numeric argument
+      // degrades to 0 rather than raising.
+      let n = typeof args[0] === "number" ? Math.trunc(args[0] as number) : 0;
+      if (n < 0) n = 0;
+      if (n > recv.length) n = recv.length;
+      return name === "take" ? recv.slice(0, n) : recv.slice(n);
+    }
+    case "values_at": {
+      // Ruby `Array#values_at(*idxs)`: one element per index, with a negative
+      // index folded from the end **once**.  An out-of-range index yields `nil`
+      // (`null`) rather than raising — matching the sibling backends.
+      const out: Val[] = [];
+      for (const arg of args) {
+        let idx = typeof arg === "number" ? Math.trunc(arg) : 0;
+        if (idx < 0) idx += recv.length;
+        out.push(idx >= 0 && idx < recv.length ? recv[idx] : null);
+      }
+      return out;
     }
     default:
       return MISS;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -255,6 +255,25 @@ describe("built-in method catalog: non-block Array (M1a)", () => {
     expect(callMethod([1, 2, 3], "fetch", 100, "def")).toBe("def");
     expect(callMethod([1, 2, 3], "fetch", -4, 0)).toBe(0);
   });
+
+  it("take / drop split the array at a count clamped to [0, len]", () => {
+    // Over-long counts saturate; a negative count folds to 0 (never-raise floor).
+    expect(callMethod([1, 2, 3, 4], "take", 2)).toEqual([1, 2]);
+    expect(callMethod([1, 2, 3, 4], "drop", 2)).toEqual([3, 4]);
+    expect(callMethod([1, 2, 3], "take", 0)).toEqual([]);
+    expect(callMethod([1, 2, 3], "drop", 0)).toEqual([1, 2, 3]);
+    expect(callMethod([1, 2, 3], "take", 99)).toEqual([1, 2, 3]);
+    expect(callMethod([1, 2, 3], "drop", 99)).toEqual([]);
+    expect(callMethod([1, 2, 3], "take", -5)).toEqual([]);
+    expect(callMethod([1, 2, 3], "drop", -5)).toEqual([1, 2, 3]);
+  });
+
+  it("values_at selects one element per index, folding negatives, nil OOB", () => {
+    expect(callMethod([10, 20, 30], "values_at", 0, 2)).toEqual([10, 30]);
+    expect(callMethod([10, 20, 30], "values_at", -1, -2)).toEqual([30, 20]);
+    expect(callMethod([10, 20, 30], "values_at", 5, -9)).toEqual([null, null]);
+    expect(callMethod([10, 20, 30], "values_at")).toEqual([]);
+  });
 });
 
 describe("built-in method catalog: universal Object (M1a)", () => {


### PR DESCRIPTION
## What

**Completes the cross-backend `take`/`drop`/`values_at` Array sweep** — the fifth and final backend (Go #7765, Rust #7769, JS #7771, Python #7772 already open). Brings the **TypeScript `sir-runtime-oop`** runtime library to parity.

Adds three non-block Ruby Array methods to `arrayMethod` and the `ARRAY_METHODS` `respond_to?` catalog:

- **`take(n)` / `drop(n)`** — first `n` elements, or all elements *after* the first `n`. `n` is clamped to `[0, len]`: Ruby raises `ArgumentError` on a negative `n`, but the never-raise floor folds it to `0`, and `slice` already saturates `n > len`. A non-numeric argument degrades to `0`.
- **`values_at(*idxs)`** — one element per index, folding a negative index from the end **once**; an out-of-range index yields `nil` (`null`) rather than raising — matching the Go/Rust/Python/JS runtimes byte-for-byte.

## Discipline

- Explicit literal-name `switch` dispatch (no reflection) — consistent with the rest of the catalog.
- Never-raise floor preserved (negative/over-long/non-numeric args degrade, never throw).
- Writes only into a fresh local array via `.push`, reads `recv[idx]` only after a numeric bounds check — no prototype-pollution surface.

## Verification

- `vitest run` — **109 passed** (2 new specs covering in-range, over-long/saturating, negative/fold-to-0, and empty-arg cases).
- New code is `tsc`-clean; the only `tsc` diagnostics are the pre-existing `@types/node`/`process` and `min_by` strict-null gaps (tracked separately), untouched here.
- Security review: **PASSED — no vulnerabilities found** (no injection / prototype-pollution / algorithmic-DoS surface).

Bumps `0.1.13 → 0.1.14`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)