### PR TITLE
feat(latex): LTXDOC03 S25 label_kind_counts census renderer (0.61.0)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.61.0] — 2026-07-08
+
+### Added — per-kind census (counts) of the winning label definitions (LTXDOC03 S25)
+
+A **new** public method `Document::label_kind_counts(&self) -> String` that renders a **per-kind
+CENSUS** of the winning `\label` definitions — one `<kind>: <n>` line per `LabelKind` that has at
+least one winning definition, carrying the integer **count** rather than a list. It is the *count*
+companion of S23's `label_definitions_by_kind` (which renders one `[kind] \label{key}` **line per
+definition**, grouped by kind): S23, S22's flat `label_definitions`, and S25 are three *views* of the
+one winning `definitions` list `resolve_references()` produces — S25 collapses each kind's group to a
+single tally line. It is to S23 what S14's `list_summary` (`"Sections: 1"`) is to a full enumeration:
+a numeric summary. It is a read-only view over `resolve_references()`; every S1–S24 output is left
+**byte-for-byte unchanged**; S25 is purely additive and leaves the `to_latex()` round-trip fixed point
+intact.
+
+- **Counts the WINNING definitions only.** S25 reads `resolve_references().definitions` — one row per
+  distinct key (the first `\label` of each key). A `\label{dup}` written twice contributes **one** to
+  its kind's count, because its later re-definition is a `Duplicate` (S20's domain), never a second row
+  in `definitions`.
+- **Per-kind counts in a fixed, document-independent order** — the `LabelKind` enum declaration order:
+  `Section`, `Table`, `Figure`, `Equation`, `Inline` (the SAME `const KIND_ORDER` slice S23/S24 use).
+  The method iterates that explicit fixed order (not a hash map keyed by kind), so the line order is
+  deterministic — the same `Vec`-scan discipline S17/S18/S23/S24 use to avoid hash-order nondeterminism.
+- **`<kind>: <n>` line shape.** Each line is the stable lowercase tag from `LabelKind::as_str()` (the
+  SAME kind string S23 renders — `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`) + `": "` +
+  the decimal count of winning definitions of that kind. There is **no** source slicing at all (only
+  the `kind` field is read).
+- **Zero-count kinds omitted.** A kind with no winning definitions contributes no line (there is never
+  a bare `table: 0` for a doc with no table labels).
+- **Stable empty marker.** No winning label definitions at all → the **same** fixed string
+  `(no label definitions)` S22/S23 use, never the empty string — the stable-marker discipline S12–S24
+  share.
+- **`\n`-joined, no trailing newline** — matching S23's `label_definitions_by_kind` and every S11–S24
+  renderer.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single
+  stable-ordered pass (fixed kind order × pre-order filter/count) over the already-bounded
+  `definitions` list. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s25_counts_multiple_kinds_in_fixed_kind_order_zero_kinds_omitted`,
+  `s25_exactly_one_kind`, `s25_no_labels_returns_marker`,
+  `s25_duplicate_definitions_count_only_the_winner`, `s25_newline_join_no_trailing_newline`, and
+  `s25_is_additive_leaves_s1_s24_outputs_unchanged` (which pins every S1–S24 output byte-for-byte,
+  including S22's flat `label_definitions` and S23's grouped `label_definitions_by_kind`, alongside the
+  new per-kind counts).
+
 ## [0.60.0] — 2026-07-08
 
 ### Added — resolved references grouped by target kind (LTXDOC03 S24)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.60.0"
+version = "0.61.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -72,6 +72,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S22 — winning `\label` definitions** | `Document::label_definitions() -> String` — a **new**, read-only method that renders the **winning** label definitions — the `\label{key}` definitions references resolve against, one `\label{key}` line per distinct key — the **label-family analogue of S19's** `bibliography_entries` (which renders the winning `\bibitem` entries) and the **winning-side counterpart of S20's** `duplicate_label_definitions` (which renders the *losing* duplicate `\label`s). It reads only `resolve_references().definitions`: S1 collects every `\label` in pre-order; the **first** of each key wins (into `definitions`, one row per distinct key) and every **later** `\label` of an already-defined key goes to `duplicates` (S20's domain). S22 emits one line per winning definition in that pre-order (**not** re-sorted, **not** de-duplicated — none needed, since `definitions` already holds one row per distinct key), each reconstructed from its key as `\label{<key>}` (no source slicing; the `\label{…}` form is right for any `LabelKind`). A `\label{dup}` written twice appears **once** — the winner. Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the fixed marker `(no label definitions)`. E.g. `sec:intro` (section), `eq:main` (equation), then a re-used `sec:intro` → `\label{sec:intro}\n\label{eq:main}` (winner once). Every S1–S21 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S23 — winning `\label` definitions grouped by kind** | `Document::label_definitions_by_kind() -> String` — a **new**, read-only method that renders the **winning** `\label` definitions **grouped by their `LabelKind`** — a per-kind census — the **by-kind grouping companion of S22's** `label_definitions` (which lists the same winning definitions *flat*); S22 and S23 are two views of the one winning `definitions` list. It reads only `resolve_references().definitions` and groups by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — iterated as an explicit slice, not a hash map, so the order is deterministic like S17/S18's `Vec`-of-groups). Within each kind, definitions keep their existing pre-order. Each line is `[<kind>] \label{<key>}` — `<kind>` from `LabelKind::as_str()` (`"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<key>` from the owned key (no source slicing). A kind with no definitions contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22 uses. E.g. `sec:intro` (section), `eq:main` (equation), `note` (inline) → `[section] \label{sec:intro}\n[equation] \label{eq:main}\n[inline] \label{note}`. Every S1–S22 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S24 — resolved references grouped by target kind** | `Document::resolved_references_by_kind() -> String` — a **new**, read-only method that renders the **resolved** `\ref`/`\eqref`/`\pageref` references **grouped by the `LabelKind` they resolved TO** — a per-kind census — the **by-kind grouping companion of S21's** `resolved_references_by_source` (which lists the same resolved refs *flat*, in source order); S21 and S24 are two views of the one `resolved` list. It mirrors S23's `label_definitions_by_kind` idiom but over the **resolved-references** list, and stays **command-aware** like S21. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23 uses, iterated explicitly, not a hash map, so the order is deterministic). Within each kind, refs keep their existing pre-order. Each line is `[<kind>] \<command>{<key>}` — `<kind>` from the ref's `target_kind.as_str()`, `<command>` the ref's own (so `\eqref`/`\pageref` render as themselves), `<key>` from the owned key (no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). A kind with no resolved refs contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21 uses. E.g. `\ref{sec:intro}` (section), `\eqref{eq:main}` (equation), `\pageref{sec:intro}` (section) → `[section] \ref{sec:intro}\n[section] \pageref{sec:intro}\n[equation] \eqref{eq:main}`. Every S1–S23 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S25 — per-kind census (counts) of the winning `\label` definitions** | `Document::label_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the winning `\label` definitions: one `<kind>: <n>` line per `LabelKind` that has at least one winning definition, carrying the integer **count** (not a list) — the **count companion of S23's** `label_definitions_by_kind` (which renders one `[kind] \label{key}` *line per definition*). S22's flat `label_definitions`, S23's grouped list, and S25's counts are three views of the one winning `definitions` list; S25 collapses each kind's group to a single tally line (it is to S23 what S14's `list_summary` is to a full enumeration). It reads only `resolve_references().definitions` (one row per distinct key — the WINNER; a `\label{dup}` written twice counts **once**, its later copy being a `Duplicate` in S20's domain) and counts by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S23 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22/S23 use. E.g. `sec:intro` (section), `eq:a`/`eq:b` (equations), `note` (inline) → `section: 1\nequation: 2\ninline: 1`. Every S1–S24 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -990,6 +991,42 @@ assert_eq!(
 A document with no resolved references (every ref dangles, or there are none) renders the **same** fixed
 `(no resolved references)` marker S21 uses. Purely additive — reuses `resolve_references`, mutates
 nothing, leaves every S1–S23 output and the `to_latex()` fixed point unchanged.
+
+### per-kind census (counts) of the winning `\label` definitions (LTXDOC03 S25)
+
+A **per-kind CENSUS** of the winning `\label` definitions — one `<kind>: <n>` line per `LabelKind`
+that has at least one winning definition, carrying the integer **count** rather than a list — the
+**count companion of S23's** `label_definitions_by_kind` (which renders one `[kind] \label{key}` line
+*per definition*, grouped by kind). S22's flat `label_definitions`, S23's grouped list, and S25's
+counts are three *views* of the one winning `definitions` list `resolve_references()` produces; S25
+collapses each kind's group to a single tally line. It is to S23 what S14's `list_summary`
+(`"Sections: 1"`) is to a full enumeration: a numeric summary. `label_kind_counts` reads only that
+`definitions` list — one row per distinct key, the WINNER (a `\label{dup}` written twice counts
+**once**, its later copy being a `Duplicate` in S20's domain) — and counts by kind in a **fixed,
+document-independent order** (the `LabelKind` enum declaration order: `Section`, `Table`, `Figure`,
+`Equation`, `Inline`, the SAME slice S23/S24 use), iterated as an explicit slice rather than a hash
+map, so the line order is deterministic. Each line is `<kind>: <n>` — the `<kind>` tag from
+`LabelKind::as_str()` (the SAME tag S23 renders), the `<n>` the decimal count (no source slicing). A
+kind with a zero count contributes no line (no bare `table: 0`).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:a} x=1 \end{equation}
+\begin{equation}\label{eq:b} y=2 \end{equation}
+\label{note}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.label_kind_counts(),
+    // one count line per non-empty kind, in the fixed kind order (Table/Figure omitted — zero)
+    "section: 1\nequation: 2\ninline: 1",
+);
+```
+
+A document with no label definitions renders the **same** fixed `(no label definitions)` marker
+S22/S23 use (S25 counts the identical list). Purely additive — reuses `resolve_references`, mutates
+nothing, leaves every S1–S24 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2515,6 +2515,114 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **per-kind CENSUS of the winning label definitions** (LTXDOC03 S25) — the *count*
+    /// companion of S23's [`label_definitions_by_kind`](Document::label_definitions_by_kind). Where
+    /// S23 renders one **line per definition** (a `[kind] \label{key}` list, grouped by kind), S25
+    /// renders one **line per kind** carrying just the integer **count** of winning definitions of
+    /// that kind — a `<kind>: <n>` tally, not a list. It is to S23 what S14's
+    /// [`list_summary`](Document::list_summary) (`"Sections: 1"`) is to a full enumeration: a numeric
+    /// summary over the *same* winning `definitions` list, so a reader sees "how many of each kind"
+    /// without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] collects the **winning** first definition of each `\label`
+    /// key into [`ReferenceResolution::definitions`] — one row per distinct key, in
+    /// [`Document::walk`] pre-order, each tagged with the [`LabelKind`] of the node it defines (a
+    /// re-`\label`ed section, table, figure, equation, or bare inline label). S22's
+    /// [`label_definitions`](Document::label_definitions) renders that list flat; S23's
+    /// [`label_definitions_by_kind`](Document::label_definitions_by_kind) renders it grouped by kind,
+    /// still one line per definition. S25 collapses each kind's group to a **single count line**: it
+    /// walks the [`LabelKind`] variants in a fixed order and, for each kind that has **at least one**
+    /// winning definition, emits `<kind>: <n>` where `<n>` is how many winning definitions carry that
+    /// kind. Only the winning `definitions` are counted — a `\label{dup}` written twice contributes
+    /// **one** to its kind's count, because its later re-definition is a [`Duplicate`] (S20's domain),
+    /// never a second row in `definitions`. S23 and S25 are two *views* of one underlying list (S23 the
+    /// per-definition list, S25 the per-kind count); neither mutates anything.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Iterate the [`LabelKind`] variants in their **enum declaration order** —
+    /// [`Section`](LabelKind::Section), [`Table`](LabelKind::Table), [`Figure`](LabelKind::Figure),
+    /// [`Equation`](LabelKind::Equation), [`Inline`](LabelKind::Inline) — a fixed, deterministic order
+    /// that does **not** depend on the document (the SAME `const KIND_ORDER` slice S23/S24 use). For
+    /// each kind, count the [`ReferenceResolution::definitions`] whose `kind` is that kind, and — only
+    /// if the count is **at least one** — emit one line `<kind>: <n>`, where `<kind>` is the stable
+    /// lowercase tag from [`LabelKind::as_str`] (`"section"`, `"table"`, `"figure"`, `"equation"`,
+    /// `"inline"`) — the **same** kind string S23 renders — and `<n>` is the decimal count. This single
+    /// stable-ordered pass keeps the output deterministic **without** a hash map — the same `Vec`-scan
+    /// discipline S17/S18/S23/S24 use to avoid hash-order nondeterminism. A kind with a **zero** count
+    /// produces **no** line (there is never a bare `table: 0` for a doc with no table labels).
+    ///
+    /// A document with **no** winning label definitions at all returns the fixed marker
+    /// `(no label definitions)` — the **same** marker S22/S23 use (S25 counts the identical list, so
+    /// the empty case is identical), never the empty string (the stable-marker discipline S12–S24
+    /// share). Lines are joined by `\n` with **no** trailing newline (matching every S11–S24 renderer).
+    ///
+    /// Concretely, for a body defining a section label `sec:intro`, two equation labels `eq:a`/`eq:b`,
+    /// and a bare inline label `note`:
+    ///
+    /// ```text
+    /// section: 1
+    /// equation: 2
+    /// inline: 1
+    /// ```
+    ///
+    /// (the `section` count leads, then `equation`, then `inline`, in the fixed kind order; the `table`
+    /// and `figure` kinds have zero definitions and so contribute no lines).
+    ///
+    /// ## Additive by construction
+    ///
+    /// S25 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1–S24 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *third view* of the same winning
+    /// `definitions` list S22 renders flat and S23 groups by kind — counting never adds, drops, or
+    /// reorders definitions relative to what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only the `kind` field is read); a single stable-ordered pass (fixed kind order × pre-order
+    /// filter/count) over the already-bounded `definitions` list. Borrows `self` immutably and returns
+    /// owned `String` data, so the result outlives any borrow of the source.
+    pub fn label_kind_counts(&self) -> String {
+        // S1 already collected the winning definitions — the first `\label` of each distinct key, in
+        // body pre-order, each tagged with its `LabelKind`. We only read (and count) that list.
+        let resolution = self.resolve_references();
+
+        if resolution.definitions.is_empty() {
+            // No `\label` at all → the SAME fixed marker S22/S23 use (S25 counts the identical list).
+            return "(no label definitions)".to_string();
+        }
+
+        // The FIXED kind order = the enum declaration order (the SAME slice S23/S24 use). Iterating this
+        // explicit slice (rather than a hash map keyed by kind) makes the line order deterministic and
+        // document-independent, the same `Vec`-scan discipline S17/S18/S23/S24 use to avoid hash-order
+        // nondeterminism.
+        const KIND_ORDER: [LabelKind; 5] = [
+            LabelKind::Section,
+            LabelKind::Table,
+            LabelKind::Figure,
+            LabelKind::Equation,
+            LabelKind::Inline,
+        ];
+
+        // One stable-ordered pass: for each kind in the fixed order, count the definitions of that kind
+        // and — only when the count is >= 1 — emit `<kind>: <n>`. A kind with zero definitions is
+        // filtered out (`filter` on `count > 0`), so it contributes no line. The kind string is the
+        // SAME `LabelKind::as_str` tag S23 renders; there is no source slicing (only `kind` is read).
+        KIND_ORDER
+            .iter()
+            .filter_map(|kind| {
+                let count = resolution
+                    .definitions
+                    .iter()
+                    .filter(|def| def.kind == *kind)
+                    .count();
+                (count > 0).then(|| format!("{}: {}", kind.as_str(), count))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -6103,6 +6211,169 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.resolved_references_by_kind(),
             "[section] \\ref{sec:intro}\n[equation] \\eqref{eq:e}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S25 — per-kind CENSUS (counts) of the winning label definitions (`label_kind_counts`).
+    // The count companion of S23's `label_definitions_by_kind`: one `<kind>: <n>` line per kind (in
+    // the fixed enum order), a numeric summary over the SAME winning `definitions` list.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s25_counts_multiple_kinds_in_fixed_kind_order_zero_kinds_omitted() {
+        // A section label, two equation labels, and a bare inline label → one `<kind>: <n>` line per
+        // kind in the fixed enum order (Section, then Equation, then Inline). The Table and Figure
+        // kinds have zero definitions and so contribute NO lines (never `table: 0`).
+        let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:a}x=1\end{equation}
+\begin{equation}\label{eq:b}y=2\end{equation}
+\label{note}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nequation: 2\ninline: 1"
+        );
+    }
+
+    #[test]
+    fn s25_exactly_one_kind() {
+        // Two inline labels of the SAME (and only) kind → a single `inline: 2` line. No other kinds,
+        // no trailing newline.
+        let src = r"\begin{document}\label{a}
+
+\label{b}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_kind_counts(), "inline: 2");
+    }
+
+    #[test]
+    fn s25_no_labels_returns_marker() {
+        // A document with no `\label` at all → the same fixed `(no label definitions)` marker S22/S23
+        // use, never the empty string.
+        let src = r"\begin{document}Just some text with no labels.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_kind_counts(), "(no label definitions)");
+    }
+
+    #[test]
+    fn s25_duplicate_definitions_count_only_the_winner() {
+        // `dup` is `\label`ed TWICE (inline); only the WINNING first definition is in `definitions`,
+        // the loser is a duplicate (S20's domain). So the inline count is 1, NOT 2 — S25 counts winning
+        // definitions, never duplicates. A distinct `once` inline label makes the winning inline count 2.
+        let src = r"\begin{document}First \label{dup} here.
+
+Second \label{dup} there.
+
+\label{once}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        // Two DISTINCT winning inline keys (`dup` once as the winner, `once`) → inline: 2.
+        assert_eq!(doc.label_kind_counts(), "inline: 2");
+        // Confirm the losing re-`\label{dup}` was routed to duplicates (S20), not counted here.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+    }
+
+    #[test]
+    fn s25_newline_join_no_trailing_newline() {
+        // A section + figure + inline label → exact string equality pins the `\n`-join with NO trailing
+        // newline, and the fixed kind order (Section, then Figure, then Inline — Table and Equation
+        // absent), each line a `<kind>: 1` count.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{figure}\includegraphics{p.png}\caption{P}\label{fig:p}\end{figure}
+
+\label{note}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nfigure: 1\ninline: 1"
+        );
+    }
+
+    #[test]
+    fn s25_is_additive_leaves_s1_s24_outputs_unchanged() {
+        // Same representative doc as the S24 additive test. S25 changes NONE of the S1-S24 outputs — it
+        // only reads `resolve_references`. S22's flat `label_definitions`, S23's grouped
+        // `label_definitions_by_kind`, and S25's per-kind counts are three views of the SAME winning
+        // `definitions` list; all are pinned here to show S25 neither adds, drops, nor reorders, and
+        // that its counts agree with S23's grouping.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\eqref{eq:e} -> Equation (1)\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\nEquations:\n  \\eqref{eq:e} -> Equation (1)"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S20 losing duplicate labels — unchanged.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // S21 resolved references (flat, source order) — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+        // S22 flat winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S23 grouped winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:intro}\n[figure] \\label{fig:p}\n[equation] \\label{eq:e}\n[inline] \\label{dup}"
+        );
+        // S24 grouped resolved references — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:intro}\n[equation] \\eqref{eq:e}"
+        );
+
+        // And S25 itself: the per-kind COUNTS of the SAME winning definitions, in the fixed enum order.
+        // One section (`sec:intro`), one figure (`fig:p`), one equation (`eq:e`), one winning inline
+        // (`dup` — its second `\label` is a duplicate, not a second definition). `\n`-joined, no
+        // trailing newline. Table has zero definitions and so is omitted.
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nfigure: 1\nequation: 1\ninline: 1"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2007,3 +2007,87 @@ check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_
 unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
 -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 31. S25 — per-kind census (counts) of the winning label definitions (`label_kind_counts`)
+
+### 31.1 Motivation
+
+S23 (`label_definitions_by_kind`) groups the **winning** `\label` definitions by their `LabelKind` and
+renders one **line per definition** (`[kind] \label{key}`). But a reader often wants not the enumeration
+but the **tally** — "how many sections do I define? how many equations? how many bare inline labels?" —
+a per-kind *count* answered at a glance, without scanning the individual keys. S14 (`list_summary`)
+already provides exactly this shape (`"Sections: 1"`) over S4's numbered-node census; S25 brings the same
+numeric-summary discipline to the **label-definitions** family. It is to S23 what a count is to a full
+list: the *same* winning `definitions` list, collapsed to one line per kind.
+
+### 31.2 Why a new method — additive by construction
+
+S25 adds a **new public method** `Document::label_kind_counts(&self) -> String`. It is a pure, read-only
+render of `resolve_references().definitions` — a *third view* of the exact list S22 renders flat and S23
+groups by kind. It reuses that list verbatim (never re-walking the body or re-resolving), so the report
+can never drift from the S1 resolution it summarises, and counting never adds, drops, or reorders
+definitions relative to what `resolve_references` produced. It mutates nothing and changes no S1–S24
+output — including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S24 it is a method the
+caller invokes directly.
+
+### 31.3 The ordering rule
+
+The output is ordered by a **fixed, document-independent** kind order — the `LabelKind` enum declaration
+order: `Section`, `Table`, `Figure`, `Equation`, `Inline` (the **same** `const KIND_ORDER` slice S23/S24
+use). S25 iterates that order as an explicit slice (**not** a hash map keyed by kind), so the line order
+is deterministic and never depends on document content or hash iteration order — the same `Vec`-scan
+discipline S17/S18/S23/S24 use to avoid hash-order nondeterminism. A kind with a **zero** count produces
+**no** line (there is never a bare `table: 0` for a doc with no table labels).
+
+### 31.4 The exact rendering contract — `Document::label_kind_counts(&self) -> String`
+
+- Iterate the fixed kind order (`Section`, `Table`, `Figure`, `Equation`, `Inline`). For each kind, count
+  the `resolve_references().definitions` whose `kind` is that kind and — only if the count is **at least
+  one** — emit one line `format!("{}: {}", kind.as_str(), count)` → the kind tag + `": "` + the decimal
+  count. The kind tag comes from `LabelKind::as_str()` (`"section"`/`"table"`/`"figure"`/`"equation"`/
+  `"inline"`) — the **same** kind string S23 renders — and there is **no** source slicing at all (only the
+  `kind` field is read; keys/spans are unused), so the render needs no source borrow and can never index
+  out of bounds.
+- Only the **winning** definitions are counted. `definitions` holds one row per distinct key (the first
+  `\label` of each key); a `\label{dup}` written twice contributes **one** to its kind's count, because
+  its later re-definition is a `Duplicate` (S20's domain), never a second row in `definitions`.
+- A kind with a zero count contributes no line and no empty header.
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S24 renderer).
+- If there are **no** winning label definitions at all, the fixed marker `(no label definitions)` is
+  returned — the **same** marker S22/S23 use (S25 counts the identical list), so the output is never the
+  empty string.
+
+Example (body defining a section label `sec:intro`, two equation labels `eq:a`/`eq:b`, and a bare inline
+label `note`):
+
+```text
+section: 1
+equation: 2
+inline: 1
+```
+
+The `section` count leads, then `equation`, then `inline`, in the fixed kind order; the `table` and
+`figure` kinds have zero definitions and so contribute no lines. This is the count companion of S23's
+per-definition grouping — a third view of the one winning `definitions` list.
+
+### 31.5 Public API (added in S25)
+
+One new method: `Document::label_kind_counts(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_references` and every S1–S24 method are unchanged; no AST or grammar change;
+no new dependency, no `unsafe`, no I/O.
+
+### 31.6 Verification (S25)
+
+`cargo test -p latex` green (6 new S25 tests: a section + two-equation + inline case rendering the
+per-kind counts in the fixed kind order with the zero-count kinds omitted; a single-kind case
+(`inline: 2`); a no-labels case returning the `(no label definitions)` marker; a duplicate-`\label` case
+proving only the WINNING definition is counted (the loser routed to S20's `duplicate_label_definitions`);
+a section + figure + inline case pinning the `\n`-join with no trailing newline; and an additivity check
+that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namerefs`, `list_summary`,
+`citations_by_source`, `duplicate_bibliography_entries`, `unresolved_citations_by_source`,
+`unresolved_references_by_source`, `bibliography_entries`, `duplicate_label_definitions`,
+`resolved_references_by_source`, `label_definitions`, S23's `label_definitions_by_kind`, and S24's
+`resolved_references_by_kind` all still produce their exact prior strings). All prior S1–S24 tests pass
+unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
+-p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S25 — `label_kind_counts` (latex 0.61.0)

Adds one additive, read-only cross-reference report renderer to the zero-dependency `latex` crate: a **per-kind count/census of winning label definitions**.

### What it does

```rust
pub fn label_kind_counts(&self) -> String
```

Counts the winning label definitions from `resolve_references().definitions`, groups them by `LabelKind`, and emits one `<kind>: <n>` line per kind that has at least one definition, in the fixed enum-declaration `KIND_ORDER` (Section, Table, Figure, Equation, Inline):

```
section: 3
figure: 1
equation: 2
```

It is the **count/census** companion to **S23** `label_definitions_by_kind` (which *lists* the winning definitions grouped by kind) — the same `LabelKind::as_str()` mapping S23 uses, applied to produce numbers instead of lists.

- Only kinds with ≥1 winning definition appear (no zero lines).
- Duplicate `\label`s never enter `definitions` (they become duplicates, S20's domain), so the count is winning-definitions-only by construction.
- A document with no label definitions returns the fixed marker `(no label definitions)` (the same marker S22/S23 use), never the empty string. Lines join with `\n`, no trailing newline.

### Guarantees

- **Additive**: a brand-new read-only method reusing `resolve_references()`; every S1–S24 output is byte-for-byte unchanged (pinned by `s25_is_additive_leaves_s1_s24_outputs_unchanged`), and the `to_latex` round-trip fixed point is intact.
- **Total & panic-free**: no `unsafe`, no `unwrap`/`expect` on parsed input, no indexing/slicing (spans/bytes never touched; `LabelKind` is a `Copy` closed enum, `as_str()` is total); a stable-ordered pass over the fixed 5-element kind order filtering the already-bounded `definitions` list. Output is bounded to at most 5 lines regardless of input size. Borrows `self` immutably, returns owned `String`.

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → 437 passed + doctest (6 new `s25_*` tests)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED

### Docs

- `Cargo.toml` version `0.60.0` → `0.61.0`
- `CHANGELOG.md`, `README.md`, and `LTXDOC03-cross-reference-resolution.md` (new S25 section) — prior sections byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
