### PR TITLE
feat(adj-ladder): rung-113 apheresis cleared-load index (a factor distributed over a difference, over a divisor)

### DIFF
--- a/code/specs/data/adj-ladder/rung113_apheresis/gen_items.py
+++ b/code/specs/data/adj-ladder/rung113_apheresis/gen_items.py
@@ -1,0 +1,255 @@
+"""Generate rung-113 (transfusion medicine / apheresis) items.json for the ADJ-LADDER.
+
+Rung 113 opens the **transfusion medicine / therapeutic apheresis** panel on the quantitative band — the arithmetic of a
+cleared-load index. A `cycle_factor` (a per-cycle scaling) TIMES the DIFFERENCE of a `pre_count` and a `post_count` (the cell
+count before and after the procedure) gives the cleared load, and that load is DIVIDED by a `session_count` (how many sessions
+the reading is averaged over) to give the cleared-load index. A **factor DISTRIBUTED over a two-term DIFFERENCE, all over a
+divisor** introduces a genuinely NEW arithmetic family on the ladder: `a*(b-c)/d`, i.e. `((a * (b - c)) / d)`.
+
+This is genuinely new — rung-112 opened the distributive frontier with `a*(b+c)/d` (a factor over a SUM); rung-113 is the FIRST
+distributive shape where the factor multiplies a parenthesised DIFFERENCE. It is the minus-sibling of rung-112 `a*(b+c)/d`. The
+flat three-term numerators (rung-108 `(a+b+c)/d`, rung-109 `(a-b+c)/d`, rung-110 `(a*b+c)/d`, rung-111 `(a*b-c)/d`) wrapped the
+WHOLE numerator; the distributive family (112 sum, 113 difference) wraps the SUM/DIFFERENCE (the multiplicand). Every prior ratio
+used either a two-term numerator (rung-37 `(a+b)/(c+d)`, rung-99 `(a*b)/(c+d)`, rung-100 `(a+b)/(c*d)`, rung-104 `(a-b)/(c*d)`,
+the difference-denominator trio rung-105 `(a+b)/(c-d)`, rung-106 `a*b/(c-d)`, rung-107 `(a-b)/(c-d)`) or a flat three-term
+numerator (108-111). Rung-113 moves to `a*(b-c)/d`. The operator order matters: `a*(b-c)/d` is `((a*(b-c))/d)` (the factor
+multiplies the whole difference, then the product is divided; `*` and `/` bind left-to-right so `a*(b-c)/d` = `(a*(b-c))/d`), NOT
+`a*b-c/d` (dropping the difference parentheses so the factor multiplies only the pre-count and the post-count is divided by the
+divisor and then subtracted) and NOT `(a*b)/(c+d)` (regrouping so only `a*b` forms the numerator and the post-count joins the
+divisor in the denominator) — the two distractors exploit exactly those confusions.
+
+The setup: a `cycle_factor`, a `pre_count`, a `post_count`, and a `session_count`. The total is:
+
+  CLEARED-LOAD INDEX  cycle_factor * (pre_count - post_count) / session_count  [ a factor over a difference, over a divisor ]
+  CLEARED LOAD        cycle_factor * (pre_count - post_count)                  [ the distributed-product numerator ]
+  SESSION COUNT       session_count                                           [ the divisor ]
+
+The **cleared-load index** is what makes this rung distinctive — it is the ladder's first **factor over a DIFFERENCE, over a
+divisor**. It is a rate (cleared load per session), framed as an *index* to keep it dimensionless-clean — the same discipline
+rungs 100/104/.../112 used for their ratios. (The cleared load `a*(b-c)` and the session count `d` ride alongside as component
+readouts, so the panel teaches the whole calculation — exactly as rungs 47-112 shipped their component
+sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries
+the arithmetic — the subtraction of the post-count from the pre-count into the cleared count, the multiplication of that
+difference by the cycle factor into the cleared load, then the division of that load by the session count (the factor distributed
+over the parenthesised difference, so a*(b-c)/d evaluates as ((a*(b-c))/d)) — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../111/112. This rung exercises the engine
+across a **factor-over-a-difference, over a divisor** — the fact that `a*(b-c)/d` is `((a*(b-c))/d)` and NOT `a*b-c/d` and NOT
+`(a*b)/(c+d)` made computable. The ratio golds are non-integer f64s; the engine's IEEE-double division matches Python's the same
+way rungs 99/100/104/.../112 relied on (well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `*`, `-` and `/` — **no
+structural constants** — so no numeric literal appears in any program, and neither the cleared load, the session count, nor any
+index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free identifiers**
+(`cycle_factor`, `pre_count`, `post_count`, `session_count`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    cycle_factor * pre_count - post_count / session_count  drop the difference parentheses so the cycle factor
+                                                                    multiplies only the pre-count and the post-count is divided by
+                                                                    the session count and then subtracted (the classic
+                                                                    `a*(b-c)/d` vs `a*b-c/d` distributivity error), and
+  SWAPPED    (cycle_factor * pre_count) / (post_count + session_count)  regroup so only the factor-times-pre-count product forms
+                                                                    the numerator and the post-count joins the session count in
+                                                                    the denominator (`(a*b)/(c+d)` instead of `a*(b-c)/d`),
+
+which are exactly the mistakes a student makes (failing to distribute the factor across the whole difference, or regrouping which
+terms belong to the numerator vs the divisor). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all
+five always appear as options.
+
+Distinctness and positivity: this rung SUBTRACTS inside the parentheses, so positivity is guaranteed by table construction. Each
+table guarantees **pre_count > post_count** (so the difference `b-c` is strictly positive, the cleared load `a*(b-c)` is
+positive, and the index is positive) AND all quantities `>= 2` (so the crossed slip `a*b - c/d` stays positive because
+`a*b >= 2b > 2c > c > c/d`, and the swapped denominator `c+d >= 4`). The **session_count >= 2** keeps the divisor away from zero,
+the cleared-load index never coincides with the session count or the cleared load, and the five family values are pairwise
+distinct with a comfortable margin; and — so all three queried readouts vary across the panel — the seven tables give distinct
+cleared-load indices, distinct cleared loads, and distinct session counts, all asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (CYCLE_FACTOR, PRE_COUNT, POST_COUNT, SESSION_COUNT) — a cycle factor times the difference of a pre-count and a post-count for
+# the cleared load, all divided by a session count, all plain positive numbers >= 2. This rung SUBTRACTS inside the parentheses,
+# so every table guarantees pre_count > post_count (b>c) which keeps the difference, the cleared load, and the index strictly
+# positive; session_count >= 2 keeps the divisor away from zero. The five family values are asserted pairwise-distinct below. The
+# seven tables give distinct cleared-load indices, distinct cleared loads, and distinct session counts so all three queried
+# readouts vary across the panel.
+TABLES = [
+    (2, 5, 2, 2),
+    (3, 6, 2, 3),
+    (5, 5, 2, 4),
+    (4, 6, 2, 5),
+    (2, 9, 2, 6),
+    (3, 8, 2, 7),
+    (4, 7, 2, 8),
+]
+
+# The option family (5 members), all built from the four observed quantities via *, - and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the
+# options.
+FAMILY = [
+    (
+        "cleared_load_index",
+        "cleared-load index (the cleared load divided by the session count)",
+        "cycle_factor * (pre_count - post_count) / session_count",
+    ),
+    (
+        "cleared_load",
+        "the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)",
+        "cycle_factor * (pre_count - post_count)",
+    ),
+    (
+        "session_count",
+        "the session count (the divisor the cleared load is divided by)",
+        "session_count",
+    ),
+    (
+        "crossed",
+        "the cycle factor times the pre count minus the post count divided by the session count, dropping the difference parentheses so the cycle factor multiplies only the pre count (a wrong distribution)",
+        "cycle_factor * pre_count - post_count / session_count",
+    ),
+    (
+        "swapped",
+        "the cycle factor times the pre count, divided by the post count plus the session count, regrouping so only that product forms the numerator (a wrong pairing)",
+        "(cycle_factor * pre_count) / (post_count + session_count)",
+    ),
+]
+QUERIED = ["cleared_load_index", "cleared_load", "session_count"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(cycle_factor, pre_count, post_count, session_count):
+    # Operation order mirrors the ADJ programs exactly (the post count subtracts from the pre count, the cycle factor multiplies
+    # that difference into the cleared load, then that numerator is divided by the session count, so a*(b-c)/d evaluates as
+    # ((a*(b-c))/d)), so the Python option value and the engine result are the same IEEE-double (well within the harness's 1e-9
+    # match tolerance).
+    return {
+        "cleared_load_index": cycle_factor * (pre_count - post_count) / session_count,
+        "cleared_load": cycle_factor * (pre_count - post_count),
+        "session_count": session_count,
+        "crossed": cycle_factor * pre_count - post_count / session_count,
+        "swapped": (cycle_factor * pre_count) / (post_count + session_count),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for cycle_factor, pre_count, post_count, session_count in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and this rung SUBTRACTS inside the parentheses, so each table
+        # guarantees pre_count > post_count (the difference b-c is strictly positive) which keeps every family member strictly
+        # positive; session_count >= 2 keeps the divisor away from zero.
+        assert (
+            cycle_factor >= 2
+            and pre_count >= 2
+            and post_count >= 2
+            and session_count >= 2
+        ), (cycle_factor, pre_count, post_count, session_count)
+        assert pre_count > post_count, (cycle_factor, pre_count, post_count, session_count)
+        fv = family_values(cycle_factor, pre_count, post_count, session_count)
+        for key, v in fv.items():
+            assert v > 0, (key, cycle_factor, pre_count, post_count, session_count, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    cycle_factor,
+                    pre_count,
+                    post_count,
+                    session_count,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                cycle_factor,
+                pre_count,
+                post_count,
+                session_count,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r113apher-{idx + 1:02d}",
+                "qtype": "cleared_load_index",
+                "stem": (
+                    f"An apheresis log records a cycle factor of {num(cycle_factor)} times a pre count of {num(pre_count)} "
+                    f"minus a post count of {num(post_count)}, divided by a session count of {num(session_count)}. What is the "
+                    f"{name_of[key]}?"
+                ),
+                "program": (
+                    f"observe cycle_factor({num(cycle_factor)})\n"
+                    f"observe pre_count({num(pre_count)})\n"
+                    f"observe post_count({num(post_count)})\n"
+                    f"observe session_count({num(session_count)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 113 — cleared-load index from four stated quantities (a NEW panel: transfusion medicine / "
+            "therapeutic apheresis). From a cycle factor times the difference of a pre-count and a post-count for the cleared "
+            "load, all divided by a session count, compute the cleared-load index "
+            "(cycle_factor*(pre_count-post_count)/session_count), the cleared load "
+            "(cycle_factor*(pre_count-post_count)), or the session count. Each item is a compute_dimensioned program (observe the "
+            "four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, A FACTOR DISTRIBUTED "
+            "OVER A DIFFERENCE, OVER A DIVISOR a*(b-c)/d (subtract the post count from the pre count, multiply the difference by "
+            "the cycle factor, divide by the session count, so a*(b-c)/d = ((a*(b-c))/d); the SECOND distributive shape and the "
+            "FIRST where the factor multiplies a parenthesised DIFFERENCE — the minus-sibling of rung-112 a*(b+c)/d. The flat "
+            "three-term numerators (108 (a+b+c)/d, 109 (a-b+c)/d, 110 (a*b+c)/d, 111 (a*b-c)/d) wrapped the WHOLE numerator; the "
+            "distributive family wraps the SUM/DIFFERENCE (the multiplicand). Every earlier ratio used a TWO-term numerator: 37 "
+            "(a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 (a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), "
+            "106 a*b/(c-d), 107 (a-b)/(c-d)) — and the harness matches the scalar to the printed options. The cleared-load index "
+            "is a rate (cleared load per session), framed as an INDEX so the dimensionless value stays honest. Contamination-"
+            "safe: every figure is built only from the four observed quantities via *, - and / — no constant leaks, and neither "
+            "the cleared load, the session count, nor any index ever appears as a literal (each is computed) — and the observed "
+            "quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family "
+            "over the same four quantities, so the distractors are exactly the slips students make: dropping the difference "
+            "parentheses so the factor multiplies only the pre count (a*b-c/d, a wrong distribution) and regrouping so only that "
+            "product forms the numerator ((a*b)/(c+d), a wrong pairing). The core confusion tested is that a*(b-c)/d is "
+            "((a*(b-c))/d), not a*b-c/d and not (a*b)/(c+d). This rung SUBTRACTS inside the parentheses, so positivity is "
+            "guaranteed by table construction: every table has pre_count > post_count (b>c) and session_count >= 2 (divisor "
+            "never zero), keeping every family member strictly positive."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung113_apheresis/items.json
+++ b/code/specs/data/adj-ladder/rung113_apheresis/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 113 \u2014 cleared-load index from four stated quantities (a NEW panel: transfusion medicine / therapeutic apheresis). From a cycle factor times the difference of a pre-count and a post-count for the cleared load, all divided by a session count, compute the cleared-load index (cycle_factor*(pre_count-post_count)/session_count), the cleared load (cycle_factor*(pre_count-post_count)), or the session count. Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, A FACTOR DISTRIBUTED OVER A DIFFERENCE, OVER A DIVISOR a*(b-c)/d (subtract the post count from the pre count, multiply the difference by the cycle factor, divide by the session count, so a*(b-c)/d = ((a*(b-c))/d); the SECOND distributive shape and the FIRST where the factor multiplies a parenthesised DIFFERENCE \u2014 the minus-sibling of rung-112 a*(b+c)/d. The flat three-term numerators (108 (a+b+c)/d, 109 (a-b+c)/d, 110 (a*b+c)/d, 111 (a*b-c)/d) wrapped the WHOLE numerator; the distributive family wraps the SUM/DIFFERENCE (the multiplicand). Every earlier ratio used a TWO-term numerator: 37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 (a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) \u2014 and the harness matches the scalar to the printed options. The cleared-load index is a rate (cleared load per session), framed as an INDEX so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed quantities via *, - and / \u2014 no constant leaks, and neither the cleared load, the session count, nor any index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the difference parentheses so the factor multiplies only the pre count (a*b-c/d, a wrong distribution) and regrouping so only that product forms the numerator ((a*b)/(c+d), a wrong pairing). The core confusion tested is that a*(b-c)/d is ((a*(b-c))/d), not a*b-c/d and not (a*b)/(c+d). This rung SUBTRACTS inside the parentheses, so positivity is guaranteed by table construction: every table has pre_count > post_count (b>c) and session_count >= 2 (divisor never zero), keeping every family member strictly positive.",
+  "items": [
+    {
+      "id": "r113apher-01",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 2 times a pre count of 5 minus a post count of 2, divided by a session count of 2. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(2)\nobserve pre_count(5)\nobserve post_count(2)\nobserve session_count(2)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r113apher-02",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 2 times a pre count of 5 minus a post count of 2, divided by a session count of 2. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(2)\nobserve pre_count(5)\nobserve post_count(2)\nobserve session_count(2)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r113apher-03",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 2 times a pre count of 5 minus a post count of 2, divided by a session count of 2. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(2)\nobserve pre_count(5)\nobserve post_count(2)\nobserve session_count(2)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r113apher-04",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 3 times a pre count of 6 minus a post count of 2, divided by a session count of 3. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(3)\nobserve pre_count(6)\nobserve post_count(2)\nobserve session_count(3)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17.333333333333332,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r113apher-05",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 3 times a pre count of 6 minus a post count of 2, divided by a session count of 3. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(3)\nobserve pre_count(6)\nobserve post_count(2)\nobserve session_count(3)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17.333333333333332,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r113apher-06",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 3 times a pre count of 6 minus a post count of 2, divided by a session count of 3. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(3)\nobserve pre_count(6)\nobserve post_count(2)\nobserve session_count(3)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 17.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r113apher-07",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 5 times a pre count of 5 minus a post count of 2, divided by a session count of 4. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(5)\nobserve pre_count(5)\nobserve post_count(2)\nobserve session_count(4)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.75,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.166666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r113apher-08",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 5 times a pre count of 5 minus a post count of 2, divided by a session count of 4. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(5)\nobserve pre_count(5)\nobserve post_count(2)\nobserve session_count(4)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.166666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r113apher-09",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 5 times a pre count of 5 minus a post count of 2, divided by a session count of 4. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(5)\nobserve pre_count(5)\nobserve post_count(2)\nobserve session_count(4)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.166666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r113apher-10",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 4 times a pre count of 6 minus a post count of 2, divided by a session count of 5. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(4)\nobserve pre_count(6)\nobserve post_count(2)\nobserve session_count(5)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23.6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.4285714285714284,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r113apher-11",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 4 times a pre count of 6 minus a post count of 2, divided by a session count of 5. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(4)\nobserve pre_count(6)\nobserve post_count(2)\nobserve session_count(5)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.4285714285714284,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r113apher-12",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 4 times a pre count of 6 minus a post count of 2, divided by a session count of 5. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(4)\nobserve pre_count(6)\nobserve post_count(2)\nobserve session_count(5)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.4285714285714284,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r113apher-13",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 2 times a pre count of 9 minus a post count of 2, divided by a session count of 6. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(2)\nobserve pre_count(9)\nobserve post_count(2)\nobserve session_count(6)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 2.3333333333333335,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 17.666666666666668,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r113apher-14",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 2 times a pre count of 9 minus a post count of 2, divided by a session count of 6. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(2)\nobserve pre_count(9)\nobserve post_count(2)\nobserve session_count(6)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.3333333333333335,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17.666666666666668,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r113apher-15",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 2 times a pre count of 9 minus a post count of 2, divided by a session count of 6. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(2)\nobserve pre_count(9)\nobserve post_count(2)\nobserve session_count(6)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.3333333333333335,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 17.666666666666668,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r113apher-16",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 3 times a pre count of 8 minus a post count of 2, divided by a session count of 7. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(3)\nobserve pre_count(8)\nobserve post_count(2)\nobserve session_count(7)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5714285714285716,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.714285714285715,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r113apher-17",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 3 times a pre count of 8 minus a post count of 2, divided by a session count of 7. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(3)\nobserve pre_count(8)\nobserve post_count(2)\nobserve session_count(7)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5714285714285716,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.714285714285715,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r113apher-18",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 3 times a pre count of 8 minus a post count of 2, divided by a session count of 7. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(3)\nobserve pre_count(8)\nobserve post_count(2)\nobserve session_count(7)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5714285714285716,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.714285714285715,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.6666666666666665,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r113apher-19",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 4 times a pre count of 7 minus a post count of 2, divided by a session count of 8. What is the cleared-load index (the cleared load divided by the session count)?",
+      "program": "observe cycle_factor(4)\nobserve pre_count(7)\nobserve post_count(2)\nobserve session_count(8)\nlet answer = cycle_factor * (pre_count - post_count) / session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 27.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r113apher-20",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 4 times a pre count of 7 minus a post count of 2, divided by a session count of 8. What is the the cleared load (the cycle factor times the difference of the pre and post counts, the numerator divided by the session count)?",
+      "program": "observe cycle_factor(4)\nobserve pre_count(7)\nobserve post_count(2)\nobserve session_count(8)\nlet answer = cycle_factor * (pre_count - post_count)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 27.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 20,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r113apher-21",
+      "qtype": "cleared_load_index",
+      "stem": "An apheresis log records a cycle factor of 4 times a pre count of 7 minus a post count of 2, divided by a session count of 8. What is the the session count (the divisor the cleared load is divided by)?",
+      "program": "observe cycle_factor(4)\nobserve pre_count(7)\nobserve post_count(2)\nobserve session_count(8)\nlet answer = session_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 27.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 2.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -150,6 +150,7 @@ SELF_CONTAINED_RUNGS = (
     "rung110_audiology",
     "rung111_dosimetry",
     "rung112_anesthesia",
+    "rung113_apheresis",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-113 — apheresis cleared-load index (a factor distributed over a difference, over a divisor)

Opens the **transfusion medicine / therapeutic apheresis** panel on the quantitative band and introduces a genuinely **new arithmetic shape**: **a factor multiplied into a parenthesised difference, all over a divisor, `a*(b-c)/d`**.

### What's new (shape novelty)

Rung-112 opened the distributive frontier with `a*(b+c)/d` (a factor over a **sum**). Rung-113 is the **first distributive shape where the factor multiplies a parenthesised DIFFERENCE** — the minus-sibling of rung-112. The flat three-term numerators (108 `(a+b+c)/d`, 109 `(a-b+c)/d`, 110 `(a*b+c)/d`, 111 `(a*b-c)/d`) wrapped the *whole* numerator; the distributive family (112 sum, 113 difference) wraps the **sum/difference** (the multiplicand).

Rung-113 is `((cycle_factor * (pre_count - post_count)) / session_count)` — `*` and `/` bind left-to-right, so `a*(b-c)/d` = `(a*(b-c))/d`.

### The clinical framing

A `cycle_factor` times the difference of a `pre_count` and a `post_count` (cell count before and after) gives the **cleared load**, then divided by a `session_count` for the **cleared-load index** (cleared load per session, framed as a dimensionless index).

- `CLEARED-LOAD INDEX = cycle_factor * (pre_count - post_count) / session_count` — the headline factor-over-a-difference ratio
- `CLEARED LOAD       = cycle_factor * (pre_count - post_count)` — the distributed-product numerator, a real component readout
- `SESSION COUNT      = session_count` — the divisor, a real component readout

### The distractor family (5 mutually-confusable scalars over the same four quantities)

- **crossed** `cycle_factor * pre_count - post_count / session_count` — drops the difference parentheses so the factor multiplies only the pre-count (the `a*(b-c)/d` vs `a*b-c/d` distributivity slip)
- **swapped** `(cycle_factor * pre_count) / (post_count + session_count)` — regroups so only that product forms the numerator (`(a*b)/(c+d)`)

The core confusion tested: `a*(b-c)/d` is `((a*(b-c))/d)`, **not** `a*b-c/d` and **not** `(a*b)/(c+d)`.

### Construction guarantees

- **Constant-free / digit-free**: every figure is built only from the four observed quantities via `*`, `-`, `/`; no numeric literal appears in any program; identifiers are digit-free (`cycle_factor`, `pre_count`, `post_count`, `session_count`).
- **This rung subtracts inside the parentheses**, so positivity is by construction: every table guarantees `pre_count > post_count` (so `b-c>0`, the cleared load and index are positive) and all quantities `>= 2` (so the crossed slip `a*b-(c/d)` stays positive since `a*b >= 2b > 2c > c > c/d`), with `session_count >= 2` (divisor never zero) — every family member strictly positive.
- Five family values asserted **pairwise-distinct** (>1e-6) per table; the seven tables give **distinct cleared-load indices, distinct cleared loads, and distinct session counts** so all three queried golds vary across the panel.
- Gold rotates A–E by `idx % 5`. 7 tables × 3 queried readouts = **21 items**.

### No harness/engine change

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing extractor — exactly as rungs 8/16/…/111/112.

### Verification

- `gen_items.py` → `wrote items.json: 21 items`
- Scratchpad distinctness/positivity checker: all 5 within-table pairwise-distinct; 3 queried golds all vary across the 7 tables.
- `python3 -m pytest test_ladder_eval.py -k rung113 -q` → **3 passed**
- Inline security review: PASSED (data-only generator; no eval/exec/I-O beyond its own items.json; every table guards `pre_count>post_count` and `session_count >= 2` so no div-by-zero and every member positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
