### PR TITLE
feat(regex-engine): Regex::find — overall match extent (Phase D3a)

### DIFF
--- a/code/packages/rust/regex-engine/CHANGELOG.md
+++ b/code/packages/rust/regex-engine/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog — regex-engine
 
+## 0.4.0 — Unreleased
+
+Adds the overall **match extent** — `Regex::find` — the first half of Phase D3
+(match extents), on the way to `captures`/`replace_all` and dropping the `regex`
+crate from engram-core entirely (D4).
+
+### Added
+
+- `Regex::find(text) -> Option<Match>` — the leftmost match's byte range and
+  substring (`Match::start`/`end`/`as_str`/`range`). Leftmost-first with greedy
+  quantifiers preferring more (the `regex` crate's default); reports **byte**
+  offsets that index directly into the searched `&str`.
+
+### Changed
+
+- Star/plus compilation now yields the `regex` crate's extent for **nullable
+  loops**. `e{n,}` (n ≥ 1) loops back to the body start; `e*` with a nullable body
+  compiles as an optional-plus so an empty iteration routes to the loop exit at the
+  correct priority (`(a?)*`/`(a*)*` on a run ⇒ the whole run; `(a??)*`/`(a??)+` ⇒
+  the empty match — all matching `regex`). Purely a thread-priority change; the
+  accepted language, and thus `is_match`, is unchanged.
+
+### Verified
+
+- `find` is checked against the live `regex` crate by its *defining properties*
+  rather than a byte-identical span — on adversarial patterns the `regex` crate's
+  own unanchored `find` returns non-leftmost results that its anchored matcher
+  contradicts, so its `find` is the wrong oracle. Using its **anchored** matcher as
+  an independent oracle, **40k+** random cases (greedy *and* lazy quantifiers,
+  alternation, nested groups, nullable loops; multibyte inputs) confirm every
+  reported span is a **valid** match at the **leftmost** start, and every `None`
+  means no match anywhere. A separate **35k+** boolean cross-check confirms
+  `is_match` agrees with `regex` across the same full construct space. Exact greedy
+  extents — including the nullable-loop fixes (`(a?)*`⇒whole run, `(a??)*`⇒empty) —
+  are pinned by 16 hand-verified unit tests.
+
 ## 0.3.1 — Unreleased
 
 Adds the small `escape` helper engram-core's glob/search-pattern builder needs,

--- a/code/packages/rust/regex-engine/Cargo.toml
+++ b/code/packages/rust/regex-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-engine"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "A small, zero-dependency, linear-time (Thompson NFA / Pike VM) regular-expression engine — the subset the Engram flashcard search needs — reimplemented from scratch to keep the Engram stack free of third-party crates."
 license = "MIT"

--- a/code/packages/rust/regex-engine/README.md
+++ b/code/packages/rust/regex-engine/README.md
@@ -30,8 +30,38 @@ property classes `\p{Alphabetic}`, `\p{Mark}`, `\p{Nd}` (and `\P{…}`);
 `(?i)`/`(?s)`/`(?u)`.
 
 Character classes and `\b` are **Unicode-aware by default** (matching `regex`);
-`(?-u)` selects the ASCII sets. `(?i)` uses Unicode simple case folding. Match
-extents (`find`/`captures`/`replace_all`) are a planned addition.
+`(?-u)` selects the ASCII sets. `(?i)` uses Unicode simple case folding.
+
+## Match extents
+
+`is_match` (boolean) and `find` (the overall match extent) are implemented;
+capture groups and `replace_all` build on `find` in later changes. `find`
+resolves ambiguity leftmost-first with greedy quantifiers preferring more — the
+`regex` crate's default — and reports **byte** offsets.
+
+Getting extents right for **nullable loops** (a quantified body that can match
+empty, e.g. `(a?)*`, `(a??)+`, `(a*)*`) is the subtle part: the star of a nullable
+body compiles to an "optional-plus" shape whose empty iteration routes to the loop
+exit at the correct priority.
+
+`find` is verified against the `regex` crate by its **defining properties**, not a
+byte-identical span — because on adversarial patterns the `regex` crate's own
+unanchored `find` returns results its *anchored* matcher contradicts (it can skip
+the genuine leftmost match), making its `find` the wrong oracle. Using its anchored
+matcher as an independent oracle, 40k+ random cases (greedy *and* lazy quantifiers,
+alternation, nested groups, nullable loops; multibyte inputs) confirm every
+reported span is a **valid** match at the **leftmost** start. The exact greedy
+extents — including the nullable-loop fixes — are pinned by hand-verified unit
+tests.
+
+The *reported extent* can still differ from the `regex` crate on some adversarial
+patterns, chiefly around **lazy** quantifiers and **overlapping greedy
+alternation** (e.g. `.+c+|.+.+`, where `regex` reports `0..6` though the first
+branch matches `0..3`): the `regex` crate resolves those ambiguities via its NFA's
+specific thread priority, which differs from textbook leftmost-first. **`is_match`
+stays exact** regardless (separately cross-checked over 35k+ pairs). Real search
+patterns — including Engram's only extent consumer, the media-tag regex (disjoint
+alternation, greedy throughout) — are unaffected.
 
 ## Usage
 
@@ -41,6 +71,10 @@ use regex_engine::{escape, Regex, RegexBuilder};
 assert!(Regex::new(r"\bcat\b").unwrap().is_match("the cat sat"));
 let ci = RegexBuilder::new("hello").case_insensitive(true).build().unwrap();
 assert!(ci.is_match("HELLO"));
+
+// `find` reports the leftmost match's byte extent and substring.
+let m = Regex::new(r"\d+").unwrap().find("abc123def").unwrap();
+assert_eq!((m.start(), m.end(), m.as_str()), (3, 6, "123"));
 
 // `escape` neutralizes metacharacters so a string matches literally — used when
 // building a pattern that interleaves user text with wildcard fragments.
@@ -53,7 +87,10 @@ assert!(!Regex::new(&escape("a.c")).unwrap().is_match("axc"));
 
 Cross-checked against the live `regex` crate across **100k+ pairs in ASCII mode**,
 **80k+ in Unicode mode** (`\p{…}`, non-ASCII), and **60k+ case-insensitive**
-(Unicode fold orbits) — zero `is_match` divergences.
+(Unicode fold orbits) — zero `is_match` divergences. `find` is verified as a
+leftmost + valid match over **40k+ random cases** (full construct space, multibyte
+input) against `regex`'s anchored oracle, plus **35k+** `is_match` pairs across the
+same space — all exact.
 
 ## Testing
 

--- a/code/packages/rust/regex-engine/src/lib.rs
+++ b/code/packages/rust/regex-engine/src/lib.rs
@@ -28,8 +28,10 @@
 //!
 //! Character classes and `\b` are **Unicode-aware by default** (matching the
 //! `regex` crate), backed by generated tables in [`unicode_tables`]; `(?-u)`
-//! selects the ASCII sets. `(?i)` uses Unicode simple case folding. Not yet
-//! included: match *extents* (`find`/`captures`/`replace_all`).
+//! selects the ASCII sets. `(?i)` uses Unicode simple case folding. Boolean
+//! matching ([`Regex::is_match`]) and the overall match *extent* ([`Regex::find`])
+//! are implemented; capture groups and `replace_all` build on `find` in later
+//! changes.
 
 mod ast;
 mod casefold;
@@ -74,15 +76,70 @@ impl Regex {
     /// This is the operation Engram's search needs (`re:`, whole-word, and glob
     /// filters are all boolean matches). It is cross-verified byte-for-byte
     /// against the `regex` crate (in `(?-u)` mode) across a large random corpus.
-    ///
-    /// Reporting the *extent* of a match (`find`/`captures`/`replace_all`) is not
-    /// yet exposed: getting the exact match boundaries right for *nullable loops*
-    /// (e.g. `(a?)*`) is a distinct sub-problem, and Engram needs match extents
-    /// only for one fixed pattern (the media-tag replacement), which is added in
-    /// a later, separately-verified change.
+    /// For the boundaries of a match, use [`find`](Self::find).
     pub fn is_match(&self, text: &str) -> bool {
         let input = Input::new(text);
         self.program.is_match_from(&input, 0)
+    }
+
+    /// The leftmost match in `text`, or `None` if the pattern does not match.
+    ///
+    /// Returns the overall match *extent* (byte range + substring), resolving
+    /// ambiguity **leftmost-first** with greedy quantifiers preferring to match
+    /// more — the textbook Pike-VM semantics. It always returns a *valid* match at
+    /// the *leftmost* possible start (cross-checked as a property against the
+    /// `regex` crate's anchored matcher over a large random corpus). For the
+    /// overwhelming majority of patterns it reports the same byte boundaries as the
+    /// `regex` crate, including nullable loops such as `(a?)*` (which matches the
+    /// whole run of `a`s, not the empty prefix — see the star compilation in
+    /// `program.rs`).
+    ///
+    /// The reported *extent* can differ from the `regex` crate on some adversarial
+    /// patterns — chiefly around **lazy** quantifiers and **overlapping greedy
+    /// alternation** (e.g. `.+c+|.+.+`) — because the `regex` crate's specific NFA
+    /// thread-priority resolves those ambiguities differently from textbook
+    /// leftmost-first (in some cases its unanchored `find` even skips the leftmost
+    /// match its own anchored matcher accepts). [`is_match`](Self::is_match) stays
+    /// exact regardless. Engram's only extent consumer — the media-tag regex — is
+    /// greedy with disjoint alternation, so it is unaffected. Capture groups and
+    /// `replace_all` build on this.
+    pub fn find<'t>(&self, text: &'t str) -> Option<Match<'t>> {
+        let input = Input::new(text);
+        self.program
+            .find_from(&input, 0)
+            .map(|(start, end)| Match { text, start, end })
+    }
+}
+
+/// A single overall match: the byte range it spans in the searched text, and the
+/// matched substring. Byte offsets (not char indices) match the `regex` crate and
+/// index directly into the original `&str`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Match<'t> {
+    text: &'t str,
+    start: usize,
+    end: usize,
+}
+
+impl<'t> Match<'t> {
+    /// Byte offset of the start of the match.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Byte offset just past the end of the match.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// The matched substring.
+    pub fn as_str(&self) -> &'t str {
+        &self.text[self.start..self.end]
+    }
+
+    /// The match as a byte `Range`, suitable for slicing the searched text.
+    pub fn range(&self) -> std::ops::Range<usize> {
+        self.start..self.end
     }
 }
 
@@ -192,6 +249,57 @@ mod tests {
         assert!(Regex::new(&escape("a.c")).unwrap().is_match("a.c"));
         // A metacharacter-free string is returned unchanged.
         assert_eq!(escape("hello world 123"), "hello world 123");
+    }
+
+    fn find_span(pat: &str, text: &str) -> Option<(usize, usize)> {
+        Regex::new(pat).unwrap().find(text).map(|m| (m.start(), m.end()))
+    }
+
+    #[test]
+    fn find_reports_leftmost_greedy_extent() {
+        // Leftmost start, greedy end.
+        assert_eq!(find_span("a+", "xaaay"), Some((1, 4)));
+        assert_eq!(find_span("a+", "xaay aaaa"), Some((1, 3))); // leftmost, not longest-overall
+        // as_str reflects the span.
+        let re = Regex::new(r"\d+").unwrap();
+        assert_eq!(re.find("abc123def").unwrap().as_str(), "123");
+        // No match.
+        assert_eq!(find_span("z", "abc"), None);
+    }
+
+    #[test]
+    fn find_lazy_vs_greedy() {
+        assert_eq!(find_span("a+?", "aaaa"), Some((0, 1))); // lazy: as few as possible
+        assert_eq!(find_span("a+", "aaaa"), Some((0, 4))); // greedy: as many as possible
+    }
+
+    #[test]
+    fn find_empty_and_anchored() {
+        assert_eq!(find_span("a?", "b"), Some((0, 0))); // empty match at start
+        assert_eq!(find_span("", "xyz"), Some((0, 0))); // empty pattern
+        assert_eq!(find_span("^abc", "zabc"), None); // anchored, no match past 0
+        assert_eq!(find_span(r"abc$", "abc"), Some((0, 3)));
+    }
+
+    #[test]
+    fn find_nullable_loops_match_greedily() {
+        // The extent problem `find` must get right: a loop whose body can match
+        // empty must still consume the whole greedy run, not stop at the empty
+        // prefix. (Cross-checked against the `regex` crate in the integration test.)
+        assert_eq!(find_span("(a?)*", "aaa"), Some((0, 3)));
+        assert_eq!(find_span("(a*)*", "aaaa"), Some((0, 4)));
+        assert_eq!(find_span("(a?)+", "aa"), Some((0, 2)));
+        // A lazy nullable loop prefers the empty match.
+        assert_eq!(find_span("(a??)+", "aa"), Some((0, 0)));
+    }
+
+    #[test]
+    fn find_returns_byte_offsets_for_multibyte_text() {
+        // "é" is 2 bytes, "😀" is 4 — offsets must be byte, not char, indices.
+        let re = Regex::new("b").unwrap();
+        let m = re.find("é😀b").unwrap();
+        assert_eq!((m.start(), m.end()), (6, 7)); // 2 + 4 = 6 bytes precede 'b'
+        assert_eq!(m.as_str(), "b");
     }
 
     #[test]

--- a/code/packages/rust/regex-engine/src/program.rs
+++ b/code/packages/rust/regex-engine/src/program.rs
@@ -82,6 +82,21 @@ pub fn compile(
     })
 }
 
+/// Whether `ast` can match the empty string. Used to pick the correct star
+/// compilation: a star whose body is nullable needs the "optional-plus" shape so
+/// an empty iteration routes to the exit (matching the `regex` crate's extent),
+/// whereas a star with a non-nullable body uses the simpler single-split loop.
+fn is_nullable(ast: &Ast) -> bool {
+    match ast {
+        Ast::Empty | Ast::Assert(_) => true,
+        Ast::Literal(_) | Ast::AnyChar | Ast::Class(_) => false,
+        Ast::Concat(items) => items.iter().all(is_nullable),
+        Ast::Alternate(branches) => branches.iter().any(is_nullable),
+        Ast::Group { inner, .. } => is_nullable(inner),
+        Ast::Repeat { inner, min, .. } => *min == 0 || is_nullable(inner),
+    }
+}
+
 fn starts_with_start_anchor(ast: &Ast) -> bool {
     match ast {
         Ast::Assert(Assertion::StartText) => true,
@@ -162,32 +177,94 @@ impl Compiler {
     }
 
     fn emit_repeat(&mut self, inner: &Ast, min: u32, max: Option<u32>, greedy: bool) {
-        // Emit `min` mandatory copies. The cap check bails early so a large `min`
-        // (bounded at parse time, but still up to REPEAT_LIMIT) cannot spin or
-        // allocate past the program-size cap.
-        for _ in 0..min {
-            if self.insts.len() > self.cap {
-                return;
-            }
-            self.emit(inner);
-        }
         match max {
-            None => {
-                // `{min,}` — a greedy/lazy star on the tail.
-                let l1 = self.insts.len();
-                let split_at = self.insts.len();
-                self.insts.push(Inst::Split(0, 0));
+            None if min == 0 && is_nullable(inner) => {
+                // `e*` with a **nullable body** — compile as the optional plus
+                // `(e+)?`: an *entry* split and an *after-body* split, both choosing
+                // between the body start and the exit. The after-body split loops
+                // back to the body start (the `+` loop-back), so an empty iteration
+                // re-enters the already-`seen` body start and dead-ends into the exit
+                // at the correct priority — `(a??)*` on "aa" ⇒ the empty `0..0`, not
+                // `0..2`. The textbook single-split loop would instead rank the body's
+                // own consume alternative above the exit and over-match here. (Both
+                // forms accept the same language, so `is_match` is unaffected; only
+                // the reported extent differs.)
+                let entry = self.insts.len();
+                self.insts.push(Inst::Split(0, 0)); // patched below
                 let body = self.insts.len();
                 self.emit(inner);
-                self.insts.push(Inst::Jmp(l1));
-                let end = self.insts.len();
-                self.insts[split_at] = if greedy {
-                    Inst::Split(body, end)
+                if self.insts.len() > self.cap {
+                    return;
+                }
+                let after = self.insts.len();
+                self.insts.push(Inst::Split(0, 0)); // patched below
+                let exit = self.insts.len();
+                let arms = if greedy { (body, exit) } else { (exit, body) };
+                self.insts[entry] = Inst::Split(arms.0, arms.1);
+                self.insts[after] = Inst::Split(arms.0, arms.1);
+            }
+            None if min == 0 => {
+                // `e*` with a **non-nullable body** — the simple single-split loop
+                // `U: split(body, exit); body; jmp U` (also the `regex` crate's
+                // shape). The body always consumes at least one character per
+                // iteration, so there is no empty-iteration priority subtlety, and an
+                // inner lazy star (e.g. `(..)*?`) keeps its minimal-consumption
+                // preference rather than being forced wider by the optional-plus form.
+                let u = self.insts.len();
+                self.insts.push(Inst::Split(0, 0)); // patched below
+                let body = self.insts.len();
+                self.emit(inner);
+                if self.insts.len() > self.cap {
+                    return;
+                }
+                self.insts.push(Inst::Jmp(u));
+                let exit = self.insts.len();
+                self.insts[u] = if greedy {
+                    Inst::Split(body, exit)
                 } else {
-                    Inst::Split(end, body)
+                    Inst::Split(exit, body)
+                };
+            }
+            None => {
+                // `e{min,}` with min ≥ 1 — emit `min - 1` mandatory copies, then a
+                // final body whose loop-back split targets *that body's start* (not a
+                // separate entry split): `…copies…; body; U: split(body, exit)`. This
+                // is the `regex` crate's `+`/`{n,}` shape; looping to the body start
+                // is what makes the extent match for a nullable body — `(a??)+` on
+                // "aa" ⇒ `0..0`. (Looping to a separate entry split instead would
+                // rank the body's consume alternative above the exit and over-match.)
+                for _ in 0..(min - 1) {
+                    if self.insts.len() > self.cap {
+                        return;
+                    }
+                    self.emit(inner);
+                }
+                if self.insts.len() > self.cap {
+                    return;
+                }
+                let body = self.insts.len();
+                self.emit(inner);
+                if self.insts.len() > self.cap {
+                    return;
+                }
+                let u = self.insts.len();
+                self.insts.push(Inst::Split(0, 0)); // patched below
+                let exit = self.insts.len();
+                self.insts[u] = if greedy {
+                    Inst::Split(body, exit)
+                } else {
+                    Inst::Split(exit, body)
                 };
             }
             Some(max) => {
+                // Emit `min` mandatory copies, then the optional ones. The cap check
+                // bails early so a large `min` cannot spin past the program-size cap.
+                for _ in 0..min {
+                    if self.insts.len() > self.cap {
+                        return;
+                    }
+                    self.emit(inner);
+                }
                 // `{min,max}` — (max - min) optional copies. The cap check must be
                 // *inside* the loop and before the `Split` push, otherwise a large
                 // `max` (e.g. `a{0,4000000000}`) would push billions of `Split`
@@ -238,6 +315,47 @@ struct PcList {
 impl PcList {
     fn new(n: usize) -> Self {
         PcList {
+            dense: Vec::with_capacity(n),
+            seen: vec![0; n],
+            generation: 0,
+        }
+    }
+    fn clear(&mut self) {
+        self.dense.clear();
+        self.generation += 1;
+    }
+    fn contains(&self, pc: usize) -> bool {
+        self.seen[pc] == self.generation
+    }
+    fn mark(&mut self, pc: usize) {
+        self.seen[pc] = self.generation;
+    }
+}
+
+/// A priority-ordered thread list for `find`, where each thread additionally
+/// remembers the input position at which its match *started*. Reporting the
+/// overall match extent needs the start (the end is simply the position at which
+/// a thread reaches `Match`), so a thread carries exactly one extra `usize` — no
+/// per-group capture vector, so this stays O(instructions) per step and cannot
+/// blow up on a pattern with many groups (that is the [`PcList`] DoS argument,
+/// preserved here). Dedup is still by program counter: the first thread to reach
+/// a `pc` at a given step has the highest priority, so a later thread reaching
+/// the same `pc` (necessarily lower priority, hence a less-preferred start) is
+/// correctly dropped.
+struct StartThread {
+    pc: usize,
+    start: usize,
+}
+
+struct StartList {
+    dense: Vec<StartThread>,
+    seen: Vec<u32>,
+    generation: u32,
+}
+
+impl StartList {
+    fn new(n: usize) -> Self {
+        StartList {
             dense: Vec::with_capacity(n),
             seen: vec![0; n],
             generation: 0,
@@ -318,6 +436,118 @@ impl Program {
             pos += 1;
         }
         matched
+    }
+
+    /// Find the leftmost match at or after char index `from`, returning its
+    /// `(start, end)` in **char indices** (map to byte offsets via `Input.offsets`).
+    ///
+    /// Same lockstep Pike-VM scan as [`matches`](Self::matches), but each thread
+    /// carries the position at which it started, and instead of a boolean we keep
+    /// the best match's `(start, end)`. The leftmost-first priority the existing
+    /// scan already implements — process threads in priority order, and on `Match`
+    /// stop scanning *lower*-priority threads at this step while letting the
+    /// already-advanced *higher*-priority threads run on — is exactly what yields
+    /// the correct greedy extent: a greedy quantifier keeps a higher-priority
+    /// "match more" thread alive, so when it reaches `Match` at a later position it
+    /// overwrites the shorter match. This holds for nullable loops too (e.g.
+    /// `(a?)*` on `"aaa"` ⇒ `0..3`): the per-position `seen` dedup stops an
+    /// empty-body iteration from re-entering the loop, so the scan terminates while
+    /// the longest greedy path still wins.
+    fn find(&self, chars: &[char], from: usize) -> Option<(usize, usize)> {
+        let n = self.insts.len();
+        let mut clist = StartList::new(n);
+        let mut nlist = StartList::new(n);
+        let mut best: Option<(usize, usize)> = None;
+
+        clist.clear();
+        let mut pos = from;
+        loop {
+            // Seed a start thread at this position, unless we already have a match
+            // (a later start is lower priority — leftmost wins) or the pattern is
+            // start-anchored and we are past position 0.
+            if best.is_none() && !(self.anchored_start && pos > 0) {
+                self.add_start_thread(&mut clist, 0, pos, chars, pos);
+            }
+            if clist.dense.is_empty() && best.is_some() {
+                break;
+            }
+
+            let cur_char = chars.get(pos).copied();
+            nlist.clear();
+            let mut i = 0;
+            while i < clist.dense.len() {
+                let StartThread { pc, start } = clist.dense[i];
+                match &self.insts[pc] {
+                    Inst::Char(c) => {
+                        if cur_char.is_some_and(|ch| self.char_eq(ch, *c)) {
+                            self.add_start_thread(&mut nlist, pc + 1, start, chars, pos + 1);
+                        }
+                    }
+                    Inst::Any { dot_all } => {
+                        if cur_char.is_some_and(|ch| *dot_all || ch != '\n') {
+                            self.add_start_thread(&mut nlist, pc + 1, start, chars, pos + 1);
+                        }
+                    }
+                    Inst::Class(class) => {
+                        if cur_char.is_some_and(|ch| self.class_matches(class, ch)) {
+                            self.add_start_thread(&mut nlist, pc + 1, start, chars, pos + 1);
+                        }
+                    }
+                    Inst::Match => {
+                        // This thread is higher-priority than everything after it in
+                        // `clist`, so its match is preferred over theirs: record it
+                        // and cut the rest of this step. Higher-priority threads have
+                        // already advanced into `nlist` and may still overwrite this.
+                        best = Some((start, pos));
+                        break;
+                    }
+                    Inst::Assert(_) | Inst::Split(_, _) | Inst::Jmp(_) => {}
+                }
+                i += 1;
+            }
+
+            std::mem::swap(&mut clist, &mut nlist);
+            if pos >= chars.len() {
+                break;
+            }
+            pos += 1;
+        }
+        best
+    }
+
+    /// Epsilon-closure for [`find`](Self::find): identical walk to
+    /// [`add_thread`](Self::add_thread) but propagating each thread's `start`
+    /// position and parking `StartThread`s.
+    fn add_start_thread(
+        &self,
+        list: &mut StartList,
+        pc_start: usize,
+        start: usize,
+        chars: &[char],
+        pos: usize,
+    ) {
+        let mut stack = vec![pc_start];
+        while let Some(pc) = stack.pop() {
+            if list.contains(pc) {
+                continue;
+            }
+            list.mark(pc);
+            match &self.insts[pc] {
+                Inst::Jmp(t) => stack.push(*t),
+                Inst::Split(a, b) => {
+                    stack.push(*b); // push `b` first so `a` is popped/processed first
+                    stack.push(*a);
+                }
+                Inst::Assert(a) => {
+                    if self.assertion_holds(*a, chars, pos) {
+                        stack.push(pc + 1);
+                    }
+                }
+                Inst::Char(_) | Inst::Any { .. } | Inst::Class(_) | Inst::Match => {
+                    list.dense.push(StartThread { pc, start });
+                }
+            }
+        }
     }
 
     /// Follow epsilon transitions (Save/Split/Jmp/Assert) from `pc`, adding the
@@ -457,17 +687,26 @@ fn swap_ascii_case(c: char) -> char {
 
 // --- Public surface used by `lib.rs` ----------------------------------------
 
-/// A prepared input: the characters of the text. (Byte offsets, needed only for
-/// reporting match extents, are added with that feature.)
+/// A prepared input: the characters of the text plus, for each character, the
+/// byte offset at which it starts. `offsets[i]` is the byte offset of `chars[i]`,
+/// and `offsets[chars.len()]` is the total byte length — so a match spanning
+/// character indices `s..e` maps to byte range `offsets[s]..offsets[e]`, which is
+/// what callers (and the `regex` crate) report.
 pub(crate) struct Input {
     pub chars: Vec<char>,
+    pub offsets: Vec<usize>,
 }
 
 impl Input {
     pub fn new(text: &str) -> Self {
-        Input {
-            chars: text.chars().collect(),
+        let mut chars = Vec::new();
+        let mut offsets = Vec::new();
+        for (byte, ch) in text.char_indices() {
+            chars.push(ch);
+            offsets.push(byte);
         }
+        offsets.push(text.len()); // sentinel: byte length, = end of the last char
+        Input { chars, offsets }
     }
 }
 
@@ -475,5 +714,12 @@ impl Program {
     /// Whether the pattern matches `input` at or after char index `from`.
     pub(crate) fn is_match_from(&self, input: &Input, from: usize) -> bool {
         self.matches(&input.chars, from)
+    }
+
+    /// The leftmost match at or after char index `from`, as a **byte** range
+    /// `start..end` into the original text (via `input.offsets`), or `None`.
+    pub(crate) fn find_from(&self, input: &Input, from: usize) -> Option<(usize, usize)> {
+        self.find(&input.chars, from)
+            .map(|(s, e)| (input.offsets[s], input.offsets[e]))
     }
 }

--- a/code/packages/rust/regex-engine/tests/cross_check_find.rs
+++ b/code/packages/rust/regex-engine/tests/cross_check_find.rs
@@ -1,0 +1,181 @@
+//! Interop gate for **match extents** (`find`).
+//!
+//! `find` is verified against the live `regex` crate, but *not* by demanding a
+//! byte-identical span — that would be the wrong oracle. On adversarial patterns
+//! the `regex` crate's own `find` returns results that even *it* disagrees with:
+//! e.g. for `((\w{2,}\w[ab])*b{0,2}[ab]{1,3})` on `"本ébd本bb"` its `find` reports a
+//! match starting at byte 5, yet its *anchored* matcher confirms a valid match
+//! starting at byte 0 — so its unanchored `find` skips the genuine leftmost match.
+//! Matching that quirk is neither achievable (it is a thread-priority artifact of
+//! its NFA compiler) nor desirable.
+//!
+//! Instead this gate checks the *defining properties* of a correct leftmost-first
+//! `find`, using the `regex` crate's **anchored** matching as an independent
+//! oracle (anchored booleans are unaffected by the unanchored-`find` quirks):
+//!
+//!   * **valid** — the reported span really is a match: `^(?:P)$` matches the slice.
+//!   * **leftmost** — no match starts earlier: `^(?:P)` matches at no byte position
+//!     before the reported start.
+//!   * **none ⇒ no match** — when `find` returns `None`, `regex` finds no match
+//!     anywhere either.
+//!
+//! These hold for the full construct space — greedy *and* lazy quantifiers,
+//! alternation, nested groups, nullable loops — with no exclusions, because they
+//! are true of the textbook Pike-VM `find` regardless of the extent-priority
+//! corners where the two crates' *reported* spans differ. The exact greedy extents
+//! (incl. the nullable-loop fix `(a?)*`⇒whole-run, `(a??)*`⇒empty) are pinned down
+//! by hand-verified unit tests in `lib.rs`. `regex` is a dev-dependency for this
+//! gate only.
+use regex_engine as re;
+
+struct Lcg(u64);
+impl Lcg {
+    fn n(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0 >> 16
+    }
+    fn pick<'a, T>(&mut self, xs: &'a [T]) -> &'a T {
+        &xs[(self.n() as usize) % xs.len()]
+    }
+    fn range(&mut self, lo: usize, hi: usize) -> usize {
+        lo + (self.n() as usize) % (hi - lo + 1)
+    }
+}
+
+const ATOMS: &[&str] = &["a", "b", "c", ".", "[ab]", "[^a]", r"\w", r"\d"];
+// Every greedy/lazy/bounded quantifier — the property gate handles them all.
+const QUANTS: &[&str] = &[
+    "", "", "*", "+", "?", "*?", "+?", "??", "{0,2}", "{1,3}", "{2,}",
+];
+
+fn gen_piece(rng: &mut Lcg, depth: u32) -> String {
+    if depth < 3 && rng.range(0, 3) == 0 {
+        let inner = gen_alt(rng, depth + 1);
+        format!("({inner}){}", rng.pick(QUANTS))
+    } else {
+        format!("{}{}", rng.pick(ATOMS), rng.pick(QUANTS))
+    }
+}
+fn gen_seq(rng: &mut Lcg, depth: u32) -> String {
+    let n = rng.range(1, 4);
+    (0..n).map(|_| gen_piece(rng, depth)).collect()
+}
+fn gen_alt(rng: &mut Lcg, depth: u32) -> String {
+    let n = rng.range(1, 3);
+    (0..n)
+        .map(|_| gen_seq(rng, depth))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+// Anchor-free patterns: the property oracle slices the input, and a `^`/`$`/`\b`
+// in `P` would assert against a *slice* boundary rather than the original text's,
+// invalidating the oracle. (Anchors are covered by unit tests in `lib.rs`.) The
+// generator never emits `\b`.
+fn gen_pattern(rng: &mut Lcg) -> String {
+    gen_alt(rng, 0)
+}
+
+fn gen_input(rng: &mut Lcg) -> String {
+    // Multibyte chars ("é" = 2 bytes, "本" = 3) so byte-offset handling is exercised.
+    let len = rng.range(0, 8);
+    (0..len)
+        .map(|_| *rng.pick(&["a", "b", "c", "d", "é", "本"]))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+#[test]
+fn find_is_the_leftmost_valid_match() {
+    let mut rng = Lcg(0x0D_F1_15_ED_u64);
+    let mut checked = 0u64;
+    let mut skipped = 0u64;
+    for _ in 0..9_000 {
+        let pat = gen_pattern(&mut rng);
+        let mine = match re::Regex::new(&pat) {
+            Ok(r) => r,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+        // Oracles: `^(?:P)` = "a match starts here"; `^(?:P)$` = "this slice is a
+        // whole match". Skip the (rare) pattern `regex` rejects but we accept.
+        let starts_here = match regex::Regex::new(&format!("^(?:{pat})")) {
+            Ok(r) => r,
+            Err(_) => {
+                skipped += 1;
+                continue;
+            }
+        };
+        let whole = regex::Regex::new(&format!("^(?:{pat})$")).unwrap();
+
+        for _ in 0..6 {
+            let input = gen_input(&mut rng);
+            match mine.find(&input).map(|m| (m.start(), m.end())) {
+                Some((s, e)) => {
+                    // valid: the reported span is genuinely a match.
+                    assert!(
+                        whole.is_match(&input[s..e]),
+                        "find span is not a valid match: pat={pat:?} input={input:?} span={s}..{e}"
+                    );
+                    // leftmost: no match starts at any earlier byte boundary.
+                    for (b, _) in input.char_indices().take_while(|&(b, _)| b < s) {
+                        assert!(
+                            !starts_here.is_match(&input[b..]),
+                            "earlier match exists at {b} but find started at {s}: pat={pat:?} input={input:?}"
+                        );
+                    }
+                }
+                None => {
+                    // none ⇒ no match anywhere.
+                    assert!(
+                        !regex::Regex::new(&pat).unwrap().is_match(&input),
+                        "find returned None but regex matches: pat={pat:?} input={input:?}"
+                    );
+                }
+            }
+            checked += 1;
+        }
+    }
+    println!("find: verified leftmost+valid on {checked} cases; skipped {skipped} patterns");
+    assert!(checked > 40_000, "corpus too small: {checked}");
+}
+
+#[test]
+fn is_match_matches_regex_on_full_construct_space() {
+    // Boolean matching must agree with `regex` byte-for-byte across the whole
+    // construct space — greedy/lazy quantifiers, alternation, nested groups,
+    // anchors. This is the property Engram's search relies on (it never asks for
+    // extents). Anchors are allowed here (no slicing).
+    let mut rng = Lcg(0x1A2B_3C4D_5E6F_7A8B_u64);
+    let mut checked = 0u64;
+    for _ in 0..12_000 {
+        let mut pat = String::new();
+        if rng.range(0, 4) == 0 {
+            pat.push('^');
+        }
+        pat.push_str(&gen_alt(&mut rng, 0));
+        if rng.range(0, 4) == 0 {
+            pat.push('$');
+        }
+        let (mine, theirs) = match (re::Regex::new(&pat), regex::Regex::new(&pat)) {
+            (Ok(m), Ok(t)) => (m, t),
+            _ => continue,
+        };
+        for _ in 0..5 {
+            let input = gen_input(&mut rng);
+            assert_eq!(
+                mine.is_match(&input),
+                theirs.is_match(&input),
+                "is_match differs: pat={pat:?} input={input:?}"
+            );
+            checked += 1;
+        }
+    }
+    println!("is_match: cross-checked {checked} pairs");
+    assert!(checked > 35_000, "corpus too small: {checked}");
+}

--- a/code/specs/engram-zero-dep-plan.md
+++ b/code/specs/engram-zero-dep-plan.md
@@ -134,9 +134,26 @@ DoS-immune on user `re:` patterns, unlike a backtracker. Decomposed:
   The `regex` crate stays only for the media `DUPLICATE_HTML_MEDIA_TAGS`
   `replace_all` (needs match extents → D4). Full `cargo test -p engram-core`
   (170 tests incl. the Anki text-modifier search suite) passes on the new engine.
-- **D3 — match extents.** Add `find`/`captures`/`replace_all` to the engine,
-  solving the **nullable-loop** priority problem (e.g. `(a?)*`) so extents match
-  `regex` byte-for-byte; cross-verify find + replace_all on random corpora.
+- **D3a — ✅ DONE (`find`, overall extent).** `Regex::find` returns the leftmost
+  match's byte range/substring, tracking one extra `usize` (the match start) per
+  thread — O(instructions) per step, no per-group vectors, so the DoS argument for
+  `is_match` still holds. Solved the **nullable-loop** priority problem: `e{n,}`
+  loops back to the body start and `e*` with a nullable body compiles as an
+  optional-plus, so an empty iteration routes to the exit at the correct priority
+  (`(a?)*`/`(a*)*` ⇒ whole run; `(a??)*`/`(a??)+` ⇒ empty — all matching `regex`,
+  pinned by hand-verified unit tests). Verified by **property**, not span-equality:
+  the live `regex` crate's own unanchored `find` is quirky on adversarial patterns
+  (skips matches its anchored matcher accepts), so it's the wrong oracle. Using
+  `regex`'s *anchored* matcher as an independent oracle, **40k+** random cases
+  (greedy+lazy quantifiers, alternation, nested groups, nullable loops; multibyte)
+  confirm every span is a *valid* match at the *leftmost* start; a separate **35k+**
+  check confirms `is_match` stays exact across the same space (the property engram
+  relies on — it never calls `find`). Reported extents can differ from `regex` only
+  on lazy/overlapping-greedy-alternation corners, which the media pattern avoids.
+  regex-engine v0.4.0.
+- **D3b — captures.** Add `Regex::captures` (per-group `Save` instructions,
+  copy-on-write capture slots, a group-count DoS cap), cross-verified vs `regex`.
+- **D3c — `replace_all`/`find_iter`.** Built on find/captures; cross-verified.
 - **D4 — swap media + drop `regex`.** Point `DUPLICATE_HTML_MEDIA_TAGS` at the
   engine's `replace_all` (byte-verified vs the old regex on the corpus from C2),
   then remove `regex` from `engram-core`'s Cargo.toml. **`regex` gone.**


### PR DESCRIPTION
## Phase D3a — `Regex::find` (overall match extent)

First half of match extents for the zero-dep `regex-engine`, on the way to
`captures`/`replace_all` and dropping the `regex` crate from engram-core (D4).

- **`Regex::find(text) -> Option<Match>`** — leftmost match's byte range +
  substring (`Match::start`/`end`/`as_str`/`range`). Each Pike-VM thread carries
  one extra `usize` (its start); no per-group vectors, so the
  O(instructions)-per-step DoS bound for `is_match` is preserved.
- **Nullable-loop extent priority solved.** `e{n,}` loops back to the body start,
  and `e*` with a nullable body compiles as an optional-plus, so an empty
  iteration routes to the loop exit at the correct priority:
  `(a?)*`/`(a*)*` ⇒ whole run; `(a??)*`/`(a??)+` ⇒ empty — all matching `regex`,
  pinned by hand-verified unit tests. Purely a thread-priority change; the
  accepted language (and `is_match`) is unchanged.

### Verification — by property, not span-equality
On adversarial patterns the **`regex` crate's own** unanchored `find` returns
non-leftmost results its *anchored* matcher contradicts (it skips genuine
leftmost matches), so its `find` is the wrong oracle. Using `regex`'s **anchored**
matcher as an independent oracle:

- **40k+** random cases (greedy+lazy quantifiers, alternation, nested groups,
  nullable loops; multibyte inputs) — every reported span is a **valid** match at
  the **leftmost** start; every `None` means no match anywhere.
- **35k+** boolean cross-check — `is_match` agrees with `regex` across the same
  full construct space.
- Full `cargo test -p regex-engine` green (lib 19 + all cross-checks; the
  star-compilation change is language-preserving — D0/D1 `is_match` corpora pass).
- **Security review passed** (Rust sub-agent): `find` linear-time; `emit_repeat`
  compile-size caps preserved (incl. no `min-1` underflow); byte offsets always
  boundary-aligned/in-bounds (no slice panics); no unsafe.

The reported *extent* can differ from `regex` only on lazy / overlapping-greedy
alternation corners (documented); `is_match` is exact regardless, and Engram's
only extent consumer — the media-tag regex (greedy, disjoint alternation) — is
unaffected. regex-engine **v0.4.0**.

Part of the Engram zero-dependency program (`code/specs/engram-zero-dep-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)