### PR TITLE
feat(visicalc-compose): file open/save over the engine via FFM bytes

### DIFF
--- a/code/programs/kotlin/visicalc-compose/README.md
+++ b/code/programs/kotlin/visicalc-compose/README.md
@@ -121,6 +121,24 @@ document held in memory and restore it (`loadBook` / `sc_deserialize`): the
 document captures only the source (formula text + typed literals) and per-cell
 formats — not the computed values, which the engine recomputes on load, so a
 loaded formula stays live.
+The **Save .xlsx / Open .xlsx / Save .csv / Open .csv** buttons open and save a
+**real spreadsheet file** over the engine's byte codecs:
+`InfiniteSheetModel.exportBytes(format)` / `importBytes(format, bytes)` bind the
+C ABI's `sc_save_<fmt>` / `sc_load_<fmt>` (`spreadsheet-capi`) through the Java
+**FFM API**, so an `.xlsx` (a ZIP, with live formulas preserved) or a `.csv`
+(text, values only) crosses as **raw bytes** — a native `(segment, len)` pair
+going in, a copied-out buffer coming back (freed with `sc_bytes_free`, the
+engine's own allocator) — never a NUL-terminated string that a `0x00` inside a
+ZIP would truncate (`size_t` binds as `JAVA_LONG`). The demo writes to / reads
+from a fixed name in a **private per-session temp directory**
+(`Files.createTempDirectory`, mode 0700 on POSIX) and echoes the result in the
+footer; a production host would swap that for an AWT `FileDialog` and hand the
+identical bytes across. All five formats the engine speaks — `.xlsx`, `.xls`,
+`.csv`, `.tsv`, `.json` — are bound on `SpreadsheetSession`
+(`loadXlsx`/`saveXlsx`/…), and the cross-platform FFM smoke (`test/EngineSmoke.kt`,
+run by `scripts/verify.sh`) round-trips each: a saved `.xlsx` is asserted to begin
+with the ZIP magic `PK\x03\x04`, an `.xls` with the OLE2 magic `0xD0CF`, and every
+codec's values survive a reopen.
 The **Undo / Redo** buttons walk the engine's snapshot history
 (`InfiniteSheetModel.undoEdit`/`redoEdit` over the C ABI's `sc_undo`/`sc_redo`);
 they disable at the history ends via `canUndo`/`canRedo`. Every edit is

--- a/code/programs/kotlin/visicalc-compose/src/main/kotlin/Engine.kt
+++ b/code/programs/kotlin/visicalc-compose/src/main/kotlin/Engine.kt
@@ -20,6 +20,7 @@ import java.lang.foreign.Linker
 import java.lang.foreign.MemorySegment
 import java.lang.foreign.SymbolLookup
 import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
 import java.io.File
 
 /// A single spreadsheet session, owning the opaque C handle.
@@ -95,6 +96,26 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     private val scAddSheet = handle("sc_add_sheet", FunctionDescriptor.of(i32, ptr, ptr))
     private val scRenameSheet = handle("sc_rename_sheet", FunctionDescriptor.of(i32, ptr, i32, ptr))
     private val scDeleteSheet = handle("sc_delete_sheet", FunctionDescriptor.of(i32, ptr, i32))
+
+    // ── File open / save — bytes in, bytes out ─────────────────────────
+    // The first calls that carry RAW FILE BYTES, not a NUL-terminated char*: an
+    // .xlsx is a ZIP, an .xls an OLE2 file, and either may contain a 0x00, so the
+    // bytes cross as an explicit (address, len) pair. `size_t` is a native-word
+    // integer → JAVA_LONG (i64). A load takes (session, bytes*, len) → int; a save
+    // takes (session, &out_len) → uint8_t*.
+    private val scLoadXlsx = handle("sc_load_xlsx", FunctionDescriptor.of(i32, ptr, ptr, i64))
+    private val scSaveXlsx = handle("sc_save_xlsx", FunctionDescriptor.of(ptr, ptr, ptr))
+    private val scLoadXls = handle("sc_load_xls", FunctionDescriptor.of(i32, ptr, ptr, i64))
+    private val scSaveXls = handle("sc_save_xls", FunctionDescriptor.of(ptr, ptr, ptr))
+    private val scLoadCsv = handle("sc_load_csv", FunctionDescriptor.of(i32, ptr, ptr, i64))
+    private val scSaveCsv = handle("sc_save_csv", FunctionDescriptor.of(ptr, ptr, ptr))
+    private val scLoadTsv = handle("sc_load_tsv", FunctionDescriptor.of(i32, ptr, ptr, i64))
+    private val scSaveTsv = handle("sc_save_tsv", FunctionDescriptor.of(ptr, ptr, ptr))
+    private val scLoadJson = handle("sc_load_json", FunctionDescriptor.of(i32, ptr, ptr, i64))
+    private val scSaveJson = handle("sc_save_json", FunctionDescriptor.of(ptr, ptr, ptr))
+    // Free a buffer an sc_save_* returned — (ptr, len) must match what it wrote
+    // (the engine's allocator, NOT libc free). Safe with (NULL, 0).
+    private val scBytesFree = handle("sc_bytes_free", FunctionDescriptor.ofVoid(ptr, i64))
 
     private val session = scNew.invoke() as MemorySegment
 
@@ -236,6 +257,66 @@ class SpreadsheetSession(libraryPath: String = resolveLibraryPath()) : AutoClose
     fun deserialize(data: String): Boolean = Arena.ofConfined().use { a ->
         (scDeserialize.invoke(session, a.allocateUtf8String(data)) as Int) != 0
     }
+
+    // ── File open / save — bytes in, bytes out ─────────────────────────
+    // Unlike every call above, these carry RAW FILE BYTES (a ZIP for .xlsx, an
+    // OLE2 file for .xls, text for CSV/TSV/JSON), which may contain a 0x00 — so
+    // they must NOT go through the char*/[take] path (which stops at the first
+    // NUL). A load copies the ByteArray into a native segment and hands the engine
+    // a (segment, len) pair; a save copies the engine's (ptr, out_len) buffer into
+    // a Kotlin ByteArray BEFORE releasing it with sc_bytes_free (the engine's
+    // allocator — never libc free).
+
+    /// Load `bytes` as a file of a format via the C ABI handle `fn` (one of
+    /// sc_load_xlsx/xls/csv/tsv/json), replacing the workbook. Returns `true` if
+    /// opened, `false` if the bytes aren't a readable file of that format (the
+    /// workbook is left untouched) or the input is empty (a safe no-op — no native
+    /// buffer for the engine to read a slice from).
+    private fun loadBytes(fn: MethodHandle, bytes: ByteArray): Boolean {
+        if (bytes.isEmpty()) return false
+        return Arena.ofConfined().use { a ->
+            val seg = a.allocateArray(ValueLayout.JAVA_BYTE, *bytes)
+            (fn.invoke(session, seg, bytes.size.toLong()) as Int) != 0
+        }
+    }
+
+    /// Serialize the workbook to a format's file bytes via the C ABI handle `fn`
+    /// (one of sc_save_xlsx/xls/csv/tsv/json). Returns an empty array for an empty
+    /// document. The engine hands back a heap buffer as a (ptr, out_len) pair; we
+    /// COPY those bytes into a Kotlin ByteArray (toArray) before releasing the
+    /// engine's buffer with sc_bytes_free, so no engine memory outlives this call.
+    private fun saveBytes(fn: MethodHandle): ByteArray = Arena.ofConfined().use { a ->
+        val lenSeg = a.allocate(i64)
+        val p = fn.invoke(session, lenSeg) as MemorySegment
+        val len = lenSeg.get(ValueLayout.JAVA_LONG, 0)
+        if (p.address() == 0L || len <= 0L) {
+            if (p.address() != 0L) scBytesFree.invoke(p, len) // free a 0-len buffer
+            ByteArray(0)
+        } else {
+            val out = p.reinterpret(len).toArray(ValueLayout.JAVA_BYTE) // copy before free
+            scBytesFree.invoke(p, len)
+            out
+        }
+    }
+
+    /// Open a real spreadsheet file the user picked, over the one engine. `.xlsx`
+    /// reloads live formulas; `.xls`/CSV/TSV/JSON are values-only. Each returns
+    /// `true` on success, `false` if the bytes aren't a readable file of that
+    /// format (the workbook is left untouched) or the input is empty.
+    fun loadXlsx(bytes: ByteArray): Boolean = loadBytes(scLoadXlsx, bytes)
+    fun loadXls(bytes: ByteArray): Boolean = loadBytes(scLoadXls, bytes)
+    fun loadCsv(bytes: ByteArray): Boolean = loadBytes(scLoadCsv, bytes)
+    fun loadTsv(bytes: ByteArray): Boolean = loadBytes(scLoadTsv, bytes)
+    fun loadJson(bytes: ByteArray): Boolean = loadBytes(scLoadJson, bytes)
+
+    /// Serialize the current document to a file's bytes in each format — what a
+    /// host writes to disk / hands to a Save dialog. An empty document yields an
+    /// empty array.
+    fun saveXlsx(): ByteArray = saveBytes(scSaveXlsx)
+    fun saveXls(): ByteArray = saveBytes(scSaveXls)
+    fun saveCsv(): ByteArray = saveBytes(scSaveCsv)
+    fun saveTsv(): ByteArray = saveBytes(scSaveTsv)
+    fun saveJson(): ByteArray = saveBytes(scSaveJson)
 
     /// Undo / redo: walk the engine's snapshot history. Each returns `true` if it
     /// changed the document (the host then re-reads the viewport), `false` if
@@ -685,6 +766,46 @@ class InfiniteSheetModel(
             formula = session.getRaw(infAddress())
         }
         return ok
+    }
+
+    /// Export the whole workbook to a real spreadsheet file's bytes in [format]
+    /// (one of [fileFormats]) — the same bytes the web download and the other
+    /// native hosts write. `.xlsx` keeps live formulas; the rest are values-only.
+    /// An unknown format or empty document yields an empty array.
+    fun exportBytes(format: String): ByteArray = when (format) {
+        "xlsx" -> session.saveXlsx()
+        "xls" -> session.saveXls()
+        "csv" -> session.saveCsv()
+        "tsv" -> session.saveTsv()
+        "json" -> session.saveJson()
+        else -> ByteArray(0)
+    }
+
+    /// Import a real spreadsheet file's [bytes] of [format] (one of [fileFormats]),
+    /// replacing the workbook. Returns `false` (workbook untouched) if the bytes
+    /// aren't a readable file of that format or the format is unknown. On success
+    /// it regrows the extent and refreshes the formula bar so the view re-reads.
+    fun importBytes(format: String, bytes: ByteArray): Boolean {
+        val ok = when (format) {
+            "xlsx" -> session.loadXlsx(bytes)
+            "xls" -> session.loadXls(bytes)
+            "csv" -> session.loadCsv(bytes)
+            "tsv" -> session.loadTsv(bytes)
+            "json" -> session.loadJson(bytes)
+            else -> false
+        }
+        if (ok) {
+            computeExtent()
+            formula = session.getRaw(infAddress())
+        }
+        return ok
+    }
+
+    companion object {
+        /// The spreadsheet file formats the demo can open / save, in menu order.
+        /// The canonical extension doubles as the format key for [exportBytes] /
+        /// [importBytes].
+        val fileFormats = listOf("xlsx", "xls", "csv", "tsv", "json")
     }
 
     /// Undo / redo: walk the engine's snapshot history. On success the extent

--- a/code/programs/kotlin/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
+++ b/code/programs/kotlin/visicalc-compose/src/main/kotlin/InfiniteSheet.kt
@@ -121,6 +121,12 @@ fun InfiniteSheet() {
     // serialized workbook here, Load restores from it. (A real app would write
     // it to a file; the demo keeps the round trip self-contained.)
     var savedSnapshot by remember { mutableStateOf("") }
+    // The most recent File → Save / Open result, echoed in the footer, plus a
+    // PRIVATE per-session scratch dir (createTempDirectory → mode 0700 on POSIX)
+    // so the on-disk round trip doesn't write a predictable name into the shared,
+    // world-writable temp root.
+    var fileStatus by remember { mutableStateOf("") }
+    val scratchDir = remember { java.nio.file.Files.createTempDirectory("visicalc-").toFile() }
 
     // Find / replace fields + a short status echoed in the footer (match/replace
     // count). The query searches every cell's SOURCE (case-insensitive).
@@ -173,6 +179,25 @@ fun InfiniteSheet() {
         model.loadBook(savedSnapshot)
         formula = model.formula
         rev++
+    }
+
+    // File → Save / Open a REAL spreadsheet file on disk over the engine's byte
+    // codecs (model.exportBytes/importBytes → sc_save_*/sc_load_*). The demo uses
+    // a fixed name in the private scratch dir; a production host would swap in an
+    // AWT FileDialog and hand the same bytes across.
+    fun exportFile(format: String, ext: String) {
+        val bytes = model.exportBytes(format)
+        val f = java.io.File(scratchDir, "visicalc-demo.$ext")
+        f.writeBytes(bytes)
+        fileStatus = "saved %.1f KB → %s".format(bytes.size / 1024.0, f.name)
+    }
+    fun openFile(format: String, ext: String) {
+        val f = java.io.File(scratchDir, "visicalc-demo.$ext")
+        if (!f.exists()) { fileStatus = "no ${f.name} yet — Save first"; return }
+        val ok = model.importBytes(format, f.readBytes())
+        formula = model.formula
+        rev++
+        fileStatus = if (ok) "opened ${f.name}" else "not a valid $ext file"
     }
 
     // Undo / redo: walk the engine's snapshot history. On success the grid
@@ -347,10 +372,21 @@ fun InfiniteSheet() {
             Spacer(Modifier.width(6.dp))
             toolButton("Paste") { pasteCell() }
             toolSep()
-            // ── File (save / load) ──
+            // ── File (save / load to memory) ──
             toolButton("Save") { saveBook() }
             Spacer(Modifier.width(6.dp))
             toolButton("Load", enabled = savedSnapshot.isNotEmpty()) { loadBook() }
+            toolSep()
+            // ── File → open / save a REAL file on disk (over the engine's byte
+            //    codecs, across Java FFM): an .xlsx (ZIP, live formulas) and a
+            //    .csv (text, values only). ──
+            toolButton("Save .xlsx") { exportFile("xlsx", "xlsx") }
+            Spacer(Modifier.width(6.dp))
+            toolButton("Open .xlsx") { openFile("xlsx", "xlsx") }
+            Spacer(Modifier.width(6.dp))
+            toolButton("Save .csv") { exportFile("csv", "csv") }
+            Spacer(Modifier.width(6.dp))
+            toolButton("Open .csv") { openFile("csv", "csv") }
             toolSep()
             // ── Structure (insert / delete the selected row or column) ──
             toolButton("+ Row") { insertRow() }
@@ -549,7 +585,8 @@ fun InfiniteSheet() {
         androidx.compose.material.Text(
             "Virtual grid: ${model.totalRows} rows × ${model.totalCols} cols" +
                 "  ·  revision ${rev.let { model.revision() }}" +
-                (if (findStatus.isNotEmpty()) "  ·  $findStatus" else ""),
+                (if (findStatus.isNotEmpty()) "  ·  $findStatus" else "") +
+                (if (fileStatus.isNotEmpty()) "  ·  $fileStatus" else ""),
             color = MUTED,
             fontSize = 12.sp,
             fontFamily = MONO,

--- a/code/programs/kotlin/visicalc-compose/test/EngineSmoke.kt
+++ b/code/programs/kotlin/visicalc-compose/test/EngineSmoke.kt
@@ -335,6 +335,73 @@ fun main() {
     check("msm Summary B3", msm.rowCells(3)[1], "300") // B3 = A1+A2 = 100+200
     msm.close()
 
+    // ── File open / save (the File → Save/Open buttons drive exportBytes/
+    // importBytes over sc_save_*/sc_load_*): open and save a REAL spreadsheet
+    // file over the engine's byte codecs. File bytes are binary (a .xlsx is a
+    // ZIP, an .xls an OLE2 file) and cross Java FFM as a native (segment, len)
+    // pair going in and a copied-out buffer coming back — never a NUL-terminated
+    // string a 0x00 inside the file would truncate.
+    val fsrc = SpreadsheetSession()
+    fsrc.setCell("A1", "15"); fsrc.setCell("B1", "3"); fsrc.setCell("C1", "=A1+B1") // 18
+
+    // .xlsx is a real ZIP (magic "PK\x03\x04") and keeps its live formula.
+    val xlsx = fsrc.saveXlsx()
+    check("xlsx ZIP magic",
+        (xlsx.size > 4 && xlsx[0] == 0x50.toByte() && xlsx[1] == 0x4B.toByte() &&
+            xlsx[2] == 0x03.toByte() && xlsx[3] == 0x04.toByte()).toString(), "true")
+    val fdstX = SpreadsheetSession()
+    check("xlsx reopens", fdstX.loadXlsx(xlsx).toString(), "true")
+    check("xlsx keeps formula", fdstX.getRaw("C1"), "=A1+B1")
+    check("xlsx computes", fdstX.display("C1"), "18")
+    fdstX.close()
+
+    // .xls is a real OLE2 file (magic D0 CF 11 E0) — the 0xD0 high bit is what a
+    // lossy string round trip would have mangled. Values only.
+    val xls = fsrc.saveXls()
+    check("xls OLE2 magic",
+        (xls.size > 8 && xls[0] == 0xD0.toByte() && xls[1] == 0xCF.toByte() &&
+            xls[2] == 0x11.toByte() && xls[3] == 0xE0.toByte()).toString(), "true")
+    val fdstL = SpreadsheetSession()
+    check("xls reopens", fdstL.loadXls(xls).toString(), "true")
+    check("xls value", fdstL.display("C1"), "18")
+    fdstL.close()
+
+    // A bad or empty payload is rejected, workbook left untouched.
+    check("xlsx rejects garbage", fsrc.loadXlsx("not a spreadsheet".toByteArray()).toString(), "false")
+    check("xlsx rejects empty", fsrc.loadXlsx(ByteArray(0)).toString(), "false")
+    check("workbook intact after reject", fsrc.display("C1"), "18")
+    fsrc.close()
+
+    // CSV / TSV / JSON: values-only. JSON's canonical shape is an array of
+    // objects, so row 1 is the HEADER (the keys) and row 2 the first data
+    // record; CSV/TSV are positional grids. A header + data row round-trips
+    // consistently through all three.
+    for (format in listOf("csv", "tsv", "json")) {
+        val t = SpreadsheetSession()
+        t.setCell("A1", "qty"); t.setCell("B1", "unit"); t.setCell("C1", "total")
+        t.setCell("A2", "15"); t.setCell("B2", "3"); t.setCell("C2", "=A2*B2") // 45
+        val bytes = when (format) { "csv" -> t.saveCsv(); "tsv" -> t.saveTsv(); else -> t.saveJson() }
+        t.close()
+        check("$format save non-empty", bytes.isNotEmpty().toString(), "true")
+        val d = SpreadsheetSession()
+        val ok = when (format) { "csv" -> d.loadCsv(bytes); "tsv" -> d.loadTsv(bytes); else -> d.loadJson(bytes) }
+        check("$format reopens", ok.toString(), "true")
+        check("$format header round-trip", d.display("A1"), "qty")
+        check("$format value round-trip", d.display("C2"), "45")
+        d.close()
+    }
+
+    // The InfiniteSheetModel exposes format-parameterised export / import.
+    val fm = InfiniteSheetModel()
+    for (format in InfiniteSheetModel.fileFormats) {
+        val bytes = fm.exportBytes(format)
+        check("model $format export", bytes.isNotEmpty().toString(), "true")
+        check("model $format import", fm.importBytes(format, bytes).toString(), "true")
+    }
+    check("model unknown export empty", fm.exportBytes("numbers").isEmpty().toString(), "true")
+    check("model unknown import false", fm.importBytes("numbers", byteArrayOf(1, 2, 3)).toString(), "false")
+    fm.close()
+
     println(if (failures == 0) "\nALL PASS" else "\n$failures FAILURE(S)")
     kotlin.system.exitProcess(if (failures == 0) 0 else 1)
 }


### PR DESCRIPTION
## What

Binds the spreadsheet C ABI's byte-based file codecs (`sc_load_<fmt>` / `sc_save_<fmt>` / `sc_bytes_free`) through the Java **Foreign Function & Memory API**, so the Compose Desktop VisiCalc demo can **open and save real spreadsheet files** — `.xlsx` / `.xls` / `.csv` / `.tsv` / `.json` — over the one shared Rust engine. The **Compose arm** of the same open/save story the web (WASM), native (C ABI), Android (JNI), Flutter (dart:ffi), .NET (P/Invoke), SwiftUI and Qt hosts have.

## Why it matters

These are the first calls carrying **raw file bytes**, not a NUL-terminated `char*`: an `.xlsx` is a ZIP, an `.xls` an OLE2 file, either may hold a `0x00`. A load copies the `ByteArray` into a confined-`Arena` native segment and hands the engine a `(segment, len)` pair; a save copies the engine's `(ptr, out_len)` buffer into a `ByteArray` (`toArray`) **before** releasing it with `sc_bytes_free` (the engine's allocator, never a JVM/Arena free of the engine pointer). `size_t` binds as `JAVA_LONG`.

## Changes

- **`Engine.kt`** — FFM downcall handles for the 10 byte functions + `sc_bytes_free`; `loadBytes`/`saveBytes` helpers; public `loadXlsx`/`saveXlsx`/… per format on `SpreadsheetSession`.
- **`InfiniteSheetModel.exportBytes(format)` / `importBytes(format, bytes)`** + a `fileFormats` companion — format-parameterised open/save that regrows the extent + refreshes the formula bar.
- **`InfiniteSheet.kt`** — Save/Open `.xlsx` and `.csv` toolbar buttons writing/reading a real file over the byte codecs, into a **private per-session temp dir** (`Files.createTempDirectory`, mode 0700); result echoed in the footer.
- **`test/EngineSmoke.kt`** — headless round-trips for all five formats: ZIP magic `PK\x03\x04` on `.xlsx`, OLE2 magic `0xD0CF` on `.xls`, values survive a reopen, bad/empty payload rejected with the workbook untouched.
- **README** — documents the feature.

## Verification

- `scripts/verify.sh` (the cross-platform **FFM smoke** — compiles `Engine.kt` + `EngineSmoke.kt` and runs under JDK 21 FFM) is green: **ALL PASS**, including the new file round-trips.
- `gradle compileKotlin` compiles the full Compose app (the UI in `InfiniteSheet.kt`) with no errors.
- Security review **passed** — FFM memory safety confirmed correct (descriptor arity, empty-guard, copy-before-free with the engine allocator, `reinterpret(len)` bounds, NUL-safe, rejected-load no-op, private-temp-dir I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)