### PR TITLE
feat(latex): LTXDOC03 S28 resolved_reference_count (single-integer total of resolved refs)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.64.0] — 2026-07-08
+
+### Added — single-integer TOTAL of the resolved references (LTXDOC03 S28)
+
+A **new** public method `Document::resolved_reference_count(&self) -> String` that renders the decimal
+**COUNT** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — the ones some `\label` defines — as one
+integer line. It is the *count-total* companion of S21's `resolved_references_by_source` and S24's
+`resolved_references_by_kind` (which render one `\<command>{key}` **line per resolved reference**, flat in
+source order or grouped by target kind): S21/S24 and S28 are two *views* of the one `resolved` list
+`resolve_references()` produces — S28 collapses the whole list to a single `.len()` tally. It is the exact
+resolved-side **twin** of S27's `unresolved_reference_count`: together S28 + S27 split every reference into
+the pair (resolved, dangling), so their two totals sum to the total reference count. It is a read-only
+view over `resolve_references()`; every S1–S27 output is left **byte-for-byte unchanged**; S28 is purely
+additive and leaves the `to_latex()` round-trip fixed point intact.
+
+- **Counts the RESOLVED refs only.** S28 reads `resolve_references().resolved.len()` — each entry a
+  `ResolvedRef` for a `\ref`/`\eqref`/`\pageref` that some `\label` defines. A dangling `\ref{nope}` lives
+  in `resolve_references().unresolved` (S18/S27's domain), never in `resolved`, so it is excluded by
+  construction.
+- **A single decimal line, always.** The output is the decimal `.len()` of the `resolved` list — one
+  line, no trailing newline. There is **no** source slicing and **no** `target_kind` read at all (unlike
+  S26's per-kind census); section, table, and equation references all fold into one total — only `.len()`
+  is taken.
+- **Zero is the honest value `"0"`.** Being a COUNT renderer, its empty case (every ref dangles, or there
+  are none at all) is the number `"0"` — **not** a `(no resolved references)` marker. This mirrors S27
+  exactly. The `(no …)` marker discipline belongs to the *list* renderers S21/S24, whose empty case has no
+  lines to show; a total count of zero *is* a number.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single read of
+  the already-bounded `resolved` list's length. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s28_two_resolved_plus_one_dangling_counts_two` (cross-checking that S27 returns `"1"`
+  on the same doc — the two totals split the references), `s28_no_resolvable_refs_counts_zero`,
+  `s28_no_references_at_all_counts_zero`, `s28_mixed_target_kinds_count_the_integer`,
+  `s28_count_equals_number_of_s21_lines` (cross-checking the total against the number of lines S21
+  enumerates), and `s28_is_additive_leaves_s1_s27_outputs_unchanged` (which pins a handful of prior
+  S1–S27 outputs byte-for-byte — including S21's `resolved_references_by_source` and S27's
+  `unresolved_reference_count` — alongside the new count).
+
 ## [0.63.0] — 2026-07-08
 
 ### Added — single-integer TOTAL of the unresolved (dangling) references (LTXDOC03 S27)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -75,6 +75,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S25 — per-kind census (counts) of the winning `\label` definitions** | `Document::label_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the winning `\label` definitions: one `<kind>: <n>` line per `LabelKind` that has at least one winning definition, carrying the integer **count** (not a list) — the **count companion of S23's** `label_definitions_by_kind` (which renders one `[kind] \label{key}` *line per definition*). S22's flat `label_definitions`, S23's grouped list, and S25's counts are three views of the one winning `definitions` list; S25 collapses each kind's group to a single tally line (it is to S23 what S14's `list_summary` is to a full enumeration). It reads only `resolve_references().definitions` (one row per distinct key — the WINNER; a `\label{dup}` written twice counts **once**, its later copy being a `Duplicate` in S20's domain) and counts by kind in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S23 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** label definitions → the **same** fixed marker `(no label definitions)` S22/S23 use. E.g. `sec:intro` (section), `eq:a`/`eq:b` (equations), `note` (inline) → `section: 1\nequation: 2\ninline: 1`. Every S1–S24 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S26 — per-kind census (counts) of the resolved references** | `Document::resolved_reference_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the RESOLVED `\ref`/`\eqref`/`\pageref` references: one `<kind>: <n>` line per `LabelKind` that has at least one resolved ref, carrying the integer **count** (not a list) — the **count companion of S24's** `resolved_references_by_kind` (which renders one `[kind] \<command>{key}` *line per resolved ref*). S21's flat `resolved_references_by_source`, S24's grouped list, and S26's counts are three views of the one `resolved` list; S26 collapses each kind's group to a single tally line (it is to S24 what S25's `label_kind_counts` is to S23). It reads only `resolve_references().resolved` (each a `ResolvedRef` carrying the `target_kind` — the kind of the label it bound to; a dangling `\ref` lives in `unresolved`, S18's domain, and is excluded by construction — never a spurious `<kind>: 0`) and counts by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24/S25 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S24 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21/S24 use. E.g. `\ref{sec:a}`, `\ref{sec:b}` (two sections), `\eqref{eq:e}` (equation) → `section: 2\nequation: 1`. Every S1–S25 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S27 — single-integer total of the unresolved (dangling) references** | `Document::unresolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\ref`/`\eqref`/`\pageref` references — the ones no `\label` defines (LaTeX's *"Reference `key' undefined"*, the `??`) — as one integer line. It is the **count-total companion of S18's** `unresolved_references_by_source` (which renders one `\<command>{key}` *line per dangling ref*): S18 and S27 are two views of the one `unresolved` list; S27 collapses the whole list to a single `.len()` tally. It is the count-total sibling of the census family (S25 `label_kind_counts`, S26 `resolved_reference_kind_counts`), but for the UNRESOLVED refs — which carry **no** `target_kind` (a dangling ref bound to nothing), so a per-kind census is not viable and a single total is the clean move. It reads only `resolve_references().unresolved.len()` (a resolved `\ref{sec:i}` lives in `resolved`, S21's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all. Being a COUNT renderer, its empty case (every ref resolves, or none at all) is the honest number `"0"` — **not** a `(no …)` marker (that discipline belongs to the *list* renderers). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\ref{nope}` + `\ref{gone}` (both dangle) → `2`. Every S1–S26 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S28 — single-integer total of the resolved references** | `Document::resolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — the ones some `\label` defines — as one integer line. It is the **count-total companion of S21's** `resolved_references_by_source` **and S24's** `resolved_references_by_kind` (which render one `\<command>{key}` *line per resolved ref*, flat in source order or grouped by target kind): S21/S24 and S28 are two views of the one `resolved` list; S28 collapses the whole list to a single `.len()` tally. It is the exact resolved-side **twin of S27's** `unresolved_reference_count` — together S28 + S27 split every reference into the pair (resolved, dangling), so their totals sum to the total reference count. It reads only `resolve_references().resolved.len()` (a dangling `\ref{nope}` lives in `unresolved`, S18/S27's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all, so section/table/equation references all fold into one total. Being a COUNT renderer, its empty case (every ref dangles, or none at all) is the honest number `"0"` — **not** a `(no resolved references)` marker (that discipline belongs to the *list* renderers; this mirrors S27). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\pageref{sec:i}` (resolves) + `\ref{nope}` (dangles) → `2`. Every S1–S27 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1099,6 +1100,38 @@ Being a COUNT renderer, a document with no dangling references (every ref resolv
 renders the honest number `"0"` — **not** a `(no …)` marker (that discipline belongs to the *list*
 renderers S18/S21/S24, whose empty case has no lines to show). Purely additive — reuses
 `resolve_references`, mutates nothing, leaves every S1–S26 output and the `to_latex()` fixed point
+unchanged.
+
+### single-integer total of the resolved references (LTXDOC03 S28)
+
+The decimal **COUNT** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — the ones some `\label`
+defines — as one integer line. It is the **count-total companion of S21's** `resolved_references_by_source`
+**and S24's** `resolved_references_by_kind` (which render one `\<command>{key}` line *per resolved ref*,
+flat in source order or grouped by target kind): S21/S24 and S28 are two *views* of the one `resolved`
+list `resolve_references()` produces; S28 collapses the whole list to a single `.len()` tally. It is the
+exact resolved-side **twin of S27's** `unresolved_reference_count` — together S28 + S27 split every
+reference into the pair (resolved, dangling), so their totals sum to the total reference count.
+`resolved_reference_count` reads only `resolve_references().resolved.len()` — a dangling `\ref{nope}`
+lives in `unresolved` (S18/S27's domain) and is excluded by construction — never a `target_kind`, with no
+source slicing at all, so section/table/equation references all fold into one total.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \pageref{sec:i} \ref{nope}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.resolved_reference_count(),
+    // two refs resolve (`\ref{sec:i}`, `\pageref{sec:i}`); the dangling `\ref{nope}` is excluded
+    "2",
+);
+```
+
+Being a COUNT renderer, a document with no resolved references (every ref dangles, or none at all)
+renders the honest number `"0"` — **not** a `(no resolved references)` marker (that discipline belongs to
+the *list* renderers S21/S24, whose empty case has no lines to show; this mirrors S27). Purely additive —
+reuses `resolve_references`, mutates nothing, leaves every S1–S27 output and the `to_latex()` fixed point
 unchanged.
 
 ## Usage

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2798,6 +2798,74 @@ impl Document {
         // no `target_kind` — a per-kind census is not viable here, and a single total is the clean move.
         self.resolve_references().unresolved.len().to_string()
     }
+
+    /// The **single-integer TOTAL of the resolved references** (LTXDOC03 S28) — the *count-total*
+    /// companion of S21's [`resolved_references_by_source`](Document::resolved_references_by_source)
+    /// and S24's [`resolved_references_by_kind`](Document::resolved_references_by_kind). Where S21/S24
+    /// render one **line per resolved reference** (a `\<command>{key}` list, flat in body pre-order or
+    /// grouped by target kind), S28 renders one **line** carrying just the decimal **count** of those
+    /// resolved refs — the number of `\ref`/`\eqref`/`\pageref` that some `\label` defines. It is the
+    /// exact resolved-side twin of S27's
+    /// [`unresolved_reference_count`](Document::unresolved_reference_count): together the two totals
+    /// split every reference into the pair (resolved, dangling), so S28 + S27 = the total reference
+    /// count. It is to S21/S24 what S25's [`label_kind_counts`](Document::label_kind_counts) and S26's
+    /// [`resolved_reference_kind_counts`](Document::resolved_reference_kind_counts) are to their list
+    /// views: a numeric summary over the *same* list — here the **resolved** references — so a reader
+    /// sees "how many refs resolve" without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] walks every `\ref`/`\eqref`/`\pageref` in body pre-order
+    /// and splits them into the **resolved** references (those a `\label` defines — S21/S24/S26's
+    /// domain, recorded in [`ReferenceResolution::resolved`] as [`ResolvedRef`]s) and the
+    /// **unresolved** (dangling) ones (S18/S27's domain). S21/S24 render that `resolved` list as one
+    /// line per resolved ref; S28 collapses the whole list to a **single count line** — the decimal
+    /// `.len()` of `resolved`. Unlike S26 (which *can* census the resolved refs by the `target_kind`
+    /// each bound to), S28 takes no per-kind view at all: it reads only the length, never a
+    /// `target_kind`, so section, table, and equation references all fold into one total. Only the
+    /// **resolved** refs are counted; a dangling `\ref{nope}` lives in
+    /// [`ReferenceResolution::unresolved`] (S18/S27), never in `resolved`, so it is excluded by
+    /// construction.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`ReferenceResolution::resolved`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no resolved references is the number `0` — the string `"0"`, **not**
+    /// a `(no resolved references)` marker (a total count of zero *is* a number; the `(no …)` marker
+    /// discipline belongs to the *list* renderers S21/S24, whose empty case has no lines to show). This
+    /// mirrors S27 exactly, which emits `"0"` for an empty `unresolved` list. There is no source
+    /// slicing and no `target_kind` read at all — only `.len()` is taken.
+    ///
+    /// Concretely, for a body defining `\label{sec:i}` and then writing `\ref{sec:i}` (resolves),
+    /// `\ref{nope}` (dangles), and `\ref{sec:i}` again (resolves):
+    ///
+    /// ```text
+    /// 2
+    /// ```
+    ///
+    /// (two references resolve; the one dangling `\ref{nope}` is excluded). A document with no resolved
+    /// references — every ref dangles, or there are none at all — returns `"0"`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S28 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1–S27 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *second view* of the same `resolved` list
+    /// S21/S24 render per-source and per-kind — counting never adds, drops, or reorders the resolved
+    /// references relative to what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read, never a `target_kind`); a single read of the already-bounded `resolved`
+    /// list's length. Borrows `self` immutably and returns owned `String` data, so the result outlives
+    /// any borrow of the source.
+    pub fn resolved_reference_count(&self) -> String {
+        // S1 already split every `\ref`/`\eqref`/`\pageref` into resolved and dangling entries, routing
+        // the resolved ones into `resolved` (in body pre-order). We only read that list's length; the
+        // dangling refs live in `unresolved` (S18/S27). No `target_kind` is read — section, table, and
+        // equation references all fold into a single total, the resolved-side twin of S27's count.
+        self.resolve_references().resolved.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -6858,6 +6926,144 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.unresolved_reference_count(),
             doc.unresolved_references_by_source().lines().count().to_string()
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S28 — single-integer TOTAL of the resolved references (`resolved_reference_count`).
+    // The count-total companion of S21's `resolved_references_by_source` / S24's
+    // `resolved_references_by_kind`: one decimal line = `.len()` of the SAME `resolved` list. It is
+    // the exact resolved-side twin of S27's `unresolved_reference_count` — together S28 + S27 split
+    // every reference into (resolved, dangling). No `target_kind` is read, so all kinds fold into one
+    // total. Being a COUNT renderer, its empty value is the honest number "0", NOT a `(no …)` marker.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s28_two_resolved_plus_one_dangling_counts_two() {
+        // Two `\ref`s that resolve (`sec:i` twice) plus one that dangles (`nope`) → the count of
+        // resolved refs is exactly "2"; the dangling `\ref{nope}` is excluded (it lands in `unresolved`).
+        // Cross-check: on the SAME doc S27 returns "1" — the two totals split the references.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\ref{sec:i} \pageref{sec:i} \ref{nope}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_reference_count(), "2");
+        // The dangling side: exactly one, so S28 + S27 = 3 = the total reference count.
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // Cross-check: the two resolved refs are exactly what S21 enumerates.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:i}\n\\pageref{sec:i}"
+        );
+    }
+
+    #[test]
+    fn s28_no_resolvable_refs_counts_zero() {
+        // Every reference dangles (no `\label` defines them) → zero resolved refs. A COUNT renderer's
+        // honest value for an empty list is the number "0" (never a `(no …)` marker).
+        let src = r"\begin{document}\ref{nope} \eqref{eq:ghost} \pageref{gone}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_reference_count(), "0");
+        // And S21 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "(no resolved references)"
+        );
+    }
+
+    #[test]
+    fn s28_no_references_at_all_counts_zero() {
+        // A document with NO references whatsoever → still "0" (the count of an empty `resolved` list).
+        let src = r"\begin{document}Just some text with no references.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_reference_count(), "0");
+    }
+
+    #[test]
+    fn s28_mixed_target_kinds_count_the_integer() {
+        // Several resolved refs across DIFFERENT target kinds — a section, a table, and an equation. No
+        // kind is tracked by S28 (only `.len()` is read), so the answer is simply the integer count of
+        // resolved refs: "3".
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{table}\caption{T}\label{tab:t}\end{table}
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+\ref{sec:i} \ref{tab:t} \eqref{eq:e}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.resolved_reference_count(), "3");
+    }
+
+    #[test]
+    fn s28_count_equals_number_of_s21_lines() {
+        // Cross-check the total against S21's per-source list: the count S28 returns MUST equal the
+        // number of lines S21 enumerates (they are two views of the SAME `resolved` list).
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+\ref{sec:i} \eqref{eq:e} \pageref{sec:i} \ref{nope}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let s21 = doc.resolved_references_by_source();
+        let s21_line_count = s21.lines().count();
+        assert_eq!(s21_line_count, 3);
+        assert_eq!(doc.resolved_reference_count(), s21_line_count.to_string());
+        assert_eq!(doc.resolved_reference_count(), "3");
+    }
+
+    #[test]
+    fn s28_is_additive_leaves_s1_s27_outputs_unchanged() {
+        // Same representative doc as the S24/S25/S26/S27 additive tests. S28 changes NONE of the S1-S27
+        // outputs — it only reads `resolve_references`. Its count is a second view of the SAME
+        // `resolved` list S21/S24 render per-source and per-kind; pinned here to show S28 neither adds,
+        // drops, nor reorders, and that its total agrees with the number of lines S21 enumerates.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A handful of prior renderers — byte-for-byte unchanged.
+        // S14 per-kind census.
+        assert_eq!(doc.list_summary(), "Sections: 1\nFigures: 1\nEquations: 1");
+        // S22 flat winning label definitions.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S21 flat resolved refs — `\ref{sec:intro}` and `\eqref{eq:e}` resolve (`\eqref{eq:ghost}`
+        // dangles; `\nameref`/`\cite` are outside the `\ref` family).
+        assert_eq!(
+            doc.resolved_references_by_source(),
+            "\\ref{sec:intro}\n\\eqref{eq:e}"
+        );
+        // S25 per-kind label-definition counts.
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nfigure: 1\nequation: 1\ninline: 1"
+        );
+        // S26 per-kind resolved-reference counts.
+        assert_eq!(
+            doc.resolved_reference_kind_counts(),
+            "section: 1\nequation: 1"
+        );
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+
+        // And S28 itself: exactly TWO references resolve, so the count is "2" — agreeing with the two
+        // lines S21 enumerates for the same doc.
+        assert_eq!(doc.resolved_reference_count(), "2");
+        assert_eq!(
+            doc.resolved_reference_count(),
+            doc.resolved_references_by_source().lines().count().to_string()
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2251,3 +2251,80 @@ check that a handful of prior renderers — `list_summary`, `bibliography_entrie
 all still produce their exact prior strings, with S27 returning `"1"` (agreeing with the single line S18
 enumerates)). All prior S1–S26 tests pass unchanged. No `cargo fmt`, no grammar regen, no new
 dependencies.
+
+## 34. S28 — single-integer total of the resolved references (`resolved_reference_count`)
+
+### 34.1 Motivation
+
+S21 (`resolved_references_by_source`) and S24 (`resolved_references_by_kind`) enumerate the **resolved**
+`\ref`/`\eqref`/`\pageref` references — the ones some `\label` defines — one **line per resolved
+reference** (`\<command>{key}`, flat in body pre-order or grouped by the target kind each ref bound to).
+But a reader often wants not the enumeration but the **total** — "how many of my references resolve?" — a
+single number answered at a glance, without scanning the individual keys. S27
+(`unresolved_reference_count`) just gave that single-total discipline to the *unresolved* (dangling) side;
+S28 is its exact resolved-side **twin**: it collapses the whole `resolved` list to its decimal `.len()`.
+Together S28 + S27 split every reference into the pair (resolved, dangling), so their two totals sum to the
+total reference count. Unlike S26 (`resolved_reference_kind_counts`, which *can* census the resolved refs
+by the `target_kind` each bound to), S28 takes no per-kind view: section, table, and equation references
+all fold into one total — a single number is the clean move.
+
+### 34.2 Why a new method — additive by construction
+
+S28 adds a **new public method** `Document::resolved_reference_count(&self) -> String`. It is a pure,
+read-only render of `resolve_references().resolved.len()` — a *second view* of the exact list S21/S24
+render per-source and per-kind. It reuses that list verbatim (never re-walking the body or re-resolving),
+so the report can never drift from the S1 resolution it summarises, and counting never adds, drops, or
+reorders references relative to what `resolve_references` produced. It mutates nothing and changes no
+S1–S27 output — including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S27 it is a
+method the caller invokes directly.
+
+### 34.3 The rendering rule
+
+The output is the decimal `.len()` of the `resolved` list, rendered as its `String`, **always** on a
+single line with **no** trailing newline. There is no ordering question (a single integer has no order)
+and no per-kind grouping (S28 reads only the length, never a `target_kind`) — only `.len()` is read, with
+**no** source slicing at all. Being a **count** renderer, its empty case is the honest number `"0"` —
+**not** a `(no resolved references)` marker, mirroring S27 exactly. The `(no …)` marker discipline belongs
+to the *list* renderers S21/S24, whose empty case has no lines to show; a total count of zero *is* a
+number, so `"0"` is its truthful value.
+
+### 34.4 The exact rendering contract — `Document::resolved_reference_count(&self) -> String`
+
+- Read `resolve_references().resolved.len()` and render it with `.to_string()` → the decimal count, one
+  line, no trailing newline. There is **no** source slicing and **no** `target_kind` read at all, so the
+  render needs no source borrow and can never index out of bounds.
+- Only the **resolved** references are counted. A dangling `\ref{nope}` lives in
+  `resolve_references().unresolved` (S18/S27's domain), never in `resolved`, so it is excluded by
+  construction.
+- The empty case (every ref dangles, or there are none at all) returns the honest number `"0"` — **not**
+  a `(no resolved references)` marker, because S28 is a count renderer (mirroring S27).
+
+Example (body defining `\label{sec:i}`, then writing `\ref{sec:i}` (resolves), `\pageref{sec:i}`
+(resolves), and `\ref{nope}` (dangles)):
+
+```text
+2
+```
+
+Two references resolve; the one dangling `\ref{nope}` is excluded. This is the count-total companion of
+S21's per-source list and S24's per-kind grouping — a second view of the one `resolved` list; the count
+equals the number of lines S21 would enumerate.
+
+### 34.5 Public API (added in S28)
+
+One new method: `Document::resolved_reference_count(&self) -> String`. No existing type, field, counter,
+or signature changes; `resolve_references` and every S1–S27 method are unchanged; no AST or grammar
+change; no new dependency, no `unsafe`, no I/O.
+
+### 34.6 Verification (S28)
+
+`cargo test -p latex` green (6 new S28 tests: two-resolved-plus-one-dangling returning `"2"`
+(cross-checked against S21's `resolved_references_by_source`, and against S27 returning `"1"` on the same
+doc — the two totals split the references); a no-resolvable-refs case returning `"0"` (cross-checked
+against S21's `(no resolved references)` marker); a no-references-at-all case returning `"0"`; a
+mixed-target-kinds case (section/table/equation) returning the integer `"3"`; a cross-check that the count
+equals the number of lines S21 enumerates (`"3"`); and an additivity check that a handful of prior
+renderers — `list_summary`, `label_definitions`, `resolved_references_by_source`, S25's `label_kind_counts`,
+S26's `resolved_reference_kind_counts`, and S27's `unresolved_reference_count` — all still produce their
+exact prior strings, with S28 returning `"2"` (agreeing with the two lines S21 enumerates)). All prior
+S1–S27 tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S28 — `resolved_reference_count` (single-integer total of resolved refs)

Adds one small, additive, read-only renderer to the `latex` crate: **`Document::resolved_reference_count(&self) -> String`** — the single-integer TOTAL of RESOLVED `\ref`/`\eqref`/`\pageref` references, and the resolved-side twin of S27's `unresolved_reference_count`.

### What it does

`resolve_references()` (S1) splits every reference into the **resolved** ones (a `\label` defines them) and the **unresolved** (dangling) ones. S21 lists the resolved refs by source, S24 groups them by target kind; S28 collapses that same `resolved` list to its **count**:

```rust
pub fn resolved_reference_count(&self) -> String {
    self.resolve_references().resolved.len().to_string()
}
```

Together, **S27 (dangling total) + S28 (resolved total) = the two-sided split** of every reference in the document. It reads only `.len()` of `ReferenceResolution::resolved` — never a `target_kind`.

### Rendering contract

- Returns the **decimal count as one line**, always — including **`"0"`** when no reference resolves. This is a *count* renderer, so zero is its honest numeric value (exactly as S27 emits `"0"`), **not** a `(no resolved references)` marker like the S21/S24 list renderers. No trailing newline.
- Total & panic-free: borrows `self` immutably, no `unwrap`/`expect`, no indexing/slicing (only `.len()`), no I/O, no `unsafe`.

### Additive by construction

Brand-new read-only method reusing `resolve_references()`; mutates nothing and changes no S1–S27 output (byte-for-byte unchanged). The test suite includes an **additivity test** pinning `list_summary`, `label_definitions`, `resolved_references_by_source`, `label_kind_counts`, `resolved_reference_kind_counts`, and `unresolved_reference_count` byte-for-byte while S28 returns its count on the same document.

### Tests (6 new)

1. two resolved + one dangling → `"2"` (with S27 returning `"1"` — the two totals split the references)
2. all dangling / none resolvable → `"0"`
3. no references at all → `"0"`
4. resolved refs across section/table/equation targets → the correct integer (no kind tracked)
5. count equals the number of S21 lines
6. additivity: S1–S27 outputs unchanged, S28 returns its count

### Verification (all re-run from the worktree)

- `cargo test -p latex` → all green (+6 new) + doc-test
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (0 failed)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED (read-only, panic-free, no I/O/unsafe/deps)

### Scope

Bumps `latex` 0.63.0 → **0.64.0**; updates CHANGELOG.md + README.md + the LTXDOC03 spec (appends a new S28 section; sections 1–33 byte-for-byte unchanged). No `cargo fmt`, no grammar regen, no new deps, no file I/O, no `unsafe`. Exactly 5 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
