### PR TITLE
feat(adj-ladder): rung-117 podiatry plantar pressure (one over a sum-minus-difference)

### DIFF
--- a/code/specs/data/adj-ladder/rung117_podiatry/gen_items.py
+++ b/code/specs/data/adj-ladder/rung117_podiatry/gen_items.py
@@ -1,0 +1,260 @@
+"""Generate rung-117 (podiatry / plantar pressure) items.json for the ADJ-LADDER.
+
+Rung 117 opens the **podiatry / plantar-pressure** panel on the quantitative band — the arithmetic of a plantar pressure
+index. A `peak_force` (the peak load the foot bears) is DIVIDED by the net weight-bearing area, where that area is the
+`forefoot_area` PLUS the `midfoot_area` MINUS the `lesion_area` (an ulcer/callus removed from the load-bearing surface), to
+give the pressure index (force per effective area). A **single term over a SUM-MINUS-DIFFERENCE denominator**, `a/(b+c-d)`,
+i.e. `(a / ((b + c) - d))`, introduces a genuinely NEW arithmetic family on the ladder — the ladder's **first denominator that
+contains a subtraction**.
+
+This is genuinely new. Rung-116 opened the three-term DENOMINATOR with the pure sum `a/(b+c+d)`; every three-term NUMERATOR
+(108 `(a+b+c)/d`, 109 `(a-b+c)/d`, 110 `(a*b+c)/d`, 111 `(a*b-c)/d`, 114 `(a+b-c)/d`, 115 `(a-b-c)/d`) sat over a SINGLE-term
+divisor `d`; the distributive pair (112 `a*(b+c)/d`, 113 `a*(b-c)/d`) still divided by a single term; and every two-term ratio
+(37 `(a+b)/(c+d)`, 99 `(a*b)/(c+d)`, 100 `(a+b)/(c*d)`, 104 `(a-b)/(c*d)`, the difference-denominator trio 105 `(a+b)/(c-d)`,
+106 `a*b/(c-d)`, 107 `(a-b)/(c-d)`) had at most TWO terms below the bar — and none of the earlier two-term difference-
+denominators had a THIRD term inside the denominator. Rung-116 was `a/(b+c+d)` (three-term SUM denominator, all plus);
+rung-117 is `a/(b+c-d)` — the SUM-MINUS-DIFFERENCE sibling, the FIRST time a three-term denominator subtracts. The operator
+order matters: `a/(b+c-d)` is `(a / ((b + c) - d))` (the forefoot and midfoot sum FIRST, the lesion subtracts from that, then
+the force is divided by the whole net area; `+` and `-` bind left-to-right inside the explicit denominator parentheses and the
+whole net area sits under the division), NOT `a/b+c-d` (dropping the denominator parentheses so only the forefoot divides the
+force and then the midfoot is added and the lesion subtracted) and NOT `(a-d)/(b+c)` (regrouping so the lesion is subtracted
+from the FORCE in the numerator and only the two areas form the denominator) — the two distractors exploit exactly those
+confusions.
+
+The setup: a `peak_force`, a `forefoot_area`, a `midfoot_area`, and a `lesion_area`. The total is:
+
+  PLANTAR PRESSURE INDEX  peak_force / (forefoot_area + midfoot_area - lesion_area)  [ one term over a sum-minus-difference denominator ]
+  EFFECTIVE AREA          forefoot_area + midfoot_area - lesion_area                 [ the three-term denominator ]
+  PEAK FORCE              peak_force                                                 [ the numerator ]
+
+The **plantar pressure index** is what makes this rung distinctive — it is the ladder's first **single term over a
+sum-minus-difference denominator**. It is a rate (force per effective area), framed as an *index* to keep it
+dimensionless-clean — the same discipline rungs 100/104/.../116 used for their ratios. (The effective area `b+c-d` and the peak
+force `a` ride alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-116 shipped
+their component sums/products/differences/ratios beside the headline figure.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries
+the arithmetic — the summation of the forefoot and midfoot areas, the subtraction of the lesion into the effective area, then
+the division of the force by that whole net area (the single-term numerator over the sum-minus-difference denominator, so
+a/(b+c-d) evaluates as (a/((b+c)-d))) — and the harness reads the scalar via the existing `compute_dimensioned` extractor. No
+harness/engine change, exactly as rungs 8/16/.../115/116. This rung exercises the engine across a **sum-minus-difference
+denominator** — the fact that `a/(b+c-d)` is `(a/((b+c)-d))` and NOT `a/b+c-d` and NOT `(a-d)/(b+c)` made computable. The ratio
+golds are non-integer f64s; the engine's IEEE-double division matches Python's the same way rungs 99/100/104/.../116 relied on
+(well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `-`, and `/` — **no
+structural constants** — so no numeric literal appears in any program, and neither the effective area, the peak force, nor any
+index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free
+identifiers** (`peak_force`, `forefoot_area`, `midfoot_area`, `lesion_area`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    peak_force / forefoot_area + midfoot_area - lesion_area  drop the denominator parentheses so only the forefoot area
+                                                                    divides the force and then the midfoot is added and the
+                                                                    lesion subtracted (the classic `a/(b+c-d)` vs `a/b+c-d`
+                                                                    grouping error), and
+  SWAPPED    (peak_force - lesion_area) / (forefoot_area + midfoot_area)  regroup so the lesion is subtracted from the FORCE in
+                                                                    the numerator and only the two areas form the denominator
+                                                                    (`(a-d)/(b+c)` instead of `a/(b+c-d)`),
+
+which are exactly the mistakes a student makes (failing to keep the whole net area under the bar, or subtracting the lesion
+from the wrong operand). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as
+options.
+
+Distinctness and positivity: this rung SUBTRACTS the lesion area inside the denominator, so positivity is guaranteed by table
+construction. Each table guarantees **midfoot_area > lesion_area** (c > d, so the effective area `b+c-d` is strictly positive,
+and the crossed slip `a/b + c - d` stays positive since its `c-d` part is > 0 and `a/b > 0`) AND **peak_force > lesion_area**
+(a > d, so the swapped numerator `a-d` is strictly positive) AND all quantities `>= 2`. The forefoot and midfoot areas keep the
+denominator away from zero (`b+c-d >= b + 1 >= 3`), the pressure index never coincides with the effective area or the peak
+force, and the five family values are pairwise distinct with a comfortable margin; and — so all three queried readouts vary
+across the panel — the seven tables give distinct pressure indices, distinct effective areas, and distinct peak forces, all
+asserted at build time.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (PEAK_FORCE, FOREFOOT_AREA, MIDFOOT_AREA, LESION_AREA) — a peak force divided by the net weight-bearing area (forefoot plus
+# midfoot minus lesion) for the pressure index, all plain positive numbers >= 2. This rung SUBTRACTS the lesion area in the
+# denominator, so every table guarantees midfoot_area > lesion_area (c>d, so the effective area b+c-d and the crossed slip's c-d
+# part stay positive) and peak_force > lesion_area (a>d, so the swapped numerator a-d stays positive); b+c-d >= 3 keeps the
+# division away from zero. The five family values are asserted pairwise-distinct below. The seven tables give distinct pressure
+# indices, distinct effective areas, and distinct peak forces so all three queried readouts vary across the panel.
+TABLES = [
+    (30, 3, 4, 3),
+    (34, 3, 5, 3),
+    (40, 4, 5, 3),
+    (45, 4, 6, 3),
+    (50, 5, 6, 3),
+    (54, 5, 7, 3),
+    (62, 6, 7, 3),
+]
+
+# The option family (5 members), all built from the four observed quantities via +, - and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the
+# options.
+FAMILY = [
+    (
+        "pressure_index",
+        "plantar pressure index (the peak force divided by the effective area)",
+        "peak_force / (forefoot_area + midfoot_area - lesion_area)",
+    ),
+    (
+        "effective_area",
+        "the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)",
+        "forefoot_area + midfoot_area - lesion_area",
+    ),
+    (
+        "peak_force",
+        "the peak force (the numerator divided by the effective area)",
+        "peak_force",
+    ),
+    (
+        "crossed",
+        "the peak force divided by the forefoot area, plus the midfoot area minus the lesion area, dropping the denominator parentheses so only the forefoot area divides (a wrong grouping)",
+        "peak_force / forefoot_area + midfoot_area - lesion_area",
+    ),
+    (
+        "swapped",
+        "the peak force minus the lesion area, divided by the forefoot plus the midfoot area, subtracting the lesion from the force instead of the area (a wrong pairing)",
+        "(peak_force - lesion_area) / (forefoot_area + midfoot_area)",
+    ),
+]
+QUERIED = ["pressure_index", "effective_area", "peak_force"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(peak_force, forefoot_area, midfoot_area, lesion_area):
+    # Operation order mirrors the ADJ programs exactly (the forefoot and midfoot areas sum first, the lesion subtracts from that,
+    # then the force is divided by that whole net area, so a/(b+c-d) evaluates as (a/((b+c)-d))), so the Python option value and
+    # the engine result are the same IEEE-double (well within the harness's 1e-9 match tolerance).
+    return {
+        "pressure_index": peak_force / (forefoot_area + midfoot_area - lesion_area),
+        "effective_area": forefoot_area + midfoot_area - lesion_area,
+        "peak_force": peak_force,
+        "crossed": peak_force / forefoot_area + midfoot_area - lesion_area,
+        "swapped": (peak_force - lesion_area) / (forefoot_area + midfoot_area),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for peak_force, forefoot_area, midfoot_area, lesion_area in TABLES:
+        # Every observed quantity is a plain positive number >= 2, and this rung SUBTRACTS the lesion area in the denominator, so
+        # each table guarantees midfoot_area > lesion_area (c>d, effective area b+c-d and the crossed c-d part strictly positive)
+        # and peak_force > lesion_area (a>d, swapped numerator a-d strictly positive), which keeps every family member strictly
+        # positive; b+c-d >= 3 keeps the division away from zero.
+        assert (
+            peak_force >= 2
+            and forefoot_area >= 2
+            and midfoot_area >= 2
+            and lesion_area >= 2
+        ), (peak_force, forefoot_area, midfoot_area, lesion_area)
+        assert midfoot_area > lesion_area, (peak_force, forefoot_area, midfoot_area, lesion_area)
+        assert peak_force > lesion_area, (peak_force, forefoot_area, midfoot_area, lesion_area)
+        fv = family_values(peak_force, forefoot_area, midfoot_area, lesion_area)
+        for key, v in fv.items():
+            assert v > 0, (key, peak_force, forefoot_area, midfoot_area, lesion_area, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    peak_force,
+                    forefoot_area,
+                    midfoot_area,
+                    lesion_area,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                peak_force,
+                forefoot_area,
+                midfoot_area,
+                lesion_area,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r117pod-{idx + 1:02d}",
+                "qtype": "pressure_index",
+                "stem": (
+                    f"A pedobarography report records a peak force of {num(peak_force)} divided by a forefoot area of "
+                    f"{num(forefoot_area)} plus a midfoot area of {num(midfoot_area)} minus a lesion area of "
+                    f"{num(lesion_area)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe peak_force({num(peak_force)})\n"
+                    f"observe forefoot_area({num(forefoot_area)})\n"
+                    f"observe midfoot_area({num(midfoot_area)})\n"
+                    f"observe lesion_area({num(lesion_area)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 117 — plantar pressure index from four stated quantities (a NEW panel: podiatry / plantar "
+            "pressure). From a peak force divided by the net weight-bearing area (forefoot area plus midfoot area minus lesion "
+            "area), compute the plantar pressure index "
+            "(peak_force/(forefoot_area+midfoot_area-lesion_area)), the effective area "
+            "(forefoot_area+midfoot_area-lesion_area), or the peak force. Each item is a compute_dimensioned program (observe "
+            "the four quantities, let answer = formula); the ADJ engine carries the arithmetic — a NEW family, a SINGLE TERM "
+            "OVER A SUM-MINUS-DIFFERENCE DENOMINATOR a/(b+c-d) (sum the forefoot and midfoot areas, subtract the lesion, divide "
+            "the force by that whole net area, so a/(b+c-d) = (a/((b+c)-d)); the ladder's FIRST denominator that contains a "
+            "subtraction. Rung-116 opened the three-term denominator with the pure sum a/(b+c+d); every three-term NUMERATOR "
+            "(108-111/114/115) sat over a SINGLE-term divisor d; the distributive pair (112/113) still divided by a single term; "
+            "and every two-term ratio had at most TWO terms below the bar (37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 "
+            "(a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) — rung-117 is the "
+            "first three-term denominator that subtracts. The harness matches the scalar to the printed options. The plantar "
+            "pressure index is a rate (force per effective area), framed as an INDEX so the dimensionless value stays honest. "
+            "Contamination-safe: every figure is built only from the four observed quantities via +, - and / — no constant leaks, "
+            "and neither the effective area, the peak force, nor any index ever appears as a literal (each is computed) — and the "
+            "observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a "
+            "family over the same four quantities, so the distractors are exactly the slips students make: dropping the "
+            "denominator parentheses so only the forefoot area divides (a/b+c-d, a wrong grouping) and subtracting the lesion "
+            "from the force instead of the area ((a-d)/(b+c), a wrong pairing). The core confusion tested is that a/(b+c-d) is "
+            "(a/((b+c)-d)), not a/b+c-d and not (a-d)/(b+c). This rung SUBTRACTS the lesion area in the denominator, so positivity "
+            "is guaranteed by table construction: every table has midfoot_area > lesion_area (c>d) and peak_force > lesion_area "
+            "(a>d), with b+c-d >= 3 (division never by zero), keeping every family member strictly positive."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung117_podiatry/items.json
+++ b/code/specs/data/adj-ladder/rung117_podiatry/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 117 \u2014 plantar pressure index from four stated quantities (a NEW panel: podiatry / plantar pressure). From a peak force divided by the net weight-bearing area (forefoot area plus midfoot area minus lesion area), compute the plantar pressure index (peak_force/(forefoot_area+midfoot_area-lesion_area)), the effective area (forefoot_area+midfoot_area-lesion_area), or the peak force. Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, a SINGLE TERM OVER A SUM-MINUS-DIFFERENCE DENOMINATOR a/(b+c-d) (sum the forefoot and midfoot areas, subtract the lesion, divide the force by that whole net area, so a/(b+c-d) = (a/((b+c)-d)); the ladder's FIRST denominator that contains a subtraction. Rung-116 opened the three-term denominator with the pure sum a/(b+c+d); every three-term NUMERATOR (108-111/114/115) sat over a SINGLE-term divisor d; the distributive pair (112/113) still divided by a single term; and every two-term ratio had at most TWO terms below the bar (37 (a+b)/(c+d), 99 (a*b)/(c+d), 100 (a+b)/(c*d), 104 (a-b)/(c*d), and the difference-denominator trio 105 (a+b)/(c-d), 106 a*b/(c-d), 107 (a-b)/(c-d)) \u2014 rung-117 is the first three-term denominator that subtracts. The harness matches the scalar to the printed options. The plantar pressure index is a rate (force per effective area), framed as an INDEX so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed quantities via +, - and / \u2014 no constant leaks, and neither the effective area, the peak force, nor any index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the denominator parentheses so only the forefoot area divides (a/b+c-d, a wrong grouping) and subtracting the lesion from the force instead of the area ((a-d)/(b+c), a wrong pairing). The core confusion tested is that a/(b+c-d) is (a/((b+c)-d)), not a/b+c-d and not (a-d)/(b+c). This rung SUBTRACTS the lesion area in the denominator, so positivity is guaranteed by table construction: every table has midfoot_area > lesion_area (c>d) and peak_force > lesion_area (a>d), with b+c-d >= 3 (division never by zero), keeping every family member strictly positive.",
+  "items": [
+    {
+      "id": "r117pod-01",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 30 divided by a forefoot area of 3 plus a midfoot area of 4 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(30)\nobserve forefoot_area(3)\nobserve midfoot_area(4)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.857142857142857,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r117pod-02",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 30 divided by a forefoot area of 3 plus a midfoot area of 4 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(30)\nobserve forefoot_area(3)\nobserve midfoot_area(4)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.857142857142857,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r117pod-03",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 30 divided by a forefoot area of 3 plus a midfoot area of 4 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(30)\nobserve forefoot_area(3)\nobserve midfoot_area(4)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7.5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 30,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.857142857142857,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r117pod-04",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 34 divided by a forefoot area of 3 plus a midfoot area of 5 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(34)\nobserve forefoot_area(3)\nobserve midfoot_area(5)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.333333333333336,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r117pod-05",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 34 divided by a forefoot area of 3 plus a midfoot area of 5 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(34)\nobserve forefoot_area(3)\nobserve midfoot_area(5)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.333333333333336,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 3.875,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 5,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r117pod-06",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 34 divided by a forefoot area of 3 plus a midfoot area of 5 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(34)\nobserve forefoot_area(3)\nobserve midfoot_area(5)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 34,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.333333333333336,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 3.875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r117pod-07",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 40 divided by a forefoot area of 4 plus a midfoot area of 5 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(40)\nobserve forefoot_area(4)\nobserve midfoot_area(5)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.111111111111111,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r117pod-08",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 40 divided by a forefoot area of 4 plus a midfoot area of 5 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(40)\nobserve forefoot_area(4)\nobserve midfoot_area(5)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.111111111111111,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r117pod-09",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 40 divided by a forefoot area of 4 plus a midfoot area of 5 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(40)\nobserve forefoot_area(4)\nobserve midfoot_area(5)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.666666666666667,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 40,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.111111111111111,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r117pod-10",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 45 divided by a forefoot area of 4 plus a midfoot area of 6 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(45)\nobserve forefoot_area(4)\nobserve midfoot_area(6)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6.428571428571429,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r117pod-11",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 45 divided by a forefoot area of 4 plus a midfoot area of 6 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(45)\nobserve forefoot_area(4)\nobserve midfoot_area(6)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.428571428571429,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r117pod-12",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 45 divided by a forefoot area of 4 plus a midfoot area of 6 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(45)\nobserve forefoot_area(4)\nobserve midfoot_area(6)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.428571428571429,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 45,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.2,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r117pod-13",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 50 divided by a forefoot area of 5 plus a midfoot area of 6 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(50)\nobserve forefoot_area(5)\nobserve midfoot_area(6)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 13.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.2727272727272725,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r117pod-14",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 50 divided by a forefoot area of 5 plus a midfoot area of 6 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(50)\nobserve forefoot_area(5)\nobserve midfoot_area(6)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 50,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.2727272727272725,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r117pod-15",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 50 divided by a forefoot area of 5 plus a midfoot area of 6 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(50)\nobserve forefoot_area(5)\nobserve midfoot_area(6)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.2727272727272725,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 50,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r117pod-16",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 54 divided by a forefoot area of 5 plus a midfoot area of 7 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(54)\nobserve forefoot_area(5)\nobserve midfoot_area(7)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r117pod-17",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 54 divided by a forefoot area of 5 plus a midfoot area of 7 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(54)\nobserve forefoot_area(5)\nobserve midfoot_area(7)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r117pod-18",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 54 divided by a forefoot area of 5 plus a midfoot area of 7 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(54)\nobserve forefoot_area(5)\nobserve midfoot_area(7)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 54,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r117pod-19",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 62 divided by a forefoot area of 6 plus a midfoot area of 7 minus a lesion area of 3. What is the plantar pressure index (the peak force divided by the effective area)?",
+      "program": "observe peak_force(62)\nobserve forefoot_area(6)\nobserve midfoot_area(7)\nobserve lesion_area(3)\nlet answer = peak_force / (forefoot_area + midfoot_area - lesion_area)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 62,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14.333333333333336,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.2,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.538461538461538,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r117pod-20",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 62 divided by a forefoot area of 6 plus a midfoot area of 7 minus a lesion area of 3. What is the the effective area (the forefoot plus the midfoot minus the lesion area, the divisor the force is divided by)?",
+      "program": "observe peak_force(62)\nobserve forefoot_area(6)\nobserve midfoot_area(7)\nobserve lesion_area(3)\nlet answer = forefoot_area + midfoot_area - lesion_area\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.2,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 62,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 14.333333333333336,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.538461538461538,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 10,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r117pod-21",
+      "qtype": "pressure_index",
+      "stem": "A pedobarography report records a peak force of 62 divided by a forefoot area of 6 plus a midfoot area of 7 minus a lesion area of 3. What is the the peak force (the numerator divided by the effective area)?",
+      "program": "observe peak_force(62)\nobserve forefoot_area(6)\nobserve midfoot_area(7)\nobserve lesion_area(3)\nlet answer = peak_force\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 62,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.2,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14.333333333333336,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 4.538461538461538,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -154,6 +154,7 @@ SELF_CONTAINED_RUNGS = (
     "rung114_fluency",
     "rung115_phlebotomy",
     "rung116_otolaryngology",
+    "rung117_podiatry",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung-117 — plantar pressure index (one term over a sum-minus-difference denominator)

Opens the **podiatry / plantar-pressure** panel on the quantitative band and introduces a genuinely **new arithmetic shape**: **a single term over a SUM-MINUS-DIFFERENCE denominator, `a/(b+c-d)`** — the ladder's **first denominator that contains a subtraction**.

### What's new (shape novelty)

Rung-116 opened the three-term denominator with the pure sum `a/(b+c+d)`. Every three-term *numerator* (108 `(a+b+c)/d`, 109 `(a-b+c)/d`, 110 `(a*b+c)/d`, 111 `(a*b-c)/d`, 114 `(a+b-c)/d`, 115 `(a-b-c)/d`) sat over a **single-term** divisor `d`; the distributive pair (112 `a*(b+c)/d`, 113 `a*(b-c)/d`) still divided by a single term; and every two-term ratio had at most **two** terms below the bar (37 `(a+b)/(c+d)`, 99 `(a*b)/(c+d)`, 100 `(a+b)/(c*d)`, 104 `(a-b)/(c*d)`, and the difference-denominator trio 105/106/107). **Rung-117 is `a/(b+c-d)` — the sum-minus-difference sibling of rung-116, the first three-term denominator that subtracts.**

Rung-117 is `(peak_force / ((forefoot_area + midfoot_area) - lesion_area))` — the two areas sum left-to-right inside the explicit denominator parens, the lesion subtracts from that, then the force is divided by the whole net area, so `a/(b+c-d)` = `(a/((b+c)-d))`.

### The clinical framing

A pedobarography report gives a `peak_force` and three areas — a `forefoot_area`, a `midfoot_area`, and a `lesion_area` (an ulcer/callus removed from the load-bearing surface). Force divided by the **net** weight-bearing area (forefoot + midfoot − lesion) gives the **plantar pressure index** (force per effective area, framed as a dimensionless index).

- `PLANTAR PRESSURE INDEX = peak_force / (forefoot_area + midfoot_area - lesion_area)` — the headline single-term-over-sum-minus-difference ratio
- `EFFECTIVE AREA         = forefoot_area + midfoot_area - lesion_area` — the three-term denominator, a real component readout
- `PEAK FORCE             = peak_force` — the numerator, a real component readout

### The distractor family (5 mutually-confusable scalars over the same four quantities)

- **crossed** `peak_force / forefoot_area + midfoot_area - lesion_area` — drops the denominator parentheses so only the forefoot area divides the force, then the midfoot is added and the lesion subtracted (the `a/(b+c-d)` vs `a/b+c-d` grouping slip)
- **swapped** `(peak_force - lesion_area) / (forefoot_area + midfoot_area)` — subtracts the lesion from the **force** in the numerator and leaves only the two areas in the denominator (`(a-d)/(b+c)`)

The core confusion tested: `a/(b+c-d)` is `(a/((b+c)-d))`, **not** `a/b+c-d` and **not** `(a-d)/(b+c)`.

### Construction guarantees

- **Constant-free / digit-free**: every figure is built only from the four observed quantities via `+`, `-`, `/`; no numeric literal appears in any program; identifiers are digit-free (`peak_force`, `forefoot_area`, `midfoot_area`, `lesion_area`).
- **This rung subtracts the lesion in the denominator**, so positivity is by construction: every table guarantees `midfoot_area > lesion_area` (c>d → effective area `b+c-d>0` and the crossed slip's `c-d` part >0) AND `peak_force > lesion_area` (a>d → swapped numerator `a-d>0`) AND all quantities `>= 2`; `b+c-d >= 3` keeps the division away from zero — every family member strictly positive.
- Five family values asserted **pairwise-distinct** (>1e-6) per table; the seven tables give **distinct pressure indices, distinct effective areas, and distinct peak forces** so all three queried golds vary across the panel.
- Gold rotates A–E by `idx % 5`. 7 tables × 3 queried readouts = **21 items**.

### No harness/engine change

Each item is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula` + `? answer`); the ADJ engine carries the arithmetic and the harness reads the scalar via the existing extractor — exactly as rungs 8/16/…/115/116.

### Verification

- `gen_items.py` → `wrote items.json: 21 items`
- Scratchpad distinctness/positivity checker: all 5 within-table pairwise-distinct; 3 queried golds all vary across the 7 tables (effective area 4–10, peak force 30–62, pressure index 6.0–7.5).
- `python3 -m pytest test_ladder_eval.py -k rung117 -q` → **3 passed**
- Inline security review: PASSED (data-only generator; no eval/exec/network/user-input; writes only its own items.json; every table guards `c>d`, `a>d`, all `>= 2` so the denominator `b+c-d >= 3` is never zero and every member positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
