### PR TITLE
test(closure-emitter): CodePrinter class-expression conformance port (CLOC12.173 PR3)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.37.1] - 2026-07-08
+
+### Added — CLOC12.173 PR3: CodePrinter class-expression conformance port
+
+New upstream test port `tests/upstream/code_printer_class_test.rs` (registered
+as `[[test]] upstream_code_printer_class`) — the twentieth CodePrinter port,
+isolating `emit_class` + `emit_class_member` + the `PREC_UNARY` classification
+that landed with `Expression::ClassExpression` (CLOC12.173 PR1). **22 active
+`#[test]`s, 0 `#[ignore]`** — the emitter conforms to every covered class shape:
+
+- **statement-start wrap** — a bare `class{}` / `class C{}` in expression-
+  statement position is parenthesised (`(class{});`) so a leading `class` does
+  not parse as a class *declaration*;
+- **surface + heritage** — anonymous/named classes as a call argument print bare
+  (`f(class{})`, `f(class C{})`); the `extends` operand prints bare for an
+  identifier / member / call heritage (`extends B`, `extends ns.B`,
+  `extends mixin(B)`) and wraps for a looser conditional
+  (`extends (a?b:c)`);
+- **members** — empty method, method with params + body, `static` method,
+  `get`/`set` accessors, `constructor`, stacked `static get`, generator `*m`,
+  `async m`, computed-key `[k]`, and two members back-to-back with no separator;
+- **whole-node precedence** — the class wraps as a member object
+  (`(class{}).x`) and a call callee (`(class{})()`) but stays bare under a
+  binary parent (`class{}+1`).
+
+Inputs are hand-constructed typed AST (the emitter is the unit under test), so
+the port also exercises generator / async / computed-key methods and multi-
+member classes the grammar cannot yet parse (bridge conversion is CLOC12.173
+PR2, exercised separately in `javascript-parser`). Test-only change — no
+production-code edit in this crate; version bumped PATCH.
+
 ## [0.37.0] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: print `ClassExpression`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -120,3 +120,7 @@ path = "tests/upstream/code_printer_object_spread_test.rs"
 [[test]]
 name = "upstream_code_printer_optional_chain"
 path = "tests/upstream/code_printer_optional_chain_test.rs"
+
+[[test]]
+name = "upstream_code_printer_class"
+path = "tests/upstream/code_printer_class_test.rs"

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -193,6 +193,27 @@ under the Apache License, Version 2.0:
       are not asserted to be valid JS (`super` is syntactically restricted to
       member/call position inside a method or derived constructor).
 
+- `code_printer_class_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the class-expression `class[ id][ extends S]{members}` printing cases)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Isolates `emit_class` + `emit_class_member` + the `PREC_UNARY`
+      classification that landed with `Expression::ClassExpression`
+      (CLOC12.173). 22 active `#[test]`s and **0 `#[ignore]`** — the emitter
+      conforms to every covered shape: the statement-start wrap (`(class{});`),
+      anonymous/named surface, the four `extends`-operand precedence cases
+      (identifier / member / call heritage print bare, a conditional heritage
+      wraps: `extends (a?b:c)`), the member forms (empty / params+body /
+      `static` / `get` / `set` / `constructor` / stacked `static get` /
+      generator `*m` / `async m` / computed `[k]` / two members back-to-back),
+      and the whole-node precedence cases where the class wraps as a member
+      object (`(class{}).x`) and a call callee (`(class{})()`) but stays bare
+      under a binary parent (`class{}+1`). Inputs are hand-constructed AST; the
+      bridge conversion of `class_expression` (CLOC12.173 PR2, gap-167) is
+      exercised separately in `javascript-parser`, and building the AST directly
+      lets the port cover generator / async / computed-key methods and
+      multi-member classes the grammar cannot yet parse.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_class_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_class_test.rs
@@ -1,0 +1,425 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **class-expression** printing cases — the
+//! `class` keyword in value position (`ClassExpression`). This is the
+//! twentieth CodePrinter port into `closure-emitter` (after core /
+//! declarations / trailing-comma / numbers / string-escape / ascii-escape /
+//! object-literal / function-expression / arrow-function / template / update /
+//! new / sequence / tagged-template / spread / yield / await / this / super)
+//! and isolates `emit_class` + `emit_class_member` + the `PREC_UNARY`
+//! classification that landed with `Expression::ClassExpression` (CLOC12.173).
+//!
+//! # How the emitter prints a class expression (recap)
+//!
+//! A class expression prints `class[ id][ extends S]{members}` with **no**
+//! separators between members (each carries its own `{…}`). One
+//! [`MethodDefinition`] prints
+//! `[static ][get|set ][async ][*]key(params){body}` — prefixes in grammar
+//! order.
+//!
+//! ```text
+//!   class {}                      → class{}
+//!   class C {}                    → class C{}
+//!   class C extends B {}          → class C extends B{}
+//!   class { m() {} }              → class{m(){}}
+//!   class { static get x() {} }   → class{static get x(){}}
+//!   class { [k]() {} }            → class{[k](){}}
+//! ```
+//!
+//! **Precedence.** `expr_prec` tags a class expression at `PREC_UNARY`
+//! (exactly like a function expression) — below the `PREC_PRIMARY` at which a
+//! member/call parent emits its base. So a class as a member object
+//! (`(class{}).x`) or a call callee (`(class{})()`) is wrapped, while looser
+//! assignment/binary parents leave it bare (`x=class{}`, `class{}+1`). At the
+//! *start* of an expression statement a leading `class` parses as a class
+//! *declaration*, so `emit_expression_statement` wraps it: `(class{});`. The
+//! `extends` operand is emitted at `PREC_PRIMARY`: an identifier / member /
+//! call heritage stays bare, a looser conditional heritage is wrapped.
+//!
+//! # Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (the emitter is the unit
+//! under test). The bridge conversion of `class_expression` (gap-167) lands in
+//! CLOC12.173 PR2 and is exercised separately in `javascript-parser`; here the
+//! emitter is driven from hand-constructed AST so this port does not depend on
+//! the bridge. Building the AST directly also lets the port exercise shapes the
+//! grammar cannot yet parse (generator / async / computed-key methods,
+//! multi-member classes without `;` separators — see `CLOC12-gaps.md`).
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    BinaryExpression, BinaryOperator, BlockStatement, CallExpression, ClassExpression, ClassMember,
+    ConditionalExpression, Expression, ExpressionStatement, FunctionExpression, FunctionParam,
+    Identifier, MemberExpression, MethodDefinition, MethodKind, NumericLiteral, Program,
+    ProgramItem, PropertyKey, ReturnStatement, SourceType, Statement,
+};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn num(value: f64, raw: &str) -> Expression {
+    Expression::NumericLiteral(NumericLiteral { cv: None, value, raw: raw.to_string() })
+}
+
+fn member(object: Expression, property: &str) -> Expression {
+    Expression::MemberExpression(MemberExpression {
+        cv: None,
+        object: Box::new(object),
+        property: Box::new(ident(property)),
+        computed: false,
+    })
+}
+
+fn binary(op: BinaryOperator, left: Expression, right: Expression) -> Expression {
+    Expression::BinaryExpression(BinaryExpression {
+        cv: None,
+        operator: op,
+        left: Box::new(left),
+        right: Box::new(right),
+    })
+}
+
+fn call(callee: Expression, arguments: Vec<Expression>) -> Expression {
+    Expression::CallExpression(CallExpression { cv: None, callee: Box::new(callee), arguments })
+}
+
+fn cond(test: Expression, consequent: Expression, alternate: Expression) -> Expression {
+    Expression::ConditionalExpression(ConditionalExpression {
+        cv: None,
+        test: Box::new(test),
+        consequent: Box::new(consequent),
+        alternate: Box::new(alternate),
+    })
+}
+
+fn ret(arg: Option<Expression>) -> Statement {
+    Statement::return_statement(ReturnStatement { cv: None, argument: arg })
+}
+
+/// Build a method body as a `FunctionExpression` (params + block), with the
+/// `generator` / `is_async` flags a method head may carry.
+fn func(params: &[&str], body: Vec<Statement>, generator: bool, is_async: bool) -> FunctionExpression {
+    FunctionExpression {
+        cv: None,
+        id: None,
+        params: params
+            .iter()
+            .map(|p| FunctionParam::Identifier(Identifier { cv: None, name: p.to_string() }))
+            .collect(),
+        body: BlockStatement { cv: None, body },
+        generator,
+        is_async,
+    }
+}
+
+/// Build one method member with an identifier key.
+fn method(name: &str, kind: MethodKind, value: FunctionExpression, is_static: bool) -> ClassMember {
+    ClassMember::Method(MethodDefinition {
+        cv: None,
+        key: PropertyKey::Identifier(Identifier { cv: None, name: name.to_string() }),
+        kind,
+        value,
+        computed: false,
+        is_static,
+    })
+}
+
+/// Build a class expression: optional name, optional `extends` operand, members.
+fn class(id: Option<&str>, super_class: Option<Expression>, body: Vec<ClassMember>) -> Expression {
+    Expression::ClassExpression(ClassExpression {
+        cv: None,
+        id: id.map(|n| Identifier { cv: None, name: n.to_string() }),
+        super_class: super_class.map(Box::new),
+        body,
+    })
+}
+
+fn stmt(expr: Expression) -> ProgramItem {
+    ProgramItem::Statement(Statement::expression_statement(ExpressionStatement {
+        cv: None,
+        expression: expr,
+    }))
+}
+
+fn emit_default(expr: Expression) -> String {
+    let prog =
+        Program::new_untraced(EsVersion::Es2025, SourceType::Module).with_body(vec![stmt(expr)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit the expression as a
+/// single-statement program and assert the emitted code equals `expected`.
+fn assert_emits(expr: Expression, expected: &str) {
+    let code = emit_default(expr);
+    assert_eq!(
+        code, expected,
+        "class emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — statement-start parenthesisation
+// =====================================================================
+
+/// A bare anonymous class expression at the start of an expression statement
+/// is wrapped, else the leading `class` parses as a class *declaration*.
+#[test]
+fn anonymous_at_statement_start_is_parenthesised() {
+    assert_emits(class(None, None, vec![]), "(class{});");
+}
+
+/// A *named* class expression at statement start is wrapped the same way; the
+/// name prints after `class` with a mandatory space.
+#[test]
+fn named_at_statement_start_is_parenthesised() {
+    assert_emits(class(Some("C"), None, vec![]), "(class C{});");
+}
+
+// =====================================================================
+// Active — the surface shape (driven from a call argument to avoid the
+// statement-start wrap, so the bare class print is isolated)
+// =====================================================================
+
+/// `f(class{})` — an anonymous empty class as a call argument prints bare
+/// (the argument context binds looser than the class's `PREC_UNARY`).
+#[test]
+fn empty_class_as_call_argument_is_bare() {
+    assert_emits(call(ident("f"), vec![class(None, None, vec![])]), "f(class{});");
+}
+
+/// `f(class C{})` — a named class carries its name.
+#[test]
+fn named_class_as_call_argument() {
+    assert_emits(call(ident("f"), vec![class(Some("C"), None, vec![])]), "f(class C{});");
+}
+
+// =====================================================================
+// Active — `extends` heritage (operand emitted at PREC_PRIMARY)
+// =====================================================================
+
+/// `class C extends B{}` — an identifier heritage prints bare with the
+/// mandatory spaces around `extends`.
+#[test]
+fn extends_identifier() {
+    assert_emits(
+        call(ident("f"), vec![class(Some("C"), Some(ident("B")), vec![])]),
+        "f(class C extends B{});",
+    );
+}
+
+/// `class extends ns.B{}` — a member heritage binds at primary and stays bare.
+#[test]
+fn extends_member_is_bare() {
+    assert_emits(
+        call(ident("f"), vec![class(None, Some(member(ident("ns"), "B")), vec![])]),
+        "f(class extends ns.B{});",
+    );
+}
+
+/// `class extends mixin(B){}` — a call heritage (`extends mixin(Base)`) binds
+/// at primary strength and stays bare.
+#[test]
+fn extends_call_is_bare() {
+    assert_emits(
+        call(ident("f"), vec![class(None, Some(call(ident("mixin"), vec![ident("B")])), vec![])]),
+        "f(class extends mixin(B){});",
+    );
+}
+
+/// `class extends (a?b:c){}` — a conditional heritage binds looser than the
+/// `PREC_PRIMARY` the operand is emitted at, so it is wrapped. The mandatory
+/// space after `extends` is still printed before the wrapping paren.
+#[test]
+fn extends_conditional_is_wrapped() {
+    assert_emits(
+        call(
+            ident("f"),
+            vec![class(None, Some(cond(ident("a"), ident("b"), ident("c"))), vec![])],
+        ),
+        "f(class extends (a?b:c){});",
+    );
+}
+
+// =====================================================================
+// Active — member shapes
+// =====================================================================
+
+/// `class{m(){}}` — a single empty method prints inside the braces with no
+/// separators.
+#[test]
+fn method_empty_body() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("m", MethodKind::Method, func(&[], vec![], false, false), false)])]),
+        "f(class{m(){}});",
+    );
+}
+
+/// `class{m(a,b){return 1}}` — params are comma-separated and the body prints
+/// between the braces.
+#[test]
+fn method_with_params_and_body() {
+    assert_emits(
+        call(
+            ident("f"),
+            vec![class(
+                None,
+                None,
+                vec![method(
+                    "m",
+                    MethodKind::Method,
+                    func(&["a", "b"], vec![ret(Some(num(1.0, "1")))], false, false),
+                    false,
+                )],
+            )],
+        ),
+        "f(class{m(a,b){return 1}});",
+    );
+}
+
+/// `class{static m(){}}` — a static member prints the `static ` prefix.
+#[test]
+fn static_method() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("m", MethodKind::Method, func(&[], vec![], false, false), true)])]),
+        "f(class{static m(){}});",
+    );
+}
+
+/// `class{get x(){}}` — a getter prints the `get ` keyword before the key.
+#[test]
+fn getter() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("x", MethodKind::Get, func(&[], vec![], false, false), false)])]),
+        "f(class{get x(){}});",
+    );
+}
+
+/// `class{set x(v){}}` — a setter prints the `set ` keyword and its one param.
+#[test]
+fn setter() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("x", MethodKind::Set, func(&["v"], vec![], false, false), false)])]),
+        "f(class{set x(v){}});",
+    );
+}
+
+/// `class{constructor(){}}` — the constructor prints like a plain method (no
+/// keyword prefix); its `kind` only matters to the passes.
+#[test]
+fn constructor() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("constructor", MethodKind::Constructor, func(&[], vec![], false, false), false)])]),
+        "f(class{constructor(){}});",
+    );
+}
+
+/// `class{static get x(){}}` — prefixes stack in grammar order: `static`, then
+/// the accessor keyword, then the key.
+#[test]
+fn static_getter() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("x", MethodKind::Get, func(&[], vec![], false, false), true)])]),
+        "f(class{static get x(){}});",
+    );
+}
+
+/// `class{*m(){}}` — a generator method prints the `*` before the key. (The
+/// grammar cannot yet parse a generator method, so the AST is hand-built.)
+#[test]
+fn generator_method() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("m", MethodKind::Method, func(&[], vec![], true, false), false)])]),
+        "f(class{*m(){}});",
+    );
+}
+
+/// `class{async m(){}}` — an async method prints the `async ` prefix. (The
+/// grammar cannot yet parse an async method, so the AST is hand-built.)
+#[test]
+fn async_method() {
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![method("m", MethodKind::Method, func(&[], vec![], false, true), false)])]),
+        "f(class{async m(){}});",
+    );
+}
+
+/// `class{[k](){}}` — a computed-key method brackets the key expression.
+#[test]
+fn computed_key_method() {
+    let member = ClassMember::Method(MethodDefinition {
+        cv: None,
+        key: PropertyKey::Expression(Box::new(ident("k"))),
+        kind: MethodKind::Method,
+        value: func(&[], vec![], false, false),
+        computed: true,
+        is_static: false,
+    });
+    assert_emits(
+        call(ident("f"), vec![class(None, None, vec![member])]),
+        "f(class{[k](){}});",
+    );
+}
+
+/// `class{a(){}b(){}}` — two members print back-to-back with no separator
+/// (each carries its own `{…}`). (The grammar requires `;` between members, so
+/// this shape is hand-built — see `CLOC12-gaps.md`.)
+#[test]
+fn multiple_members_back_to_back() {
+    assert_emits(
+        call(
+            ident("f"),
+            vec![class(
+                None,
+                None,
+                vec![
+                    method("a", MethodKind::Method, func(&[], vec![], false, false), false),
+                    method("b", MethodKind::Method, func(&[], vec![], false, false), false),
+                ],
+            )],
+        ),
+        "f(class{a(){}b(){}});",
+    );
+}
+
+// =====================================================================
+// Active — the whole node's precedence (class tags at PREC_UNARY)
+// =====================================================================
+
+/// `(class{}).x` — a member parent binds at primary strength; the looser class
+/// object is wrapped.
+#[test]
+fn class_member_object_is_wrapped() {
+    assert_emits(member(class(None, None, vec![]), "x"), "(class{}).x;");
+}
+
+/// `(class{})()` — a call callee likewise wraps the class.
+#[test]
+fn class_call_callee_is_wrapped() {
+    assert_emits(call(class(None, None, vec![]), vec![]), "(class{})();");
+}
+
+/// `class{}+1` — a binary parent binds looser than the class's `PREC_UNARY`,
+/// so the class stays bare on the left.
+#[test]
+fn class_under_binary_parent_is_bare() {
+    assert_emits(binary(BinaryOperator::Add, class(None, None, vec![]), num(1.0, "1")), "class{}+1;");
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2302,8 +2302,20 @@ and the method body + sibling arg fold; `tests/diff/advanced-class-constructor/`
 
 16 bridge unit tests (`class_*`) cover the accepted forms and the declines.
 
-**PR3 (CodePrinter conformance port)** — `closure-emitter` (PATCH), a
-`tests/upstream/code_printer_class_test.rs` — remains.
+**PR3 (DONE) — `closure-emitter` 0.37.1.** New upstream port
+`tests/upstream/code_printer_class_test.rs` (registered as `[[test]]
+upstream_code_printer_class`), isolating `emit_class` + `emit_class_member` +
+the `PREC_UNARY` classification from PR1. **22 active `#[test]`s, 0
+`#[ignore]`** — the statement-start wrap (`(class{});`), anonymous/named
+surface, the four `extends`-operand precedence cases (identifier / member / call
+heritage bare, conditional heritage wrapped `extends (a?b:c)`), the member forms
+(empty / params+body / `static` / `get` / `set` / `constructor` / stacked
+`static get` / generator `*m` / `async m` / computed `[k]` / two members
+back-to-back), and the whole-node precedence cases (`(class{}).x`,
+`(class{})()`, `class{}+1`). Inputs are hand-constructed AST, so the port also
+covers the generator / async / computed-key / multi-member shapes the grammar
+cannot yet parse. Test-only change (no production edit); ATTRIBUTION.md updated.
+This closes the CLOC12.173 class-expression arc.
 
 ## CLOC12.172 — `RegExpLiteral` leaf node (`/pattern/flags`): node + emit + passes (PR1)
 


### PR DESCRIPTION
## CLOC12.173 PR3 — CodePrinter class-expression conformance port

The final PR of the CLOC12.173 class-expression arc (after PR1 #7820, the
atomic node + emit + pass arms, and PR2 #7825, the bridge). Adds the upstream
`CodePrinterTest` conformance port for class expressions.

### What it does
New `tests/upstream/code_printer_class_test.rs` (registered as `[[test]]
upstream_code_printer_class`) — the **twentieth** CodePrinter port into
`closure-emitter`, isolating `emit_class` + `emit_class_member` + the
`PREC_UNARY` classification that landed with `Expression::ClassExpression`
(PR1). **22 active `#[test]`s, 0 `#[ignore]`** — the emitter conforms to every
covered shape:

- **statement-start wrap** — `(class{});` / `(class C{});` (a leading `class`
  would otherwise parse as a class *declaration*);
- **surface + heritage** — `f(class{})` / `f(class C{})`; the `extends` operand
  prints bare for identifier / member / call heritage
  (`extends B`, `extends ns.B`, `extends mixin(B)`) and wraps for a looser
  conditional (`extends (a?b:c)`);
- **members** — empty, params+body, `static`, `get`/`set`, `constructor`,
  stacked `static get`, generator `*m`, `async m`, computed `[k]`, two members
  back-to-back;
- **whole-node precedence** — wraps as a member object (`(class{}).x`) and a
  call callee (`(class{})()`) but stays bare under a binary parent (`class{}+1`).

Inputs are hand-constructed typed AST (the emitter is the unit under test), so
the port also exercises generator / async / computed-key methods and
multi-member classes the grammar cannot yet parse (bridge conversion is PR2,
exercised separately in `javascript-parser`).

### No production change
Test-only. `closure-emitter` 0.37.0 → **0.37.1** (PATCH). `ATTRIBUTION.md` lists
the new port; `CLOC12-gaps.md` §CLOC12.173 marks **PR3 DONE**, closing the arc.

closure-emitter full suite: green (my 22-test file among them, 0 ignored).
Security review: PASSED (test + docs only, no attacker surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)