### PR TITLE
feat(visicalc-android): file open/save over the engine via JNI bytes + SAF

### DIFF
--- a/code/programs/kotlin/visicalc-android/README.md
+++ b/code/programs/kotlin/visicalc-android/README.md
@@ -43,6 +43,26 @@ identical dispatch — editing behaves the same in both; only the shape
 changes. This is the Android sibling of the Qt / Compose / Flutter toggles
 and the web demo's switcher (the UI30 "one component, many layouts" invariant).
 
+### File open / save (over the engine's byte codecs)
+
+**Save .xlsx / Open .xlsx / Save .csv / Open .csv** buttons open and save a
+**real spreadsheet file** over the one engine, via Android's **Storage Access
+Framework** (`ActivityResultContracts.OpenDocument` / `CreateDocument`). The
+picked document's bytes cross to the engine through
+`Engine.exportBytes(format)` / `importBytes(format, bytes)`, which call the
+`nativeSave<Fmt>` / `nativeLoad<Fmt>` JNI methods in
+[`spreadsheet-android-jni`](../../../packages/rust/spreadsheet-android-jni) (0.2.0,
+over the zero-dependency [`jni-bridge`](../../../packages/rust/jni-bridge) byte-array
+helpers). A Java `byte[]` carries the raw file bytes intact — an `.xlsx` is a ZIP,
+an `.xls` an OLE2 file, either may hold a `0x00` — so nothing goes through a
+`String`/`char*` path that a NUL would truncate. `.xlsx` keeps live formulas;
+`.xls` / CSV / TSV / JSON are lower-fidelity (values only) per
+[`spreadsheet-io`](../../../packages/rust/spreadsheet-io). All five formats the
+engine speaks are bound on `Engine`; a Save/Open re-reads the grid from the
+reloaded workbook. This is the Android arm of the same open/save story the web
+(WASM), native (C ABI), Flutter (dart:ffi), .NET (P/Invoke), SwiftUI, Qt and
+Compose Desktop hosts have.
+
 ## What this demo does NOT yet do
 
 - No `mosaic-compile --backend compose` exists yet (tracked as

--- a/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/Engine.kt
+++ b/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/Engine.kt
@@ -58,6 +58,42 @@ class Engine : AutoCloseable {
         }
     }
 
+    // ── File open / save — bytes in, bytes out ──────────────────────────────
+    // Open and save a REAL spreadsheet file over the one engine. A Java `byte[]`
+    // carries the raw file bytes intact — an .xlsx is a ZIP, an .xls an OLE2 file,
+    // either may hold a 0x00 — so nothing goes through the String/char* path a NUL
+    // would truncate. The JNI side (spreadsheet-android-jni) marshals the byte[]
+    // via jni-bridge's jni_get_byte_array / jni_new_byte_array_from. `.xlsx` keeps
+    // live formulas; `.xls`/CSV/TSV/JSON are values-only per spreadsheet-io.
+
+    /** Open a file's [bytes] as [format] (one of [fileFormats]), replacing the
+     *  workbook. Returns `true` if opened, `false` if the bytes aren't a readable
+     *  file of that format (the document is untouched) or the input is empty. The
+     *  caller re-reads [viewportRows] / [rawAt] afterwards. */
+    fun importBytes(format: String, bytes: ByteArray): Boolean {
+        if (bytes.isEmpty()) return false
+        return when (format) {
+            "xlsx" -> nativeLoadXlsx(ptr, bytes)
+            "xls" -> nativeLoadXls(ptr, bytes)
+            "csv" -> nativeLoadCsv(ptr, bytes)
+            "tsv" -> nativeLoadTsv(ptr, bytes)
+            "json" -> nativeLoadJson(ptr, bytes)
+            else -> false
+        }
+    }
+
+    /** Serialize the current document to [format]'s file bytes (one of
+     *  [fileFormats]) — the bytes a host writes to the file the user picked. An
+     *  unknown format yields an empty array. */
+    fun exportBytes(format: String): ByteArray = when (format) {
+        "xlsx" -> nativeSaveXlsx(ptr)
+        "xls" -> nativeSaveXls(ptr)
+        "csv" -> nativeSaveCsv(ptr)
+        "tsv" -> nativeSaveTsv(ptr)
+        "json" -> nativeSaveJson(ptr)
+        else -> ByteArray(0)
+    }
+
     override fun close() {
         nativeFree(ptr)
     }
@@ -73,8 +109,23 @@ class Engine : AutoCloseable {
     private external fun nativeGetRaw(ptr: Long, a1: String): String
     private external fun nativeGetDisplayWindow(ptr: Long, row0: Int, col0: Int, row1: Int, col1: Int): String
     private external fun nativeColumnLetters(ptr: Long, index: Int): String
+    // File open / save (bytes in, bytes out) — added in spreadsheet-android-jni
+    // 0.2.0; the byte[] crosses via jni-bridge's byte-array helpers.
+    private external fun nativeLoadXlsx(ptr: Long, data: ByteArray): Boolean
+    private external fun nativeSaveXlsx(ptr: Long): ByteArray
+    private external fun nativeLoadXls(ptr: Long, data: ByteArray): Boolean
+    private external fun nativeSaveXls(ptr: Long): ByteArray
+    private external fun nativeLoadCsv(ptr: Long, data: ByteArray): Boolean
+    private external fun nativeSaveCsv(ptr: Long): ByteArray
+    private external fun nativeLoadTsv(ptr: Long, data: ByteArray): Boolean
+    private external fun nativeSaveTsv(ptr: Long): ByteArray
+    private external fun nativeLoadJson(ptr: Long, data: ByteArray): Boolean
+    private external fun nativeSaveJson(ptr: Long): ByteArray
 
     companion object {
+        /** The spreadsheet file formats the demo can open / save, in menu order. */
+        val fileFormats = listOf("xlsx", "xls", "csv", "tsv", "json")
+
         init {
             System.loadLibrary("spreadsheet_android_jni")
         }

--- a/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/MainActivity.kt
+++ b/code/programs/kotlin/visicalc-android/app/src/main/java/com/example/visicalc/MainActivity.kt
@@ -20,11 +20,18 @@ package com.example.visicalc
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Button
@@ -95,6 +102,41 @@ private fun VisiCalcApp() {
     // runtime toggle — the Android sibling of the Qt/Compose/Flutter toggles.
     var touch by remember { mutableStateOf(true) }
 
+    // File open / save via the Storage Access Framework: a document picker for
+    // Open, a "create document" flow for Save. The bytes cross the Rust engine's
+    // byte codecs (engine.exportBytes / importBytes → the nativeLoad* / nativeSave*
+    // JNI methods). One `pendingFormat` selects which codec a launched dialog uses;
+    // `fileStatus` echoes the result under the toolbar.
+    val context = LocalContext.current
+    var pendingFormat by remember { mutableStateOf("xlsx") }
+    var fileStatus by remember { mutableStateOf("") }
+    val openLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri != null) {
+            val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                ?: ByteArray(0)
+            val ok = engine.importBytes(pendingFormat, bytes)
+            if (ok) {
+                // The load replaced the whole workbook — re-read the grid + bar.
+                viewportRows = engine.viewportRows()
+                formulaText =
+                    if (selectedCol.toInt() >= 1) engine.rawAt(cellAddress(selectedRow, selectedCol))
+                    else ""
+            }
+            fileStatus = if (ok) "opened .$pendingFormat" else "not a valid .$pendingFormat file"
+        }
+    }
+    val saveLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/octet-stream"),
+    ) { uri ->
+        if (uri != null) {
+            context.contentResolver.openOutputStream(uri)
+                ?.use { it.write(engine.exportBytes(pendingFormat)) }
+            fileStatus = "saved .$pendingFormat"
+        }
+    }
+
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(
             text = "VISICALC · MOSAIC ANDROID DEMO",
@@ -107,6 +149,28 @@ private fun VisiCalcApp() {
         // Column at runtime — both drive the same engine identically.
         Button(onClick = { touch = !touch }) {
             Text(if (touch) "Desktop bar" else "Touch bar")
+        }
+
+        // File: open / save a REAL spreadsheet file via the Storage Access
+        // Framework, over the engine's byte codecs (.xlsx keeps live formulas;
+        // .csv is values only). Horizontally scrollable so the row fits a phone.
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()).padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Button(onClick = { pendingFormat = "xlsx"; saveLauncher.launch("visicalc-demo.xlsx") }) { Text("Save .xlsx") }
+            Button(onClick = { pendingFormat = "xlsx"; openLauncher.launch(arrayOf("*/*")) }) { Text("Open .xlsx") }
+            Button(onClick = { pendingFormat = "csv"; saveLauncher.launch("visicalc-demo.csv") }) { Text("Save .csv") }
+            Button(onClick = { pendingFormat = "csv"; openLauncher.launch(arrayOf("*/*")) }) { Text("Open .csv") }
+        }
+        if (fileStatus.isNotEmpty()) {
+            Text(
+                text = fileStatus,
+                color = Color(0xFF9D9D9D),
+                fontSize = 11.sp,
+                fontFamily = FontFamily.Monospace,
+                modifier = Modifier.padding(top = 4.dp),
+            )
         }
 
         Box(modifier = Modifier.padding(top = 8.dp)) {


### PR DESCRIPTION
## What

Wires the Android VisiCalc demo to **open and save real spreadsheet files** — `.xlsx` / `.xls` / `.csv` / `.tsv` / `.json` — over the one shared Rust engine. The **Android arm** of the same open/save story the web (WASM), native (C ABI), Flutter (dart:ffi), .NET (P/Invoke), SwiftUI, Qt and Compose Desktop hosts have. The Rust JNI side (`nativeLoad*`/`nativeSave*` in `spreadsheet-android-jni` 0.2.0) landed in #7755; this adds the Kotlin binding + UI.

## Why it matters

A Java `byte[]` carries the raw file bytes intact — an `.xlsx` is a ZIP, an `.xls` an OLE2 file, either may hold a `0x00` — so nothing goes through the `String`/`char*` path a NUL would truncate.

## Changes

- **`Engine.kt`** — `external fun nativeLoad<Fmt>(ptr, ByteArray): Boolean` / `nativeSave<Fmt>(ptr): ByteArray` for all five formats (matching the merged `Java_com_example_visicalc_Engine_native*` symbols), plus high-level `importBytes(format, bytes)` / `exportBytes(format)` and a `fileFormats` list. Empty input is a safe no-op.
- **`MainActivity.kt`** — Save/Open `.xlsx` and `.csv` buttons over the **Storage Access Framework** (`ActivityResultContracts.OpenDocument` / `CreateDocument("application/octet-stream")`); the picked document's bytes are read/written via `ContentResolver` (`.use{}`-scoped) and handed to the engine's byte codecs. A successful Open re-reads the grid + formula bar; the result is echoed under the toolbar.
- **README** — documents the feature.

## Verification

- `scripts/build.sh` cross-compiles the engine `.so` (arm64-v8a + x86_64 via the NDK) and `gradle :app:assembleDebug` builds the app **green** — the Kotlin `external fun`s + SAF UI compile and the `.so` is packaged.
- The byte marshalling itself (`jni-bridge`'s `jni_get_byte_array` / `jni_new_byte_array_from`) is covered by `spreadsheet-android-jni`'s mock-JNIEnv tests (a real JNIEnv comes only from a running device/emulator); the `external fun` signatures match the merged Rust symbols exactly.
- Security review **passed** — JNI binding correctness (signature match), empty-guard, NUL-safe `byte[]` path, rejected-load no-op, `.use{}`-scoped `ContentResolver` streams over user-chosen `content://` URIs, no handle leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)