### PR TITLE
feat(visicalc-swiftui): file open/save over the engine via the C ABI bytes

### DIFF
--- a/code/programs/swift/visicalc-swiftui/README.md
+++ b/code/programs/swift/visicalc-swiftui/README.md
@@ -98,6 +98,22 @@ document held in memory and restore it (`loadBook` / `sc_deserialize`): the
 document captures only the source (formula text + typed literals) and per-cell
 formats — not the computed values, which the engine recomputes on load, so a
 loaded formula stays live.
+The **Save .xlsx / Open .xlsx / Save .csv / Open .csv** buttons open and save a
+**real spreadsheet file** over the engine's byte codecs:
+`WindowedSheetModel.exportBytes(_:)` / `importBytes(_:_:)` bind the C ABI's
+`sc_save_<fmt>` / `sc_load_<fmt>` (`spreadsheet-capi`), so an `.xlsx` (a ZIP,
+with live formulas preserved) or a `.csv` (text, values only) crosses the C ABI
+as **raw bytes** — a `Data`'s storage handed in as a `(pointer, count)` pair, a
+copied-out heap buffer coming back (freed with `sc_bytes_free`) — never a
+NUL-terminated string that a `0x00` inside a ZIP would truncate. The demo writes
+to / reads from a fixed name in a **private per-session temp directory** (mode
+0700, freshly created) and echoes the result in the status bar; a production host
+would swap that for a SwiftUI `.fileExporter` / `.fileImporter` and hand the
+identical bytes across. All five formats the engine speaks — `.xlsx`, `.xls`,
+`.csv`, `.tsv`, `.json` — are bound on `SpreadsheetSession`
+(`loadXlsx`/`saveXlsx`/…), and `Tests/VisiCalcTests` round-trips each: a saved
+`.xlsx` is asserted to begin with the ZIP magic `PK\x03\x04`, an `.xls` with the
+OLE2 magic `0xD0CF`, and every codec's values survive a reopen.
 The **Undo / Redo** buttons walk the engine's snapshot history
 (`WindowedSheetModel.undoEdit`/`redoEdit` over the C ABI's `sc_undo`/`sc_redo`);
 they disable at the history ends via `canUndo`/`canRedo` (re-evaluated whenever

--- a/code/programs/swift/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
+++ b/code/programs/swift/visicalc-swiftui/Sources/CSpreadsheetEngine/include/spreadsheet.h
@@ -22,6 +22,7 @@
 #define SPREADSHEET_CAPI_H
 
 #include <stdint.h> /* uint32_t / uint64_t for the viewport calls */
+#include <stddef.h> /* size_t for the file byte lengths */
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,6 +150,46 @@ char *sc_column_letters(ScSession *s, uint32_t index); /* 1-based index -> "A"/"
 uint64_t sc_current_revision(ScSession *s);     /* per-edit revision clock (0 if s==NULL) */
 char *sc_changed_since(ScSession *s, uint64_t since);  /* -> {"revision":N,"changed":[..]} |
                                                             {"revision":N,"stale":true}    */
+
+/* Column widths & row heights on the active sheet (presentation chrome the engine
+   stores but never computes with). A 1-based column / row index; a `double` size
+   in host units. A returned `0.0` means "no custom size — use the host default"
+   (a valid size is always > 0). The setters return 1 if the size changed, 0 if
+   rejected (non-finite / <= 0 size, or index 0); they persist through save/load
+   and shift with their column/row on an insert/delete. The *_widths/_heights
+   readers return a heap JSON array (free with sc_string_free). */
+double sc_column_width(ScSession *s, uint32_t col);     /* -> width  | 0.0 if unset/NULL */
+double sc_row_height(ScSession *s, uint32_t row);       /* -> height | 0.0 if unset/NULL */
+int   sc_set_column_width(ScSession *s, uint32_t col, double width);  /* 1 changed / 0 rejected */
+int   sc_set_row_height(ScSession *s, uint32_t row, double height);   /* 1 changed / 0 rejected */
+int   sc_clear_column_width(ScSession *s, uint32_t col); /* 1 if a width was removed, else 0 */
+int   sc_clear_row_height(ScSession *s, uint32_t row);   /* 1 if a height was removed, else 0 */
+char *sc_column_widths(ScSession *s, uint32_t col0, uint32_t col1); /* -> [{"col":N,"w":F},..] */
+char *sc_row_heights(ScSession *s, uint32_t row0, uint32_t row1);   /* -> [{"row":N,"h":F},..] */
+
+/* File open / save — bytes in, bytes out. Open a real spreadsheet file the user
+   picked and save the current document as one, over the one engine. File bytes
+   are binary (a .xlsx is a ZIP, a .xls an OLE2 file) and may contain NUL, so they
+   cross as an explicit (ptr, len) pair, never a C string.
+     - sc_load_<fmt>(s, bytes, len) -> 1 opened / 0 not a readable file of that
+       format (or s NULL). A failed open leaves the current document untouched.
+     - sc_save_<fmt>(s, &out_len)   -> heap uint8_t* of length *out_len; free it
+       with sc_bytes_free(ptr, out_len). NULL / *out_len = 0 for an empty doc.
+   .xlsx keeps live formulas; .xls/.csv/.tsv/.json are lower-fidelity (values). */
+int      sc_load_xlsx(ScSession *s, const uint8_t *bytes, size_t len);
+uint8_t *sc_save_xlsx(ScSession *s, size_t *out_len);
+int      sc_load_xls(ScSession *s, const uint8_t *bytes, size_t len);
+uint8_t *sc_save_xls(ScSession *s, size_t *out_len);
+int      sc_load_csv(ScSession *s, const uint8_t *bytes, size_t len);
+uint8_t *sc_save_csv(ScSession *s, size_t *out_len);
+int      sc_load_tsv(ScSession *s, const uint8_t *bytes, size_t len);
+uint8_t *sc_save_tsv(ScSession *s, size_t *out_len);
+int      sc_load_json(ScSession *s, const uint8_t *bytes, size_t len);
+uint8_t *sc_save_json(ScSession *s, size_t *out_len);
+
+/* Free a byte buffer returned by an sc_save_* function. (ptr, len) must match
+   what that call returned/wrote. Safe with (NULL, 0). */
+void  sc_bytes_free(uint8_t *ptr, size_t len);
 
 /* Free a string returned by any sc_* function. */
 void  sc_string_free(char *p);

--- a/code/programs/swift/visicalc-swiftui/Sources/VisiCalc/Engine.swift
+++ b/code/programs/swift/visicalc-swiftui/Sources/VisiCalc/Engine.swift
@@ -107,6 +107,56 @@ final class SpreadsheetSession {
         sc_deserialize(handle, data) != 0
     }
 
+    // ── File open / save — bytes in, bytes out ──────────────────────
+    // Unlike every call above, these carry RAW FILE BYTES (a ZIP for .xlsx, an
+    // OLE2 file for .xls, text for CSV/TSV/JSON), which may contain a 0x00 — so
+    // they must NOT go through the char*/`take` path (which stops at the first
+    // NUL). A load hands the engine a (pointer, count) pair borrowed from a
+    // Data's own storage; a save copies the engine's (ptr, out_len) buffer into
+    // a Swift Data BEFORE releasing it with sc_bytes_free (the engine's
+    // allocator — never Swift's). Reach `sc_load_<fmt>` / `sc_save_<fmt>`.
+
+    /// Hand `data`'s bytes to a C `sc_load_*` (via `call`), replacing the
+    /// workbook. Returns `true` if opened, `false` if the bytes aren't a readable
+    /// file of that format (the workbook is left untouched) or the input is empty
+    /// (a safe no-op — an empty Data has no base address to borrow).
+    private func loadBytes(_ data: Data, _ call: (UnsafePointer<UInt8>?, Int) -> Int32) -> Bool {
+        if data.isEmpty { return false }
+        return data.withUnsafeBytes { raw in
+            call(raw.bindMemory(to: UInt8.self).baseAddress, data.count) != 0
+        }
+    }
+
+    /// Copy an engine-returned byte buffer into a Swift `Data` and free it with
+    /// the engine's allocator (sc_bytes_free — NOT Swift's). A NULL pointer or a
+    /// non-positive length yields an empty `Data`; a non-NULL buffer is always
+    /// freed (the `defer` runs after the copy, and even a zero-length buffer is
+    /// released).
+    private func takeBytes(_ ptr: UnsafeMutablePointer<UInt8>?, _ len: Int) -> Data {
+        guard let ptr = ptr else { return Data() }
+        defer { sc_bytes_free(ptr, len) }
+        return len > 0 ? Data(bytes: ptr, count: len) : Data()
+    }
+
+    /// Open a real spreadsheet file the user picked, over the one engine. `.xlsx`
+    /// reloads live formulas; `.xls`/CSV/TSV/JSON are values-only. Each returns
+    /// `true` on success, `false` if the bytes aren't a readable file of that
+    /// format (the workbook is left untouched) or the input is empty.
+    func loadXlsx(_ data: Data) -> Bool { loadBytes(data) { sc_load_xlsx(handle, $0, $1) } }
+    func loadXls(_ data: Data) -> Bool { loadBytes(data) { sc_load_xls(handle, $0, $1) } }
+    func loadCsv(_ data: Data) -> Bool { loadBytes(data) { sc_load_csv(handle, $0, $1) } }
+    func loadTsv(_ data: Data) -> Bool { loadBytes(data) { sc_load_tsv(handle, $0, $1) } }
+    func loadJson(_ data: Data) -> Bool { loadBytes(data) { sc_load_json(handle, $0, $1) } }
+
+    /// Serialize the current document to a file's bytes in each format — what a
+    /// host writes to disk / hands to a share sheet. An empty document yields an
+    /// empty `Data`.
+    func saveXlsx() -> Data { var len = 0; return takeBytes(sc_save_xlsx(handle, &len), len) }
+    func saveXls() -> Data { var len = 0; return takeBytes(sc_save_xls(handle, &len), len) }
+    func saveCsv() -> Data { var len = 0; return takeBytes(sc_save_csv(handle, &len), len) }
+    func saveTsv() -> Data { var len = 0; return takeBytes(sc_save_tsv(handle, &len), len) }
+    func saveJson() -> Data { var len = 0; return takeBytes(sc_save_json(handle, &len), len) }
+
     /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
     /// changed the document (the host then re-reads the viewport), `false` if
     /// there was nothing to do. canUndo/canRedo gate a host's Undo/Redo controls.

--- a/code/programs/swift/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
+++ b/code/programs/swift/visicalc-swiftui/Sources/VisiCalc/InfiniteGrid.swift
@@ -12,6 +12,7 @@
 // every row, and tapping a cell selects it for editing in the formula bar.
 
 import SwiftUI
+import Foundation
 
 /// Engine-backed model for the virtualized sheet: seeds a deliberately far-flung,
 /// sparse dataset, exposes windowed reads + the data extent, and tracks the
@@ -316,6 +317,50 @@ final class WindowedSheetModel: ObservableObject {
         return ok
     }
 
+    /// The spreadsheet file formats the demo can open / save, in menu order. The
+    /// canonical extension doubles as the format key for `exportBytes(_:)` /
+    /// `importBytes(_:_:)`.
+    static let fileFormats = ["xlsx", "xls", "csv", "tsv", "json"]
+
+    /// Export the whole workbook to a real spreadsheet file's bytes in `format`
+    /// (one of `fileFormats`) — the same bytes the web download and the other
+    /// native hosts write. `.xlsx` keeps live formulas; the rest are values-only.
+    /// An unknown format or empty document yields an empty `Data`.
+    func exportBytes(_ format: String) -> Data {
+        switch format {
+        case "xlsx": return session.saveXlsx()
+        case "xls": return session.saveXls()
+        case "csv": return session.saveCsv()
+        case "tsv": return session.saveTsv()
+        case "json": return session.saveJson()
+        default: return Data()
+        }
+    }
+
+    /// Import a real spreadsheet file's `bytes` of `format` (one of
+    /// `fileFormats`), replacing the workbook. Returns `false` (workbook
+    /// untouched) if the bytes aren't a readable file of that format or the
+    /// format is unknown. On success it resizes the extent, refreshes the formula
+    /// bar, and bumps `revision` so the view re-reads.
+    @discardableResult
+    func importBytes(_ format: String, _ bytes: Data) -> Bool {
+        let ok: Bool
+        switch format {
+        case "xlsx": ok = session.loadXlsx(bytes)
+        case "xls": ok = session.loadXls(bytes)
+        case "csv": ok = session.loadCsv(bytes)
+        case "tsv": ok = session.loadTsv(bytes)
+        case "json": ok = session.loadJson(bytes)
+        default: ok = false
+        }
+        if ok {
+            resize()
+            formulaText = session.getRaw(address(selectedRow, selectedCol))
+            revision += 1
+        }
+        return ok
+    }
+
     /// Undo / redo: walk the engine's snapshot history. On success the extent
     /// resizes, the formula bar refreshes, and `revision` bumps (which re-renders
     /// the SwiftUI view, re-evaluating the canUndo/canRedo button gates); a
@@ -409,6 +454,11 @@ struct InfiniteGridView: View {
     // serialized workbook here, Load restores from it. (A real app would write it
     // to a file; the demo keeps the round trip self-contained.)
     @State private var savedSnapshot = ""
+    // The most recent File → Save / Open result, echoed in the status bar, plus a
+    // PRIVATE per-session scratch dir (created lazily, mode 0700) so the on-disk
+    // round trip doesn't write a predictable name into the shared temp root.
+    @State private var fileStatus = ""
+    @State private var scratchDir: URL?
     // Drives the formula field's accent focus ring.
     @FocusState private var formulaFocused: Bool
     // Multi-sheet: the index being renamed (non-nil shows the rename alert) and
@@ -548,7 +598,8 @@ struct InfiniteGridView: View {
             Rectangle().fill(line).frame(height: 1)
             HStack {
                 Text("Virtual grid: \(model.totalRows) rows × \(model.totalCols) cols  ·  revision \(model.revision)"
-                    + (model.findStatus.isEmpty ? "" : "  ·  \(model.findStatus)"))
+                    + (model.findStatus.isEmpty ? "" : "  ·  \(model.findStatus)")
+                    + (fileStatus.isEmpty ? "" : "  ·  \(fileStatus)"))
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(muted)
                 Spacer()
@@ -556,6 +607,47 @@ struct InfiniteGridView: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 6)
         }
+    }
+
+    // ── File → Save / Open a REAL spreadsheet file on disk ────────────
+    // Unlike the in-memory Save / Load above, these write and read an actual file
+    // over the engine's byte codecs (WindowedSheetModel.exportBytes/importBytes →
+    // sc_save_*/sc_load_*). The demo uses a fixed name in a private per-session
+    // temp dir (mode 0700, freshly created — not a predictable name in the shared
+    // temp root); a production host would swap in `.fileExporter` / `.fileImporter`
+    // and hand the same bytes across.
+    private func scratchDirectory() -> URL {
+        if let dir = scratchDir { return dir }
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("visicalc-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        scratchDir = dir
+        return dir
+    }
+
+    private func demoURL(_ ext: String) -> URL {
+        scratchDirectory().appendingPathComponent("visicalc-demo.\(ext)")
+    }
+
+    private func exportFile(_ format: String) {
+        let bytes = model.exportBytes(format)
+        let url = demoURL(format)
+        try? bytes.write(to: url)
+        let kb = String(format: "%.1f", Double(bytes.count) / 1024.0)
+        fileStatus = "saved \(kb) KB → \(url.lastPathComponent)"
+    }
+
+    private func openFile(_ format: String) {
+        let url = demoURL(format)
+        guard let bytes = try? Data(contentsOf: url) else {
+            fileStatus = "no \(url.lastPathComponent) yet — Save first"
+            return
+        }
+        fileStatus = model.importBytes(format, bytes)
+            ? "opened \(url.lastPathComponent)"
+            : "not a valid \(format) file"
     }
 
     // The editable formula bar for the selected cell: a panel holding the address
@@ -608,6 +700,18 @@ struct InfiniteGridView: View {
             Button("Load") { if !savedSnapshot.isEmpty { model.loadBook(savedSnapshot) } }
                 .disabled(savedSnapshot.isEmpty)
                 .help("Restore the workbook from the last save")
+            toolSep
+            // ── File → open / save a REAL file on disk (over the engine's byte
+            //    codecs, across the C ABI): an .xlsx (ZIP, live formulas) and a
+            //    .csv (text, values only). ──
+            Button("Save .xlsx") { exportFile("xlsx") }
+                .help("Write the workbook to visicalc-demo.xlsx (a real ZIP; keeps live formulas)")
+            Button("Open .xlsx") { openFile("xlsx") }
+                .help("Reopen visicalc-demo.xlsx over the engine (reloads live formulas)")
+            Button("Save .csv") { exportFile("csv") }
+                .help("Write the workbook to visicalc-demo.csv (values only)")
+            Button("Open .csv") { openFile("csv") }
+                .help("Reopen visicalc-demo.csv over the engine (values only)")
             toolSep
             // ── Structure (insert / delete the selected row or column) ──
             Button("+ Row") { model.insertRow() }

--- a/code/programs/swift/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
+++ b/code/programs/swift/visicalc-swiftui/Tests/VisiCalcTests/WindowedModelTests.swift
@@ -165,6 +165,85 @@ final class WindowedModelTests: XCTestCase {
         XCTAssertEqual(m.window(rows: 1...1, cols: 5...5)[0][0], "28.00")
     }
 
+    /// File open / save over the engine's byte codecs (sc_load_*/sc_save_*): raw
+    /// file bytes cross the C ABI intact — a ZIP for .xlsx, an OLE2 file for .xls
+    /// — including bytes a NUL-terminated string would truncate. Values-only
+    /// codecs (CSV/TSV/JSON) round-trip a header + data row.
+    func testFileOpenSaveRoundTrips() {
+        // A tiny workbook with a live formula, so we can tell a values-only codec
+        // from a formula-preserving one (.xlsx) after a round trip.
+        func seeded() -> SpreadsheetSession {
+            let s = SpreadsheetSession()
+            _ = s.setCell("A1", "15"); _ = s.setCell("B1", "3"); _ = s.setCell("C1", "=A1+B1") // 18
+            return s
+        }
+
+        // .xlsx is a real ZIP (magic "PK\x03\x04") and keeps its live formula.
+        let xlsx = seeded().saveXlsx()
+        XCTAssertGreaterThan(xlsx.count, 4)
+        XCTAssertEqual(Array(xlsx.prefix(4)), [0x50, 0x4B, 0x03, 0x04])
+        let dstX = SpreadsheetSession()
+        XCTAssertTrue(dstX.loadXlsx(xlsx))
+        XCTAssertEqual(dstX.getRaw("C1"), "=A1+B1") // formula survives .xlsx
+        XCTAssertEqual(dstX.display("C1"), "18")
+
+        // .xls is a real OLE2 file (magic D0 CF 11 E0) — the 0xD0 high bit is what
+        // a lossy string round-trip would have mangled.
+        let xls = seeded().saveXls()
+        XCTAssertGreaterThan(xls.count, 8)
+        XCTAssertEqual(Array(xls.prefix(4)), [0xD0, 0xCF, 0x11, 0xE0])
+        let dstL = SpreadsheetSession()
+        XCTAssertTrue(dstL.loadXls(xls))
+        XCTAssertEqual(dstL.display("C1"), "18") // values-only, value is right
+
+        // CSV / TSV / JSON: values-only. JSON's canonical shape is an array of
+        // objects, so row 1 is the HEADER (the keys) and row 2 the first data
+        // record; CSV/TSV are positional grids. A header + data row round-trips
+        // consistently through all three.
+        for format in ["csv", "tsv", "json"] {
+            let t = SpreadsheetSession()
+            _ = t.setCell("A1", "qty"); _ = t.setCell("B1", "unit"); _ = t.setCell("C1", "total")
+            _ = t.setCell("A2", "15"); _ = t.setCell("B2", "3"); _ = t.setCell("C2", "=A2*B2") // 45
+            let bytes: Data
+            switch format {
+            case "csv": bytes = t.saveCsv()
+            case "tsv": bytes = t.saveTsv()
+            default: bytes = t.saveJson()
+            }
+            XCTAssertFalse(bytes.isEmpty, "\(format) save produced bytes")
+            let d = SpreadsheetSession()
+            let ok: Bool
+            switch format {
+            case "csv": ok = d.loadCsv(bytes)
+            case "tsv": ok = d.loadTsv(bytes)
+            default: ok = d.loadJson(bytes)
+            }
+            XCTAssertTrue(ok, "\(format) reopened")
+            XCTAssertEqual(d.display("A1"), "qty", "\(format) header round-tripped")
+            XCTAssertEqual(d.display("C2"), "45", "\(format) value round-tripped")
+        }
+
+        // A bad or empty payload is rejected, workbook left untouched.
+        let s = seeded()
+        XCTAssertFalse(s.loadXlsx(Data("not a spreadsheet".utf8)))
+        XCTAssertEqual(s.display("C1"), "18")
+        XCTAssertFalse(s.loadCsv(Data()))
+        XCTAssertEqual(s.display("C1"), "18")
+    }
+
+    /// The WindowedSheetModel exposes format-parameterised export / import.
+    func testModelExportImport() {
+        let m = WindowedSheetModel()
+        for format in WindowedSheetModel.fileFormats {
+            let bytes = m.exportBytes(format)
+            XCTAssertFalse(bytes.isEmpty, "\(format) export")
+            XCTAssertTrue(m.importBytes(format, bytes), "\(format) import")
+        }
+        // An unknown format is a safe no-op both ways.
+        XCTAssertTrue(m.exportBytes("numbers").isEmpty)
+        XCTAssertFalse(m.importBytes("numbers", Data([1, 2, 3])))
+    }
+
     /// Undo / redo: make two edits, walk history back and forward, and confirm a
     /// restored formula recomputes live. (The model seeds its budget via setCell,
     /// so history is non-empty from construction — undoing into the seed is


### PR DESCRIPTION
## What

Binds the spreadsheet C ABI's byte-based file codecs (`sc_load_<fmt>` / `sc_save_<fmt>` / `sc_bytes_free`) through the `CSpreadsheetEngine` module, so the SwiftUI VisiCalc demo can **open and save real spreadsheet files** — `.xlsx` / `.xls` / `.csv` / `.tsv` / `.json` — over the one shared Rust engine. The **SwiftUI arm** of the same open/save story the web (WASM), native (C ABI), Android (JNI), Flutter (dart:ffi) and .NET (P/Invoke) hosts have.

## Why it matters

These are the first calls carrying **raw file bytes**, not a NUL-terminated `char*`: an `.xlsx` is a ZIP, an `.xls` an OLE2 file, either may hold a `0x00`. A load borrows a `Data`'s storage as a `(pointer, count)` pair via `withUnsafeBytes`; a save copies the engine's `(ptr, out_len)` buffer into a Swift `Data` **before** releasing it with `sc_bytes_free` (the engine's allocator, in a `defer` that runs after the copy — even a zero-length buffer is released).

## Changes

- **`Engine.swift`** — `loadXlsx`/`saveXlsx`/… per format on `SpreadsheetSession` (`loadBytes`/`takeBytes` helpers).
- **`WindowedSheetModel.exportBytes(_:)` / `importBytes(_:_:)`** — format-parameterised open/save that resizes the extent + refreshes the formula bar + bumps `revision`.
- **`InfiniteGrid.swift`** — Save/Open `.xlsx` and `.csv` toolbar buttons writing/reading a real file over the byte codecs, into a **private per-session temp dir** (`FileManager`, mode 0700); result echoed in the status bar.
- **`Tests/VisiCalcTests`** — headless round-trips for all five formats: ZIP magic `PK\x03\x04` on `.xlsx`, OLE2 magic `0xD0CF` on `.xls`, values survive a reopen, bad/empty payload rejected with the workbook untouched.
- Refresh the vendored `CSpreadsheetEngine` header (`build.sh` copies it from `spreadsheet-capi`) so it declares the new byte functions.
- **README** — documents the feature.

## Verification

- `swift test` green — **20 tests**, including the 2 new file round-trips, against the vendored host engine (`bash scripts/build.sh`). The SwiftUI UI code compiles as part of the test-target build.
- Security review **passed** — Swift↔C memory safety confirmed correct (non-escaping borrowed pointer with empty-guard, copy-before-free with the engine's allocator, NUL-safe, rejected-load no-op, private-temp-dir I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)