### PR TITLE
feat(javascript-ast,closure-emitter): RegExpLiteral leaf node /pattern/flags + emit + passes (CLOC12.172 PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.36.0] - 2026-07-08
+
+### Added — CLOC12.172 PR1: print `RegExpLiteral` (`/pattern/flags`)
+
+`emit_regexp` prints the regex-literal leaf added in `javascript-ast` 0.31.0:
+`/` + `pattern` + `/` + `flags`. The pattern is opaque text (its own `\/`
+escapes are already part of it) and no quote-choice/escaping applies — a regex
+has exactly one spelling. `RegExpLiteral` is `PREC_PRIMARY` (an atomic primary
+that never needs wrapping). 3 unit tests (flags, no-flags, pattern-internal
+escapes). Emitter-only; the bridge that builds the node is CLOC12.172 PR2 and
+the CodePrinter conformance port is PR3.
+
 ## [0.35.1] - 2026-07-08
 
 ### Added — CLOC12.171 PR3: CodePrinter optional-chaining `a?.b` / `a?.[k]` / `a?.()` conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -77,6 +77,7 @@ use coding_adventures_javascript_ast::{
     MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem, SequenceExpression,
     ObjectMember, Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
+    RegExpLiteral,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
     TaggedTemplateExpression, SpreadElement, YieldExpression, AwaitExpression, ThisExpression,
     Super, NewTarget, ImportMeta, ImportExpression,
@@ -1122,6 +1123,7 @@ impl<'a> Emitter<'a> {
             Expression::NullLiteral(n) => self.emit_null(n),
             Expression::BigIntLiteral(b) => self.emit_bigint(b),
             Expression::UndefinedLiteral(u) => self.emit_undefined(u),
+            Expression::RegExpLiteral(r) => self.emit_regexp(r),
             Expression::BinaryExpression(b) => self.emit_binary(b),
             Expression::LogicalExpression(l) => self.emit_logical(l),
             Expression::UnaryExpression(u) => self.emit_unary(u),
@@ -1247,6 +1249,19 @@ impl<'a> Emitter<'a> {
     fn emit_undefined(&mut self, u: &UndefinedLiteral) {
         self.maybe_map(&u.cv);
         self.write_str("void 0");
+    }
+
+    /// `/pattern/flags` — a regex literal. The source is reconstructed
+    /// verbatim: `pattern` is the opaque body between the slashes (its own `\/`
+    /// escapes are already part of the text) and `flags` is the trailing flag
+    /// set. No escaping or quote-choice applies — a regex has exactly one
+    /// spelling.
+    fn emit_regexp(&mut self, r: &RegExpLiteral) {
+        self.maybe_map(&r.cv);
+        self.write_str("/");
+        self.write_str(&r.pattern);
+        self.write_str("/");
+        self.write_str(&r.flags);
     }
 
     fn emit_binary(&mut self, b: &BinaryExpression) {
@@ -2129,6 +2144,9 @@ fn expr_prec(e: &Expression) -> u8 {
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
+        // A regex literal `/…/g` is an atomic primary — it never needs
+        // wrapping and no operand context forces a paren around it.
+        | Expression::RegExpLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
         | Expression::ArrayExpression(_)
@@ -2583,6 +2601,23 @@ mod tests {
             cv: None,
             name: name.to_string(),
         })
+    }
+    fn regexp(pattern: &str, flags: &str) -> Expression {
+        Expression::RegExpLiteral(RegExpLiteral {
+            cv: None,
+            pattern: pattern.to_string(),
+            flags: flags.to_string(),
+        })
+    }
+
+    #[test]
+    fn regexp_literal_reconstructs_slashes_and_flags() {
+        // `/ab+c/gi` — pattern + flags round-trip verbatim.
+        assert_eq!(emit_expr(regexp("ab+c", "gi")), "/ab+c/gi;");
+        // No flags → a bare `/…/`.
+        assert_eq!(emit_expr(regexp("a.b", "")), "/a.b/;");
+        // Pattern-internal escapes/metachars are opaque text, emitted as-is.
+        assert_eq!(emit_expr(regexp("\\d+\\/x", "u")), "/\\d+\\/x/u;");
     }
     fn boolean(v: bool) -> Expression {
         Expression::BooleanLiteral(BooleanLiteral { cv: None, value: v })

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -497,6 +497,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         Expression::Identifier(_)
         | Expression::NumericLiteral(_)
         | Expression::StringLiteral(_)
+        // A regex literal (`/ab+c/gi`) is a leaf like a string: nothing inside
+        // to fold, and it is never a foldable constant, so it passes through
+        // unchanged exactly like StringLiteral.
+        | Expression::RegExpLiteral(_)
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -1163,6 +1163,7 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — no sub-expression to walk, never dead on
         // its own, so it clones through like the literals.
         | Expression::ThisExpression(_)

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -265,6 +265,7 @@ fn expression_cv(expr: &Expression) -> Option<String> {
         BooleanLiteral(e) => e.cv.clone(),
         NullLiteral(e) => e.cv.clone(),
         BigIntLiteral(e) => e.cv.clone(),
+        RegExpLiteral(e) => e.cv.clone(),
         UndefinedLiteral(e) => e.cv.clone(),
         BinaryExpression(e) => e.cv.clone(),
         LogicalExpression(e) => e.cv.clone(),
@@ -1366,6 +1367,7 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — nothing inside to fold, so it clones
         // through like the literals.
         | Expression::ThisExpression(_)

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -729,6 +729,7 @@ fn count_uses_expr(expr: &Expression, name: &str, count: &mut usize) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` binds no variable name — nothing to count or propagate into.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
@@ -1061,6 +1062,7 @@ fn propagate_in_expr(expr: &mut Expression, cand: &ConstCandidate) -> bool {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` binds no variable name — nothing to count or propagate into.
         | Expression::ThisExpression(_)
         | Expression::Super(_)

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -437,6 +437,9 @@ fn expr_node_count(expr: &Expression) -> usize {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — it counts like a StringLiteral: 0 sub-nodes.
+        | Expression::RegExpLiteral(_)
         // `this` is a single leaf keyword — it contributes one node like the
         // other leaves (which this arm counts as 0 sub-nodes).
         | Expression::ThisExpression(_)
@@ -770,6 +773,9 @@ fn collect_binding_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — these traversals treat it exactly like a StringLiteral.
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — it binds/references no identifier and has
         // no sub-expression, so these traversals do nothing for it. (It is
         // deliberately NOT treated as a freely-substitutable primary: `this` is
@@ -1083,6 +1089,9 @@ fn tally_expr(expr: &Expression, cand: &InlineCandidate, t: &mut Tally) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — these traversals treat it exactly like a StringLiteral.
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — it binds/references no identifier and has
         // no sub-expression, so these traversals do nothing for it. (It is
         // deliberately NOT treated as a freely-substitutable primary: `this` is
@@ -1456,6 +1465,9 @@ fn inline_in_expr(expr: &mut Expression, cand: &InlineCandidate) -> bool {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — these traversals treat it exactly like a StringLiteral.
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — it binds/references no identifier and has
         // no sub-expression, so these traversals do nothing for it. (It is
         // deliberately NOT treated as a freely-substitutable primary: `this` is
@@ -1624,6 +1636,9 @@ fn substitute(expr: &mut Expression, map: &HashMap<String, Expression>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — these traversals treat it exactly like a StringLiteral.
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — it binds/references no identifier and has
         // no sub-expression, so these traversals do nothing for it. (It is
         // deliberately NOT treated as a freely-substitutable primary: `this` is
@@ -2205,6 +2220,9 @@ fn expr_collect_mutated_params(
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — these traversals treat it exactly like a StringLiteral.
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — it binds/references no identifier and has
         // no sub-expression, so these traversals do nothing for it. (It is
         // deliberately NOT treated as a freely-substitutable primary: `this` is
@@ -3558,6 +3576,9 @@ fn rename_in_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal is an inert leaf (no sub-expression, references no
+        // identifier) — these traversals treat it exactly like a StringLiteral.
+        | Expression::RegExpLiteral(_)
         // `this` is a leaf keyword — it binds/references no identifier and has
         // no sub-expression, so these traversals do nothing for it. (It is
         // deliberately NOT treated as a freely-substitutable primary: `this` is

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -634,6 +634,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` binds no global name — nothing to collect or rename.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
@@ -986,6 +987,7 @@ fn rename_apply_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` binds no global name — nothing to collect or rename.
         | Expression::ThisExpression(_)
         | Expression::Super(_)

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1145,6 +1145,9 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal (like `/ab+c/g`) is an inert leaf: no sub-expressions
+        // and no property names, so it is grouped with the other literals.
+        | Expression::RegExpLiteral(_)
         // `this` holds no property name to classify or rewrite.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
@@ -1461,6 +1464,9 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        // A regex literal (like `/ab+c/g`) is an inert leaf: no sub-expressions
+        // and no property names, so it is grouped with the other literals.
+        | Expression::RegExpLiteral(_)
         // `this` holds no property name to classify or rewrite.
         | Expression::ThisExpression(_)
         | Expression::Super(_)

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -912,6 +912,7 @@ fn collect_all_idents_expr(expr: &Expression, out: &mut HashSet<String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` is a reserved-word leaf — never a renameable identifier.
         | Expression::ThisExpression(_)
         | Expression::Super(_)
@@ -1248,6 +1249,7 @@ fn rewrite_uses_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` is a reserved-word leaf — never a renameable identifier.
         | Expression::ThisExpression(_)
         | Expression::Super(_)

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -849,6 +849,7 @@ fn walk_expression(
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
         // `this` binds no lexical name — it is resolved by the runtime, not by
         // scope analysis — so it introduces and references nothing.
         | Expression::ThisExpression(_)

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.31.0] - 2026-07-08
+
+### Added — CLOC12.172 PR1: `RegExpLiteral` leaf node (`/pattern/flags`)
+
+New `Expression::RegExpLiteral(RegExpLiteral { cv, pattern, flags })` — a regex
+literal modelled as its own leaf, alongside the other literal leaves. Previously
+the bridge fell back to an `Identifier` whose name was the regex source, which
+round-tripped only by accident (the text is not a valid identifier, so the
+rename passes skipped it) and left a latent hazard. The two halves are stored
+split (`pattern` = the body between the slashes, `flags` = the trailing flag
+set) so passes can reason about the flags without re-parsing; the printer
+reconstructs `/{pattern}/{flags}`. Mirrors ESTree's `RegExpLiteral` minus the
+live-`RegExp` `value` a source-to-source minifier never needs.
+
+Purely additive — no existing node changed. This is the atomic node PR of the
+CLOC12.172 arc; the bridge that *builds* it (replacing the identifier fallback)
+is PR2, and the CodePrinter conformance port is PR3.
+
 ## [0.30.0] - 2026-07-08
 
 ### Added — CLOC12.171 PR1: optional chaining `a?.b` / `a?.[k]` / `a?.()` (ES2020)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -45,6 +45,7 @@ pub enum Expression {
     NullLiteral(NullLiteral),
     BigIntLiteral(BigIntLiteral),
     UndefinedLiteral(UndefinedLiteral),
+    RegExpLiteral(RegExpLiteral),
     BinaryExpression(BinaryExpression),
     LogicalExpression(LogicalExpression),
     UnaryExpression(UnaryExpression),
@@ -113,6 +114,29 @@ pub struct StringLiteral {
     pub cv: Option<CvId>,
     pub value: String,
     pub raw: String,
+}
+
+/// A regular-expression literal — `/ab+c/gi`. Modelled as its own leaf so a
+/// regex is never confused with an ordinary reference: previously the bridge
+/// fell back to an [`Identifier`] whose name happened to be the regex source,
+/// which round-tripped only by accident (the text is not a valid identifier,
+/// so the rename passes skipped it) and left a latent hazard.
+///
+/// The two halves are stored split so passes can reason about the flags
+/// without re-parsing: `pattern` is the body between the slashes (`ab+c`) and
+/// `flags` is the trailing flag set (`gi`, possibly empty). The printer
+/// reconstructs the source as `/{pattern}/{flags}` — the slashes and the
+/// pattern's own escapes are part of `pattern`'s opaque text, so no escaping
+/// is applied. Mirrors ESTree's `RegExpLiteral` (its `regex: {pattern, flags}`
+/// companion object), minus the `value` field (a live `RegExp`, which a
+/// source-to-source minifier never needs).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegExpLiteral {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    pub pattern: String,
+    pub flags: String,
 }
 
 /// A boolean literal — `true` / `false`.

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -140,6 +140,7 @@ pub use expression::{
     NewExpression,
     NullLiteral, NumericLiteral, ObjectExpression, ObjectMember, OptionalCallExpression,
     OptionalMemberExpression, Property, PropertyKey, PropertyKind,
+    RegExpLiteral,
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,
     UndefinedLiteral, UpdateExpression, UpdateOperator,

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2138,6 +2138,27 @@ shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
 
+## CLOC12.172 — `RegExpLiteral` leaf node (`/pattern/flags`): node + emit + passes (PR1)
+
+Regex literals were previously bridged via a **"treat as identifier" fallback**
+(`javascript-parser` `convert_primary`'s catch-all) — an `Identifier` whose name
+was the regex source. It round-tripped only by accident (the text is not a valid
+identifier, so the rename passes skipped it as a candidate) and left a latent
+hazard: any pass that treated it as a real reference could corrupt it.
+
+PR1 models it properly as `Expression::RegExpLiteral(RegExpLiteral { cv, pattern,
+flags })` (`javascript-ast` 0.31.0) — a leaf beside the other literal leaves.
+The two halves are stored split (`pattern` between the slashes, `flags` the
+trailing set) so passes reason about the flags without re-parsing.
+`closure-emitter` (0.36.0) `emit_regexp` reconstructs `/{pattern}/{flags}` with
+no escaping (a regex has one spelling) at `PREC_PRIMARY`; 3 unit tests. All
+downstream pass/analysis crates group `RegExpLiteral` into their existing inert
+leaf-literal arm (same treatment as `StringLiteral`/`NumericLiteral`: no
+recursion, no renaming, not a foldable constant) — several already covered it
+via a `_` catch-all. All in ONE atomic commit. The bridge that *builds* the node
+(replacing the identifier fallback, closes gap-RegExpAsIdentifier) is PR2; the
+CodePrinter conformance port is PR3.
+
 ## CLOC12.171 — optional chaining `a?.b` / `a?.[k]` / `a?.()`: nodes + emit + passes (PR1)
 
 Optional chaining (ES2020) lets a member/call short-circuit to `undefined`


### PR DESCRIPTION
## CLOC12.172 PR1 — `RegExpLiteral` leaf node

Atomic node PR of the CLOC12.172 arc: model regex literals `/pattern/flags` properly, in ONE commit so the workspace never has a broken `match`.

### Why
Regex literals were bridged via a **"treat as identifier" fallback** — an `Identifier` whose name was the regex source. They round-tripped only by accident: the text isn't a valid identifier, so the rename passes happened to skip it as a candidate. That left a latent hazard (any pass treating it as a real reference could corrupt it) and modelled a regex as something it isn't.

### AST — `javascript-ast` 0.31.0
New `Expression::RegExpLiteral(RegExpLiteral { cv, pattern, flags })` — a leaf beside the other literal leaves. The two halves are stored split (`pattern` = body between the slashes, `flags` = trailing set) so passes reason about the flags without re-parsing. Mirrors ESTree's `RegExpLiteral` minus the live-`RegExp` `value` a source-to-source minifier never needs.

### Emit — `closure-emitter` 0.36.0
`emit_regexp` reconstructs `/{pattern}/{flags}` with no escaping (the pattern is opaque tokenized text; a regex has one spelling) at `PREC_PRIMARY`. 3 unit tests (flags / no-flags / pattern-internal escapes).

### Passes / analysis
Nine crates group `RegExpLiteral` into their existing **inert leaf-literal arm** (identical to `StringLiteral`/`NumericLiteral`: no recursion, no renaming, not a foldable constant). `treeshake`/`remove-unused-vars`/`collapse-properties` already covered it via a `_` catch-all (no edit).

### Verification
- 204 javascript-ast + closure-emitter tests, all 9 touched passes, and 685 closurec e2e tests green.
- Security review: **PASSED** — no `unsafe`/panic/recursion; all pass arms verified inert. (INFO for PR2: the bridge should guarantee `pattern` has no unescaped `/` or line terminators and `flags` matches `[dgimsuy]*`.)
- Spec: CLOC12.172 section added.

Bridge that builds the node (replaces the identifier fallback, closes gap-RegExpAsIdentifier) is PR2; CodePrinter conformance port is PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)