### PR TITLE
feat(adj-ladder): rung-104 hematology coagulation mixing-study ((a-b)/(c*d), a difference over a product)

### DIFF
--- a/code/specs/data/adj-ladder/rung104_coag_mixing/gen_items.py
+++ b/code/specs/data/adj-ladder/rung104_coag_mixing/gen_items.py
@@ -1,0 +1,256 @@
+"""Generate rung-104 (hematology / coagulation mixing-study) items.json for the ADJ-LADDER.
+
+Rung 104 opens the **hematology / coagulation mixing-study** panel on the quantitative band — the arithmetic of a mixing
+study's correction index. A `patient_time` (a prolonged clotting time) MINUS a `control_time` (the normal plasma's time)
+gives the prolongation (how far above normal the patient's clot sits, the difference), a `mix_ratio` TIMES an
+`incubation_factor` gives the dilution load (the product the prolongation is spread across), and the prolongation is
+DIVIDED by the dilution load to give the correction index. A **difference over a product** introduces a genuinely NEW
+arithmetic family on the ladder: `(a-b)/(c*d)`, i.e. `((a-b) / (c*d))`.
+
+This is genuinely new — the first time the ladder divides a bare DIFFERENCE by a bare PRODUCT. It is the **mirror-sibling of
+rung-100** `(a+b)/(c*d)` (a SUM over a product): rung-100 divided a *sum* by the product, rung-104 divides a *difference*.
+No prior rung divides a difference by a product: rung-99 `(a*b)/(c+d)` divided a product by a sum, rung-37 `(a+b)/(c+d)`
+divided a sum by a sum, and rungs 75/76 divide a binomial by a bare factor `c` then multiply by `d` (`(a∓b)/c*d`), not by a
+`c*d` product. The operator order matters: `(a-b)/(c*d)` is `((a-b) / (c*d))` (the difference forms, the product forms, then
+the difference is divided by the product — the parentheses on both sides are what make it a clean ratio), NOT `a-b/(c*d)`
+(dropping the numerator parentheses so only the control time is divided by the dilution load and then subtracted from the
+patient time) and NOT `(a*b)/(c+d)` (multiplying the numerator pair and summing the denominator pair, mispairing which pair
+is the product and which is the difference) — the two distractors exploit exactly those confusions.
+
+The setup: a `patient_time`, a `control_time`, a `mix_ratio`, and an `incubation_factor`. The total is:
+
+  CORRECTION INDEX   (patient_time - control_time) / (mix_ratio * incubation_factor)  [ a difference over a product ]
+  PROLONGATION       patient_time - control_time                                      [ the difference, the numerator ]
+  DILUTION LOAD      mix_ratio * incubation_factor                                    [ the product, the denominator ]
+
+The **correction index** is what makes this rung distinctive — it is the ladder's first **bare DIFFERENCE over a bare
+PRODUCT**. It is a dimensionless ratio (the prolongation per unit of dilution load), so it naturally lands below one; framing
+it as an *index* (not a physical time) keeps the sub-one values honest — the same discipline rung-100 used for its
+`focus ratio`. (The prolongation `a-b` and the dilution load `c*d` ride alongside as component readouts, so the panel
+teaches the whole calculation — exactly as rungs 47-103 shipped their component sums/products/differences/ratios beside the
+headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the subtraction of the control time from the patient time into the prolongation, the multiplication
+of the mix ratio by the incubation factor into the dilution load, then the division of the prolongation by the dilution load
+(both parenthesized, so (a-b)/(c*d) evaluates as ((a-b)/(c*d))) — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../102/103. This rung exercises the engine
+across a **difference over a product** — the fact that `(a-b)/(c*d)` is `((a-b)/(c*d))` and NOT `a-b/(c*d)` and NOT
+`(a*b)/(c+d)` made computable. The ratio golds are non-integer f64s; the engine's IEEE-double division matches Python's the
+same way rungs 99/100 relied on (well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `-`, `*`, and `/` —
+**no structural constants** — so no numeric literal appears in any program, and neither the prolongation, the dilution load,
+nor any index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free
+identifiers** (`patient_time`, `control_time`, `mix_ratio`, `incubation_factor`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    patient_time - control_time / (mix_ratio * incubation_factor)  drop the numerator parentheses so only the
+                                                                            control time is divided by the dilution load and
+                                                                            then subtracted from the patient time (the classic
+                                                                            `(a-b)/(c*d)` vs `a-b/(c*d)` precedence error), and
+  SWAPPED    (patient_time * control_time) / (mix_ratio + incubation_factor)  multiply the numerator pair and sum the
+                                                                            denominator pair, mispairing which pair is the
+                                                                            product and which is the difference (`(a*b)/(c+d)`
+                                                                            instead of `(a-b)/(c*d)`),
+
+which are exactly the mistakes a student makes (dropping the numerator parentheses before dividing, or mispairing which pair
+is a difference and which is a product). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all
+five always appear as options.
+
+Distinctness and positivity: the tables are chosen so `patient_time > control_time` (prolongation strictly positive — the
+patient's clot always sits above normal, so the correction index is strictly positive too), and every denominator is a
+product or a sum of quantities `>= 2` (the dilution load `c*d >= 4` and the swapped denominator `c+d >= 4` are never zero, and
+there is NO subtraction in any denominator), so no family member is ever zero, negative, or undefined; every observed
+quantity is `>= 2`. The crossed figure `a - b/(c*d)` is positive because `b/(c*d) < b <= patient_time`. The tables are chosen
+so the five family values are pairwise distinct with a comfortable margin, and — so all three queried readouts vary across
+the panel — the seven tables give distinct correction indices, distinct prolongations, and distinct dilution loads, all
+asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (PATIENT_TIME, CONTROL_TIME, MIX_RATIO, INCUBATION_FACTOR) — a patient time minus a control time for the prolongation, a
+# mix ratio times an incubation factor for the dilution load, all plain positive numbers >= 2. Each table satisfies
+# patient_time > control_time (prolongation > 0 => correction index > 0); every denominator (c*d and c+d) is >= 4 with no
+# subtraction, so nothing is ever zero or undefined. The five family values are asserted pairwise-distinct below. The seven
+# tables give distinct correction indices, distinct prolongations, and distinct dilution loads so all three queried readouts
+# vary across the panel.
+TABLES = [
+    (4, 2, 2, 3),
+    (6, 3, 3, 4),
+    (8, 4, 4, 2),
+    (10, 5, 5, 6),
+    (12, 6, 6, 7),
+    (14, 7, 7, 5),
+    (16, 8, 8, 9),
+]
+
+# The option family (5 members), all built from the four observed quantities via -, *, and /. Every identifier is
+# DIGIT-FREE. key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always
+# appear as the options.
+FAMILY = [
+    (
+        "correction_index",
+        "correction index (the prolongation divided by the dilution load)",
+        "(patient_time - control_time) / (mix_ratio * incubation_factor)",
+    ),
+    (
+        "prolongation",
+        "the prolongation (the patient time minus the control time, the numerator divided by the dilution load)",
+        "patient_time - control_time",
+    ),
+    (
+        "dilution_load",
+        "the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)",
+        "mix_ratio * incubation_factor",
+    ),
+    (
+        "crossed",
+        "the patient time minus the control time divided by the dilution load, dropping the numerator parentheses so only the control time is divided before subtracting (a wrong grouping)",
+        "patient_time - control_time / (mix_ratio * incubation_factor)",
+    ),
+    (
+        "swapped",
+        "the patient time times the control time, divided by the mix ratio plus the incubation factor, multiplying the numerator pair and summing the denominator pair instead (a wrong pairing)",
+        "(patient_time * control_time) / (mix_ratio + incubation_factor)",
+    ),
+]
+QUERIED = ["correction_index", "prolongation", "dilution_load"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(patient_time, control_time, mix_ratio, incubation_factor):
+    # Operation order mirrors the ADJ programs exactly (the difference forms, the product forms, then the difference is
+    # divided by the product, so (a-b)/(c*d) evaluates as ((a-b)/(c*d))), so the Python option value and the engine result
+    # are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "correction_index": (patient_time - control_time) / (mix_ratio * incubation_factor),
+        "prolongation": patient_time - control_time,
+        "dilution_load": mix_ratio * incubation_factor,
+        "crossed": patient_time - control_time / (mix_ratio * incubation_factor),
+        "swapped": (patient_time * control_time) / (mix_ratio + incubation_factor),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for patient_time, control_time, mix_ratio, incubation_factor in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and the tables guarantee patient_time > control_time
+        # (prolongation > 0 => correction index > 0); every denominator (mix_ratio*incubation_factor and
+        # mix_ratio+incubation_factor) is >= 4 with no subtraction, so nothing is ever zero, negative, or undefined.
+        assert (
+            patient_time >= 2
+            and control_time >= 2
+            and mix_ratio >= 2
+            and incubation_factor >= 2
+        ), (patient_time, control_time, mix_ratio, incubation_factor)
+        assert patient_time > control_time, (
+            patient_time, control_time, mix_ratio, incubation_factor,
+        )
+        fv = family_values(patient_time, control_time, mix_ratio, incubation_factor)
+        for key, v in fv.items():
+            assert v > 0, (key, patient_time, control_time, mix_ratio, incubation_factor, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    patient_time,
+                    control_time,
+                    mix_ratio,
+                    incubation_factor,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                patient_time,
+                control_time,
+                mix_ratio,
+                incubation_factor,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r104hemix-{idx + 1:02d}",
+                "qtype": "hemix_correction_index",
+                "stem": (
+                    f"A coagulation mixing study records a patient time of {num(patient_time)} minus a control time of "
+                    f"{num(control_time)}, divided by a mix ratio of {num(mix_ratio)} times an incubation factor of "
+                    f"{num(incubation_factor)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe patient_time({num(patient_time)})\n"
+                    f"observe control_time({num(control_time)})\n"
+                    f"observe mix_ratio({num(mix_ratio)})\n"
+                    f"observe incubation_factor({num(incubation_factor)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 104 — coagulation mixing-study correction index from four stated quantities (a NEW panel: "
+            "hematology / coagulation mixing-study). From a patient time minus a control time for the prolongation, a mix "
+            "ratio times an incubation factor for the dilution load, and the prolongation divided by the dilution load, "
+            "compute the correction index ((patient_time-control_time)/(mix_ratio*incubation_factor)), the prolongation "
+            "(patient_time-control_time), or the dilution load (mix_ratio*incubation_factor). Each item is a "
+            "compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW family, A DIFFERENCE OVER A PRODUCT (a-b)/(c*d) (subtract b from a, multiply c and d, divide "
+            "the difference by the product, so (a-b)/(c*d) = ((a-b)/(c*d)); the FIRST time the ladder divides a bare "
+            "DIFFERENCE by a bare PRODUCT — the MIRROR-SIBLING of rung-100 (a+b)/(c*d) which divided a SUM by the product; "
+            "rung-99 (a*b)/(c+d) divided a product by a sum, rung-37 (a+b)/(c+d) a sum by a sum) — and the harness matches "
+            "the scalar to the printed options. The correction index is a dimensionless ratio that naturally lands below "
+            "one, framed as an INDEX (not a physical time) so the sub-one values stay honest. Contamination-safe: every "
+            "figure is built only from the four observed quantities via -, *, and / — no constant leaks, and neither the "
+            "prolongation, the dilution load, nor any index ever appears as a literal (each is computed) — and the observed "
+            "quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a "
+            "family over the same four quantities, so the distractors are exactly the slips students make: dropping the "
+            "numerator parentheses so only the control time is divided before subtracting (a-b/(c*d), a wrong grouping) and "
+            "multiplying the numerator pair while summing the denominator pair ((a*b)/(c+d), a wrong pairing). The core "
+            "confusion tested is that (a-b)/(c*d) is ((a-b)/(c*d)), not a-b/(c*d) and not (a*b)/(c+d). Each table guarantees "
+            "the patient time exceeds the control time and every denominator is a product or sum of quantities >= 2 (never "
+            "zero, no subtraction), so every figure stays strictly positive and well-defined."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung104_coag_mixing/items.json
+++ b/code/specs/data/adj-ladder/rung104_coag_mixing/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 104 \u2014 coagulation mixing-study correction index from four stated quantities (a NEW panel: hematology / coagulation mixing-study). From a patient time minus a control time for the prolongation, a mix ratio times an incubation factor for the dilution load, and the prolongation divided by the dilution load, compute the correction index ((patient_time-control_time)/(mix_ratio*incubation_factor)), the prolongation (patient_time-control_time), or the dilution load (mix_ratio*incubation_factor). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, A DIFFERENCE OVER A PRODUCT (a-b)/(c*d) (subtract b from a, multiply c and d, divide the difference by the product, so (a-b)/(c*d) = ((a-b)/(c*d)); the FIRST time the ladder divides a bare DIFFERENCE by a bare PRODUCT \u2014 the MIRROR-SIBLING of rung-100 (a+b)/(c*d) which divided a SUM by the product; rung-99 (a*b)/(c+d) divided a product by a sum, rung-37 (a+b)/(c+d) a sum by a sum) \u2014 and the harness matches the scalar to the printed options. The correction index is a dimensionless ratio that naturally lands below one, framed as an INDEX (not a physical time) so the sub-one values stay honest. Contamination-safe: every figure is built only from the four observed quantities via -, *, and / \u2014 no constant leaks, and neither the prolongation, the dilution load, nor any index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the numerator parentheses so only the control time is divided before subtracting (a-b/(c*d), a wrong grouping) and multiplying the numerator pair while summing the denominator pair ((a*b)/(c+d), a wrong pairing). The core confusion tested is that (a-b)/(c*d) is ((a-b)/(c*d)), not a-b/(c*d) and not (a*b)/(c+d). Each table guarantees the patient time exceeds the control time and every denominator is a product or sum of quantities >= 2 (never zero, no subtraction), so every figure stays strictly positive and well-defined.",
+  "items": [
+    {
+      "id": "r104hemix-01",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 4 minus a control time of 2, divided by a mix ratio of 2 times an incubation factor of 3. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(4)\nobserve control_time(2)\nobserve mix_ratio(2)\nobserve incubation_factor(3)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r104hemix-02",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 4 minus a control time of 2, divided by a mix ratio of 2 times an incubation factor of 3. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(4)\nobserve control_time(2)\nobserve mix_ratio(2)\nobserve incubation_factor(3)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r104hemix-03",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 4 minus a control time of 2, divided by a mix ratio of 2 times an incubation factor of 3. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(4)\nobserve control_time(2)\nobserve mix_ratio(2)\nobserve incubation_factor(3)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r104hemix-04",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 6 minus a control time of 3, divided by a mix ratio of 3 times an incubation factor of 4. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(6)\nobserve control_time(3)\nobserve mix_ratio(3)\nobserve incubation_factor(4)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.5714285714285716,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r104hemix-05",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 6 minus a control time of 3, divided by a mix ratio of 3 times an incubation factor of 4. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(6)\nobserve control_time(3)\nobserve mix_ratio(3)\nobserve incubation_factor(4)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.5714285714285716,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r104hemix-06",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 6 minus a control time of 3, divided by a mix ratio of 3 times an incubation factor of 4. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(6)\nobserve control_time(3)\nobserve mix_ratio(3)\nobserve incubation_factor(4)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.5714285714285716,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r104hemix-07",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 8 minus a control time of 4, divided by a mix ratio of 4 times an incubation factor of 2. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(8)\nobserve control_time(4)\nobserve mix_ratio(4)\nobserve incubation_factor(2)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r104hemix-08",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 8 minus a control time of 4, divided by a mix ratio of 4 times an incubation factor of 2. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(8)\nobserve control_time(4)\nobserve mix_ratio(4)\nobserve incubation_factor(2)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r104hemix-09",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 8 minus a control time of 4, divided by a mix ratio of 4 times an incubation factor of 2. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(8)\nobserve control_time(4)\nobserve mix_ratio(4)\nobserve incubation_factor(2)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r104hemix-10",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 10 minus a control time of 5, divided by a mix ratio of 5 times an incubation factor of 6. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(10)\nobserve control_time(5)\nobserve mix_ratio(5)\nobserve incubation_factor(6)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.833333333333334,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.545454545454546,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r104hemix-11",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 10 minus a control time of 5, divided by a mix ratio of 5 times an incubation factor of 6. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(10)\nobserve control_time(5)\nobserve mix_ratio(5)\nobserve incubation_factor(6)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.833333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.545454545454546,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r104hemix-12",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 10 minus a control time of 5, divided by a mix ratio of 5 times an incubation factor of 6. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(10)\nobserve control_time(5)\nobserve mix_ratio(5)\nobserve incubation_factor(6)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.16666666666666666,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.833333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.545454545454546,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r104hemix-13",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 12 minus a control time of 6, divided by a mix ratio of 6 times an incubation factor of 7. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(12)\nobserve control_time(6)\nobserve mix_ratio(6)\nobserve incubation_factor(7)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 42,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.14285714285714285,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.857142857142858,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.538461538461538,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r104hemix-14",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 12 minus a control time of 6, divided by a mix ratio of 6 times an incubation factor of 7. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(12)\nobserve control_time(6)\nobserve mix_ratio(6)\nobserve incubation_factor(7)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.14285714285714285,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 42,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 11.857142857142858,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5.538461538461538,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r104hemix-15",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 12 minus a control time of 6, divided by a mix ratio of 6 times an incubation factor of 7. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(12)\nobserve control_time(6)\nobserve mix_ratio(6)\nobserve incubation_factor(7)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.14285714285714285,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 11.857142857142858,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.538461538461538,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 42,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r104hemix-16",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 14 minus a control time of 7, divided by a mix ratio of 7 times an incubation factor of 5. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(14)\nobserve control_time(7)\nobserve mix_ratio(7)\nobserve incubation_factor(5)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.166666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r104hemix-17",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 14 minus a control time of 7, divided by a mix ratio of 7 times an incubation factor of 5. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(14)\nobserve control_time(7)\nobserve mix_ratio(7)\nobserve incubation_factor(5)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.166666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r104hemix-18",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 14 minus a control time of 7, divided by a mix ratio of 7 times an incubation factor of 5. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(14)\nobserve control_time(7)\nobserve mix_ratio(7)\nobserve incubation_factor(5)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 35,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8.166666666666666,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r104hemix-19",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 16 minus a control time of 8, divided by a mix ratio of 8 times an incubation factor of 9. What is the correction index (the prolongation divided by the dilution load)?",
+      "program": "observe patient_time(16)\nobserve control_time(8)\nobserve mix_ratio(8)\nobserve incubation_factor(9)\nlet answer = (patient_time - control_time) / (mix_ratio * incubation_factor)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.88888888888889,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.1111111111111111,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7.529411764705882,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r104hemix-20",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 16 minus a control time of 8, divided by a mix ratio of 8 times an incubation factor of 9. What is the the prolongation (the patient time minus the control time, the numerator divided by the dilution load)?",
+      "program": "observe patient_time(16)\nobserve control_time(8)\nobserve mix_ratio(8)\nobserve incubation_factor(9)\nlet answer = patient_time - control_time\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.1111111111111111,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15.88888888888889,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.529411764705882,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r104hemix-21",
+      "qtype": "hemix_correction_index",
+      "stem": "A coagulation mixing study records a patient time of 16 minus a control time of 8, divided by a mix ratio of 8 times an incubation factor of 9. What is the the dilution load (the mix ratio times the incubation factor, the denominator the prolongation is divided by)?",
+      "program": "observe patient_time(16)\nobserve control_time(8)\nobserve mix_ratio(8)\nobserve incubation_factor(9)\nlet answer = mix_ratio * incubation_factor\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 72,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.1111111111111111,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.88888888888889,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7.529411764705882,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -141,6 +141,7 @@ SELF_CONTAINED_RUNGS = (
     "rung101_range_of_motion",
     "rung102_training_load",
     "rung103_gi_transit",
+    "rung104_coag_mixing",
 )
 
 


### PR DESCRIPTION
## rung-104 correction-index arc (`(a-b)/(c*d)` — a difference over a product)

Opens the **hematology / coagulation mixing-study** panel on the ADJ-LADDER quantitative band, and introduces a genuinely **NEW arithmetic family**: `(a-b)/(c*d)` — a **bare difference over a bare product**. Rung **104**. With the `(a±b)±c*d` quartet complete (91/101/102/103), the ladder now moves into the **ratio-with-difference** family.

### Why this shape is new
It is the **first time the ladder divides a difference by a product**, and the **mirror-sibling of rung-100** `(a+b)/(c*d)` (a sum over a product):

| rung | shape | note |
|---|---|---|
| 37 | `(a+b)/(c+d)` | sum over a **sum** |
| 99 | `(a*b)/(c+d)` | product over a **sum** |
| 100 | `(a+b)/(c*d)` | a **sum** over a product |
| **104** | **`(a-b)/(c*d)`** | **a difference over a product** |

Operator order matters: `(a-b)/(c*d)` is `((a-b) / (c*d))` (both sides parenthesized), NOT `a-b/(c*d)` (drop the numerator parens, so only the control time is divided then subtracted) and NOT `(a*b)/(c+d)` (mispair which pair is the product vs the difference) — the two distractors exploit exactly those slips.

### The panel
Four observed quantities — `patient_time`, `control_time`, `mix_ratio`, `incubation_factor`:

| readout | formula | shape |
|---|---|---|
| **correction index** (headline) | `(patient_time-control_time) / (mix_ratio*incubation_factor)` | `(a-b)/(c*d)` |
| prolongation (queried) | `patient_time-control_time` | `a-b` (the numerator) |
| dilution load (queried) | `mix_ratio*incubation_factor` | `c*d` (the denominator) |
| crossed *(distractor)* | `patient_time - control_time / (mix_ratio*incubation_factor)` | `a-b/(c*d)` (numerator parens dropped) |
| swapped *(distractor)* | `(patient_time*control_time) / (mix_ratio+incubation_factor)` | `(a*b)/(c+d)` (product/difference & sum pairs swapped) |

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness matches the scalar to the printed options. No harness/engine change. 7 tables × 3 queried = **21 items**, gold rotates A–E. **All three queried golds vary** across the tables — correction index 0.11–0.5, prolongation 2–8, dilution load 6–72.

The correction index is a **dimensionless ratio** that naturally lands below one, so it's framed as an *index* (not a physical time) — the same discipline rung-100 used for its focus ratio. The ratio golds are non-integer f64s; the engine's IEEE-double division matches Python's within the harness's 1e-9 tolerance (as rungs 99/100 relied on).

### Contamination-safe by construction
Built ONLY from the four observed quantities via `-`, `*`, and `/` — **no numeric constants**, no readout ever a literal, identifiers **digit-free**. Every table guarantees `patient_time > control_time` (prolongation > 0 ⇒ correction index > 0), and every denominator is a product (`c*d ≥ 4`) or a sum (`c+d ≥ 4`) of quantities ≥ 2 — **never zero, no subtraction in any denominator** — so all 5 family members stay strictly positive and well-defined; the crossed figure `a - b/(c*d)` is positive because `b/(c*d) < b ≤ patient_time`. Build asserts all 5 positive + pairwise-distinct (>1e-6).

### Verification
- `pytest test_ladder_eval.py -k rung104` → **3 passed** (with `adj-lang-cli` built; the engine's f64 division matches the Python ratio golds exactly).
- Single-parent commit; scoped diff = 3 files (`rung104_coag_mixing/gen_items.py`, `rung104_coag_mixing/items.json`, `test_ladder_eval.py`).
- Inline security review PASSED (data-only generator; no eval/exec/subprocess/network/user-input; no division-by-zero possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
