### PR TITLE
feat(adj-ladder): rung-116 otolaryngology airway patency (one over a three-term sum)

### DIFF
--- a/code/specs/data/adj-ladder/rung116_otolaryngology/gen_items.py
+++ b/code/specs/data/adj-ladder/rung116_otolaryngology/gen_items.py
@@ -1,0 +1,253 @@
+"""Generate rung-116 (otolaryngology / nasal airway) items.json for the ADJ-LADDER.
+
+Rung 116 opens the **otolaryngology / nasal-airway** panel on the quantitative band — the arithmetic of an airway patency
+index. A `total_airflow` (the air moved through the nose) is DIVIDED by the SUM OF THREE resistances — a `septal_resistance`
+(from the nasal septum), a `turbinate_resistance` (from the inferior turbinate), and a `valve_resistance` (from the internal
+nasal valve) — to give the patency index (airflow per unit of combined resistance). A **single term over a THREE-term SUM
+DENOMINATOR**, `a/(b+c+d)`, i.e. `(a / ((b + c) + d))`, introduces a genuinely NEW arithmetic family on the ladder — the
+ladder's **first three-term denominator**.
+
+This is genuinely new — every earlier ratio put its multi-term structure in the NUMERATOR, never the denominator. The three-term
+NUMERATOR family shipped rung-108 `(a+b+c)/d`, rung-109 `(a-b+c)/d`, rung-110 `(a*b+c)/d`, rung-111 `(a*b-c)/d`, rung-114
+`(a+b-c)/d`, and rung-115 `(a-b-c)/d`; the distributive pair (rung-112 `a*(b+c)/d`, rung-113 `a*(b-c)/d`) wrapped a
+sum/difference inside a factor but still divided by a SINGLE term `d`; and every two-term ratio (rung-37 `(a+b)/(c+d)`, rung-99
+`(a*b)/(c+d)`, rung-100 `(a+b)/(c*d)`, rung-104 `(a-b)/(c*d)`, the difference-denominator trio rung-105 `(a+b)/(c-d)`, rung-106
+`a*b/(c-d)`, rung-107 `(a-b)/(c-d)`) had at most TWO terms below the bar. Rung-116 moves to `a/(b+c+d)`: a bare single-term
+numerator over a THREE-term sum denominator — the first time the ladder divides by a sum of three quantities. The operator order
+matters: `a/(b+c+d)` is `(a / ((b + c) + d))` (the three resistances sum FIRST, then the airflow is divided by that whole sum;
+`+` binds left-to-right inside the explicit denominator parentheses and the whole sum sits under the division), NOT `a/b+c+d`
+(dropping the denominator parentheses so only the septal resistance divides the airflow and then the other two resistances are
+added on) and NOT `a/(b+c)+d` (regrouping so only two of the three resistances form the denominator and the valve resistance is
+added outside) — the two distractors exploit exactly those confusions.
+
+The setup: a `total_airflow`, a `septal_resistance`, a `turbinate_resistance`, and a `valve_resistance`. The total is:
+
+  AIRWAY PATENCY INDEX  total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)  [ one term over a 3-term sum denominator ]
+  TOTAL RESISTANCE      septal_resistance + turbinate_resistance + valve_resistance                     [ the three-term denominator ]
+  TOTAL AIRFLOW         total_airflow                                                                   [ the numerator ]
+
+The **airway patency index** is what makes this rung distinctive — it is the ladder's first **single term over a three-term sum
+denominator**. It is a rate (airflow per unit of combined resistance), framed as an *index* to keep it dimensionless-clean — the
+same discipline rungs 100/104/.../115 used for their ratios. (The total resistance `b+c+d` and the total airflow `a` ride
+alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-115 shipped their component
+sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries
+the arithmetic — the summation of the three resistances into the total resistance, then the division of the airflow by that
+whole sum (the single-term numerator over the three-term sum denominator, so a/(b+c+d) evaluates as (a/((b+c)+d))) — and the
+harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs
+8/16/.../114/115. This rung exercises the engine across a **three-term sum denominator** — the fact that `a/(b+c+d)` is
+`(a/((b+c)+d))` and NOT `a/b+c+d` and NOT `a/(b+c)+d` made computable. The ratio golds are non-integer f64s; the engine's IEEE-
+double division matches Python's the same way rungs 99/100/104/.../115 relied on (well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+` and `/` — **no
+structural constants** — so no numeric literal appears in any program, and neither the total resistance, the total airflow, nor
+any index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free
+identifiers** (`total_airflow`, `septal_resistance`, `turbinate_resistance`, `valve_resistance`) so no numeral hides inside a
+variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    total_airflow / septal_resistance + turbinate_resistance + valve_resistance  drop the denominator parentheses so
+                                                                    only the septal resistance divides the airflow and the other
+                                                                    two resistances are added on (the classic `a/(b+c+d)` vs
+                                                                    `a/b+c+d` grouping error), and
+  SWAPPED    total_airflow / (septal_resistance + turbinate_resistance) + valve_resistance  regroup so only two of the three
+                                                                    resistances form the denominator and the valve resistance is
+                                                                    added outside (`a/(b+c)+d` instead of `a/(b+c+d)`),
+
+which are exactly the mistakes a student makes (failing to keep the whole three-term sum under the bar, or regrouping which
+resistances belong to the denominator). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five
+always appear as options.
+
+Distinctness and positivity: every observed quantity is a plain positive number `>= 2` and this rung uses only `+` and `/`, so
+every family member is strictly positive by construction (no subtraction anywhere). The **total_airflow >= 2** and every
+resistance `>= 2` keep all five values positive; the three-term denominator `b+c+d >= 6` keeps the division away from zero, the
+airway patency index never coincides with the total resistance or the total airflow, and the five family values are pairwise
+distinct with a comfortable margin; and — so all three queried readouts vary across the panel — the seven tables give distinct
+airway patency indices, distinct total resistances, and distinct total airflows, all asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (TOTAL_AIRFLOW, SEPTAL_RESISTANCE, TURBINATE_RESISTANCE, VALVE_RESISTANCE) — an airflow divided by the sum of three
+# resistances for the patency index, all plain positive numbers >= 2. This rung uses only + and /, so every family member is
+# strictly positive by construction; the three-term denominator b+c+d >= 6 keeps the division away from zero. The five family
+# values are asserted pairwise-distinct below. The seven tables give distinct airway patency indices, distinct total resistances,
+# and distinct total airflows so all three queried readouts vary across the panel.
+TABLES = [
+    (30, 2, 3, 5),
+    (34, 3, 4, 5),
+    (40, 4, 3, 6),
+    (45, 3, 5, 6),
+    (50, 4, 5, 6),
+    (52, 3, 6, 7),
+    (58, 5, 6, 7),
+]
+
+# The option family (5 members), all built from the four observed quantities via + and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the
+# options.
+FAMILY = [
+    (
+        "patency_index",
+        "airway patency index (the total airflow divided by the sum of the three resistances)",
+        "total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)",
+    ),
+    (
+        "total_resistance",
+        "the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)",
+        "septal_resistance + turbinate_resistance + valve_resistance",
+    ),
+    (
+        "total_airflow",
+        "the total airflow (the numerator divided by the total resistance)",
+        "total_airflow",
+    ),
+    (
+        "crossed",
+        "the total airflow divided by the septal resistance, plus the turbinate resistance plus the valve resistance, dropping the denominator parentheses so only the septal resistance divides (a wrong grouping)",
+        "total_airflow / septal_resistance + turbinate_resistance + valve_resistance",
+    ),
+    (
+        "swapped",
+        "the total airflow divided by the septal plus the turbinate resistance, plus the valve resistance, regrouping so only two resistances form the denominator (a wrong pairing)",
+        "total_airflow / (septal_resistance + turbinate_resistance) + valve_resistance",
+    ),
+]
+QUERIED = ["patency_index", "total_resistance", "total_airflow"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(total_airflow, septal_resistance, turbinate_resistance, valve_resistance):
+    # Operation order mirrors the ADJ programs exactly (the three resistances sum first, then the airflow is divided by that whole
+    # sum, so a/(b+c+d) evaluates as (a/((b+c)+d))), so the Python option value and the engine result are the same IEEE-double
+    # (well within the harness's 1e-9 match tolerance).
+    return {
+        "patency_index": total_airflow / (septal_resistance + turbinate_resistance + valve_resistance),
+        "total_resistance": septal_resistance + turbinate_resistance + valve_resistance,
+        "total_airflow": total_airflow,
+        "crossed": total_airflow / septal_resistance + turbinate_resistance + valve_resistance,
+        "swapped": total_airflow / (septal_resistance + turbinate_resistance) + valve_resistance,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for total_airflow, septal_resistance, turbinate_resistance, valve_resistance in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and this rung uses only + and /, so every family member is
+        # strictly positive by construction (no subtraction anywhere); the three-term denominator b+c+d >= 6 keeps the division
+        # away from zero.
+        assert (
+            total_airflow >= 2
+            and septal_resistance >= 2
+            and turbinate_resistance >= 2
+            and valve_resistance >= 2
+        ), (total_airflow, septal_resistance, turbinate_resistance, valve_resistance)
+        fv = family_values(total_airflow, septal_resistance, turbinate_resistance, valve_resistance)
+        for key, v in fv.items():
+            assert v > 0, (key, total_airflow, septal_resistance, turbinate_resistance, valve_resistance, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    total_airflow,
+                    septal_resistance,
+                    turbinate_resistance,
+                    valve_resistance,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                total_airflow,
+                septal_resistance,
+                turbinate_resistance,
+                valve_resistance,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r116ent-{idx + 1:02d}",
+                "qtype": "patency_index",
+                "stem": (
+                    f"A rhinomanometry report records a total airflow of {num(total_airflow)} divided by a septal resistance of "
+                    f"{num(septal_resistance)} plus a turbinate resistance of {num(turbinate_resistance)} plus a valve "
+                    f"resistance of {num(valve_resistance)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe total_airflow({num(total_airflow)})\n"
+                    f"observe septal_resistance({num(septal_resistance)})\n"
+                    f"observe turbinate_resistance({num(turbinate_resistance)})\n"
+                    f"observe valve_resistance({num(valve_resistance)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 116 — airway patency index from four stated quantities (a NEW panel: otolaryngology / nasal "
+            "airway). From a total airflow divided by the sum of a septal resistance, a turbinate resistance, and a valve "
+            "resistance, compute the airway patency index "
+            "(total_airflow/(septal_resistance+turbinate_resistance+valve_resistance)), the total resistance "
+            "(septal_resistance+turbinate_resistance+valve_resistance), or the total airflow. Each item is a compute_dimensioned "
+            "program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, a "
+            "SINGLE TERM OVER A THREE-TERM SUM DENOMINATOR a/(b+c+d) (sum the three resistances, divide the airflow by that whole "
+            "sum, so a/(b+c+d) = (a/((b+c)+d)); the ladder's FIRST three-term denominator. Every earlier three-term structure "
+            "lived in the NUMERATOR (108 (a+b+c)/d, 109 (a-b+c)/d, 110 (a*b+c)/d, 111 (a*b-c)/d, 114 (a+b-c)/d, 115 (a-b-c)/d) "
+            "over a SINGLE-term divisor d; the distributive pair (112 a*(b+c)/d, 113 a*(b-c)/d) still divided by a single term; "
+            "and every two-term ratio had at most TWO terms below the bar (37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 "
+            "(a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) — rung-116 is the "
+            "first to divide by a sum of THREE quantities. The harness matches the scalar to the printed options. The airway "
+            "patency index is a rate (airflow per unit of combined resistance), framed as an INDEX so the dimensionless value "
+            "stays honest. Contamination-safe: every figure is built only from the four observed quantities via + and / — no "
+            "constant leaks, and neither the total resistance, the total airflow, nor any index ever appears as a literal (each "
+            "is computed) — and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. "
+            "The five options are a family over the same four quantities, so the distractors are exactly the slips students make: "
+            "dropping the denominator parentheses so only the septal resistance divides (a/b+c+d, a wrong grouping) and "
+            "regrouping so only two resistances form the denominator (a/(b+c)+d, a wrong pairing). The core confusion tested is "
+            "that a/(b+c+d) is (a/((b+c)+d)), not a/b+c+d and not a/(b+c)+d. This rung uses only + and /, so positivity is "
+            "guaranteed by construction: every observed quantity is >= 2 and the three-term denominator b+c+d >= 6 (division "
+            "never by zero), keeping every family member strictly positive."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung116_otolaryngology/items.json
+++ b/code/specs/data/adj-ladder/rung116_otolaryngology/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 116 \u2014 airway patency index from four stated quantities (a NEW panel: otolaryngology / nasal airway). From a total airflow divided by the sum of a septal resistance, a turbinate resistance, and a valve resistance, compute the airway patency index (total_airflow/(septal_resistance+turbinate_resistance+valve_resistance)), the total resistance (septal_resistance+turbinate_resistance+valve_resistance), or the total airflow. Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, a SINGLE TERM OVER A THREE-TERM SUM DENOMINATOR a/(b+c+d) (sum the three resistances, divide the airflow by that whole sum, so a/(b+c+d) = (a/((b+c)+d)); the ladder's FIRST three-term denominator. Every earlier three-term structure lived in the NUMERATOR (108 (a+b+c)/d, 109 (a-b+c)/d, 110 (a*b+c)/d, 111 (a*b-c)/d, 114 (a+b-c)/d, 115 (a-b-c)/d) over a SINGLE-term divisor d; the distributive pair (112 a*(b+c)/d, 113 a*(b-c)/d) still divided by a single term; and every two-term ratio had at most TWO terms below the bar (37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 (a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) \u2014 rung-116 is the first to divide by a sum of THREE quantities. The harness matches the scalar to the printed options. The airway patency index is a rate (airflow per unit of combined resistance), framed as an INDEX so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed quantities via + and / \u2014 no constant leaks, and neither the total resistance, the total airflow, nor any index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the denominator parentheses so only the septal resistance divides (a/b+c+d, a wrong grouping) and regrouping so only two resistances form the denominator (a/(b+c)+d, a wrong pairing). The core confusion tested is that a/(b+c+d) is (a/((b+c)+d)), not a/b+c+d and not a/(b+c)+d. This rung uses only + and /, so positivity is guaranteed by construction: every observed quantity is >= 2 and the three-term denominator b+c+d >= 6 (division never by zero), keeping every family member strictly positive.",
+  "items": [
+    {
+      "id": "r116ent-01",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 30 divided by a septal resistance of 2 plus a turbinate resistance of 3 plus a valve resistance of 5. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(30)\nobserve septal_resistance(2)\nobserve turbinate_resistance(3)\nobserve valve_resistance(5)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r116ent-02",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 30 divided by a septal resistance of 2 plus a turbinate resistance of 3 plus a valve resistance of 5. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(30)\nobserve septal_resistance(2)\nobserve turbinate_resistance(3)\nobserve valve_resistance(5)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r116ent-03",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 30 divided by a septal resistance of 2 plus a turbinate resistance of 3 plus a valve resistance of 5. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(30)\nobserve septal_resistance(2)\nobserve turbinate_resistance(3)\nobserve valve_resistance(5)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r116ent-04",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 34 divided by a septal resistance of 3 plus a turbinate resistance of 4 plus a valve resistance of 5. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(34)\nobserve septal_resistance(3)\nobserve turbinate_resistance(4)\nobserve valve_resistance(5)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.333333333333336,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 2.8333333333333335,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.857142857142858,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r116ent-05",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 34 divided by a septal resistance of 3 plus a turbinate resistance of 4 plus a valve resistance of 5. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(34)\nobserve septal_resistance(3)\nobserve turbinate_resistance(4)\nobserve valve_resistance(5)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 2.8333333333333335,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 20.333333333333336,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.857142857142858,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r116ent-06",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 34 divided by a septal resistance of 3 plus a turbinate resistance of 4 plus a valve resistance of 5. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(34)\nobserve septal_resistance(3)\nobserve turbinate_resistance(4)\nobserve valve_resistance(5)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 2.8333333333333335,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 20.333333333333336,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.857142857142858,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r116ent-07",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 40 divided by a septal resistance of 4 plus a turbinate resistance of 3 plus a valve resistance of 6. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(40)\nobserve septal_resistance(4)\nobserve turbinate_resistance(3)\nobserve valve_resistance(6)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.076923076923077,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.714285714285715,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r116ent-08",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 40 divided by a septal resistance of 4 plus a turbinate resistance of 3 plus a valve resistance of 6. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(40)\nobserve septal_resistance(4)\nobserve turbinate_resistance(3)\nobserve valve_resistance(6)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.076923076923077,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 19.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.714285714285715,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r116ent-09",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 40 divided by a septal resistance of 4 plus a turbinate resistance of 3 plus a valve resistance of 6. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(40)\nobserve septal_resistance(4)\nobserve turbinate_resistance(3)\nobserve valve_resistance(6)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.076923076923077,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 19.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.714285714285715,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r116ent-10",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 45 divided by a septal resistance of 3 plus a turbinate resistance of 5 plus a valve resistance of 6. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(45)\nobserve septal_resistance(3)\nobserve turbinate_resistance(5)\nobserve valve_resistance(6)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 26.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.625,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.2142857142857144,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r116ent-11",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 45 divided by a septal resistance of 3 plus a turbinate resistance of 5 plus a valve resistance of 6. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(45)\nobserve septal_resistance(3)\nobserve turbinate_resistance(5)\nobserve valve_resistance(6)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.2142857142857144,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.625,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r116ent-12",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 45 divided by a septal resistance of 3 plus a turbinate resistance of 5 plus a valve resistance of 6. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(45)\nobserve septal_resistance(3)\nobserve turbinate_resistance(5)\nobserve valve_resistance(6)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.2142857142857144,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 26.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.625,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r116ent-13",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 50 divided by a septal resistance of 4 plus a turbinate resistance of 5 plus a valve resistance of 6. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(50)\nobserve septal_resistance(4)\nobserve turbinate_resistance(5)\nobserve valve_resistance(6)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 3.3333333333333335,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 23.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.555555555555555,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r116ent-14",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 50 divided by a septal resistance of 4 plus a turbinate resistance of 5 plus a valve resistance of 6. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(50)\nobserve septal_resistance(4)\nobserve turbinate_resistance(5)\nobserve valve_resistance(6)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.3333333333333335,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 11.555555555555555,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r116ent-15",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 50 divided by a septal resistance of 4 plus a turbinate resistance of 5 plus a valve resistance of 6. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(50)\nobserve septal_resistance(4)\nobserve turbinate_resistance(5)\nobserve valve_resistance(6)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.3333333333333335,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 23.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.555555555555555,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r116ent-16",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 52 divided by a septal resistance of 3 plus a turbinate resistance of 6 plus a valve resistance of 7. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(52)\nobserve septal_resistance(3)\nobserve turbinate_resistance(6)\nobserve valve_resistance(7)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.777777777777779,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r116ent-17",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 52 divided by a septal resistance of 3 plus a turbinate resistance of 6 plus a valve resistance of 7. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(52)\nobserve septal_resistance(3)\nobserve turbinate_resistance(6)\nobserve valve_resistance(7)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.777777777777779,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r116ent-18",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 52 divided by a septal resistance of 3 plus a turbinate resistance of 6 plus a valve resistance of 7. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(52)\nobserve septal_resistance(3)\nobserve turbinate_resistance(6)\nobserve valve_resistance(7)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 52,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 30.333333333333332,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.777777777777779,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r116ent-19",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 58 divided by a septal resistance of 5 plus a turbinate resistance of 6 plus a valve resistance of 7. What is the airway patency index (the total airflow divided by the sum of the three resistances)?",
+      "program": "observe total_airflow(58)\nobserve septal_resistance(5)\nobserve turbinate_resistance(6)\nobserve valve_resistance(7)\nlet answer = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 58,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.2222222222222223,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.272727272727273,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r116ent-20",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 58 divided by a septal resistance of 5 plus a turbinate resistance of 6 plus a valve resistance of 7. What is the the total resistance (the septal plus the turbinate plus the valve resistance, the divisor the airflow is divided by)?",
+      "program": "observe total_airflow(58)\nobserve septal_resistance(5)\nobserve turbinate_resistance(6)\nobserve valve_resistance(7)\nlet answer = septal_resistance + turbinate_resistance + valve_resistance\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.2222222222222223,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 58,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 24.6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.272727272727273,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 18,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r116ent-21",
+      "qtype": "patency_index",
+      "stem": "A rhinomanometry report records a total airflow of 58 divided by a septal resistance of 5 plus a turbinate resistance of 6 plus a valve resistance of 7. What is the the total airflow (the numerator divided by the total resistance)?",
+      "program": "observe total_airflow(58)\nobserve septal_resistance(5)\nobserve turbinate_resistance(6)\nobserve valve_resistance(7)\nlet answer = total_airflow\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 58,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 3.2222222222222223,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 18,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 24.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 12.272727272727273,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -153,6 +153,7 @@ SELF_CONTAINED_RUNGS = (
     "rung113_apheresis",
     "rung114_fluency",
     "rung115_phlebotomy",
+    "rung116_otolaryngology",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-116 — airway patency index (one term over a three-term sum denominator)

Opens the **otolaryngology / nasal-airway** panel on the quantitative band and introduces a genuinely **new arithmetic shape**: **a single term over a THREE-term SUM denominator, `a/(b+c+d)`** — the ladder's **first three-term denominator**.

### What's new (shape novelty)

Every earlier ratio put its multi-term structure in the **numerator** over a **single-term** or two-term divisor. The three-term *numerator* family shipped rung-108 `(a+b+c)/d`, rung-109 `(a-b+c)/d`, rung-110 `(a*b+c)/d`, rung-111 `(a*b-c)/d`, rung-114 `(a+b-c)/d`, rung-115 `(a-b-c)/d` — all over a **single** divisor `d`; the distributive pair (rung-112 `a*(b+c)/d`, rung-113 `a*(b-c)/d`) still divided by a single term; and every two-term ratio had at most **two** terms below the bar (rung-37 `(a+b)/(c+d)`, rung-99 `(a*b)/(c+d)`, rung-100 `(a+b)/(c*d)`, rung-104 `(a-b)/(c*d)`, and the difference-denominator trio rung-105/106/107). **Rung-116 is the first to divide by a sum of THREE quantities.**

Rung-116 is `(total_airflow / ((septal_resistance + turbinate_resistance) + valve_resistance))` — the three resistances sum left-to-right inside the explicit denominator parentheses, then the airflow is divided by that whole sum, so `a/(b+c+d)` = `(a/((b+c)+d))`.

### The clinical framing

A rhinomanometry report gives a `total_airflow` and three resistances — a `septal_resistance`, a `turbinate_resistance`, and a `valve_resistance` (nasal septum, inferior turbinate, internal nasal valve). Airflow divided by the **combined** resistance gives the **airway patency index** (airflow per unit of combined resistance, framed as a dimensionless index).

- `AIRWAY PATENCY INDEX = total_airflow / (septal_resistance + turbinate_resistance + valve_resistance)` — the headline single-term-over-three-term-sum ratio
- `TOTAL RESISTANCE     = septal_resistance + turbinate_resistance + valve_resistance` — the three-term denominator, a real component readout
- `TOTAL AIRFLOW        = total_airflow` — the numerator, a real component readout

### The distractor family (5 mutually-confusable scalars over the same four quantities)

- **crossed** `total_airflow / septal_resistance + turbinate_resistance + valve_resistance` — drops the denominator parentheses so only the septal resistance divides the airflow and the other two resistances are added on (the `a/(b+c+d)` vs `a/b+c+d` grouping slip)
- **swapped** `total_airflow / (septal_resistance + turbinate_resistance) + valve_resistance` — regroups so only two of the three resistances form the denominator and the valve resistance is added outside (`a/(b+c)+d`)

The core confusion tested: `a/(b+c+d)` is `(a/((b+c)+d))`, **not** `a/b+c+d` and **not** `a/(b+c)+d`.

### Construction guarantees

- **Constant-free / digit-free**: every figure is built only from the four observed quantities via `+`, `/`; no numeric literal appears in any program; identifiers are digit-free (`total_airflow`, `septal_resistance`, `turbinate_resistance`, `valve_resistance`).
- **This rung uses only `+` and `/`** (no subtraction anywhere), so positivity is by construction: every observed quantity is `>= 2` and the three-term denominator `b+c+d >= 6` (division never by zero), keeping every family member strictly positive.
- Five family values asserted **pairwise-distinct** (>1e-6) per table; the seven tables give **distinct patency indices, distinct total resistances, and distinct total airflows** so all three queried golds vary across the panel.
- Gold rotates A–E by `idx % 5`. 7 tables × 3 queried readouts = **21 items**.

### No harness/engine change

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing extractor — exactly as rungs 8/16/…/114/115.

### Verification

- `gen_items.py` → `wrote items.json: 21 items`
- Scratchpad distinctness/positivity checker: all 5 within-table pairwise-distinct; 3 queried golds all vary across the 7 tables.
- `python3 -m pytest test_ladder_eval.py -k rung116 -q` → **3 passed**
- Inline security review: PASSED (data-only generator; no eval/exec/network/user-input; writes only its own items.json; every table guards all four quantities `>= 2` so the three-term denominator is never zero and every member positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
