### PR TITLE
feat(engram-core): drop the third-party regex crate (Phase D4)

### DIFF
--- a/code/packages/rust/engram-core/Cargo.toml
+++ b/code/packages/rust/engram-core/Cargo.toml
@@ -10,11 +10,17 @@ serde = ["dep:serde"]
 
 [dependencies]
 fsrs = { path = "../fsrs" }
-regex = "1"
 regex-engine = { path = "../regex-engine" }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = "1"
 unicode-normalize = { path = "../unicode-normalize" }
+
+# `regex` is a DEV-dependency only — it is the independent oracle the
+# `html_scan` cross-check test measures the zero-dep `strip_tags` scanner
+# against. No runtime code path depends on it: search + media-tag replacement
+# both run on `regex-engine` (Phase D4 removed the last runtime use).
+[dev-dependencies]
+regex = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.4.2", features = ["wasm_js"] }

--- a/code/packages/rust/engram-core/src/search.rs
+++ b/code/packages/rust/engram-core/src/search.rs
@@ -10,19 +10,20 @@ use crate::model::{
 };
 use crate::queue::{is_new_progress_overlay, is_reviewable};
 use crate::sm2::ONE_DAY_MS as MS_PER_DAY;
-// Engram's boolean search matching — user `re:` patterns, whole-word, and
-// `*`/`_` globs — runs on the zero-dependency `regex_engine` (Pike VM,
-// linear-time). The one place a match *extent* is still needed, the media-tag
-// `replace_all` below, keeps the third-party `regex` crate (fully qualified)
-// until a later, separately-verified change adds extents to `regex_engine`.
+// Engram's search matching runs entirely on the zero-dependency `regex_engine`
+// (Pike VM, linear-time): the boolean uses — user `re:` patterns, whole-word,
+// and `*`/`_` globs — plus the one place a match *extent* is needed, the
+// media-tag `replace_all` below. No third-party regex crate remains in the
+// runtime dependency graph (`regex` is now a dev-dependency, used only by the
+// `html_scan` cross-check test).
 use regex_engine::{Regex, RegexBuilder};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use unicode_normalize::{char::is_combining_mark, UnicodeNormalize};
 
-static DUPLICATE_HTML_MEDIA_TAGS: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(
+static DUPLICATE_HTML_MEDIA_TAGS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
         r#"(?is)<(?:img|audio|video|object|source)[^>]*(?:src|data)\s*=\s*(?:"([^"]+)"|'([^']+)'|([^ >]+))[^>]*>"#,
     )
     .expect("duplicate media tag regex should compile")
@@ -2276,14 +2277,15 @@ fn rendered_search_text(value: &str) -> Cow<'_, str> {
         return Cow::Borrowed(value);
     }
 
-    let with_media = DUPLICATE_HTML_MEDIA_TAGS.replace_all(value, |captures: &regex::Captures| {
-        let filename = captures
-            .get(1)
-            .or_else(|| captures.get(2))
-            .or_else(|| captures.get(3))
-            .map_or("", |capture| capture.as_str());
-        format!(" {filename} ")
-    });
+    let with_media =
+        DUPLICATE_HTML_MEDIA_TAGS.replace_all(value, |captures: &regex_engine::Captures| {
+            let filename = captures
+                .get(1)
+                .or_else(|| captures.get(2))
+                .or_else(|| captures.get(3))
+                .map_or("", |capture| capture.as_str());
+            format!(" {filename} ")
+        });
     let without_tags = crate::html_scan::strip_tags(&with_media);
     Cow::Owned(decode_search_html_entities(&without_tags))
 }

--- a/code/specs/engram-zero-dep-plan.md
+++ b/code/specs/engram-zero-dep-plan.md
@@ -21,7 +21,7 @@ so each landed PR is independently green.
 | `zstd_crate` | engram-anki-package | prod | repo `zstd` — **currently INCOMPLETE** (see below) | **L** | must bidirectionally interop with real zstd (Anki `.anki21b`) |
 | `prost` (protobuf) | engram-anki-package | prod | new tiny `protobuf` codec (4 messages) | **S/M** | must byte-interop with Anki `meta`/`media` protobufs |
 | `fsrs 6.6.1` | engram-core | prod | reimplement forward FSRS-5/6 (~200 LOC) | **M** | **numeric** — must match crate output |
-| `regex` | engram-core (search.rs) | prod | hand-scanners + glob matcher; mini regex engine only for `re:` | **S…L** | `re:` user-search is the only true-regex need |
+| `regex` | engram-core (**✅ DONE — now test-only dev-dep**; was prod in search.rs) | dev | zero-dep `regex-engine` (Pike VM) — all boolean uses + media `replace_all` moved over (Phase D); `regex` kept only as the `html_scan` cross-check oracle | **S…L** | `re:` user-search + media extent both run on `regex-engine` now |
 | `unicode-normalization` | engram-core (search.rs, template.rs) | prod | NFD/combining-class tables (+ NFC for dedup) | **M** | Unicode tables shared with regex whole-word |
 | `serde` + `serde_json` | engram-core, -core-wasm, -capi, -anki-package | prod | repo `json-value`/`json-parser`/`json-serializer` + **new `json-derive` macro** | **L** | **wire-critical** — JS/Swift/Anki parse the exact bytes |
 | `tempfile` | engram-capi (**test-only, already dev-dep**), engram-anki-package (test) | test | drop with rusqlite | trivial | — |
@@ -165,11 +165,17 @@ DoS-immune on user `re:` patterns, unlike a backtracker. Decomposed:
   `find_iter`, `captures_iter`. Non-overlapping iteration matches `regex` (resume
   at prev end; skip empty match at that end). Cross-verified vs live `regex`: 84k
   iteration checks + 84k replace-output comparisons (byte-identical where the two
-  iterate identically). regex-engine v0.6.0. **D4 next: point engram-core's media
-  `DUPLICATE_HTML_MEDIA_TAGS` at this + remove `regex`.**
-- **D4 — swap media + drop `regex`.** Point `DUPLICATE_HTML_MEDIA_TAGS` at the
-  engine's `replace_all` (byte-verified vs the old regex on the corpus from C2),
-  then remove `regex` from `engram-core`'s Cargo.toml. **`regex` gone.**
+  iterate identically). regex-engine v0.6.0.
+- **D4 — ✅ DONE (swap media + drop `regex`).** `DUPLICATE_HTML_MEDIA_TAGS` now
+  compiles on `regex_engine::Regex` and its `replace_all` closure takes
+  `&regex_engine::Captures` (same `get()`/`Match::as_str()` API — the media
+  pattern is greedy with disjoint quote-alternation, so the new engine's leftmost
+  extents match the old crate exactly; the full `engram-core` suite, incl. the
+  media-dedup tests, is byte-identical). `regex` is **removed from
+  `[dependencies]`** and kept only as a **`[dev-dependency]`** — its sole
+  remaining use is the `html_scan` cross-check test's independent oracle. No
+  non-test `regex::` reference remains in `engram-core/src`. **`regex` gone from
+  the runtime graph — Phase D complete; the whole regex removal is done.**
 - Rationale for the split: `is_match` (D0) is the bulk of engram's use and is
   cross-verifiable independently; extents (D3) are a genuinely separate, harder
   sub-problem, so they get their own PR rather than blocking the core.


### PR DESCRIPTION
## Phase D4 — the payoff of the D-arc: `regex` is gone from engram-core's runtime

This closes the Engram zero-dependency program's regex removal. Across D0–D3c a from-scratch, linear-time `regex_engine` (Pike VM / Thompson NFA) grew `is_match` → `find` → `captures` → `replace_all`/iterators, each cross-verified against the live `regex` crate. This PR points engram-core's **last** runtime use of `regex` — the media-tag dedup `replace_all` — at that engine and removes `regex` from the dependency graph.

### Changes
- **`search.rs`** — `DUPLICATE_HTML_MEDIA_TAGS` now compiles on `regex_engine::Regex`; its `replace_all` closure takes `&regex_engine::Captures`. Same `get()` / `Match::as_str()` API, so the closure body is unchanged. The pattern string is byte-identical. The media pattern is greedy with disjoint quote-alternation, so `regex_engine`'s leftmost extents match the old crate exactly.
- **`Cargo.toml`** — `regex` moves from `[dependencies]` → `[dev-dependencies]`. It is kept **only** as the independent oracle the `html_scan` cross-check test measures the zero-dep `strip_tags` scanner against; no runtime code path depends on it.
- **spec** — dependency table marks `regex` as a test-only dev-dep; Phase D4 marked DONE.

### Verification
- `cargo test -p engram-core` — **170 tests green**, incl. the media-dedup tests and the `html_scan` regex cross-check (`matches_regex_across_random_corpus`).
- The non-test lib build no longer compiles `regex` at all; `cargo tree -e normal` shows only `regex-engine`.
- Downstream `engram-core-wasm` / `engram-capi` / `engram-anki-package` all build.
- Only remaining `regex::` reference is `html_scan.rs:69`, inside `#[cfg(test)]` — no non-test refs.
- clippy: no new warnings; fmt clean.
- Security review (sub-agent, Rust): **PASSED** — repointing to the linear-time engine can only *reduce* catastrophic-backtracking DoS exposure on hostile flashcard HTML; `Captures::get` uses `checked_mul`, all slices land on UTF-8 boundaries, the static `.expect` runs once on a fixed developer-controlled pattern.

**`regex` gone from engram-core's runtime dependency graph — Phase D complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)