### PR TITLE
feat(adj-ladder): rung-101 range-of-motion (a sum minus a product, a+b-c*d)

### DIFF
--- a/code/specs/data/adj-ladder/rung101_range_of_motion/gen_items.py
+++ b/code/specs/data/adj-ladder/rung101_range_of_motion/gen_items.py
@@ -1,0 +1,254 @@
+"""Generate rung-101 (orthopedics / range-of-motion) items.json for the ADJ-LADDER.
+
+Rung 101 opens the **orthopedics / range-of-motion** panel on the quantitative band — the arithmetic of a joint's net
+motion arc. A `flexion_arc` PLUS an `extension_arc` gives the combined arc (how much motion the two directions contribute
+together), a `brace_factor` TIMES a `stiffness_factor` gives the brace load (the product the arc is docked by), and the
+brace load is SUBTRACTED from the combined arc to give the net arc. A **sum minus a product** introduces a genuinely NEW
+arithmetic family on the ladder: `a+b-c*d`, i.e. `((a+b) - (c*d))`.
+
+This is genuinely new — the first time the ladder subtracts a bare PRODUCT from a bare SUM. It is the **minus-sibling of
+rung-91** `a+b+c*d` (a sum plus a product): rung-91 added the product to the sum, rung-101 subtracts it. No prior rung took
+a sum minus a product: rung-34 `a*b+c*d` summed two products, rung-35 `a*b-c*d` subtracted two products, rung-31 subtracted
+two differences, and rungs 79/80 attach a `c/d` division rather than a `c*d` product to the `a*b` term. The operator order
+matters: `a+b-c*d` is `((a+b) - (c*d))` (the sum forms, the product forms, then the product is subtracted from the sum
+— multiplication binds tighter than the subtraction), NOT `(a+b-c)*d` (folding the subtraction inside so the brace factor
+is subtracted from the combined arc *before* multiplying by the stiffness factor) and NOT `(a*b) - (c+d)` (multiplying the
+first pair and summing the second pair, mispairing which pair is the product and which is the sum) — the two distractors
+exploit exactly those confusions.
+
+The setup: a `flexion_arc`, an `extension_arc`, a `brace_factor`, and a `stiffness_factor`. The total is:
+
+  NET ARC        (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)  [ a sum minus a product ]
+  COMBINED ARC   flexion_arc + extension_arc                                        [ the sum, the minuend ]
+  BRACE LOAD     brace_factor * stiffness_factor                                    [ the product, subtracted ]
+
+The **net arc** is what makes this rung distinctive — it is the ladder's first **bare SUM minus a bare PRODUCT**. (The
+combined arc `a+b` and the brace load `c*d` ride alongside as component readouts, so the panel teaches the whole
+calculation — exactly as rungs 47-100 shipped their component sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the addition of the flexion arc and extension arc into the combined arc, the multiplication of the
+brace factor by the stiffness factor into the brace load, then the subtraction of the brace load from the combined arc (the
+product forming before it is subtracted, so a+b-c*d evaluates as ((a+b)-(c*d))) — and the harness reads the scalar via the
+existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../99/100. This rung exercises
+the engine across a **sum minus a product** — the fact that `a+b-c*d` is `((a+b)-(c*d))` and NOT `(a+b-c)*d` and NOT
+`(a*b)-(c+d)` made computable.
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `*` —
+**no structural constants** — so no numeric literal appears in any program, and neither the combined arc, the brace load,
+nor any net figure is ever a literal (each is computed from the observed quantities). The observed quantities carry
+**digit-free identifiers** (`flexion_arc`, `extension_arc`, `brace_factor`, `stiffness_factor`) so no numeral hides inside a
+variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    (flexion_arc + extension_arc - brace_factor) * stiffness_factor  fold the subtraction inside the parentheses
+                                                                              so the brace factor is subtracted from the
+                                                                              combined arc *before* multiplying by the
+                                                                              stiffness factor (the classic `a+b-c*d` vs
+                                                                              `(a+b-c)*d` precedence error), and
+  SWAPPED    (flexion_arc * extension_arc) - (brace_factor + stiffness_factor)  multiply the first pair and sum the second
+                                                                              pair, mispairing which pair is the product and
+                                                                              which is the sum (`(a*b)-(c+d)` instead of
+                                                                              `(a+b)-(c*d)`),
+
+which are exactly the mistakes a student makes (folding the subtraction inside the parentheses before multiplying, or
+mispairing which pair is a sum and which is a product). Gold rotates A-E by index. QUERIED (used as gold) = the three real
+readouts; all five always appear as options.
+
+Distinctness and positivity: the tables are chosen so `flexion_arc + extension_arc > brace_factor * stiffness_factor`
+(net arc strictly positive — the combined arc always exceeds the brace load it is docked by) and `flexion_arc *
+extension_arc > brace_factor + stiffness_factor` (the swapped figure strictly positive), so no family member is ever zero or
+negative; every observed quantity is >= 2. The combined arc (a sum of positives) and the brace load (a product of positives)
+are trivially positive, and the crossed figure `(a+b-c)*d` is positive because `a+b > c*d >= 2c > c` so `a+b-c > 0`. The
+tables are chosen so the five family values are pairwise distinct with a comfortable margin, and — so all three queried
+readouts vary across the panel — the seven tables give distinct net arcs, distinct combined arcs, and distinct brace loads,
+all asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (FLEXION_ARC, EXTENSION_ARC, BRACE_FACTOR, STIFFNESS_FACTOR) — a flexion arc plus an extension arc for the combined arc,
+# a brace factor times a stiffness factor for the brace load, all plain positive numbers >= 2. Each table satisfies
+# flexion_arc + extension_arc > brace_factor * stiffness_factor (net arc > 0) and flexion_arc * extension_arc >
+# brace_factor + stiffness_factor (swapped > 0), so every family member is strictly positive (no negatives anywhere); the
+# five family values are asserted pairwise-distinct below. The seven tables give distinct net arcs, distinct combined arcs,
+# and distinct brace loads so all three queried readouts vary across the panel.
+TABLES = [
+    (2, 3, 2, 2),
+    (2, 6, 2, 3),
+    (2, 9, 2, 4),
+    (2, 11, 3, 3),
+    (2, 13, 2, 5),
+    (5, 13, 2, 6),
+    (8, 13, 2, 7),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, -, and *. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "net_arc",
+        "total net arc (the combined arc minus the brace load)",
+        "(flexion_arc + extension_arc) - (brace_factor * stiffness_factor)",
+    ),
+    (
+        "combined_arc",
+        "the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)",
+        "flexion_arc + extension_arc",
+    ),
+    (
+        "brace_load",
+        "the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)",
+        "brace_factor * stiffness_factor",
+    ),
+    (
+        "crossed",
+        "the flexion arc plus the extension arc minus the brace factor, all multiplied by the stiffness factor, folding the subtraction inside the parentheses so the brace factor is subtracted before multiplying (a wrong grouping)",
+        "(flexion_arc + extension_arc - brace_factor) * stiffness_factor",
+    ),
+    (
+        "swapped",
+        "the flexion arc times the extension arc, minus the brace factor plus the stiffness factor, multiplying the first pair and summing the second pair instead (a wrong pairing)",
+        "(flexion_arc * extension_arc) - (brace_factor + stiffness_factor)",
+    ),
+]
+QUERIED = ["net_arc", "combined_arc", "brace_load"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(flexion_arc, extension_arc, brace_factor, stiffness_factor):
+    # Operation order mirrors the ADJ programs exactly (the sum forms, the product forms, then the product is subtracted
+    # from the sum, so a+b-c*d evaluates as ((a+b)-(c*d))), so the Python option value and the engine result are the same
+    # IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "net_arc": (flexion_arc + extension_arc) - (brace_factor * stiffness_factor),
+        "combined_arc": flexion_arc + extension_arc,
+        "brace_load": brace_factor * stiffness_factor,
+        "crossed": (flexion_arc + extension_arc - brace_factor) * stiffness_factor,
+        "swapped": (flexion_arc * extension_arc) - (brace_factor + stiffness_factor),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for flexion_arc, extension_arc, brace_factor, stiffness_factor in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and the tables guarantee flexion_arc + extension_arc >
+        # brace_factor * stiffness_factor (net arc > 0) and flexion_arc * extension_arc > brace_factor + stiffness_factor
+        # (swapped > 0), so every family member is strictly positive with no negative anywhere.
+        assert (
+            flexion_arc >= 2
+            and extension_arc >= 2
+            and brace_factor >= 2
+            and stiffness_factor >= 2
+        ), (flexion_arc, extension_arc, brace_factor, stiffness_factor)
+        assert flexion_arc + extension_arc > brace_factor * stiffness_factor, (
+            flexion_arc, extension_arc, brace_factor, stiffness_factor,
+        )
+        assert flexion_arc * extension_arc > brace_factor + stiffness_factor, (
+            flexion_arc, extension_arc, brace_factor, stiffness_factor,
+        )
+        fv = family_values(flexion_arc, extension_arc, brace_factor, stiffness_factor)
+        for key, v in fv.items():
+            assert v > 0, (key, flexion_arc, extension_arc, brace_factor, stiffness_factor, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    flexion_arc,
+                    extension_arc,
+                    brace_factor,
+                    stiffness_factor,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                flexion_arc,
+                extension_arc,
+                brace_factor,
+                stiffness_factor,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r101rom-{idx + 1:02d}",
+                "qtype": "rom_net_arc",
+                "stem": (
+                    f"A range-of-motion study records a flexion arc of {num(flexion_arc)} plus an extension arc of "
+                    f"{num(extension_arc)}, minus a brace factor of {num(brace_factor)} times a stiffness factor of "
+                    f"{num(stiffness_factor)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe flexion_arc({num(flexion_arc)})\n"
+                    f"observe extension_arc({num(extension_arc)})\n"
+                    f"observe brace_factor({num(brace_factor)})\n"
+                    f"observe stiffness_factor({num(stiffness_factor)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 101 — net range-of-motion arc from four stated quantities (a NEW panel: orthopedics / "
+            "range-of-motion). From a flexion arc plus an extension arc for the combined arc, a brace factor times a "
+            "stiffness factor for the brace load, and the brace load subtracted from the combined arc, compute the net arc "
+            "((flexion_arc+extension_arc)-(brace_factor*stiffness_factor)), the combined arc (flexion_arc+extension_arc), or "
+            "the brace load (brace_factor*stiffness_factor). Each item is a compute_dimensioned program (observe the four "
+            "quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, A SUM MINUS A PRODUCT "
+            "a+b-c*d (add a and b, multiply c and d, subtract the product from the sum, so a+b-c*d = ((a+b)-(c*d)); the "
+            "FIRST time the ladder subtracts a bare PRODUCT from a bare SUM — the MINUS-SIBLING of rung-91 a+b+c*d which "
+            "added the product to the sum; rung-34 a*b+c*d summed two products, rung-35 a*b-c*d subtracted two products) — "
+            "and the harness matches the scalar to the printed options. Contamination-safe: every figure is built only from "
+            "the four observed quantities via +, -, and * — no constant leaks, and neither the combined arc, the brace load, "
+            "nor any net figure ever appears as a literal (each is computed) — and the observed quantities carry digit-free "
+            "identifiers so no numeral hides inside a variable name. The five options are a family over the same four "
+            "quantities, so the distractors are exactly the slips students make: folding the subtraction inside the "
+            "parentheses so the brace factor is subtracted before multiplying ((a+b-c)*d, a wrong grouping) and multiplying "
+            "the first pair while summing the second pair ((a*b)-(c+d), a wrong pairing). The core confusion tested is that "
+            "a+b-c*d is ((a+b)-(c*d)), not (a+b-c)*d and not (a*b)-(c+d). Each table guarantees the combined arc exceeds the "
+            "brace load and the flexion-times-extension product exceeds the brace-plus-stiffness sum, so every figure stays "
+            "strictly positive."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung101_range_of_motion/items.json
+++ b/code/specs/data/adj-ladder/rung101_range_of_motion/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 101 \u2014 net range-of-motion arc from four stated quantities (a NEW panel: orthopedics / range-of-motion). From a flexion arc plus an extension arc for the combined arc, a brace factor times a stiffness factor for the brace load, and the brace load subtracted from the combined arc, compute the net arc ((flexion_arc+extension_arc)-(brace_factor*stiffness_factor)), the combined arc (flexion_arc+extension_arc), or the brace load (brace_factor*stiffness_factor). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, A SUM MINUS A PRODUCT a+b-c*d (add a and b, multiply c and d, subtract the product from the sum, so a+b-c*d = ((a+b)-(c*d)); the FIRST time the ladder subtracts a bare PRODUCT from a bare SUM \u2014 the MINUS-SIBLING of rung-91 a+b+c*d which added the product to the sum; rung-34 a*b+c*d summed two products, rung-35 a*b-c*d subtracted two products) \u2014 and the harness matches the scalar to the printed options. Contamination-safe: every figure is built only from the four observed quantities via +, -, and * \u2014 no constant leaks, and neither the combined arc, the brace load, nor any net figure ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: folding the subtraction inside the parentheses so the brace factor is subtracted before multiplying ((a+b-c)*d, a wrong grouping) and multiplying the first pair while summing the second pair ((a*b)-(c+d), a wrong pairing). The core confusion tested is that a+b-c*d is ((a+b)-(c*d)), not (a+b-c)*d and not (a*b)-(c+d). Each table guarantees the combined arc exceeds the brace load and the flexion-times-extension product exceeds the brace-plus-stiffness sum, so every figure stays strictly positive.",
+  "items": [
+    {
+      "id": "r101rom-01",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 3, minus a brace factor of 2 times a stiffness factor of 2. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(3)\nobserve brace_factor(2)\nobserve stiffness_factor(2)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r101rom-02",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 3, minus a brace factor of 2 times a stiffness factor of 2. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(3)\nobserve brace_factor(2)\nobserve stiffness_factor(2)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r101rom-03",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 3, minus a brace factor of 2 times a stiffness factor of 2. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(3)\nobserve brace_factor(2)\nobserve stiffness_factor(2)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r101rom-04",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 6, minus a brace factor of 2 times a stiffness factor of 3. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(6)\nobserve brace_factor(2)\nobserve stiffness_factor(3)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r101rom-05",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 6, minus a brace factor of 2 times a stiffness factor of 3. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(6)\nobserve brace_factor(2)\nobserve stiffness_factor(3)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r101rom-06",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 6, minus a brace factor of 2 times a stiffness factor of 3. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(6)\nobserve brace_factor(2)\nobserve stiffness_factor(3)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r101rom-07",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 9, minus a brace factor of 2 times a stiffness factor of 4. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(9)\nobserve brace_factor(2)\nobserve stiffness_factor(4)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r101rom-08",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 9, minus a brace factor of 2 times a stiffness factor of 4. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(9)\nobserve brace_factor(2)\nobserve stiffness_factor(4)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r101rom-09",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 9, minus a brace factor of 2 times a stiffness factor of 4. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(9)\nobserve brace_factor(2)\nobserve stiffness_factor(4)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 36,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r101rom-10",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 11, minus a brace factor of 3 times a stiffness factor of 3. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(11)\nobserve brace_factor(3)\nobserve stiffness_factor(3)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r101rom-11",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 11, minus a brace factor of 3 times a stiffness factor of 3. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(11)\nobserve brace_factor(3)\nobserve stiffness_factor(3)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r101rom-12",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 11, minus a brace factor of 3 times a stiffness factor of 3. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(11)\nobserve brace_factor(3)\nobserve stiffness_factor(3)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r101rom-13",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 5. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(5)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 65,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 19,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r101rom-14",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 5. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(5)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 65,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 19,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r101rom-15",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 2 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 5. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(2)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(5)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 65,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r101rom-16",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 5 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 6. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(5)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(6)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 96,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 57,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r101rom-17",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 5 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 6. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(5)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(6)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 96,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 57,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r101rom-18",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 5 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 6. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(5)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(6)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 96,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 57,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r101rom-19",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 8 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 7. What is the total net arc (the combined arc minus the brace load)?",
+      "program": "observe flexion_arc(8)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(7)\nlet answer = (flexion_arc + extension_arc) - (brace_factor * stiffness_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 133,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 95,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r101rom-20",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 8 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 7. What is the the combined arc (the flexion arc plus the extension arc, the minuend before subtracting)?",
+      "program": "observe flexion_arc(8)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(7)\nlet answer = flexion_arc + extension_arc\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 133,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 95,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 21,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r101rom-21",
+      "qtype": "rom_net_arc",
+      "stem": "A range-of-motion study records a flexion arc of 8 plus an extension arc of 13, minus a brace factor of 2 times a stiffness factor of 7. What is the the brace load (the brace factor times the stiffness factor, the product subtracted from the combined arc)?",
+      "program": "observe flexion_arc(8)\nobserve extension_arc(13)\nobserve brace_factor(2)\nobserve stiffness_factor(7)\nlet answer = brace_factor * stiffness_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 21,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 133,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 95,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -138,6 +138,7 @@ SELF_CONTAINED_RUNGS = (
     "rung98_segmental_pressure",
     "rung99_clearance_fraction",
     "rung100_refraction_focus",
+    "rung101_range_of_motion",
 )
 
 


### PR DESCRIPTION
## rung-101 net range-of-motion arc (`a+b-c*d` — a sum minus a product)

Opens the **orthopedics / range-of-motion** panel on the ADJ-LADDER quantitative band, and introduces a genuinely **NEW arithmetic family**: `a+b-c*d` — a **bare sum minus a bare product**. Rung **101**.

### Why this shape is new
It is the **first time the ladder subtracts a product from a sum**, and the **minus-sibling of rung-91** `a+b+c*d` (a sum plus a product):

| rung | shape | note |
|---|---|---|
| 34 | `a*b+c*d` | sum of two **products** |
| 35 | `a*b-c*d` | difference of two **products** |
| 91 | `a+b+c*d` | a sum **plus** a product |
| **101** | **`a+b-c*d`** | **a sum minus a product** |

Operator order matters: `a+b-c*d` is `((a+b) - (c*d))` (multiplication binds tighter than the subtraction), NOT `(a+b-c)*d` (subtract the brace factor *before* multiplying) and NOT `(a*b)-(c+d)` (mispair which pair is the product vs the sum) — the two distractors exploit exactly those slips.

### The panel
Four observed quantities — `flexion_arc`, `extension_arc`, `brace_factor`, `stiffness_factor`:

| readout | formula | shape |
|---|---|---|
| **net arc** (headline) | `(flexion_arc+extension_arc) - (brace_factor*stiffness_factor)` | `a+b-c*d` |
| combined arc (queried) | `flexion_arc+extension_arc` | `a+b` (the minuend sum) |
| brace load (queried) | `brace_factor*stiffness_factor` | `c*d` (the subtracted product) |
| crossed *(distractor)* | `(flexion_arc+extension_arc-brace_factor) * stiffness_factor` | `(a+b-c)*d` (subtraction folded inside, before the multiply) |
| swapped *(distractor)* | `(flexion_arc*extension_arc) - (brace_factor+stiffness_factor)` | `(a*b)-(c+d)` (product/sum pairs swapped) |

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness matches the scalar to the printed options. No harness/engine change. 7 tables × 3 queried = **21 items**, gold rotates A–E. **All three queried golds vary** across the tables — net arc 1–7, combined arc 5–21, brace load 4–14.

### Contamination-safe by construction
Built ONLY from the four observed quantities via `+`, `-`, and `*` — **no numeric constants**, no readout ever a literal, identifiers **digit-free**. Every table guarantees `flexion_arc+extension_arc > brace_factor*stiffness_factor` (net arc > 0) and `flexion_arc*extension_arc > brace_factor+stiffness_factor` (swapped > 0), so every one of the 5 family members stays strictly positive; the crossed figure `(a+b-c)*d` is positive because `a+b > c*d ≥ 2c > c`. Build asserts all 5 positive + pairwise-distinct (>1e-6).

### Verification
- `pytest test_ladder_eval.py -k rung101` → **3 passed** (with `adj-lang-cli` built; the engine's arithmetic matches the Python integers exactly).
- Single-parent commit; scoped diff = 3 files (`rung101_range_of_motion/gen_items.py`, `rung101_range_of_motion/items.json`, `test_ladder_eval.py`).
- Inline security review PASSED (data-only generator; no eval/exec/subprocess/network/user-input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
