### PR TITLE
feat(latex): LTXDOC03 S16 — duplicate (multiply-defined) bibliography entries report

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.52.0] — 2026-07-07
+
+### Added — duplicate (multiply-defined) bibliography entries (LTXDOC03 S16)
+
+A **new** public method `Document::duplicate_bibliography_entries(&self) -> String` that surfaces the
+**duplicate (multiply-defined) `\bibitem` entries** — LaTeX's *"Citation `key' multiply defined"*
+warnings. These were already computed by S2 (`resolve_citations().duplicate_entries`) but rendered by
+**no** method until now. It is the citation-family parallel of S6's *"Dangling citations"* footer, for
+the *other* bibliography warning. Every S1–S15 output is left **byte-for-byte unchanged**; S16 is
+purely additive and leaves the `to_latex()` round-trip fixed point intact.
+
+- **One line per losing duplicate, in pre-order.** S2 collects every `\bibitem{key}` in `walk`
+  pre-order; the **first** of each key wins, and every **later** `\bibitem` of an already-defined key
+  is a losing duplicate in `duplicate_entries`. S16 emits one line per duplicate, in that existing
+  pre-order (**not** re-sorted). Each line is the offending command **reconstructed from its key**:
+  `\bibitem{` + the duplicate's key + `}`. We reconstruct from the owned key rather than slice
+  `&src[span]` (matching S13 `resolve_namerefs` and S15 `citations_by_source`), so the render needs no
+  source borrow and can never index out of bounds.
+- **Every duplicate, never de-duplicated.** If a key is defined *three* times, both the second and the
+  third lose, so two `\bibitem{key}` lines are emitted (one per *"multiply defined"* warning LaTeX
+  would raise) — the point is to surface every warning, not the fact that a key is duplicated. The
+  winning first `\bibitem` is never listed (it is an entry, not a duplicate). Lines are joined by `\n`
+  with **no** trailing newline (matching S11 `to_plain_text_by_kind`, S12 `list_of_floats`, S13
+  `resolve_namerefs`, S14 `list_summary`, S15 `citations_by_source`).
+- **Empty marker.** A document with **no** duplicate entries — no bibliography, or every key defined
+  exactly once — returns the fixed marker `"(no duplicate bibliography entries)"`, so the output is
+  never the empty string (the same stable-marker discipline S12/S13/S14/S15 use).
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all — keys
+  are already owned `String`s); a single pass over the already-bounded `duplicate_entries` list.
+  Borrows `self` immutably, returns owned `String`.
+
+Four `s16_*` tests pin the exact rendered strings: a bibliography defining `smith` twice and `jones`
+once (`\bibitem{smith}`, only the loser), two distinct keys each defined twice
+(`\bibitem{a}\n\bibitem{b}` in pre-order), a no-duplicate bibliography returning the
+`(no duplicate bibliography entries)` marker, and an additivity check that `to_plain_text`,
+`to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, and
+`citations_by_source` all still produce their exact prior strings.
+
 ## [0.51.0] — 2026-07-07
 
 ### Added — resolved citations grouped by their source `\cite` (LTXDOC03 S15)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -63,6 +63,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S13 — `\nameref` resolution to a target's name** | `Document::resolve_namerefs() -> String` — a **new** method that resolves every `\nameref{key}` to the **name** (title/caption text) of its target — the name-valued sibling of `\ref` (number) and `\pageref` (page). `\nameref` is **not** a `REF_COMMAND`, so it appears in neither the resolved nor unresolved ref table (an AST probe confirms it lowers to `Inline::CrossRef { command: "nameref", .. }`); S13 reads the same S1 `\label` table but answers "*what is it called?*", so it is purely additive. One document-order walk collects each `nameref` cross-ref; the key is resolved against the winning label table and the name read from its defining node via the S3 `label_def_node` accessor — a `Section` → its title inlines flattened, a `Figure`/`Table` → its `\caption` via the shared `caption_text` helper (S12's flatten factored into a module-level `flatten_inlines_to_text`, reused by both so they can never drift). An `Equation`/`Inline` target (a number, not a title) → `(no name)`; an undefined key → `(undefined nameref: <key>)`; no `\nameref` at all → `(no namerefs)`. Each line is `\nameref{<key>} -> <name>`, joined by `\n`, no trailing newline. Every S1–S12 output is byte-for-byte unchanged. Total & panic-free. | ✅ |
 | **LTXDOC03 S14 — per-kind census of the numbered-label table** | `Document::list_summary() -> String` — a **new**, read-only method that renders a compact per-kind **count** of the document's numbered labels: how many sections, figures, tables, and equations carry a `\label`. It is a pure tally of the rows `number_labels()` returns, grouped by `LabelKind`, so it can never drift from the S4 numbering it summarises. Only the four numberable kinds reach that table — a bare inline `\label{…}` (`LabelKind::Inline`) is not numbered and is counted nowhere. One line per non-zero kind in the **fixed order** `Sections`, `Figures`, `Tables`, `Equations` (deterministic, not source order), formatted `<Kind>: <count>` with a **fixed plural** label regardless of count (a single section still prints `Sections: 1`); a kind with count 0 is **omitted** (mirroring S11). Lines joined by `\n`, no trailing newline. A document with **no** numbered label at all → the fixed marker `(no labels)`. E.g. two labeled sections + a figure + a table + an equation → `Sections: 2\nFigures: 1\nTables: 1\nEquations: 1`. Every S1–S13 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S15 — resolved citations grouped by their source `\cite`** | `Document::citations_by_source() -> String` — a **new**, read-only method that renders the resolved citations **grouped by the source `\cite` they came from** — the citation-family parallel of S11's `to_plain_text_by_kind` and S13's `resolve_namerefs`. It reads only `resolve_citations().resolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping them back by `cite_span` in **first-appearance order** (source order of the `\cite`s) with keys kept in their left-to-right order. One line per source `\cite`: `\cite{` + the group's **resolved** keys joined by `", "` + `}`. A **dangling** key never entered `resolved`, so it is excluded — `\cite{a,ghost}` where only `a` resolves renders `\cite{a}` (we reconstruct from resolved keys rather than slice `&src[cite_span]`, which would still show `ghost`). Lines joined by `\n`, no trailing newline. A document with **no** resolved citations (none present, or every key dangling) → the fixed marker `(no resolved citations)`. E.g. `\cite{a,b}` (both defined) then `\cite{c}` → `\cite{a, b}\n\cite{c}`. Every S1–S14 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S16 — duplicate (multiply-defined) `\bibitem` entries** | `Document::duplicate_bibliography_entries() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\bibitem`s — LaTeX's *"Citation `key' multiply defined"* warnings — the citation-family parallel of S6's *"Dangling citations"* footer (for the *other* bibliography warning). These were already computed by S2 (`resolve_citations().duplicate_entries`) but rendered by **no** method until now. S2 collects every `\bibitem` in `walk` pre-order; the **first** of each key wins and every **later** `\bibitem` of an already-defined key is a losing duplicate. S16 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\bibitem{<key>}` (no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** duplicates (no bibliography, or every key once) → the fixed marker `(no duplicate bibliography entries)`. E.g. `smith` defined twice + `jones` once → `\bibitem{smith}` (only the loser). Every S1–S15 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -699,6 +700,35 @@ assert_eq!(
 A document with no resolved citations — none present, or every cited key dangling — renders the fixed
 `(no resolved citations)` marker. Purely additive — reuses `resolve_citations`, mutates nothing, leaves
 every S1–S14 output and the `to_latex()` fixed point unchanged.
+
+### duplicate (multiply-defined) bibliography entries (LTXDOC03 S16)
+
+S2's `resolve_citations` collects every `\bibitem` in pre-order: the **first** of each key wins (it is
+the entry citations resolve against), and every **later** `\bibitem` of an already-defined key becomes
+a losing duplicate in `duplicate_entries` — LaTeX's *"Citation `key' multiply defined"* warning.
+`duplicate_bibliography_entries` reads only that list and emits one line per losing duplicate, in the
+existing pre-order (not re-sorted, not de-duplicated), each reconstructed from its key as
+`\bibitem{<key>}`.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\cite{smith}.
+\begin{thebibliography}{9}
+\bibitem{smith} First Smith. 1990.
+\bibitem{jones} Jones. 1991.
+\bibitem{smith} Second Smith. 1992.
+\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.duplicate_bibliography_entries(),
+    "\\bibitem{smith}",   // only the SECOND `\bibitem{smith}` loses; `jones` (once) is not listed
+);
+```
+
+A document with no duplicates — no bibliography, or every key defined exactly once — renders the fixed
+`(no duplicate bibliography entries)` marker. Purely additive — reuses `resolve_citations`, mutates
+nothing, leaves every S1–S15 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1671,6 +1671,86 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **duplicate (multiply-defined) bibliography entries** (LTXDOC03 S16) — the citation-family
+    /// parallel of S6's *"Dangling citations"* footer, but for the *other* bibliography warning LaTeX
+    /// emits: *"Citation `key' multiply defined"*.
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] collects every `\bibitem{key}` inside a `thebibliography`
+    /// in [`Document::walk`] pre-order. The **first** `\bibitem` of each key wins (it becomes the row
+    /// citations resolve against); every **later** `\bibitem` of an already-defined key is a *losing*
+    /// duplicate, recorded in [`CitationResolution::duplicate_entries`]. No method has surfaced that
+    /// list until now — this method renders it, one warning per losing `\bibitem`.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// One line per losing duplicate, in the existing pre-order of `duplicate_entries` (the source
+    /// order of the offending `\bibitem`s — **not** re-sorted). Each line is the offending command
+    /// **reconstructed from its key**: `\bibitem{` + the duplicate's key + `}`. We reconstruct from the
+    /// owned key rather than slice `&src[span]` — matching how S13's `resolve_namerefs` and S15's
+    /// `citations_by_source` rebuild commands from keys — so the render needs no source borrow and can
+    /// never index out of bounds.
+    ///
+    /// **Every** losing `\bibitem` yields its own line; we do **not** de-duplicate. If a key is defined
+    /// *three* times, the second and third both lose, so two `\bibitem{key}` lines are emitted (one per
+    /// *"multiply defined"* warning LaTeX would raise) — surfacing every duplicate, not the fact that a
+    /// key is duplicated. The winning first `\bibitem` is never listed here (it is the entry in
+    /// [`CitationResolution::entries`], not a duplicate).
+    ///
+    /// A document with **no** duplicate entries — no bibliography, or every key defined exactly once —
+    /// returns the fixed marker `(no duplicate bibliography entries)`, never the empty string (the same
+    /// stable-marker discipline S12/S13/S14/S15 use). Lines are joined by `\n` with **no** trailing
+    /// newline (matching S11's `to_plain_text_by_kind`, S12's `list_of_floats`, S13's
+    /// `resolve_namerefs`, S14's `list_summary`, and S15's `citations_by_source`).
+    ///
+    /// Concretely, for a `thebibliography` that defines `smith` twice and `jones` once:
+    ///
+    /// ```text
+    /// \begin{thebibliography}{9}
+    /// \bibitem{smith} First Smith. 1990.
+    /// \bibitem{jones} Jones. 1991.
+    /// \bibitem{smith} Second Smith. 1992.
+    /// \end{thebibliography}
+    /// ```
+    ///
+    /// only the *second* `\bibitem{smith}` loses, so the report is the single line:
+    ///
+    /// ```text
+    /// \bibitem{smith}
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S16 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1-S15 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single pass over the already-bounded `duplicate_entries`
+    /// list. Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow
+    /// of the source.
+    pub fn duplicate_bibliography_entries(&self) -> String {
+        // S2 already routed every later `\bibitem` of an already-defined key into `duplicate_entries`,
+        // in body pre-order (first-entry-wins). We only read that list.
+        let resolution = self.resolve_citations();
+
+        if resolution.duplicate_entries.is_empty() {
+            // No multiply-defined `\bibitem` → the fixed marker, never the empty string.
+            return "(no duplicate bibliography entries)".to_string();
+        }
+
+        // One line per losing duplicate, in the existing pre-order (NOT re-sorted; NOT de-duplicated —
+        // every "multiply defined" warning gets its own line). Reconstruct `\bibitem{key}` from the
+        // owned key, so there is no source slicing.
+        resolution
+            .duplicate_entries
+            .iter()
+            .map(|dup| format!("\\bibitem{{{}}}", dup.key))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -4138,5 +4218,100 @@ See Section~\ref{sec:intro}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b
 
         // And S15 itself groups the resolved cites: `{a,b}` fully resolves; `{c,ghost}` keeps only `c`.
         assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S16 — duplicate (multiply-defined) bibliography entries (`duplicate_bibliography_entries`).
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s16_reports_duplicate_bibitem() {
+        // A `thebibliography` defining `smith` TWICE and `jones` once. The first `\bibitem{smith}` wins;
+        // the SECOND is the losing duplicate. `jones` (defined once) is not a duplicate. So exactly one
+        // line — the offending `\bibitem{smith}` — is surfaced.
+        let src = r"\begin{document}\cite{smith}.
+\begin{thebibliography}{9}
+\bibitem{smith} First Smith. 1990.
+\bibitem{jones} Jones. 1991.
+\bibitem{smith} Second Smith. 1992.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{smith}");
+    }
+
+    #[test]
+    fn s16_two_distinct_duplicates() {
+        // Two different keys, `a` and `b`, EACH defined twice. Each losing (second) `\bibitem` yields its
+        // own line, in pre-order: the duplicate of `a` appears before the duplicate of `b` (source order
+        // of the losing entries), so the report is `\bibitem{a}` then `\bibitem{b}`.
+        let src = r"\begin{document}
+\begin{thebibliography}{9}
+\bibitem{a} First A.
+\bibitem{b} First B.
+\bibitem{a} Second A.
+\bibitem{b} Second B.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}\n\\bibitem{b}");
+    }
+
+    #[test]
+    fn s16_empty_returns_marker() {
+        // A bibliography whose every key is defined exactly once has NO duplicates → the fixed marker,
+        // never the empty string.
+        let src = r"\begin{document}
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_entries(), "(no duplicate bibliography entries)");
+    }
+
+    #[test]
+    fn s16_is_additive_leaves_s1_s15_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a `\ref`, a `\nameref`,
+        // two `\cite`s (one multi-key, one dangling key), AND a duplicate `\bibitem` (`a` defined twice),
+        // S16 changes NONE of the S1-S15 outputs — it only reads `resolve_citations`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+See Section~\ref{sec:intro}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — the resolved `\ref` and the three resolved `\cite`s with their `[n]`
+        // markers, plus the dangling `ghost` footer, all unchanged by S16.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — the single ref under its `Sections:` group, unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — one figure line, unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — both namerefs render their names, unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — one section, one figure, one equation, unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped cites — `{a,b}` fully resolves; `{c,ghost}` keeps only `c`, unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+
+        // And S16 itself surfaces the one duplicate: the SECOND `\bibitem{a}`.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1300,3 +1300,82 @@ all-dangling doc returning the `(no resolved citations)` marker; and an additivi
 still produce their exact prior strings). All prior S1–S14 tests pass unchanged. `cargo clippy -p latex
 --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo
 build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 22. S16 — duplicate (multiply-defined) bibliography entries (`duplicate_bibliography_entries`)
+
+### 22.1 Motivation
+
+S2's `resolve_citations` returns `duplicate_entries: Vec<DuplicateBib>` — every `\bibitem` that
+redefines an already-defined key, i.e. LaTeX's *"Citation `key' multiply defined"* warning. S6's flat
+report surfaces the *dangling* bibliography warning (undefined citations, a "Dangling citations:"
+footer), but the *other* bibliography warning — the multiply-defined `\bibitem`s — was computed by S2
+yet rendered by **no** method. S16 fills that gap: it is the citation-family analogue of the dangling
+footer, for duplicate definitions.
+
+### 22.2 Why a new method — additive by construction
+
+S16 adds a **new public method** `Document::duplicate_bibliography_entries(&self) -> String`. It is a
+pure, read-only render of `resolve_citations().duplicate_entries`. It reuses that table verbatim (never
+re-walking the body or re-collecting `\bibitem`s), so the report can never drift from the S2 resolution
+it summarises. It mutates nothing and changes no S1–S15 output — including `to_latex()`'s round-trip
+fixed point — byte-for-byte. Like S11–S15 it is a method the caller invokes directly.
+
+### 22.3 The ordering and multiplicity rule
+
+S2 collects every `\bibitem{key}` inside a `thebibliography` in `Document::walk` **pre-order**. The
+**first** `\bibitem` of each key wins (it is the entry citations resolve against, in `entries`); every
+**later** `\bibitem` of an already-defined key is a losing duplicate, appended to `duplicate_entries`
+in that same pre-order. S16 renders `duplicate_entries` **in that order, unchanged** — it does **not**
+re-sort. It also does **not** de-duplicate: if a key is defined three times, the second and third both
+lose, so `duplicate_entries` holds two rows and S16 emits two lines — one per *"multiply defined"*
+warning LaTeX would raise. The winning first `\bibitem` is never listed (it is an entry, not a
+duplicate).
+
+### 22.4 The exact rendering contract — `Document::duplicate_bibliography_entries(&self) -> String`
+
+- One line per losing duplicate `\bibitem`, in the existing pre-order of `duplicate_entries` (source
+  order of the offending `\bibitem`s, **not** re-sorted).
+- Each line is the offending command **reconstructed from its key**: `\bibitem{` + the duplicate's key
+  + `}`. We reconstruct from the owned key rather than slice the raw `&src[span]` (matching S13
+  `resolve_namerefs` and S15 `citations_by_source`), so the render needs no source borrow and can never
+  index out of bounds.
+- Every losing `\bibitem` yields its own line — **no** de-duplication (a key defined three times yields
+  two lines).
+- Lines are joined by `\n` with **no** trailing newline (matching S11 `to_plain_text_by_kind`, S12
+  `list_of_floats`, S13 `resolve_namerefs`, S14 `list_summary`, S15 `citations_by_source`).
+- If there are **no** duplicate entries (no bibliography, or every key defined exactly once), the fixed
+  marker `(no duplicate bibliography entries)` is returned, so the output is never the empty string.
+
+Example (`thebibliography` defining `smith` twice and `jones` once):
+
+```text
+\begin{thebibliography}{9}
+\bibitem{smith} First Smith. 1990.
+\bibitem{jones} Jones. 1991.
+\bibitem{smith} Second Smith. 1992.
+\end{thebibliography}
+```
+
+only the *second* `\bibitem{smith}` loses, so the report is the single line:
+
+```text
+\bibitem{smith}
+```
+
+### 22.5 Public API (added in S16)
+
+One new method: `Document::duplicate_bibliography_entries(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_citations` and every S1–S15 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 22.6 Verification (S16)
+
+`cargo test -p latex` green (4 new S16 tests: a bibliography defining `smith` twice and `jones` once
+rendering `\bibitem{smith}` (only the loser); two distinct keys each defined twice rendering
+`\bibitem{a}\n\bibitem{b}` in pre-order; a no-duplicate bibliography returning the
+`(no duplicate bibliography entries)` marker; and an additivity check that `to_plain_text`,
+`to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, and
+`citations_by_source` all still produce their exact prior strings). All prior S1–S15 tests pass
+unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p
+adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`,
+no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S16 — report duplicate (multiply-defined) bibliography entries

Adds a new read-only method `Document::duplicate_bibliography_entries(&self) -> String` to the `latex` crate, surfacing the **multiply-defined `\bibitem` warnings** — LaTeX's *"Citation `key' multiply defined"* — which S2's `resolve_citations` already computes into `CitationResolution::duplicate_entries` but **no method has rendered until now**. The citation-family parallel of S6's *"Dangling citations"* footer, in the method+doc+test style of S15 `citations_by_source`. Bumps `latex` **0.51.0 → 0.52.0**.

### What it does

S2 collects every `\bibitem{key}` in a `thebibliography` in walk pre-order; the **first** of each key wins (it becomes the entry citations resolve against), and every **later** `\bibitem` of an already-defined key is a *losing* duplicate recorded in `duplicate_entries`. S16 reads only that list.

| aspect | rule |
|---|---|
| line format | `\bibitem{` + the duplicate's key + `}` (reconstructed from the owned key, not sliced from source) |
| ordering | existing `duplicate_entries` pre-order (source order) — **not** re-sorted |
| multiplicity | **one line per losing `\bibitem`**, not de-duplicated — a key defined thrice yields two lines (one per warning) |
| winner | the first `\bibitem` is never listed (it's the entry, not a duplicate) |
| empty | fixed marker `(no duplicate bibliography entries)`, never `""` |
| joining | `\n`-joined, **no** trailing newline (matches S11–S15) |

Example — a `thebibliography` defining `smith` twice and `jones` once → only the second `\bibitem{smith}` loses:

```text
\bibitem{smith}
```

### Additive by construction

Brand-new, read-only method that reuses `resolve_citations` and mutates nothing. **Total & panic-free**: no source slicing/indexing, no `unwrap`/`expect`, no `unsafe`, a single pass over the already-bounded `duplicate_entries`. All **S1–S15 outputs stay byte-for-byte unchanged**, pinned by a dedicated additivity test. The `to_latex` round-trip fixed point is untouched.

### Tests (exact strings, real output)

- `s16_reports_duplicate_bibitem` — `smith` twice + `jones` once → `"\\bibitem{smith}"` (only the losing duplicate)
- `s16_two_distinct_duplicates` — `a`,`b` each twice → `"\\bibitem{a}\n\\bibitem{b}"` (pre-order)
- `s16_empty_returns_marker` — no duplicate keys → `"(no duplicate bibliography entries)"`
- `s16_is_additive_leaves_s1_s15_outputs_unchanged` — pins `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, and `citations_by_source` to their exact prior strings on a representative doc

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → **388 passed; 0 failed** (was 384; +4 S16) + doc-tests ok
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → all green (0 failed)
- `cargo build -p latex --no-default-features` → builds
- Inline security review PASSED (returned `String`, no injection sink; total/panic-free; no DoS regression).
- Single-parent commit; scoped diff = 5 files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
