### PR TITLE
feat(engram): wire search matching onto zero-dep regex-engine (Phase D2)

### DIFF
--- a/code/packages/rust/engram-core/CHANGELOG.md
+++ b/code/packages/rust/engram-core/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Search matching now runs on the zero-dep `regex-engine` (Phase D2)
+
+The three **boolean** regex uses in `search.rs` — user `re:` patterns
+(`build_search_regex`), whole-word matching (`build_whole_word_regex` and the
+runtime `whole_word_pattern_matches`), and `*`/`_` glob matching
+(`search_pattern_regex_source` compiled in `contains_search_pattern` /
+`search_pattern_matches`) — now use `regex_engine::{Regex, RegexBuilder}`
+(linear-time Pike VM, zero third-party deps) instead of the `regex` crate. The
+glob-source builder's `regex::escape` calls become `regex_engine::escape`. All
+170 `engram-core` tests, including the Anki text-modifier search suite (words,
+combining marks, clozes, and `re:`), pass unchanged on the new engine.
+
+The `regex` crate is **still a dependency** — the media-tag
+`DUPLICATE_HTML_MEDIA_TAGS` pattern uses `replace_all` (a match *extent*, not a
+boolean), which the engine gains in a later, separately-verified step (Phase D4,
+after `regex-engine` adds `find`/`captures`/`replace_all`). Part of the Engram
+zero-dependency program (`code/specs/engram-zero-dep-plan.md`, Phase D2).
+
 ### HTML tag-strip no longer uses `regex` (zero-dep step)
 
 `rendered_search_text` (search) stripped HTML tags with the `regex` pattern

--- a/code/packages/rust/engram-core/Cargo.toml
+++ b/code/packages/rust/engram-core/Cargo.toml
@@ -11,6 +11,7 @@ serde = ["dep:serde"]
 [dependencies]
 fsrs = { path = "../fsrs" }
 regex = "1"
+regex-engine = { path = "../regex-engine" }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = "1"
 unicode-normalize = { path = "../unicode-normalize" }

--- a/code/packages/rust/engram-core/src/search.rs
+++ b/code/packages/rust/engram-core/src/search.rs
@@ -10,14 +10,19 @@ use crate::model::{
 };
 use crate::queue::{is_new_progress_overlay, is_reviewable};
 use crate::sm2::ONE_DAY_MS as MS_PER_DAY;
-use regex::{Regex, RegexBuilder};
+// Engram's boolean search matching — user `re:` patterns, whole-word, and
+// `*`/`_` globs — runs on the zero-dependency `regex_engine` (Pike VM,
+// linear-time). The one place a match *extent* is still needed, the media-tag
+// `replace_all` below, keeps the third-party `regex` crate (fully qualified)
+// until a later, separately-verified change adds extents to `regex_engine`.
+use regex_engine::{Regex, RegexBuilder};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use unicode_normalize::{char::is_combining_mark, UnicodeNormalize};
 
-static DUPLICATE_HTML_MEDIA_TAGS: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(
+static DUPLICATE_HTML_MEDIA_TAGS: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
         r#"(?is)<(?:img|audio|video|object|source)[^>]*(?:src|data)\s*=\s*(?:"([^"]+)"|'([^']+)'|([^ >]+))[^>]*>"#,
     )
     .expect("duplicate media tag regex should compile")
@@ -980,9 +985,9 @@ fn search_pattern_regex_source(pattern: &str, scope: WildcardScope) -> String {
             match chars.peek().copied() {
                 Some('*' | '_') => {
                     let escaped = chars.next().expect("peeked wildcard exists");
-                    source.push_str(&regex::escape(&escaped.to_string()));
+                    source.push_str(&regex_engine::escape(&escaped.to_string()));
                 }
-                _ => source.push_str(&regex::escape(&ch.to_string())),
+                _ => source.push_str(&regex_engine::escape(&ch.to_string())),
             }
             continue;
         }
@@ -996,7 +1001,7 @@ fn search_pattern_regex_source(pattern: &str, scope: WildcardScope) -> String {
                 WildcardScope::Text => source.push('.'),
                 WildcardScope::Word => source.push_str("[\\p{Alphabetic}\\p{Mark}\\p{Nd}_]"),
             },
-            _ => source.push_str(&regex::escape(&ch.to_string())),
+            _ => source.push_str(&regex_engine::escape(&ch.to_string())),
         }
     }
     source

--- a/code/packages/rust/regex-engine/CHANGELOG.md
+++ b/code/packages/rust/regex-engine/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — regex-engine
 
+## 0.3.1 — Unreleased
+
+Adds the small `escape` helper engram-core's glob/search-pattern builder needs,
+completing the API surface for Phase D2 (pointing engram-core's boolean search
+at this engine).
+
+### Added
+
+- `regex_engine::escape(text) -> String` — escapes every regular-expression
+  metacharacter so `text` matches literally. Mirrors `regex::escape` (same
+  metacharacter set as `regex-syntax`), so an interleaved glob source built from
+  escaped literals plus `*`/`_` wildcard fragments is byte-identical whether the
+  old (`regex`) or new (`regex_engine`) path builds it. Unit-tested for
+  metacharacter neutralization and literal round-trip.
+
 ## 0.3.0 — Unreleased
 
 Adds **Unicode simple case folding** to `(?i)` matching — the last engine

--- a/code/packages/rust/regex-engine/Cargo.toml
+++ b/code/packages/rust/regex-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-engine"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A small, zero-dependency, linear-time (Thompson NFA / Pike VM) regular-expression engine — the subset the Engram flashcard search needs — reimplemented from scratch to keep the Engram stack free of third-party crates."
 license = "MIT"

--- a/code/packages/rust/regex-engine/README.md
+++ b/code/packages/rust/regex-engine/README.md
@@ -36,11 +36,17 @@ extents (`find`/`captures`/`replace_all`) are a planned addition.
 ## Usage
 
 ```rust
-use regex_engine::{Regex, RegexBuilder};
+use regex_engine::{escape, Regex, RegexBuilder};
 
 assert!(Regex::new(r"\bcat\b").unwrap().is_match("the cat sat"));
 let ci = RegexBuilder::new("hello").case_insensitive(true).build().unwrap();
 assert!(ci.is_match("HELLO"));
+
+// `escape` neutralizes metacharacters so a string matches literally — used when
+// building a pattern that interleaves user text with wildcard fragments.
+assert_eq!(escape("a.c"), r"a\.c");
+assert!(Regex::new(&escape("a.c")).unwrap().is_match("a.c"));
+assert!(!Regex::new(&escape("a.c")).unwrap().is_match("axc"));
 ```
 
 ## Fidelity

--- a/code/packages/rust/regex-engine/src/lib.rs
+++ b/code/packages/rust/regex-engine/src/lib.rs
@@ -86,6 +86,47 @@ impl Regex {
     }
 }
 
+/// Escape every regular-expression metacharacter in `text`, returning a pattern
+/// that matches `text` literally. Mirrors `regex::escape` (same metacharacter
+/// set as `regex-syntax`), so a glob/search-pattern builder that interleaves
+/// escaped literals with wildcard fragments produces the same source string.
+pub fn escape(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if is_meta_character(c) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// The regex metacharacters `escape` guards, matching `regex-syntax`'s
+/// `is_meta_character`. Escaping any of these makes it a literal; the parser
+/// treats `\<char>` as a literal for all of them.
+fn is_meta_character(c: char) -> bool {
+    matches!(
+        c,
+        '\\' | '.'
+            | '+'
+            | '*'
+            | '?'
+            | '('
+            | ')'
+            | '|'
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | '^'
+            | '$'
+            | '#'
+            | '&'
+            | '-'
+            | '~'
+    )
+}
+
 /// A builder for a [`Regex`] with configurable flags, mirroring the small part
 /// of `regex::RegexBuilder` that Engram uses.
 pub struct RegexBuilder<'a> {
@@ -137,6 +178,21 @@ impl<'a> RegexBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn escape_neutralizes_metacharacters_and_round_trips() {
+        // Every escaped metacharacter becomes a literal, so the escaped string
+        // matches itself exactly and matches nothing broader.
+        let raw = r"a.b*c+d?(e)|[f]{g}^h$#&-~i\j";
+        let escaped = escape(raw);
+        let re = Regex::new(&escaped).unwrap();
+        assert!(re.is_match(raw), "escaped pattern must match its own literal");
+        // `.` is escaped, so it must NOT act as a wildcard.
+        assert!(!Regex::new(&escape("a.c")).unwrap().is_match("axc"));
+        assert!(Regex::new(&escape("a.c")).unwrap().is_match("a.c"));
+        // A metacharacter-free string is returned unchanged.
+        assert_eq!(escape("hello world 123"), "hello world 123");
+    }
 
     #[test]
     fn literals_and_dot() {

--- a/code/specs/engram-zero-dep-plan.md
+++ b/code/specs/engram-zero-dep-plan.md
@@ -122,13 +122,18 @@ DoS-immune on user `re:` patterns, unlike a backtracker. Decomposed:
   `\b` uses the Unicode word set, `(?u)`/`(?-u)` flags. Cross-verified vs live
   `regex` in default Unicode mode across 80k+ pairs (non-ASCII inputs) — zero
   divergences. Unicode CASE FOLDING deferred to D2 (needed when wiring the CI uses).
-- **D2 — IN PROGRESS.** Prereq **Unicode simple case folding** added to
-  regex-engine (v0.3.0): `(?i)` uses Unicode fold orbits, cross-verified vs live
-  `regex` (60k+ pairs incl. tricky orbits). NEXT: point the boolean uses at it.
-- **D2 (wiring) — swap the boolean uses.** Point `re:` (`build_search_regex`), whole-word
-  (`build_whole_word_regex`), and glob (`search_pattern_regex_source`) at the new
-  engine's `is_match`. Provide a `regex_engine::escape` for the glob builder.
-  `regex` stays only for the media `replace_all`.
+- **D2a — ✅ DONE (Unicode case folding).** Prereq added to regex-engine (v0.3.0):
+  `(?i)` uses Unicode fold orbits, cross-verified vs live `regex` (60k+ pairs incl.
+  tricky orbits — σ/ς/Σ, Kelvin/Ångström, long-s, titlecase digraphs).
+- **D2 (wiring) — ✅ DONE.** engram-core's `search.rs` now imports
+  `regex_engine::{Regex, RegexBuilder}` for all three boolean uses — `re:`
+  (`build_search_regex`), whole-word (`build_whole_word_regex` + the runtime
+  `whole_word_pattern_matches`), and glob (`search_pattern_regex_source` compiled
+  in `contains_search_pattern` / `search_pattern_matches`). Added
+  `regex_engine::escape` (v0.3.1) for the glob builder (replaces `regex::escape`).
+  The `regex` crate stays only for the media `DUPLICATE_HTML_MEDIA_TAGS`
+  `replace_all` (needs match extents → D4). Full `cargo test -p engram-core`
+  (170 tests incl. the Anki text-modifier search suite) passes on the new engine.
 - **D3 — match extents.** Add `find`/`captures`/`replace_all` to the engine,
   solving the **nullable-loop** priority problem (e.g. `(a?)*`) so extents match
   `regex` byte-for-byte; cross-verify find + replace_all on random corpora.


### PR DESCRIPTION
## Phase D2 — wire engram-core search onto the zero-dep `regex-engine`

First PR that actually **removes `regex`-crate usage** from engram-core's search
path. Points the three **boolean** regex uses in `search.rs` at the from-scratch,
zero-dependency `regex_engine` (linear-time Pike VM) built in D0–D2a:

| use | function(s) |
|-----|-------------|
| user `re:` patterns | `build_search_regex` |
| whole-word matching | `build_whole_word_regex`, `whole_word_pattern_matches` |
| `*`/`_` glob matching | `search_pattern_regex_source` → `contains_search_pattern`, `search_pattern_matches` |

- `use regex::{Regex, RegexBuilder}` → `use regex_engine::{Regex, RegexBuilder}`.
- `regex::escape` → new `regex_engine::escape` (regex-engine **v0.3.1**): mirrors
  `regex::escape` (same `regex-syntax` metacharacter set) so the interleaved glob
  source is byte-identical whether the old or new path builds it.
- The third-party `regex` crate is **kept only** for the media-tag
  `DUPLICATE_HTML_MEDIA_TAGS` `replace_all` (a match *extent*, not a boolean),
  fully qualified as `regex::Regex` / `regex::Captures`. It moves to the engine in
  **Phase D4** once regex-engine gains `find`/`captures`/`replace_all` (D3), after
  which `regex` is removed from engram-core entirely.

### Verification
- `cargo test -p engram-core` → **170 passed**, incl. the Anki text-modifier
  search suite (words, combining marks, clozes, `re:`) — unchanged on the new engine.
- `cargo test -p regex-engine` → all `is_match` cross-checks vs live `regex`
  (ASCII + Unicode + case-fold, 200k+ pairs) + new `escape` unit test — green.
- **Security review passed** (Rust sub-agent): `escape` set byte-identical to
  `regex-syntax 0.8.11`; no user-pattern panics; Pike VM DoS guards
  (`MAX_PROGRAM_INSTS`/`REPEAT_LIMIT`/`NEST_LIMIT`) all still enforced; no injection.

Part of the Engram zero-dependency program (`code/specs/engram-zero-dep-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)