### PR TITLE
feat(visicalc-flutter): file open/save over the engine via dart:ffi bytes

### DIFF
--- a/code/programs/dart/visicalc-flutter/README.md
+++ b/code/programs/dart/visicalc-flutter/README.md
@@ -152,7 +152,22 @@ serialize the whole workbook (`InfiniteSheetModel.saveBook` over the C ABI's
 `sc_serialize`) to a JSON document held in memory and restore it
 (`loadBook` / `sc_deserialize`): the document captures only the source (formula
 text + typed literals) and per-cell formats — not the computed values, which the
-engine recomputes on load, so a loaded formula stays live. The **Undo / Redo**
+engine recomputes on load, so a loaded formula stays live. The **Save .xlsx /
+Open .xlsx / Save .csv / Open .csv** buttons open and save a **real spreadsheet
+file** over the engine's byte codecs: `InfiniteSheetModel.exportBytes(format)` /
+`importBytes(format, bytes)` bind the C ABI's `sc_save_<fmt>` / `sc_load_<fmt>`
+(`spreadsheet-capi`) through `dart:ffi`, so an `.xlsx` (a ZIP, with live formulas
+preserved) or a `.csv` (text, values only) crosses the boundary as **raw bytes**
+— a `(ptr, len)` pair, never a NUL-terminated string that a `0x00` inside a ZIP
+would truncate. The demo writes to / reads from a fixed path in the system temp
+dir (`visicalc-demo.xlsx` / `.csv`) and echoes the result in the status bar; a
+production host would swap the fixed path for an OS Save/Open dialog and hand the
+identical bytes across. All five formats the engine speaks — `.xlsx`, `.xls`,
+`.csv`, `.tsv`, `.json` — are bound on `SpreadsheetSession`
+(`loadXlsx`/`saveXlsx`/…); `test/file_io_test.dart` round-trips each headlessly
+(a saved `.xlsx` is asserted to begin with the ZIP magic `PK\x03\x04`, an `.xls`
+with the OLE2 magic `0xD0CF`, and every codec's values survive a reopen). The
+**Undo / Redo**
 buttons walk the engine's snapshot history (`InfiniteSheetModel.undoEdit`/
 `redoEdit` over the C ABI's `sc_undo`/`sc_redo`); they disable at the history
 ends via `canUndo`/`canRedo`. Every edit is reversible and a restored formula

--- a/code/programs/dart/visicalc-flutter/lib/engine.dart
+++ b/code/programs/dart/visicalc-flutter/lib/engine.dart
@@ -17,6 +17,7 @@ import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io' show Directory, File, Platform;
 import 'dart:math' show max;
+import 'dart:typed_data' show Uint8List;
 
 // ---------------------------------------------------------------------------
 // C ABI function signatures (see spreadsheet-capi/include/spreadsheet.h).
@@ -120,6 +121,28 @@ typedef _PasteD = int Function(Pointer<Void>, Pointer<Uint8>);
 typedef _FlagC = Int32 Function(Pointer<Void>);
 typedef _FlagD = int Function(Pointer<Void>);
 
+// ── File open / save — bytes in, bytes out (see spreadsheet.h) ────────
+// These are the first calls that carry RAW FILE BYTES, not NUL-terminated C
+// strings: an .xlsx is a ZIP, an .xls an OLE2 file, and either may contain a NUL
+// byte, so the bytes cross as an explicit (ptr, len) pair — never a `char*` that
+// a NUL would truncate. `size_t` is a native-word integer, so the FFI type is
+// `Size` (Dart `int` on the Dart side).
+//
+//   sc_load_<fmt>(session, bytes, len)  → int (1 opened / 0 not a readable file
+//                                         of that format; the doc is untouched
+//                                         on failure).
+//   sc_save_<fmt>(session, &out_len)    → uint8_t* heap buffer of *out_len bytes
+//                                         (NULL / 0 for an empty doc); free it
+//                                         with sc_bytes_free(ptr, out_len).
+typedef _LoadBytesC = Int32 Function(Pointer<Void>, Pointer<Uint8>, Size);
+typedef _LoadBytesD = int Function(Pointer<Void>, Pointer<Uint8>, int);
+typedef _SaveBytesC = Pointer<Uint8> Function(Pointer<Void>, Pointer<Size>);
+typedef _SaveBytesD = Pointer<Uint8> Function(Pointer<Void>, Pointer<Size>);
+// sc_bytes_free(ptr, len) → void. Frees a buffer an sc_save_* returned; the
+// (ptr, len) must match what that call wrote (the engine's allocator, NOT free).
+typedef _BytesFreeC = Void Function(Pointer<Uint8>, Size);
+typedef _BytesFreeD = void Function(Pointer<Uint8>, int);
+
 /// A single spreadsheet session, owning the opaque C handle.
 class SpreadsheetSession {
   final DynamicLibrary _lib;
@@ -158,6 +181,21 @@ class SpreadsheetSession {
   late final _FlagD _redoFn;
   late final _FlagD _canUndoFn;
   late final _FlagD _canRedoFn;
+  // File open / save — one (load, save) pair per format. The load takes file
+  // bytes and replaces the workbook; the save returns the workbook as that
+  // format's file bytes. .xlsx keeps live formulas; .xls/.csv/.tsv/.json are
+  // lower-fidelity (values only) per spreadsheet-io.
+  late final _LoadBytesD _loadXlsxFn;
+  late final _SaveBytesD _saveXlsxFn;
+  late final _LoadBytesD _loadXlsFn;
+  late final _SaveBytesD _saveXlsFn;
+  late final _LoadBytesD _loadCsvFn;
+  late final _SaveBytesD _saveCsvFn;
+  late final _LoadBytesD _loadTsvFn;
+  late final _SaveBytesD _saveTsvFn;
+  late final _LoadBytesD _loadJsonFn;
+  late final _SaveBytesD _saveJsonFn;
+  late final _BytesFreeD _bytesFreeFn;
   late final _NoArgD _usedRangeFn;
   late final _ColLettersD _columnLettersFn;
   late final _CurrentRevD _currentRevisionFn;
@@ -200,6 +238,17 @@ class SpreadsheetSession {
     _redoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_redo');
     _canUndoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_can_undo');
     _canRedoFn = _lib.lookupFunction<_FlagC, _FlagD>('sc_can_redo');
+    _loadXlsxFn = _lib.lookupFunction<_LoadBytesC, _LoadBytesD>('sc_load_xlsx');
+    _saveXlsxFn = _lib.lookupFunction<_SaveBytesC, _SaveBytesD>('sc_save_xlsx');
+    _loadXlsFn = _lib.lookupFunction<_LoadBytesC, _LoadBytesD>('sc_load_xls');
+    _saveXlsFn = _lib.lookupFunction<_SaveBytesC, _SaveBytesD>('sc_save_xls');
+    _loadCsvFn = _lib.lookupFunction<_LoadBytesC, _LoadBytesD>('sc_load_csv');
+    _saveCsvFn = _lib.lookupFunction<_SaveBytesC, _SaveBytesD>('sc_save_csv');
+    _loadTsvFn = _lib.lookupFunction<_LoadBytesC, _LoadBytesD>('sc_load_tsv');
+    _saveTsvFn = _lib.lookupFunction<_SaveBytesC, _SaveBytesD>('sc_save_tsv');
+    _loadJsonFn = _lib.lookupFunction<_LoadBytesC, _LoadBytesD>('sc_load_json');
+    _saveJsonFn = _lib.lookupFunction<_SaveBytesC, _SaveBytesD>('sc_save_json');
+    _bytesFreeFn = _lib.lookupFunction<_BytesFreeC, _BytesFreeD>('sc_bytes_free');
     _usedRangeFn = _lib.lookupFunction<_NoArgC, _NoArgD>('sc_used_range');
     _columnLettersFn = _lib.lookupFunction<_ColLettersC, _ColLettersD>('sc_column_letters');
     _currentRevisionFn = _lib.lookupFunction<_CurrentRevC, _CurrentRevD>('sc_current_revision');
@@ -558,6 +607,74 @@ class SpreadsheetSession {
     }
   }
 
+  // ── File open / save — bytes in, bytes out ───────────────────────────
+  // Unlike every other call above, these carry RAW FILE BYTES: an .xlsx is a
+  // ZIP, an .xls an OLE2 file, and either may hold a NUL byte, so we must NOT
+  // route them through _toCString/_takeString (which stop at the first NUL).
+  // We hand the load a (buffer, length) pair, and copy the save's (ptr, length)
+  // out before freeing the engine's buffer with its own allocator.
+
+  /// Load [bytes] as a file of the given format, replacing the workbook via the
+  /// C ABI `fn` (one of sc_load_xlsx/xls/csv/tsv/json). Returns `true` if opened,
+  /// `false` if the bytes aren't a readable file of that format (the workbook is
+  /// left untouched — the engine validates before it mutates). Empty input is a
+  /// no-op `false`. The buffer goes through libc malloc/free like every other
+  /// string we pass INTO the engine, but is filled by raw byte copy (no NUL
+  /// terminator — the length is explicit).
+  bool _loadBytes(_LoadBytesD fn, Uint8List bytes) {
+    if (bytes.isEmpty) return false;
+    final buf = _malloc(bytes.length);
+    buf.asTypedList(bytes.length).setRange(0, bytes.length, bytes);
+    try {
+      return fn(_handle, buf, bytes.length) != 0;
+    } finally {
+      _freeCString(buf);
+    }
+  }
+
+  /// Serialize the workbook to the given format's file bytes via the C ABI `fn`
+  /// (one of sc_save_xlsx/xls/csv/tsv/json). Returns an empty list for an empty
+  /// document. The engine hands back a heap buffer as a (ptr, out_len) pair; we
+  /// COPY those bytes into a Dart-owned Uint8List before releasing the engine's
+  /// buffer with sc_bytes_free (its allocator — never libc free), so no engine
+  /// memory outlives this call. The out-length cell is a single native-word slot
+  /// we borrow from libc malloc.
+  Uint8List _saveBytes(_SaveBytesD fn) {
+    final lenPtr = _malloc(sizeOf<Size>()).cast<Size>();
+    try {
+      final ptr = fn(_handle, lenPtr);
+      final len = lenPtr.value;
+      if (ptr == nullptr || len == 0) {
+        if (ptr != nullptr) _bytesFreeFn(ptr, len);
+        return Uint8List(0);
+      }
+      final out = Uint8List.fromList(ptr.asTypedList(len)); // copy before free
+      _bytesFreeFn(ptr, len);
+      return out;
+    } finally {
+      _free(lenPtr.cast());
+    }
+  }
+
+  /// Open a real spreadsheet file the user picked, over the one engine. `.xlsx`
+  /// reloads live formulas; `.xls`/CSV/TSV/JSON are values-only. Each returns
+  /// `true` on success, `false` if the bytes aren't a readable file of that
+  /// format (the workbook is left untouched).
+  bool loadXlsx(Uint8List bytes) => _loadBytes(_loadXlsxFn, bytes);
+  bool loadXls(Uint8List bytes) => _loadBytes(_loadXlsFn, bytes);
+  bool loadCsv(Uint8List bytes) => _loadBytes(_loadCsvFn, bytes);
+  bool loadTsv(Uint8List bytes) => _loadBytes(_loadTsvFn, bytes);
+  bool loadJson(Uint8List bytes) => _loadBytes(_loadJsonFn, bytes);
+
+  /// Serialize the current document to a file's bytes in each format — what a
+  /// host writes to disk / hands to a download. An empty document yields an
+  /// empty list.
+  Uint8List saveXlsx() => _saveBytes(_saveXlsxFn);
+  Uint8List saveXls() => _saveBytes(_saveXlsFn);
+  Uint8List saveCsv() => _saveBytes(_saveCsvFn);
+  Uint8List saveTsv() => _saveBytes(_saveTsvFn);
+  Uint8List saveJson() => _saveBytes(_saveJsonFn);
+
   /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
   /// changed the document (the host then re-reads the viewport), `false` if there
   /// was nothing to do. canUndo/canRedo gate a host's Undo/Redo controls.
@@ -901,6 +1018,59 @@ class InfiniteSheetModel {
   String saveBook() => _session.serialize();
   bool loadBook(String data) {
     final ok = _session.deserialize(data);
+    if (ok) {
+      computeExtent();
+      formula = _session.getRaw(infAddress);
+    }
+    return ok;
+  }
+
+  /// The spreadsheet file formats the demo can open / save, in menu order. The
+  /// canonical extension doubles as the format key passed to [exportBytes] /
+  /// [importBytes].
+  static const List<String> fileFormats = ['xlsx', 'xls', 'csv', 'tsv', 'json'];
+
+  /// Export the whole workbook to a real spreadsheet file's bytes in [format]
+  /// (one of [fileFormats]) — the same bytes the web download and the native
+  /// hosts write. `.xlsx` keeps live formulas; the rest are values-only. An
+  /// unknown format or empty document yields an empty list.
+  Uint8List exportBytes(String format) {
+    switch (format) {
+      case 'xlsx':
+        return _session.saveXlsx();
+      case 'xls':
+        return _session.saveXls();
+      case 'csv':
+        return _session.saveCsv();
+      case 'tsv':
+        return _session.saveTsv();
+      case 'json':
+        return _session.saveJson();
+      default:
+        return Uint8List(0);
+    }
+  }
+
+  /// Import a real spreadsheet file's [bytes] of [format] (one of [fileFormats]),
+  /// replacing the workbook. Returns `false` (workbook untouched) if the bytes
+  /// aren't a readable file of that format or the format is unknown. On success
+  /// it regrows the extent and refreshes the formula bar so the view re-reads.
+  bool importBytes(String format, Uint8List bytes) {
+    final bool ok;
+    switch (format) {
+      case 'xlsx':
+        ok = _session.loadXlsx(bytes);
+      case 'xls':
+        ok = _session.loadXls(bytes);
+      case 'csv':
+        ok = _session.loadCsv(bytes);
+      case 'tsv':
+        ok = _session.loadTsv(bytes);
+      case 'json':
+        ok = _session.loadJson(bytes);
+      default:
+        ok = false;
+    }
     if (ok) {
       computeExtent();
       formula = _session.getRaw(infAddress);

--- a/code/programs/dart/visicalc-flutter/lib/infinite_grid.dart
+++ b/code/programs/dart/visicalc-flutter/lib/infinite_grid.dart
@@ -27,6 +27,8 @@
 //   • body vertical scroll  → gutter.jumpTo(offset)   (gutter follows ↕)
 //   • body horizontal scroll → header.jumpTo(offset)  (header follows ↔)
 
+import 'dart:io' show Directory, File;
+
 import 'package:flutter/material.dart';
 import 'engine.dart';
 
@@ -88,6 +90,21 @@ class _InfiniteGridState extends State<InfiniteGrid> {
   // this string to a file; the demo keeps the round trip self-contained.)
   String _savedSnapshot = '';
 
+  // The most recent File → Save / Open result, echoed in the status bar (e.g.
+  // "saved 4.2 KB → visicalc-demo.xlsx" / "opened visicalc-demo.csv"). Empty
+  // until the first file action.
+  String _fileMsg = '';
+
+  // A PRIVATE per-session scratch directory for the File → Save / Open demo,
+  // created lazily on first use with `createTemp` (mode 0700 on POSIX). Writing
+  // into our own freshly-made directory — rather than a fixed name in the shared,
+  // world-writable system temp root (/tmp, mode 1777) — avoids a local
+  // symlink-clobber on save and keeps the file from being world-readable, while
+  // still letting Open read back what Save wrote (it's a stable per-session dir).
+  Directory? _fileDir;
+  Directory get _scratchDir =>
+      _fileDir ??= Directory.systemTemp.createTempSync('visicalc-');
+
   @override
   void initState() {
     super.initState();
@@ -118,6 +135,10 @@ class _InfiniteGridState extends State<InfiniteGrid> {
     _formulaFocus.dispose();
     _findCtrl.dispose();
     _replaceCtrl.dispose();
+    // Best-effort cleanup of the private scratch dir (the OS also reclaims temp).
+    try {
+      _fileDir?.deleteSync(recursive: true);
+    } catch (_) {/* already gone / racing OS cleanup — ignore */}
     _model.dispose();
     super.dispose();
   }
@@ -160,6 +181,43 @@ class _InfiniteGridState extends State<InfiniteGrid> {
       _formulaCtrl.text = _model.formula;
     });
   }
+
+  // ── File → Save / Open a REAL spreadsheet file on disk ────────────────
+  // Unlike the in-memory Save / Load above, these write and read an actual file
+  // — an .xlsx (a ZIP, keeping live formulas) or a .csv (text, values only) —
+  // proving the engine's file codecs cross dart:ffi as raw bytes. The demo uses
+  // a fixed path in the system temp dir (no plugin file picker); a production
+  // host would swap in an OS Save/Open dialog and hand the same bytes across.
+  String _demoPath(String ext) => '${_scratchDir.path}/visicalc-demo.$ext';
+
+  // Serialize the workbook to `format` bytes and write them to the demo path.
+  void _exportFile(String format, String ext) {
+    final bytes = _model.exportBytes(format);
+    final path = _demoPath(ext);
+    File(path).writeAsBytesSync(bytes);
+    final kb = (bytes.length / 1024).toStringAsFixed(1);
+    setState(() => _fileMsg = 'saved $kb KB → ${_baseName(path)}');
+  }
+
+  // Read the demo path's bytes back and open them as `format`, replacing the
+  // workbook. Reports "no <file> yet" if it was never saved, or "not a valid
+  // <ext>" if the engine rejects the bytes (the workbook is left untouched).
+  void _openFile(String format, String ext) {
+    final file = File(_demoPath(ext));
+    if (!file.existsSync()) {
+      setState(() => _fileMsg = 'no ${_baseName(file.path)} yet — Save first');
+      return;
+    }
+    final ok = _model.importBytes(format, file.readAsBytesSync());
+    setState(() {
+      _formulaCtrl.text = _model.formula;
+      _fileMsg = ok
+          ? 'opened ${_baseName(file.path)}'
+          : 'not a valid $ext file';
+    });
+  }
+
+  static String _baseName(String path) => path.split('/').last;
 
   // Undo / redo: walk the engine's snapshot history. On success the whole grid
   // re-reads and the formula bar re-syncs; the buttons disable at the history
@@ -438,11 +496,30 @@ class _InfiniteGridState extends State<InfiniteGrid> {
               'Paste the clipboard at the selected cell, shifting relative references',
               _paste),
           _toolSep(),
-          // ── File (save / load) ──
+          // ── File (save / load to memory) ──
           _toolButton('Save', 'Serialize the whole workbook to memory', _save),
           const SizedBox(width: 6),
           _toolButton('Load', 'Restore the workbook from the last save', _load,
               enabled: _savedSnapshot.isNotEmpty),
+          _toolSep(),
+          // ── File → open / save a REAL file on disk (over the engine's byte
+          //    codecs, across dart:ffi): an .xlsx (ZIP, live formulas) and a
+          //    .csv (text, values only). ──
+          _toolButton('Save .xlsx',
+              'Write the workbook to visicalc-demo.xlsx (a real ZIP; keeps live formulas)',
+              () => _exportFile('xlsx', 'xlsx')),
+          const SizedBox(width: 6),
+          _toolButton('Open .xlsx',
+              'Reopen visicalc-demo.xlsx over the engine (reloads live formulas)',
+              () => _openFile('xlsx', 'xlsx')),
+          const SizedBox(width: 6),
+          _toolButton('Save .csv',
+              'Write the workbook to visicalc-demo.csv (values only)',
+              () => _exportFile('csv', 'csv')),
+          const SizedBox(width: 6),
+          _toolButton('Open .csv',
+              'Reopen visicalc-demo.csv over the engine (values only)',
+              () => _openFile('csv', 'csv')),
           _toolSep(),
           // ── Structure (insert / delete the selected row or column) ──
           _toolButton('+ Row',
@@ -583,7 +660,8 @@ class _InfiniteGridState extends State<InfiniteGrid> {
           padding: const EdgeInsets.fromLTRB(10, 6, 10, 10),
           child: Text(
             'Virtual grid: ${_model.totalRows} rows × ${_model.totalCols} cols'
-            '  ·  revision ${_model.revision}',
+            '  ·  revision ${_model.revision}'
+            '${_fileMsg.isEmpty ? '' : '  ·  $_fileMsg'}',
             style: const TextStyle(color: _cMuted, fontSize: 12, fontFamily: _mono),
           ),
         ),

--- a/code/programs/dart/visicalc-flutter/test/file_io_test.dart
+++ b/code/programs/dart/visicalc-flutter/test/file_io_test.dart
@@ -1,0 +1,144 @@
+// file_io_test.dart — headless proof that the Flutter VisiCalc demo can open and
+// save real spreadsheet FILES over the shared Rust engine, with no widgets in
+// the loop. The Dart sibling of the C-ABI's own round-trip tests: it drives the
+// dart:ffi byte bindings (sc_load_*/sc_save_*/sc_bytes_free) end to end.
+//
+// Run (after `bash scripts/build.sh` has vendored native/libspreadsheet_capi.*):
+//   flutter test test/file_io_test.dart
+//
+// A green run proves the Dart ↔ C ABI ↔ Rust byte path: raw file bytes (a ZIP
+// for .xlsx, an OLE2 file for .xls, text for CSV/TSV/JSON) cross the boundary
+// intact — including bytes a NUL-terminated string would have truncated.
+
+import 'dart:typed_data' show Uint8List;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:visicalc_flutter/engine.dart';
+
+void main() {
+  // A tiny workbook with one live formula, so we can tell a values-only codec
+  // (CSV/TSV/JSON/.xls) from a formula-preserving one (.xlsx) after a round trip.
+  SpreadsheetSession seeded() {
+    final s = SpreadsheetSession();
+    s.setCell('A1', '15');
+    s.setCell('B1', '3');
+    s.setCell('C1', '=A1+B1'); // 18
+    return s;
+  }
+
+  group('file open / save over the Rust engine (dart:ffi bytes)', () {
+    test('.xlsx save is a real ZIP and reload keeps the live formula', () {
+      final src = seeded();
+      addTearDown(src.dispose);
+      final bytes = src.saveXlsx();
+
+      // A non-empty buffer beginning with the ZIP local-file magic "PK\x03\x04"
+      // — proof the raw binary crossed FFI without NUL truncation.
+      expect(bytes.length, greaterThan(4));
+      expect(bytes.sublist(0, 4), <int>[0x50, 0x4B, 0x03, 0x04]);
+
+      final dst = SpreadsheetSession();
+      addTearDown(dst.dispose);
+      expect(dst.loadXlsx(bytes), isTrue);
+      expect(dst.getRaw('C1'), '=A1+B1'); // formula survives .xlsx
+      expect(dst.display('C1'), '18'); // and still computes
+    });
+
+    test('.xls save is a real OLE2 file (0xD0CF magic) and reloads values', () {
+      final src = seeded();
+      addTearDown(src.dispose);
+      final bytes = src.saveXls();
+
+      expect(bytes.length, greaterThan(8));
+      // OLE2 / Compound File Binary signature D0 CF 11 E0 — the high bit in 0xD0
+      // is exactly what a lossy UTF-8 string round trip would have mangled.
+      expect(bytes.sublist(0, 4), <int>[0xD0, 0xCF, 0x11, 0xE0]);
+
+      final dst = SpreadsheetSession();
+      addTearDown(dst.dispose);
+      expect(dst.loadXls(bytes), isTrue);
+      expect(dst.display('C1'), '18'); // values-only, but the value is right
+    });
+
+    test('CSV / TSV / JSON round-trip a header + data row', () {
+      // These three are values-only tabular codecs. JSON's canonical shape is an
+      // array of objects, so row 1 is the HEADER (the keys) and row 2 the first
+      // data record; CSV/TSV are positional grids. A header row + one data row
+      // round-trips consistently through all three: the header lands back on
+      // row 1, the data on row 2.
+      SpreadsheetSession table() {
+        final s = SpreadsheetSession();
+        s.setCell('A1', 'qty'); // header labels (text)
+        s.setCell('B1', 'unit');
+        s.setCell('C1', 'total');
+        s.setCell('A2', '15'); // one data row
+        s.setCell('B2', '3');
+        s.setCell('C2', '=A2*B2'); // 45 — a formula the codec stores as its value
+        return s;
+      }
+
+      for (final format in const ['csv', 'tsv', 'json']) {
+        final src = table();
+        final bytes = src.exportBytesForFormat(format);
+        src.dispose();
+        expect(bytes.isNotEmpty, isTrue, reason: '$format save produced bytes');
+
+        final dst = SpreadsheetSession();
+        expect(dst.loadForFormat(format, bytes), isTrue,
+            reason: '$format reopened');
+        expect(dst.display('A1'), 'qty', reason: '$format header round-tripped');
+        expect(dst.display('C2'), '45', reason: '$format value round-tripped');
+        dst.dispose();
+      }
+    });
+
+    test('a bad payload is rejected and leaves the workbook untouched', () {
+      final s = seeded();
+      addTearDown(s.dispose);
+      // Not a ZIP — .xlsx open must fail (return false) without disturbing C1.
+      expect(s.loadXlsx(Uint8List.fromList('not a spreadsheet'.codeUnits)),
+          isFalse);
+      expect(s.display('C1'), '18');
+      // Empty input is a no-op false, too.
+      expect(s.loadCsv(Uint8List(0)), isFalse);
+      expect(s.display('C1'), '18');
+    });
+
+    test('the model exposes format-parameterised export / import', () {
+      final model = InfiniteSheetModel();
+      addTearDown(model.dispose);
+      for (final format in InfiniteSheetModel.fileFormats) {
+        final bytes = model.exportBytes(format);
+        expect(bytes.isNotEmpty, isTrue, reason: '$format export');
+        expect(model.importBytes(format, bytes), isTrue,
+            reason: '$format import');
+      }
+      // An unknown format is a safe no-op both ways.
+      expect(model.exportBytes('numbers').isEmpty, isTrue);
+      expect(model.importBytes('numbers', Uint8List.fromList([1, 2, 3])),
+          isFalse);
+    });
+  });
+}
+
+// Small test-only shims so the round-trip loop can pick a codec by name without
+// re-implementing the switch the model already has.
+extension _FormatDispatch on SpreadsheetSession {
+  Uint8List exportBytesForFormat(String format) => switch (format) {
+        'xlsx' => saveXlsx(),
+        'xls' => saveXls(),
+        'csv' => saveCsv(),
+        'tsv' => saveTsv(),
+        'json' => saveJson(),
+        _ => Uint8List(0),
+      };
+
+  bool loadForFormat(String format, Uint8List bytes) => switch (format) {
+        'xlsx' => loadXlsx(bytes),
+        'xls' => loadXls(bytes),
+        'csv' => loadCsv(bytes),
+        'tsv' => loadTsv(bytes),
+        'json' => loadJson(bytes),
+        _ => false,
+      };
+}


### PR DESCRIPTION
## What

Binds the spreadsheet C ABI's byte-based file codecs (`sc_load_<fmt>` / `sc_save_<fmt>` / `sc_bytes_free`) through **dart:ffi**, so the Flutter VisiCalc demo can **open and save real spreadsheet files** — `.xlsx` / `.xls` / `.csv` / `.tsv` / `.json` — over the one shared Rust engine. This is the **Dart arm** of the same open/save story the web (WASM) and native (C ABI / JNI) hosts already have.

## Why it matters

These are the first calls that carry **raw file bytes**, not NUL-terminated C strings: an `.xlsx` is a ZIP, an `.xls` an OLE2 file, and either may contain a `0x00`. So the bytes cross as an explicit `(ptr, len)` pair — never a `char*` a NUL would truncate.

## Changes

- **`lib/engine.dart`** — new `(load, save)` FFI typedefs (`Size` for `size_t`). `_loadBytes` fills a libc buffer by raw copy and frees it once; `_saveBytes` copies the engine's `(ptr, out_len)` buffer into a Dart-owned `Uint8List` **before** releasing it with `sc_bytes_free` (the engine's allocator, never libc `free`). Public `loadXlsx`/`saveXlsx`/… per format on `SpreadsheetSession`.
- **`InfiniteSheetModel.exportBytes(format)` / `importBytes(format, bytes)`** — format-parameterised open/save that regrows the extent + refreshes the formula bar.
- **`lib/infinite_grid.dart`** — Save/Open `.xlsx` and `.csv` toolbar buttons that write/read a real file on disk over the byte codecs, with a status-bar echo. Writes into a **private per-session temp dir** (`createTemp`, mode 0700) rather than a fixed name in the shared temp root, so there's no local symlink-clobber and the file isn't world-readable. (A production host swaps the fixed path for an OS Save/Open dialog; the bytes cross identically.)
- **`test/file_io_test.dart`** — headless round-trips for all five formats: asserts a saved `.xlsx` begins with the ZIP magic `PK\x03\x04`, an `.xls` with the OLE2 magic `0xD0CF`, values survive a reopen, and a bad/empty payload is rejected with the workbook left untouched.
- **README** — documents the feature.

## Verification

- `flutter analyze` clean (only pre-existing generated-file warnings).
- `flutter test` green — **31 tests**, including the 5 new file round-trips — against the vendored host engine (`bash scripts/build.sh`).
- Security review passed: FFI memory-safety surface confirmed correct (single alloc/free, copy-before-free, engine allocator not crossed, NUL-safe, rejected-load no-op). The one LOW finding (predictable shared-temp path) is fixed by the private-temp-dir change above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)