### PR TITLE
feat(latex): LTXDOC03 S17 — unresolved (dangling) citations grouped by source \cite

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.53.0] — 2026-07-07
+
+### Added — unresolved (dangling) citations grouped by source `\cite` (LTXDOC03 S17)
+
+A **new** public method `Document::unresolved_citations_by_source(&self) -> String` that surfaces the
+**unresolved (dangling) citations grouped per source `\cite`** — the DANGLING-key mirror of S15's
+`citations_by_source`, and the citation-family parallel of S6's flat *"Dangling citations"* footer but
+rendered **per source `\cite`** (a distinct new view). These keys were already computed by S2
+(`resolve_citations().unresolved`) but grouped-by-source by **no** method until now. Every S1–S16
+output is left **byte-for-byte unchanged**; S17 is purely additive and leaves the `to_latex()`
+round-trip fixed point intact.
+
+- **One line per source `\cite` with ≥1 dangling key.** S2 flattens every `\cite` into per-key rows,
+  splitting them into resolved keys and unresolved (dangling) keys, each tagged with the citing
+  `\cite`'s `cite_span`. S17 groups the *dangling* keys by their shared `cite_span`, preserving the
+  **first-appearance order** of the cite_spans (source order) via a `Vec<(Span, Vec<&str>)>` — **not**
+  a hash map — so the order is deterministic. Keys within a group stay in left-to-right order. Each
+  line is `\cite{` + that group's dangling keys joined by `", "` + `}`, reconstructed from the owned
+  `key` `String`s (no source slicing, matching S13 `resolve_namerefs`, S15 `citations_by_source`, and
+  S16 `duplicate_bibliography_entries`).
+- **Only dangling keys shown.** Because `unresolved` holds only the dangling keys, a `\cite{a, ghost}`
+  where `a` resolves and `ghost` dangles renders `\cite{ghost}` — the exact analogue of how S15 shows
+  only the *resolved* keys of a mixed `\cite`. Lines are joined by `\n` with **no** trailing newline
+  (matching S11 `to_plain_text_by_kind`, S12 `list_of_floats`, S13 `resolve_namerefs`, S14
+  `list_summary`, S15 `citations_by_source`, S16 `duplicate_bibliography_entries`).
+- **Empty marker.** A document with **no** unresolved citations — every cited key resolves, or there
+  are no citations at all — returns the fixed marker `"(no unresolved citations)"`, so the output is
+  never the empty string (the same stable-marker discipline S12/S13/S14/S15/S16 use).
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all — keys
+  are already owned `String`s); a single pass over the already-bounded `unresolved` list. Borrows
+  `self` immutably, returns owned `String`.
+
+Six `s17_*` tests pin the exact rendered strings: a single dangling `\cite{ghost}` (`\cite{ghost}`), a
+mixed `\cite{known, ghost}` showing only the dangling key (`\cite{ghost}`), a fully-dangling
+`\cite{x, y}` reuniting both keys on one line (`\cite{x, y}`), two distinct dangling `\cite`s in source
+order (`\cite{ghost1}\n\cite{ghost2}`), an all-resolved document returning the
+`(no unresolved citations)` marker, and an additivity check that `to_plain_text`,
+`to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`,
+and `duplicate_bibliography_entries` are all byte-for-byte unchanged.
+
 ## [0.52.0] — 2026-07-07
 
 ### Added — duplicate (multiply-defined) bibliography entries (LTXDOC03 S16)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -64,6 +64,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S14 — per-kind census of the numbered-label table** | `Document::list_summary() -> String` — a **new**, read-only method that renders a compact per-kind **count** of the document's numbered labels: how many sections, figures, tables, and equations carry a `\label`. It is a pure tally of the rows `number_labels()` returns, grouped by `LabelKind`, so it can never drift from the S4 numbering it summarises. Only the four numberable kinds reach that table — a bare inline `\label{…}` (`LabelKind::Inline`) is not numbered and is counted nowhere. One line per non-zero kind in the **fixed order** `Sections`, `Figures`, `Tables`, `Equations` (deterministic, not source order), formatted `<Kind>: <count>` with a **fixed plural** label regardless of count (a single section still prints `Sections: 1`); a kind with count 0 is **omitted** (mirroring S11). Lines joined by `\n`, no trailing newline. A document with **no** numbered label at all → the fixed marker `(no labels)`. E.g. two labeled sections + a figure + a table + an equation → `Sections: 2\nFigures: 1\nTables: 1\nEquations: 1`. Every S1–S13 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S15 — resolved citations grouped by their source `\cite`** | `Document::citations_by_source() -> String` — a **new**, read-only method that renders the resolved citations **grouped by the source `\cite` they came from** — the citation-family parallel of S11's `to_plain_text_by_kind` and S13's `resolve_namerefs`. It reads only `resolve_citations().resolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping them back by `cite_span` in **first-appearance order** (source order of the `\cite`s) with keys kept in their left-to-right order. One line per source `\cite`: `\cite{` + the group's **resolved** keys joined by `", "` + `}`. A **dangling** key never entered `resolved`, so it is excluded — `\cite{a,ghost}` where only `a` resolves renders `\cite{a}` (we reconstruct from resolved keys rather than slice `&src[cite_span]`, which would still show `ghost`). Lines joined by `\n`, no trailing newline. A document with **no** resolved citations (none present, or every key dangling) → the fixed marker `(no resolved citations)`. E.g. `\cite{a,b}` (both defined) then `\cite{c}` → `\cite{a, b}\n\cite{c}`. Every S1–S14 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S16 — duplicate (multiply-defined) `\bibitem` entries** | `Document::duplicate_bibliography_entries() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\bibitem`s — LaTeX's *"Citation `key' multiply defined"* warnings — the citation-family parallel of S6's *"Dangling citations"* footer (for the *other* bibliography warning). These were already computed by S2 (`resolve_citations().duplicate_entries`) but rendered by **no** method until now. S2 collects every `\bibitem` in `walk` pre-order; the **first** of each key wins and every **later** `\bibitem` of an already-defined key is a losing duplicate. S16 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\bibitem{<key>}` (no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** duplicates (no bibliography, or every key once) → the fixed marker `(no duplicate bibliography entries)`. E.g. `smith` defined twice + `jones` once → `\bibitem{smith}` (only the loser). Every S1–S15 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S17 — unresolved (dangling) citations grouped by source `\cite`** | `Document::unresolved_citations_by_source() -> String` — a **new**, read-only method that renders the **dangling** citations **grouped by the source `\cite` they came from** — the DANGLING-key mirror of S15's `citations_by_source`, and the per-`\cite` view of S6's flat *"Dangling citations"* footer. It reads only `resolve_citations().unresolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping the dangling keys back by `cite_span` in **first-appearance order** (source order) with keys kept left-to-right. One line per source `\cite` with ≥1 dangling key: `\cite{` + the group's **dangling** keys joined by `", "` + `}`. A **resolved** key never entered `unresolved`, so `\cite{a,ghost}` where only `a` resolves renders `\cite{ghost}` (reconstructed from keys, no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** unresolved citations → the fixed marker `(no unresolved citations)`. E.g. `\cite{known,ghost}` (only `known` defined) then `\cite{x,y}` (neither) → `\cite{ghost}\n\cite{x, y}`. Every S1–S16 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -729,6 +730,37 @@ assert_eq!(
 A document with no duplicates — no bibliography, or every key defined exactly once — renders the fixed
 `(no duplicate bibliography entries)` marker. Purely additive — reuses `resolve_citations`, mutates
 nothing, leaves every S1–S15 output and the `to_latex()` fixed point unchanged.
+
+### unresolved (dangling) citations grouped by source `\cite` (LTXDOC03 S17)
+
+The DANGLING-key mirror of S15's `citations_by_source`, and the per-`\cite` view of S6's flat
+*"Dangling citations"* footer. S2's `resolve_citations` flattens every `\cite` into per-key rows,
+splitting them into the **resolved** keys and the **unresolved** (dangling) keys, each tagged with the
+citing `\cite`'s `cite_span`. `unresolved_citations_by_source` reads only that `unresolved` list and
+groups the dangling keys back by `cite_span` in **first-appearance order** (source order of the
+`\cite`s), emitting one line per source `\cite` that has ≥1 dangling key: `\cite{` + its dangling keys
+joined by `", "` + `}`. Because only dangling keys are in `unresolved`, a `\cite{a, ghost}` where `a`
+resolves renders `\cite{ghost}`.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}
+See \cite{known, ghost} and \cite{x, y}.
+\begin{thebibliography}{9}
+\bibitem{known} Author K.
+\end{thebibliography}
+\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.unresolved_citations_by_source(),
+    "\\cite{ghost}\n\\cite{x, y}",   // first drops resolved `known`; second is fully dangling
+);
+```
+
+A document with no unresolved citations — every cited key resolves, or none present — renders the fixed
+`(no unresolved citations)` marker. Purely additive — reuses `resolve_citations`, mutates nothing,
+leaves every S1–S16 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1751,6 +1751,96 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **unresolved (dangling) citations grouped by their source `\cite`** (LTXDOC03 S17) — the
+    /// citation-family parallel of S6's flat *"Dangling citations"* footer, but rendered **per source
+    /// `\cite`**: a distinct new view, and the DANGLING-key mirror of S15's
+    /// [`citations_by_source`](Document::citations_by_source).
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] flattens every `\cite` into per-key rows, splitting them
+    /// into the **resolved** keys (those a `\bibitem` defines) and the **unresolved** keys (LaTeX's
+    /// *"Citation `key' undefined"*, the `[?]` in the output), each row tagged with the citing `\cite`'s
+    /// own `cite_span`. S6 already reports the dangling keys as one *flat* footer line; S15 groups the
+    /// *resolved* keys per source `\cite`. S17 fills the remaining cell of that 2×2: it groups the
+    /// *dangling* keys per source `\cite`, emitting one reconstructed `\cite{…}` line per source `\cite`
+    /// that has **at least one** dangling key.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read [`CitationResolution::unresolved`] and group its keys by their shared `cite_span`,
+    /// preserving the **first-appearance order** of the cite_spans (source order of the `\cite`s) — a
+    /// `Vec` of `(cite_span, keys)`, **not** a hash map, so the order is deterministic. Keys within a
+    /// group stay in their existing left-to-right order.
+    ///
+    /// One line per source `\cite` with ≥1 dangling key: `\cite{` + that group's dangling keys joined
+    /// by `", "` + `}`, reconstructed from the owned `key` `String`s (no source slicing, matching S13's
+    /// `resolve_namerefs`, S15's `citations_by_source`, and S16's `duplicate_bibliography_entries`).
+    /// Because `unresolved` holds **only** the dangling keys, a `\cite{a, ghost}` where `a` resolves and
+    /// `ghost` dangles renders `\cite{ghost}` (only the dangling key) — the exact analogue of how S15
+    /// shows only the *resolved* keys of a mixed `\cite`.
+    ///
+    /// A document with **no** unresolved citations — every cited key resolves, or there are no
+    /// citations at all — returns the fixed marker `(no unresolved citations)`, never the empty string
+    /// (the same stable-marker discipline S12/S13/S14/S15/S16 use). Lines are joined by `\n` with **no**
+    /// trailing newline (matching S11's `to_plain_text_by_kind`, S12's `list_of_floats`, S13's
+    /// `resolve_namerefs`, S14's `list_summary`, S15's `citations_by_source`, and S16's
+    /// `duplicate_bibliography_entries`).
+    ///
+    /// Concretely, for a body citing `\cite{a, ghost}` (where `a` resolves) and `\cite{x, y}` (neither
+    /// defined):
+    ///
+    /// ```text
+    /// \cite{ghost}
+    /// \cite{x, y}
+    /// ```
+    ///
+    /// The first line drops the resolved `a` and keeps only the dangling `ghost`; the second reunites
+    /// both dangling keys of the fully-dangling `\cite` on one comma-space-joined line, in source order.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S17 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1-S16 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single pass over the already-bounded `unresolved` list.
+    /// Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow of
+    /// the source.
+    pub fn unresolved_citations_by_source(&self) -> String {
+        // S2 already flattened every `\cite` into per-key rows and routed the dangling keys into
+        // `unresolved` (in body pre-order, and within a multi-key `\cite` in left-to-right order), each
+        // tagged with its source `\cite`'s span. We only read that list.
+        let resolution = self.resolve_citations();
+
+        // Group the dangling keys by their shared `cite_span`, preserving the FIRST-APPEARANCE order of
+        // the cite_spans (source order of the `\cite`s). A `Vec` of `(cite_span, keys)` — not a hash
+        // map — keeps that order deterministic and the code allocation-light (the number of distinct
+        // `\cite`s is small). Keys within a group stay in their existing left-to-right order.
+        let mut groups: Vec<(Span, Vec<&str>)> = Vec::new();
+        for cite in &resolution.unresolved {
+            match groups.iter_mut().find(|(span, _)| *span == cite.cite_span) {
+                Some((_, keys)) => keys.push(&cite.key),
+                None => groups.push((cite.cite_span, vec![&cite.key])),
+            }
+        }
+
+        if groups.is_empty() {
+            // Every cited key resolved (or there were no citations) → the fixed marker, never the empty
+            // string.
+            return "(no unresolved citations)".to_string();
+        }
+
+        // One line per source `\cite` with ≥1 dangling key: `\cite{` + its dangling keys joined by
+        // `", "` + `}`. Resolved keys never entered `unresolved`, so they are excluded by construction.
+        groups
+            .iter()
+            .map(|(_, keys)| format!("\\cite{{{}}}", keys.join(", ")))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -4313,5 +4403,133 @@ See Section~\ref{sec:intro}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b
 
         // And S16 itself surfaces the one duplicate: the SECOND `\bibitem{a}`.
         assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S17 — unresolved (dangling) citations grouped by source `\cite`
+    // (`unresolved_citations_by_source`).
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s17_reports_dangling_cite() {
+        // A `\cite{ghost}` whose key no `\bibitem` defines (the bibliography defines a DIFFERENT key).
+        // `ghost` dangles → one line, the reconstructed `\cite{ghost}`.
+        let src = r"\begin{document}
+See \cite{ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+    }
+
+    #[test]
+    fn s17_groups_multi_key_only_dangling_shown() {
+        // A `\cite{known, ghost}` where `known` resolves and `ghost` dangles → the line shows ONLY the
+        // dangling key (`\cite{ghost}`). `unresolved` holds only the dangling keys, so the resolved
+        // `known` is excluded by construction — the DANGLING mirror of S15's resolved-only rendering.
+        let src = r"\begin{document}
+See \cite{known, ghost}.
+\begin{thebibliography}{9}
+\bibitem{known} Author K.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+    }
+
+    #[test]
+    fn s17_fully_dangling_multi_key() {
+        // A `\cite{x, y}` where NEITHER key is defined → both dangling keys reunite on ONE line, in
+        // left-to-right source order, comma-space joined: `\cite{x, y}`.
+        let src = r"\begin{document}
+See \cite{x, y}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{x, y}");
+    }
+
+    #[test]
+    fn s17_two_distinct_cites_source_order() {
+        // Two separate dangling `\cite`s → two lines, in the source order the `\cite`s appear, joined
+        // by `\n`. The first-appearance grouping keeps `ghost1` ahead of `ghost2`.
+        let src = r"\begin{document}
+See \cite{ghost1} and later \cite{ghost2}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.unresolved_citations_by_source(),
+            "\\cite{ghost1}\n\\cite{ghost2}"
+        );
+    }
+
+    #[test]
+    fn s17_empty_returns_marker() {
+        // A document whose every cited key resolves has NO unresolved citations → the fixed
+        // `(no unresolved citations)` marker, never the empty string.
+        let src = r"\begin{document}
+See \cite{a}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citations_by_source(), "(no unresolved citations)");
+    }
+
+    #[test]
+    fn s17_is_additive_leaves_s1_s16_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a `\ref`, a `\nameref`,
+        // two `\cite`s (one multi-key, one dangling key), AND a duplicate `\bibitem` (`a` defined
+        // twice), S17 changes NONE of the S1-S16 outputs — it only reads `resolve_citations`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+See Section~\ref{sec:intro}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+
+        // And S17 itself groups the dangling cites: `{a,b}` fully resolves (no line); `{c,ghost}` keeps
+        // only the dangling `ghost`.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1379,3 +1379,78 @@ rendering `\bibitem{smith}` (only the loser); two distinct keys each defined twi
 unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p
 adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`,
 no grammar regen, no new dependencies.
+
+## 23. S17 — unresolved (dangling) citations grouped by source `\cite` (`unresolved_citations_by_source`)
+
+### 23.1 Motivation
+
+S2's `resolve_citations` returns `unresolved: Vec<UnresolvedCite>` — every `\cite` key that matched no
+`\bibitem`, i.e. LaTeX's *"Citation `key' undefined"* warning (the `[?]` in the output). S6's flat
+report already surfaces these dangling keys as a single "Dangling citations:" footer, and S15's
+`citations_by_source` groups the *resolved* keys per source `\cite`. S17 fills the remaining cell of
+that 2×2: it groups the *dangling* keys per source `\cite` — the DANGLING-key mirror of S15, and a
+distinct new per-`\cite` view of the same information S6 renders flat.
+
+### 23.2 Why a new method — additive by construction
+
+S17 adds a **new public method** `Document::unresolved_citations_by_source(&self) -> String`. It is a
+pure, read-only render of `resolve_citations().unresolved`. It reuses that table verbatim (never
+re-walking the body or re-resolving citations), so the report can never drift from the S2 resolution it
+summarises. It mutates nothing and changes no S1–S16 output — including `to_latex()`'s round-trip fixed
+point — byte-for-byte. Like S11–S16 it is a method the caller invokes directly.
+
+### 23.3 The grouping and ordering rule
+
+S2 flattens every `\cite` into per-key rows, splitting them into resolved keys and unresolved
+(dangling) keys, each row tagged with the citing `\cite`'s own `cite_span` (shared by every key of a
+multi-key `\cite`). S17 groups the dangling keys by their shared `cite_span`, preserving the
+**first-appearance order** of the cite_spans (source order of the `\cite`s) via a `Vec<(Span,
+Vec<&str>)>` — **not** a hash map — so the order is deterministic. Keys within a group stay in their
+existing left-to-right order. Because `unresolved` holds **only** the dangling keys, a resolved key of
+a mixed `\cite` never appears — the exact analogue of how S15 shows only the *resolved* keys.
+
+### 23.4 The exact rendering contract — `Document::unresolved_citations_by_source(&self) -> String`
+
+- One line per source `\cite` that has **at least one** dangling key, in the first-appearance order of
+  the cite_spans (source order of the `\cite`s, **not** re-sorted).
+- Each line is `\cite{` + that group's **dangling** keys joined by `", "` + `}`, reconstructed from the
+  owned keys rather than sliced from `&src[span]` (matching S13 `resolve_namerefs`, S15
+  `citations_by_source`, S16 `duplicate_bibliography_entries`), so the render needs no source borrow and
+  can never index out of bounds.
+- A `\cite{a, ghost}` where `a` resolves and `ghost` dangles renders `\cite{ghost}` (only the dangling
+  key), because `unresolved` contains only the dangling keys.
+- Lines are joined by `\n` with **no** trailing newline (matching S11 `to_plain_text_by_kind`, S12
+  `list_of_floats`, S13 `resolve_namerefs`, S14 `list_summary`, S15 `citations_by_source`, S16
+  `duplicate_bibliography_entries`).
+- If there are **no** unresolved citations (every cited key resolves, or none present), the fixed marker
+  `(no unresolved citations)` is returned, so the output is never the empty string.
+
+Example (body citing `\cite{a, ghost}` where `a` resolves, then `\cite{x, y}` where neither is
+defined):
+
+```text
+\cite{ghost}
+\cite{x, y}
+```
+
+the first line drops the resolved `a` and keeps only the dangling `ghost`; the second reunites both
+dangling keys of the fully-dangling `\cite` on one comma-space-joined line, in source order.
+
+### 23.5 Public API (added in S17)
+
+One new method: `Document::unresolved_citations_by_source(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_citations` and every S1–S16 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 23.6 Verification (S17)
+
+`cargo test -p latex` green (6 new S17 tests: a single dangling `\cite{ghost}` rendering `\cite{ghost}`;
+a mixed `\cite{known, ghost}` (only `known` defined) rendering `\cite{ghost}`; a fully-dangling
+`\cite{x, y}` rendering `\cite{x, y}` (both keys, one line); two distinct dangling `\cite`s rendering
+`\cite{ghost1}\n\cite{ghost2}` in source order; an all-resolved document returning the
+`(no unresolved citations)` marker; and an additivity check that `to_plain_text`,
+`to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`,
+and `duplicate_bibliography_entries` all still produce their exact prior strings). All prior S1–S16
+tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test
+-p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`,
+no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S17 — report unresolved (dangling) citations grouped by source `\cite`

Adds a new read-only method `Document::unresolved_citations_by_source(&self) -> String` to the `latex` crate — the **dangling-key mirror of S15's `citations_by_source`**. Where S15 groups the *resolved* `\cite` keys per source `\cite`, S17 groups the **unresolved (undefined) keys** — LaTeX's *"Citation `key' undefined"* — per source `\cite`. Bumps `latex` **0.52.0 → 0.53.0**.

### What it does

S2's `resolve_citations` flattens every `\cite{a,b}` into per-key rows and records each dangling key (no `\bibitem` defines it) in `CitationResolution::unresolved`, every key carrying its source `\cite`'s `cite_span`. S6's `to_plain_text` already lists dangling keys as a **flat** *"Dangling citations: k1 k2"* footer; S17 is the distinct **grouped-by-source** view — one `\cite{…}` line per citing command that has ≥1 dangling key.

| aspect | rule |
|---|---|
| line format | `\cite{` + the group's dangling keys joined by `", "` + `}` (reconstructed from owned keys, not sliced from source) |
| grouping | by shared `cite_span`, **first-appearance order** (source order), via a `Vec<(Span, Vec<&str>)>` — mirrors S15 exactly |
| partial cite | `\cite{known, ghost}` where only `ghost` dangles → `\cite{ghost}` (only the unresolved keys, since `unresolved` holds only those) |
| fully dangling | `\cite{x, y}` (neither defined) → `\cite{x, y}` (both keys, one line) |
| empty | fixed marker `(no unresolved citations)`, never `""` |
| joining | `\n`-joined, **no** trailing newline (matches S11–S16) |

Example — `\cite{smith}` (defined) then `\cite{a, ghost}` (only `a` defined) then `\cite{lost}` (undefined):

```text
\cite{ghost}
\cite{lost}
```

### Additive by construction

Brand-new, read-only method that reuses `resolve_citations` and mutates nothing. **Total & panic-free**: no source slicing/indexing, no `unwrap`/`expect`, no `unsafe`, a single pass over the already-bounded `unresolved` list, returning owned `String` data. All **S1–S16 outputs stay byte-for-byte unchanged**, pinned by a dedicated additivity test. The `to_latex` round-trip fixed point is untouched.

### Tests (exact strings, real output)

- `s17_reports_dangling_cite` — `\cite{ghost}` vs a bib defining another key → `"\\cite{ghost}"`
- `s17_groups_multi_key_only_dangling_shown` — `\cite{known, ghost}` (known defined) → `"\\cite{ghost}"`
- `s17_fully_dangling_multi_key` — `\cite{x, y}` (neither defined) → `"\\cite{x, y}"`
- `s17_two_distinct_cites_source_order` — two dangling `\cite`s → `"\\cite{ghost1}\n\\cite{ghost2}"` (source order)
- `s17_empty_returns_marker` — every key resolves → `"(no unresolved citations)"`
- `s17_is_additive_leaves_s1_s16_outputs_unchanged` — pins `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`, and `duplicate_bibliography_entries` to their exact prior strings

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → **394 passed; 0 failed** (was 388; +6 S17) + doc-tests ok
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → all green (0 failed)
- `cargo build -p latex --no-default-features` → builds
- Inline security review PASSED (returned `String`, no injection sink; total/panic-free; same bounded grouping already shipped in S15).
- Single-parent commit; scoped diff = 5 files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
