### PR TITLE
feat(latex): LTXDOC03 S23 label_definitions_by_kind (per-kind census)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.59.0] — 2026-07-08
+
+### Added — winning label definitions grouped by kind (LTXDOC03 S23)
+
+A **new** public method `Document::label_definitions_by_kind(&self) -> String` that renders the
+**winning label definitions grouped by their `LabelKind`** — a per-kind census of the `\label`
+definitions. It is the by-kind grouping companion of S22's `label_definitions` (which lists the same
+winning definitions **flat**, one `\label{key}` per line in pure pre-order): S22 and S23 are two
+*views* of the one winning `definitions` list `resolve_references()` produces. It is a read-only view
+over `resolve_references()`; every S1–S22 output is left **byte-for-byte unchanged**; S23 is purely
+additive and leaves the `to_latex()` round-trip fixed point intact.
+
+- **Grouped by kind in a fixed, document-independent order** — the `LabelKind` enum declaration order:
+  `Section`, `Table`, `Figure`, `Equation`, `Inline`. The method iterates that explicit fixed order
+  (not a hash map keyed by kind), so the group order is deterministic — the same `Vec`-of-groups
+  discipline S17/S18 use to avoid hash-order nondeterminism.
+- **Pre-order within each kind.** Definitions of a given kind keep their existing pre-order from
+  `definitions`; grouping never reorders within a kind.
+- **`[kind] \label{key}` line shape.** Each line is `[` + the stable lowercase tag from
+  `LabelKind::as_str()` (`"section"`, `"table"`, `"figure"`, `"equation"`, `"inline"`) + `] \label{` +
+  the definition's **owned `key` `String`** + `}` — so there is **no** source slicing at all (matching
+  S13 `resolve_namerefs`, S19 `bibliography_entries`, S20 `duplicate_label_definitions`, and S22
+  `label_definitions`). The `[kind]` prefix makes the census visible on every line while staying
+  one-line-per-definition; it is a report annotation, not round-trippable LaTeX.
+- **No empty groups.** A kind with no definitions contributes no lines and no bare `[table]` header.
+- **Stable empty marker.** No label definitions at all → the **same** fixed string
+  `(no label definitions)` S22 uses (S23 groups the identical list), never the empty string — the
+  stable-marker discipline S12–S22 share.
+- **`\n`-joined, no trailing newline** — matching S11's `to_plain_text_by_kind` and every S12–S22
+  renderer.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single
+  stable-ordered pass (fixed kind order × pre-order filter) over the already-bounded `definitions`
+  list. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s23_groups_different_kinds_in_fixed_kind_order`,
+  `s23_reorders_source_to_fixed_kind_order`, `s23_same_kind_grouped_in_preorder`,
+  `s23_no_labels_returns_marker`, `s23_newline_join_no_trailing_newline`, and
+  `s23_is_additive_leaves_s1_s22_outputs_unchanged` (which pins every S1–S22 output byte-for-byte,
+  including S22's flat `label_definitions`, alongside the new grouped output).
+
 ## [0.58.0] — 2026-07-08
 
 ### Added — winning label definitions report (LTXDOC03 S22)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -70,6 +70,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S20 — losing duplicate `\label` definitions** | `Document::duplicate_label_definitions() -> String` — a **new**, read-only method that surfaces the **multiply-defined** `\label`s — LaTeX's *"Label `key' multiply defined"* warnings — the **label-family mirror of S16's** `duplicate_bibliography_entries` (which surfaces the losing `\bibitem` duplicates). It reads only `resolve_references().duplicates`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, what `\ref`/`\eqref`/`\pageref` resolve against) and every **later** `\label` of an already-defined key is a losing duplicate. S20 emits one line per duplicate in that pre-order (**not** re-sorted, **not** de-duplicated — a key defined three times yields two lines), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). Lines joined by `\n`, no trailing newline. A document with **no** duplicate labels (every key once, or none) → the fixed marker `(no duplicate label definitions)`. E.g. `dup` defined twice + `once` once → `\label{dup}` (only the loser). Every S1–S19 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S21 — resolved references grouped by source `\ref`** | `Document::resolved_references_by_source() -> String` — a **new**, read-only method that renders the **resolved** (successfully-matched) references, one reconstructed `\<command>{key}` line each — the **RESOLVED mirror of S18's** `unresolved_references_by_source` (which renders the *dangling* half of the same split), **command-aware** so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). Lines joined by `\n`, no trailing newline. A document with **no** resolved references (every ref dangles, or none) → the fixed marker `(no resolved references)`. E.g. `\ref{sec:intro}`, `\eqref{eq:main}`, `\pageref{sec:intro}` (all defined) → `\ref{sec:intro}\n\eqref{eq:main}\n\pageref{sec:intro}`. Every S1–S20 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S22 — winning `\label` definitions** | `Document::label_definitions() -> String` — a **new**, read-only method that renders the **winning** label definitions — the `\label{key}` definitions references resolve against, one `\label{key}` line per distinct key — the **label-family analogue of S19's** `bibliography_entries` (which renders the winning `\bibitem` entries) and the **winning-side counterpart of S20's** `duplicate_label_definitions` (which renders the *losing* duplicate `\label`s). It reads only `resolve_references().definitions`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, one row per distinct key) and every **later** `\label` of an already-defined key goes to `duplicates` (S20's domain). S22 emits one line per winning definition in that pre-order (**not** re-sorted, **not** de-duplicated — none needed, since `definitions` already holds one row per distinct key), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). A `\label{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the fixed marker `(no label definitions)`. E.g. `sec:intro` (section), `eq:main` (equation), then a re-used `sec:intro` → `\label{sec:intro}\n\label{eq:main}` (winner once). Every S1–S21 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S23 — winning `\label` definitions grouped by kind** | `Document::label_definitions_by_kind() -> String` — a **new**, read-only method that renders the **winning** `\label` definitions **grouped by their `LabelKind`** — a per-kind census — the **by-kind grouping companion of S22's** `label_definitions` (which lists the same winning definitions *flat*); S22 and S23 are two views of the one winning `definitions` list. It reads only `resolve_references().definitions` and groups by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — iterated as an explicit slice, not a hash map, so the order is deterministic like S17/S18's `Vec`-of-groups). Within each kind, definitions keep their existing pre-order. Each line is `[<kind>] \label{<key>}` — `<kind>` from `LabelKind::as_str()` (`"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<key>` from the owned key (no source slicing). A kind with no definitions contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22 uses. E.g. `sec:intro` (section), `eq:main` (equation), `note` (inline) → `[section] \label{sec:intro}\n[equation] \label{eq:main}\n[inline] \label{note}`. Every S1–S22 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -922,6 +923,37 @@ assert_eq!(
 A document with no label definitions renders the fixed `(no label definitions)` marker. Purely
 additive — reuses `resolve_references`, mutates nothing, leaves every S1–S21 output and the `to_latex()`
 fixed point unchanged.
+
+### winning `\label` definitions grouped by kind (LTXDOC03 S23)
+
+The **winning** `\label` definitions **grouped by their `LabelKind`** — a per-kind census — the
+**by-kind grouping companion of S22's** `label_definitions` (which lists the same winning definitions
+*flat*, one `\label{key}` per line in pure pre-order). S22 and S23 are two *views* of the one winning
+`definitions` list `resolve_references()` produces. `label_definitions_by_kind` reads only that
+`definitions` list and groups it by kind in a **fixed, document-independent order** — the `LabelKind`
+enum declaration order (`Section`, `Table`, `Figure`, `Equation`, `Inline`), iterated as an explicit
+slice rather than a hash map, so the group order is deterministic (the same `Vec`-of-groups discipline
+S17/S18 use). Within each kind, definitions keep their existing pre-order. Each line is
+`[<kind>] \label{<key>}` — the `<kind>` tag from `LabelKind::as_str()`, the `<key>` from the owned key
+(no source slicing). A kind with no definitions contributes no lines (no empty `[table]` header).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:main} x=1 \end{equation}
+\label{note}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.label_definitions_by_kind(),
+    // grouped in the fixed kind order: section, then equation, then inline
+    "[section] \\label{sec:intro}\n[equation] \\label{eq:main}\n[inline] \\label{note}",
+);
+```
+
+A document with no label definitions renders the **same** fixed `(no label definitions)` marker S22
+uses (S23 groups the identical list). Purely additive — reuses `resolve_references`, mutates nothing,
+leaves every S1–S22 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2181,6 +2181,123 @@ impl Document {
             .join("\n")
     }
 
+    /// The **winning label definitions grouped by their [`LabelKind`]** (LTXDOC03 S23) — a per-kind
+    /// census of the `\label` definitions, the by-kind grouping companion of S22's
+    /// [`label_definitions`](Document::label_definitions) (the same discipline S18's
+    /// [`unresolved_references_by_source`](Document::unresolved_references_by_source) and S17's
+    /// [`unresolved_citations_by_source`](Document::unresolved_citations_by_source) bring to the
+    /// reference/citation families).
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] collects the **winning** first definition of each `\label`
+    /// key into [`ReferenceResolution::definitions`] — one row per distinct key, in
+    /// [`Document::walk`] pre-order, each tagged with the [`LabelKind`] of the node it defines (a
+    /// re-`\label`ed section, table, figure, equation, or bare inline label). S22's
+    /// [`label_definitions`](Document::label_definitions) renders that list **flat**, one
+    /// `\label{key}` per line in pure pre-order. S23 renders the *same* winning `definitions` list
+    /// **grouped by kind**: it walks the [`LabelKind`] variants in a fixed order and, for each kind
+    /// that has at least one definition, emits every definition of that kind — so a reader can see, at
+    /// a glance, which keys are sections, which are equations, which are bare inline labels. S22 and
+    /// S23 are two *views* of one underlying list (S22 by source order, S23 by kind); neither mutates
+    /// anything.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Iterate the [`LabelKind`] variants in their **enum declaration order** —
+    /// [`Section`](LabelKind::Section), [`Table`](LabelKind::Table), [`Figure`](LabelKind::Figure),
+    /// [`Equation`](LabelKind::Equation), [`Inline`](LabelKind::Inline) — a fixed, deterministic
+    /// order that does **not** depend on the document. For each kind, filter
+    /// [`ReferenceResolution::definitions`] to the definitions of that kind, **preserving their
+    /// existing pre-order** within the kind, and emit one line each. This single stable-ordered pass
+    /// (fixed kind order on the outside, pre-order on the inside) keeps the output deterministic
+    /// **without** a hash map — mirroring the `Vec`-of-groups discipline S17/S18 use to avoid
+    /// hash-order nondeterminism.
+    ///
+    /// Each line has the shape `[<kind>] \label{<key>}`, where `<kind>` is the stable lowercase tag
+    /// from [`LabelKind::as_str`] (`"section"`, `"table"`, `"figure"`, `"equation"`, `"inline"`) and
+    /// `<key>` is reconstructed from the definition's **owned `key` `String`** — there is **no** source
+    /// slicing at all (matching S13's `resolve_namerefs`, S19's `bibliography_entries`, S20's
+    /// `duplicate_label_definitions`, and S22's `label_definitions`). Prefixing every line with its
+    /// `[kind]` makes the per-kind census visible on each line while staying one-line-per-definition
+    /// and never re-parseable back as raw LaTeX (the `[kind]` prefix is a report annotation, not source
+    /// — S23 is a *report*, not a round-trippable rendering). A kind with **no** definitions produces
+    /// **no** lines and **no** empty header (there is never a bare `[table]` group for a doc with no
+    /// tables).
+    ///
+    /// A document with **no** label definitions at all returns the fixed marker
+    /// `(no label definitions)` — the **same** marker S22 uses (S23 groups the identical list, so the
+    /// empty case is identical), never the empty string (the stable-marker discipline S12-S22 share).
+    /// Lines are joined by `\n` with **no** trailing newline (matching S11's `to_plain_text_by_kind`
+    /// and every S12-S22 renderer).
+    ///
+    /// Concretely, for a body defining a section label `sec:intro`, an equation label `eq:main`, and a
+    /// bare inline label `note`:
+    ///
+    /// ```text
+    /// \section{Intro}\label{sec:intro}
+    /// \begin{equation}\label{eq:main} x=1 \end{equation}
+    /// \label{note}
+    /// ```
+    ///
+    /// the winning definitions render grouped by kind (`section` sorts before `equation` and `inline`
+    /// in the fixed order, so `sec:intro` leads even though `note` is also a definition):
+    ///
+    /// ```text
+    /// [section] \label{sec:intro}
+    /// [equation] \label{eq:main}
+    /// [inline] \label{note}
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S23 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1-S22 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *second view* of the same winning
+    /// `definitions` list S22 renders flat — grouping never adds, drops, or reorders definitions
+    /// relative to what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// keys are already owned `String`s); a single stable-ordered pass (fixed kind order × pre-order
+    /// filter) over the already-bounded `definitions` list. Borrows `self` immutably and returns owned
+    /// `String` data, so the result outlives any borrow of the source.
+    pub fn label_definitions_by_kind(&self) -> String {
+        // S1 already collected the winning definitions — the first `\label` of each distinct key, in
+        // body pre-order, each tagged with its `LabelKind`. We only read that list.
+        let resolution = self.resolve_references();
+
+        if resolution.definitions.is_empty() {
+            // No `\label` at all → the SAME fixed marker S22 uses (S23 groups the identical list).
+            return "(no label definitions)".to_string();
+        }
+
+        // The FIXED kind order = the enum declaration order. Iterating this explicit slice (rather than
+        // a hash map keyed by kind) makes the group order deterministic and document-independent, the
+        // same `Vec`-of-groups discipline S17/S18 use to avoid hash-order nondeterminism.
+        const KIND_ORDER: [LabelKind; 5] = [
+            LabelKind::Section,
+            LabelKind::Table,
+            LabelKind::Figure,
+            LabelKind::Equation,
+            LabelKind::Inline,
+        ];
+
+        // One stable-ordered pass: for each kind in the fixed order, take the definitions of that kind
+        // in their existing pre-order and emit `[<kind>] \label{<key>}`. A kind with no definitions
+        // contributes no lines (no empty header). Keys are owned, so there is no source slicing.
+        KIND_ORDER
+            .iter()
+            .flat_map(|kind| {
+                resolution
+                    .definitions
+                    .iter()
+                    .filter(move |def| def.kind == *kind)
+                    .map(|def| format!("[{}] \\label{{{}}}", def.kind.as_str(), def.key))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// The **resolved (successfully-matched) references grouped by their source `\ref`** (LTXDOC03
     /// S21) — the exact structural mirror of S18's
     /// [`unresolved_references_by_source`](Document::unresolved_references_by_source), but for the
@@ -5555,6 +5672,155 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.label_definitions(),
             "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S23 — winning label definitions grouped by kind (`label_definitions_by_kind`). The
+    // by-kind grouping companion of S22's flat `label_definitions`; two views of one list.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s23_groups_different_kinds_in_fixed_kind_order() {
+        // A section label, an equation label, and a bare inline label → grouped by kind in the fixed
+        // enum order (Section before Equation before Inline), each `[kind] \label{key}`. Note the
+        // source order is section, equation, inline — which already matches the fixed kind order here.
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:main}x=1\end{equation}
+\label{note}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:intro}\n[equation] \\label{eq:main}\n[inline] \\label{note}"
+        );
+    }
+
+    #[test]
+    fn s23_reorders_source_to_fixed_kind_order() {
+        // Source order is inline THEN section, but the fixed kind order pulls the section ahead of the
+        // inline — proving S23 groups by kind rather than echoing source order.
+        let src = r"\begin{document}\label{note}
+\section{Intro}\label{sec:intro}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:intro}\n[inline] \\label{note}"
+        );
+    }
+
+    #[test]
+    fn s23_same_kind_grouped_in_preorder() {
+        // Two inline labels of the SAME kind → listed together under `inline`, in their existing
+        // pre-order (`a` before `b`). Only the `inline` group appears; no empty groups for other kinds.
+        let src = r"\begin{document}\label{a}
+
+\label{b}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[inline] \\label{a}\n[inline] \\label{b}"
+        );
+    }
+
+    #[test]
+    fn s23_no_labels_returns_marker() {
+        // A document with no `\label` at all → the same fixed `(no label definitions)` marker S22 uses,
+        // never the empty string.
+        let src = r"\begin{document}Just some text with no labels.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definitions_by_kind(), "(no label definitions)");
+    }
+
+    #[test]
+    fn s23_newline_join_no_trailing_newline() {
+        // A section + figure + inline label → exact string equality pins the `\n`-join with NO trailing
+        // newline, and the fixed kind order (Section, then Figure, then Inline).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{figure}\includegraphics{p.png}\caption{P}\label{fig:p}\end{figure}
+
+\label{note}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:i}\n[figure] \\label{fig:p}\n[inline] \\label{note}"
+        );
+    }
+
+    #[test]
+    fn s23_is_additive_leaves_s1_s22_outputs_unchanged() {
+        // Same representative doc as the S22 additive test: a section, a figure, an equation, a
+        // resolved `\ref`, a resolved `\eqref`, `\nameref`s, two `\cite`s (one multi-key, one dangling),
+        // a duplicate `\bibitem`, a dangling `\eqref`, AND a duplicate `\label{dup}`. S23 changes NONE
+        // of the S1-S22 outputs — it only reads `resolve_references`. S22's flat `label_definitions`
+        // and S23's grouped `label_definitions_by_kind` are two views of the SAME winning `definitions`
+        // list; both are pinned here to show S23 neither adds, drops, nor reorders relative to S22.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\eqref{eq:e} -> Equation (1)\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\nEquations:\n  \\eqref{eq:e} -> Equation (1)"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S20 losing duplicate labels — unchanged.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // S21 resolved references — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+        // S22 flat winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+
+        // And S23 itself: the SAME winning definitions, grouped by kind in the fixed enum order
+        // (Section, Figure, Equation, Inline). `sec:intro` (section) leads, then `fig:p` (figure),
+        // then `eq:e` (equation), then `dup` (a bare inline `\label`). `\n`-joined, no trailing newline.
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:intro}\n[figure] \\label{fig:p}\n[equation] \\label{eq:e}\n[inline] \\label{dup}"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1827,3 +1827,88 @@ a three-label case pinning the `\n`-join with no trailing newline; and an additi
 unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
 -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 29. S23 — winning label definitions grouped by kind (`label_definitions_by_kind`)
+
+### 29.1 Motivation
+
+S22 (`label_definitions`) renders the **winning** `\label` definitions **flat** — one `\label{key}` line
+per distinct key, in `walk` pre-order. But each winning definition also carries a `LabelKind`
+(`Section`, `Table`, `Figure`, `Equation`, or `Inline`), and a reader often wants the definitions
+organised **by that kind** — a per-kind census answering "which keys are sections? which are equations?
+which are bare inline labels?" at a glance. The citation/reference families already have their by-source
+groupings (S15/S17/S18 `citations_by_source`, `unresolved_citations_by_source`,
+`unresolved_references_by_source`); the label family had a flat winning-definitions list (S22) but no
+by-kind grouping. S23 fills that cell by rendering the *same* winning `definitions` list grouped by
+`LabelKind`, the by-kind companion of S22.
+
+### 29.2 Why a new method — additive by construction
+
+S23 adds a **new public method** `Document::label_definitions_by_kind(&self) -> String`. It is a pure,
+read-only render of `resolve_references().definitions` — a *second view* of the exact list S22 renders
+flat. It reuses that table verbatim (never re-walking the body or re-collecting definitions), so the
+report can never drift from the S1 resolution it summarises, and grouping never adds, drops, or reorders
+definitions relative to what `resolve_references` produced. It mutates nothing and changes no S1–S22
+output — including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S22 it is a method the
+caller invokes directly.
+
+### 29.3 The ordering rule
+
+The output is ordered by a **fixed, document-independent** kind order — the `LabelKind` enum declaration
+order: `Section`, `Table`, `Figure`, `Equation`, `Inline`. S23 iterates that order as an explicit slice
+(**not** a hash map keyed by kind), so the group order is deterministic and never depends on document
+content or hash iteration order — the same `Vec`-of-groups discipline S17/S18 use to avoid hash-order
+nondeterminism. **Within** each kind, the definitions keep their existing `definitions` pre-order;
+grouping never reorders within a kind. A kind with **no** definitions produces **no** lines (there is
+never an empty `[table]` group for a doc with no tables).
+
+### 29.4 The exact rendering contract — `Document::label_definitions_by_kind(&self) -> String`
+
+- Iterate the fixed kind order (`Section`, `Table`, `Figure`, `Equation`, `Inline`). For each kind, take
+  the definitions of that kind from `resolve_references().definitions` in their existing pre-order and
+  emit one line each: `format!("[{}] \\label{{{}}}", def.kind.as_str(), def.key)` → `[` + the kind tag +
+  `] \label{` + the definition's `key` + `}`. The kind tag comes from `LabelKind::as_str()`
+  (`"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`); the key is reconstructed from the owned
+  `key` `String` rather than sliced from `&src[span]` (matching S13 `resolve_namerefs`, S19
+  `bibliography_entries`, S20 `duplicate_label_definitions`, and S22 `label_definitions`), so the render
+  needs no source borrow and can never index out of bounds.
+- The `[kind]` prefix makes the per-kind census visible on every line while staying
+  one-line-per-definition; it is a **report annotation**, not round-trippable LaTeX (S23 is a *report*).
+- A kind with no definitions contributes no lines and no empty header.
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S22 renderer).
+- If there are **no** label definitions at all, the fixed marker `(no label definitions)` is returned —
+  the **same** marker S22 uses (S23 groups the identical list), so the output is never the empty string.
+
+Example (body defining a section label `sec:intro`, an equation label `eq:main`, and a bare inline label
+`note`):
+
+```text
+[section] \label{sec:intro}
+[equation] \label{eq:main}
+[inline] \label{note}
+```
+
+`sec:intro` (kind `Section`) leads even though `note` is also a definition, because `Section` sorts
+before `Equation` and `Inline` in the fixed kind order. This is the by-kind grouping companion of S22's
+flat winning-definitions list — two views of the one `definitions` list.
+
+### 29.5 Public API (added in S23)
+
+One new method: `Document::label_definitions_by_kind(&self) -> String`. No existing type, field, counter,
+or signature changes; `resolve_references` and every S1–S22 method are unchanged; no AST or grammar
+change; no new dependency, no `unsafe`, no I/O.
+
+### 29.6 Verification (S23)
+
+`cargo test -p latex` green (6 new S23 tests: a section+equation+inline case rendering grouped in the
+fixed kind order; a source-order-reversed case proving the fixed kind order pulls the section ahead of an
+earlier inline; two same-kind inline labels grouped together in pre-order under `inline`; a doc with no
+labels returning the `(no label definitions)` marker; a section+figure+inline case pinning the `\n`-join
+with no trailing newline; and an additivity check that `to_plain_text`, `to_plain_text_by_kind`,
+`list_of_floats`, `resolve_namerefs`, `list_summary`, `citations_by_source`,
+`duplicate_bibliography_entries`, `unresolved_citations_by_source`, `unresolved_references_by_source`,
+`bibliography_entries`, `duplicate_label_definitions`, `resolved_references_by_source`, and S22's flat
+`label_definitions` all still produce their exact prior strings). All prior S1–S22 tests pass unchanged.
+`cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p
+adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S23 — `label_definitions_by_kind` (latex 0.59.0)

Adds one additive, read-only cross-reference report renderer to the zero-dependency `latex` crate: the **winning label definitions grouped by kind** — a per-kind census.

### What it does

```rust
pub fn label_definitions_by_kind(&self) -> String
```

Groups the winning `\label` definitions by their `LabelKind` (Section, Table, Figure, Equation, Inline) and renders each as `[<kind>] \label{<key>}`, emitting the kinds in a fixed deterministic order and each kind's defs in source pre-order:

```
[section] \label{sec:intro}
[equation] \label{eq:main}
[inline] \label{note}
```

This is the by-kind grouping companion to the shipped **S22** `label_definitions` (which lists the same winning defs flat, one `\label{key}` per line) — two views of the same `resolve_references().definitions`.

- Only kinds that have at least one definition appear (no empty groups).
- The kind tag comes from `LabelKind::as_str()` (stable lowercase), not Debug formatting.
- A document with no labels returns the fixed marker `(no label definitions)`, never the empty string — the shared S11–S22 stable-marker discipline. Lines join with `\n`, no trailing newline.

### Guarantees

- **Additive**: a brand-new read-only method reusing `resolve_references()`; every S1–S22 output is byte-for-byte unchanged (pinned by `s23_is_additive_leaves_s1_s22_outputs_unchanged`), and the `to_latex` round-trip fixed point is intact.
- **Total & panic-free**: no `unsafe`, no `unwrap`/`expect`, no indexing/slicing (keys are owned `String`s); a stable-ordered pass over the fixed kind order filtering the already-bounded `definitions` list; borrows `self` immutably and returns owned `String`.

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → all green (S23 tests added)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED

### Docs

- `Cargo.toml` version `0.58.0` → `0.59.0`
- `CHANGELOG.md`, `README.md`, and `LTXDOC03-cross-reference-resolution.md` (new §29 / S23 section) — prior sections byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
