### PR TITLE
feat(adj-ladder): rung-107 optometry contact-lens fit index (a difference over a difference)

### DIFF
--- a/code/specs/data/adj-ladder/rung107_contact_lens/gen_items.py
+++ b/code/specs/data/adj-ladder/rung107_contact_lens/gen_items.py
@@ -1,0 +1,266 @@
+"""Generate rung-107 (optometry / contact-lens fitting) items.json for the ADJ-LADDER.
+
+Rung 107 opens the **optometry / contact-lens fitting** panel on the quantitative band — the arithmetic of a contact-lens
+fit index. A `corneal_reading` (the steep corneal curvature) MINUS a `base_curve` (the lens's back curve) gives the sagittal
+gap (how much steeper the cornea sits than the lens, the difference), a `lens_diameter` (the lens's overall width) MINUS a
+`pupil_diameter` (the pupil width) gives the coverage margin (how far the lens overhangs the pupil, the difference), and the
+sagittal gap is DIVIDED by the coverage margin to give the fit index. A **difference over a difference** introduces a
+genuinely NEW arithmetic family on the ladder: `(a-b)/(c-d)`, i.e. `((a-b) / (c-d))`.
+
+This is genuinely new — the first time the ladder divides a bare DIFFERENCE by a bare DIFFERENCE. It **completes the
+difference-denominator family** that rungs 105-106 opened: rung-105 `(a+b)/(c-d)` divided a SUM by a difference, rung-106
+`a*b/(c-d)` a PRODUCT by a difference, and rung-107 divides a DIFFERENCE by a difference — the three numerator shapes (sum,
+product, difference) over a difference denominator are now all shipped. No prior rung put a difference over a difference:
+rung-104 `(a-b)/(c*d)` divided a difference by a product, rung-37 `(a+b)/(c+d)` a sum by a sum. The operator order matters:
+`(a-b)/(c-d)` is `((a-b) / (c-d))` (both sides parenthesized), NOT `a-b/(c-d)` (dropping the numerator parentheses so only the
+base curve is divided by the coverage margin and then subtracted from the corneal reading) and NOT `(a-b)/(c+d)` (summing the
+denominator pair instead of subtracting, mispairing which pair is the coverage difference) — the two distractors exploit
+exactly those confusions.
+
+The setup: a `corneal_reading`, a `base_curve`, a `lens_diameter`, and a `pupil_diameter`. The total is:
+
+  FIT INDEX        (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)  [ a difference over a difference ]
+  SAGITTAL GAP     corneal_reading - base_curve                                        [ the numerator difference ]
+  COVERAGE MARGIN  lens_diameter - pupil_diameter                                      [ the denominator difference ]
+
+The **fit index** is what makes this rung distinctive — it is the ladder's first **bare DIFFERENCE over a bare DIFFERENCE**.
+It is a dimensionless ratio (the sagittal gap per unit of coverage margin), framed as an *index* to keep it honest — the same
+discipline rungs 100/104/105/106 used for their ratios. (The sagittal gap `a-b` and the coverage margin `c-d` ride alongside
+as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-106 shipped their component
+sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine
+carries the arithmetic — the subtraction of the base curve from the corneal reading into the sagittal gap, the subtraction of
+the pupil diameter from the lens diameter into the coverage margin, then the division of the sagittal gap by the coverage
+margin (both parenthesized, so (a-b)/(c-d) evaluates as ((a-b)/(c-d))) — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../105/106. This rung exercises the engine
+across a **difference over a difference** — the fact that `(a-b)/(c-d)` is `((a-b)/(c-d))` and NOT `a-b/(c-d)` and NOT
+`(a-b)/(c+d)` made computable. The ratio golds are non-integer f64s; the engine's IEEE-double division matches Python's the
+same way rungs 99/100/104/105/106 relied on (well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `-` and `/` — **no
+structural constants** — so no numeric literal appears in any program, and neither the sagittal gap, the coverage margin, nor
+any index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free
+identifiers** (`corneal_reading`, `base_curve`, `lens_diameter`, `pupil_diameter`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    corneal_reading - base_curve / (lens_diameter - pupil_diameter)  drop the numerator parentheses so only the base
+                                                                              curve is divided by the coverage margin and then
+                                                                              subtracted from the corneal reading (the classic
+                                                                              `(a-b)/(c-d)` vs `a-b/(c-d)` precedence error), and
+  SWAPPED    (corneal_reading - base_curve) / (lens_diameter + pupil_diameter)  sum the denominator pair instead of
+                                                                              subtracting, mispairing which pair is the
+                                                                              coverage difference (`(a-b)/(c+d)` instead of
+                                                                              `(a-b)/(c-d)`),
+
+which are exactly the mistakes a student makes (dropping the numerator parentheses before dividing, or summing the
+denominator pair that should be a difference). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts;
+all five always appear as options.
+
+Distinctness and positivity: the tables are chosen so `corneal_reading > base_curve` (the sagittal gap `a-b` stays strictly
+positive) and `lens_diameter > pupil_diameter` with a comfortable margin (the coverage margin `c-d` — the headline denominator
+— is strictly positive and the fit index stays finite and clean, never blowing up on a tiny difference), and every observed
+quantity is `>= 2`. The two differences are chosen unequal (`a-b != c-d`) so the numerator and denominator readouts never
+coincide; the swapped denominator `c+d >= 4` is a sum with no subtraction, never zero; the crossed figure `a - b/(c-d)` is
+positive because `b/(c-d) < b <= corneal_reading`. The tables are chosen so the five family values are pairwise distinct with a
+comfortable margin, and — so all three queried readouts vary across the panel — the seven tables give distinct fit indices,
+distinct sagittal gaps, and distinct coverage margins, all asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (CORNEAL_READING, BASE_CURVE, LENS_DIAMETER, PUPIL_DIAMETER) — a corneal reading minus a base curve for the sagittal gap, a
+# lens diameter minus a pupil diameter for the coverage margin, all plain positive numbers >= 2. Each table satisfies
+# corneal_reading > base_curve (sagittal gap > 0) and lens_diameter > pupil_diameter with a comfortable margin (coverage
+# margin = c-d >= 2 => fit index finite and > 0), and a-b != c-d (numerator and denominator readouts distinct); the swapped
+# denominator (c+d) is >= 4 with no subtraction, so nothing is ever zero or undefined. The five family values are asserted
+# pairwise-distinct below. The seven tables give distinct fit indices, distinct sagittal gaps, and distinct coverage margins
+# so all three queried readouts vary across the panel.
+TABLES = [
+    (8, 2, 5, 3),
+    (10, 3, 7, 4),
+    (12, 4, 8, 3),
+    (13, 4, 11, 5),
+    (14, 4, 9, 2),
+    (16, 5, 12, 4),
+    (15, 3, 13, 4),
+]
+
+# The option family (5 members), all built from the four observed quantities via - and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the
+# options.
+FAMILY = [
+    (
+        "fit_index",
+        "fit index (the sagittal gap divided by the coverage margin)",
+        "(corneal_reading - base_curve) / (lens_diameter - pupil_diameter)",
+    ),
+    (
+        "sagittal_gap",
+        "the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)",
+        "corneal_reading - base_curve",
+    ),
+    (
+        "coverage_margin",
+        "the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)",
+        "lens_diameter - pupil_diameter",
+    ),
+    (
+        "crossed",
+        "the corneal reading minus the base curve divided by the coverage margin, dropping the numerator parentheses so only the base curve is divided before subtracting (a wrong grouping)",
+        "corneal_reading - base_curve / (lens_diameter - pupil_diameter)",
+    ),
+    (
+        "swapped",
+        "the corneal reading minus the base curve, divided by the lens diameter plus the pupil diameter, summing the denominator pair instead of subtracting (a wrong pairing)",
+        "(corneal_reading - base_curve) / (lens_diameter + pupil_diameter)",
+    ),
+]
+QUERIED = ["fit_index", "sagittal_gap", "coverage_margin"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(corneal_reading, base_curve, lens_diameter, pupil_diameter):
+    # Operation order mirrors the ADJ programs exactly (the numerator difference forms, the denominator difference forms, then
+    # the numerator is divided by the denominator, so (a-b)/(c-d) evaluates as ((a-b)/(c-d))), so the Python option value and
+    # the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "fit_index": (corneal_reading - base_curve) / (lens_diameter - pupil_diameter),
+        "sagittal_gap": corneal_reading - base_curve,
+        "coverage_margin": lens_diameter - pupil_diameter,
+        "crossed": corneal_reading - base_curve / (lens_diameter - pupil_diameter),
+        "swapped": (corneal_reading - base_curve) / (lens_diameter + pupil_diameter),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for corneal_reading, base_curve, lens_diameter, pupil_diameter in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and the tables guarantee corneal_reading > base_curve
+        # (sagittal gap > 0) and lens_diameter > pupil_diameter with a comfortable margin (coverage margin =
+        # lens_diameter-pupil_diameter >= 2 => fit index finite and > 0), and a-b != c-d (numerator and denominator readouts
+        # distinct); the swapped denominator (lens_diameter+pupil_diameter) is >= 4 with no subtraction, so nothing is ever
+        # zero, negative, or undefined.
+        assert (
+            corneal_reading >= 2
+            and base_curve >= 2
+            and lens_diameter >= 2
+            and pupil_diameter >= 2
+        ), (corneal_reading, base_curve, lens_diameter, pupil_diameter)
+        assert corneal_reading > base_curve, (
+            corneal_reading, base_curve, lens_diameter, pupil_diameter,
+        )
+        assert lens_diameter - pupil_diameter >= 2, (
+            corneal_reading, base_curve, lens_diameter, pupil_diameter,
+        )
+        assert (corneal_reading - base_curve) != (lens_diameter - pupil_diameter), (
+            corneal_reading, base_curve, lens_diameter, pupil_diameter,
+        )
+        fv = family_values(corneal_reading, base_curve, lens_diameter, pupil_diameter)
+        for key, v in fv.items():
+            assert v > 0, (key, corneal_reading, base_curve, lens_diameter, pupil_diameter, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    corneal_reading,
+                    base_curve,
+                    lens_diameter,
+                    pupil_diameter,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                corneal_reading,
+                base_curve,
+                lens_diameter,
+                pupil_diameter,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r107clfit-{idx + 1:02d}",
+                "qtype": "clfit_fit_index",
+                "stem": (
+                    f"A contact-lens fitting records a corneal reading of {num(corneal_reading)} minus a base curve of "
+                    f"{num(base_curve)}, divided by a lens diameter of {num(lens_diameter)} minus a pupil diameter of "
+                    f"{num(pupil_diameter)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe corneal_reading({num(corneal_reading)})\n"
+                    f"observe base_curve({num(base_curve)})\n"
+                    f"observe lens_diameter({num(lens_diameter)})\n"
+                    f"observe pupil_diameter({num(pupil_diameter)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 107 — contact-lens fit index from four stated quantities (a NEW panel: optometry / contact-lens "
+            "fitting). From a corneal reading minus a base curve for the sagittal gap, a lens diameter minus a pupil diameter "
+            "for the coverage margin, and the sagittal gap divided by the coverage margin, compute the fit index "
+            "((corneal_reading-base_curve)/(lens_diameter-pupil_diameter)), the sagittal gap (corneal_reading-base_curve), or "
+            "the coverage margin (lens_diameter-pupil_diameter). Each item is a compute_dimensioned program (observe the four "
+            "quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, A DIFFERENCE OVER A "
+            "DIFFERENCE (a-b)/(c-d) (subtract b from a, subtract d from c, divide the numerator difference by the denominator "
+            "difference, so (a-b)/(c-d) = ((a-b)/(c-d)); the FIRST time the ladder divides a bare DIFFERENCE by a bare "
+            "DIFFERENCE — COMPLETING the difference-denominator family: rung-105 (a+b)/(c-d) sum/difference, rung-106 "
+            "a*b/(c-d) product/difference, rung-107 difference/difference; rung-104 (a-b)/(c*d) divided a difference by a "
+            "product, rung-37 (a+b)/(c+d) a sum by a sum) — and the harness matches the scalar to the printed options. The fit "
+            "index is a dimensionless ratio, framed as an INDEX so the value stays honest. Contamination-safe: every figure is "
+            "built only from the four observed quantities via - and / — no constant leaks, and neither the sagittal gap, the "
+            "coverage margin, nor any index ever appears as a literal (each is computed) — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same "
+            "four quantities, so the distractors are exactly the slips students make: dropping the numerator parentheses so "
+            "only the base curve is divided before subtracting (a-b/(c-d), a wrong grouping) and summing the denominator pair "
+            "that should be a difference ((a-b)/(c+d), a wrong pairing). The core confusion tested is that (a-b)/(c-d) is "
+            "((a-b)/(c-d)), not a-b/(c-d) and not (a-b)/(c+d). Each table guarantees the corneal reading exceeds the base "
+            "curve and the lens diameter exceeds the pupil diameter with a comfortable margin (both differences strictly "
+            "positive, fit index finite), the two differences are unequal (numerator and denominator readouts distinct), and "
+            "the swapped denominator is a sum of quantities >= 2 (never zero, no subtraction), so every figure stays strictly "
+            "positive and well-defined."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung107_contact_lens/items.json
+++ b/code/specs/data/adj-ladder/rung107_contact_lens/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 107 \u2014 contact-lens fit index from four stated quantities (a NEW panel: optometry / contact-lens fitting). From a corneal reading minus a base curve for the sagittal gap, a lens diameter minus a pupil diameter for the coverage margin, and the sagittal gap divided by the coverage margin, compute the fit index ((corneal_reading-base_curve)/(lens_diameter-pupil_diameter)), the sagittal gap (corneal_reading-base_curve), or the coverage margin (lens_diameter-pupil_diameter). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, A DIFFERENCE OVER A DIFFERENCE (a-b)/(c-d) (subtract b from a, subtract d from c, divide the numerator difference by the denominator difference, so (a-b)/(c-d) = ((a-b)/(c-d)); the FIRST time the ladder divides a bare DIFFERENCE by a bare DIFFERENCE \u2014 COMPLETING the difference-denominator family: rung-105 (a+b)/(c-d) sum/difference, rung-106 a*b/(c-d) product/difference, rung-107 difference/difference; rung-104 (a-b)/(c*d) divided a difference by a product, rung-37 (a+b)/(c+d) a sum by a sum) \u2014 and the harness matches the scalar to the printed options. The fit index is a dimensionless ratio, framed as an INDEX so the value stays honest. Contamination-safe: every figure is built only from the four observed quantities via - and / \u2014 no constant leaks, and neither the sagittal gap, the coverage margin, nor any index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the numerator parentheses so only the base curve is divided before subtracting (a-b/(c-d), a wrong grouping) and summing the denominator pair that should be a difference ((a-b)/(c+d), a wrong pairing). The core confusion tested is that (a-b)/(c-d) is ((a-b)/(c-d)), not a-b/(c-d) and not (a-b)/(c+d). Each table guarantees the corneal reading exceeds the base curve and the lens diameter exceeds the pupil diameter with a comfortable margin (both differences strictly positive, fit index finite), the two differences are unequal (numerator and denominator readouts distinct), and the swapped denominator is a sum of quantities >= 2 (never zero, no subtraction), so every figure stays strictly positive and well-defined.",
+  "items": [
+    {
+      "id": "r107clfit-01",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 8 minus a base curve of 2, divided by a lens diameter of 5 minus a pupil diameter of 3. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(8)\nobserve base_curve(2)\nobserve lens_diameter(5)\nobserve pupil_diameter(3)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r107clfit-02",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 8 minus a base curve of 2, divided by a lens diameter of 5 minus a pupil diameter of 3. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(8)\nobserve base_curve(2)\nobserve lens_diameter(5)\nobserve pupil_diameter(3)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r107clfit-03",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 8 minus a base curve of 2, divided by a lens diameter of 5 minus a pupil diameter of 3. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(8)\nobserve base_curve(2)\nobserve lens_diameter(5)\nobserve pupil_diameter(3)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r107clfit-04",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 10 minus a base curve of 3, divided by a lens diameter of 7 minus a pupil diameter of 4. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(10)\nobserve base_curve(3)\nobserve lens_diameter(7)\nobserve pupil_diameter(4)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.3333333333333335,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6363636363636364,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r107clfit-05",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 10 minus a base curve of 3, divided by a lens diameter of 7 minus a pupil diameter of 4. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(10)\nobserve base_curve(3)\nobserve lens_diameter(7)\nobserve pupil_diameter(4)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.3333333333333335,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.6363636363636364,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r107clfit-06",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 10 minus a base curve of 3, divided by a lens diameter of 7 minus a pupil diameter of 4. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(10)\nobserve base_curve(3)\nobserve lens_diameter(7)\nobserve pupil_diameter(4)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.3333333333333335,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6363636363636364,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r107clfit-07",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 12 minus a base curve of 4, divided by a lens diameter of 8 minus a pupil diameter of 3. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(12)\nobserve base_curve(4)\nobserve lens_diameter(8)\nobserve pupil_diameter(3)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7272727272727273,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r107clfit-08",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 12 minus a base curve of 4, divided by a lens diameter of 8 minus a pupil diameter of 3. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(12)\nobserve base_curve(4)\nobserve lens_diameter(8)\nobserve pupil_diameter(3)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7272727272727273,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r107clfit-09",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 12 minus a base curve of 4, divided by a lens diameter of 8 minus a pupil diameter of 3. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(12)\nobserve base_curve(4)\nobserve lens_diameter(8)\nobserve pupil_diameter(3)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 11.2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7272727272727273,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r107clfit-10",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 13 minus a base curve of 4, divided by a lens diameter of 11 minus a pupil diameter of 5. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(13)\nobserve base_curve(4)\nobserve lens_diameter(11)\nobserve pupil_diameter(5)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.333333333333334,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.5625,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r107clfit-11",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 13 minus a base curve of 4, divided by a lens diameter of 11 minus a pupil diameter of 5. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(13)\nobserve base_curve(4)\nobserve lens_diameter(11)\nobserve pupil_diameter(5)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.333333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5625,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r107clfit-12",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 13 minus a base curve of 4, divided by a lens diameter of 11 minus a pupil diameter of 5. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(13)\nobserve base_curve(4)\nobserve lens_diameter(11)\nobserve pupil_diameter(5)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.333333333333334,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5625,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r107clfit-13",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 14 minus a base curve of 4, divided by a lens diameter of 9 minus a pupil diameter of 2. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(14)\nobserve base_curve(4)\nobserve lens_diameter(9)\nobserve pupil_diameter(2)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.4285714285714286,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.9090909090909091,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r107clfit-14",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 14 minus a base curve of 4, divided by a lens diameter of 9 minus a pupil diameter of 2. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(14)\nobserve base_curve(4)\nobserve lens_diameter(9)\nobserve pupil_diameter(2)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.4285714285714286,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.428571428571429,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.9090909090909091,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r107clfit-15",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 14 minus a base curve of 4, divided by a lens diameter of 9 minus a pupil diameter of 2. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(14)\nobserve base_curve(4)\nobserve lens_diameter(9)\nobserve pupil_diameter(2)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.4285714285714286,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.428571428571429,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.9090909090909091,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 7,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r107clfit-16",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 16 minus a base curve of 5, divided by a lens diameter of 12 minus a pupil diameter of 4. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(16)\nobserve base_curve(5)\nobserve lens_diameter(12)\nobserve pupil_diameter(4)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.375,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r107clfit-17",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 16 minus a base curve of 5, divided by a lens diameter of 12 minus a pupil diameter of 4. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(16)\nobserve base_curve(5)\nobserve lens_diameter(12)\nobserve pupil_diameter(4)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.375,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r107clfit-18",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 16 minus a base curve of 5, divided by a lens diameter of 12 minus a pupil diameter of 4. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(16)\nobserve base_curve(5)\nobserve lens_diameter(12)\nobserve pupil_diameter(4)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.375,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.6875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r107clfit-19",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 15 minus a base curve of 3, divided by a lens diameter of 13 minus a pupil diameter of 4. What is the fit index (the sagittal gap divided by the coverage margin)?",
+      "program": "observe corneal_reading(15)\nobserve base_curve(3)\nobserve lens_diameter(13)\nobserve pupil_diameter(4)\nlet answer = (corneal_reading - base_curve) / (lens_diameter - pupil_diameter)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14.666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7058823529411765,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r107clfit-20",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 15 minus a base curve of 3, divided by a lens diameter of 13 minus a pupil diameter of 4. What is the the sagittal gap (the corneal reading minus the base curve, the numerator divided by the coverage margin)?",
+      "program": "observe corneal_reading(15)\nobserve base_curve(3)\nobserve lens_diameter(13)\nobserve pupil_diameter(4)\nlet answer = corneal_reading - base_curve\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14.666666666666666,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.7058823529411765,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r107clfit-21",
+      "qtype": "clfit_fit_index",
+      "stem": "A contact-lens fitting records a corneal reading of 15 minus a base curve of 3, divided by a lens diameter of 13 minus a pupil diameter of 4. What is the the coverage margin (the lens diameter minus the pupil diameter, the denominator the sagittal gap is divided by)?",
+      "program": "observe corneal_reading(15)\nobserve base_curve(3)\nobserve lens_diameter(13)\nobserve pupil_diameter(4)\nlet answer = lens_diameter - pupil_diameter\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.666666666666666,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.7058823529411765,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -144,6 +144,7 @@ SELF_CONTAINED_RUNGS = (
     "rung104_coag_mixing",
     "rung105_sleep_study",
     "rung106_exercise_load",
+    "rung107_contact_lens",
 )
 
 


### PR DESCRIPTION
## rung-107 fit-index arc (`(a-b)/(c-d)` — a difference over a difference)

Opens the **optometry / contact-lens fitting** panel on the ADJ-LADDER quantitative band, and introduces a genuinely **NEW arithmetic family**: `(a-b)/(c-d)` — a **bare difference over a bare difference**. Rung **107**. It **completes the difference-denominator family** rungs 105–106 opened.

### Why this shape is new
It is the **first time the ladder divides a difference by a difference**, closing out the difference-denominator family:

| rung | shape | note |
|---|---|---|
| 37 | `(a+b)/(c+d)` | sum over a **sum** |
| 104 | `(a-b)/(c*d)` | difference over a **product** |
| 105 | `(a+b)/(c-d)` | sum over a difference |
| 106 | `a*b/(c-d)` | product over a difference |
| **107** | **`(a-b)/(c-d)`** | **a difference over a DIFFERENCE** |

The three numerator shapes (sum, product, difference) over a difference denominator are now all shipped. Operator order matters: `(a-b)/(c-d)` is `((a-b)/(c-d))`, NOT `a-b/(c-d)` (drop the numerator parens, so only the base curve is divided then subtracted) and NOT `(a-b)/(c+d)` (sum the denominator pair instead of subtracting) — the two distractors exploit exactly those slips.

### The panel
Four observed quantities — `corneal_reading`, `base_curve`, `lens_diameter`, `pupil_diameter`:

| readout | formula | shape |
|---|---|---|
| **fit index** (headline) | `(corneal_reading-base_curve) / (lens_diameter-pupil_diameter)` | `(a-b)/(c-d)` |
| sagittal gap (queried) | `corneal_reading-base_curve` | `a-b` (the numerator) |
| coverage margin (queried) | `lens_diameter-pupil_diameter` | `c-d` (the denominator) |
| crossed *(distractor)* | `corneal_reading - base_curve / (lens_diameter-pupil_diameter)` | `a-b/(c-d)` (numerator parens dropped) |
| swapped *(distractor)* | `(corneal_reading-base_curve) / (lens_diameter+pupil_diameter)` | `(a-b)/(c+d)` (denom difference→sum) |

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness matches the scalar to the printed options. No harness/engine change. 7 tables × 3 queried = **21 items**, gold rotates A–E. **All three queried golds vary** — fit index 1.33–3.0, sagittal gap 6–12, coverage margin 2–9.

The fit index is a **dimensionless ratio**, framed as an *index* to keep the value honest — the same discipline rungs 100/104/105/106 used. The ratio golds are non-integer f64s; the engine's IEEE-double division matches Python's within the harness's 1e-9 tolerance.

### Contamination-safe by construction
Built ONLY from the four observed quantities via `-` and `/` — **no numeric constants**, no readout ever a literal, identifiers **digit-free**. Every table guarantees `corneal_reading > base_curve` (numerator `a-b > 0`) and `lens_diameter > pupil_diameter` with a **comfortable margin** (coverage margin `c-d ≥ 2`, so the headline denominator is strictly positive and the index stays finite). The two differences are chosen **unequal** (`a-b ≠ c-d`) so the numerator and denominator readouts never coincide. The swapped denominator `c+d ≥ 4` is a sum with no subtraction; the crossed figure `a - b/(c-d)` is positive because `b/(c-d) < b ≤ a`. Build asserts all 5 positive + pairwise-distinct (>1e-6).

### Verification
- `pytest test_ladder_eval.py -k rung107` → **3 passed** (with `adj-lang-cli` built; the engine's f64 division matches the Python ratio golds exactly).
- Single-parent commit; scoped diff = 3 files (`rung107_contact_lens/gen_items.py`, `rung107_contact_lens/items.json`, `test_ladder_eval.py`).
- Inline security review PASSED (data-only generator; no eval/exec/subprocess/network/user-input; denominators guarded so no division-by-zero possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
