### PR TITLE
feat(latex): LTXDOC03 S24 resolved_references_by_kind (by target kind)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.60.0] — 2026-07-08
+
+### Added — resolved references grouped by target kind (LTXDOC03 S24)
+
+A **new** public method `Document::resolved_references_by_kind(&self) -> String` that renders the
+**resolved `\ref`/`\eqref`/`\pageref` references grouped by the `LabelKind` they resolved TO** — a
+per-kind census of the successfully-matched references. It is the by-kind grouping companion of S21's
+`resolved_references_by_source` (which lists the same resolved references **flat**, one
+`\<command>{key}` per line in source pre-order): S21 and S24 are two *views* of the one `resolved` list
+`resolve_references()` produces. It mirrors S23's `label_definitions_by_kind` idiom (same
+`const KIND_ORDER`, same flat_map/filter pass) but over the **resolved-references** list instead of the
+**definitions** list, and stays **command-aware** like S21. It is a read-only view over
+`resolve_references()`; every S1–S23 output is left **byte-for-byte unchanged**; S24 is purely additive
+and leaves the `to_latex()` round-trip fixed point intact.
+
+- **Grouped by target kind in a fixed, document-independent order** — the `LabelKind` enum declaration
+  order: `Section`, `Table`, `Figure`, `Equation`, `Inline` (the SAME `const KIND_ORDER` slice S23
+  uses). The method iterates that explicit fixed order (not a hash map keyed by kind), so the group
+  order is deterministic — the same `Vec`-scan discipline S17/S18/S23 use to avoid hash-order
+  nondeterminism.
+- **Pre-order within each kind.** Refs that resolved to a given kind keep their existing pre-order from
+  `resolved`; grouping never reorders within a kind.
+- **`[kind] \<command>{key}` line shape, command-aware.** Each line is `[` + the stable lowercase tag
+  from `LabelKind::as_str()` (of the ref's `target_kind`) + `] \` + the ref's **own** `command` + `{` +
+  its **owned `key` `String`** + `}` — so a resolved `\eqref` renders `[equation] \eqref{eq:m}` and a
+  resolved `\pageref` renders `[section] \pageref{sec:i}`; the command is **never** hard-coded to
+  `\ref`. There is **no** source slicing at all (matching S21 `resolved_references_by_source` and S23
+  `label_definitions_by_kind`). The `[kind]` prefix makes the census visible on every line while
+  staying one-line-per-ref; it is a report annotation, not round-trippable LaTeX.
+- **Dangling refs excluded by construction.** A `\ref{nope}` with no `\label` never entered `resolved`,
+  so it appears in S18's `unresolved_references_by_source`, not here.
+- **No empty groups.** A kind with no resolved refs contributes no lines and no bare `[table]` header.
+- **Stable empty marker.** No resolved references at all (every ref dangles, or there are none) → the
+  **same** fixed string `(no resolved references)` S21 uses, never the empty string — the stable-marker
+  discipline S12–S23 share.
+- **`\n`-joined, no trailing newline** — matching S21's `resolved_references_by_source` and every
+  S11–S23 renderer.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing (`ref_span`/
+  `target_span` unused); a single stable-ordered pass (fixed kind order × pre-order filter) over the
+  already-bounded `resolved` list. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s24_groups_different_kinds_in_fixed_kind_order`,
+  `s24_reorders_source_to_fixed_kind_order`, `s24_same_kind_grouped_in_preorder_command_aware`,
+  `s24_only_dangling_or_none_returns_marker`, `s24_newline_join_no_trailing_newline_excludes_dangling`,
+  and `s24_is_additive_leaves_s1_s23_outputs_unchanged` (which pins every S1–S23 output byte-for-byte,
+  including S21's flat `resolved_references_by_source`, alongside the new grouped output).
+
 ## [0.59.0] — 2026-07-08
 
 ### Added — winning label definitions grouped by kind (LTXDOC03 S23)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.59.0"
+version = "0.60.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -71,6 +71,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S21 — resolved references grouped by source `\ref`** | `Document::resolved_references_by_source() -> String` — a **new**, read-only method that renders the **resolved** (successfully-matched) references, one reconstructed `\<command>{key}` line each — the **RESOLVED mirror of S18's** `unresolved_references_by_source` (which renders the *dangling* half of the same split), **command-aware** so `\eqref`/`\pageref` render as themselves, not flattened to `\ref`. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `ref_span` in **first-appearance order** (source order); because each `\ref`/`\eqref`/`\pageref` takes exactly one key, every group is a single entry emitting one line: `\` + the ref's own `command` + `{` + its `key` + `}` (reconstructed from the owned strings, no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). Lines joined by `\n`, no trailing newline. A document with **no** resolved references (every ref dangles, or none) → the fixed marker `(no resolved references)`. E.g. `\ref{sec:intro}`, `\eqref{eq:main}`, `\pageref{sec:intro}` (all defined) → `\ref{sec:intro}\n\eqref{eq:main}\n\pageref{sec:intro}`. Every S1–S20 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S22 — winning `\label` definitions** | `Document::label_definitions() -> String` — a **new**, read-only method that renders the **winning** label definitions — the `\label{key}` definitions references resolve against, one `\label{key}` line per distinct key — the **label-family analogue of S19's** `bibliography_entries` (which renders the winning `\bibitem` entries) and the **winning-side counterpart of S20's** `duplicate_label_definitions` (which renders the *losing* duplicate `\label`s). It reads only `resolve_references().definitions`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, one row per distinct key) and every **later** `\label` of an already-defined key goes to `duplicates` (S20's domain). S22 emits one line per winning definition in that pre-order (**not** re-sorted, **not** de-duplicated — none needed, since `definitions` already holds one row per distinct key), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). A `\label{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the fixed marker `(no label definitions)`. E.g. `sec:intro` (section), `eq:main` (equation), then a re-used `sec:intro` → `\label{sec:intro}\n\label{eq:main}` (winner once). Every S1–S21 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S23 — winning `\label` definitions grouped by kind** | `Document::label_definitions_by_kind() -> String` — a **new**, read-only method that renders the **winning** `\label` definitions **grouped by their `LabelKind`** — a per-kind census — the **by-kind grouping companion of S22's** `label_definitions` (which lists the same winning definitions *flat*); S22 and S23 are two views of the one winning `definitions` list. It reads only `resolve_references().definitions` and groups by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — iterated as an explicit slice, not a hash map, so the order is deterministic like S17/S18's `Vec`-of-groups). Within each kind, definitions keep their existing pre-order. Each line is `[<kind>] \label{<key>}` — `<kind>` from `LabelKind::as_str()` (`"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<key>` from the owned key (no source slicing). A kind with no definitions contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22 uses. E.g. `sec:intro` (section), `eq:main` (equation), `note` (inline) → `[section] \label{sec:intro}\n[equation] \label{eq:main}\n[inline] \label{note}`. Every S1–S22 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S24 — resolved references grouped by target kind** | `Document::resolved_references_by_kind() -> String` — a **new**, read-only method that renders the **resolved** `\ref`/`\eqref`/`\pageref` references **grouped by the `LabelKind` they resolved TO** — a per-kind census — the **by-kind grouping companion of S21's** `resolved_references_by_source` (which lists the same resolved refs *flat*, in source order); S21 and S24 are two views of the one `resolved` list. It mirrors S23's `label_definitions_by_kind` idiom but over the **resolved-references** list, and stays **command-aware** like S21. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23 uses, iterated explicitly, not a hash map, so the order is deterministic). Within each kind, refs keep their existing pre-order. Each line is `[<kind>] \<command>{<key>}` — `<kind>` from the ref's `target_kind.as_str()`, `<command>` the ref's own (so `\eqref`/`\pageref` render as themselves), `<key>` from the owned key (no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). A kind with no resolved refs contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21 uses. E.g. `\ref{sec:intro}` (section), `\eqref{eq:main}` (equation), `\pageref{sec:intro}` (section) → `[section] \ref{sec:intro}\n[section] \pageref{sec:intro}\n[equation] \eqref{eq:main}`. Every S1–S23 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -954,6 +955,41 @@ assert_eq!(
 A document with no label definitions renders the **same** fixed `(no label definitions)` marker S22
 uses (S23 groups the identical list). Purely additive — reuses `resolve_references`, mutates nothing,
 leaves every S1–S22 output and the `to_latex()` fixed point unchanged.
+
+### resolved references grouped by target kind (LTXDOC03 S24)
+
+The **resolved** `\ref`/`\eqref`/`\pageref` references **grouped by the `LabelKind` they resolved TO**
+— a per-kind census — the **by-kind grouping companion of S21's** `resolved_references_by_source`
+(which lists the same resolved refs *flat*, one `\<command>{key}` per line in source pre-order). S21
+and S24 are two *views* of the one `resolved` list `resolve_references()` produces. It is the exact
+`resolved`-refs analogue of S23's `label_definitions_by_kind` (same `const KIND_ORDER`, same
+`flat_map`/`filter` pass), and stays **command-aware** like S21. `resolved_references_by_kind` reads
+only that `resolved` list and groups it by `target_kind` in a **fixed, document-independent order** —
+the `LabelKind` enum declaration order (`Section`, `Table`, `Figure`, `Equation`, `Inline`, the SAME
+slice S23 uses), iterated as an explicit slice rather than a hash map, so the group order is
+deterministic. Within each kind, refs keep their existing pre-order. Each line is
+`[<kind>] \<command>{<key>}` — the `<kind>` tag from the ref's `target_kind.as_str()`, the `<command>`
+the ref's own (so `\eqref`/`\pageref` render as themselves), the `<key>` from the owned key (no source
+slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). A kind
+with no resolved refs contributes no lines (no empty `[table]` header).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:main} x=1 \end{equation}
+\ref{sec:intro} \eqref{eq:main} \pageref{sec:intro}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.resolved_references_by_kind(),
+    // grouped in the fixed kind order: both section refs (in pre-order), then the equation ref
+    "[section] \\ref{sec:intro}\n[section] \\pageref{sec:intro}\n[equation] \\eqref{eq:main}",
+);
+```
+
+A document with no resolved references (every ref dangles, or there are none) renders the **same** fixed
+`(no resolved references)` marker S21 uses. Purely additive — reuses `resolve_references`, mutates
+nothing, leaves every S1–S23 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2396,6 +2396,125 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **resolved (successfully-matched) references grouped by the [`LabelKind`] they resolved
+    /// TO** (LTXDOC03 S24) — the exact by-kind grouping companion of S21's
+    /// [`resolved_references_by_source`](Document::resolved_references_by_source), the same discipline
+    /// S23's [`label_definitions_by_kind`](Document::label_definitions_by_kind) brings to the *label
+    /// definitions* family. Where S21 lists the resolved references flat in source order, S24 buckets
+    /// the **same** resolved references by the *kind of node each one pointed at*, so a reader can see,
+    /// at a glance, which references land on sections, which on equations, which on bare inline labels.
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] walks every `\ref`/`\eqref`/`\pageref` in body pre-order
+    /// and splits them into the **resolved** references (those a `\label` defines — recorded in
+    /// [`ReferenceResolution::resolved`] as a [`ResolvedRef`]) and the **unresolved** references
+    /// (LaTeX's *"Reference `key' undefined"*, the `??` in the output). Each [`ResolvedRef`] carries
+    /// its `key`, the `command` that was used (`"ref"` / `"eqref"` / `"pageref"`), and the
+    /// [`LabelKind`] (`target_kind`) of the definition it bound to. S21 renders that `resolved` list
+    /// **flat**, one `\<command>{key}` per line in source pre-order. S24 renders the *same* `resolved`
+    /// list **grouped by `target_kind`**: it walks the [`LabelKind`] variants in a fixed order and, for
+    /// each kind that has at least one resolved ref, emits every ref that resolved to that kind. S21
+    /// and S24 are two *views* of one underlying list (S21 by source order, S24 by target kind);
+    /// neither mutates anything.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Iterate the [`LabelKind`] variants in their **enum declaration order** —
+    /// [`Section`](LabelKind::Section), [`Table`](LabelKind::Table), [`Figure`](LabelKind::Figure),
+    /// [`Equation`](LabelKind::Equation), [`Inline`](LabelKind::Inline) — a fixed, deterministic order
+    /// that does **not** depend on the document (the SAME `const KIND_ORDER` slice S23 uses). For each
+    /// kind, filter [`ReferenceResolution::resolved`] to the refs whose `target_kind` is that kind,
+    /// **preserving their existing pre-order** within the kind, and emit one line each. This single
+    /// stable-ordered pass (fixed kind order on the outside, pre-order on the inside) keeps the output
+    /// deterministic **without** a hash map — the same `Vec`-scan discipline S17/S18/S23 use to avoid
+    /// hash-order nondeterminism.
+    ///
+    /// Each line has the shape `[<kind>] \<command>{<key>}`, where `<kind>` is the stable lowercase tag
+    /// from [`LabelKind::as_str`] (`"section"`, `"table"`, `"figure"`, `"equation"`, `"inline"`),
+    /// `<command>` is the ref's **own** command (so a resolved `\eqref{eq:m}` renders
+    /// `[equation] \eqref{eq:m}` and a resolved `\pageref{sec:i}` renders `[section] \pageref{sec:i}` —
+    /// the command is **never** hard-coded to `\ref`, matching S21's command-awareness), and `<key>` is
+    /// reconstructed from the ref's **owned `key` `String`** — there is **no** source slicing at all
+    /// (matching S21's `resolved_references_by_source` and S23's `label_definitions_by_kind`). Prefixing
+    /// every line with its `[kind]` makes the per-kind census visible on each line while staying
+    /// one-line-per-ref; the `[kind]` prefix is a report annotation, not source — S24 is a *report*, not
+    /// a round-trippable rendering. A kind with **no** resolved refs produces **no** lines and **no**
+    /// empty header (there is never a bare `[table]` group for a doc that references no tables).
+    /// Dangling references never entered `resolved`, so they are excluded by construction (a
+    /// `\ref{nope}` with no `\label` appears in S18's `unresolved_references_by_source`, not here).
+    ///
+    /// A document with **no** resolved references — every reference dangles, or there are none at all —
+    /// returns the fixed marker `(no resolved references)`, the **same** marker S21 uses (S24 groups
+    /// the identical list, so the empty case is identical), never the empty string (the stable-marker
+    /// discipline S12-S23 share). Lines are joined by `\n` with **no** trailing newline (matching S21's
+    /// `resolved_references_by_source` and every S11-S23 renderer).
+    ///
+    /// Concretely, for a body defining `\label{sec:intro}` (a section) and `\label{eq:main}` (an
+    /// equation) and then writing `\ref{sec:intro}`, `\eqref{eq:main}`, and `\pageref{sec:intro}` (all
+    /// of which resolve), the resolved refs render grouped by target kind (`section` sorts before
+    /// `equation` in the fixed order, so both refs to `sec:intro` lead even though the `\eqref` appears
+    /// between them in source):
+    ///
+    /// ```text
+    /// [section] \ref{sec:intro}
+    /// [section] \pageref{sec:intro}
+    /// [equation] \eqref{eq:main}
+    /// ```
+    ///
+    /// ## Additive by construction
+    ///
+    /// S24 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1-S23 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *second view* of the same `resolved` list
+    /// S21 renders flat — grouping never adds, drops, or reorders resolved references relative to what
+    /// `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// `command` and `key` are already owned `String`s; `ref_span`/`target_span` are not used); a
+    /// single stable-ordered pass (fixed kind order × pre-order filter) over the already-bounded
+    /// `resolved` list. Borrows `self` immutably and returns owned `String` data, so the result
+    /// outlives any borrow of the source.
+    pub fn resolved_references_by_kind(&self) -> String {
+        // S1 already split every `\ref`/`\eqref`/`\pageref` into resolved and dangling entries, routing
+        // the resolved ones into `resolved` (in body pre-order), each carrying its own `command`, `key`,
+        // and `target_kind` (the kind of the label it bound to). We only read that list.
+        let resolution = self.resolve_references();
+
+        if resolution.resolved.is_empty() {
+            // Every reference dangled (or there were none) → the SAME fixed marker S21 uses.
+            return "(no resolved references)".to_string();
+        }
+
+        // The FIXED kind order = the enum declaration order (the SAME slice S23 uses). Iterating this
+        // explicit slice (rather than a hash map keyed by kind) makes the group order deterministic and
+        // document-independent, the same `Vec`-scan discipline S17/S18/S23 use to avoid hash-order
+        // nondeterminism.
+        const KIND_ORDER: [LabelKind; 5] = [
+            LabelKind::Section,
+            LabelKind::Table,
+            LabelKind::Figure,
+            LabelKind::Equation,
+            LabelKind::Inline,
+        ];
+
+        // One stable-ordered pass: for each kind in the fixed order, take the resolved refs whose
+        // `target_kind` is that kind, in their existing pre-order, and emit `[<kind>] \<command>{<key>}`.
+        // A kind with no resolved refs contributes no lines (no empty header). Command is the ref's own,
+        // so `\eqref`/`\pageref` render as themselves; keys are owned, so there is no source slicing.
+        KIND_ORDER
+            .iter()
+            .flat_map(|kind| {
+                resolution
+                    .resolved
+                    .iter()
+                    .filter(move |r| r.target_kind == *kind)
+                    .map(|r| format!("[{}] \\{}{{{}}}", r.target_kind.as_str(), r.command, r.key))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -5821,6 +5940,169 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.label_definitions_by_kind(),
             "[section] \\label{sec:intro}\n[figure] \\label{fig:p}\n[equation] \\label{eq:e}\n[inline] \\label{dup}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S24 — resolved references grouped by the KIND they resolved TO
+    // (`resolved_references_by_kind`). The by-kind grouping companion of S21's flat, source-ordered
+    // `resolved_references_by_source`; two views of one `resolved` list, command-aware.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s24_groups_different_kinds_in_fixed_kind_order() {
+        // A `\ref` to a section and an `\eqref` to an equation → grouped by target kind in the fixed
+        // enum order (Section before Equation), each `[kind] \<command>{key}` (command-aware). Source
+        // order here already matches the fixed kind order.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:m}x=1\end{equation}
+\ref{sec:i} \eqref{eq:m}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:i}\n[equation] \\eqref{eq:m}"
+        );
+    }
+
+    #[test]
+    fn s24_reorders_source_to_fixed_kind_order() {
+        // Source order is the `\eqref` (equation) THEN the `\ref` (section), but the fixed kind order
+        // pulls the section ahead of the equation — proving S24 groups by target kind rather than
+        // echoing source order.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:m}x=1\end{equation}
+\eqref{eq:m} \ref{sec:i}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:i}\n[equation] \\eqref{eq:m}"
+        );
+    }
+
+    #[test]
+    fn s24_same_kind_grouped_in_preorder_command_aware() {
+        // Two refs to the SAME section (a `\ref` then a `\pageref`) → listed together under `section`,
+        // in their existing pre-order (`\ref` before `\pageref`), each preserving its own command. Only
+        // the `section` group appears; no empty groups for other kinds.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \pageref{sec:i}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:i}\n[section] \\pageref{sec:i}"
+        );
+    }
+
+    #[test]
+    fn s24_only_dangling_or_none_returns_marker() {
+        // A document whose only reference dangles (`\ref{nope}` with no `\label`) → the fixed
+        // `(no resolved references)` marker S21 uses, never the empty string.
+        let dangling = r"\begin{document}\ref{nope}\end{document}";
+        let doc = parse_document(dangling).expect("parse");
+        assert_eq!(doc.resolved_references_by_kind(), "(no resolved references)");
+
+        // And a document with no references at all → the SAME marker.
+        let none = r"\begin{document}Just some text with no references.\end{document}";
+        let doc = parse_document(none).expect("parse");
+        assert_eq!(doc.resolved_references_by_kind(), "(no resolved references)");
+    }
+
+    #[test]
+    fn s24_newline_join_no_trailing_newline_excludes_dangling() {
+        // A `\ref` to a section, an `\eqref` to an equation, plus a DANGLING `\ref{nope}` →
+        // exact string equality pins the `\n`-join with NO trailing newline, the fixed kind order
+        // (Section then Equation), AND that the dangling `\ref{nope}` is excluded (it never entered
+        // `resolved`).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:m}x=1\end{equation}
+\ref{sec:i} \eqref{eq:m} \ref{nope}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:i}\n[equation] \\eqref{eq:m}"
+        );
+        // The dangling ref shows up in S18, confirming it was routed to `unresolved`, not `resolved`.
+        assert_eq!(doc.unresolved_references_by_source(), "\\ref{nope}");
+    }
+
+    #[test]
+    fn s24_is_additive_leaves_s1_s23_outputs_unchanged() {
+        // Same representative doc as the S23 additive test. S24 changes NONE of the S1-S23 outputs — it
+        // only reads `resolve_references`. S21's flat `resolved_references_by_source` and S24's grouped
+        // `resolved_references_by_kind` are two views of the SAME `resolved` list; both are pinned here
+        // to show S24 neither adds, drops, nor reorders relative to S21.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\eqref{eq:e} -> Equation (1)\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\nEquations:\n  \\eqref{eq:e} -> Equation (1)"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S20 losing duplicate labels — unchanged.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // S21 resolved references (flat, source order) — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+        // S22 flat winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S23 grouped winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:intro}\n[figure] \\label{fig:p}\n[equation] \\label{eq:e}\n[inline] \\label{dup}"
+        );
+
+        // And S24 itself: the SAME resolved refs S21 lists flat, now grouped by target kind in the
+        // fixed enum order. The `\ref{sec:intro}` (section) leads, then the `\eqref{eq:e}` (equation);
+        // the `\eqref{eq:ghost}` dangled and never entered `resolved`. `\n`-joined, no trailing newline.
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:intro}\n[equation] \\eqref{eq:e}"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -1912,3 +1912,98 @@ with no trailing newline; and an additivity check that `to_plain_text`, `to_plai
 `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p
 adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 30. S24 — resolved references grouped by target kind (`resolved_references_by_kind`)
+
+### 30.1 Motivation
+
+S21 (`resolved_references_by_source`) renders the **resolved** `\ref`/`\eqref`/`\pageref` references
+**flat** — one reconstructed `\<command>{key}` line per resolved reference, in `walk` pre-order. But each
+resolved reference also carries a `target_kind` (`Section`, `Table`, `Figure`, `Equation`, or `Inline`) —
+the `LabelKind` of the definition it bound to — and a reader often wants the resolved references
+organised **by that kind**: a per-kind census answering "which of my references land on sections? which
+on equations? which on bare inline labels?" at a glance. The label family already got its by-kind
+grouping in S23 (`label_definitions_by_kind`, the by-kind companion of S22's flat `label_definitions`);
+S24 brings the *same* discipline to the **resolved-references** family — it is to S21 exactly what S23 is
+to S22.
+
+### 30.2 Why a new method — additive by construction
+
+S24 adds a **new public method** `Document::resolved_references_by_kind(&self) -> String`. It is a pure,
+read-only render of `resolve_references().resolved` — a *second view* of the exact list S21 renders flat.
+It reuses that list verbatim (never re-walking the body or re-resolving references), so the report can
+never drift from the S1 resolution it summarises, and grouping never adds, drops, or reorders references
+relative to what `resolve_references` produced. It mutates nothing and changes no S1–S23 output —
+including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S23 it is a method the caller
+invokes directly.
+
+### 30.3 The ordering rule
+
+The output is ordered by a **fixed, document-independent** kind order — the `LabelKind` enum declaration
+order: `Section`, `Table`, `Figure`, `Equation`, `Inline` (the **same** `const KIND_ORDER` slice S23
+uses). S24 iterates that order as an explicit slice (**not** a hash map keyed by kind), so the group
+order is deterministic and never depends on document content or hash iteration order — the same
+`Vec`-scan discipline S17/S18/S23 use to avoid hash-order nondeterminism. **Within** each kind, the
+resolved references keep their existing `resolved` pre-order; grouping never reorders within a kind. A
+kind with **no** resolved references produces **no** lines (there is never an empty `[table]` group for a
+doc that references no tables).
+
+### 30.4 The exact rendering contract — `Document::resolved_references_by_kind(&self) -> String`
+
+- Iterate the fixed kind order (`Section`, `Table`, `Figure`, `Equation`, `Inline`). For each kind, take
+  the resolved references whose `target_kind` is that kind from `resolve_references().resolved` in their
+  existing pre-order and emit one line each:
+  `format!("[{}] \\{}{{{}}}", r.target_kind.as_str(), r.command, r.key)` → `[` + the kind tag + `] \` +
+  the ref's own `command` + `{` + its `key` + `}`. The kind tag comes from `LabelKind::as_str()`
+  (`"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`); the `command` is the reference's **own**
+  (so a resolved `\eqref` renders `\eqref` and a resolved `\pageref` renders `\pageref`, never
+  hard-coded to `\ref` — matching S21's command-awareness); the key is reconstructed from the owned `key`
+  `String` rather than sliced from `&src[span]` (matching S21 `resolved_references_by_source` and S23
+  `label_definitions_by_kind`), so the render needs no source borrow and can never index out of bounds
+  (`ref_span`/`target_span` are unused).
+- The `[kind]` prefix makes the per-kind census visible on every line while staying one-line-per-ref; it
+  is a **report annotation**, not round-trippable LaTeX (S24 is a *report*).
+- Dangling references never entered `resolved`, so they are excluded by construction (a `\ref{nope}` with
+  no `\label` appears in S18's `unresolved_references_by_source`, not here).
+- A kind with no resolved references contributes no lines and no empty header.
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S23 renderer).
+- If there are **no** resolved references at all (every reference dangles, or there are none), the fixed
+  marker `(no resolved references)` is returned — the **same** marker S21 uses (S24 groups the identical
+  list), so the output is never the empty string.
+
+Example (body defining a section label `sec:intro` and an equation label `eq:main`, then writing
+`\ref{sec:intro}`, `\eqref{eq:main}`, and `\pageref{sec:intro}` — all of which resolve):
+
+```text
+[section] \ref{sec:intro}
+[section] \pageref{sec:intro}
+[equation] \eqref{eq:main}
+```
+
+Both references to `sec:intro` (kind `Section`) lead — in their pre-order, `\ref` before `\pageref` —
+even though the `\eqref` appears between them in source, because `Section` sorts before `Equation` in the
+fixed kind order. This is the by-kind grouping companion of S21's flat resolved-references list — two
+views of the one `resolved` list.
+
+### 30.5 Public API (added in S24)
+
+One new method: `Document::resolved_references_by_kind(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_references` and every S1–S23 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 30.6 Verification (S24)
+
+`cargo test -p latex` green (6 new S24 tests: a `\ref`-to-section + `\eqref`-to-equation case rendering
+grouped in the fixed kind order; a source-order-reversed case proving the fixed kind order pulls the
+section ahead of an earlier equation; two same-section refs (`\ref` then `\pageref`) grouped together in
+pre-order under `section`, command-aware; a dangling-only and a no-references case both returning the
+`(no resolved references)` marker; a section+equation case with a trailing dangling `\ref{nope}` pinning
+the `\n`-join with no trailing newline and confirming the dangling ref is excluded; and an additivity
+check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`,
+`list_summary`, `citations_by_source`, `duplicate_bibliography_entries`,
+`unresolved_citations_by_source`, `unresolved_references_by_source`, `bibliography_entries`,
+`duplicate_label_definitions`, `resolved_references_by_source`, `label_definitions`, and S23's grouped
+`label_definitions_by_kind` all still produce their exact prior strings). All prior S1–S23 tests pass
+unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
+-p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S24 — `resolved_references_by_kind` (latex 0.60.0)

Adds one additive, read-only cross-reference report renderer to the zero-dependency `latex` crate: the **resolved references grouped by the kind of label they resolved to**.

### What it does

```rust
pub fn resolved_references_by_kind(&self) -> String
```

Groups the resolved `\ref`/`\eqref`/`\pageref` references by the `LabelKind` (Section, Table, Figure, Equation, Inline) of the label each one bound to (`ResolvedRef::target_kind`), and renders each as `[<kind>] \<command>{<key>}` — command-aware, so `\eqref`/`\pageref` render as themselves. Kinds are emitted in the fixed enum-declaration order; within each kind, refs stay in source pre-order:

```
[section] \ref{sec:intro}
[equation] \eqref{eq:main}
[section] \pageref{sec:intro}
```

It is the by-kind grouping companion to **S23** `label_definitions_by_kind` (which groups the winning *label definitions*), applied instead to the **resolved-references** list — and the command-aware rendering mirrors **S21** `resolved_references_by_source`.

- Only kinds that have at least one resolved ref appear (no empty groups).
- Dangling references (in `unresolved`, S18's domain) are excluded by construction.
- A document with no resolved references returns the fixed marker `(no resolved references)` (the same marker S21 uses), never the empty string. Lines join with `\n`, no trailing newline.

### Guarantees

- **Additive**: a brand-new read-only method reusing `resolve_references()`; every S1–S23 output is byte-for-byte unchanged (pinned by `s24_is_additive_leaves_s1_s23_outputs_unchanged`), and the `to_latex` round-trip fixed point is intact.
- **Total & panic-free**: no `unsafe`, no `unwrap`/`expect`, no indexing/slicing (keys are owned `String`s; spans unused); a stable-ordered pass over the fixed kind order filtering the already-bounded `resolved` list; borrows `self` immutably and returns owned `String`.

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → all green (S24 tests added)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED

### Docs

- `Cargo.toml` version `0.59.0` → `0.60.0`
- `CHANGELOG.md`, `README.md`, and `LTXDOC03-cross-reference-resolution.md` (new §30 / S24 section) — prior sections byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
