### PR TITLE
feat(latex): LTXDOC03 S26 resolved_reference_kind_counts census renderer (0.62.0)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.62.0] — 2026-07-08
+
+### Added — per-kind census (counts) of the resolved references (LTXDOC03 S26)
+
+A **new** public method `Document::resolved_reference_kind_counts(&self) -> String` that renders a
+**per-kind CENSUS** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — one `<kind>: <n>` line per
+`LabelKind` that has at least one resolved ref, carrying the integer **count** rather than a list. It is
+the *count* companion of S24's `resolved_references_by_kind` (which renders one `[kind] \<command>{key}`
+**line per resolved reference**, grouped by the kind each ref bound to): S24, S21's flat
+`resolved_references_by_source`, and S26 are three *views* of the one `resolved` list
+`resolve_references()` produces — S26 collapses each kind's group to a single tally line. It is to S24
+what S25's `label_kind_counts` is to S23: a numeric summary. It is a read-only view over
+`resolve_references()`; every S1–S25 output is left **byte-for-byte unchanged**; S26 is purely additive
+and leaves the `to_latex()` round-trip fixed point intact.
+
+- **Counts the RESOLVED refs only.** S26 reads `resolve_references().resolved` — each a `ResolvedRef`
+  carrying the `target_kind` (the `LabelKind` of the label it bound to). A dangling `\ref{nope}` lives
+  in `resolve_references().unresolved` (S18's domain), never in `resolved`, so it is excluded by
+  construction — never contributing a spurious `<kind>: 0` line.
+- **Per-kind counts in a fixed, document-independent order** — the `LabelKind` enum declaration order:
+  `Section`, `Table`, `Figure`, `Equation`, `Inline` (the SAME `const KIND_ORDER` slice S23/S24/S25
+  use). The method iterates that explicit fixed order (not a hash map keyed by kind), so the line order
+  is deterministic — the same `Vec`-scan discipline S17/S18/S23/S24/S25 use to avoid hash-order
+  nondeterminism.
+- **`<kind>: <n>` line shape.** Each line is the stable lowercase tag from `LabelKind::as_str()` (the
+  SAME kind string S24 renders — `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`) + `": "` +
+  the decimal count of resolved refs whose `target_kind` is that kind. There is **no** source slicing
+  at all (only the `target_kind` field is read).
+- **Zero-count kinds omitted.** A kind with no resolved refs contributes no line (there is never a bare
+  `table: 0` for a doc that references no tables).
+- **Stable empty marker.** No resolved references at all → the **same** fixed string
+  `(no resolved references)` S21/S24 use, never the empty string — the stable-marker discipline S12–S25
+  share.
+- **`\n`-joined, no trailing newline** — matching S24's `resolved_references_by_kind` and every S11–S25
+  renderer.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single
+  stable-ordered pass (fixed kind order × pre-order filter/count) over the already-bounded `resolved`
+  list. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s26_counts_multiple_kinds_in_fixed_kind_order_zero_kinds_omitted`,
+  `s26_exactly_one_kind`, `s26_two_refs_to_two_section_labels_count_two`,
+  `s26_all_dangling_or_none_returns_marker`, `s26_newline_join_no_trailing_newline_excludes_dangling`,
+  and `s26_is_additive_leaves_s1_s25_outputs_unchanged` (which pins every S1–S25 output byte-for-byte,
+  including S24's grouped `resolved_references_by_kind` and S25's `label_kind_counts`, alongside the new
+  per-kind counts).
+
 ## [0.61.0] — 2026-07-08
 
 ### Added — per-kind census (counts) of the winning label definitions (LTXDOC03 S25)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -73,6 +73,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S23 — winning `\label` definitions grouped by kind** | `Document::label_definitions_by_kind() -> String` — a **new**, read-only method that renders the **winning** `\label` definitions **grouped by their `LabelKind`** — a per-kind census — the **by-kind grouping companion of S22's** `label_definitions` (which lists the same winning definitions *flat*); S22 and S23 are two views of the one winning `definitions` list. It reads only `resolve_references().definitions` and groups by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — iterated as an explicit slice, not a hash map, so the order is deterministic like S17/S18's `Vec`-of-groups). Within each kind, definitions keep their existing pre-order. Each line is `[<kind>] \label{<key>}` — `<kind>` from `LabelKind::as_str()` (`"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<key>` from the owned key (no source slicing). A kind with no definitions contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22 uses. E.g. `sec:intro` (section), `eq:main` (equation), `note` (inline) → `[section] \label{sec:intro}\n[equation] \label{eq:main}\n[inline] \label{note}`. Every S1–S22 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S24 — resolved references grouped by target kind** | `Document::resolved_references_by_kind() -> String` — a **new**, read-only method that renders the **resolved** `\ref`/`\eqref`/`\pageref` references **grouped by the `LabelKind` they resolved TO** — a per-kind census — the **by-kind grouping companion of S21's** `resolved_references_by_source` (which lists the same resolved refs *flat*, in source order); S21 and S24 are two views of the one `resolved` list. It mirrors S23's `label_definitions_by_kind` idiom but over the **resolved-references** list, and stays **command-aware** like S21. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23 uses, iterated explicitly, not a hash map, so the order is deterministic). Within each kind, refs keep their existing pre-order. Each line is `[<kind>] \<command>{<key>}` — `<kind>` from the ref's `target_kind.as_str()`, `<command>` the ref's own (so `\eqref`/`\pageref` render as themselves), `<key>` from the owned key (no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). A kind with no resolved refs contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21 uses. E.g. `\ref{sec:intro}` (section), `\eqref{eq:main}` (equation), `\pageref{sec:intro}` (section) → `[section] \ref{sec:intro}\n[section] \pageref{sec:intro}\n[equation] \eqref{eq:main}`. Every S1–S23 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S25 — per-kind census (counts) of the winning `\label` definitions** | `Document::label_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the winning `\label` definitions: one `<kind>: <n>` line per `LabelKind` that has at least one winning definition, carrying the integer **count** (not a list) — the **count companion of S23's** `label_definitions_by_kind` (which renders one `[kind] \label{key}` *line per definition*). S22's flat `label_definitions`, S23's grouped list, and S25's counts are three views of the one winning `definitions` list; S25 collapses each kind's group to a single tally line (it is to S23 what S14's `list_summary` is to a full enumeration). It reads only `resolve_references().definitions` (one row per distinct key — the WINNER; a `\label{dup}` written twice counts **once**, its later copy being a `Duplicate` in S20's domain) and counts by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S23 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22/S23 use. E.g. `sec:intro` (section), `eq:a`/`eq:b` (equations), `note` (inline) → `section: 1\nequation: 2\ninline: 1`. Every S1–S24 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S26 — per-kind census (counts) of the resolved references** | `Document::resolved_reference_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the RESOLVED `\ref`/`\eqref`/`\pageref` references: one `<kind>: <n>` line per `LabelKind` that has at least one resolved ref, carrying the integer **count** (not a list) — the **count companion of S24's** `resolved_references_by_kind` (which renders one `[kind] \<command>{key}` *line per resolved ref*). S21's flat `resolved_references_by_source`, S24's grouped list, and S26's counts are three views of the one `resolved` list; S26 collapses each kind's group to a single tally line (it is to S24 what S25's `label_kind_counts` is to S23). It reads only `resolve_references().resolved` (each a `ResolvedRef` carrying the `target_kind` — the kind of the label it bound to; a dangling `\ref` lives in `unresolved`, S18's domain, and is excluded by construction — never a spurious `<kind>: 0`) and counts by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24/S25 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S24 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21/S24 use. E.g. `\ref{sec:a}`, `\ref{sec:b}` (two sections), `\eqref{eq:e}` (equation) → `section: 2\nequation: 1`. Every S1–S25 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1027,6 +1028,44 @@ assert_eq!(
 A document with no label definitions renders the **same** fixed `(no label definitions)` marker
 S22/S23 use (S25 counts the identical list). Purely additive — reuses `resolve_references`, mutates
 nothing, leaves every S1–S24 output and the `to_latex()` fixed point unchanged.
+
+### per-kind census (counts) of the resolved references (LTXDOC03 S26)
+
+A **per-kind CENSUS** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — one `<kind>: <n>` line
+per `LabelKind` that has at least one resolved ref, carrying the integer **count** rather than a list —
+the **count companion of S24's** `resolved_references_by_kind` (which renders one `[kind] \<command>{key}`
+line *per resolved ref*, grouped by the kind each ref bound to). S21's flat `resolved_references_by_source`,
+S24's grouped list, and S26's counts are three *views* of the one `resolved` list `resolve_references()`
+produces; S26 collapses each kind's group to a single tally line. It is to S24 what S25's
+`label_kind_counts` is to S23: a numeric summary. `resolved_reference_kind_counts` reads only that
+`resolved` list — each entry a `ResolvedRef` carrying the `target_kind` (the kind of the label it bound
+to; a dangling `\ref` lives in `unresolved`, S18's domain, and is excluded by construction — never a
+spurious `<kind>: 0`) — and counts by `target_kind` in a **fixed, document-independent order** (the
+`LabelKind` enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline`, the SAME slice
+S23/S24/S25 use), iterated as an explicit slice rather than a hash map, so the line order is
+deterministic. Each line is `<kind>: <n>` — the `<kind>` tag from `LabelKind::as_str()` (the SAME tag
+S24 renders), the `<n>` the decimal count (no source slicing). A kind with a zero count contributes no
+line (no bare `table: 0`).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{One}\label{sec:a}
+\section{Two}\label{sec:b}
+\begin{equation}\label{eq:e} E=mc^2 \end{equation}
+\ref{sec:a} \ref{sec:b} \eqref{eq:e}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.resolved_reference_kind_counts(),
+    // one count line per non-empty kind, in the fixed kind order (Table/Figure/Inline omitted — zero)
+    "section: 2\nequation: 1",
+);
+```
+
+A document with no resolved references (all dangling, or none at all) renders the **same** fixed
+`(no resolved references)` marker S21/S24 use (S26 counts the identical list). Purely additive — reuses
+`resolve_references`, mutates nothing, leaves every S1–S25 output and the `to_latex()` fixed point
+unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2623,6 +2623,117 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **per-kind CENSUS of the resolved references** (LTXDOC03 S26) — the *count* companion of
+    /// S24's [`resolved_references_by_kind`](Document::resolved_references_by_kind). Where S24 renders
+    /// one **line per resolved reference** (an `[kind] \<command>{key}` list, grouped by the kind of
+    /// node each ref bound to), S26 renders one **line per kind** carrying just the integer **count**
+    /// of resolved references that landed on that kind — a `<kind>: <n>` tally, not a list. It is to
+    /// S24 what S25's [`label_kind_counts`](Document::label_kind_counts) is to S23: a numeric summary
+    /// over the *same* list (here the **resolved** references), so a reader sees "how many refs land on
+    /// each kind" without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] walks every `\ref`/`\eqref`/`\pageref` in body pre-order
+    /// and splits them into the **resolved** references (those a `\label` defines — recorded in
+    /// [`ReferenceResolution::resolved`] as a [`ResolvedRef`]) and the **unresolved** (dangling) ones
+    /// (LaTeX's *"Reference `key' undefined"*, the `??` in the output — S18's domain). Each
+    /// [`ResolvedRef`] carries the [`LabelKind`] (`target_kind`) of the definition it bound to. S21
+    /// renders that `resolved` list **flat**, S24 renders it **grouped by `target_kind`** (one line per
+    /// ref). S26 collapses each kind's group to a **single count line**: it walks the [`LabelKind`]
+    /// variants in a fixed order and, for each kind that has **at least one** resolved ref, emits
+    /// `<kind>: <n>` where `<n>` is how many resolved refs carry that `target_kind`. Only the
+    /// **resolved** refs are counted — a dangling `\ref{nope}` lives in
+    /// [`ReferenceResolution::unresolved`] (S18), never in `resolved`, so it is excluded by
+    /// construction. S24 and S26 are two *views* of one underlying list (S24 the per-ref list, S26 the
+    /// per-kind count); neither mutates anything.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Iterate the [`LabelKind`] variants in their **enum declaration order** —
+    /// [`Section`](LabelKind::Section), [`Table`](LabelKind::Table), [`Figure`](LabelKind::Figure),
+    /// [`Equation`](LabelKind::Equation), [`Inline`](LabelKind::Inline) — a fixed, deterministic order
+    /// that does **not** depend on the document (the SAME `const KIND_ORDER` slice S23/S24/S25 use).
+    /// For each kind, count the [`ReferenceResolution::resolved`] refs whose `target_kind` is that kind,
+    /// and — only if the count is **at least one** — emit one line `<kind>: <n>`, where `<kind>` is the
+    /// stable lowercase tag from [`LabelKind::as_str`] (`"section"`, `"table"`, `"figure"`,
+    /// `"equation"`, `"inline"`) — the **same** kind string S24 renders — and `<n>` is the decimal
+    /// count. This single stable-ordered pass keeps the output deterministic **without** a hash map —
+    /// the same `Vec`-scan discipline S17/S18/S23/S24/S25 use to avoid hash-order nondeterminism. A kind
+    /// with a **zero** count produces **no** line (there is never a bare `table: 0` for a doc with no
+    /// refs to tables).
+    ///
+    /// A document with **no** resolved references — every reference dangles, or there are none at all —
+    /// returns the fixed marker `(no resolved references)`, the **same** marker S21/S24 use (S26 counts
+    /// the identical list, so the empty case is identical), never the empty string (the stable-marker
+    /// discipline S12–S25 share). Lines are joined by `\n` with **no** trailing newline (matching every
+    /// S11–S25 renderer).
+    ///
+    /// Concretely, for a body defining two section labels `sec:a`/`sec:b` and one equation label
+    /// `eq:e`, then writing `\ref{sec:a}`, `\ref{sec:b}`, and `\eqref{eq:e}` (all of which resolve):
+    ///
+    /// ```text
+    /// section: 2
+    /// equation: 1
+    /// ```
+    ///
+    /// (the `section` count leads, then `equation`, in the fixed kind order; the `table`, `figure`, and
+    /// `inline` kinds have zero resolved refs and so contribute no lines).
+    ///
+    /// ## Additive by construction
+    ///
+    /// S26 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1–S25 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *third view* of the same `resolved` list
+    /// S21 renders flat and S24 groups by kind — counting never adds, drops, or reorders resolved
+    /// references relative to what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only the `target_kind` field is read); a single stable-ordered pass (fixed kind order × pre-order
+    /// filter/count) over the already-bounded `resolved` list. Borrows `self` immutably and returns
+    /// owned `String` data, so the result outlives any borrow of the source.
+    pub fn resolved_reference_kind_counts(&self) -> String {
+        // S1 already split every `\ref`/`\eqref`/`\pageref` into resolved and dangling entries, routing
+        // the resolved ones into `resolved` (in body pre-order), each carrying the `target_kind` of the
+        // label it bound to. We only read (and count) that list; dangling refs live in `unresolved`.
+        let resolution = self.resolve_references();
+
+        if resolution.resolved.is_empty() {
+            // Every reference dangled (or there were none) → the SAME fixed marker S21/S24 use.
+            return "(no resolved references)".to_string();
+        }
+
+        // The FIXED kind order = the enum declaration order (the SAME slice S23/S24/S25 use). Iterating
+        // this explicit slice (rather than a hash map keyed by kind) makes the line order deterministic
+        // and document-independent, the same `Vec`-scan discipline S17/S18/S23/S24/S25 use to avoid
+        // hash-order nondeterminism.
+        const KIND_ORDER: [LabelKind; 5] = [
+            LabelKind::Section,
+            LabelKind::Table,
+            LabelKind::Figure,
+            LabelKind::Equation,
+            LabelKind::Inline,
+        ];
+
+        // One stable-ordered pass: for each kind in the fixed order, count the resolved refs whose
+        // `target_kind` is that kind and — only when the count is >= 1 — emit `<kind>: <n>`. A kind with
+        // zero resolved refs is filtered out (`filter` on `count > 0`), so it contributes no line. The
+        // kind string is the SAME `LabelKind::as_str` tag S24 renders; there is no source slicing (only
+        // `target_kind` is read).
+        KIND_ORDER
+            .iter()
+            .filter_map(|kind| {
+                let count = resolution
+                    .resolved
+                    .iter()
+                    .filter(|r| r.target_kind == *kind)
+                    .count();
+                (count > 0).then(|| format!("{}: {}", kind.as_str(), count))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -6374,6 +6485,186 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.label_kind_counts(),
             "section: 1\nfigure: 1\nequation: 1\ninline: 1"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S26 — per-kind CENSUS (counts) of the RESOLVED references
+    // (`resolved_reference_kind_counts`). The count companion of S24's
+    // `resolved_references_by_kind`: one `<kind>: <n>` line per kind (in the fixed enum order), a
+    // numeric summary over the SAME `resolved` list. Dangling refs live in `unresolved` (S18).
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s26_counts_multiple_kinds_in_fixed_kind_order_zero_kinds_omitted() {
+        // A `\ref` to a section, two `\eqref`s to two equations, and a `\ref` to a bare inline label →
+        // one `<kind>: <n>` line per kind in the fixed enum order (Section, then Equation, then Inline).
+        // The Table and Figure kinds have zero resolved refs and so contribute NO lines (never
+        // `table: 0`).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:a}x=1\end{equation}
+\begin{equation}\label{eq:b}y=2\end{equation}
+\label{note}
+\ref{sec:i} \eqref{eq:a} \eqref{eq:b} \ref{note}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "section: 1\nequation: 2\ninline: 1"
+        );
+    }
+
+    #[test]
+    fn s26_exactly_one_kind() {
+        // Two refs to the SAME (and only) section → a single `section: 2` line. No other kinds, no
+        // trailing newline.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \pageref{sec:i}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_reference_kind_counts(), "section: 2");
+    }
+
+    #[test]
+    fn s26_two_refs_to_two_section_labels_count_two() {
+        // Two `\ref`s to two DIFFERENT section labels → `section: 2` (multiple resolved refs to the
+        // same kind aggregate into the kind's count).
+        let src = r"\begin{document}\section{One}\label{sec:a}
+\section{Two}\label{sec:b}
+\ref{sec:a} \ref{sec:b}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_reference_kind_counts(), "section: 2");
+    }
+
+    #[test]
+    fn s26_all_dangling_or_none_returns_marker() {
+        // A document whose only reference dangles (`\ref{nope}` with no `\label`) → the fixed
+        // `(no resolved references)` marker S21/S24 use, never a `<kind>: 0` line — the dangling ref
+        // lands in `unresolved` (S18), not `resolved`.
+        let dangling = r"\begin{document}\ref{nope}\end{document}";
+        let doc = parse_document(dangling).expect("parse");
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "(no resolved references)"
+        );
+        // Cross-check: the dangling ref is in `unresolved`, so it never contributed a zero count.
+        assert_eq!(doc.unresolved_references_by_source(), "\\ref{nope}");
+
+        // And a document with no references at all → the SAME marker.
+        let none = r"\begin{document}Just some text with no references.\end{document}";
+        let doc = parse_document(none).expect("parse");
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "(no resolved references)"
+        );
+    }
+
+    #[test]
+    fn s26_newline_join_no_trailing_newline_excludes_dangling() {
+        // A `\ref` to a section, an `\eqref` to an equation, plus a DANGLING `\ref{nope}` → exact
+        // string equality pins the `\n`-join with NO trailing newline, the fixed kind order (Section
+        // then Equation), AND that the dangling `\ref{nope}` is excluded from the counts (it never
+        // entered `resolved`).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:m}x=1\end{equation}
+\ref{sec:i} \eqref{eq:m} \ref{nope}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "section: 1\nequation: 1"
+        );
+        // The dangling ref shows up in S18, confirming it was routed to `unresolved`, not counted here.
+        assert_eq!(doc.unresolved_references_by_source(), "\\ref{nope}");
+    }
+
+    #[test]
+    fn s26_is_additive_leaves_s1_s25_outputs_unchanged() {
+        // Same representative doc as the S24/S25 additive tests. S26 changes NONE of the S1-S25 outputs
+        // — it only reads `resolve_references`. S21's flat `resolved_references_by_source`, S24's
+        // grouped `resolved_references_by_kind`, and S26's per-kind counts are three views of the SAME
+        // `resolved` list; all are pinned here to show S26 neither adds, drops, nor reorders, and that
+        // its counts agree with S24's grouping.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // S1/S6 flat report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text(),
+            "\\ref{sec:intro} -> Section 1\n\\eqref{eq:e} -> Equation (1)\n\\cite{a} -> [1]\n\\cite{b} -> [2]\n\\cite{c} -> [3]\nDangling references: eq:ghost\nDangling citations: ghost"
+        );
+        // S11 grouped-by-kind report — unchanged.
+        assert_eq!(
+            doc.cross_reference_report().to_plain_text_by_kind(),
+            "Sections:\n  \\ref{sec:intro} -> Section 1\nEquations:\n  \\eqref{eq:e} -> Equation (1)"
+        );
+        // S12 list of floats — unchanged.
+        assert_eq!(doc.list_of_floats(), "List of Figures\n1. A plot");
+        // S13 nameref resolution — unchanged.
+        assert_eq!(
+            doc.resolve_namerefs(),
+            "\\nameref{sec:intro} -> Introduction\n\\nameref{fig:p} -> A plot"
+        );
+        // S14 per-kind census — unchanged.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S15 grouped resolved cites — unchanged.
+        assert_eq!(doc.citations_by_source(), "\\cite{a, b}\n\\cite{c}");
+        // S16 duplicate bibliography entries — unchanged.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S17 grouped dangling cites — unchanged.
+        assert_eq!(doc.unresolved_citations_by_source(), "\\cite{ghost}");
+        // S18 grouped dangling refs — unchanged.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S19 numbered winning bibliography — unchanged.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S20 losing duplicate labels — unchanged.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // S21 resolved references (flat, source order) — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+        // S22 flat winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S23 grouped winning label definitions — unchanged.
+        assert_eq!(
+            doc.label_definitions_by_kind(),
+            "[section] \\label{sec:intro}\n[figure] \\label{fig:p}\n[equation] \\label{eq:e}\n[inline] \\label{dup}"
+        );
+        // S24 grouped resolved references — unchanged.
+        assert_eq!(
+            doc.resolved_references_by_kind(),
+            "[section] \\ref{sec:intro}\n[equation] \\eqref{eq:e}"
+        );
+        // S25 per-kind label-definition counts — unchanged.
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nfigure: 1\nequation: 1\ninline: 1"
+        );
+
+        // And S26 itself: the per-kind COUNTS of the SAME resolved references, in the fixed enum order.
+        // One resolved ref lands on a section (`\ref{sec:intro}`) and one on an equation (`\eqref{eq:e}`);
+        // the `\eqref{eq:ghost}` dangles (excluded). `\n`-joined, no trailing newline. Table, figure,
+        // and inline have zero resolved refs and so are omitted.
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "section: 1\nequation: 1"
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2091,3 +2091,88 @@ that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`, `resolve_namere
 unchanged. `cargo clippy -p latex --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang
 -p adj-lang-cli` green; `cargo build -p latex --no-default-features` builds. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 32. S26 — per-kind census (counts) of the resolved references (`resolved_reference_kind_counts`)
+
+### 32.1 Motivation
+
+S24 (`resolved_references_by_kind`) groups the **resolved** `\ref`/`\eqref`/`\pageref` references by the
+`LabelKind` they resolved TO and renders one **line per resolved reference** (`[kind] \<command>{key}`).
+But a reader often wants not the enumeration but the **tally** — "how many of my references land on
+sections? how many on equations? how many on bare inline labels?" — a per-kind *count* answered at a
+glance, without scanning the individual keys. S25 (`label_kind_counts`) already brought exactly this
+numeric-summary discipline to the **label-definitions** family (a `<kind>: <n>` tally over the winning
+`definitions` list); S26 brings the same shape to the **resolved-references** family. It is to S24 what
+S25 is to S23: the *same* `resolved` list, collapsed to one line per kind.
+
+### 32.2 Why a new method — additive by construction
+
+S26 adds a **new public method** `Document::resolved_reference_kind_counts(&self) -> String`. It is a
+pure, read-only render of `resolve_references().resolved` — a *third view* of the exact list S21 renders
+flat and S24 groups by kind. It reuses that list verbatim (never re-walking the body or re-resolving), so
+the report can never drift from the S1 resolution it summarises, and counting never adds, drops, or
+reorders references relative to what `resolve_references` produced. It mutates nothing and changes no
+S1–S25 output — including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S25 it is a
+method the caller invokes directly.
+
+### 32.3 The ordering rule
+
+The output is ordered by a **fixed, document-independent** kind order — the `LabelKind` enum declaration
+order: `Section`, `Table`, `Figure`, `Equation`, `Inline` (the **same** `const KIND_ORDER` slice
+S23/S24/S25 use). S26 iterates that order as an explicit slice (**not** a hash map keyed by kind), so the
+line order is deterministic and never depends on document content or hash iteration order — the same
+`Vec`-scan discipline S17/S18/S23/S24/S25 use to avoid hash-order nondeterminism. A kind with a **zero**
+count produces **no** line (there is never a bare `table: 0` for a doc that references no tables).
+
+### 32.4 The exact rendering contract — `Document::resolved_reference_kind_counts(&self) -> String`
+
+- Iterate the fixed kind order (`Section`, `Table`, `Figure`, `Equation`, `Inline`). For each kind, count
+  the `resolve_references().resolved` refs whose `target_kind` is that kind and — only if the count is
+  **at least one** — emit one line `format!("{}: {}", kind.as_str(), count)` → the kind tag + `": "` + the
+  decimal count. The kind tag comes from `LabelKind::as_str()` (`"section"`/`"table"`/`"figure"`/
+  `"equation"`/`"inline"`) — the **same** kind string S24 renders — and there is **no** source slicing at
+  all (only the `target_kind` field is read; keys/commands/spans are unused for the count), so the render
+  needs no source borrow and can never index out of bounds.
+- Only the **resolved** references are counted. A dangling `\ref{nope}` lives in
+  `resolve_references().unresolved` (S18's domain), never in `resolved`, so it is excluded by construction
+  and never contributes a spurious `<kind>: 0` line.
+- A kind with a zero count contributes no line and no empty header.
+- Lines are joined by `\n` with **no** trailing newline (matching every S11–S25 renderer).
+- If there are **no** resolved references at all (every reference dangles, or there are none), the fixed
+  marker `(no resolved references)` is returned — the **same** marker S21/S24 use (S26 counts the
+  identical list), so the output is never the empty string.
+
+Example (body defining two section labels `sec:a`/`sec:b` and one equation label `eq:e`, then writing
+`\ref{sec:a}`, `\ref{sec:b}`, and `\eqref{eq:e}`, all of which resolve):
+
+```text
+section: 2
+equation: 1
+```
+
+The `section` count leads, then `equation`, in the fixed kind order; the `table`, `figure`, and `inline`
+kinds have zero resolved refs and so contribute no lines. This is the count companion of S24's per-ref
+grouping — a third view of the one `resolved` list.
+
+### 32.5 Public API (added in S26)
+
+One new method: `Document::resolved_reference_kind_counts(&self) -> String`. No existing type, field,
+counter, or signature changes; `resolve_references` and every S1–S25 method are unchanged; no AST or
+grammar change; no new dependency, no `unsafe`, no I/O.
+
+### 32.6 Verification (S26)
+
+`cargo test -p latex` green (6 new S26 tests: a section + two-equation + inline case rendering the
+per-kind counts in the fixed kind order with the zero-count kinds omitted; a single-kind case
+(`section: 2`, two refs to one section); a two-section-labels case proving multiple resolved refs to the
+same kind aggregate (`section: 2`); an all-dangling / no-references case returning the
+`(no resolved references)` marker (cross-checked against S18's `unresolved_references_by_source`); a
+section + equation + dangling-ref case pinning the `\n`-join with no trailing newline and the dangling
+ref's exclusion; and an additivity check that `to_plain_text`, `to_plain_text_by_kind`, `list_of_floats`,
+`resolve_namerefs`, `list_summary`, `citations_by_source`, `duplicate_bibliography_entries`,
+`unresolved_citations_by_source`, `unresolved_references_by_source`, `bibliography_entries`,
+`duplicate_label_definitions`, `resolved_references_by_source`, `label_definitions`, S23's
+`label_definitions_by_kind`, S24's `resolved_references_by_kind`, and S25's `label_kind_counts` all still
+produce their exact prior strings). All prior S1–S25 tests pass unchanged. `cargo clippy -p latex
+--all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo
+build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S26 — `resolved_reference_kind_counts` (latex 0.62.0)

Adds one additive, read-only cross-reference report renderer to the zero-dependency `latex` crate: a **per-kind count/census of resolved references**.

### What it does

```rust
pub fn resolved_reference_kind_counts(&self) -> String
```

Counts the resolved `\ref`/`\eqref`/`\pageref` references from `resolve_references().resolved`, groups them by the `LabelKind` each one bound to (`ResolvedRef::target_kind`), and emits one `<kind>: <n>` line per kind with ≥1 resolved ref, in the fixed enum-declaration `KIND_ORDER` (Section, Table, Figure, Equation, Inline):

```
section: 2
equation: 1
```

It is the **count/census** companion to **S24** `resolved_references_by_kind` (which *lists* the resolved refs grouped by target kind) — the same `ResolvedRef::target_kind` grouping and `LabelKind::as_str()` mapping S24 uses, applied to produce numbers instead of lists. It parallels **S25** `label_kind_counts` (label-definition census) on the resolved-references side.

- Only kinds with ≥1 resolved ref appear (no zero lines).
- Dangling references (in `unresolved`, S18's domain) are excluded by construction.
- A document with no resolved references returns the fixed marker `(no resolved references)` (the same marker S21/S24 use), never the empty string. Lines join with `\n`, no trailing newline.

### Guarantees

- **Additive**: a brand-new read-only method reusing `resolve_references()`; every S1–S25 output is byte-for-byte unchanged (pinned by `s26_is_additive_leaves_s1_s25_outputs_unchanged`), and the `to_latex` round-trip fixed point is intact.
- **Total & panic-free**: no `unsafe`, no `unwrap`/`expect` on parsed input, no indexing/slicing (spans never touched; `target_kind` is a `Copy` enum, `as_str()` total); a stable pass over the fixed 5-element kind order filtering the already-bounded `resolved` list. Output is bounded to at most 5 lines regardless of input size. Borrows `self` immutably, returns owned `String`.

### Verification (from `code/packages/rust/`)

- `cargo test -p latex` → 443 passed + doctest (6 new `s26_*` tests)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED

### Docs

- `Cargo.toml` version `0.61.0` → `0.62.0`
- `CHANGELOG.md`, `README.md`, and `LTXDOC03-cross-reference-resolution.md` (new S26 section) — prior sections byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
