### PR TITLE
feat(apl): MA-4b -- apl.tokens/apl.grammar, the two-nonterminal grammar

### DIFF
--- a/code/grammars/apl/apl.grammar
+++ b/code/grammars/apl/apl.grammar
@@ -1,0 +1,130 @@
+# @version 1
+
+# =============================================================================
+# apl.grammar — Parser grammar for the APL historical core (MA-4b)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from the APL lexer (code/grammars/apl/apl.tokens). See
+# code/specs/MA05-apl-language.md, especially §3 (the grammar design this
+# file implements) and §4 (the exact primitive/operator scope).
+#
+# Token names (UPPERCASE) come from the APL lexer:
+#   NUMBER NAME                        literals and variables
+#   ARROW (←)                          assignment
+#   PLUS MINUS TIMES DIVIDE CEILING FLOOR RHO IOTA RAVEL   primitive functions
+#   EQ NE LT LE GE GT                  dyadic comparison primitives
+#   REDUCE (/)  SCAN (\)  OUTER (∘.)   operators
+#   LPAREN RPAREN                      grouping
+#   NEWLINE
+#
+# -----------------------------------------------------------------------------
+# Two nonterminals, not one (MA05 §3 bullet 1)
+# -----------------------------------------------------------------------------
+# Unlike every other frontend in this repo (Macsyma/MATLAB/Wolfram), APL needs
+# TWO expression nonterminals, because its operators (`/`, `\`, `∘.`) combine
+# with FUNCTIONS, not values:
+#
+#   value_expr     — arrays and scalars (what every other language just calls
+#                    "expr"). Built from `term`s combined by `function_expr`s.
+#   function_expr  — a primitive glyph, or a primitive glyph with a reduce/
+#                    scan/outer-product operator applied to it (a "derived
+#                    function"). A function_expr is never itself a value —
+#                    it only ever appears as the thing an application
+#                    production (below) combines with one or two value_exprs.
+#
+# -----------------------------------------------------------------------------
+# One precedence tier, right-to-left (MA05 §3 bullet 2)
+# -----------------------------------------------------------------------------
+# There is no precedence cascade to climb (contrast MATLAB's dozen-tier
+# cascade, MA01). `value_expr`'s dyadic continuation is a SINGLE right-
+# recursive rule: `a F b G c` parses as `a F (b G c)`, matching APL's
+# right-to-left evaluation exactly (`2×3+4` is `2×(3+4)`, not `(2×3)+4`).
+#
+# -----------------------------------------------------------------------------
+# Monadic vs. dyadic is a parser-production choice, not a lexer concern
+# (MA05 §3 bullet 3)
+# -----------------------------------------------------------------------------
+# `value_expr`'s two productions that start with a function_expr (monadic:
+# nothing precedes it) vs. that have a term before it (dyadic) are exactly
+# the "which application rule matched" the runtime later reads off — no
+# lexer-level context hook is needed, unlike MA01 §3's `'` problem.
+#
+# -----------------------------------------------------------------------------
+# Divergence from MA05 §3's inline illustrative example (documented, not a
+# silent change — see this PR's commit message)
+# -----------------------------------------------------------------------------
+# §3 bullet 1 illustrates the operator-production shape with
+# `outer = function_expr "∘." function_expr` — a function_expr on BOTH sides
+# of `∘.`. That does not match §1.1/§2's own semantic description of outer
+# product: `v ∘.F w` (MA05 §2) has exactly ONE function operand (F, appearing
+# immediately after the dot) and TWO VALUE operands (v, w) — there is no
+# "left function" in real APL's outer-product idiom (jot-dot always takes
+# its one function argument on the right; general function composition via
+# jot alone is deferred, see MA05 §4). This grammar therefore gives `outer`
+# a single function_atom operand (`OUTER function_atom`, i.e. `∘.F`), which
+# then plugs into the ordinary dyadic `value_expr` production like any other
+# function_expr — no special-casing needed. MA05 §3 has been corrected to
+# match this file, not the other way around.
+# =============================================================================
+
+program = { line } ;
+
+line = statement NEWLINE
+     | statement
+     | NEWLINE ;
+
+statement = assignment ;
+
+# Assignment (MA05 §4) is right-associative and, like everything else in
+# APL, evaluates right-to-left: the right-hand side is not a restricted
+# "simpler" rule, it recurses back through `assignment` itself, so
+# `A←2+3` assigns the value of `2+3` (not `2`) to `A`, and chained
+# assignment `A←B←3` assigns 3 to both `B` and `A`.
+assignment = NAME ARROW assignment
+           | value_expr ;
+
+# The core two-nonterminal, one-precedence-tier, right-to-left application
+# chain (MA05 §3). Ordered as ONE alternative per starting-token class (a
+# `term`-starting value vs. a `function_expr`-starting one) with the dyadic
+# continuation as an OPTIONAL trailing part of the first alternative — NOT
+# two competing "bare term" vs. "term then more" alternatives, which would
+# let a naive first-match-wins choice silently stop after a bare term even
+# when a dyadic continuation follows (mirrors the `X [ continuation ]` idiom
+# used throughout code/grammars/wolfram/wolfram.grammar for the same reason).
+value_expr = term [ function_expr value_expr ]
+           | function_expr value_expr ;
+
+# A value atom: a run of one or more juxtaposed NUMBER literals ("stranding"
+# — `1 2 3` is a 3-element vector; a single NUMBER is a rank-0 scalar, MA05
+# §4: "a scalar is a rank-0 array"), a NAME (a previously-assigned variable),
+# or a fully parenthesised value_expr. Stranding of non-numeric atoms (names,
+# parenthesised sub-expressions) is an honest textbook-subset restriction,
+# not a grammar limitation: `1 2 3` strands, `A B` does not (yet).
+term = NUMBER { NUMBER }
+     | NAME
+     | LPAREN value_expr RPAREN ;
+
+# The other nonterminal (MA05 §3 bullet 1): function-valued expressions.
+# Every function_atom is one of the MA05 §4 primitive glyphs — user-defined
+# functions/dfns (`∇`, `{...}`) are deferred, so function_atom is never
+# anything but a bare primitive. There is deliberately no parenthesised
+# function_expr and no "trains" (tacit function composition): both are out
+# of scope for this first cut, and omitting them avoids a real grammar
+# ambiguity a parenthesised-function form would otherwise introduce (`( … )`
+# would then be ambiguous between grouping a value_expr and grouping a
+# function_expr).
+function_atom = PLUS | MINUS | TIMES | DIVIDE | CEILING | FLOOR
+              | RHO | IOTA | RAVEL
+              | EQ | NE | LT | LE | GE | GT ;
+
+# An OPERATOR production takes a function_expr and produces a NEW
+# function_expr (MA05 §3 bullet 1). The three in scope (MA05 §4): reduce and
+# scan are POSTFIX on the function (`+/`, `+\`); outer product is PREFIX on
+# the function (`∘.×`) — see this file's header for why outer's shape
+# diverges from §3's own inline example. REDUCE/SCAN/OUTER's operand is
+# restricted to a bare `function_atom` (not the full recursive
+# `function_expr`) — stacking operators (e.g. applying reduce to an
+# already-reduced function) is not part of this first cut's scope.
+function_expr = function_atom [ REDUCE | SCAN ]
+              | OUTER function_atom ;

--- a/code/grammars/apl/apl.tokens
+++ b/code/grammars/apl/apl.tokens
@@ -1,0 +1,121 @@
+# APL Token Grammar
+# ============================================================================
+#
+# Tokenizes the historical-core subset of APL fixed by MA-4a
+# (code/specs/MA05-apl-language.md §4): dense numeric arrays, the primitive
+# functions `+ - × ÷ ⌈ ⌊ ⍴ ⍳ , = ≠ < ≤ ≥ >`, the three operators
+# `/` (reduce) `\` (scan) `∘.` (outer product), assignment `←`, parenthesised
+# grouping, and `⍝` line comments.
+#
+# Per MA05 §3 bullet 4 ("Glyph tokenization is easy"): every APL primitive is
+# a single dedicated Unicode code point, so each glyph below is its own
+# unambiguous single-token literal rule (mirroring the spec's own example,
+# `RHO = "⍴"`) — there is no character overloading of the kind MATLAB's `'`
+# or `.` need (see MA01 §3), so no lexer-level disambiguation hook is needed
+# anywhere in this file.
+#
+# Source is taken as native UTF-8 glyphs — no keyboard-mapping/transliteration
+# layer (that is a historical editor/input-method concern, out of scope for a
+# source-string-in frontend, per MA05 §3 bullet 4).
+#
+# There is no STRING token: MA05 §4 scopes this first cut to numeric arrays
+# only (mixed numeric+character arrays are explicitly deferred), so there is
+# no character/string literal syntax to tokenize yet.
+#
+# @version 1
+
+# ============================================================================
+# SECTION 1: Multi-character operators (declared before any single-character
+# token they could be confused with, per this repo's longest-match-first
+# lexer convention — see e.g. code/grammars/wolfram/wolfram.tokens)
+#
+# OUTER ("∘." — jot immediately followed by a dot) is the two-codepoint outer
+# -product operator (MA05 §4). Jot (∘) alone is not used for anything else in
+# this subset (general function composition/"trains" are deferred, MA05 §4),
+# so there is no ordering hazard the way `//.` vs `/.` vs `/` has in Wolfram —
+# it is listed here purely for the "multi-character tokens go first" grouping
+# convention, not because a real ambiguity exists.
+# ============================================================================
+
+OUTER = "∘."
+
+# ============================================================================
+# SECTION 2: Assignment and the primitive function glyphs (MA05 §4)
+#
+# Each dyadic/monadic pair shares ONE glyph — which meaning applies is a
+# PARSER-production concern (which application rule matched), not a lexer
+# concern (MA05 §3 bullet 3). The token name here is neutral between the two
+# readings, e.g. RHO is "shape" monadically and "reshape" dyadically.
+# ============================================================================
+
+ARROW   = "←"
+
+# conjugate / add, negate / subtract, sign / multiply, reciprocal / divide,
+# ceiling·floor / max·min, shape / reshape, index-generator / index-of,
+# ravel / catenate — one glyph per row, in MA05 §4's listed order.
+PLUS    = "+"
+MINUS   = "-"
+TIMES   = "×"
+DIVIDE  = "÷"
+CEILING = "⌈"
+FLOOR   = "⌊"
+RHO     = "⍴"
+IOTA    = "⍳"
+RAVEL   = ","
+
+EQ = "="
+NE = "≠"
+LT = "<"
+LE = "≤"
+GE = "≥"
+GT = ">"
+
+# ============================================================================
+# SECTION 3: Operators (MA05 §4) and grouping
+#
+# REDUCE and SCAN are postfix on the function they modify (`+/`, `+\`);
+# OUTER (Section 1) is prefix on the function it modifies (`∘.×`) — see
+# apl.grammar's `function_expr` for how the two shapes differ.
+# ============================================================================
+
+REDUCE = "/"
+SCAN   = "\"
+
+LPAREN = "("
+RPAREN = ")"
+
+# ============================================================================
+# SECTION 4: Literal value tokens
+#
+# NUMBER uses APL's historical "high minus" ¯ (U+00AF, macron) for a literal
+# negative sign, in the mantissa and/or the exponent (e.g. `¯3`, `1.5E¯3`) —
+# never the ASCII `-`, which is always the MINUS function token above. This
+# is not a stylistic choice: `-` must stay unambiguously a function so that
+# `A-B` (dyadic subtract) and a hypothetical negative literal never collide.
+#
+# NAME is a plain ASCII identifier (previously-assigned variables). APL's
+# `⎕`-prefixed system names/quad I/O are out of scope for this first cut
+# (MA05 §4 does not mention them).
+# ============================================================================
+
+NUMBER = /¯?[0-9]+(\.[0-9]+)?([Ee]¯?[0-9]+)?/
+NAME   = /[A-Za-z][A-Za-z0-9]*/
+
+# ============================================================================
+# SECTION 5: Significant newlines + skip patterns
+#
+# A newline separates statements, exactly like Wolfram (see wolfram.tokens
+# SECTION 4) — one difference is honestly simpler: this first cut does not
+# drop newlines inside `( … )`, so every parenthesised expression must stay
+# on one line for now (multi-line parenthesised grouping is a follow-on, not
+# a MA05 §4 in-scope item).
+#
+# `⍝` starts a line comment, consumed to (but not including) the end of the
+# line, so the following NEWLINE is still matched as its own token.
+# ============================================================================
+
+NEWLINE = /\r?\n/
+
+skip:
+  WHITESPACE = /[ \t]+/
+  COMMENT    = /⍝[^\r\n]*/

--- a/code/specs/MA05-apl-language.md
+++ b/code/specs/MA05-apl-language.md
@@ -81,13 +81,22 @@ enough for both of APL's novel properties without a hand-written parser:
 - **Two nonterminals, not one.** `value_expr` (arrays/scalars) and
   `function_expr` (primitive glyphs, derived functions, user-defined dfns).
   An **operator** production takes a `function_expr` and produces a
-  `function_expr` (`reduce = function_expr "/"`, `outer = function_expr
-  "∘." function_expr`). An **application** production takes a
-  `function_expr` and one or two `value_expr`s (monadic: `function_expr
-  value_expr`; dyadic: `value_expr function_expr value_expr`) and produces a
-  `value_expr`. This is an ordinary two-nonterminal CFG — no parser
-  generator changes needed, just a grammar shaped differently from
-  MATLAB/Wolfram's single-nonterminal expression grammars.
+  `function_expr`. Reduce and scan are postfix on the function (`reduce =
+  function_expr "/"`, `scan = function_expr "\"`); outer product is
+  **prefix** on the function (`outer = "∘." function_expr`), not infix
+  between two function_exprs — `∘.` (jot-dot) always takes exactly ONE
+  function operand, immediately to its right (`∘.×` is "outer product with
+  ×"); the value operands (`v ∘.F w`, §2) are supplied entirely by the
+  surrounding application production below, never by `outer` itself. (This
+  corrects an earlier draft of this bullet, which showed `outer` with a
+  function_expr on both sides — that shape has no counterpart in §1.1/§2's
+  semantic description and was never implemented; see MA-4b's
+  `apl.grammar`.) An **application** production takes a `function_expr` and
+  one or two `value_expr`s (monadic: `function_expr value_expr`; dyadic:
+  `value_expr function_expr value_expr`) and produces a `value_expr`. This
+  is an ordinary two-nonterminal CFG — no parser generator changes needed,
+  just a grammar shaped differently from MATLAB/Wolfram's single-nonterminal
+  expression grammars.
 - **Right-to-left, one precedence tier.** A dyadic chain is right-recursive
   with **no** precedence levels between different glyphs: `value_expr =
   term | term function_expr value_expr`. This is simpler than MATLAB's
@@ -175,8 +184,11 @@ apl-repl/     src/{lib.rs, main.rs}       ← MA-4e (the `apl` binary)
   Landed as `ops::reduce`/`ops::scan`/`ops::outer`, CPU-reference only
   (rank ≤ 2, matching this crate's existing ceiling) — GPU-dispatch wiring
   through `accel`/`exec` is a follow-up, not required to unblock MA-4e.
-- **MA-4b — `apl.tokens`/`apl.grammar`**: the two-nonterminal grammar (§3),
-  validated with `grammar-tools validate`.
+- **MA-4b — `apl.tokens`/`apl.grammar`** (✅ done): the two-nonterminal
+  grammar (§3), validated with `grammar-tools validate` (24 tokens, 2 skip
+  patterns, 8 rules, zero cross-validation warnings — every declared token
+  is referenced). Files: `code/grammars/apl/apl.tokens`,
+  `code/grammars/apl/apl.grammar`.
 - **MA-4c — `apl-lexer`.** Single-codepoint glyph tokens, `⍝` line comments.
 - **MA-4d — `apl-parser`.** The `value_expr`/`function_expr` grammar,
   monadic/dyadic application, reduce/scan/outer-product operator


### PR DESCRIPTION
## Summary
- Adds `code/grammars/apl/{apl.tokens,apl.grammar}`: the historical-core APL subset fixed by MA-4a (`code/specs/MA05-apl-language.md` §4) -- dense numeric arrays, the primitive functions (`+ - × ÷ ⌈ ⌊ ⍴ ⍳ , = ≠ < ≤ ≥ >`), the three operators (`/` reduce, `\` scan, `∘.` outer product), assignment `←`, parenthesised grouping, and `⍝` line comments.
- Wraps the shared `GrammarLexer`/`GrammarParser` per `feedback_no_handwritten_lexers_parsers` -- no hand-written lexer or parser.
- Implements §3's two-nonterminal design (`value_expr`/`function_expr`) with a single right-recursive, precedence-free dyadic chain -- no operator-precedence cascade, unlike every other frontend in this repo.
- `value_expr`'s dyadic continuation is written as `term [ function_expr value_expr ]` (one alternative per starting-token class, continuation optional) rather than two competing "bare term" vs. "term then more" alternatives, mirroring the `X [ continuation ]` idiom already used throughout `wolfram.grammar` -- the naive two-alternative shape would let a first-match-wins PEG parser silently stop after a bare term even when a dyadic continuation follows.

## Spec correction (documented, not silent)
§3's own inline illustrative example for outer product showed a `function_expr` on **both** sides of `∘.` -- that shape has no counterpart in §1.1/§2's semantic description (`v ∘.F w` has a VALUE, never a function, to the left of `∘.`) and doesn't match real APL (jot-dot always takes exactly one function operand, to its right). The grammar instead gives `outer` a single `function_atom` operand (`∘.F`), which then plugs into the ordinary dyadic `value_expr` production like any other `function_expr`. §3 and §6 are updated to match the implementation.

## Verification
1. `grammar-tools validate` -- 24 tokens, 2 skip patterns, 8 rules, **zero** cross-validation warnings (every declared token is referenced -- for comparison, `algol60.tokens` has 5 unused-token warnings).
2. A throwaway Rust test (not part of this PR -- MA-4b's scope is the two grammar files only, per §6) loaded both files through the real `grammar-tools`/`lexer`/`parser` crates and confirmed 11 hand-traced examples all parse with the exact AST shape the design predicts: dyadic chains (`1+2+3` → right-associative), monadic application (`⍴v`), dyadic reshape with vector stranding (`2 3⍴⍳6`), reduce (`+/1 2 3 4`), outer product (`1 2∘.×3 4`), parenthesised grouping, plain and chained assignment, comments + multi-line programs, negative-number literals via the historical high-minus glyph (`¯3`), and comparison (`3=3`).

MA-4c (`apl-lexer`) and MA-4d (`apl-parser`), which compile these two files into committed `_grammar.rs` via the grammar-tools CLI, are separate follow-on PRs per §6's one-item-per-PR discipline.

## Test plan
- [x] `grammar-tools validate apl.tokens apl.grammar` -- all checks passed, zero warnings
- [x] 11/11 hand-traced examples parse with the predicted AST shape (verified via throwaway test, not shipped)
- [x] `/security-review` passed clean, first round -- no vulnerabilities found (checked in particular for ReDoS in the new token regexes; all are linear, no nested/overlapping quantifiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)