### PR TITLE
feat(latex): LTXDOC03 S27 unresolved_reference_count (single-integer total of dangling refs)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.63.0] — 2026-07-08
+
+### Added — single-integer TOTAL of the unresolved (dangling) references (LTXDOC03 S27)
+
+A **new** public method `Document::unresolved_reference_count(&self) -> String` that renders the decimal
+**COUNT** of the UNRESOLVED (dangling) `\ref`/`\eqref`/`\pageref` references — the ones no `\label`
+defines (LaTeX's *"Reference `key' undefined"*, the `??`) — as one integer line. It is the *count-total*
+companion of S18's `unresolved_references_by_source` (which renders one `\<command>{key}` **line per
+dangling reference**): S18 and S27 are two *views* of the one `unresolved` list `resolve_references()`
+produces — S27 collapses the whole list to a single `.len()` tally. It is the count-total sibling of the
+census family (S25 `label_kind_counts`, S26 `resolved_reference_kind_counts`), but for the UNRESOLVED
+refs — which carry **no** `target_kind` (a dangling ref bound to nothing), so a per-kind census is not
+viable; a single total is the clean move. It is a read-only view over `resolve_references()`; every
+S1–S26 output is left **byte-for-byte unchanged**; S27 is purely additive and leaves the `to_latex()`
+round-trip fixed point intact.
+
+- **Counts the UNRESOLVED refs only.** S27 reads `resolve_references().unresolved.len()` — each entry an
+  `UnresolvedRef` for a dangling `\ref`/`\eqref`/`\pageref`. A resolved `\ref{sec:i}` lives in
+  `resolve_references().resolved` (S21's domain), never in `unresolved`, so it is excluded by
+  construction.
+- **A single decimal line, always.** The output is the decimal `.len()` of the `unresolved` list — one
+  line, no trailing newline. There is **no** source slicing and **no** `target_kind` read at all (a
+  dangling ref never carries one); only `.len()` is taken.
+- **Zero is the honest value `"0"`.** Being a COUNT renderer, its empty case (every ref resolves, or
+  there are none at all) is the number `"0"` — **not** a `(no …)` marker. The `(no …)` marker discipline
+  belongs to the *list* renderers S18/S21/S24, whose empty case has no lines to show; a total count of
+  zero *is* a number.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single read
+  of the already-bounded `unresolved` list's length. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s27_two_dangling_plus_one_resolved_counts_two`, `s27_all_refs_resolve_counts_zero`,
+  `s27_no_references_at_all_counts_zero`, `s27_mixed_kinds_of_danglers_count_the_integer`,
+  `s27_count_equals_number_of_s18_lines` (cross-checking the total against the number of lines S18
+  enumerates), and `s27_is_additive_leaves_s1_s26_outputs_unchanged` (which pins a handful of prior
+  S1–S26 outputs byte-for-byte — including S18's `unresolved_references_by_source` and S26's
+  `resolved_reference_kind_counts` — alongside the new count).
+
 ## [0.62.0] — 2026-07-08
 
 ### Added — per-kind census (counts) of the resolved references (LTXDOC03 S26)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.62.0"
+version = "0.63.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -74,6 +74,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S24 — resolved references grouped by target kind** | `Document::resolved_references_by_kind() -> String` — a **new**, read-only method that renders the **resolved** `\ref`/`\eqref`/`\pageref` references **grouped by the `LabelKind` they resolved TO** — a per-kind census — the **by-kind grouping companion of S21's** `resolved_references_by_source` (which lists the same resolved refs *flat*, in source order); S21 and S24 are two views of the one `resolved` list. It mirrors S23's `label_definitions_by_kind` idiom but over the **resolved-references** list, and stays **command-aware** like S21. It reads only `resolve_references().resolved` (a `Vec<ResolvedRef { key, command, ref_span, target_span, target_kind }>`) and groups by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23 uses, iterated explicitly, not a hash map, so the order is deterministic). Within each kind, refs keep their existing pre-order. Each line is `[<kind>] \<command>{<key>}` — `<kind>` from the ref's `target_kind.as_str()`, `<command>` the ref's own (so `\eqref`/`\pageref` render as themselves), `<key>` from the owned key (no source slicing). A **dangling** `\ref` never entered `resolved`, so it is excluded (it lives in S18). A kind with no resolved refs contributes no lines (no empty `[table]` header). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21 uses. E.g. `\ref{sec:intro}` (section), `\eqref{eq:main}` (equation), `\pageref{sec:intro}` (section) → `[section] \ref{sec:intro}\n[section] \pageref{sec:intro}\n[equation] \eqref{eq:main}`. Every S1–S23 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S25 — per-kind census (counts) of the winning `\label` definitions** | `Document::label_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the winning `\label` definitions: one `<kind>: <n>` line per `LabelKind` that has at least one winning definition, carrying the integer **count** (not a list) — the **count companion of S23's** `label_definitions_by_kind` (which renders one `[kind] \label{key}` *line per definition*). S22's flat `label_definitions`, S23's grouped list, and S25's counts are three views of the one winning `definitions` list; S25 collapses each kind's group to a single tally line (it is to S23 what S14's `list_summary` is to a full enumeration). It reads only `resolve_references().definitions` (one row per distinct key — the WINNER; a `\label{dup}` written twice counts **once**, its later copy being a `Duplicate` in S20's domain) and counts by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S23 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22/S23 use. E.g. `sec:intro` (section), `eq:a`/`eq:b` (equations), `note` (inline) → `section: 1\nequation: 2\ninline: 1`. Every S1–S24 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S26 — per-kind census (counts) of the resolved references** | `Document::resolved_reference_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the RESOLVED `\ref`/`\eqref`/`\pageref` references: one `<kind>: <n>` line per `LabelKind` that has at least one resolved ref, carrying the integer **count** (not a list) — the **count companion of S24's** `resolved_references_by_kind` (which renders one `[kind] \<command>{key}` *line per resolved ref*). S21's flat `resolved_references_by_source`, S24's grouped list, and S26's counts are three views of the one `resolved` list; S26 collapses each kind's group to a single tally line (it is to S24 what S25's `label_kind_counts` is to S23). It reads only `resolve_references().resolved` (each a `ResolvedRef` carrying the `target_kind` — the kind of the label it bound to; a dangling `\ref` lives in `unresolved`, S18's domain, and is excluded by construction — never a spurious `<kind>: 0`) and counts by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24/S25 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S24 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21/S24 use. E.g. `\ref{sec:a}`, `\ref{sec:b}` (two sections), `\eqref{eq:e}` (equation) → `section: 2\nequation: 1`. Every S1–S25 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S27 — single-integer total of the unresolved (dangling) references** | `Document::unresolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\ref`/`\eqref`/`\pageref` references — the ones no `\label` defines (LaTeX's *"Reference `key' undefined"*, the `??`) — as one integer line. It is the **count-total companion of S18's** `unresolved_references_by_source` (which renders one `\<command>{key}` *line per dangling ref*): S18 and S27 are two views of the one `unresolved` list; S27 collapses the whole list to a single `.len()` tally. It is the count-total sibling of the census family (S25 `label_kind_counts`, S26 `resolved_reference_kind_counts`), but for the UNRESOLVED refs — which carry **no** `target_kind` (a dangling ref bound to nothing), so a per-kind census is not viable and a single total is the clean move. It reads only `resolve_references().unresolved.len()` (a resolved `\ref{sec:i}` lives in `resolved`, S21's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all. Being a COUNT renderer, its empty case (every ref resolves, or none at all) is the honest number `"0"` — **not** a `(no …)` marker (that discipline belongs to the *list* renderers). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\ref{nope}` + `\ref{gone}` (both dangle) → `2`. Every S1–S26 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1065,6 +1066,39 @@ assert_eq!(
 A document with no resolved references (all dangling, or none at all) renders the **same** fixed
 `(no resolved references)` marker S21/S24 use (S26 counts the identical list). Purely additive — reuses
 `resolve_references`, mutates nothing, leaves every S1–S25 output and the `to_latex()` fixed point
+unchanged.
+
+### single-integer total of the unresolved (dangling) references (LTXDOC03 S27)
+
+The decimal **COUNT** of the UNRESOLVED (dangling) `\ref`/`\eqref`/`\pageref` references — the ones no
+`\label` defines (LaTeX's *"Reference `key' undefined"*, the `??`) — as one integer line. It is the
+**count-total companion of S18's** `unresolved_references_by_source` (which renders one `\<command>{key}`
+line *per dangling ref*, in body pre-order): S18 and S27 are two *views* of the one `unresolved` list
+`resolve_references()` produces; S27 collapses the whole list to a single `.len()` tally. It is the
+count-total sibling of the census family (S25's `label_kind_counts`, S26's
+`resolved_reference_kind_counts`), but for the UNRESOLVED refs — which carry **no** `target_kind` (a
+dangling ref bound to nothing), so a per-kind census is not viable and a single total is the clean move.
+`unresolved_reference_count` reads only `resolve_references().unresolved.len()` — a resolved `\ref{sec:i}`
+lives in `resolved` (S21's domain) and is excluded by construction — never a `target_kind`, with no
+source slicing at all.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \ref{nope} \ref{gone}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.unresolved_reference_count(),
+    // two refs dangle (`nope`, `gone`); the resolved `\ref{sec:i}` is excluded
+    "2",
+);
+```
+
+Being a COUNT renderer, a document with no dangling references (every ref resolves, or none at all)
+renders the honest number `"0"` — **not** a `(no …)` marker (that discipline belongs to the *list*
+renderers S18/S21/S24, whose empty case has no lines to show). Purely additive — reuses
+`resolve_references`, mutates nothing, leaves every S1–S26 output and the `to_latex()` fixed point
 unchanged.
 
 ## Usage

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2734,6 +2734,70 @@ impl Document {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    /// The **single-integer TOTAL of the unresolved (dangling) references** (LTXDOC03 S27) — the
+    /// *count-total* companion of S18's
+    /// [`unresolved_references_by_source`](Document::unresolved_references_by_source). Where S18
+    /// renders one **line per dangling reference** (a `\<command>{key}` list, in body pre-order),
+    /// S27 renders one **line** carrying just the decimal **count** of those dangling refs — the
+    /// number of `\ref`/`\eqref`/`\pageref` that no `\label` defines. It is to S18 what S25's
+    /// [`label_kind_counts`](Document::label_kind_counts) and S26's
+    /// [`resolved_reference_kind_counts`](Document::resolved_reference_kind_counts) are to their
+    /// list views: a numeric summary over the *same* list — here the **unresolved** references — so
+    /// a reader sees "how many refs dangle" without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] walks every `\ref`/`\eqref`/`\pageref` in body pre-order
+    /// and splits them into the **resolved** references (those a `\label` defines — S21/S24/S26's
+    /// domain) and the **unresolved** (dangling) ones — LaTeX's *"Reference `key' undefined"*, the
+    /// `??` in the output — recorded in [`ReferenceResolution::unresolved`] as [`UnresolvedRef`]s.
+    /// S18 renders that `unresolved` list as one line per dangling ref; S27 collapses the whole list
+    /// to a **single count line** — the decimal `.len()` of `unresolved`. Unlike S25/S26, no per-kind
+    /// census is possible here: a dangling ref bound to **no** definition, so it carries **no**
+    /// `target_kind` — there is nothing to group by, so a single total is the clean move. Only the
+    /// **unresolved** refs are counted; a resolved `\ref{sec:i}` lives in
+    /// [`ReferenceResolution::resolved`] (S21), never in `unresolved`, so it is excluded by
+    /// construction.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`ReferenceResolution::unresolved`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no dangling references is the number `0` — the string `"0"`, **not**
+    /// a `(no …)` marker (a total count of zero *is* a number; the `(no …)` marker discipline belongs
+    /// to the *list* renderers S18/S21/S24, whose empty case has no lines to show). There is no source
+    /// slicing and no `target_kind` read at all — only `.len()` is taken.
+    ///
+    /// Concretely, for a body defining `\label{sec:i}` and then writing `\ref{sec:i}` (resolves),
+    /// `\ref{nope}` (dangles), and `\ref{gone}` (dangles):
+    ///
+    /// ```text
+    /// 2
+    /// ```
+    ///
+    /// (two references dangle; the one resolved `\ref{sec:i}` is excluded). A document with no dangling
+    /// references — every ref resolves, or there are none at all — returns `"0"`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S27 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1–S26 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *second view* of the same `unresolved`
+    /// list S18 renders per-source — counting never adds, drops, or reorders the dangling references
+    /// relative to what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read, never a `target_kind`, which a dangling ref never carries); a single
+    /// read of the already-bounded `unresolved` list's length. Borrows `self` immutably and returns
+    /// owned `String` data, so the result outlives any borrow of the source.
+    pub fn unresolved_reference_count(&self) -> String {
+        // S1 already split every `\ref`/`\eqref`/`\pageref` into resolved and dangling entries, routing
+        // the dangling ones into `unresolved` (in body pre-order). We only read that list's length; the
+        // resolved refs live in `resolved` (S21). A dangling ref bound to no definition, so it carries
+        // no `target_kind` — a per-kind census is not viable here, and a single total is the clean move.
+        self.resolve_references().unresolved.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -6665,6 +6729,135 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.resolved_reference_kind_counts(),
             "section: 1\nequation: 1"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S27 — single-integer TOTAL of the unresolved (dangling) references
+    // (`unresolved_reference_count`). The count-total companion of S18's
+    // `unresolved_references_by_source`: one decimal line = `.len()` of the SAME `unresolved` list.
+    // Dangling refs carry no `target_kind`, so no per-kind census is possible — a total is the move.
+    // Being a COUNT renderer, its empty value is the honest number "0", NOT a `(no …)` marker.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s27_two_dangling_plus_one_resolved_counts_two() {
+        // Two `\ref`s that dangle (`nope`, `gone`) plus one that resolves (`sec:i`) → the count of
+        // dangling refs is exactly "2"; the resolved `\ref{sec:i}` is excluded (it lands in `resolved`).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \ref{nope} \ref{gone}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_reference_count(), "2");
+        // Cross-check: the two dangling refs are exactly what S18 enumerates.
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "\\ref{nope}\n\\ref{gone}"
+        );
+    }
+
+    #[test]
+    fn s27_all_refs_resolve_counts_zero() {
+        // Every reference resolves to a real `\label` → zero danglers. A COUNT renderer's honest value
+        // for an empty list is the number "0" (never a `(no …)` marker).
+        let src = r"\begin{document}\section{One}\label{sec:a}
+\section{Two}\label{sec:b}
+\ref{sec:a} \ref{sec:b} \pageref{sec:a}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_reference_count(), "0");
+        // And S18 (the list view) has no lines to show for the same doc.
+        assert_eq!(
+            doc.unresolved_references_by_source(),
+            "(no unresolved references)"
+        );
+    }
+
+    #[test]
+    fn s27_no_references_at_all_counts_zero() {
+        // A document with NO references whatsoever → still "0" (the count of an empty `unresolved` list).
+        let src = r"\begin{document}Just some text with no references.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_reference_count(), "0");
+    }
+
+    #[test]
+    fn s27_mixed_kinds_of_danglers_count_the_integer() {
+        // Several danglers of DIFFERENT intended kinds — a `\ref`, an `\eqref`, and a `\pageref`, none
+        // of which any `\label` defines. No kind is tracked for a dangling ref (it bound to nothing), so
+        // the answer is simply the integer count of dangling refs: "3".
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \ref{no1} \eqref{eq:no2} \pageref{no3}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_reference_count(), "3");
+    }
+
+    #[test]
+    fn s27_count_equals_number_of_s18_lines() {
+        // Cross-check the total against S18's per-source list: the count S27 returns MUST equal the
+        // number of lines S18 enumerates (they are two views of the SAME `unresolved` list).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \ref{a} \eqref{eq:b} \pageref{c} \ref{d}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let s18 = doc.unresolved_references_by_source();
+        let s18_line_count = s18.lines().count();
+        assert_eq!(s18_line_count, 4);
+        assert_eq!(doc.unresolved_reference_count(), s18_line_count.to_string());
+        assert_eq!(doc.unresolved_reference_count(), "4");
+    }
+
+    #[test]
+    fn s27_is_additive_leaves_s1_s26_outputs_unchanged() {
+        // Same representative doc as the S24/S25/S26 additive tests. S27 changes NONE of the S1-S26
+        // outputs — it only reads `resolve_references`. Its count is a second view of the SAME
+        // `unresolved` list S18 renders per-source; pinned here to show S27 neither adds, drops, nor
+        // reorders, and that its total agrees with the number of lines S18 enumerates.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A handful of prior renderers — byte-for-byte unchanged.
+        // S14 per-kind census.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S19 numbered winning bibliography.
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S22 flat winning label definitions.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S18 grouped dangling refs — the one `\eqref{eq:ghost}` dangles.
+        assert_eq!(doc.unresolved_references_by_source(), "\\eqref{eq:ghost}");
+        // S25 per-kind label-definition counts.
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nfigure: 1\nequation: 1\ninline: 1"
+        );
+        // S26 per-kind resolved-reference counts.
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "section: 1\nequation: 1"
+        );
+
+        // And S27 itself: exactly ONE reference dangles (`\eqref{eq:ghost}`), so the count is "1" —
+        // agreeing with the single line S18 enumerates for the same doc.
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        assert_eq!(
+            doc.unresolved_reference_count(),
+            doc.unresolved_references_by_source().lines().count().to_string()
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2176,3 +2176,78 @@ ref's exclusion; and an additivity check that `to_plain_text`, `to_plain_text_by
 produce their exact prior strings). All prior S1–S25 tests pass unchanged. `cargo clippy -p latex
 --all-targets -- -D warnings` clean; downstream `cargo test -p adj-lang -p adj-lang-cli` green; `cargo
 build -p latex --no-default-features` builds. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 33. S27 — single-integer total of the unresolved (dangling) references (`unresolved_reference_count`)
+
+### 33.1 Motivation
+
+S18 (`unresolved_references_by_source`) enumerates the **unresolved** (dangling) `\ref`/`\eqref`/`\pageref`
+references — the ones no `\label` defines (LaTeX's *"Reference `key' undefined"*, the `??`) — one **line
+per dangling reference** (`\<command>{key}`, in body pre-order). But a reader often wants not the
+enumeration but the **total** — "how many of my references dangle?" — a single number answered at a
+glance, without scanning the individual keys. S25 (`label_kind_counts`) and S26
+(`resolved_reference_kind_counts`) already brought a numeric-summary discipline to the label-definitions
+and resolved-references families, respectively, as *per-kind* censuses. But the unresolved refs carry
+**no** `target_kind` — a dangling ref bound to no definition, so there is nothing to group by; a per-kind
+census is not viable. The clean move is a **single total**: S27 collapses the whole `unresolved` list to
+its decimal `.len()`. It is the count-total sibling of the census family, but for the UNRESOLVED refs.
+
+### 33.2 Why a new method — additive by construction
+
+S27 adds a **new public method** `Document::unresolved_reference_count(&self) -> String`. It is a pure,
+read-only render of `resolve_references().unresolved.len()` — a *second view* of the exact list S18
+renders per-source. It reuses that list verbatim (never re-walking the body or re-resolving), so the
+report can never drift from the S1 resolution it summarises, and counting never adds, drops, or reorders
+references relative to what `resolve_references` produced. It mutates nothing and changes no S1–S26 output
+— including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S26 it is a method the caller
+invokes directly.
+
+### 33.3 The rendering rule
+
+The output is the decimal `.len()` of the `unresolved` list, rendered as its `String`, **always** on a
+single line with **no** trailing newline. There is no ordering question (a single integer has no order)
+and no per-kind grouping (a dangling ref carries no `target_kind` to group by) — only `.len()` is read,
+with **no** source slicing at all. Being a **count** renderer, its empty case is the honest number `"0"`
+— **not** a `(no …)` marker. The `(no …)` marker discipline belongs to the *list* renderers
+S18/S21/S24, whose empty case has no lines to show; a total count of zero *is* a number, so `"0"` is its
+truthful value.
+
+### 33.4 The exact rendering contract — `Document::unresolved_reference_count(&self) -> String`
+
+- Read `resolve_references().unresolved.len()` and render it with `.to_string()` → the decimal count, one
+  line, no trailing newline. There is **no** source slicing and **no** `target_kind` read at all (a
+  dangling ref never carries one), so the render needs no source borrow and can never index out of bounds.
+- Only the **unresolved** references are counted. A resolved `\ref{sec:i}` lives in
+  `resolve_references().resolved` (S21's domain), never in `unresolved`, so it is excluded by construction.
+- The empty case (every ref resolves, or there are none at all) returns the honest number `"0"` — **not**
+  a `(no …)` marker, because S27 is a count renderer.
+
+Example (body defining `\label{sec:i}`, then writing `\ref{sec:i}` (resolves), `\ref{nope}` (dangles), and
+`\ref{gone}` (dangles)):
+
+```text
+2
+```
+
+Two references dangle; the one resolved `\ref{sec:i}` is excluded. This is the count-total companion of
+S18's per-source list — a second view of the one `unresolved` list; the count equals the number of lines
+S18 would enumerate.
+
+### 33.5 Public API (added in S27)
+
+One new method: `Document::unresolved_reference_count(&self) -> String`. No existing type, field, counter,
+or signature changes; `resolve_references` and every S1–S26 method are unchanged; no AST or grammar
+change; no new dependency, no `unsafe`, no I/O.
+
+### 33.6 Verification (S27)
+
+`cargo test -p latex` green (6 new S27 tests: two-danglers-plus-one-resolved returning `"2"`
+(cross-checked against S18's `unresolved_references_by_source`); an all-refs-resolve case returning `"0"`
+(cross-checked against S18's `(no unresolved references)` marker); a no-references-at-all case returning
+`"0"`; a mixed-kinds-of-danglers case (`\ref`/`\eqref`/`\pageref`, none defined) returning the integer
+`"3"`; a cross-check that the count equals the number of lines S18 enumerates (`"4"`); and an additivity
+check that a handful of prior renderers — `list_summary`, `bibliography_entries`, `label_definitions`,
+`unresolved_references_by_source`, S25's `label_kind_counts`, and S26's `resolved_reference_kind_counts` —
+all still produce their exact prior strings, with S27 returning `"1"` (agreeing with the single line S18
+enumerates)). All prior S1–S26 tests pass unchanged. No `cargo fmt`, no grammar regen, no new
+dependencies.


### PR DESCRIPTION
## LTXDOC03 S27 — `unresolved_reference_count` (single-integer total of dangling refs)

Adds one small, additive, read-only renderer to the `latex` crate: **`Document::unresolved_reference_count(&self) -> String`** — the single-integer TOTAL companion of S18's `unresolved_references_by_source`.

### What it does

`resolve_references()` (S1) walks every `\ref`/`\eqref`/`\pageref` in body pre-order and splits them into the **resolved** refs (a `\label` defines them) and the **unresolved** (dangling) ones — LaTeX's *"Reference `key' undefined"*, the `??` in the output. S18 already renders the unresolved list **grouped by source**. S27 collapses that same list to its **count**:

```rust
pub fn unresolved_reference_count(&self) -> String {
    self.resolve_references().unresolved.len().to_string()
}
```

It reads only `.len()` of `ReferenceResolution::unresolved` — never a `target_kind` (dangling refs never bound, so they carry no kind, which is exactly why a per-kind census like S25/S26 is **not** viable for them and a single total is the clean move).

### Rendering contract

- Returns the **decimal count as one line**, always — including **`"0"`** when there are no dangling references. This is a *count* renderer, so zero is its honest numeric value, not a `(no …)` marker (unlike the S18 list renderer it totals). No trailing newline.
- Total & panic-free: borrows `self` immutably, no `unwrap`/`expect`, no indexing/slicing (only `.len()`), no file/network I/O, no `unsafe`.

### Additive by construction

S27 is a brand-new read-only method that reuses `resolve_references()` and mutates nothing — it changes no S1–S26 output (byte-for-byte unchanged) and leaves the `to_latex` round-trip fixed point intact. The added test suite includes an **additivity test** that pins `list_summary`, `bibliography_entries`, `label_definitions`, `unresolved_references_by_source`, `label_kind_counts`, and `resolved_reference_kind_counts` byte-for-byte while S27 returns its count on the same document.

### Tests (6 new)

1. two dangling + one resolved → `"2"` (cross-checks S18)
2. all refs resolve → `"0"` (while S18 returns `(no unresolved references)`)
3. no references at all → `"0"`
4. mixed `\ref`/`\eqref`/`\pageref` danglers → `"3"` (no kind tracked)
5. count equals the number of S18 lines → `"4"`
6. additivity: S1–S26 outputs unchanged, S27 returns `"1"`

### Verification (all re-run from the worktree)

- `cargo test -p latex` → **449 passed** (+6 new) + 1 doc-test
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (0 failed)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED (read-only, panic-free, no I/O/unsafe/deps)

### Scope

Bumps `latex` 0.62.0 → **0.63.0**; updates CHANGELOG.md + README.md + the LTXDOC03 spec (appends a new S27 section; sections 1–32 byte-for-byte unchanged). No `cargo fmt`, no grammar regen, no new deps, no file I/O, no `unsafe`. Exactly 5 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
