### PR TITLE
feat(visicalc-xaml): file open/save over the engine via P/Invoke bytes

### DIFF
--- a/code/programs/csharp/visicalc-xaml/Engine.cs
+++ b/code/programs/csharp/visicalc-xaml/Engine.cs
@@ -136,6 +136,29 @@ internal static class ScNative
         [MarshalAs(UnmanagedType.LPUTF8Str)] string newName);
     [DllImport("spreadsheet_capi")] internal static extern int sc_delete_sheet(IntPtr s, uint index);
 
+    // ── File open / save — bytes in, bytes out (see spreadsheet.h) ──
+    // The first calls that carry RAW FILE BYTES, not a NUL-terminated char*: an
+    // .xlsx is a ZIP, an .xls an OLE2 file, and either may contain a 0x00 byte,
+    // so the bytes cross as an explicit (bytes, len) pair. `size_t` maps to
+    // `nuint` (a native-word unsigned int). A `byte[]` in-parameter is marshalled
+    // as a pinned pointer to its first element; the sc_save_* results come back
+    // as a raw IntPtr + an out length, copied out and freed with sc_bytes_free.
+    //   sc_load_<fmt>(s, bytes, len) -> 1 opened / 0 not a readable file (or NULL s).
+    //   sc_save_<fmt>(s, &out_len)   -> heap uint8_t* of *out_len bytes (NULL/0 empty).
+    [DllImport("spreadsheet_capi")] internal static extern int sc_load_xlsx(IntPtr s, byte[] bytes, nuint len);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_save_xlsx(IntPtr s, out nuint outLen);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_load_xls(IntPtr s, byte[] bytes, nuint len);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_save_xls(IntPtr s, out nuint outLen);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_load_csv(IntPtr s, byte[] bytes, nuint len);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_save_csv(IntPtr s, out nuint outLen);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_load_tsv(IntPtr s, byte[] bytes, nuint len);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_save_tsv(IntPtr s, out nuint outLen);
+    [DllImport("spreadsheet_capi")] internal static extern int sc_load_json(IntPtr s, byte[] bytes, nuint len);
+    [DllImport("spreadsheet_capi")] internal static extern IntPtr sc_save_json(IntPtr s, out nuint outLen);
+    // Free a buffer an sc_save_* returned — (ptr, len) must match what it wrote
+    // (the engine's allocator, NOT the CLR / C free). Safe with (NULL, 0).
+    [DllImport("spreadsheet_capi")] internal static extern void sc_bytes_free(IntPtr ptr, nuint len);
+
     [DllImport("spreadsheet_capi")] internal static extern void sc_string_free(IntPtr p);
 
     /// Resolve the vendored engine library: an explicit CAPI_LIB env var, or
@@ -248,6 +271,66 @@ public sealed class SpreadsheetSession : IDisposable
     /// workbook is left untouched — the engine validates before it mutates).
     /// Formulas reload live.
     public bool Deserialize(string data) => ScNative.sc_deserialize(_handle, data) != 0;
+
+    // ── File open / save — bytes in, bytes out ────────────────────────
+    // Unlike every other call, these carry RAW FILE BYTES (a ZIP for .xlsx, an
+    // OLE2 file for .xls, text for CSV/TSV/JSON), which may contain a 0x00 — so
+    // they must NOT go through the char*/PtrToStringUTF8 path (which stops at the
+    // first NUL). A load hands the engine a (byte[], len) pair; a save copies the
+    // engine's (ptr, out_len) buffer into a managed byte[] BEFORE releasing it
+    // with sc_bytes_free (the engine's allocator — never the CLR / C free).
+    private delegate int LoadFn(IntPtr s, byte[] bytes, nuint len);
+    private delegate IntPtr SaveFn(IntPtr s, out nuint outLen);
+
+    private bool LoadBytes(LoadFn fn, byte[] bytes)
+    {
+        // Empty input is a safe no-op: nothing to open, and a zero-length array
+        // could otherwise marshal to a pointer the engine would read a slice from.
+        if (bytes is null || bytes.Length == 0) return false;
+        return fn(_handle, bytes, (nuint)bytes.Length) != 0;
+    }
+
+    private byte[] SaveBytes(SaveFn fn)
+    {
+        IntPtr ptr = fn(_handle, out nuint outLen);
+        if (ptr == IntPtr.Zero || outLen == 0)
+        {
+            if (ptr != IntPtr.Zero) ScNative.sc_bytes_free(ptr, outLen); // free a 0-len buffer
+            return Array.Empty<byte>();
+        }
+        // Marshal.Copy takes an int length. A spreadsheet file never approaches
+        // 2 GiB here, but if one somehow did, free the engine buffer BEFORE we
+        // bail — a checked cast that throws first would leak it.
+        if (outLen > int.MaxValue)
+        {
+            ScNative.sc_bytes_free(ptr, outLen);
+            throw new InvalidOperationException($"saved file too large to marshal: {outLen} bytes");
+        }
+        int len = (int)outLen;
+        var managed = new byte[len];
+        Marshal.Copy(ptr, managed, 0, len); // COPY out before we free the engine buffer
+        ScNative.sc_bytes_free(ptr, outLen);
+        return managed;
+    }
+
+    /// Open a real spreadsheet file the user picked, over the one engine. `.xlsx`
+    /// reloads live formulas; `.xls`/CSV/TSV/JSON are values-only. Each returns
+    /// `true` on success, `false` if the bytes aren't a readable file of that
+    /// format (the workbook is left untouched) or the input is empty.
+    public bool LoadXlsx(byte[] bytes) => LoadBytes(ScNative.sc_load_xlsx, bytes);
+    public bool LoadXls(byte[] bytes) => LoadBytes(ScNative.sc_load_xls, bytes);
+    public bool LoadCsv(byte[] bytes) => LoadBytes(ScNative.sc_load_csv, bytes);
+    public bool LoadTsv(byte[] bytes) => LoadBytes(ScNative.sc_load_tsv, bytes);
+    public bool LoadJson(byte[] bytes) => LoadBytes(ScNative.sc_load_json, bytes);
+
+    /// Serialize the current document to a file's bytes in each format — what a
+    /// host writes to disk / hands to a Save dialog. An empty document yields an
+    /// empty array.
+    public byte[] SaveXlsx() => SaveBytes(ScNative.sc_save_xlsx);
+    public byte[] SaveXls() => SaveBytes(ScNative.sc_save_xls);
+    public byte[] SaveCsv() => SaveBytes(ScNative.sc_save_csv);
+    public byte[] SaveTsv() => SaveBytes(ScNative.sc_save_tsv);
+    public byte[] SaveJson() => SaveBytes(ScNative.sc_save_json);
 
     /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
     /// changed the document (the host then re-reads the viewport), `false` if
@@ -767,6 +850,49 @@ public sealed class InfiniteSheetModel : IDisposable
     public bool LoadBook(string data)
     {
         bool ok = _session.Deserialize(data);
+        if (ok)
+        {
+            ComputeExtent();
+            Formula = _session.GetRaw(InfAddress);
+        }
+        return ok;
+    }
+
+    /// The spreadsheet file formats the demo can open / save, in menu order. The
+    /// canonical extension doubles as the format key for <see cref="ExportBytes"/>
+    /// / <see cref="ImportBytes"/>.
+    public static readonly string[] FileFormats = { "xlsx", "xls", "csv", "tsv", "json" };
+
+    /// Export the whole workbook to a real spreadsheet file's bytes in `format`
+    /// (one of <see cref="FileFormats"/>) — the same bytes the web download and
+    /// the other native hosts write. `.xlsx` keeps live formulas; the rest are
+    /// values-only. An unknown format or empty document yields an empty array.
+    public byte[] ExportBytes(string format) => format switch
+    {
+        "xlsx" => _session.SaveXlsx(),
+        "xls" => _session.SaveXls(),
+        "csv" => _session.SaveCsv(),
+        "tsv" => _session.SaveTsv(),
+        "json" => _session.SaveJson(),
+        _ => Array.Empty<byte>(),
+    };
+
+    /// Import a real spreadsheet file's `bytes` of `format` (one of
+    /// <see cref="FileFormats"/>), replacing the workbook. Returns `false`
+    /// (workbook untouched) if the bytes aren't a readable file of that format or
+    /// the format is unknown. On success it regrows the extent and refreshes the
+    /// formula bar so the view re-reads.
+    public bool ImportBytes(string format, byte[] bytes)
+    {
+        bool ok = format switch
+        {
+            "xlsx" => _session.LoadXlsx(bytes),
+            "xls" => _session.LoadXls(bytes),
+            "csv" => _session.LoadCsv(bytes),
+            "tsv" => _session.LoadTsv(bytes),
+            "json" => _session.LoadJson(bytes),
+            _ => false,
+        };
         if (ok)
         {
             ComputeExtent();

--- a/code/programs/csharp/visicalc-xaml/InfiniteSheet.xaml
+++ b/code/programs/csharp/visicalc-xaml/InfiniteSheet.xaml
@@ -144,6 +144,26 @@
                             ToolTipService.ToolTip="Restore the workbook from the last save"
                             Click="LoadButton_Click"/>
                     <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
+                    <!-- File -> open / save a REAL file on disk (over the engine's
+                         byte codecs, across P/Invoke): an .xlsx (ZIP, live
+                         formulas) and a .csv (text, values only). -->
+                    <Button x:Name="SaveXlsxButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Save .xlsx"
+                            ToolTipService.ToolTip="Write the workbook to visicalc-demo.xlsx (a real ZIP; keeps live formulas)"
+                            Click="SaveXlsxButton_Click"/>
+                    <Button x:Name="OpenXlsxButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Open .xlsx"
+                            ToolTipService.ToolTip="Reopen visicalc-demo.xlsx over the engine (reloads live formulas)"
+                            Click="OpenXlsxButton_Click"/>
+                    <Button x:Name="SaveCsvButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
+                            Content="Save .csv"
+                            ToolTipService.ToolTip="Write the workbook to visicalc-demo.csv (values only)"
+                            Click="SaveCsvButton_Click"/>
+                    <Button x:Name="OpenCsvButton" Style="{StaticResource ToolChip}"
+                            Content="Open .csv"
+                            ToolTipService.ToolTip="Reopen visicalc-demo.csv over the engine (values only)"
+                            Click="OpenCsvButton_Click"/>
+                    <Border Width="1" Height="22" Margin="6,0,6,0" Background="#2C313A"/>
                     <!-- Structure (insert / delete the selected row or column) -->
                     <Button x:Name="InsRowButton" Style="{StaticResource ToolChip}" Margin="0,0,6,0"
                             Content="+ Row"

--- a/code/programs/csharp/visicalc-xaml/InfiniteSheet.xaml.cs
+++ b/code/programs/csharp/visicalc-xaml/InfiniteSheet.xaml.cs
@@ -65,6 +65,22 @@ public sealed partial class InfiniteSheet : UserControl
 
     /// Short find/replace status (match/replace count) echoed in the footer.
     private string _findStatus = string.Empty;
+
+    /// The most recent File → Save / Open result, echoed in the footer.
+    private string _fileStatus = string.Empty;
+
+    /// A PRIVATE per-session scratch directory for the File → Save / Open demo,
+    /// created lazily with CreateTempSubdirectory (mode 0700 on Unix). Writing
+    /// into our own freshly-made directory — rather than a fixed name in the
+    /// shared, world-writable system temp root — avoids a local symlink-clobber
+    /// on save and keeps the file from being world-readable, while still letting
+    /// Open read back what Save wrote (a stable per-session dir).
+    private string? _fileDir;
+    private string ScratchDir => _fileDir ??=
+        System.IO.Directory.CreateTempSubdirectory("visicalc-").FullName;
+    private string DemoPath(string ext) =>
+        System.IO.Path.Combine(ScratchDir, $"visicalc-demo.{ext}");
+
     private ScrollViewer? _bodyInnerSv, _gutterInnerSv;
 
     public InfiniteSheet()
@@ -422,6 +438,47 @@ public sealed partial class InfiniteSheet : UserControl
         }
     }
 
+    // ── File → Save / Open a REAL spreadsheet file on disk ────────────
+    // Unlike the in-memory Save / Load above, these write and read an actual file
+    // — an .xlsx (a ZIP, keeping live formulas) or a .csv (text, values only) —
+    // over the engine's byte codecs (InfiniteSheetModel.ExportBytes/ImportBytes
+    // → sc_save_*/sc_load_*), proving file bytes cross P/Invoke intact. The demo
+    // uses a fixed name in a private per-session temp dir (no OS picker); a
+    // production host would swap in a FileSavePicker / FileOpenPicker and hand the
+    // same bytes across.
+    private void SaveXlsxButton_Click(object sender, RoutedEventArgs e) => ExportFile("xlsx");
+    private void OpenXlsxButton_Click(object sender, RoutedEventArgs e) => OpenFile("xlsx");
+    private void SaveCsvButton_Click(object sender, RoutedEventArgs e) => ExportFile("csv");
+    private void OpenCsvButton_Click(object sender, RoutedEventArgs e) => OpenFile("csv");
+
+    private void ExportFile(string format)
+    {
+        byte[] bytes = _model.ExportBytes(format);
+        string path = DemoPath(format);
+        System.IO.File.WriteAllBytes(path, bytes);
+        _fileStatus = $"saved {bytes.Length / 1024.0:0.0} KB → {System.IO.Path.GetFileName(path)}";
+        UpdateStatus();
+    }
+
+    private void OpenFile(string format)
+    {
+        string path = DemoPath(format);
+        if (!System.IO.File.Exists(path))
+        {
+            _fileStatus = $"no {System.IO.Path.GetFileName(path)} yet — Save first";
+            UpdateStatus();
+            return;
+        }
+        bool ok = _model.ImportBytes(format, System.IO.File.ReadAllBytes(path));
+        _fileStatus = ok ? $"opened {System.IO.Path.GetFileName(path)}" : $"not a valid {format} file";
+        if (ok)
+        {
+            RefreshFormulaBar();
+            RepaintRealizedRows();
+        }
+        UpdateStatus();
+    }
+
     /// Undo / redo: walk the engine's snapshot history. On success the formula
     /// bar re-reads and the realized rows repaint (any cell could have changed);
     /// the buttons enable/disable off CanUndo/CanRedo via RefreshHistoryButtons.
@@ -513,7 +570,8 @@ public sealed partial class InfiniteSheet : UserControl
     private void UpdateStatus() =>
         StatusText.Text =
             $"Virtual grid: {_model.TotalRows} rows × {_model.TotalCols} cols  ·  revision {_model.Revision}"
-            + (_findStatus.Length > 0 ? $"  ·  {_findStatus}" : string.Empty);
+            + (_findStatus.Length > 0 ? $"  ·  {_findStatus}" : string.Empty)
+            + (_fileStatus.Length > 0 ? $"  ·  {_fileStatus}" : string.Empty);
 
     /// Rebuild only the currently-realized rows (body + gutter) and the header so
     /// the selection highlight, accent-tinted row/column headers, and recomputed

--- a/code/programs/csharp/visicalc-xaml/README.md
+++ b/code/programs/csharp/visicalc-xaml/README.md
@@ -161,6 +161,22 @@ document held in memory and restore it (`LoadBook` / `sc_deserialize`): the
 document captures only the source (formula text + typed literals) and per-cell
 formats — not the computed values, which the engine recomputes on load, so a
 loaded formula stays live.
+The **Save .xlsx / Open .xlsx / Save .csv / Open .csv** buttons open and save a
+**real spreadsheet file** over the engine's byte codecs:
+`InfiniteSheetModel.ExportBytes(format)` / `ImportBytes(format, bytes)` P/Invoke
+the C ABI's `sc_save_<fmt>` / `sc_load_<fmt>` (`spreadsheet-capi`), so an `.xlsx`
+(a ZIP, with live formulas preserved) or a `.csv` (text, values only) crosses
+P/Invoke as **raw bytes** — a `byte[]` going in, a copied-out heap buffer coming
+back (freed with `sc_bytes_free`) — never a NUL-terminated string that a `0x00`
+inside a ZIP would truncate. The demo writes to / reads from a fixed name in a
+**private per-session temp directory** (`Directory.CreateTempSubdirectory`, mode
+0700 on Unix) and echoes the result in the footer; a production host would swap
+that for a WinUI `FileSavePicker` / `FileOpenPicker` and hand the identical bytes
+across. All five formats the engine speaks — `.xlsx`, `.xls`, `.csv`, `.tsv`,
+`.json` — are bound on `SpreadsheetSession` (`LoadXlsx`/`SaveXlsx`/…), and the
+cross-platform smoke (`test/Program.cs`, run by `scripts/verify.sh`) round-trips
+each: a saved `.xlsx` is asserted to begin with the ZIP magic `PK\x03\x04`, an
+`.xls` with the OLE2 magic `0xD0CF`, and every codec's values survive a reopen.
 The **Undo / Redo** buttons walk the engine's snapshot history
 (`InfiniteSheetModel.UndoEdit`/`RedoEdit` over the C ABI's `sc_undo`/`sc_redo`);
 they enable/disable off `CanUndo`/`CanRedo` (refreshed after every edit). Every

--- a/code/programs/csharp/visicalc-xaml/test/Program.cs
+++ b/code/programs/csharp/visicalc-xaml/test/Program.cs
@@ -347,5 +347,82 @@ using (var msm = new InfiniteSheetModel())
     Check("msm Summary B3", msm.RowCells(3)[1], "300"); // B3 = A1+A2 = 100+200
 }
 
+// ── File open / save (the File → Save/Open buttons drive ExportBytes/
+// ImportBytes over sc_save_*/sc_load_*): open and save a REAL spreadsheet file
+// over the engine's byte codecs. File bytes are binary (a .xlsx is a ZIP, an
+// .xls an OLE2 file) and cross P/Invoke as a (byte[], len) pair going in and a
+// copied-out heap buffer coming back — never a NUL-terminated string a 0x00
+// inside the file would truncate.
+using (var src = new SpreadsheetSession())
+{
+    src.SetCell("A1", "15"); src.SetCell("B1", "3"); src.SetCell("C1", "=A1+B1"); // 18
+
+    // .xlsx is a real ZIP (magic "PK\x03\x04") and keeps its live formula.
+    byte[] xlsx = src.SaveXlsx();
+    Check("xlsx ZIP magic",
+        (xlsx.Length > 4 && xlsx[0] == 0x50 && xlsx[1] == 0x4B && xlsx[2] == 0x03 && xlsx[3] == 0x04).ToString(),
+        "True");
+    using (var dst = new SpreadsheetSession())
+    {
+        Check("xlsx reopens", dst.LoadXlsx(xlsx).ToString(), "True");
+        Check("xlsx keeps formula", dst.GetRaw("C1"), "=A1+B1");
+        Check("xlsx computes", dst.Display("C1"), "18");
+    }
+
+    // .xls is a real OLE2 file (magic D0 CF 11 E0) — the 0xD0 high bit is exactly
+    // what a lossy string round-trip would have mangled.
+    byte[] xls = src.SaveXls();
+    Check("xls OLE2 magic",
+        (xls.Length > 8 && xls[0] == 0xD0 && xls[1] == 0xCF && xls[2] == 0x11 && xls[3] == 0xE0).ToString(),
+        "True");
+    using (var dst = new SpreadsheetSession())
+    {
+        Check("xls reopens", dst.LoadXls(xls).ToString(), "True");
+        Check("xls value", dst.Display("C1"), "18");
+    }
+
+    // A bad or empty payload is rejected (no exception), workbook left untouched.
+    Check("xlsx rejects garbage",
+        src.LoadXlsx(System.Text.Encoding.UTF8.GetBytes("not a spreadsheet")).ToString(), "False");
+    Check("xlsx rejects empty", src.LoadXlsx(Array.Empty<byte>()).ToString(), "False");
+    Check("workbook intact after reject", src.Display("C1"), "18");
+}
+
+// CSV / TSV / JSON are values-only tabular codecs. JSON's canonical shape is an
+// array of objects, so row 1 is the HEADER (the keys) and row 2 the first data
+// record; CSV/TSV are positional grids. A header row + one data row round-trips
+// consistently through all three.
+foreach (var format in new[] { "csv", "tsv", "json" })
+{
+    byte[] bytes;
+    using (var t = new SpreadsheetSession())
+    {
+        t.SetCell("A1", "qty"); t.SetCell("B1", "unit"); t.SetCell("C1", "total");
+        t.SetCell("A2", "15"); t.SetCell("B2", "3"); t.SetCell("C2", "=A2*B2"); // 45
+        bytes = format switch { "csv" => t.SaveCsv(), "tsv" => t.SaveTsv(), _ => t.SaveJson() };
+    }
+    Check($"{format} save non-empty", (bytes.Length > 0).ToString(), "True");
+    using (var t2 = new SpreadsheetSession())
+    {
+        bool ok = format switch { "csv" => t2.LoadCsv(bytes), "tsv" => t2.LoadTsv(bytes), _ => t2.LoadJson(bytes) };
+        Check($"{format} reopens", ok.ToString(), "True");
+        Check($"{format} header round-trip", t2.Display("A1"), "qty");
+        Check($"{format} value round-trip", t2.Display("C2"), "45");
+    }
+}
+
+// The InfiniteSheetModel exposes format-parameterised ExportBytes/ImportBytes.
+using (var fm = new InfiniteSheetModel())
+{
+    foreach (var format in InfiniteSheetModel.FileFormats)
+    {
+        byte[] bytes = fm.ExportBytes(format);
+        Check($"model {format} export", (bytes.Length > 0).ToString(), "True");
+        Check($"model {format} import", fm.ImportBytes(format, bytes).ToString(), "True");
+    }
+    Check("model unknown export empty", (fm.ExportBytes("numbers").Length == 0).ToString(), "True");
+    Check("model unknown import false", fm.ImportBytes("numbers", new byte[] { 1, 2, 3 }).ToString(), "False");
+}
+
 Console.WriteLine(failures == 0 ? "\nALL PASS" : $"\n{failures} FAILURE(S)");
 return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Binds the spreadsheet C ABI's byte-based file codecs (`sc_load_<fmt>` / `sc_save_<fmt>` / `sc_bytes_free`) through **P/Invoke**, so the .NET/XAML (WinUI) VisiCalc demo can **open and save real spreadsheet files** — `.xlsx` / `.xls` / `.csv` / `.tsv` / `.json` — over the one shared Rust engine. The **.NET arm** of the same open/save story the web (WASM), native (C ABI), Android (JNI) and Flutter (dart:ffi) hosts have.

## Why it matters

These are the first calls carrying **raw file bytes**, not a NUL-terminated `char*`: an `.xlsx` is a ZIP, an `.xls` an OLE2 file, and either may hold a `0x00`. A load hands the engine a `(byte[], len)` pair; a save copies the engine's `(ptr, out_len)` buffer into a managed `byte[]` **before** releasing it with `sc_bytes_free` (the engine's allocator, never the CLR/C free). `size_t` maps to `nuint`.

## Changes

- **`Engine.cs`** — `[DllImport]` decls for the 10 byte functions + `sc_bytes_free`; `LoadBytes`/`SaveBytes` helpers (empty-input guard; copy-before-free; free-before-bail on the unreachable >2 GiB path); public `LoadXlsx`/`SaveXlsx`/… per format on `SpreadsheetSession`.
- **`InfiniteSheetModel.ExportBytes(format)` / `ImportBytes(format, bytes)`** — format-parameterised open/save that regrows the extent + refreshes the formula bar.
- **`InfiniteSheet.xaml(.cs)`** — Save/Open `.xlsx` and `.csv` toolbar buttons writing/reading a real file over the byte codecs, into a **private per-session temp dir** (`CreateTempSubdirectory`, mode 0700) — no symlink-clobber, not world-readable; result echoed in the footer.
- **`test/Program.cs`** — headless round-trips for all five formats: ZIP magic `PK\x03\x04` on `.xlsx`, OLE2 magic `0xD0CF` on `.xls`, values survive a reopen, bad/empty payload rejected with the workbook untouched.
- **README** — documents the feature.

## Verification

- `scripts/verify.sh` (the cross-platform **EngineSmoke** harness — compiles `Engine.cs` + `Program.cs` and P/Invokes the vendored engine on macOS/Linux/Windows) is green: **ALL PASS**, including the new file round-trips.
- The WinUI UI wiring is Windows-only and mirrors the existing Save/Load handlers (WinUI is not built in headless CI — unchanged by this PR).
- Security review **passed** — P/Invoke marshalling and memory safety confirmed correct (`nuint` mapping, `byte[]` pinning, copy-before-free with the engine's allocator, NUL-safe, rejected-load no-op, private-temp-dir I/O). The one robustness nit it raised (leak-before-throw on a >2 GiB save) is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)