### PR TITLE
feat(latex): LTXDOC03 S19 bibliography_entries — numbered winning-entry list

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.55.0] — 2026-07-07
+
+### Added — numbered winning-bibliography-entry list (LTXDOC03 S19)
+
+A **new** public method `Document::bibliography_entries(&self) -> String` that renders the **winning
+bibliography entries as a numbered list** — the rendered bibliography a reader actually sees, and the
+table citations resolve against. It is a **distinct** view over `resolve_citations()`: S16
+(`duplicate_bibliography_entries`) renders the **losing** `duplicate_entries` as `\bibitem{key}` warning
+lines, and S15 (`citations_by_source`) renders the per-source *resolved cite keys* — S19 fills the
+remaining cell by rendering the **winning** `entries` themselves. Every S1–S18 output is left
+**byte-for-byte unchanged**; S19 is purely additive and leaves the `to_latex()` round-trip fixed point
+intact.
+
+- **One numbered line per winning entry, 1-based, in pre-order.** S2 already collects the first
+  `\bibitem{key}` of each distinct key into `resolve_citations().entries` (body pre-order; later
+  re-definitions go to `duplicate_entries`, never here). S19 numbers that list 1-based via
+  `enumerate()` + `n + 1`, emitting `format!("[{}] {}", n + 1, entry.key)` → `[1] smith2020`,
+  `[2] jones2019`, …. Each line is reconstructed from the entry's **owned `key` `String`** (no source
+  slicing at all, matching S13 `resolve_namerefs`, S15 `citations_by_source`, S16
+  `duplicate_bibliography_entries`, and S17/S18's dangling reports).
+- **`[n] key` chosen deliberately.** The numbered shape reads as a *rendered bibliography* and is
+  **visually distinct** from S16's `\bibitem{key}` losing-duplicate lines, so the two never look alike
+  even when they list overlapping keys.
+- **Duplicates appear once.** Because `entries` holds only the **first** `\bibitem` of each key, a
+  `\bibitem{dup}` written twice appears **once** here — the winner — exactly as a real bibliography
+  renders one line per key. The losing re-definitions remain the S16 view.
+- **Empty marker.** A document with **no** bibliography entries — no `thebibliography`, or an empty one
+  — returns the fixed marker `"(no bibliography entries)"`, so the output is never the empty string
+  (the same stable-marker discipline S12/S13/S14/S15/S16/S17/S18 use). Lines are joined by `\n` with
+  **no** trailing newline.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all — keys
+  are already owned `String`s); a single pass over the already-bounded `entries` list. Borrows `self`
+  immutably, returns owned `String`.
+
+Five `s19_*` tests pin the exact rendered strings: two distinct entries (`[1] a\n[2] b`), a duplicate
+key winning once with a peer (`[1] dup\n[2] other`), three entries numbered in pre-order
+(`[1] x\n[2] y\n[3] z`), a bibliography-free document returning the `(no bibliography entries)` marker,
+and an additivity check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`,
+`resolve_namerefs`, `list_summary`, `citations_by_source`, `duplicate_bibliography_entries`,
+`unresolved_citations_by_source`, and `unresolved_references_by_source` are all byte-for-byte unchanged.
+
 ## [0.54.0] — 2026-07-07
 
 ### Added — unresolved (dangling) references grouped by source `\ref` (LTXDOC03 S18)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -66,6 +66,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S16 — duplicate (multiply-defined) `\bibitem` entries** | `Document::duplicate_bibliography_entries() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\bibitem`s — LaTeX's *"Citation `key' multiply defined"* warnings — the citation-family parallel of S6's *"Dangling citations"* footer (for the *other* bibliography warning). These were already computed by S2 (`resolve_citations().duplicate_entries`) but rendered by **no** method until now. S2 collects every `\bibitem` in `walk` pre-order; the **first** of each key wins and every **later** `\bibitem` of an already-defined key is a losing duplicate. S16 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\bibitem{<key>}` (no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** duplicates (no bibliography, or every key once) → the fixed marker `(no duplicate bibliography entries)`. E.g. `smith` defined twice + `jones` once → `\bibitem{smith}` (only the loser). Every S1–S15 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S17 — unresolved (dangling) citations grouped by source `\cite`** | `Document::unresolved_citations_by_source() -> String` — a **new**, read-only method that renders the **dangling** citations **grouped by the source `\cite` they came from** — the DANGLING-key mirror of S15's `citations_by_source`, and the per-`\cite` view of S6's flat *"Dangling citations"* footer. It reads only `resolve_citations().unresolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping the dangling keys back by `cite_span` in **first-appearance order** (source order) with keys kept left-to-right. One line per source `\cite` with ≥1 dangling key: `\cite{` + the group's **dangling** keys joined by `", "` + `}`. A **resolved** key never entered `unresolved`, so `\cite{a,ghost}` where only `a` resolves renders `\cite{ghost}` (reconstructed from keys, no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** unresolved citations → the fixed marker `(no unresolved citations)`. E.g. `\cite{known,ghost}` (only `known` defined) then `\cite{x,y}` (neither) → `\cite{ghost}\n\cite{x, y}`. Every S1–S16 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S18 — unresolved (dangling) references grouped by source `\ref`** | `Document::unresolved_references_by_source() -> String` — a **new**, read-only method that renders the **dangling** references, one reconstructed `\<command>{key}` line each — the `\ref`-family parallel of S17's dangling-CITATION report, and a **distinct** view from S6's flat *"Dangling references: k1, k2"* footer (S18 is **command-aware**, so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`). It reads only `resolve_references().unresolved` (a `Vec<UnresolvedRef { key, command, ref_span }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **resolved** `\ref` never entered `unresolved`, so it is excluded. Lines joined by `\n`, no trailing newline. A document with **no** unresolved references → the fixed marker `(no unresolved references)`. E.g. `\eqref{eq:ghost}` then `\pageref{p:ghost}` (neither defined) → `\eqref{eq:ghost}\n\pageref{p:ghost}`. Every S1–S17 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S19 — numbered winning-bibliography-entry list** | `Document::bibliography_entries() -> String` — a **new**, read-only method that renders the **winning** bibliography entries as a **numbered list** — the rendered bibliography a reader sees, and the table citations resolve against. A **distinct** view over `resolve_citations()`: S16 (`duplicate_bibliography_entries`) renders the **losing** `duplicate_entries` as `\bibitem{key}` lines, S15 (`citations_by_source`) renders per-source *resolved cite keys*; S19 renders the **winning** `entries`. It reads only `resolve_citations().entries` (the first `\bibitem` of each distinct key, body pre-order; later re-definitions live in `duplicate_entries`) and numbers it **1-based**, one line per entry as `[n] key` (reconstructed from the owned key, no source slicing). The `[n] key` shape is deliberately distinct from S16's `\bibitem{key}` lines. A `\bibitem{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** bibliography entries → the fixed marker `(no bibliography entries)`. E.g. `smith` (twice) + `jones` → `[1] smith\n[2] jones`. Every S1–S18 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -791,6 +792,40 @@ assert_eq!(
 A document with no unresolved references — every reference resolves, or none present — renders the fixed
 `(no unresolved references)` marker. Purely additive — reuses `resolve_references`, mutates nothing,
 leaves every S1–S17 output and the `to_latex()` fixed point unchanged.
+
+### numbered winning-bibliography-entry list (LTXDOC03 S19)
+
+The **winning** bibliography entries rendered as a **numbered list** — the rendered bibliography a reader
+actually sees, and the table citations resolve against. A **distinct** view over `resolve_citations()`:
+S16 (`duplicate_bibliography_entries`) renders the **losing** duplicates as `\bibitem{key}` warning
+lines, and S15 (`citations_by_source`) renders per-source *resolved cite keys* — S19 renders the
+**winning** `entries` themselves. S2 collects the first `\bibitem{key}` of each distinct key into
+`resolve_citations().entries` (body pre-order; later re-definitions go to `duplicate_entries`, never
+here). `bibliography_entries` numbers that list **1-based** and emits one line per winning entry as
+`[n] key` (reconstructed from the owned key — no source slicing). The `[n] key` shape is deliberately
+distinct from S16's `\bibitem{key}` lines, so the winning list never looks like the losing-duplicate
+report even when keys overlap. A `\bibitem{dup}` written twice appears **once** — the winner.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}
+\begin{thebibliography}{9}
+\bibitem{smith} First Smith.
+\bibitem{jones} Jones.
+\bibitem{smith} Second Smith.
+\end{thebibliography}
+\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.bibliography_entries(),
+    "[1] smith\n[2] jones",   // numbered, 1-based, pre-order; the duplicate `smith` wins once
+);
+```
+
+A document with no bibliography entries — no `thebibliography`, or an empty one — renders the fixed
+`(no bibliography entries)` marker. Purely additive — reuses `resolve_citations`, mutates nothing, leaves
+every S1–S18 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -1938,6 +1938,93 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **winning bibliography entries as a numbered list** (LTXDOC03 S19) — the rendered
+    /// bibliography a reader actually sees: one numbered line per *winning* `\bibitem`, the table
+    /// citations resolve against.
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] collects every `\bibitem{key}` inside a `thebibliography`
+    /// environment, keeping the **first** `\bibitem` of each distinct key as the *winning* entry (in
+    /// [`CitationResolution::entries`], body pre-order) and routing every later re-definition into the
+    /// *losing* [`CitationResolution::duplicate_entries`]. The other renderers view neighboring cells
+    /// of that resolution: S16's [`duplicate_bibliography_entries`](Document::duplicate_bibliography_entries)
+    /// renders the **losing** `duplicate_entries` (as `\bibitem{key}` warning lines); S15's
+    /// [`citations_by_source`](Document::citations_by_source) renders the per-source *resolved cite
+    /// keys*. S19 fills the remaining view: the **winning** `entries` themselves, rendered as a
+    /// bibliography looks — a distinct, brand-new view over the same resolution.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read [`CitationResolution::entries`] in its existing pre-order and number it **1-based**, one
+    /// line per winning entry: `format!("[{}] {}", n, entry.key)` → `[1] smith2020`, `[2] jones2019`,
+    /// … The `[n] key` shape is chosen **deliberately** so this reads as a *rendered bibliography* and
+    /// is visually distinct from S16's `\bibitem{key}` losing-duplicate lines — the two never look
+    /// alike even when they list overlapping keys. Each line is reconstructed from the entry's **owned
+    /// `key` `String`** (no source slicing at all, matching S13's `resolve_namerefs`, S15's
+    /// `citations_by_source`, S16's `duplicate_bibliography_entries`, and S17/S18's dangling reports).
+    ///
+    /// Because `entries` already holds only the **first** `\bibitem` of each key (later re-definitions
+    /// live in `duplicate_entries`, never here), a `\bibitem{dup}` written twice appears **once** in
+    /// this list — the winning entry — exactly as a real bibliography renders one line per key.
+    ///
+    /// A document with **no** bibliography entries — no `thebibliography`, or an empty one — returns
+    /// the fixed marker `(no bibliography entries)`, never the empty string (the same stable-marker
+    /// discipline S12/S13/S14/S15/S16/S17/S18 use). Lines are joined by `\n` with **no** trailing
+    /// newline (matching S11's `to_plain_text_by_kind` and every S12-S18 renderer).
+    ///
+    /// Concretely, for a `thebibliography` defining `smith` (twice) and `jones`:
+    ///
+    /// ```text
+    /// \begin{thebibliography}{9}
+    /// \bibitem{smith} First Smith. 1990.
+    /// \bibitem{jones} Jones. 1991.
+    /// \bibitem{smith} Second Smith. 1992.
+    /// \end{thebibliography}
+    /// ```
+    ///
+    /// the winning list is the two numbered lines (the second `\bibitem{smith}` is a duplicate, not a
+    /// second entry):
+    ///
+    /// ```text
+    /// [1] smith
+    /// [2] jones
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S19 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1-S18 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single pass over the already-bounded `entries` list.
+    /// Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow of
+    /// the source.
+    pub fn bibliography_entries(&self) -> String {
+        // S2 already collected the winning entries — the first `\bibitem` of each distinct key, in
+        // body pre-order (later re-definitions went to `duplicate_entries`, not here). We only read
+        // that list.
+        let resolution = self.resolve_citations();
+
+        if resolution.entries.is_empty() {
+            // No `thebibliography` (or an empty one) → the fixed marker, never the empty string.
+            return "(no bibliography entries)".to_string();
+        }
+
+        // One numbered line per winning entry, 1-based, in the existing pre-order. `enumerate()` is
+        // 0-based, so `n + 1` gives the 1-based label. Reconstruct `[n] key` from the owned key, so
+        // there is no source slicing; the `[n] key` shape is deliberately distinct from S16's
+        // `\bibitem{key}` losing-duplicate lines.
+        resolution
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(n, entry)| format!("[{}] {}", n + 1, entry.key))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -4753,5 +4840,115 @@ See Section~\ref{sec:intro}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig
             doc.unresolved_references_by_source(),
             "\\eqref{eq:ghost}"
         );
+    }
+
+    #[test]
+    fn s19_lists_winning_entries() {
+        // Two distinct `\bibitem`s → a numbered list, one line each, 1-based, in source order.
+        let src = r"\begin{document}
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b");
+    }
+
+    #[test]
+    fn s19_only_first_of_duplicate_key_wins() {
+        // A `\bibitem{dup}` written twice yields ONE winning entry (`dup`); the later re-definition
+        // lives in `duplicate_entries` (S16), not in the winning list. A peer `\bibitem{other}` shows
+        // the numbering/order stays 1-based in source order.
+        let src = r"\begin{document}
+\begin{thebibliography}{9}
+\bibitem{dup} First dup.
+\bibitem{other} Other.
+\bibitem{dup} Second dup.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entries(), "[1] dup\n[2] other");
+        // Cross-check: the losing duplicate is the S16 view, not the S19 winning list.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{dup}");
+    }
+
+    #[test]
+    fn s19_numbered_in_preorder() {
+        // Three distinct entries → three numbered lines in source (pre-order) order.
+        let src = r"\begin{document}
+\begin{thebibliography}{9}
+\bibitem{x} X.
+\bibitem{y} Y.
+\bibitem{z} Z.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entries(), "[1] x\n[2] y\n[3] z");
+    }
+
+    #[test]
+    fn s19_empty_returns_marker() {
+        // A document with no `thebibliography` at all → the fixed `(no bibliography entries)` marker,
+        // never the empty string.
+        let src = r"\begin{document}
+Just some text with no bibliography.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entries(), "(no bibliography entries)");
+    }
+
+    #[test]
+    fn s19_is_additive_leaves_s1_s18_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a resolved `\ref`, a
+        // `\nameref`, two `\cite`s (one multi-key, one dangling key), a duplicate `\bibitem`, AND a
+        // dangling `\eqref` (`eq:ghost`), S19 changes NONE of the S1-S18 outputs — it only reads
+        // `resolve_citations`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+See Section~\ref{sec:intro}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+
+        // And S19 itself surfaces the winning entries as a numbered list — the duplicate `a` appears
+        // once (the winner), `b` and `c` follow, in source pre-order.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1534,3 +1534,75 @@ marker; a reference-free document returning the same marker; and an additivity c
 produce their exact prior strings). All prior S1–S17 tests pass unchanged. `cargo clippy -p latex
 --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo
 build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 25. S19 — numbered winning-bibliography-entry list (`bibliography_entries`)
+
+### 25.1 Motivation
+
+S2's `resolve_citations` returns `entries: Vec<BibEntry>` — the **winning** bibliography entries, one row
+per distinct citation key (the first `\bibitem{key}` seen), in body pre-order. This is the table
+citations resolve against, and it is exactly what a reader sees rendered as the document's bibliography.
+Yet no method rendered it: S16 (`duplicate_bibliography_entries`) renders the **losing**
+`duplicate_entries` as `\bibitem{key}` warning lines, and S15 (`citations_by_source`) renders the
+per-source *resolved cite keys* — neither shows the winning entries themselves. S19 fills the remaining
+cell of that view-matrix by rendering `entries` as a **numbered list**, the way a bibliography actually
+looks.
+
+### 25.2 Why a new method — additive by construction
+
+S19 adds a **new public method** `Document::bibliography_entries(&self) -> String`. It is a pure,
+read-only render of `resolve_citations().entries`. It reuses that table verbatim (never re-walking the
+body or re-collecting entries), so the report can never drift from the S2 resolution it summarises. It
+mutates nothing and changes no S1–S18 output — including `to_latex()`'s round-trip fixed point —
+byte-for-byte. Like S11–S18 it is a method the caller invokes directly.
+
+### 25.3 The numbering and ordering rule
+
+S2 collects every `\bibitem{key}` inside a `thebibliography` environment in body pre-order, keeping the
+**first** `\bibitem` of each distinct key in `entries` and routing every later re-definition into
+`duplicate_entries` (never into `entries`). S19 numbers `entries` **1-based** in that existing pre-order,
+emitting one line per winning entry. Because `entries` already holds only the first `\bibitem` of each
+key, a `\bibitem{dup}` written twice appears **once** — the winner — exactly as a real bibliography
+renders one line per key; its losing re-definitions remain the S16 view.
+
+### 25.4 The exact rendering contract — `Document::bibliography_entries(&self) -> String`
+
+- One numbered line per winning entry, **1-based**, in the existing pre-order (**not** re-sorted): the
+  n-th entry renders `format!("[{}] {}", n, entry.key)` → `[1] smith2020`, `[2] jones2019`, ….
+- Each line is reconstructed from the entry's owned `key` `String` rather than sliced from `&src[span]`
+  (matching S13 `resolve_namerefs`, S15 `citations_by_source`, S16 `duplicate_bibliography_entries`, and
+  S17/S18's dangling reports), so the render needs no source borrow and can never index out of bounds.
+- The `[n] key` shape is chosen **deliberately** so the winning list reads as a *rendered bibliography*
+  and is visually distinct from S16's `\bibitem{key}` losing-duplicate lines — the two never look alike
+  even when they list overlapping keys.
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S18 renderer).
+- If there are **no** bibliography entries (no `thebibliography`, or an empty one), the fixed marker
+  `(no bibliography entries)` is returned, so the output is never the empty string.
+
+Example (`thebibliography` defining `smith` twice and `jones` once):
+
+```text
+[1] smith
+[2] jones
+```
+
+the second `\bibitem{smith}` is a duplicate (the S16 view), not a second entry, so the winning list is
+two lines. This is distinct from S16's `\bibitem{smith}` losing-duplicate line, which renders the loser.
+
+### 25.5 Public API (added in S19)
+
+One new method: `Document::bibliography_entries(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_citations` and every S1–S18 method are unchanged; no AST or grammar change;
+no new dependency, no `unsafe`, no I/O.
+
+### 25.6 Verification (S19)
+
+`cargo test -p latex` green (5 new S19 tests: two distinct entries rendering `[1] a\n[2] b`; a duplicate
+key winning once with a peer rendering `[1] dup\n[2] other`; three entries numbered in pre-order
+rendering `[1] x\n[2] y\n[3] z`; a bibliography-free document returning the `(no bibliography entries)`
+marker; and an additivity check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`,
+`resolve_namerefs`, `list_summary`, `citations_by_source`, `duplicate_bibliography_entries`,
+`unresolved_citations_by_source`, and `unresolved_references_by_source` all still produce their exact
+prior strings). All prior S1–S18 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D
+warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex
+--no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S19 — list the winning bibliography entries as a numbered `[n] key` bibliography

Adds a new read-only method `Document::bibliography_entries(&self) -> String` to the `latex` crate — the **winning-entry** view of the citation resolution. Where S16 `duplicate_bibliography_entries` renders the *losing* (multiply-defined) `\bibitem`s and S15 `citations_by_source` renders the per-source `\cite` keys, S19 renders the **winning** bibliography entries — `resolve_citations().entries`, the first `\bibitem` of each distinct key in body pre-order, the table citations actually resolve against — as a **numbered `[n] key` bibliography**. Bumps `latex` **0.54.0 → 0.55.0**.

### What it does

S2's `resolve_citations` collects the winning bibliography entries into `CitationResolution::entries` (a `Vec<BibEntry>`, first-`\bibitem`-of-each-key, pre-order). No prior method rendered that winning list: S15 groups the *citing* `\cite` keys per source, S16 lists the *losing* duplicate `\bibitem`s. S19 fills the gap — the winning entries, numbered as a rendered bibliography looks.

| aspect | rule |
|---|---|
| line format | `[n] key` — 1-based ordinal + the entry's own `key` (e.g. `[1] smith2020`) |
| why numbered | deliberately **not** `\bibitem{key}` per line, so it is visually distinct from S16's losing-duplicate lines; this is the WINNING-entry view rendered like a real bibliography |
| source | reconstructed from the owned `key` String — **not** sliced from source |
| ordering | body pre-order (first-entry-wins order) |
| duplicates | a multiply-defined key appears **once** (only the winning first `\bibitem` is in `entries`; the losers live in `duplicate_entries`, S16's domain) |
| empty | fixed marker `(no bibliography entries)`, never `""` |
| joining | `\n`-joined, **no** trailing newline (matches S11–S18) |

Example — `\bibitem{smith2020}` then `\bibitem{jones2019}`:

```text
[1] smith2020
[2] jones2019
```

### Additive by construction

Brand-new, read-only method that reuses `resolve_citations` and mutates nothing. **Total & panic-free**: no source slicing/indexing, no `unwrap`/`expect`, no `unsafe`, a single pass over the already-bounded `entries` list, returning owned `String` data. All **S1–S18 outputs stay byte-for-byte unchanged**, pinned by a dedicated additivity test. The `to_latex` round-trip fixed point is untouched.

### Tests (exact strings, real output)

- `s19_lists_winning_entries` — two `\bibitem`s → `"[1] a\n[2] b"`
- `s19_only_first_of_duplicate_key_wins` — a duplicated key appears once in the winning list
- `s19_numbered_in_preorder` — three entries → `"[1] x\n[2] y\n[3] z"` in source order
- `s19_empty_returns_marker` — no bibliography → `"(no bibliography entries)"`
- `s19_is_additive_leaves_s1_s18_outputs_unchanged` — pins `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`, `duplicate_bibliography_entries`, `unresolved_citations_by_source`, and `unresolved_references_by_source`

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → all passing (S18 left it at 400; +5 S19) + doc-tests ok
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → all green (0 failed)
- `cargo build -p latex --no-default-features` → builds
- Inline security review PASSED (returned `String`, no injection sink; total/panic-free; same bounded rendering already shipped in S15/S16/S17/S18).
- Single-parent commit; scoped diff = 5 files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
