### PR TITLE
feat(latex): LTXDOC03 S21 resolved_references_by_source (command-aware, by source)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.57.0] — 2026-07-08
+
+### Added — resolved-references-by-source report (LTXDOC03 S21)
+
+A **new** public method `Document::resolved_references_by_source(&self) -> String` that renders the
+**resolved (successfully-matched) `\ref`/`\eqref`/`\pageref` references grouped by their source `\ref`**
+— the exact structural mirror of S18's `unresolved_references_by_source` (which renders the *dangling*
+half of the same split), but for the references that **did** resolve to a real `\label`. It is a
+read-only view over `resolve_references()`: S3 splits every reference into the **resolved** ones
+(`resolved`, a `Vec<ResolvedRef>`) and the **unresolved** (dangling) ones (`unresolved`); S21 renders
+the `resolved` list. Every S1–S20 output is left **byte-for-byte unchanged**; S21 is purely additive and
+leaves the `to_latex()` round-trip fixed point intact.
+
+- **Command-aware, one line per resolved reference.** Each line is reconstructed from the ref's **own**
+  `command` and `key` as `format!("\\{}{{{}}}", r.command, r.key)`, so a resolved `\eqref{eq:main}`
+  renders `\eqref{eq:main}` and a resolved `\pageref{sec:intro}` renders `\pageref{sec:intro}` — the
+  command is **never** hard-coded to `\ref`. No source slicing at all (matching S13
+  `resolve_namerefs`, S15 `citations_by_source`, S17/S18's reports).
+- **First-appearance grouping, source order.** Entries are grouped by their shared `ref_span` into a
+  `Vec<(Span, Vec<&ResolvedRef>)>` (not a hash map) preserving first-appearance order — the same
+  grouping idiom as S18. Each reference takes exactly one key, so every group emits one line.
+- **Dangling refs excluded by construction.** A `\ref{nope}` with no `\label` lives in `unresolved`
+  (S18), never in `resolved`, so it never appears here.
+- **Stable empty marker.** No resolved references (every ref dangles, or none at all) → the fixed string
+  `(no resolved references)`, never `""` (the same discipline S12–S20 use). Lines are joined by `\n`
+  with **no** trailing newline.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single pass
+  over the already-bounded `resolved`. Borrows `self` immutably and returns owned `String`.
+
+Tests: `s21_preserves_command_ref_eqref_pageref`, `s21_no_references_returns_marker`,
+`s21_only_dangling_returns_marker`, `s21_mixed_lists_only_resolved`, and an additivity test
+`s21_is_additive_leaves_s1_s20_outputs_unchanged` pinning S1–S20 outputs (including
+`duplicate_label_definitions`) byte-for-byte alongside the new method.
+
 ## [0.56.0] — 2026-07-07
 
 ### Added — losing duplicate-`\label` report (LTXDOC03 S20)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -68,6 +68,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S18 — unresolved (dangling) references grouped by source `\ref`** | `Document::unresolved_references_by_source() -> String` — a **new**, read-only method that renders the **dangling** references, one reconstructed `\<command>{key}` line each — the `\ref`-family parallel of S17's dangling-CITATION report, and a **distinct** view from S6's flat *"Dangling references: k1, k2"* footer (S18 is **command-aware**, so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`). It reads only `resolve_references().unresolved` (a `Vec<UnresolvedRef { key, command, ref_span }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **resolved** `\ref` never entered `unresolved`, so it is excluded. Lines joined by `\n`, no trailing newline. A document with **no** unresolved references → the fixed marker `(no unresolved references)`. E.g. `\eqref{eq:ghost}` then `\pageref{p:ghost}` (neither defined) → `\eqref{eq:ghost}\n\pageref{p:ghost}`. Every S1–S17 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S19 — numbered winning-bibliography-entry list** | `Document::bibliography_entries() -> String` — a **new**, read-only method that renders the **winning** bibliography entries as a **numbered list** — the rendered bibliography a reader sees, and the table citations resolve against. A **distinct** view over `resolve_citations()`: S16 (`duplicate_bibliography_entries`) renders the **losing** `duplicate_entries` as `\bibitem{key}` lines, S15 (`citations_by_source`) renders per-source *resolved cite keys*; S19 renders the **winning** `entries`. It reads only `resolve_citations().entries` (the first `\bibitem` of each distinct key, body pre-order; later re-definitions live in `duplicate_entries`) and numbers it **1-based**, one line per entry as `[n] key` (reconstructed from the owned key, no source slicing). The `[n] key` shape is deliberately distinct from S16's `\bibitem{key}` lines. A `\bibitem{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** bibliography entries → the fixed marker `(no bibliography entries)`. E.g. `smith` (twice) + `jones` → `[1] smith\n[2] jones`. Every S1–S18 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S20 — losing duplicate `\label` definitions** | `Document::duplicate_label_definitions() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\label`s — LaTeX's *"Label `key' multiply defined"* warnings — the **label-family mirror of S16's** `duplicate_bibliography_entries` (which surfaces the losing `\bibitem` duplicates). It reads only `resolve_references().duplicates`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, what `\ref`/`\eqref`/`\pageref` resolve against) and every **later** `\label` of an already-defined key is a losing duplicate. S20 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). Lines joined by `\n`, no trailing newline. A document with **no** duplicate labels (every key once, or none) → the fixed marker `(no duplicate label definitions)`. E.g. `dup` defined twice + `once` once → `\label{dup}` (only the loser). Every S1–S19 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S21 — resolved references grouped by source `\ref`** | `Document::resolved_references_by_source() -> String` — a **new**, read-only method that renders the **resolved** (successfully-matched) references, one reconstructed `\<command>{key}` line each — the **RESOLVED mirror of S18's** `unresolved_references_by_source` (which renders the *dangling* half of the same split), **command-aware** so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). Lines joined by `\n`, no trailing newline. A document with **no** resolved references (every ref dangles, or none) → the fixed marker `(no resolved references)`. E.g. `\ref{sec:intro}`, `\eqref{eq:main}`, `\pageref{sec:intro}` (all defined) → `\ref{sec:intro}\n\eqref{eq:main}\n\pageref{sec:intro}`. Every S1–S20 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -858,6 +859,37 @@ assert_eq!(
 A document with no duplicate labels — every key defined once, or none at all — renders the fixed
 `(no duplicate label definitions)` marker. Purely additive — reuses `resolve_references`, mutates
 nothing, leaves every S1–S19 output and the `to_latex()` fixed point unchanged.
+
+### resolved references grouped by source `\ref` (LTXDOC03 S21)
+
+The **resolved** (successfully-matched) references — the **RESOLVED mirror of S18's**
+`unresolved_references_by_source` (which renders the *dangling* half of the same split). S3 splits every
+`\ref`/`\eqref`/`\pageref` into the **resolved** references (`resolve_references().resolved`, those a
+`\label` defines) and the **unresolved** (dangling) ones (`unresolved`). `resolved_references_by_source`
+reads only that `resolved` list and groups by `ref_span` in **first-appearance order** (source order),
+emitting one line per resolved reference — reconstructed from its **own** `command` and `key` as
+`\<command>{<key>}` (no source slicing) — so a resolved `\eqref{eq:main}` renders `\eqref{eq:main}` and a
+resolved `\pageref{sec:intro}` renders `\pageref{sec:intro}`; the command is **never** flattened to
+`\ref`. A dangling `\ref` never entered `resolved`, so it is excluded (it lives in S18).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+See \ref{sec:intro} and \eqref{eq:main} and \pageref{sec:intro}. Also \ref{nope}.
+\begin{equation}\label{eq:main}x=1\end{equation}
+\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.resolved_references_by_source(),
+    // three resolved refs, command preserved, in source order; the dangling `\ref{nope}` is excluded
+    "\\ref{sec:intro}\n\\eqref{eq:main}\n\\pageref{sec:intro}",
+);
+```
+
+A document with no resolved references — every reference dangles, or there are none at all — renders the
+fixed `(no resolved references)` marker. Purely additive — reuses `resolve_references`, mutates nothing,
+leaves every S1–S20 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2097,6 +2097,105 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **resolved (successfully-matched) references grouped by their source `\ref`** (LTXDOC03
+    /// S21) — the exact structural mirror of S18's
+    /// [`unresolved_references_by_source`](Document::unresolved_references_by_source), but for the
+    /// references that **did** resolve: one reconstructed `\<command>{key}` line per resolved
+    /// reference, **command-aware** so `\eqref` and `\pageref` render as themselves.
+    ///
+    /// ## What it does
+    ///
+    /// S3's [`Document::resolve_references`] walks every `\ref`/`\eqref`/`\pageref` in body pre-order
+    /// and splits them into the **resolved** references (those a `\label` defines — recorded in
+    /// [`ReferenceResolution::resolved`] as a [`ResolvedRef`]) and the **unresolved** references
+    /// (LaTeX's *"Reference `key' undefined"*, the `??` in the output). S18 reports the *dangling*
+    /// half of that split; S21 reports the **winning** half — the references that bound to a real
+    /// `\label`. Each [`ResolvedRef`] carries the `key`, the `command` that was used (`"ref"` /
+    /// `"eqref"` / `"pageref"`), and its own `ref_span` (plus the `target_span`/`target_kind` of the
+    /// definition it bound to, which S21 does not need to render). S21 reconstructs each resolved
+    /// reference on **its own line**, preserving the command it was written with, so a caller can
+    /// point at the exact matched `\eqref{…}` rather than a flattened `\ref`-shaped list.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read [`ReferenceResolution::resolved`] and group its entries by their shared `ref_span`,
+    /// preserving the **first-appearance order** of the ref_spans (source order of the references) —
+    /// a `Vec` of `(ref_span, refs)`, **not** a hash map, so the order is deterministic and the code
+    /// reads identically to S18's grouping. As in S18, a `\ref`/`\eqref`/`\pageref` takes exactly
+    /// **one** key, so every group holds a single entry — the structural mirror is kept for
+    /// readability, but each group emits exactly one line.
+    ///
+    /// One line per resolved reference: `\` + that reference's own `command` + `{` + its `key` + `}`,
+    /// reconstructed from the owned `command`/`key` `String`s (no source slicing, matching S13's
+    /// `resolve_namerefs`, S15's `citations_by_source`, S17's `unresolved_citations_by_source`, and
+    /// S18's `unresolved_references_by_source`). Because the line is rebuilt from the ref's **own**
+    /// `command`, a resolved `\eqref{eq:main}` renders `\eqref{eq:main}` and a resolved
+    /// `\pageref{sec:intro}` renders `\pageref{sec:intro}` — the command is **never** hard-coded to
+    /// `\ref`. Dangling references never entered `resolved`, so they are excluded by construction (a
+    /// `\ref{nope}` with no `\label` appears in S18, not here).
+    ///
+    /// A document with **no** resolved references — every reference dangles, or there are none at all
+    /// — returns the fixed marker `(no resolved references)`, never the empty string (the same
+    /// stable-marker discipline S12/S13/S14/S15/S16/S17/S18/S19/S20 use). Lines are joined by `\n`
+    /// with **no** trailing newline (matching S15's `citations_by_source` and S18's
+    /// `unresolved_references_by_source`).
+    ///
+    /// Concretely, for a body defining `\label{sec:intro}` and `\label{eq:main}` and then writing
+    /// `\ref{sec:intro}`, `\eqref{eq:main}`, and `\pageref{sec:intro}` (all of which resolve):
+    ///
+    /// ```text
+    /// \ref{sec:intro}
+    /// \eqref{eq:main}
+    /// \pageref{sec:intro}
+    /// ```
+    ///
+    /// Each line preserves the command it was written with, one resolved reference per line, in
+    /// source order.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S21 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1-S20 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// `command` and `key` are already owned `String`s); a single pass over the already-bounded
+    /// `resolved` list. Borrows `self` immutably and returns owned `String` data, so the result
+    /// outlives any borrow of the source.
+    pub fn resolved_references_by_source(&self) -> String {
+        // S3 already split every `\ref`/`\eqref`/`\pageref` into resolved and dangling entries, routing
+        // the resolved ones into `resolved` (in body pre-order), each carrying its own `command`,
+        // `key`, and `ref_span`. We only read that list.
+        let resolution = self.resolve_references();
+
+        // Group the resolved references by their shared `ref_span`, preserving the FIRST-APPEARANCE
+        // order of the ref_spans (source order of the references). A `Vec` of `(ref_span, refs)` — not a
+        // hash map — keeps that order deterministic and mirrors S18's grouping idiom exactly. Unlike a
+        // multi-key `\cite`, each reference takes exactly one key, so every group holds a single entry;
+        // the structural mirror is kept only so this code reads identically to S18.
+        let mut groups: Vec<(Span, Vec<&ResolvedRef>)> = Vec::new();
+        for r in &resolution.resolved {
+            match groups.iter_mut().find(|(span, _)| *span == r.ref_span) {
+                Some((_, refs)) => refs.push(r),
+                None => groups.push((r.ref_span, vec![r])),
+            }
+        }
+
+        if groups.is_empty() {
+            // Every reference dangled (or there were none) → the fixed marker, never the empty string.
+            return "(no resolved references)".to_string();
+        }
+
+        // One line per resolved reference, reconstructed from its OWN command and key: `\<command>{key}`.
+        // We iterate each group's single entry so `\eqref` / `\pageref` render as themselves rather than
+        // all being flattened to `\ref`.
+        groups
+            .iter()
+            .flat_map(|(_, refs)| refs.iter().map(|r| format!("\\{}{{{}}}", r.command, r.key)))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -5121,5 +5220,135 @@ See Section~\ref{sec:intro}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig
 
         // And S20 itself surfaces only the losing later `\label{dup}` (the first `dup` wins).
         assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S21 — resolved (successfully-matched) references grouped by source `\ref`
+    // (`resolved_references_by_source`). The RESOLVED mirror of S18, command-aware.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s21_preserves_command_ref_eqref_pageref() {
+        // A resolved `\ref`, `\eqref`, and `\pageref` (each bound to a real `\label`) → each line
+        // preserves the command it was written with (NOT flattened to `\ref`), one per line, in source
+        // order. This is the command-aware core of S21.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+See \ref{sec:intro} and \eqref{eq:main} and \pageref{sec:intro}.
+\begin{equation}\label{eq:main}x=1\end{equation}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:main}\n\\pageref{sec:intro}"
+        );
+    }
+
+    #[test]
+    fn s21_no_references_returns_marker() {
+        // A document with no references at all → the fixed `(no resolved references)` marker, never the
+        // empty string.
+        let src = r"\begin{document}
+Just some text with no references.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "(no resolved references)"
+        );
+    }
+
+    #[test]
+    fn s21_only_dangling_returns_marker() {
+        // A document whose ONLY reference dangles (`\ref{nope}` with no `\label`) has zero resolved
+        // references → the fixed marker, never the empty string. The dangling ref lives in S18, not here.
+        let src = r"\begin{document}
+See \ref{nope}.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "(no resolved references)"
+        );
+    }
+
+    #[test]
+    fn s21_mixed_lists_only_resolved() {
+        // A doc mixing a resolved `\ref{sec:intro}` with a dangling `\ref{nope}` → S21 lists ONLY the
+        // resolved one; the dangling `\ref{nope}` must NOT appear (it is excluded by construction).
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+See \ref{sec:intro} and also \ref{nope}.
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_references_by_source(), "\\ref{sec:intro}");
+    }
+
+    #[test]
+    fn s21_is_additive_leaves_s1_s20_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a resolved `\ref`, a
+        // `\nameref`, two `\cite`s (one multi-key, one dangling key), a duplicate `\bibitem`, a
+        // dangling `\eqref` (`eq:ghost`), a duplicate `\label{dup}`, AND a resolved `\eqref{eq:e}`,
+        // S21 changes NONE of the S1-S20 outputs — it only reads `resolve_references`. This also pins
+        // the `\n`-join with no trailing newline on the multi-ref S21 case.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — the resolved `\eqref{eq:e}` (Equation (1)) now appears alongside the
+        // resolved `\ref`; the dangling `eq:ghost` stays in the footer. S6's content is a function of
+        // the same resolution S21 reads, so this string is what S6 already produces for this doc —
+        // running S21 does not perturb it.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\eqref{eq:e} -> Equation (1)\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — the resolved `\eqref{eq:e}` shows under Equations.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\nEquations:\n  \\eqref{eq:e} -> Equation (1)"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged (only the dangling `\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S20 losing duplicate labels — unchanged.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+
+        // And S21 itself surfaces only the RESOLVED references: the `\ref{sec:intro}` and the
+        // `\eqref{eq:e}` (command preserved), in source order, `\n`-joined with no trailing newline.
+        // The dangling `\eqref{eq:ghost}` is excluded (it lives in S18).
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1676,3 +1676,75 @@ that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namere
 strings). All prior S1–S19 tests pass unchanged. `cargo clippy -p latex --all-targets -- -D warnings`
 clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo build -p latex
 --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 27. S21 — resolved references grouped by source `\ref` (`resolved_references_by_source`)
+
+### 27.1 Motivation
+
+S3's `resolve_references` returns `resolved: Vec<ResolvedRef>` — every `\ref`/`\eqref`/`\pageref` that
+bound to a real `\label`, one row per resolved reference, in body pre-order. S18
+(`unresolved_references_by_source`) already renders the **dangling** half of that split — the references
+that matched no `\label`, LaTeX's *"Reference `key' undefined"* — as one command-aware `\<command>{key}`
+line each. But the **resolved** half — the references that *did* match — had no by-source renderer: S6
+reports the flat *"Dangling references"* footer, S18 the dangling per-line view, but nothing renders the
+successfully-matched references on their own lines with their commands preserved. S21 fills that cell by
+rendering `resolved` as the resolved-reference report, the exact RESOLVED mirror of S18's dangling view.
+
+### 27.2 Why a new method — additive by construction
+
+S21 adds a **new public method** `Document::resolved_references_by_source(&self) -> String`. It is a pure,
+read-only render of `resolve_references().resolved`. It reuses that table verbatim (never re-walking the
+body or re-resolving references), so the report can never drift from the S3 resolution it summarises. It
+mutates nothing and changes no S1–S20 output — including `to_latex()`'s round-trip fixed point —
+byte-for-byte. Like S11–S20 it is a method the caller invokes directly.
+
+### 27.3 The exact rendering contract — `Document::resolved_references_by_source(&self) -> String`
+
+- Read `resolve_references().resolved` and group its entries by their shared `ref_span`, preserving the
+  **first-appearance order** of the ref_spans (source order of the references) — a `Vec` of
+  `(ref_span, refs)`, **not** a hash map, so the order is deterministic and the code reads identically to
+  S18's grouping. A `\ref`/`\eqref`/`\pageref` takes exactly **one** key, so every group holds a single
+  entry and emits exactly one line.
+- One line per resolved reference: `format!("\\{}{{{}}}", r.command, r.key)` → `\` + the reference's own
+  `command` + `{` + its `key` + `}`. Reconstructed from the owned `command`/`key` `String`s rather than
+  sliced from `&src[span]` (matching S13 `resolve_namerefs`, S15 `citations_by_source`, and S17/S18's
+  reports), so the render needs no source borrow and can never index out of bounds. Because the line is
+  rebuilt from the ref's **own** `command`, a resolved `\eqref{eq:main}` renders `\eqref{eq:main}` and a
+  resolved `\pageref{sec:intro}` renders `\pageref{sec:intro}` — the command is **never** hard-coded to
+  `\ref`. Dangling references never entered `resolved`, so they are excluded by construction (a
+  `\ref{nope}` with no `\label` appears in S18, not here).
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S20 renderer).
+- If there are **no** resolved references (every reference dangles, or none at all), the fixed marker
+  `(no resolved references)` is returned, so the output is never the empty string.
+
+Example (body defining `\label{sec:intro}` and `\label{eq:main}`, then writing `\ref{sec:intro}`,
+`\eqref{eq:main}`, `\pageref{sec:intro}`, and a dangling `\ref{nope}`):
+
+```text
+\ref{sec:intro}
+\eqref{eq:main}
+\pageref{sec:intro}
+```
+
+each resolved reference on its own line, command preserved, in source order; the dangling `\ref{nope}` is
+excluded (it lives in S18). This is the RESOLVED mirror of S18's dangling `\<command>{key}` view.
+
+### 27.4 Public API (added in S21)
+
+One new method: `Document::resolved_references_by_source(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_references` and every S1–S20 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 27.5 Verification (S21)
+
+`cargo test -p latex` green (5 new S21 tests: a resolved `\ref`+`\eqref`+`\pageref` rendering each as its
+own command-aware line in source order; a doc with no references returning the `(no resolved references)`
+marker; a doc whose only reference dangles returning the same marker; a mixed doc listing only the
+resolved reference and excluding the dangling `\ref{nope}`; and an additivity check that `to_plain_text`,
+`to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`,
+`duplicate_bibliography_entries`, `unresolved_citations_by_source`, `unresolved_references_by_source`,
+`bibliography_entries`, and `duplicate_label_definitions` all still produce their exact prior strings,
+which also pins the `\n`-join with no trailing newline on a multi-ref case). All prior S1–S20 tests pass
+unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
+-p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S21 — `resolved_references_by_source` (latex 0.57.0)

Adds one additive, read-only cross-reference report renderer to the zero-dependency `latex` crate, completing the resolved/unresolved pair for references.

### What it does

```rust
pub fn resolved_references_by_source(&self) -> String
```

Renders the **resolved** (successfully-matched) `\ref`/`\eqref`/`\pageref` references, grouped by source appearance, one line each — the mirror image of the shipped **S18** `unresolved_references_by_source`. Where S18 lists the dangling references, S21 lists the ones that found their `\label`.

It reads `resolve_references().resolved` (a `Vec<ResolvedRef>`), groups by `ref_span` into a `Vec<(Span, Vec<&ResolvedRef>)>` preserving first-appearance (source) order — the exact grouping idiom S18 uses — and renders each entry from its **own** command and key:

```
\ref{sec:intro}
\eqref{eq:main}
\pageref{sec:intro}
```

The rendering is **command-aware**: `\eqref` and `\pageref` render as themselves rather than being flattened to `\ref`. A document with no resolved references (none present, or all dangling) returns the fixed marker `(no resolved references)`, never the empty string — the shared S11–S20 stable-marker discipline. Lines join with `\n`, no trailing newline.

### Guarantees

- **Additive**: a brand-new read-only method reusing `resolve_references()`; every S1–S20 output is byte-for-byte unchanged (pinned by the `s21_is_additive_leaves_s1_s20_outputs_unchanged` test), and the `to_latex` round-trip fixed point is intact.
- **Total & panic-free**: no `unsafe`, no `unwrap`/`expect`, no indexing/slicing (keys are owned `String`s), a single pass over the already-bounded `resolved` list; borrows `self` immutably and returns owned `String`.

### Tests (5 new, in the existing `#[cfg(test)]` module)

- `s21_preserves_command_ref_eqref_pageref` — command-aware, one line each, source order
- `s21_no_references_returns_marker` — empty → `(no resolved references)`
- `s21_only_dangling_returns_marker` — a doc with only dangling refs returns the marker
- `s21_mixed_lists_only_resolved` — resolved listed, dangling `\ref{nope}` excluded
- `s21_is_additive_leaves_s1_s20_outputs_unchanged` — pins S1–S20 outputs + the `\n`-join/no-trailing-newline contract

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → **414 lib tests + 1 doc-test pass**
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED

### Docs

- `Cargo.toml` version `0.56.0` → `0.57.0`
- `CHANGELOG.md`, `README.md` (table row + prose), and `LTXDOC03-cross-reference-resolution.md` (new §27 / S21 section, 27.1–27.5) — prior sections byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
