### PR TITLE
feat(latex): LTXDOC03 S20 duplicate_label_definitions — losing duplicate \label report

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.56.0] — 2026-07-07
+
+### Added — losing duplicate-`\label` report (LTXDOC03 S20)
+
+A **new** public method `Document::duplicate_label_definitions(&self) -> String` that renders the
+**losing duplicate `\label` definitions** — the label-family mirror of S16's
+`duplicate_bibliography_entries` (which renders the losing `\bibitem` duplicates). It is a read-only
+view over `resolve_references()`: S1 splits every `\label` into the **winning** first definition of each
+key (`definitions`) and the **losing** later re-definitions of an already-defined key (`duplicates` —
+LaTeX's *"Label `key' multiply defined"* warning); S20 renders that `duplicates` list. Every S1–S19
+output is left **byte-for-byte unchanged**; S20 is purely additive and leaves the `to_latex()`
+round-trip fixed point intact.
+
+- **One line per losing duplicate, in pre-order.** The `duplicates` list is already in body pre-order
+  (first-definition-wins). S20 renders it verbatim — **not** re-sorted, **not** de-duplicated — so
+  every *"multiply defined"* warning gets its own line, exactly like S16.
+- **`\label{key}` reconstructed from the owned key.** Each line is `format!("\\label{{{}}}", dup.key)`
+  — no source slicing at all (matching S13 `resolve_namerefs`, S15 `citations_by_source`, S16
+  `duplicate_bibliography_entries`, and S17–S19's reports). Labels are always defined by `\label{…}`,
+  so `\label{key}` is the correct reconstruction regardless of the duplicate's `LabelKind` (a
+  re-`\label`ed section, figure, equation, or bare inline label all render the same `\label{key}`).
+- **Winner lives elsewhere.** The winning first definition of each key stays in `definitions` (what
+  `\ref`/`\eqref`/`\pageref` resolve against), never in this report.
+- **Stable empty marker.** No duplicate labels (every key defined once, or no labels at all) → the
+  fixed string `(no duplicate label definitions)`, never `""` (the same discipline S12–S19 use). Lines
+  are joined by `\n` with **no** trailing newline.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single pass
+  over the already-bounded `duplicates`. Borrows `self` immutably and returns owned `String`.
+
+Tests: `s20_reports_duplicate_label`, `s20_two_distinct_duplicates_preorder`,
+`s20_no_duplicates_returns_marker`, and an additivity test
+`s20_is_additive_leaves_s1_s19_outputs_unchanged` pinning S1–S19 outputs (including
+`bibliography_entries`) byte-for-byte alongside the new method.
+
 ## [0.55.0] — 2026-07-07
 
 ### Added — numbered winning-bibliography-entry list (LTXDOC03 S19)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -67,6 +67,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S17 — unresolved (dangling) citations grouped by source `\cite`** | `Document::unresolved_citations_by_source() -> String` — a **new**, read-only method that renders the **dangling** citations **grouped by the source `\cite` they came from** — the DANGLING-key mirror of S15's `citations_by_source`, and the per-`\cite` view of S6's flat *"Dangling citations"* footer. It reads only `resolve_citations().unresolved` and re-assembles the per-key rows S2 flattened out of each multi-key `\cite`, grouping the dangling keys back by `cite_span` in **first-appearance order** (source order) with keys kept left-to-right. One line per source `\cite` with ≥1 dangling key: `\cite{` + the group's **dangling** keys joined by `", "` + `}`. A **resolved** key never entered `unresolved`, so `\cite{a,ghost}` where only `a` resolves renders `\cite{ghost}` (reconstructed from keys, no source slicing). Lines joined by `\n`, no trailing newline. A document with **no** unresolved citations → the fixed marker `(no unresolved citations)`. E.g. `\cite{known,ghost}` (only `known` defined) then `\cite{x,y}` (neither) → `\cite{ghost}\n\cite{x, y}`. Every S1–S16 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S18 — unresolved (dangling) references grouped by source `\ref`** | `Document::unresolved_references_by_source() -> String` — a **new**, read-only method that renders the **dangling** references, one reconstructed `\<command>{key}` line each — the `\ref`-family parallel of S17's dangling-CITATION report, and a **distinct** view from S6's flat *"Dangling references: k1, k2"* footer (S18 is **command-aware**, so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`). It reads only `resolve_references().unresolved` (a `Vec<UnresolvedRef { key, command, ref_span }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **resolved** `\ref` never entered `unresolved`, so it is excluded. Lines joined by `\n`, no trailing newline. A document with **no** unresolved references → the fixed marker `(no unresolved references)`. E.g. `\eqref{eq:ghost}` then `\pageref{p:ghost}` (neither defined) → `\eqref{eq:ghost}\n\pageref{p:ghost}`. Every S1–S17 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S19 — numbered winning-bibliography-entry list** | `Document::bibliography_entries() -> String` — a **new**, read-only method that renders the **winning** bibliography entries as a **numbered list** — the rendered bibliography a reader sees, and the table citations resolve against. A **distinct** view over `resolve_citations()`: S16 (`duplicate_bibliography_entries`) renders the **losing** `duplicate_entries` as `\bibitem{key}` lines, S15 (`citations_by_source`) renders per-source *resolved cite keys*; S19 renders the **winning** `entries`. It reads only `resolve_citations().entries` (the first `\bibitem` of each distinct key, body pre-order; later re-definitions live in `duplicate_entries`) and numbers it **1-based**, one line per entry as `[n] key` (reconstructed from the owned key, no source slicing). The `[n] key` shape is deliberately distinct from S16's `\bibitem{key}` lines. A `\bibitem{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** bibliography entries → the fixed marker `(no bibliography entries)`. E.g. `smith` (twice) + `jones` → `[1] smith\n[2] jones`. Every S1–S18 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S20 — losing duplicate `\label` definitions** | `Document::duplicate_label_definitions() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\label`s — LaTeX's *"Label `key' multiply defined"* warnings — the **label-family mirror of S16's** `duplicate_bibliography_entries` (which surfaces the losing `\bibitem` duplicates). It reads only `resolve_references().duplicates`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, what `\ref`/`\eqref`/`\pageref` resolve against) and every **later** `\label` of an already-defined key is a losing duplicate. S20 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). Lines joined by `\n`, no trailing newline. A document with **no** duplicate labels (every key once, or none) → the fixed marker `(no duplicate label definitions)`. E.g. `dup` defined twice + `once` once → `\label{dup}` (only the loser). Every S1–S19 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -826,6 +827,37 @@ assert_eq!(
 A document with no bibliography entries — no `thebibliography`, or an empty one — renders the fixed
 `(no bibliography entries)` marker. Purely additive — reuses `resolve_citations`, mutates nothing, leaves
 every S1–S18 output and the `to_latex()` fixed point unchanged.
+
+### losing duplicate `\label` definitions (LTXDOC03 S20)
+
+The **losing** duplicate `\label` definitions — LaTeX's *"Label `key' multiply defined"* warnings —
+the **label-family mirror of S16's** `duplicate_bibliography_entries` (which renders the losing
+`\bibitem` duplicates). S1 splits every `\label` into the **winning** first definition of each key
+(`resolve_references().definitions`, what `\ref`/`\eqref`/`\pageref` resolve against) and the **losing**
+later re-definitions (`duplicates`, in body pre-order). `duplicate_label_definitions` reads only that
+`duplicates` list and emits one line per losing duplicate — **not** re-sorted, **not** de-duplicated, so
+every *"multiply defined"* warning gets its own line — each reconstructed from its owned key as
+`\label{<key>}` (no source slicing; the `\label{…}` form is correct for any `LabelKind`, whether the
+re-`\label`ed node was a section, figure, equation, or bare inline label).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}First \label{dup} here.
+
+Second \label{dup} there.
+
+And \label{once}.\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.duplicate_label_definitions(),
+    "\\label{dup}",   // only the losing second `\label{dup}`; the first wins, `once` isn't a dup
+);
+```
+
+A document with no duplicate labels — every key defined once, or none at all — renders the fixed
+`(no duplicate label definitions)` marker. Purely additive — reuses `resolve_references`, mutates
+nothing, leaves every S1–S19 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2025,6 +2025,78 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **losing duplicate label definitions** (LTXDOC03 S20) — the label-family mirror of S16's
+    /// [`duplicate_bibliography_entries`](Document::duplicate_bibliography_entries).
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] splits every `\label` into the **winning** first
+    /// definition of each key ([`ReferenceResolution::definitions`]) and the **losing** later
+    /// re-definitions of an already-defined key ([`ReferenceResolution::duplicates`] — LaTeX's *"Label
+    /// `key' multiply defined"* warning). S16 renders the losing `\bibitem` duplicates; S20 is the
+    /// exact `\label` parallel: it renders the losing `\label` duplicates, one reconstructed
+    /// `\label{key}` line per multiply-defined definition. The winning first definition of each key
+    /// lives in `definitions` (and is what `\ref`/`\eqref`/`\pageref` resolve against), never here.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// One line per losing duplicate, in the existing pre-order (**NOT** re-sorted, **NOT**
+    /// de-duplicated — every *"multiply defined"* warning gets its own line, exactly like S16). Each
+    /// line is reconstructed as `\label{` + `dup.key` + `}` from the owned `key` `String` — there is
+    /// **no** source slicing at all (matching S13's `resolve_namerefs`, S15's `citations_by_source`,
+    /// S16's `duplicate_bibliography_entries`, and S17-S19's reports). Labels are always *defined* by
+    /// `\label{…}`, so `\label{key}` is the correct reconstruction regardless of the duplicate's
+    /// [`LabelKind`] (a re-`\label`ed section, figure, equation, or bare inline label all render the
+    /// same `\label{key}` form).
+    ///
+    /// A document with **no** duplicate labels — every key defined exactly once, or no labels at all —
+    /// returns the fixed marker `(no duplicate label definitions)`, never the empty string (the same
+    /// stable-marker discipline S12-S19 use). Lines are joined by `\n` with **no** trailing newline
+    /// (matching S11's `to_plain_text_by_kind` and every S12-S19 renderer).
+    ///
+    /// Concretely, for a body that writes `\label{dup}` twice (and `\label{once}` once):
+    ///
+    /// ```text
+    /// First \label{dup} here.  Second \label{dup} there.  And \label{once}.
+    /// ```
+    ///
+    /// only the *second* `\label{dup}` loses, so the report is the single line:
+    ///
+    /// ```text
+    /// \label{dup}
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S20 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1-S19 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single pass over the already-bounded `duplicates` list.
+    /// Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow of
+    /// the source.
+    pub fn duplicate_label_definitions(&self) -> String {
+        // S1 already routed every later `\label` of an already-defined key into `duplicates`, in body
+        // pre-order (first-definition-wins). We only read that list.
+        let resolution = self.resolve_references();
+
+        if resolution.duplicates.is_empty() {
+            // No multiply-defined `\label` → the fixed marker, never the empty string.
+            return "(no duplicate label definitions)".to_string();
+        }
+
+        // One line per losing duplicate, in the existing pre-order (NOT re-sorted; NOT de-duplicated —
+        // every "multiply defined" warning gets its own line). Reconstruct `\label{key}` from the
+        // owned key, so there is no source slicing; `\label{…}` is the right form for any LabelKind.
+        resolution
+            .duplicates
+            .iter()
+            .map(|dup| format!("\\label{{{}}}", dup.key))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -4950,5 +5022,104 @@ See Section~\ref{sec:intro}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig
         // And S19 itself surfaces the winning entries as a numbered list — the duplicate `a` appears
         // once (the winner), `b` and `c` follow, in source pre-order.
         assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+    }
+
+    #[test]
+    fn s20_reports_duplicate_label() {
+        // A `\label{dup}` written twice: the FIRST wins (→ `definitions`), the SECOND loses (→
+        // `duplicates`). S20 renders only the losing later one, reconstructed as `\label{dup}`.
+        let src = r"\begin{document}First \label{dup} here.
+
+Second \label{dup} there.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+    }
+
+    #[test]
+    fn s20_two_distinct_duplicates_preorder() {
+        // Two different keys, each defined twice. Each losing (second) definition gets its own line,
+        // in body pre-order: `alpha`'s duplicate appears before `beta`'s.
+        let src = r"\begin{document}A \label{alpha} one.
+
+B \label{beta} two.
+
+A' \label{alpha} again.
+
+B' \label{beta} again.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.duplicate_label_definitions(),
+            "\\label{alpha}\n\\label{beta}"
+        );
+    }
+
+    #[test]
+    fn s20_no_duplicates_returns_marker() {
+        // Every label defined exactly once → the fixed marker, never the empty string.
+        let src = r"\begin{document}One \label{one} here, two \label{two} there.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.duplicate_label_definitions(),
+            "(no duplicate label definitions)"
+        );
+    }
+
+    #[test]
+    fn s20_is_additive_leaves_s1_s19_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a resolved `\ref`, a
+        // `\nameref`, two `\cite`s (one multi-key, one dangling key), a duplicate `\bibitem`, a
+        // dangling `\eqref` (`eq:ghost`), AND a duplicate `\label{dup}`, S20 changes NONE of the
+        // S1-S19 outputs — it only reads `resolve_references`.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+
+        // And S20 itself surfaces only the losing later `\label{dup}` (the first `dup` wins).
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1606,3 +1606,73 @@ marker; and an additivity check that `to_plain_text`, `to_plain_text_by_kind`, `
 prior strings). All prior S1–S18 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D
 warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex
 --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 26. S20 — losing duplicate `\label` definitions (`duplicate_label_definitions`)
+
+### 26.1 Motivation
+
+S1's `resolve_references` returns `duplicates: Vec<Duplicate>` — the **losing** later re-definitions of
+an already-defined label key, one row per multiply-defined `\label`, in body pre-order. This is exactly
+LaTeX's *"Label `key' multiply defined"* warning list: the first `\label{key}` seen wins (into
+`definitions`, the table `\ref`/`\eqref`/`\pageref` resolve against) and every later `\label` of that key
+is a loser. Yet no method rendered it. S16 (`duplicate_bibliography_entries`) does the *citation-family*
+equivalent — it renders the losing `\bibitem` duplicates — but its `\label` mirror was missing. S20 fills
+that cell by rendering `duplicates` as the losing-`\label` report, the exact label-family parallel of S16.
+
+### 26.2 Why a new method — additive by construction
+
+S20 adds a **new public method** `Document::duplicate_label_definitions(&self) -> String`. It is a pure,
+read-only render of `resolve_references().duplicates`. It reuses that table verbatim (never re-walking the
+body or re-collecting labels), so the report can never drift from the S1 resolution it summarises. It
+mutates nothing and changes no S1–S19 output — including `to_latex()`'s round-trip fixed point —
+byte-for-byte. Like S11–S19 it is a method the caller invokes directly.
+
+### 26.3 The ordering rule
+
+S1 collects every `\label` (hoisted onto a section/table/figure/equation, or a bare inline `\label`) in
+body pre-order, keeping the **first** of each distinct key in `definitions` and routing every later
+re-definition of an already-defined key into `duplicates` (never into `definitions`). S20 renders
+`duplicates` verbatim in that existing pre-order — **not** re-sorted and **not** de-duplicated — so a key
+defined three times yields two lines, and every *"multiply defined"* warning gets its own line, exactly
+like S16. The winning first definition of each key stays in `definitions` and is never in this report.
+
+### 26.4 The exact rendering contract — `Document::duplicate_label_definitions(&self) -> String`
+
+- One line per losing duplicate, in the existing pre-order (**not** re-sorted, **not** de-duplicated),
+  each rendering `format!("\\label{{{}}}", dup.key)` → `\label{dup}`.
+- Each line is reconstructed from the duplicate's owned `key` `String` rather than sliced from
+  `&src[span]` (matching S13 `resolve_namerefs`, S15 `citations_by_source`, S16
+  `duplicate_bibliography_entries`, and S17–S19's reports), so the render needs no source borrow and can
+  never index out of bounds. Labels are always *defined* by `\label{…}`, so `\label{key}` is the correct
+  reconstruction regardless of the duplicate's `LabelKind` — a re-`\label`ed section, figure, equation,
+  or bare inline label all render the same `\label{key}` form.
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S19 renderer).
+- If there are **no** duplicate labels (every key defined once, or no labels at all), the fixed marker
+  `(no duplicate label definitions)` is returned, so the output is never the empty string.
+
+Example (body writing `\label{dup}` twice and `\label{once}` once):
+
+```text
+\label{dup}
+```
+
+only the second `\label{dup}` loses; the first `dup` wins (into `definitions`) and `once` is defined once,
+so the report is the single losing line. This is the label-family mirror of S16's `\bibitem{key}` view.
+
+### 26.5 Public API (added in S20)
+
+One new method: `Document::duplicate_label_definitions(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_references` and every S1–S19 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 26.6 Verification (S20)
+
+`cargo test -p latex` green (4 new S20 tests: a `\label{dup}` written twice rendering `\label{dup}` (only
+the loser); two distinct keys each multiply-defined rendering `\label{alpha}\n\label{beta}` in pre-order;
+labels all defined once returning the `(no duplicate label definitions)` marker; and an additivity check
+that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`,
+`citations_by_source`, `duplicate_bibliography_entries`, `unresolved_citations_by_source`,
+`unresolved_references_by_source`, and `bibliography_entries` all still produce their exact prior
+strings). All prior S1–S19 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings`
+clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex
+--no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S20 — report the duplicate (multiply-defined) label definitions, the label-family mirror of S16

Adds a new read-only method `Document::duplicate_label_definitions(&self) -> String` to the `latex` crate — the **`\label`-family mirror of S16's `duplicate_bibliography_entries`**. Where S16 renders the losing duplicate `\bibitem`s (LaTeX's *"Citation `key' multiply defined"*), S20 renders the losing duplicate **label** definitions — LaTeX's *"Label `key' multiply defined"* — one reconstructed `\label{key}` per losing duplicate. Bumps `latex` **0.55.0 → 0.56.0**.

### What it does

S2's `resolve_references` records every `\label` whose key was **already** defined by an earlier definition into `ReferenceResolution::duplicates` (each `Duplicate` carries its `key`, its `kind`, and its `span`; the winning first definition lives in `definitions`). No prior method rendered that losing-duplicate list — S16 rendered the bibliography's duplicates, S15/S17/S18 the citation/reference bindings, S19 the winning bibliography entries. S20 fills the remaining cell: the losing duplicate labels.

| aspect | rule |
|---|---|
| line format | `\label{` + the duplicate's own `key` + `}` — reconstructed from the owned key (labels are always defined by `\label{…}`) |
| source | reconstructed from the owned `key` String — **not** sliced from source |
| ordering | body pre-order (the "first definition wins" stable rule); **not** re-sorted, **not** de-duplicated — every "multiply defined" warning gets its own line (exactly like S16) |
| winning def | the first `\label{key}` never enters `duplicates`, so it is excluded by construction |
| empty | fixed marker `(no duplicate label definitions)`, never `""` |
| joining | `\n`-joined, **no** trailing newline (matches S11–S19) |

Example — `\label{dup}` defined, then re-defined `\label{dup}` (the second loses):

```text
\label{dup}
```

### Additive by construction

Brand-new, read-only method that reuses `resolve_references` and mutates nothing. **Total & panic-free**: no source slicing/indexing, no `unwrap`/`expect`, no `unsafe`, a single pass over the already-bounded `duplicates` list, returning owned `String` data. All **S1–S19 outputs stay byte-for-byte unchanged**, pinned by a dedicated additivity test. The `to_latex` round-trip fixed point is untouched.

### Tests (exact strings, real output)

- `s20_reports_duplicate_label` — a key defined twice → `"\\label{dup}"` (only the losing later one)
- `s20_two_distinct_duplicates_preorder` — two multiply-defined keys → two `\n`-joined lines in source order
- `s20_no_duplicates_returns_marker` — labels all defined once → `"(no duplicate label definitions)"`
- `s20_is_additive_leaves_s1_s19_outputs_unchanged` — pins `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`, `duplicate_bibliography_entries`, `unresolved_citations_by_source`, `unresolved_references_by_source`, and `bibliography_entries`

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → all passing (S19 left it at 405; +4 S20) + doc-tests ok
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → all green (0 failed)
- `cargo build -p latex --no-default-features` → builds
- Inline security review PASSED (returned `String`, no injection sink; total/panic-free; same bounded rendering already shipped in S16/S19).
- Single-parent commit; scoped diff = 5 files (`references.rs`, `Cargo.toml`, `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
