### PR TITLE
feat(visicalc-qt): file open/save over the engine via the C ABI bytes

### DIFF
--- a/code/programs/cpp/visicalc-qt/InfiniteSheet.qml
+++ b/code/programs/cpp/visicalc-qt/InfiniteSheet.qml
@@ -31,6 +31,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQuick.Dialogs
 
 Item {
     id: sheet
@@ -46,6 +47,36 @@ Item {
     // this string to a file or QSettings; the demo keeps it in memory so the
     // round trip is self-contained.)
     property string savedSnapshot: ""
+
+    // Map a chosen file's URL to the engine's format key (its lowercase
+    // extension). Drives the File → Save…/Open… dialogs below; an unrecognised
+    // suffix falls back to "xlsx".
+    function formatOf(fileUrl) {
+        var s = fileUrl.toString();
+        var dot = s.lastIndexOf(".");
+        return dot >= 0 ? s.substring(dot + 1).toLowerCase() : "xlsx";
+    }
+
+    // File → Save / Open a REAL spreadsheet file on disk. A proper OS dialog (Qt
+    // Quick Dialogs) picks the path; the C++ model reads/writes the bytes over the
+    // engine's byte codecs (saveFile/openFile → sc_save_*/sc_load_*). The format
+    // is the chosen file's extension.
+    FileDialog {
+        id: saveDialog
+        title: "Save spreadsheet"
+        fileMode: FileDialog.SaveFile
+        defaultSuffix: "xlsx"
+        nameFilters: ["Excel (*.xlsx)", "Legacy Excel (*.xls)", "CSV (*.csv)",
+                      "TSV (*.tsv)", "JSON (*.json)"]
+        onAccepted: if (doc) doc.saveFile(selectedFile, sheet.formatOf(selectedFile))
+    }
+    FileDialog {
+        id: openDialog
+        title: "Open spreadsheet"
+        fileMode: FileDialog.OpenFile
+        nameFilters: ["Spreadsheets (*.xlsx *.xls *.csv *.tsv *.json)", "All files (*)"]
+        onAccepted: if (doc) doc.openFile(selectedFile, sheet.formatOf(selectedFile))
+    }
 
     // Cell geometry (pixels). The gutter and body share rowH so their two
     // ListViews scroll in lockstep. (Roomier to match the web reference.)
@@ -243,6 +274,23 @@ Item {
                     ToolTip.visible: hovered
                     ToolTip.text: "Restore the workbook from the last save"
                     onClicked: if (doc) doc.deserialize(sheet.savedSnapshot)
+                }
+                Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
+
+                // ── File → open / save a REAL spreadsheet file on disk (over the
+                //    engine's byte codecs, across the C ABI): a proper OS Save/Open
+                //    dialog. .xlsx keeps live formulas; .csv is values only. ──
+                ToolButton {
+                    text: "Save…"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Save the workbook to a real spreadsheet file (.xlsx keeps live formulas; .xls/.csv/.tsv/.json are values only)"
+                    onClicked: saveDialog.open()
+                }
+                ToolButton {
+                    text: "Open…"
+                    ToolTip.visible: hovered
+                    ToolTip.text: "Open a real spreadsheet file over the engine"
+                    onClicked: openDialog.open()
                 }
                 Rectangle { Layout.preferredWidth: 1; Layout.fillHeight: true; Layout.topMargin: 4; Layout.bottomMargin: 4; color: sheet.cLine }
 

--- a/code/programs/cpp/visicalc-qt/README.md
+++ b/code/programs/cpp/visicalc-qt/README.md
@@ -137,6 +137,19 @@ the C ABI's `sc_serialize`) to a JSON document held in memory and restore it
 (`model.deserialize` / `sc_deserialize`): the document captures only the source
 (formula text + typed literals) and per-cell formats — not the computed values,
 which the engine recomputes on load, so a loaded formula stays live.
+The **Save… / Open…** buttons open and save a **real spreadsheet file** through a
+proper OS dialog (Qt Quick `FileDialog`): `model.saveFile(path, format)` /
+`openFile(path, format)` wrap `model.exportBytes(format)` / `importBytes(format,
+bytes)`, which bind the C ABI's `sc_save_<fmt>` / `sc_load_<fmt>`
+(`spreadsheet-capi`). File bytes ride in a **`QByteArray`** — an `.xlsx` (a ZIP,
+with live formulas preserved) or an `.xls`/`.csv`/`.tsv`/`.json` crosses the C ABI
+as raw bytes, never a `QString` that a `0x00` inside a ZIP would truncate; a save
+copies the engine's `(ptr, len)` buffer out and frees it with `sc_bytes_free` (the
+engine's own allocator). Unlike the plugin-free hosts, Qt's `FileDialog` gives a
+genuine path, so there's no fixed demo file. The headless `test/tst_model`
+round-trips the bytes: a saved `.xlsx` is asserted to begin with the ZIP magic
+`PK\x03\x04` (and its formula still recomputes after a reopen), an `.xls` with the
+OLE2 magic `0xD0CF`, and unknown/empty inputs are safe no-ops.
 The **Undo / Redo** buttons walk the engine's snapshot history (`model.undo`/
 `redo` over the C ABI's `sc_undo`/`sc_redo`); they enable off the `canUndo`/
 `canRedo` Q_PROPERTYs (which notify on `revisionChanged`, so they re-evaluate

--- a/code/programs/cpp/visicalc-qt/src/SpreadsheetModel.cpp
+++ b/code/programs/cpp/visicalc-qt/src/SpreadsheetModel.cpp
@@ -15,6 +15,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QByteArray>
+#include <QFile>
+#include <QUrl>
 
 #include <cmath>
 
@@ -497,6 +499,83 @@ bool SpreadsheetModel::deserialize(const QString &data) {
         emit revisionChanged();
     }
     return ok;
+}
+
+// ── File open / save — bytes in, bytes out ─────────────────────────────
+// A QByteArray carries raw file bytes intact (an .xlsx is a ZIP, an .xls an OLE2
+// file) — unlike takeString's char* path, a 0x00 in the middle doesn't truncate
+// it. exportBytes copies the engine's (ptr, len) buffer into a QByteArray and
+// frees it with sc_bytes_free (the engine's own allocator — NOT free()); a save
+// that returns a null pointer / empty doc yields an empty QByteArray. importBytes
+// hands the engine a borrowed (constData, size) pair and, on success, refreshes
+// the grid exactly as deserialize() does.
+
+QByteArray SpreadsheetModel::exportBytes(const QString &format) const {
+    size_t len = 0;
+    uint8_t *ptr = nullptr;
+    if (format == QLatin1String("xlsx")) ptr = sc_save_xlsx(session_, &len);
+    else if (format == QLatin1String("xls")) ptr = sc_save_xls(session_, &len);
+    else if (format == QLatin1String("csv")) ptr = sc_save_csv(session_, &len);
+    else if (format == QLatin1String("tsv")) ptr = sc_save_tsv(session_, &len);
+    else if (format == QLatin1String("json")) ptr = sc_save_json(session_, &len);
+    else return QByteArray();
+    if (ptr == nullptr) return QByteArray();
+    // Copy the bytes out BEFORE releasing the engine's buffer with its allocator.
+    // Use qsizetype (64-bit in Qt 6) for the length so a large file can't wrap a
+    // narrower int.
+    QByteArray bytes(reinterpret_cast<const char *>(ptr), static_cast<qsizetype>(len));
+    sc_bytes_free(ptr, len);
+    return bytes;
+}
+
+bool SpreadsheetModel::importBytes(const QString &format, const QByteArray &bytes) {
+    if (bytes.isEmpty()) return false; // empty input is a safe no-op
+    const auto *p = reinterpret_cast<const uint8_t *>(bytes.constData());
+    const auto n = static_cast<size_t>(bytes.size());
+    int ok = 0;
+    if (format == QLatin1String("xlsx")) ok = sc_load_xlsx(session_, p, n);
+    else if (format == QLatin1String("xls")) ok = sc_load_xls(session_, p, n);
+    else if (format == QLatin1String("csv")) ok = sc_load_csv(session_, p, n);
+    else if (format == QLatin1String("tsv")) ok = sc_load_tsv(session_, p, n);
+    else if (format == QLatin1String("json")) ok = sc_load_json(session_, p, n);
+    else return false;
+    if (ok) {
+        recompute();
+        computeExtent();
+        infFormula_ = rawAt(infAddress());
+        revision_++;
+        emit changed();
+        emit infSelectionChanged();
+        emit revisionChanged();
+    }
+    return ok != 0;
+}
+
+// saveFile/openFile wrap the codec core with QFile so QML's FileDialog can hand a
+// real path (a proper OS Save/Open dialog — no fixed demo path needed here, unlike
+// the plugin-free hosts). QML's FileDialog reports a `file://` URL, so accept both
+// a local path and a URL (normalising through QUrl). A failed file open, or a codec
+// that rejects the bytes, returns false and leaves the workbook untouched.
+static QString localPathOf(const QString &pathOrUrl) {
+    const QUrl url(pathOrUrl);
+    return url.isLocalFile() ? url.toLocalFile() : pathOrUrl;
+}
+
+bool SpreadsheetModel::saveFile(const QString &path, const QString &format) {
+    const QByteArray bytes = exportBytes(format);
+    QFile file(localPathOf(path));
+    if (!file.open(QIODevice::WriteOnly)) return false;
+    const bool ok = file.write(bytes) == bytes.size();
+    file.close();
+    return ok;
+}
+
+bool SpreadsheetModel::openFile(const QString &path, const QString &format) {
+    QFile file(localPathOf(path));
+    if (!file.open(QIODevice::ReadOnly)) return false;
+    const QByteArray bytes = file.readAll();
+    file.close();
+    return importBytes(format, bytes);
 }
 
 // Undo / redo availability — thin reads of the engine's history stacks; the

--- a/code/programs/cpp/visicalc-qt/src/SpreadsheetModel.h
+++ b/code/programs/cpp/visicalc-qt/src/SpreadsheetModel.h
@@ -20,6 +20,7 @@
 #ifndef VISICALC_QT_SPREADSHEET_MODEL_H
 #define VISICALC_QT_SPREADSHEET_MODEL_H
 
+#include <QByteArray>
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -171,6 +172,18 @@ public:
     // regrows the extent, and bumps `revision` so the visible rows re-fetch.
     Q_INVOKABLE QString serialize() const;
     Q_INVOKABLE bool deserialize(const QString &data);
+    // ── File open / save — bytes in, bytes out ─────────────────────
+    // Open and save a REAL spreadsheet file over the engine's byte codecs. File
+    // bytes are binary (an .xlsx is a ZIP, an .xls an OLE2 file) and may contain a
+    // NUL, so they live in a QByteArray — never a QString, which the serialize()
+    // path above uses for the JSON document. exportBytes/importBytes are the codec
+    // core; saveFile/openFile wrap them with QFile so QML's FileDialog can hand a
+    // chosen path across. `.xlsx` keeps live formulas; `.xls`/`.csv`/`.tsv`/`.json`
+    // are lower-fidelity (values only). A failed open leaves the workbook intact.
+    Q_INVOKABLE QByteArray exportBytes(const QString &format) const;
+    Q_INVOKABLE bool importBytes(const QString &format, const QByteArray &bytes);
+    Q_INVOKABLE bool saveFile(const QString &path, const QString &format);
+    Q_INVOKABLE bool openFile(const QString &path, const QString &format);
     // Undo / redo: walk the engine's snapshot history. Each returns true if it
     // changed the document; on success the grid recomputes, the extent regrows,
     // the formula bar refreshes, and `revision` bumps (which re-evaluates the

--- a/code/programs/cpp/visicalc-qt/test/tst_model.cpp
+++ b/code/programs/cpp/visicalc-qt/test/tst_model.cpp
@@ -25,6 +25,11 @@ private slots:
     // A formula entry computes, and a division-by-zero error propagates through
     // a binary operator (matching Excel; the engine's documented behaviour).
     void formulaAndErrorPropagation();
+    // File open / save over the engine's byte codecs: raw file bytes cross the C
+    // ABI in a QByteArray intact — a ZIP for .xlsx (with the live formula still
+    // recomputing after a reopen), an OLE2 file for .xls — and unknown/empty
+    // inputs are safe no-ops.
+    void fileOpenSaveRoundTrips();
 };
 
 void TstModel::seededTotalsAreEngineComputed() {
@@ -74,4 +79,53 @@ void TstModel::formulaAndErrorPropagation() {
 }
 
 QTEST_MAIN(TstModel)
+void TstModel::fileOpenSaveRoundTrips() {
+    SpreadsheetModel src;
+    src.setCell("C1", "=A1+B1"); // override the seeded literal: 15+3 = 18
+
+    // .xlsx is a real ZIP (magic "PK\x03\x04"): the raw binary crossed the C ABI
+    // in a QByteArray without a NUL truncating it.
+    const QByteArray xlsx = src.exportBytes("xlsx");
+    QVERIFY(xlsx.size() > 4);
+    QVERIFY(xlsx.at(0) == char(0x50) && xlsx.at(1) == char(0x4B)
+            && xlsx.at(2) == char(0x03) && xlsx.at(3) == char(0x04));
+    SpreadsheetModel dstX;
+    QVERIFY(dstX.importBytes("xlsx", xlsx));
+    QCOMPARE(dstX.display("C1"), QStringLiteral("18"));
+    // .xlsx keeps the formula LIVE, not a frozen value: edit a precedent and C1
+    // recomputes (15+3 → 115+3).
+    dstX.setCell("A1", "115");
+    QCOMPARE(dstX.display("C1"), QStringLiteral("118"));
+
+    // .xls is a real OLE2 file (magic D0 CF 11 E0) — the 0xD0 high bit is exactly
+    // what a lossy string round trip would have mangled. Values only.
+    const QByteArray xls = src.exportBytes("xls");
+    QVERIFY(xls.size() > 8);
+    QVERIFY(xls.at(0) == char(0xD0) && xls.at(1) == char(0xCF)
+            && xls.at(2) == char(0x11) && xls.at(3) == char(0xE0));
+    SpreadsheetModel dstL;
+    QVERIFY(dstL.importBytes("xls", xls));
+    QCOMPARE(dstL.display("C1"), QStringLiteral("18"));
+
+    // CSV / TSV / JSON: values-only tabular codecs. The QByteArray marshalling is
+    // proven by a non-empty export that reopens cleanly (the per-codec value
+    // semantics are asserted against the same engine in the Dart/.NET/Swift
+    // suites; here the seeded budget makes exact cell reshaping format-specific).
+    for (const QString &format : {QStringLiteral("csv"), QStringLiteral("tsv"),
+                                  QStringLiteral("json")}) {
+        const QByteArray bytes = src.exportBytes(format);
+        QVERIFY2(!bytes.isEmpty(), qPrintable(format + " export produced bytes"));
+        SpreadsheetModel dst;
+        QVERIFY2(dst.importBytes(format, bytes), qPrintable(format + " reopened"));
+    }
+
+    // Unknown format and empty input are safe no-ops.
+    QVERIFY(src.exportBytes("numbers").isEmpty());
+    QVERIFY(!src.importBytes("numbers", QByteArray("x")));
+    QVERIFY(!src.importBytes("xlsx", QByteArray()));
+    // A non-spreadsheet payload is rejected and leaves the workbook untouched.
+    QVERIFY(!src.importBytes("xlsx", QByteArray("not a spreadsheet")));
+    QCOMPARE(src.display("C1"), QStringLiteral("18"));
+}
+
 #include "tst_model.moc"


### PR DESCRIPTION
## What

Binds the spreadsheet C ABI's byte-based file codecs (`sc_load_<fmt>` / `sc_save_<fmt>` / `sc_bytes_free`) in the C++ `SpreadsheetModel`, so the Qt/QML VisiCalc demo can **open and save real spreadsheet files** — `.xlsx` / `.xls` / `.csv` / `.tsv` / `.json` — over the one shared Rust engine. The **Qt arm** of the same open/save story the web (WASM), native (C ABI), Android (JNI), Flutter (dart:ffi), .NET (P/Invoke) and SwiftUI hosts have.

## Why it matters

File bytes ride in a **`QByteArray`** — an `.xlsx` is a ZIP, an `.xls` an OLE2 file, either may hold a `0x00`, so they never touch the `QString`/`char*` path (`takeString`) that a NUL would truncate. A save copies the engine's `(ptr, len)` buffer out **before** freeing it with `sc_bytes_free` (the engine's own allocator).

## Changes

- **`SpreadsheetModel`** — `Q_INVOKABLE exportBytes(format)` / `importBytes(format, bytes)` (the codec core) + `saveFile`/`openFile` (QFile wrappers). `saveFile`/`openFile` normalise a `file://` URL (from QML's `FileDialog`) or a plain path via `QUrl`. Length copied out with `qsizetype` (no narrowing).
- **`InfiniteSheet.qml`** — **Save… / Open…** toolbar buttons driving a Qt Quick `FileDialog` — a genuine OS Save/Open dialog (no fixed demo path, unlike the plugin-free hosts). The chosen file's extension picks the format.
- **`test/tst_model`** — headless `QByteArray` round-trip: a saved `.xlsx` begins with the ZIP magic `PK\x03\x04` and its formula still recomputes after a reopen, an `.xls` with the OLE2 magic `0xD0CF`, CSV/TSV/JSON export non-empty + reopen cleanly, unknown/empty/garbage inputs are safe no-ops.
- **README** — documents the feature.

## Verification

- `cd test && qmake tst_model.pro && make && ./tst_model` green — **6 tests**, including the new `fileOpenSaveRoundTrips` (Qt 6.11, host engine vendored by `scripts/build.sh`).
- `qmllint InfiniteSheet.qml` — **0 errors** (the `QtQuick.Dialogs` import + `FileDialog`s resolve; only the file's pre-existing unqualified-`doc` style warnings remain).
- Security review **passed** — C++/C memory safety confirmed correct (copy-before-free with the engine's allocator, NULL/empty guards, NUL-safe QByteArray path, rejected-load no-op, user-chosen path via the OS dialog). Its one INFO (an `int` narrowing) is fixed here by using `qsizetype`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)