### PR TITLE
feat(latex): LTXDOC03 S18 — unresolved (dangling) references, command-aware, per source \ref

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.54.0] — 2026-07-07
+
+### Added — unresolved (dangling) references grouped by source `\ref` (LTXDOC03 S18)
+
+A **new** public method `Document::unresolved_references_by_source(&self) -> String` that surfaces the
+**unresolved (dangling) references grouped per source `\ref`** — the `\ref`-family parallel of S17's
+dangling-CITATION report, and a **distinct** view from S6's flat *"Dangling references: k1, k2"* footer:
+S18 reconstructs each dangling reference on **its own line**, **command-aware**, so `\eqref` and
+`\pageref` render as themselves rather than being flattened to `\ref`. These keys were already computed
+by S3 (`resolve_references().unresolved`) but grouped-by-source by **no** method until now. Every
+S1–S17 output is left **byte-for-byte unchanged**; S18 is purely additive and leaves the `to_latex()`
+round-trip fixed point intact.
+
+- **One line per dangling reference, command preserved.** S3 walks every `\ref`/`\eqref`/`\pageref` in
+  body pre-order and routes the dangling ones into `unresolved` as `UnresolvedRef { key, command,
+  ref_span }`. S18 groups them by their shared `ref_span`, preserving the **first-appearance order** of
+  the ref_spans (source order) via a `Vec<(Span, Vec<&UnresolvedRef>)>` — **not** a hash map — so the
+  order is deterministic. Unlike a multi-key `\cite`, each reference takes exactly **one** key, so every
+  group holds a single entry (the structural mirror of S17 is kept for readability). Each line is `\` +
+  the reference's own `command` + `{` + its `key` + `}`, reconstructed from the owned `command`/`key`
+  `String`s (no source slicing, matching S13 `resolve_namerefs`, S15 `citations_by_source`, and S17
+  `unresolved_citations_by_source`) — so a dangling `\eqref{eq:x}` renders `\eqref{eq:x}` and a dangling
+  `\pageref{p}` renders `\pageref{p}`, never a hard-coded `\ref`.
+- **Only dangling references shown.** A `\ref` that resolves to a `\label` never enters `unresolved`, so
+  it is excluded by construction. Lines are joined by `\n` with **no** trailing newline (matching S15
+  `citations_by_source` and S17 `unresolved_citations_by_source`).
+- **Empty marker.** A document with **no** unresolved references — every reference resolves, or there
+  are none at all — returns the fixed marker `"(no unresolved references)"`, so the output is never the
+  empty string (the same stable-marker discipline S12/S13/S14/S15/S16/S17 use).
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+  `command` and `key` are already owned `String`s); a single pass over the already-bounded `unresolved`
+  list. Borrows `self` immutably, returns owned `String`.
+
+Six `s18_*` tests pin the exact rendered strings: a single dangling `\ref{nope}` (`\ref{nope}`), a
+dangling `\eqref{eq:ghost}` and `\pageref{p:ghost}` preserving their commands
+(`\eqref{eq:ghost}\n\pageref{p:ghost}`), two distinct dangling `\ref`s in source order
+(`\ref{nope1}\n\ref{nope2}`), a resolved `\ref` excluded so a fully-resolved document returns the
+`(no unresolved references)` marker, a reference-free document returning the same marker, and an
+additivity check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`,
+`list_summary`, `citations_by_source`, `duplicate_bibliography_entries`, and
+`unresolved_citations_by_source` are all byte-for-byte unchanged.
+
 ## [0.53.0] — 2026-07-07
 
 ### Added — unresolved (dangling) citations grouped by source `\cite` (LTXDOC03 S17)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -65,6 +65,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S15 — resolved citations grouped by their source `\cite`** | `Document::citations_by_source() -> String` — a **new**, read-only method that renders the resolved citations **grouped by the source `\cite` they came from** — the citation-family parallel of S11's `to_plain_text_by_kind` and S13's `resolve_namerefs`. It reads only `resolve_citations().resolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping them back by `cite_span` in **first-appearance order** (source order of the `\cite`s) with keys kept in their left-to-right order. One line per source `\cite`: `\cite{` + the group's **resolved** keys joined by `", "` + `}`. A **dangling** key never entered `resolved`, so it is excluded — `\cite{a,ghost}` where only `a` resolves renders `\cite{a}` (we reconstruct from resolved keys rather than slice `&src[cite_span]`, which would still show `ghost`). Lines joined by `\n`, no trailing newline. A document with **no** resolved citations (none present, or every key dangling) → the fixed marker `(no resolved citations)`. E.g. `\cite{a,b}` (both defined) then `\cite{c}` → `\cite{a, b}\n\cite{c}`. Every S1–S14 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S16 — duplicate (multiply-defined) `\bibitem` entries** | `Document::duplicate_bibliography_entries() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\bibitem`s — LaTeX's *"Citation `key' multiply defined"* warnings — the citation-family parallel of S6's *"Dangling citations"* footer (for the *other* bibliography warning). These were already computed by S2 (`resolve_citations().duplicate_entries`) but rendered by **no** method until now. S2 collects every `\bibitem` in `walk` pre-order; the **first** of each key wins and every **later** `\bibitem` of an already-defined key is a losing duplicate. S16 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\bibitem{<key>}` (no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** duplicates (no bibliography, or every key once) → the fixed marker `(no duplicate bibliography entries)`. E.g. `smith` defined twice + `jones` once → `\bibitem{smith}` (only the loser). Every S1–S15 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S17 — unresolved (dangling) citations grouped by source `\cite`** | `Document::unresolved_citations_by_source() -> String` — a **new**, read-only method that renders the **dangling** citations **grouped by the source `\cite` they came from** — the DANGLING-key mirror of S15's `citations_by_source`, and the per-`\cite` view of S6's flat *"Dangling citations"* footer. It reads only `resolve_citations().unresolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping the dangling keys back by `cite_span` in **first-appearance order** (source order) with keys kept left-to-right. One line per source `\cite` with ≥1 dangling key: `\cite{` + the group's **dangling** keys joined by `", "` + `}`. A **resolved** key never entered `unresolved`, so `\cite{a,ghost}` where only `a` resolves renders `\cite{ghost}` (reconstructed from keys, no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** unresolved citations → the fixed marker `(no unresolved citations)`. E.g. `\cite{known,ghost}` (only `known` defined) then `\cite{x,y}` (neither) → `\cite{ghost}\n\cite{x, y}`. Every S1–S16 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S18 — unresolved (dangling) references grouped by source `\ref`** | `Document::unresolved_references_by_source() -> String` — a **new**, read-only method that renders the **dangling** references, one reconstructed `\<command>{key}` line each — the `\ref`-family parallel of S17's dangling-CITATION report, and a **distinct** view from S6's flat *"Dangling references: k1, k2"* footer (S18 is **command-aware**, so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`). It reads only `resolve_references().unresolved` (a `Vec<UnresolvedRef { key, command, ref_span }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **resolved** `\ref` never entered `unresolved`, so it is excluded. Lines joined by `\n`, no trailing newline. A document with **no** unresolved references → the fixed marker `(no unresolved references)`. E.g. `\eqref{eq:ghost}` then `\pageref{p:ghost}` (neither defined) → `\eqref{eq:ghost}\n\pageref{p:ghost}`. Every S1–S17 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -761,6 +762,35 @@ assert_eq!(
 A document with no unresolved citations — every cited key resolves, or none present — renders the fixed
 `(no unresolved citations)` marker. Purely additive — reuses `resolve_citations`, mutates nothing,
 leaves every S1–S16 output and the `to_latex()` fixed point unchanged.
+
+### unresolved (dangling) references grouped by source `\ref` (LTXDOC03 S18)
+
+The `\ref`-family parallel of S17's dangling-CITATION report, and a **distinct** view from S6's flat
+*"Dangling references: k1, k2"* footer: S18 reconstructs each dangling reference on **its own line**,
+**command-aware**. S3's `resolve_references` walks every `\ref`/`\eqref`/`\pageref` in body pre-order and
+routes the dangling ones into `unresolved` as `UnresolvedRef { key, command, ref_span }`.
+`unresolved_references_by_source` reads only that `unresolved` list and groups by `ref_span` in
+**first-appearance order** (source order). Because each reference takes exactly **one** key, every group
+is a single entry emitting one line: `\` + the reference's own `command` + `{` + its `key` + `}`. Rebuilt
+from the ref's own `command`, a dangling `\eqref{eq:x}` renders `\eqref{eq:x}` and a dangling
+`\pageref{p}` renders `\pageref{p}` — never a hard-coded `\ref`.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}
+See \eqref{eq:ghost} on \pageref{p:ghost}.
+\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.unresolved_references_by_source(),
+    "\\eqref{eq:ghost}\n\\pageref{p:ghost}",   // each command preserved, one per line, source order
+);
+```
+
+A document with no unresolved references — every reference resolves, or none present — renders the fixed
+`(no unresolved references)` marker. Purely additive — reuses `resolve_references`, mutates nothing,
+leaves every S1–S17 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1841,6 +1841,103 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **unresolved (dangling) references grouped by their source `\ref`** (LTXDOC03 S18) — the
+    /// `\ref`-family parallel of S17's dangling-CITATION report, and the DANGLING mirror of the resolved
+    /// `\ref` family: one reconstructed `\<command>{key}` line per dangling reference, **command-aware**
+    /// so `\eqref` and `\pageref` render as themselves.
+    ///
+    /// ## What it does
+    ///
+    /// S3's [`Document::resolve_references`] walks every `\ref`/`\eqref`/`\pageref` in body pre-order and
+    /// splits them into the **resolved** references (those a `\label` defines) and the **unresolved**
+    /// references (LaTeX's *"Reference `key' undefined"*, the `??` in the output), each recorded in
+    /// [`ReferenceResolution::unresolved`] as an [`UnresolvedRef`] carrying its dangling `key`, the
+    /// `command` that was used (`"ref"` / `"eqref"` / `"pageref"`), and its own `ref_span`. S6 already
+    /// reports the dangling keys as one *flat* comma-joined footer (`"Dangling references: k1, k2"`); S18
+    /// is a **distinct** view — it reconstructs each dangling reference on **its own line**, preserving
+    /// the command it was written with, so a caller can point at the exact offending `\eqref{…}` rather
+    /// than a flattened `\ref`-shaped list.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read [`ReferenceResolution::unresolved`] and group its entries by their shared `ref_span`,
+    /// preserving the **first-appearance order** of the ref_spans (source order of the references) — a
+    /// `Vec` of `(ref_span, keys)`, **not** a hash map, so the order is deterministic and the code reads
+    /// identically to S17's grouping. Unlike a `\cite{a, b}` (multi-key), a `\ref`/`\eqref`/`\pageref`
+    /// takes exactly **one** key, so every group holds a single entry — the structural mirror is kept for
+    /// readability, but each group emits exactly one line.
+    ///
+    /// One line per dangling reference: `\` + that reference's own `command` + `{` + its `key` + `}`,
+    /// reconstructed from the owned `command`/`key` `String`s (no source slicing, matching S13's
+    /// `resolve_namerefs`, S15's `citations_by_source`, and S17's `unresolved_citations_by_source`).
+    /// Because the line is rebuilt from the ref's **own** `command`, a dangling `\eqref{eq:x}` renders
+    /// `\eqref{eq:x}` and a dangling `\pageref{p}` renders `\pageref{p}` — the command is **never**
+    /// hard-coded to `\ref`.
+    ///
+    /// A document with **no** unresolved references — every reference resolves, or there are none at all
+    /// — returns the fixed marker `(no unresolved references)`, never the empty string (the same
+    /// stable-marker discipline S12/S13/S14/S15/S16/S17 use). Lines are joined by `\n` with **no**
+    /// trailing newline (matching S15's `citations_by_source` and S17's
+    /// `unresolved_citations_by_source`).
+    ///
+    /// Concretely, for a body with `\eqref{eq:ghost}` and `\pageref{p:ghost}` (neither defined by a
+    /// `\label`):
+    ///
+    /// ```text
+    /// \eqref{eq:ghost}
+    /// \pageref{p:ghost}
+    /// ```
+    ///
+    /// Each line preserves the command it was written with, one dangling reference per line, in source
+    /// order.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S18 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1-S17 output (they are byte-for-byte unchanged) and leaves the
+    /// `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// `command` and `key` are already owned `String`s); a single pass over the already-bounded
+    /// `unresolved` list. Borrows `self` immutably and returns owned `String` data, so the result
+    /// outlives any borrow of the source.
+    pub fn unresolved_references_by_source(&self) -> String {
+        // S3 already split every `\ref`/`\eqref`/`\pageref` into resolved and dangling entries, routing
+        // the dangling ones into `unresolved` (in body pre-order), each carrying its own `command`,
+        // `key`, and `ref_span`. We only read that list.
+        let resolution = self.resolve_references();
+
+        // Group the dangling references by their shared `ref_span`, preserving the FIRST-APPEARANCE
+        // order of the ref_spans (source order of the references). A `Vec` of `(ref_span, refs)` — not a
+        // hash map — keeps that order deterministic and mirrors S17's grouping idiom exactly. Unlike a
+        // multi-key `\cite`, each reference takes exactly one key, so every group holds a single entry;
+        // the structural mirror is kept only so this code reads identically to S17.
+        let mut groups: Vec<(Span, Vec<&UnresolvedRef>)> = Vec::new();
+        for u in &resolution.unresolved {
+            match groups.iter_mut().find(|(span, _)| *span == u.ref_span) {
+                Some((_, refs)) => refs.push(u),
+                None => groups.push((u.ref_span, vec![u])),
+            }
+        }
+
+        if groups.is_empty() {
+            // Every reference resolved (or there were none) → the fixed marker, never the empty string.
+            return "(no unresolved references)".to_string();
+        }
+
+        // One line per dangling reference, reconstructed from its OWN command and key: `\<command>{key}`.
+        // We iterate each group's single entry so `\eqref` / `\pageref` render as themselves rather than
+        // all being flattened to `\ref`.
+        groups
+            .iter()
+            .flat_map(|(_, refs)| {
+                refs.iter()
+                    .map(|u| format!("\\{}{{{}}}", u.command, u.key))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -4531,5 +4628,130 @@ See Section~\ref{sec:intro}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b
         // And S17 itself groups the dangling cites: `{a,b}` fully resolves (no line); `{c,ghost}` keeps
         // only the dangling `ghost`.
         assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S18 — unresolved (dangling) references grouped by source `\ref`
+    // (`unresolved_references_by_source`). The `\ref`-family mirror of S17, command-aware.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s18_reports_dangling_ref() {
+        // A `\ref{nope}` whose key no `\label` defines → one line, the reconstructed `\ref{nope}`.
+        let src = r"\begin{document}
+See \ref{nope}.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_references_by_source(), "\\ref{nope}");
+    }
+
+    #[test]
+    fn s18_preserves_command_eqref_pageref() {
+        // A dangling `\eqref{eq:ghost}` and a dangling `\pageref{p:ghost}` → each line preserves the
+        // command it was written with (NOT flattened to `\ref`), one per line, in source order.
+        let src = r"\begin{document}
+See \eqref{eq:ghost} on \pageref{p:ghost}.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "\\eqref{eq:ghost}\n\\pageref{p:ghost}"
+        );
+    }
+
+    #[test]
+    fn s18_two_distinct_dangling_refs_source_order() {
+        // Two separate dangling `\ref`s → two lines, in the source order the references appear, joined by
+        // `\n`. The first-appearance grouping keeps `nope1` ahead of `nope2`.
+        let src = r"\begin{document}
+See \ref{nope1} and later \ref{nope2}.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "\\ref{nope1}\n\\ref{nope2}"
+        );
+    }
+
+    #[test]
+    fn s18_resolved_ref_excluded() {
+        // A `\ref{sec:intro}` that DOES resolve to a `\label{sec:intro}` never enters `unresolved`, so it
+        // is excluded by construction. With no dangling references, the fixed marker is returned.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+See Section~\ref{sec:intro}.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "(no unresolved references)"
+        );
+    }
+
+    #[test]
+    fn s18_empty_returns_marker() {
+        // A document with no references at all → the fixed `(no unresolved references)` marker, never the
+        // empty string.
+        let src = r"\begin{document}
+Just some text with no references.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "(no unresolved references)"
+        );
+    }
+
+    #[test]
+    fn s18_is_additive_leaves_s1_s17_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a resolved `\ref`, a
+        // `\nameref`, two `\cite`s (one multi-key, one dangling key), a duplicate `\bibitem`, AND a
+        // dangling `\eqref` (`eq:ghost`), S18 changes NONE of the S1-S17 outputs — it only reads
+        // `resolve_references`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+See Section~\ref{sec:intro}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+
+        // And S18 itself surfaces the dangling `\eqref`, command preserved.
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "\\eqref{eq:ghost}"
+        );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1454,3 +1454,83 @@ and `duplicate_bibliography_entries` all still produce their exact prior strings
 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test
 -p adj-lang -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`,
 no grammar regen, no new dependencies.
+
+## 24. S18 — unresolved (dangling) references grouped by source `\ref` (`unresolved_references_by_source`)
+
+### 24.1 Motivation
+
+S3's `resolve_references` returns `unresolved: Vec<UnresolvedRef>` — every `\ref`/`\eqref`/`\pageref`
+key that matched no `\label`, i.e. LaTeX's *"Reference `key' undefined"* warning (the `??` in the
+output). Each `UnresolvedRef` carries not just the dangling `key` and its `ref_span` but the `command`
+that was written (`"ref"` / `"eqref"` / `"pageref"`). S6's flat report already surfaces these dangling
+keys as a single "Dangling references: k1, k2" footer, and S17 gives the citation family its per-source
+dangling view. S18 is the `\ref`-family parallel of S17 — but it is a **distinct** view from S6's
+footer: it reconstructs each dangling reference on **its own line**, and it is **command-aware**, so a
+dangling `\eqref` renders `\eqref{…}` and a dangling `\pageref` renders `\pageref{…}` rather than being
+flattened into an undifferentiated `\ref`-shaped comma list.
+
+### 24.2 Why a new method — additive by construction
+
+S18 adds a **new public method** `Document::unresolved_references_by_source(&self) -> String`. It is a
+pure, read-only render of `resolve_references().unresolved`. It reuses that table verbatim (never
+re-walking the body or re-resolving references), so the report can never drift from the S3 resolution it
+summarises. It mutates nothing and changes no S1–S17 output — including `to_latex()`'s round-trip fixed
+point — byte-for-byte. Like S11–S17 it is a method the caller invokes directly.
+
+### 24.3 The grouping and ordering rule
+
+S3 walks every `\ref`/`\eqref`/`\pageref` in body pre-order and splits them into resolved references and
+unresolved (dangling) references, each dangling row recorded as `UnresolvedRef { key, command, ref_span
+}`. S18 groups the dangling references by their shared `ref_span`, preserving the **first-appearance
+order** of the ref_spans (source order of the references) via a `Vec<(Span, Vec<&UnresolvedRef>)>` —
+**not** a hash map — so the order is deterministic and the code reads identically to S17's grouping.
+Unlike a multi-key `\cite`, a `\ref`/`\eqref`/`\pageref` takes exactly **one** key, so every group holds
+a single entry; the structural mirror of S17 is kept only for readability, and each group emits exactly
+one line. Because `unresolved` holds **only** the dangling references, a `\ref` that resolves to a
+`\label` never appears — the exact analogue of how S17 shows only the *dangling* keys.
+
+### 24.4 The exact rendering contract — `Document::unresolved_references_by_source(&self) -> String`
+
+- One line per dangling reference, in the first-appearance order of the ref_spans (source order of the
+  references, **not** re-sorted).
+- Each line is `\` + that reference's own `command` + `{` + its `key` + `}`, reconstructed from the
+  owned `command`/`key` `String`s rather than sliced from `&src[span]` (matching S13 `resolve_namerefs`,
+  S15 `citations_by_source`, S17 `unresolved_citations_by_source`), so the render needs no source borrow
+  and can never index out of bounds. The command is taken from the reference's **own** `command` field —
+  it is **never** hard-coded to `\ref`, so a dangling `\eqref{eq:x}` renders `\eqref{eq:x}` and a
+  dangling `\pageref{p}` renders `\pageref{p}`.
+- A `\ref` that resolves to a `\label` never entered `unresolved`, so it is excluded by construction.
+- Lines are joined by `\n` with **no** trailing newline (matching S15 `citations_by_source`, S17
+  `unresolved_citations_by_source`).
+- If there are **no** unresolved references (every reference resolves, or none present), the fixed marker
+  `(no unresolved references)` is returned, so the output is never the empty string.
+
+Example (body with `\eqref{eq:ghost}` and `\pageref{p:ghost}`, neither defined by a `\label`):
+
+```text
+\eqref{eq:ghost}
+\pageref{p:ghost}
+```
+
+each line preserves the command it was written with, one dangling reference per line, in source order.
+This is distinct from S6's flat *"Dangling references: eq:ghost, p:ghost"* footer, which drops the
+per-reference command and comma-joins the keys.
+
+### 24.5 Public API (added in S18)
+
+One new method: `Document::unresolved_references_by_source(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_references` and every S1–S17 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 24.6 Verification (S18)
+
+`cargo test -p latex` green (6 new S18 tests: a single dangling `\ref{nope}` rendering `\ref{nope}`; a
+dangling `\eqref{eq:ghost}` and `\pageref{p:ghost}` rendering `\eqref{eq:ghost}\n\pageref{p:ghost}` with
+each command preserved; two distinct dangling `\ref`s rendering `\ref{nope1}\n\ref{nope2}` in source
+order; a resolved `\ref` excluded so a fully-resolved document returns the `(no unresolved references)`
+marker; a reference-free document returning the same marker; and an additivity check that
+`to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`,
+`citations_by_source`, `duplicate_bibliography_entries`, and `unresolved_citations_by_source` all still
+produce their exact prior strings). All prior S1–S17 tests pass unchanged. `cargo clippy -p latex
+--all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo
+build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S18 — report unresolved (dangling) references, command-aware, one per source `\ref`

Adds a new read-only method `Document::unresolved_references_by_source(&self) -> String` to the `latex` crate — the **`\ref`-family mirror of S17's `unresolved_citations_by_source`**. Where S17 groups the dangling *citation* keys per source `\cite`, S18 renders the **dangling reference keys** — LaTeX's *"Reference `key' undefined"* (the `??` in the output) — one reconstructed `\<command>{key}` per source reference. Bumps `latex` **0.53.0 → 0.54.0**.

### What it does

S2's `resolve_references` records every `\ref`/`\eqref`/`\pageref` whose key matched **no** `\label` in `ReferenceResolution::unresolved` (each `UnresolvedRef` carries its `key`, its `command`, and its `ref_span`). S6's `to_plain_text` already lists those keys as a **flat** *"Dangling references: k1, k2"* comma footer; S18 is the distinct **command-aware, one-per-line** view.

| aspect | rule |
|---|---|
| line format | `\` + the ref's **own `command`** + `{` + key + `}` — so `\eqref{x}` stays `\eqref{x}` and `\pageref{p}` stays `\pageref{p}`, never collapsed to `\ref` |
| source | reconstructed from the owned `command`/`key` Strings — **not** sliced from source |
| ordering | body pre-order (the order the references appear) |
| resolved refs | a `\ref` that resolves to a `\label` never enters `unresolved`, so it is excluded by construction |
| empty | fixed marker `(no unresolved references)`, never `""` |
| joining | `\n`-joined, **no** trailing newline (matches S11–S17) |

Example — `\ref{nope}`, then `\eqref{eq:ghost}`, then a resolving `\ref{sec:intro}`:

```text
\ref{nope}
\eqref{eq:ghost}
```

### Additive by construction

Brand-new, read-only method that reuses `resolve_references` and mutates nothing. **Total & panic-free**: no source slicing/indexing, no `unwrap`/`expect`, no `unsafe`, a single pass over the already-bounded `unresolved` list, returning owned `String` data. All **S1–S17 outputs stay byte-for-byte unchanged**, pinned by a dedicated additivity test. The `to_latex` round-trip fixed point is untouched.

### Tests (exact strings, real output)

- `s18_reports_dangling_ref` — `\ref{nope}` → `"\\ref{nope}"`
- `s18_preserves_command_eqref_pageref` — `\eqref{eq:ghost}` / `\pageref{p:ghost}` render with their own commands
- `s18_two_distinct_dangling_refs_source_order` — two dangling refs → two `\n`-joined lines in source order
- `s18_resolved_ref_excluded` — a resolving `\ref` is not listed
- `s18_empty_returns_marker` — no refs / all resolve → `"(no unresolved references)"`
- `s18_is_additive_leaves_s1_s17_outputs_unchanged` — pins `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`, `duplicate_bibliography_entries`, and `unresolved_citations_by_source`

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → all passing (was 394; +6 S18) + doc-tests ok
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → all green (0 failed)
- `cargo build -p latex --no-default-features` → builds
- Inline security review PASSED (returned `String`, no injection sink; total/panic-free; same bounded grouping already shipped in S15/S17).
- Single-parent commit; scoped diff = 5 files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
