### PR TITLE
feat(adj-ladder): rung-109 wound care wound burden index (a mixed three-term numerator over a divisor)

### DIFF
--- a/code/specs/data/adj-ladder/rung109_wound_care/gen_items.py
+++ b/code/specs/data/adj-ladder/rung109_wound_care/gen_items.py
@@ -1,0 +1,251 @@
+"""Generate rung-109 (wound care / burn surface accounting) items.json for the ADJ-LADDER.
+
+Rung 109 opens the **wound care / burn surface accounting** panel on the quantitative band — the arithmetic of a wound
+burden index. A `baseline_area` (the original wound area) has some `healed_area` SUBTRACTED (tissue that has closed) and some
+`dehisced_area` ADDED (tissue that has reopened), and that net open area is DIVIDED by a `dressing_count` (how many dressing
+changes the reading is averaged over) to give the wound burden index. A **three-term numerator WITH a subtraction over a single
+divisor** introduces a genuinely NEW arithmetic family on the ladder: `(a-b+c)/d`, i.e. `((a - b + c) / d)`.
+
+This is genuinely new — rung-108 opened the three-term-numerator frontier with `(a+b+c)/d` (a bare three-way SUM over a
+divisor); rung-109 is the FIRST three-term numerator that MIXES a subtraction and an addition over a divisor. Every prior ratio
+used a two-term numerator (rung-37 `(a+b)/(c+d)`, rung-99 `(a*b)/(c+d)`, rung-100 `(a+b)/(c*d)`, rung-104 `(a-b)/(c*d)`, the
+difference-denominator trio rung-105 `(a+b)/(c-d)`, rung-106 `a*b/(c-d)`, rung-107 `(a-b)/(c-d)`) or the pure three-term sum
+rung-108 `(a+b+c)/d`. Rung-109 moves to `(a-b+c)/d`. The operator order matters: `(a-b+c)/d` is `((a-b+c) / d)` (the whole
+net-open numerator is divided), NOT `a-b+c/d` (dropping the numerator parentheses so only the dehisced area is divided by the
+dressing count and then combined with the other two areas) and NOT `(a-b)/(c+d)` (regrouping so only the first two areas form
+the numerator and the dehisced area joins the dressing count in the denominator) — the two distractors exploit exactly those
+confusions.
+
+The setup: a `baseline_area`, a `healed_area`, a `dehisced_area`, and a `dressing_count`. The total is:
+
+  WOUND BURDEN INDEX  (baseline_area - healed_area + dehisced_area) / dressing_count  [ a mixed three-term numerator over a divisor ]
+  NET OPEN AREA       baseline_area - healed_area + dehisced_area                     [ the three-term numerator ]
+  DRESSING COUNT      dressing_count                                                  [ the divisor ]
+
+The **wound burden index** is what makes this rung distinctive — it is the ladder's first **three-term numerator that mixes a
+subtraction and an addition over a single divisor**. It is a rate (net open wound area per dressing change), framed as an
+*index* to keep it dimensionless-clean — the same discipline rungs 100/104/105/106/107/108 used for their ratios. (The net open
+area `a-b+c` and the dressing count `d` ride alongside as component readouts, so the panel teaches the whole calculation —
+exactly as rungs 47-108 shipped their component sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries
+the arithmetic — the subtraction of the healed area and the addition of the dehisced area into the net open area, then the
+division of that net area by the dressing count (the whole three-term numerator parenthesized, so (a-b+c)/d evaluates as
+((a-b+c)/d)) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change,
+exactly as rungs 8/16/.../107/108. This rung exercises the engine across a **mixed three-term numerator over a divisor** — the
+fact that `(a-b+c)/d` is `((a-b+c)/d)` and NOT `a-b+c/d` and NOT `(a-b)/(c+d)` made computable. The ratio golds are non-integer
+f64s; the engine's IEEE-double division matches Python's the same way rungs 99/100/104/105/106/107/108 relied on (well within
+the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `/` — **no
+structural constants** — so no numeric literal appears in any program, and neither the net open area, the dressing count, nor
+any index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free
+identifiers** (`baseline_area`, `healed_area`, `dehisced_area`, `dressing_count`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    baseline_area - healed_area + dehisced_area / dressing_count  drop the numerator parentheses so only the dehisced
+                                                                          area is divided by the dressing count and then
+                                                                          combined with the other two areas (the classic
+                                                                          `(a-b+c)/d` vs `a-b+c/d` precedence error), and
+  SWAPPED    (baseline_area - healed_area) / (dehisced_area + dressing_count)  regroup so only the first two areas form the
+                                                                          numerator and the dehisced area joins the dressing
+                                                                          count in the denominator (`(a-b)/(c+d)` instead of
+                                                                          `(a-b+c)/d`),
+
+which are exactly the mistakes a student makes (dropping the numerator parentheses before dividing, or regrouping which terms
+belong to the numerator vs the divisor). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five
+always appear as options.
+
+Distinctness and positivity: this rung SUBTRACTS, so positivity is guaranteed by table construction rather than automatic. Each
+table guarantees **baseline_area > healed_area** (so the difference `a-b` is strictly positive and the net open area
+`a-b+c = (a-b)+c` is positive), the **dressing_count >= 2** (divisor never zero), the wound burden index never coincides with
+the dressing count or the net open area, and the five family values are pairwise distinct with a comfortable margin; and — so
+all three queried readouts vary across the panel — the seven tables give distinct wound burden indices, distinct net open
+areas, and distinct dressing counts, all asserted at build time. (crossed `a-b+c/d = (a-b)+(c/d)` is positive because `a>b` and
+`c/d>0`; swapped `(a-b)/(c+d)` is positive because `a>b` and the denominator is a sum of positives.)
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (BASELINE_AREA, HEALED_AREA, DEHISCED_AREA, DRESSING_COUNT) — an original wound area with a healed area subtracted and a
+# dehisced area added for the net open area, all divided by a dressing count, all plain positive numbers >= 2. This rung
+# SUBTRACTS (the healed area), so every table guarantees baseline_area > healed_area (a-b>0) which — together with the added
+# dehisced area — keeps every family member strictly positive; dressing_count >= 2 keeps the divisor away from zero. The five
+# family values are asserted pairwise-distinct below. The seven tables give distinct wound burden indices, distinct net open
+# areas, and distinct dressing counts so all three queried readouts vary across the panel.
+TABLES = [
+    (5, 2, 4, 2),
+    (6, 3, 5, 3),
+    (7, 4, 7, 4),
+    (9, 4, 10, 5),
+    (6, 5, 8, 6),
+    (8, 4, 10, 7),
+    (10, 5, 13, 8),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, - and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the
+# options.
+FAMILY = [
+    (
+        "wound_burden_index",
+        "wound burden index (the net open area divided by the dressing count)",
+        "(baseline_area - healed_area + dehisced_area) / dressing_count",
+    ),
+    (
+        "net_open_area",
+        "the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)",
+        "baseline_area - healed_area + dehisced_area",
+    ),
+    (
+        "dressing_count",
+        "the dressing count (the divisor the net open area is divided by)",
+        "dressing_count",
+    ),
+    (
+        "crossed",
+        "the baseline minus healed area plus the dehisced area divided by the dressing count, dropping the numerator parentheses so only the dehisced area is divided before combining (a wrong grouping)",
+        "baseline_area - healed_area + dehisced_area / dressing_count",
+    ),
+    (
+        "swapped",
+        "the baseline minus healed area, divided by the dehisced area plus the dressing count, regrouping so only the first two areas form the numerator (a wrong pairing)",
+        "(baseline_area - healed_area) / (dehisced_area + dressing_count)",
+    ),
+]
+QUERIED = ["wound_burden_index", "net_open_area", "dressing_count"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(baseline_area, healed_area, dehisced_area, dressing_count):
+    # Operation order mirrors the ADJ programs exactly (the mixed three-term numerator forms, then the numerator is divided by
+    # the dressing count, so (a-b+c)/d evaluates as ((a-b+c)/d)), so the Python option value and the engine result are the same
+    # IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "wound_burden_index": (baseline_area - healed_area + dehisced_area) / dressing_count,
+        "net_open_area": baseline_area - healed_area + dehisced_area,
+        "dressing_count": dressing_count,
+        "crossed": baseline_area - healed_area + dehisced_area / dressing_count,
+        "swapped": (baseline_area - healed_area) / (dehisced_area + dressing_count),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for baseline_area, healed_area, dehisced_area, dressing_count in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and this rung SUBTRACTS the healed area, so each table
+        # guarantees baseline_area > healed_area (the difference a-b is strictly positive) which — together with the added
+        # dehisced area — keeps every family member strictly positive; dressing_count >= 2 keeps the divisor away from zero.
+        assert (
+            baseline_area >= 2
+            and healed_area >= 2
+            and dehisced_area >= 2
+            and dressing_count >= 2
+        ), (baseline_area, healed_area, dehisced_area, dressing_count)
+        assert baseline_area > healed_area, (baseline_area, healed_area, dehisced_area, dressing_count)
+        fv = family_values(baseline_area, healed_area, dehisced_area, dressing_count)
+        for key, v in fv.items():
+            assert v > 0, (key, baseline_area, healed_area, dehisced_area, dressing_count, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    baseline_area,
+                    healed_area,
+                    dehisced_area,
+                    dressing_count,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                baseline_area,
+                healed_area,
+                dehisced_area,
+                dressing_count,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r109wound-{idx + 1:02d}",
+                "qtype": "wound_burden_index",
+                "stem": (
+                    f"A wound chart records a baseline area of {num(baseline_area)} minus a healed area of "
+                    f"{num(healed_area)} plus a dehisced area of {num(dehisced_area)}, divided by a dressing count of "
+                    f"{num(dressing_count)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe baseline_area({num(baseline_area)})\n"
+                    f"observe healed_area({num(healed_area)})\n"
+                    f"observe dehisced_area({num(dehisced_area)})\n"
+                    f"observe dressing_count({num(dressing_count)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 109 — wound burden index from four stated quantities (a NEW panel: wound care / burn surface "
+            "accounting). From a baseline area minus a healed area plus a dehisced area for the net open area, all divided by a "
+            "dressing count, compute the wound burden index ((baseline_area-healed_area+dehisced_area)/dressing_count), the net "
+            "open area (baseline_area-healed_area+dehisced_area), or the dressing count. Each item is a compute_dimensioned "
+            "program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, "
+            "A MIXED THREE-TERM NUMERATOR OVER A DIVISOR (a-b+c)/d (subtract the healed area, add the dehisced area, divide by "
+            "the dressing count, so (a-b+c)/d = ((a-b+c)/d); the FIRST time the ladder puts a three-term numerator that MIXES a "
+            "subtraction and an addition over a divisor — rung-108 opened the frontier with the pure sum (a+b+c)/d, and every "
+            "earlier ratio used a TWO-term numerator: 37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 (a-b)/(c*d), and the "
+            "difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) — and the harness matches the scalar "
+            "to the printed options. The wound burden index is a rate (net open area per dressing change), framed as an INDEX so "
+            "the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed "
+            "quantities via +, - and / — no constant leaks, and neither the net open area, the dressing count, nor any index "
+            "ever appears as a literal (each is computed) — and the observed quantities carry digit-free identifiers so no "
+            "numeral hides inside a variable name. The five options are a family over the same four quantities, so the "
+            "distractors are exactly the slips students make: dropping the numerator parentheses so only the dehisced area is "
+            "divided before combining (a-b+c/d, a wrong grouping) and regrouping so only the first two areas form the numerator "
+            "((a-b)/(c+d), a wrong pairing). The core confusion tested is that (a-b+c)/d is ((a-b+c)/d), not a-b+c/d and not "
+            "(a-b)/(c+d). This rung SUBTRACTS the healed area, so positivity is guaranteed by table construction: every table "
+            "has baseline_area > healed_area (a-b>0) and dressing_count >= 2 (divisor never zero), keeping every family member "
+            "strictly positive."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung109_wound_care/items.json
+++ b/code/specs/data/adj-ladder/rung109_wound_care/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 109 \u2014 wound burden index from four stated quantities (a NEW panel: wound care / burn surface accounting). From a baseline area minus a healed area plus a dehisced area for the net open area, all divided by a dressing count, compute the wound burden index ((baseline_area-healed_area+dehisced_area)/dressing_count), the net open area (baseline_area-healed_area+dehisced_area), or the dressing count. Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, A MIXED THREE-TERM NUMERATOR OVER A DIVISOR (a-b+c)/d (subtract the healed area, add the dehisced area, divide by the dressing count, so (a-b+c)/d = ((a-b+c)/d); the FIRST time the ladder puts a three-term numerator that MIXES a subtraction and an addition over a divisor \u2014 rung-108 opened the frontier with the pure sum (a+b+c)/d, and every earlier ratio used a TWO-term numerator: 37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 (a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) \u2014 and the harness matches the scalar to the printed options. The wound burden index is a rate (net open area per dressing change), framed as an INDEX so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed quantities via +, - and / \u2014 no constant leaks, and neither the net open area, the dressing count, nor any index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the numerator parentheses so only the dehisced area is divided before combining (a-b+c/d, a wrong grouping) and regrouping so only the first two areas form the numerator ((a-b)/(c+d), a wrong pairing). The core confusion tested is that (a-b+c)/d is ((a-b+c)/d), not a-b+c/d and not (a-b)/(c+d). This rung SUBTRACTS the healed area, so positivity is guaranteed by table construction: every table has baseline_area > healed_area (a-b>0) and dressing_count >= 2 (divisor never zero), keeping every family member strictly positive.",
+  "items": [
+    {
+      "id": "r109wound-01",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 5 minus a healed area of 2 plus a dehisced area of 4, divided by a dressing count of 2. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(5)\nobserve healed_area(2)\nobserve dehisced_area(4)\nobserve dressing_count(2)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r109wound-02",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 5 minus a healed area of 2 plus a dehisced area of 4, divided by a dressing count of 2. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(5)\nobserve healed_area(2)\nobserve dehisced_area(4)\nobserve dressing_count(2)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r109wound-03",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 5 minus a healed area of 2 plus a dehisced area of 4, divided by a dressing count of 2. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(5)\nobserve healed_area(2)\nobserve dehisced_area(4)\nobserve dressing_count(2)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r109wound-04",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 6 minus a healed area of 3 plus a dehisced area of 5, divided by a dressing count of 3. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(6)\nobserve healed_area(3)\nobserve dehisced_area(5)\nobserve dressing_count(3)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r109wound-05",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 6 minus a healed area of 3 plus a dehisced area of 5, divided by a dressing count of 3. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(6)\nobserve healed_area(3)\nobserve dehisced_area(5)\nobserve dressing_count(3)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.375,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r109wound-06",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 6 minus a healed area of 3 plus a dehisced area of 5, divided by a dressing count of 3. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(6)\nobserve healed_area(3)\nobserve dehisced_area(5)\nobserve dressing_count(3)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.375,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r109wound-07",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 7 minus a healed area of 4 plus a dehisced area of 7, divided by a dressing count of 4. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(7)\nobserve healed_area(4)\nobserve dehisced_area(7)\nobserve dressing_count(4)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.2727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r109wound-08",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 7 minus a healed area of 4 plus a dehisced area of 7, divided by a dressing count of 4. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(7)\nobserve healed_area(4)\nobserve dehisced_area(7)\nobserve dressing_count(4)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.2727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r109wound-09",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 7 minus a healed area of 4 plus a dehisced area of 7, divided by a dressing count of 4. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(7)\nobserve healed_area(4)\nobserve dehisced_area(7)\nobserve dressing_count(4)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.2727272727272727,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r109wound-10",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 9 minus a healed area of 4 plus a dehisced area of 10, divided by a dressing count of 5. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(9)\nobserve healed_area(4)\nobserve dehisced_area(10)\nobserve dressing_count(5)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r109wound-11",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 9 minus a healed area of 4 plus a dehisced area of 10, divided by a dressing count of 5. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(9)\nobserve healed_area(4)\nobserve dehisced_area(10)\nobserve dressing_count(5)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r109wound-12",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 9 minus a healed area of 4 plus a dehisced area of 10, divided by a dressing count of 5. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(9)\nobserve healed_area(4)\nobserve dehisced_area(10)\nobserve dressing_count(5)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r109wound-13",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 6 minus a healed area of 5 plus a dehisced area of 8, divided by a dressing count of 6. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(6)\nobserve healed_area(5)\nobserve dehisced_area(8)\nobserve dressing_count(6)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.07142857142857142,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r109wound-14",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 6 minus a healed area of 5 plus a dehisced area of 8, divided by a dressing count of 6. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(6)\nobserve healed_area(5)\nobserve dehisced_area(8)\nobserve dressing_count(6)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.07142857142857142,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r109wound-15",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 6 minus a healed area of 5 plus a dehisced area of 8, divided by a dressing count of 6. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(6)\nobserve healed_area(5)\nobserve dehisced_area(8)\nobserve dressing_count(6)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.333333333333333,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.07142857142857142,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r109wound-16",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 8 minus a healed area of 4 plus a dehisced area of 10, divided by a dressing count of 7. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(8)\nobserve healed_area(4)\nobserve dehisced_area(10)\nobserve dressing_count(7)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.23529411764705882,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r109wound-17",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 8 minus a healed area of 4 plus a dehisced area of 10, divided by a dressing count of 7. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(8)\nobserve healed_area(4)\nobserve dehisced_area(10)\nobserve dressing_count(7)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.23529411764705882,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r109wound-18",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 8 minus a healed area of 4 plus a dehisced area of 10, divided by a dressing count of 7. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(8)\nobserve healed_area(4)\nobserve dehisced_area(10)\nobserve dressing_count(7)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.428571428571429,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.23529411764705882,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r109wound-19",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 10 minus a healed area of 5 plus a dehisced area of 13, divided by a dressing count of 8. What is the wound burden index (the net open area divided by the dressing count)?",
+      "program": "observe baseline_area(10)\nobserve healed_area(5)\nobserve dehisced_area(13)\nobserve dressing_count(8)\nlet answer = (baseline_area - healed_area + dehisced_area) / dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.625,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.23809523809523808,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r109wound-20",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 10 minus a healed area of 5 plus a dehisced area of 13, divided by a dressing count of 8. What is the the net open area (the baseline area minus the healed area plus the dehisced area, the numerator divided by the dressing count)?",
+      "program": "observe baseline_area(10)\nobserve healed_area(5)\nobserve dehisced_area(13)\nobserve dressing_count(8)\nlet answer = baseline_area - healed_area + dehisced_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.625,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.23809523809523808,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r109wound-21",
+      "qtype": "wound_burden_index",
+      "stem": "A wound chart records a baseline area of 10 minus a healed area of 5 plus a dehisced area of 13, divided by a dressing count of 8. What is the the dressing count (the divisor the net open area is divided by)?",
+      "program": "observe baseline_area(10)\nobserve healed_area(5)\nobserve dehisced_area(13)\nobserve dressing_count(8)\nlet answer = dressing_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.625,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.23809523809523808,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -146,6 +146,7 @@ SELF_CONTAINED_RUNGS = (
     "rung106_exercise_load",
     "rung107_contact_lens",
     "rung108_periodontal",
+    "rung109_wound_care",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-109 — wound care wound burden index (a mixed three-term numerator over a divisor)

Opens the **wound care / burn surface accounting** panel on the quantitative band and introduces a genuinely **new arithmetic shape**: **a mixed three-term numerator (subtraction + addition) over a single divisor, `(a-b+c)/d`**.

### What's new (shape novelty)

Rung-108 opened the three-term-numerator frontier with the pure sum `(a+b+c)/d`. Rung-109 is the **first time the ladder puts a three-term numerator that MIXES a subtraction and an addition over a divisor**. Every earlier ratio used a two-term numerator:
- rung-37 `(a+b)/(c+d)`, rung-99 `(a*b)/(c+d)`, rung-100 `(a+b)/(c*d)`, rung-104 `(a-b)/(c*d)`
- the difference-denominator trio 105 `(a+b)/(c-d)`, 106 `a*b/(c-d)`, 107 `(a-b)/(c-d)`
- rung-108 `(a+b+c)/d`

Rung-109 is `((baseline_area - healed_area + dehisced_area) / dressing_count)`.

### The clinical framing

A wound's `baseline_area` has a `healed_area` **subtracted** (tissue that closed) and a `dehisced_area` **added** (tissue that reopened) for the **net open area**, then divided by a `dressing_count` to give the **wound burden index** (net open area per dressing change, framed as a dimensionless index).

- `WOUND BURDEN INDEX = (baseline_area - healed_area + dehisced_area) / dressing_count` — the headline mixed three-term ratio
- `NET OPEN AREA      = baseline_area - healed_area + dehisced_area` — the numerator, a real component readout
- `DRESSING COUNT     = dressing_count` — the divisor, a real component readout

### The distractor family (5 mutually-confusable scalars over the same four quantities)

- **crossed** `baseline_area - healed_area + dehisced_area / dressing_count` — drops the numerator parentheses so only the dehisced area is divided (`(a-b+c)/d` vs `a-b+c/d` precedence slip)
- **swapped** `(baseline_area - healed_area) / (dehisced_area + dressing_count)` — regroups so only the first two areas form the numerator (`(a-b)/(c+d)`)

The core confusion tested: `(a-b+c)/d` is `((a-b+c)/d)`, **not** `a-b+c/d` and **not** `(a-b)/(c+d)`.

### Construction guarantees

- **Constant-free / digit-free**: every figure is built only from the four observed quantities via `+`, `-`, `/`; no numeric literal appears in any program; identifiers are digit-free (`baseline_area`, `healed_area`, `dehisced_area`, `dressing_count`).
- **This rung subtracts**, so positivity is by construction: every table guarantees `baseline_area > healed_area` (so `a-b>0` and the net area `(a-b)+c>0`) and `dressing_count >= 2` (divisor never zero) — every family member strictly positive.
- Five family values asserted **pairwise-distinct** (>1e-6) per table; the seven tables give **distinct wound burden indices, distinct net open areas, and distinct dressing counts** so all three queried golds vary across the panel.
- Gold rotates A–E by `idx % 5`. 7 tables × 3 queried readouts = **21 items**.

### No harness/engine change

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing extractor — exactly as rungs 8/16/…/107/108.

### Verification

- `gen_items.py` → `wrote items.json: 21 items`
- Scratchpad distinctness/positivity checker: all 5 within-table pairwise-distinct; 3 queried golds all vary across the 7 tables.
- `python3 -m pytest test_ladder_eval.py -k rung109 -q` → **3 passed**
- Inline security review: PASSED (data-only generator; no eval/exec/I-O beyond its own items.json; every table guards `a>b` and `d>=2` so no div-by-zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
