### PR TITLE
feat(latex): LTXDOC03 S22 label_definitions (winning label defs)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.58.0] — 2026-07-08
+
+### Added — winning label definitions report (LTXDOC03 S22)
+
+A **new** public method `Document::label_definitions(&self) -> String` that renders the **winning label
+definitions** — the `\label{key}` definitions that references resolve against, one `\label{key}` line
+per distinct key. It is the label-family analogue of S19's `bibliography_entries` (which renders the
+winning `\bibitem` entries) and the *winning-side* counterpart of S20's `duplicate_label_definitions`
+(which renders the *losing* duplicate `\label` definitions). It is a read-only view over
+`resolve_references()`: S1 splits every `\label` into the **winning** first definition of each key
+(`definitions`, a `Vec<LabelDef>` with one row per distinct key, in pre-order) and the **losing** later
+re-definitions (`duplicates`); S22 renders the `definitions` list. Every S1–S21 output is left
+**byte-for-byte unchanged**; S22 is purely additive and leaves the `to_latex()` round-trip fixed point
+intact.
+
+- **One reconstructed `\label{key}` line per winning definition**, in the existing pre-order — **not**
+  re-sorted and **not** de-duplicated (no de-duplication is needed: `definitions` already holds exactly
+  one row per distinct key, later re-definitions having gone to `duplicates`). Each line is
+  reconstructed from the definition's **owned `key` `String`** via `format!("\\label{{{}}}", def.key)`,
+  so there is **no** source slicing at all (matching S13 `resolve_namerefs`, S15 `citations_by_source`,
+  S16 `duplicate_bibliography_entries`, S19 `bibliography_entries`, and S20
+  `duplicate_label_definitions`). `\label{key}` is the correct form for any `LabelKind` (section,
+  figure, equation, or bare inline label).
+- **Winning key appears once.** A `\label{dup}` written twice appears **once** here — the winning first
+  definition; its losing second definition lives in S20 (`duplicate_label_definitions`), never here.
+- **Stable empty marker.** No label definitions at all → the fixed string `(no label definitions)`,
+  never `""` (the same discipline S12–S21 use). Lines are joined by `\n` with **no** trailing newline.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single pass
+  over the already-bounded `definitions` list. Borrows `self` immutably and returns owned `String`.
+- Tests: winning definitions in pre-order, empty-marker, duplicate-key-wins-once (cross-checked against
+  S20's losing side), `\n`-join with no trailing newline, and an additivity test pinning every S1–S21
+  output byte-for-byte on a representative document.
+
 ## [0.57.0] — 2026-07-08
 
 ### Added — resolved-references-by-source report (LTXDOC03 S21)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -69,6 +69,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S19 — numbered winning-bibliography-entry list** | `Document::bibliography_entries() -> String` — a **new**, read-only method that renders the **winning** bibliography entries as a **numbered list** — the rendered bibliography a reader sees, and the table citations resolve against. A **distinct** view over `resolve_citations()`: S16 (`duplicate_bibliography_entries`) renders the **losing** `duplicate_entries` as `\bibitem{key}` lines, S15 (`citations_by_source`) renders per-source *resolved cite keys*; S19 renders the **winning** `entries`. It reads only `resolve_citations().entries` (the first `\bibitem` of each distinct key, body pre-order; later re-definitions live in `duplicate_entries`) and numbers it **1-based**, one line per entry as `[n] key` (reconstructed from the owned key, no source slicing). The `[n] key` shape is deliberately distinct from S16's `\bibitem{key}` lines. A `\bibitem{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** bibliography entries → the fixed marker `(no bibliography entries)`. E.g. `smith` (twice) + `jones` → `[1] smith\n[2] jones`. Every S1–S18 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S20 — losing duplicate `\label` definitions** | `Document::duplicate_label_definitions() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\label`s — LaTeX's *"Label `key' multiply defined"* warnings — the **label-family mirror of S16's** `duplicate_bibliography_entries` (which surfaces the losing `\bibitem` duplicates). It reads only `resolve_references().duplicates`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, what `\ref`/`\eqref`/`\pageref` resolve against) and every **later** `\label` of an already-defined key is a losing duplicate. S20 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). Lines joined by `\n`, no trailing newline. A document with **no** duplicate labels (every key once, or none) → the fixed marker `(no duplicate label definitions)`. E.g. `dup` defined twice + `once` once → `\label{dup}` (only the loser). Every S1–S19 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S21 — resolved references grouped by source `\ref`** | `Document::resolved_references_by_source() -> String` — a **new**, read-only method that renders the **resolved** (successfully-matched) references, one reconstructed `\<command>{key}` line each — the **RESOLVED mirror of S18's** `unresolved_references_by_source` (which renders the *dangling* half of the same split), **command-aware** so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). Lines joined by `\n`, no trailing newline. A document with **no** resolved references (every ref dangles, or none) → the fixed marker `(no resolved references)`. E.g. `\ref{sec:intro}`, `\eqref{eq:main}`, `\pageref{sec:intro}` (all defined) → `\ref{sec:intro}\n\eqref{eq:main}\n\pageref{sec:intro}`. Every S1–S20 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S22 — winning `\label` definitions** | `Document::label_definitions() -> String` — a **new**, read-only method that renders the **winning** label definitions — the `\label{key}` definitions references resolve against, one `\label{key}` line per distinct key — the **label-family analogue of S19's** `bibliography_entries` (which renders the winning `\bibitem` entries) and the **winning-side counterpart of S20's** `duplicate_label_definitions` (which renders the *losing* duplicate `\label`s). It reads only `resolve_references().definitions`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, one row per distinct key) and every **later** `\label` of an already-defined key goes to `duplicates` (S20's domain). S22 emits one line per winning definition in that pre-order (**not** re-sorted, **not** de-duplicated — none needed, since `definitions` already holds one row per distinct key), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). A `\label{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the fixed marker `(no label definitions)`. E.g. `sec:intro` (section), `eq:main` (equation), then a re-used `sec:intro` → `\label{sec:intro}\n\label{eq:main}` (winner once). Every S1–S21 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -890,6 +891,37 @@ assert_eq!(
 A document with no resolved references — every reference dangles, or there are none at all — renders the
 fixed `(no resolved references)` marker. Purely additive — reuses `resolve_references`, mutates nothing,
 leaves every S1–S20 output and the `to_latex()` fixed point unchanged.
+
+### winning `\label` definitions (LTXDOC03 S22)
+
+The **winning** label definitions — the `\label{key}` definitions references resolve against — the
+**label-family analogue of S19's** `bibliography_entries` (which renders the winning `\bibitem` entries)
+and the **winning-side counterpart of S20's** `duplicate_label_definitions` (which renders the *losing*
+duplicate `\label`s). S1 splits every `\label` into the **winning** first definition of each key
+(`resolve_references().definitions`, one row per distinct key, in pre-order) and the **losing** later
+re-definitions (`duplicates`). `label_definitions` reads only that `definitions` list and emits one line
+per winning definition, in pre-order — reconstructed from its owned `key` as `\label{<key>}` (no source
+slicing; the `\label{…}` form is right for any `LabelKind`). No re-sorting and no de-duplication are
+needed, because `definitions` already holds exactly one row per distinct key; a `\label{dup}` written
+twice appears **once** here (its losing second definition lives in S20).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:main} x=1 \end{equation}
+\subsection{Dup}\label{sec:intro}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.label_definitions(),
+    // the winning key `sec:intro` appears once; the later re-`\label`ed `sec:intro` is a duplicate (S20)
+    "\\label{sec:intro}\n\\label{eq:main}",
+);
+```
+
+A document with no label definitions renders the fixed `(no label definitions)` marker. Purely
+additive — reuses `resolve_references`, mutates nothing, leaves every S1–S21 output and the `to_latex()`
+fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2098,6 +2098,89 @@ impl Document {
             .join("\n")
     }
 
+    /// The **winning label definitions** (LTXDOC03 S22) — the `\label{key}` definitions that
+    /// references resolve against, the label-family analogue of S19's
+    /// [`bibliography_entries`](Document::bibliography_entries) and the *winning-side* counterpart of
+    /// S20's [`duplicate_label_definitions`](Document::duplicate_label_definitions).
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] splits every `\label` into the **winning** first
+    /// definition of each key ([`ReferenceResolution::definitions`] — one row per distinct key, in
+    /// [`Document::walk`] pre-order, and precisely what `\ref`/`\eqref`/`\pageref` resolve against) and
+    /// the **losing** later re-definitions ([`ReferenceResolution::duplicates`] — LaTeX's *"Label
+    /// `key' multiply defined"* warning). The neighboring label renderers view the other cells of that
+    /// resolution: S20's [`duplicate_label_definitions`](Document::duplicate_label_definitions) renders
+    /// the **losing** `duplicates` (as `\label{key}` warning lines). S22 fills the remaining view: the
+    /// **winning** `definitions` themselves — one reconstructed `\label{key}` line per distinct key, in
+    /// the order the definitions were first seen. It is the exact `\label` parallel of S19, which
+    /// renders the winning `\bibitem` entries.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read [`ReferenceResolution::definitions`] in its existing pre-order and render one line per
+    /// winning definition: `\label{` + `def.key` + `}`. The list is **NOT** re-sorted and **NOT**
+    /// de-duplicated — but no de-duplication is needed, because `definitions` already holds exactly one
+    /// row per distinct key (every later re-definition of an already-defined key went to `duplicates`,
+    /// S20's domain, never here). Each line is reconstructed from the definition's **owned `key`
+    /// `String`** — there is **no** source slicing at all (matching S13's `resolve_namerefs`, S15's
+    /// `citations_by_source`, S16's `duplicate_bibliography_entries`, S19's `bibliography_entries`, and
+    /// S20's `duplicate_label_definitions`). Labels are always *defined* by `\label{…}`, so `\label{key}`
+    /// is the correct reconstruction regardless of the definition's [`LabelKind`] (a section, figure,
+    /// equation, or bare inline label all render the same `\label{key}` form).
+    ///
+    /// A document with **no** label definitions returns the fixed marker `(no label definitions)`,
+    /// never the empty string (the same stable-marker discipline S12-S21 use). Lines are joined by `\n`
+    /// with **no** trailing newline (matching S11's `to_plain_text_by_kind` and every S12-S21 renderer).
+    ///
+    /// Concretely, for a body that defines `\label{sec:intro}` (a section), `\label{eq:main}` (an
+    /// equation), and then re-uses `\label{sec:intro}` on a later subsection:
+    ///
+    /// ```text
+    /// \section{Intro}\label{sec:intro}
+    /// \begin{equation}\label{eq:main} x=1 \end{equation}
+    /// \subsection{Dup}\label{sec:intro}
+    /// ```
+    ///
+    /// only the *first* `\label{sec:intro}` wins, so the winning key `sec:intro` appears **once**
+    /// (its later re-definition is a duplicate, surfaced by S20, not a second `definitions` row):
+    ///
+    /// ```text
+    /// \label{sec:intro}
+    /// \label{eq:main}
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S22 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1-S21 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single pass over the already-bounded `definitions` list.
+    /// Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow of
+    /// the source.
+    pub fn label_definitions(&self) -> String {
+        // S1 already collected the winning definitions — the first `\label` of each distinct key, in
+        // body pre-order (later re-definitions went to `duplicates`, not here). We only read that list.
+        let resolution = self.resolve_references();
+
+        if resolution.definitions.is_empty() {
+            // No `\label` at all → the fixed marker, never the empty string.
+            return "(no label definitions)".to_string();
+        }
+
+        // One line per winning definition, in the existing pre-order (NOT re-sorted; NOT de-duplicated —
+        // `definitions` already holds exactly one row per distinct key). Reconstruct `\label{key}` from
+        // the owned key, so there is no source slicing; `\label{…}` is the right form for any LabelKind.
+        resolution
+            .definitions
+            .iter()
+            .map(|def| format!("\\label{{{}}}", def.key))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// The **resolved (successfully-matched) references grouped by their source `\ref`** (LTXDOC03
     /// S21) — the exact structural mirror of S18's
     /// [`unresolved_references_by_source`](Document::unresolved_references_by_source), but for the
@@ -5349,6 +5432,129 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.resolved_references_by_source(),
             "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S22 — winning label definitions (`label_definitions`). The label-family mirror of
+    // S19's `bibliography_entries`, and the winning-side counterpart of S20.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s22_lists_winning_definitions_in_preorder() {
+        // Two distinct labels defined in source order → each renders `\label{key}`, one per line, in
+        // body pre-order (`k1` before `k2`).
+        let src = r"\begin{document}First \label{k1} here.
+
+Second \label{k2} there.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definitions(), "\\label{k1}\n\\label{k2}");
+    }
+
+    #[test]
+    fn s22_no_labels_returns_marker() {
+        // A document with no `\label` at all → the fixed `(no label definitions)` marker, never the
+        // empty string.
+        let src = r"\begin{document}Just some text with no labels.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definitions(), "(no label definitions)");
+    }
+
+    #[test]
+    fn s22_duplicate_key_wins_once() {
+        // `\label{dup}` written twice: the FIRST wins (→ `definitions`), the SECOND loses (→
+        // `duplicates`). S22 renders the winning key EXACTLY ONCE; the losing later one is S20's domain.
+        let src = r"\begin{document}First \label{dup} here.
+
+Second \label{dup} there.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        // Winning side: the key appears once.
+        assert_eq!(doc.label_definitions(), "\\label{dup}");
+        // Cross-check the losing side: S20 surfaces the second (losing) `\label{dup}`.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+    }
+
+    #[test]
+    fn s22_newline_join_no_trailing_newline() {
+        // Three distinct labels → exact string equality pins the `\n`-join with NO trailing newline.
+        let src = r"\begin{document}\label{a}
+
+\label{b}
+
+\label{c}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definitions(), "\\label{a}\n\\label{b}\n\\label{c}");
+    }
+
+    #[test]
+    fn s22_is_additive_leaves_s1_s21_outputs_unchanged() {
+        // On a representative doc carrying a section, a figure, an equation, a resolved `\ref`, a
+        // resolved `\eqref`, a `\nameref`, two `\cite`s (one multi-key, one dangling key), a duplicate
+        // `\bibitem`, a dangling `\eqref` (`eq:ghost`), AND a duplicate `\label{dup}`, S22 changes NONE
+        // of the S1-S21 outputs — it only reads `resolve_references`. This also pins the `\n`-join with
+        // no trailing newline on the multi-label S22 case, and that the winning `dup` appears ONCE.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\eqref{eq:e} -> Equation (1)\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\nEquations:\n  \\eqref{eq:e} -> Equation (1)"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S20 losing duplicate labels — unchanged.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // S21 resolved references — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+
+        // And S22 itself surfaces only the WINNING label definitions — one row per distinct key, in
+        // pre-order, `\n`-joined with no trailing newline. The duplicate `dup` appears ONCE (its losing
+        // second definition lives in S20, not here).
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1748,3 +1748,82 @@ which also pins the `\n`-join with no trailing newline on a multi-ref case). All
 unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
 -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 28. S22 — winning label definitions (`label_definitions`)
+
+### 28.1 Motivation
+
+S1's `resolve_references` returns `definitions: Vec<LabelDef>` — the **winning** label definitions, one
+row per **distinct** key (the first `\label` of each key seen), in `walk` pre-order. This is precisely the
+label table `\ref`/`\eqref`/`\pageref` resolve against. S20 (`duplicate_label_definitions`) already
+renders the **losing** half of the `\label` split — the later re-definitions of an already-defined key,
+LaTeX's *"Label `key' multiply defined"* — one `\label{key}` line each. But the **winning** half — the
+definitions references actually bind to — had no renderer: S19 renders the winning `\bibitem` entries for
+the citation family, yet the exact `\label` analogue was missing. S22 fills that cell by rendering
+`definitions` as the winning-label report, the label-family analogue of S19 and the winning-side
+counterpart of S20.
+
+### 28.2 Why a new method — additive by construction
+
+S22 adds a **new public method** `Document::label_definitions(&self) -> String`. It is a pure, read-only
+render of `resolve_references().definitions`. It reuses that table verbatim (never re-walking the body or
+re-collecting definitions), so the report can never drift from the S1 resolution it summarises. It mutates
+nothing and changes no S1–S21 output — including `to_latex()`'s round-trip fixed point — byte-for-byte.
+Like S11–S21 it is a method the caller invokes directly.
+
+### 28.3 The ordering rule
+
+`definitions` is already in `walk` pre-order with **one row per distinct key**: S1's `collect_definitions`
+keeps the **first** `\label` of each key as the winner and routes every later re-definition of an
+already-defined key into `duplicates` (never into `definitions`). S22 renders `definitions` in that
+existing pre-order — **not** re-sorted and **not** de-duplicated, because no de-duplication is needed
+(the list already holds exactly one row per distinct key). A `\label{dup}` written twice therefore appears
+**once** here — the winner; its losing second definition lives in S20.
+
+### 28.4 The exact rendering contract — `Document::label_definitions(&self) -> String`
+
+- Read `resolve_references().definitions` in its existing pre-order and emit one line per winning
+  definition: `format!("\\label{{{}}}", def.key)` → `\label{` + the definition's `key` + `}`.
+  Reconstructed from the owned `key` `String` rather than sliced from `&src[span]` (matching S13
+  `resolve_namerefs`, S15 `citations_by_source`, S16 `duplicate_bibliography_entries`, S19
+  `bibliography_entries`, and S20 `duplicate_label_definitions`), so the render needs no source borrow and
+  can never index out of bounds. `\label{key}` is the correct reconstruction for any `LabelKind` (a
+  section, figure, equation, or bare inline label all render the same `\label{key}` form).
+- One line per winning definition, in the existing pre-order — **not** re-sorted, **not** de-duplicated
+  (none needed, since `definitions` already holds one row per distinct key).
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S21 renderer).
+- If there are **no** label definitions, the fixed marker `(no label definitions)` is returned, so the
+  output is never the empty string.
+
+Example (body defining `\label{sec:intro}` on a section, `\label{eq:main}` on an equation, then re-using
+`\label{sec:intro}` on a later subsection):
+
+```text
+\label{sec:intro}
+\label{eq:main}
+```
+
+only the *first* `\label{sec:intro}` wins, so the winning key `sec:intro` appears **once**; its later
+re-definition is a duplicate (surfaced by S20, not a second `definitions` row). This is the winning-label
+analogue of S19's numbered `\bibitem` list and the winning-side counterpart of S20's losing-duplicate
+view.
+
+### 28.5 Public API (added in S22)
+
+One new method: `Document::label_definitions(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_references` and every S1–S21 method are unchanged; no AST or grammar change;
+no new dependency, no `unsafe`, no I/O.
+
+### 28.6 Verification (S22)
+
+`cargo test -p latex` green (5 new S22 tests: two distinct labels rendering `\label{k1}\n\label{k2}` in
+source pre-order; a doc with no labels returning the `(no label definitions)` marker; a `\label{dup}`
+written twice rendering `\label{dup}` **once** (the winner) and cross-checked against S20's losing side;
+a three-label case pinning the `\n`-join with no trailing newline; and an additivity check that
+`to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`,
+`citations_by_source`, `duplicate_bibliography_entries`, `unresolved_citations_by_source`,
+`unresolved_references_by_source`, `bibliography_entries`, `duplicate_label_definitions`, and
+`resolved_references_by_source` all still produce their exact prior strings). All prior S1–S21 tests pass
+unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
+-p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S22 — `label_definitions` (latex 0.58.0)

Adds one additive, read-only cross-reference report renderer to the zero-dependency `latex` crate: the **winning label definitions**.

### What it does

```rust
pub fn label_definitions(&self) -> String
```

Renders the **winning `\label{key}` definitions** — the ones references resolve against — one `\label{key}` per line, in source pre-order. This is the reference-side analogue of the shipped **S19** `bibliography_entries` (winning `\bibitem` entries) but for labels, and the winning-side counterpart to **S20** `duplicate_label_definitions` (the *losing* duplicate label defs).

It reads `resolve_references().definitions` (a `Vec<LabelDef>`, one row per distinct key, first-definition-wins in `walk` pre-order) and renders each as `format!("\\label{{{}}}", def.key)`:

```
\label{sec:intro}
\label{eq:main}
```

A key defined twice appears **once** — the winning definition; the later re-definition lives in `duplicates` (S20's domain), never in `definitions`. A document with no labels returns the fixed marker `(no label definitions)`, never the empty string — the shared S11–S21 stable-marker discipline. Lines join with `\n`, no trailing newline.

### Guarantees

- **Additive**: a brand-new read-only method reusing `resolve_references()`; every S1–S21 output is byte-for-byte unchanged (pinned by `s22_is_additive_leaves_s1_s21_outputs_unchanged`), and the `to_latex` round-trip fixed point is intact.
- **Total & panic-free**: no `unsafe`, no `unwrap`/`expect`, no indexing/slicing (keys are owned `String`s), a single pass over the already-bounded `definitions` list; borrows `self` immutably and returns owned `String`.

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → all green (S22 tests added)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED

### Docs

- `Cargo.toml` version `0.57.0` → `0.58.0`
- `CHANGELOG.md`, `README.md`, and `LTXDOC03-cross-reference-resolution.md` (new §28 / S22 section) — prior sections byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
