### PR TITLE
feat(document-ast-to-docx): render the Document AST to a .docx (Markdown→DOCX bridge)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -871,4 +871,5 @@ members = [
     "xlsx-eval",
     "xls",
     "spreadsheet-io",
+  "document-ast-to-docx",
 ]

--- a/code/packages/rust/document-ast-to-docx/BUILD
+++ b/code/packages/rust/document-ast-to-docx/BUILD
@@ -1,0 +1,1 @@
+cargo test -p document-ast-to-docx -- --nocapture

--- a/code/packages/rust/document-ast-to-docx/CHANGELOG.md
+++ b/code/packages/rust/document-ast-to-docx/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to `document-ast-to-docx` are documented here. The format
+follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres
+to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-08
+
+### Added
+
+- Initial release — the **Document AST → `.docx`** bridge (spec
+  `code/specs/MD02-markdown-to-docx.md`).
+- `to_docx_document(&DocumentNode) -> docx_writer::Document` and
+  `to_docx_bytes(&DocumentNode) -> Vec<u8>` — map the shared Document AST onto the
+  enriched `docx-writer` model (headings → `Heading N`, code → `Code`, quotes →
+  `Quote`, lists → prefixed `ListParagraph`s, tables → `<w:tbl>`), flattening
+  inlines to formatted runs (`Strong`→bold, `Emphasis`→italic, `CodeSpan`→mono,
+  combining down the tree).
+- Composing `commonmark-parser::parse` with `to_docx_bytes` yields a native
+  Markdown → `.docx` conversion; any Document-AST frontend gets `.docx` for free.
+- Documented, text-lossless fidelity limits (MD02 §6): raw HTML dropped, links as
+  `text (url)`, images as `[alt] (url)`, strikethrough/hard-break degrade to
+  plain text/space, lists as prefixed paragraphs, table cells flattened.
+- **Recursion-depth DoS guard (CWE-674).** The AST comes from untrusted Markdown,
+  which the upstream parser doesn't cap (`>>>>…>` nests blockquotes, `***…*`
+  emphasis, arbitrarily deep); a naive recursive walker would overflow the native
+  stack (an uncatchable SIGSEGV). Both the block and inline walkers are bounded to
+  `MAX_DEPTH` (256) — past that they drop the over-deep subtree instead of
+  recursing. Verified adversarially: a 50 000-deep AST converts without
+  overflowing, over-deep content is dropped, and neutering the guard makes the
+  boundary test render the buried content (confirming it's load-bearing).
+- 14 tests: `word/document.xml` shape assertions (styles + run properties, via
+  the independent `opc` reader), a round-trip through the `wordprocessingml`
+  reader (visible text + block structure), and the depth-guard tests above.
+  `#![forbid(unsafe_code)]`, clippy-clean, total and panic-free on any AST.

--- a/code/packages/rust/document-ast-to-docx/Cargo.toml
+++ b/code/packages/rust/document-ast-to-docx/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "document-ast-to-docx"
+version = "0.1.0"
+edition = "2021"
+description = "Render a document-ast DocumentNode to a .docx via docx-writer — the Markdown→DOCX bridge from the shared Document AST (MD02)"
+license = "MIT"
+
+[dependencies]
+document-ast = { path = "../document-ast" }
+coding-adventures-docx-writer = { path = "../docx-writer" }
+
+[dev-dependencies]
+# Round-trip proof: reopen our .docx bytes with the read-side WordprocessingML reader.
+coding-adventures-wordprocessingml = { path = "../wordprocessingml" }
+# Inspect the emitted document.xml (assert paragraph styles + run formatting).
+coding-adventures-opc = { path = "../opc" }

--- a/code/packages/rust/document-ast-to-docx/README.md
+++ b/code/packages/rust/document-ast-to-docx/README.md
@@ -1,0 +1,79 @@
+# document-ast-to-docx
+
+Render a shared **Document AST** ([`document-ast`](../document-ast)) to a real
+Word **`.docx`**, over the [`docx-writer`](../docx-writer) writer. The OOXML
+sibling of [`document-ast-to-html`](../document-ast-to-html): where that renders a
+`DocumentNode` to HTML, this renders it to WordprocessingML bytes.
+
+Spec: [`code/specs/MD02-markdown-to-docx.md`](../../../specs/MD02-markdown-to-docx.md).
+
+## Where it fits
+
+```text
+  document_ast::DocumentNode
+       │  to_docx_document        (this crate — map blocks & inlines)
+       ▼
+  docx_writer::Document
+       │  docx_writer::write_docx
+       ▼
+  .docx bytes
+```
+
+Markdown already parses to a `DocumentNode` (`commonmark-parser::parse`), so
+composing that with `to_docx_bytes` is a native **Markdown → `.docx`** converter
+(the `markdown-docx` crate does exactly that). Any frontend that targets the
+Document AST — GFM, ASCIIDoc, HTML — gets `.docx` output for free.
+
+## Usage
+
+```rust
+use document_ast_to_docx::to_docx_bytes;
+
+// From any DocumentNode — e.g. one parsed from Markdown:
+let ast = commonmark_parser::parse("# Title\n\nA **bold** word.\n\n- one\n- two\n");
+let bytes = to_docx_bytes(&ast);
+std::fs::write("out.docx", bytes).unwrap();
+```
+
+`to_docx_document(&DocumentNode) -> docx_writer::Document` is also public if you
+want to add content before serializing.
+
+## What maps to what
+
+| Block | `.docx` |
+|---|---|
+| Heading (1–6) | `Heading N` styled paragraph |
+| Paragraph | `Normal` paragraph, formatted runs |
+| Code block | one monospace `Code` paragraph per line |
+| Blockquote | child blocks in the `Quote` style |
+| List | prefixed `ListParagraph`s (`• ` / `1. `, indented by nesting) |
+| Task item | `☑ ` / `☐ ` prefix |
+| Thematic break | a box-drawing rule paragraph |
+| Table | a `<w:tbl>` of cell text |
+
+Inlines flatten to runs, combining down the tree: `Strong` → **bold**,
+`Emphasis` → *italic*, `CodeSpan` → `monospace`, so `**_x_**` is a single
+bold+italic run.
+
+## Fidelity (documented, MD02 §6)
+
+- **Raw HTML** (`RawBlock`/`RawInline`) is **dropped**, never injected.
+- **Links** render as `text (url)`; **images** as `[alt] (url)`.
+- **Strikethrough** renders as plain text; **hard breaks** as a space (the writer
+  has no strike flag / `<w:br/>` yet).
+- **Lists** are prefixed paragraphs, not native Word numbering; **table cells**
+  carry flattened text (header not bolded yet).
+
+Each limit is lossless for the visible text and pinned by a test, so a future
+enrichment is a deliberate change. `#![forbid(unsafe_code)]`, total and
+panic-free.
+
+## Testing
+
+```bash
+bash BUILD   # cargo test -p document-ast-to-docx
+```
+
+Tests assert the emitted `word/document.xml` shape (styles + run properties, via
+the independent `opc` reader) and reopen the `.docx` with the `wordprocessingml`
+reader to verify the visible text + block structure.

--- a/code/packages/rust/document-ast-to-docx/src/lib.rs
+++ b/code/packages/rust/document-ast-to-docx/src/lib.rs
@@ -1,0 +1,385 @@
+//! # `document-ast-to-docx` — render a Document AST to a `.docx`
+//!
+//! The bridge from the shared, format-agnostic [`document_ast`] IR to a real Word
+//! `.docx`, over the [`coding_adventures_docx_writer`] writer. It's the OOXML
+//! sibling of [`document-ast-to-html`](https://docs.rs/) — where that renders a
+//! [`DocumentNode`] to HTML, this renders it to WordprocessingML bytes.
+//!
+//! ```text
+//!   document_ast::DocumentNode
+//!        │  to_docx_document      (this crate — map blocks & inlines)
+//!        ▼
+//!   docx_writer::Document
+//!        │  docx_writer::write_docx
+//!        ▼
+//!   .docx bytes
+//! ```
+//!
+//! Because Markdown already parses to a [`DocumentNode`]
+//! (`commonmark-parser::parse`), composing that with [`to_docx_bytes`] gives a
+//! native **Markdown → `.docx`** converter — the point of spec
+//! `code/specs/MD02-markdown-to-docx.md`. Any other frontend that targets the
+//! Document AST (GFM, ASCIIDoc, HTML, …) gets `.docx` output for free.
+//!
+//! ## What maps to what
+//!
+//! Blocks become paragraphs (headings → `Heading N` style, code → `Code` style,
+//! quotes → `Quote` style, list items → indented `ListParagraph`s with a bullet
+//! or number prefix) and tables. Inlines flatten to formatted runs: `Strong` →
+//! bold, `Emphasis` → italic, `CodeSpan` → monospace, combining down the tree so
+//! `**_x_**` is a single bold+italic run.
+//!
+//! ## Fidelity (documented, per MD02 §6)
+//!
+//! - **Raw HTML** (`RawBlock`/`RawInline`) is **dropped**, never injected.
+//! - **Links** render as `text (url)`; **images** as `[alt] (url)` — no clickable
+//!   hyperlink or embedded media in v1.
+//! - **Strikethrough** renders as plain text (the writer has no strike run flag).
+//! - **Hard breaks** render as a space (the writer has no `<w:br/>`), a documented
+//!   divergence from MD02 §4.2; a follow-up can add `<w:br/>` to `docx-writer`.
+//! - **Lists** are prefixed paragraphs, not native Word numbering.
+//! - **Table cells** carry flattened inline text (no per-cell bold header yet).
+//!
+//! Every limit is lossless for the visible *text*; a future enrichment is a
+//! deliberate change, pinned by the tests.
+
+#![forbid(unsafe_code)]
+
+use coding_adventures_docx_writer::{write_docx, Document, ParagraphStyle, Run};
+use document_ast::{
+    BlockNode, DocumentNode, InlineNode, ListChildNode, ListNode, TableNode, TableRowNode,
+};
+
+/// Render a [`DocumentNode`] into a [`docx_writer::Document`](Document) ready for
+/// [`write_docx`]. Pure and total: any tree yields a valid document (an empty
+/// tree yields an empty document), never a panic.
+pub fn to_docx_document(doc: &DocumentNode) -> Document {
+    let mut out = Document::new();
+    render_blocks(&doc.children, &mut out, Ctx::default());
+    out
+}
+
+/// Render a [`DocumentNode`] straight to `.docx` bytes — `write_docx(&to_docx_document(doc))`.
+///
+/// The one-call entry a frontend uses: `to_docx_bytes(&commonmark_parser::parse(md))`
+/// is a native Markdown → `.docx` conversion.
+pub fn to_docx_bytes(doc: &DocumentNode) -> Vec<u8> {
+    write_docx(&to_docx_document(doc))
+}
+
+// ===========================================================================
+// Block rendering
+// ===========================================================================
+
+/// Maximum recursion depth for both the block and inline tree walkers. The AST
+/// comes from UNTRUSTED Markdown, and the upstream `commonmark-parser` bounds
+/// nesting NOWHERE (its container stack is iterative, so a one-line input of
+/// `>>>>…> x` yields an arbitrarily deep `Blockquote` chain, and `***…*` an
+/// arbitrarily deep emphasis chain). A recursive walker over that would overflow
+/// the native stack — an uncatchable SIGSEGV, defeating this crate's "total,
+/// panic-free" contract. So every recursive descent is bounded: past this depth
+/// we stop descending (drop the over-deep subtree) rather than recurse. The limit
+/// sits far above any legitimate document's nesting (256 levels).
+const MAX_DEPTH: usize = 256;
+
+/// The ambient state threaded through block rendering: how deep we are inside
+/// lists (for indentation), whether we're inside a blockquote (paragraphs get the
+/// `Quote` style), and the total recursion depth (bounded by [`MAX_DEPTH`]).
+/// `Copy` so a child call gets its own adjusted copy.
+#[derive(Clone, Copy, Default)]
+struct Ctx {
+    /// Nesting depth of the enclosing lists (0 = not in a list). Drives the list
+    /// item's leading indentation.
+    list_depth: usize,
+    /// Inside a blockquote — paragraphs render with `ParagraphStyle::Quote`.
+    in_quote: bool,
+    /// Total block-recursion depth, checked against [`MAX_DEPTH`] to bound
+    /// stack use on adversarially nested input.
+    depth: usize,
+}
+
+/// Render a sequence of block nodes into `out`.
+fn render_blocks(blocks: &[BlockNode], out: &mut Document, ctx: Ctx) {
+    for block in blocks {
+        render_block(block, out, ctx);
+    }
+}
+
+/// Render one block node into `out`.
+fn render_block(block: &BlockNode, out: &mut Document, ctx: Ctx) {
+    // Bound stack use on adversarially nested input: past MAX_DEPTH, stop
+    // descending. Leaf content already rendered above this depth is kept; the
+    // over-deep subtree is dropped rather than overflowing the stack.
+    if ctx.depth > MAX_DEPTH {
+        return;
+    }
+    // Every recursive descent below happens one level deeper.
+    let deeper = Ctx {
+        depth: ctx.depth + 1,
+        ..ctx
+    };
+    match block {
+        // A nested document root — flatten its children (rare; keeps traversal total).
+        BlockNode::Document(d) => render_blocks(&d.children, out, deeper),
+
+        BlockNode::Heading(h) => {
+            out.add_styled_paragraph(
+                ParagraphStyle::Heading(h.level),
+                inlines_to_runs(&h.children),
+            );
+        }
+
+        BlockNode::Paragraph(p) => {
+            let style = if ctx.in_quote {
+                ParagraphStyle::Quote
+            } else {
+                ParagraphStyle::Normal
+            };
+            out.add_styled_paragraph(style, inlines_to_runs(&p.children));
+        }
+
+        // Each source line becomes its own monospace `Code` paragraph, preserving
+        // line breaks. A single trailing newline (common on fenced blocks) is
+        // stripped so it doesn't add a spurious blank paragraph.
+        BlockNode::CodeBlock(c) => {
+            let body = c.value.strip_suffix('\n').unwrap_or(&c.value);
+            for line in body.split('\n') {
+                out.add_styled_paragraph(ParagraphStyle::Code, vec![Run::plain(line).mono()]);
+            }
+        }
+
+        // Child blocks render inside the quote context (their paragraphs take the
+        // Quote style). Blockquotes can nest and hold any blocks.
+        BlockNode::Blockquote(b) => {
+            render_blocks(
+                &b.children,
+                out,
+                Ctx {
+                    in_quote: true,
+                    ..deeper
+                },
+            );
+        }
+
+        BlockNode::List(l) => render_list(l, out, deeper),
+
+        // A stray list item outside a List — render its blocks as a one-item list
+        // at the current depth (defensive; a well-formed AST wraps items in List).
+        BlockNode::ListItem(item) => render_item_blocks(&item.children, out, deeper, "• "),
+        BlockNode::TaskItem(item) => {
+            let mark = if item.checked { "☑ " } else { "☐ " };
+            render_item_blocks(&item.children, out, deeper, mark);
+        }
+
+        // A horizontal rule — the writer has no paragraph borders, so we render a
+        // visible box-drawing rule (a documented rendering choice).
+        BlockNode::ThematicBreak(_) => {
+            out.add_styled_paragraph(ParagraphStyle::Normal, vec![Run::plain("────────")]);
+        }
+
+        BlockNode::Table(t) => render_table(t, out),
+
+        // Raw HTML is dropped, never injected into the .docx (MD02 §6).
+        BlockNode::RawBlock(_) => {}
+
+        // Table rows/cells never appear as top-level blocks in a well-formed AST;
+        // ignore them defensively rather than panic.
+        BlockNode::TableRow(_) | BlockNode::TableCell(_) => {}
+    }
+}
+
+/// Render a list: each item becomes one paragraph, prefixed with a bullet (`• `)
+/// or its number (`1. `, `2. `…, honouring the list's `start`), and indented by
+/// its nesting depth. Nested lists recurse with a deeper `list_depth`.
+fn render_list(list: &ListNode, out: &mut Document, ctx: Ctx) {
+    if ctx.depth > MAX_DEPTH {
+        return;
+    }
+    let mut number = list.start.unwrap_or(1);
+    for child in &list.children {
+        match child {
+            ListChildNode::ListItem(item) => {
+                let prefix = if list.ordered {
+                    format!("{number}. ")
+                } else {
+                    "• ".to_string()
+                };
+                render_item_blocks(&item.children, out, ctx, &prefix);
+                number = number.saturating_add(1);
+            }
+            ListChildNode::TaskItem(item) => {
+                let mark = if item.checked { "☑ " } else { "☐ " };
+                render_item_blocks(&item.children, out, ctx, mark);
+            }
+        }
+    }
+}
+
+/// Render a list item's blocks. The item's FIRST paragraph gets the bullet/number
+/// prefix + indentation; any further blocks (a nested list, a second paragraph)
+/// render normally at a deeper list depth. This keeps `- a\n  - b` readable
+/// (`• a` then an indented `• b`) without native Word numbering.
+fn render_item_blocks(blocks: &[BlockNode], out: &mut Document, ctx: Ctx, prefix: &str) {
+    if ctx.depth > MAX_DEPTH {
+        return;
+    }
+    let indent: String = "    ".repeat(ctx.list_depth);
+    let inner = Ctx {
+        list_depth: ctx.list_depth + 1,
+        depth: ctx.depth + 1,
+        ..ctx
+    };
+    let mut first_para_done = false;
+    for block in blocks {
+        match block {
+            // The item's leading paragraph carries the marker.
+            BlockNode::Paragraph(p) if !first_para_done => {
+                first_para_done = true;
+                let mut runs = vec![Run::plain(&format!("{indent}{prefix}"))];
+                runs.extend(inlines_to_runs(&p.children));
+                out.add_styled_paragraph(ParagraphStyle::List, runs);
+            }
+            // Nested lists deepen the indentation.
+            BlockNode::List(l) => render_list(l, out, inner),
+            // Any other block in the item renders at the item's depth.
+            other => render_block(other, out, inner),
+        }
+    }
+}
+
+/// Render a GFM table via the writer's plain-text table. Each cell is its inlines
+/// flattened to text (no per-cell formatting in v1, so the header row isn't
+/// bolded — a documented follow-up). An empty table yields an empty `<w:tbl>`.
+fn render_table(table: &TableNode, out: &mut Document) {
+    let rows: Vec<Vec<String>> = table
+        .children
+        .iter()
+        .map(|row: &TableRowNode| {
+            row.children
+                .iter()
+                .map(|c| inlines_to_plain(&c.children))
+                .collect()
+        })
+        .collect();
+    out.add_table(&rows);
+}
+
+// ===========================================================================
+// Inline rendering
+// ===========================================================================
+
+/// The character formatting carried down the inline tree. Nested `Strong` /
+/// `Emphasis` / `CodeSpan` combine (a code span inside a `**bold**` span is a
+/// bold monospace run).
+#[derive(Clone, Copy, Default)]
+struct Fmt {
+    bold: bool,
+    italic: bool,
+    mono: bool,
+}
+
+impl Fmt {
+    /// A run of `text` carrying this formatting.
+    fn run(self, text: &str) -> Run {
+        let mut r = Run::plain(text);
+        r.bold = self.bold;
+        r.italic = self.italic;
+        r.mono = self.mono;
+        r
+    }
+}
+
+/// Flatten a sequence of inline nodes into formatted runs (top-level, no ambient
+/// formatting).
+fn inlines_to_runs(inlines: &[InlineNode]) -> Vec<Run> {
+    let mut runs = Vec::new();
+    for node in inlines {
+        push_inline(node, Fmt::default(), 0, &mut runs);
+    }
+    runs
+}
+
+/// Append the runs for one inline node, carrying `fmt` down into children.
+///
+/// `depth` bounds the inline recursion the same way the block walker is bounded:
+/// nested emphasis/strong/link inlines come from untrusted Markdown with no
+/// upstream cap (`***…*` nests arbitrarily), so past [`MAX_DEPTH`] we drop the
+/// over-deep node rather than overflow the stack.
+fn push_inline(node: &InlineNode, fmt: Fmt, depth: usize, runs: &mut Vec<Run>) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let d = depth + 1;
+    match node {
+        InlineNode::Text(t) => runs.push(fmt.run(&t.value)),
+        InlineNode::Strong(s) => push_children(&s.children, Fmt { bold: true, ..fmt }, d, runs),
+        InlineNode::Emphasis(e) => push_children(
+            &e.children,
+            Fmt {
+                italic: true,
+                ..fmt
+            },
+            d,
+            runs,
+        ),
+        // No strike run flag in the writer — render the text plainly (MD02 §6).
+        InlineNode::Strikethrough(s) => push_children(&s.children, fmt, d, runs),
+        InlineNode::CodeSpan(c) => runs.push(Fmt { mono: true, ..fmt }.run(&c.value)),
+        // Link: its child text, then the URL in parentheses (no clickable hyperlink v1).
+        InlineNode::Link(l) => {
+            push_children(&l.children, fmt, d, runs);
+            runs.push(fmt.run(&format!(" ({})", l.destination)));
+        }
+        // Image: "[alt] (url)" as plain text (no embedded media v1).
+        InlineNode::Image(i) => {
+            runs.push(fmt.run(&format!("[{}]", i.alt)));
+            runs.push(fmt.run(&format!(" ({})", i.destination)));
+        }
+        InlineNode::Autolink(a) => runs.push(fmt.run(&a.destination)),
+        // Hard/soft breaks both become a space (the writer has no <w:br/>).
+        InlineNode::HardBreak(_) | InlineNode::SoftBreak(_) => runs.push(fmt.run(" ")),
+        // Raw inline HTML is dropped, never injected.
+        InlineNode::RawInline(_) => {}
+    }
+}
+
+/// Push the runs for a child inline sequence under `fmt` at recursion depth `depth`.
+fn push_children(children: &[InlineNode], fmt: Fmt, depth: usize, runs: &mut Vec<Run>) {
+    for node in children {
+        push_inline(node, fmt, depth, runs);
+    }
+}
+
+/// Flatten inlines to a single plain-text string (for table cells) — formatting
+/// is dropped, breaks become spaces, raw inline is dropped, images become their
+/// alt text.
+fn inlines_to_plain(inlines: &[InlineNode]) -> String {
+    let mut s = String::new();
+    for node in inlines {
+        plain_inline(node, 0, &mut s);
+    }
+    s
+}
+
+/// Depth-bounded (see [`push_inline`]) plain-text flattening.
+fn plain_inline(node: &InlineNode, depth: usize, s: &mut String) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let d = depth + 1;
+    match node {
+        InlineNode::Text(t) => s.push_str(&t.value),
+        InlineNode::CodeSpan(c) => s.push_str(&c.value),
+        InlineNode::Autolink(a) => s.push_str(&a.destination),
+        InlineNode::Strong(n) => n.children.iter().for_each(|c| plain_inline(c, d, s)),
+        InlineNode::Emphasis(n) => n.children.iter().for_each(|c| plain_inline(c, d, s)),
+        InlineNode::Strikethrough(n) => n.children.iter().for_each(|c| plain_inline(c, d, s)),
+        InlineNode::Link(n) => n.children.iter().for_each(|c| plain_inline(c, d, s)),
+        InlineNode::Image(i) => s.push_str(&i.alt),
+        InlineNode::HardBreak(_) | InlineNode::SoftBreak(_) => s.push(' '),
+        InlineNode::RawInline(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/document-ast-to-docx/src/tests.rs
+++ b/code/packages/rust/document-ast-to-docx/src/tests.rs
@@ -1,0 +1,377 @@
+//! Tests for `document-ast-to-docx`.
+//!
+//! Two kinds of proof:
+//! 1. **XML-shape** — build a `DocumentNode`, render it, inflate the emitted
+//!    package with the independent `opc` reader, and assert `word/document.xml`
+//!    carries the right `<w:pStyle>` / `<w:rPr>` shapes.
+//! 2. **Round-trip** — reopen the `.docx` bytes with the read-side
+//!    `wordprocessingml` reader and assert the visible text + block structure.
+
+use super::*;
+use coding_adventures_opc::Package;
+use coding_adventures_wordprocessingml::open_docx;
+use document_ast::*;
+
+/// The emitted `word/document.xml` as a string, for XML-shape assertions.
+fn body_xml(doc: &DocumentNode) -> String {
+    let bytes = to_docx_bytes(doc);
+    let pkg = Package::open(&bytes).expect("emitted .docx must be a valid OPC package");
+    String::from_utf8(pkg.read_part("/word/document.xml").unwrap().to_vec()).unwrap()
+}
+
+// ── small constructors to keep the tests readable ──────────────────────────
+fn text(s: &str) -> InlineNode {
+    InlineNode::Text(TextNode {
+        value: s.to_string(),
+    })
+}
+fn para(children: Vec<InlineNode>) -> BlockNode {
+    BlockNode::Paragraph(ParagraphNode { children })
+}
+fn doc(children: Vec<BlockNode>) -> DocumentNode {
+    DocumentNode { children }
+}
+
+/// An empty AST renders to a valid, empty `.docx`.
+#[test]
+fn empty_document_is_valid() {
+    let bytes = to_docx_bytes(&doc(vec![]));
+    assert_eq!(&bytes[..2], b"PK", "a valid OPC/ZIP package");
+    let read = open_docx(&bytes).expect("empty doc opens");
+    assert_eq!(read.text(), "");
+}
+
+/// A heading renders as a `Heading N` styled paragraph.
+#[test]
+fn heading_maps_to_heading_style() {
+    let d = doc(vec![BlockNode::Heading(HeadingNode {
+        level: 2,
+        children: vec![text("Chapter Two")],
+    })]);
+    let xml = body_xml(&d);
+    assert!(xml.contains("<w:pStyle w:val=\"Heading2\"/>"), "{xml}");
+    assert!(xml.contains("Chapter Two"), "{xml}");
+}
+
+/// Strong → bold, Emphasis → italic, CodeSpan → monospace, and nesting combines.
+#[test]
+fn inline_formatting_maps_to_run_properties() {
+    let d = doc(vec![para(vec![
+        InlineNode::Strong(StrongNode {
+            children: vec![text("b")],
+        }),
+        InlineNode::Emphasis(EmphasisNode {
+            children: vec![text("i")],
+        }),
+        InlineNode::CodeSpan(CodeSpanNode {
+            value: "c".to_string(),
+        }),
+        // Emphasis inside Strong ⇒ a bold+italic run.
+        InlineNode::Strong(StrongNode {
+            children: vec![InlineNode::Emphasis(EmphasisNode {
+                children: vec![text("bi")],
+            })],
+        }),
+    ])]);
+    let xml = body_xml(&d);
+    assert!(xml.contains("<w:rPr><w:b/></w:rPr>"), "bold: {xml}");
+    assert!(xml.contains("<w:rPr><w:i/></w:rPr>"), "italic: {xml}");
+    assert!(
+        xml.contains("w:ascii=\"Consolas\""),
+        "mono code span: {xml}"
+    );
+    assert!(
+        xml.contains("<w:rPr><w:b/><w:i/></w:rPr>"),
+        "combined bold+italic: {xml}"
+    );
+}
+
+/// A fenced code block becomes one monospace `Code` paragraph per source line,
+/// with no spurious trailing blank paragraph.
+#[test]
+fn code_block_becomes_code_paragraphs_per_line() {
+    let d = doc(vec![BlockNode::CodeBlock(CodeBlockNode {
+        language: Some("rust".to_string()),
+        value: "let x = 1;\nlet y = 2;\n".to_string(),
+    })]);
+    let xml = body_xml(&d);
+    assert_eq!(
+        xml.matches("<w:pStyle w:val=\"Code\"/>").count(),
+        2,
+        "two code lines: {xml}"
+    );
+    assert!(
+        xml.contains("let x = 1;") && xml.contains("let y = 2;"),
+        "{xml}"
+    );
+}
+
+/// Ordered and unordered lists become prefixed `ListParagraph`s; ordered lists
+/// honour `start` and increment.
+#[test]
+fn lists_become_prefixed_paragraphs() {
+    let item = |s: &str| {
+        ListChildNode::ListItem(ListItemNode {
+            children: vec![para(vec![text(s)])],
+        })
+    };
+
+    let unordered = BlockNode::List(ListNode {
+        ordered: false,
+        start: None,
+        tight: true,
+        children: vec![item("apple"), item("pear")],
+    });
+    let ordered = BlockNode::List(ListNode {
+        ordered: true,
+        start: Some(3),
+        tight: true,
+        children: vec![item("third"), item("fourth")],
+    });
+    let d = doc(vec![unordered, ordered]);
+    // The prefix and content are separate runs, so assert style on the XML and
+    // the rejoined marker+text via the reader (which concatenates runs).
+    assert!(
+        body_xml(&d).contains("<w:pStyle w:val=\"ListParagraph\"/>"),
+        "list style"
+    );
+    let text = open_docx(&to_docx_bytes(&d)).unwrap().text();
+    assert!(
+        text.contains("• apple") && text.contains("• pear"),
+        "bullets: {text:?}"
+    );
+    assert!(
+        text.contains("3. third") && text.contains("4. fourth"),
+        "numbering from start=3: {text:?}"
+    );
+}
+
+/// GFM task items render with a checked/unchecked box marker.
+#[test]
+fn task_items_render_checkboxes() {
+    let d = doc(vec![BlockNode::List(ListNode {
+        ordered: false,
+        start: None,
+        tight: true,
+        children: vec![
+            ListChildNode::TaskItem(TaskItemNode {
+                checked: true,
+                children: vec![para(vec![text("done")])],
+            }),
+            ListChildNode::TaskItem(TaskItemNode {
+                checked: false,
+                children: vec![para(vec![text("todo")])],
+            }),
+        ],
+    })]);
+    let text = open_docx(&to_docx_bytes(&d)).unwrap().text();
+    assert!(text.contains("☑ done"), "checked: {text:?}");
+    assert!(text.contains("☐ todo"), "unchecked: {text:?}");
+}
+
+/// A blockquote's paragraphs take the `Quote` style.
+#[test]
+fn blockquote_uses_quote_style() {
+    let d = doc(vec![BlockNode::Blockquote(BlockquoteNode {
+        children: vec![para(vec![text("quoted")])],
+    })]);
+    let xml = body_xml(&d);
+    assert!(xml.contains("<w:pStyle w:val=\"Quote\"/>"), "{xml}");
+    assert!(xml.contains("quoted"), "{xml}");
+}
+
+/// A GFM table renders as a `<w:tbl>` with the cells' flattened text.
+#[test]
+fn table_renders_with_cell_text() {
+    let cell = |s: &str| TableCellNode {
+        children: vec![text(s)],
+    };
+    let d = doc(vec![BlockNode::Table(TableNode {
+        align: vec![TableAlignment::None, TableAlignment::None],
+        children: vec![
+            TableRowNode {
+                is_header: true,
+                children: vec![cell("H1"), cell("H2")],
+            },
+            TableRowNode {
+                is_header: false,
+                children: vec![cell("a"), cell("b")],
+            },
+        ],
+    })]);
+    let read = open_docx(&to_docx_bytes(&d)).expect("open");
+    let tables: Vec<_> = read.tables().collect();
+    assert_eq!(tables.len(), 1);
+    assert_eq!(tables[0].rows.len(), 2);
+    assert_eq!(tables[0].rows[0][0].text, "H1");
+    assert_eq!(tables[0].rows[1][1].text, "b");
+}
+
+/// Links render as `text (url)`, images as `[alt] (url)`.
+#[test]
+fn links_and_images_render_text_and_url() {
+    let d = doc(vec![para(vec![
+        InlineNode::Link(LinkNode {
+            destination: "https://example.com".to_string(),
+            title: None,
+            children: vec![text("site")],
+        }),
+        InlineNode::Image(ImageNode {
+            destination: "cat.png".to_string(),
+            title: None,
+            alt: "a cat".to_string(),
+        }),
+    ])]);
+    let xml = body_xml(&d);
+    assert!(
+        xml.contains("site") && xml.contains("(https://example.com)"),
+        "link: {xml}"
+    );
+    assert!(
+        xml.contains("[a cat]") && xml.contains("(cat.png)"),
+        "image: {xml}"
+    );
+}
+
+/// Raw HTML blocks and inlines are DROPPED, never injected into the .docx.
+#[test]
+fn raw_html_is_dropped() {
+    let d = doc(vec![
+        BlockNode::RawBlock(RawBlockNode {
+            format: "html".to_string(),
+            value: "<script>alert(1)</script>".to_string(),
+        }),
+        para(vec![
+            text("before "),
+            InlineNode::RawInline(RawInlineNode {
+                format: "html".to_string(),
+                value: "<b>evil</b>".to_string(),
+            }),
+            text("after"),
+        ]),
+    ]);
+    let xml = body_xml(&d);
+    assert!(!xml.contains("script"), "raw block dropped: {xml}");
+    assert!(!xml.contains("evil"), "raw inline dropped: {xml}");
+    // The surrounding text survives.
+    assert!(xml.contains("before ") && xml.contains("after"), "{xml}");
+}
+
+/// The headline round-trip: a rich AST → `.docx` → reopened text + structure.
+#[test]
+fn rich_document_round_trips() {
+    let d = doc(vec![
+        BlockNode::Heading(HeadingNode {
+            level: 1,
+            children: vec![text("Title")],
+        }),
+        para(vec![
+            text("A "),
+            InlineNode::Strong(StrongNode {
+                children: vec![text("bold ")],
+            }),
+            text("word."),
+        ]),
+        BlockNode::List(ListNode {
+            ordered: false,
+            start: None,
+            tight: true,
+            children: vec![
+                ListChildNode::ListItem(ListItemNode {
+                    children: vec![para(vec![text("one")])],
+                }),
+                ListChildNode::ListItem(ListItemNode {
+                    children: vec![para(vec![text("two")])],
+                }),
+            ],
+        }),
+    ]);
+    let bytes = to_docx_bytes(&d);
+    let read = open_docx(&bytes).expect("reopen the rendered .docx");
+    let text = read.text();
+    assert!(text.contains("Title"), "heading text: {text:?}");
+    assert!(text.contains("A bold word."), "bold run rejoined: {text:?}");
+    assert!(
+        text.contains("• one") && text.contains("• two"),
+        "list items: {text:?}"
+    );
+    // Heading, body, and two list items are four distinct paragraphs.
+    assert_eq!(read.paragraphs().count(), 4, "para count");
+}
+
+// ===========================================================================
+// Recursion-depth DoS guard (CWE-674)
+// ===========================================================================
+// The AST comes from untrusted Markdown, which the upstream parser doesn't cap:
+// `>>>>…> x` nests blockquotes arbitrarily, `***…*` emphasis arbitrarily. A
+// recursive walker over that would overflow the native stack (an uncatchable
+// SIGSEGV). MAX_DEPTH bounds the descent; these tests pin that boundary.
+
+/// Wrap `inner` in `n` nested blockquotes (built inside-out — a loop, no
+/// construction recursion).
+fn nest_blockquotes(n: usize, inner: Vec<BlockNode>) -> BlockNode {
+    let mut node = BlockNode::Blockquote(BlockquoteNode { children: inner });
+    for _ in 1..n {
+        node = BlockNode::Blockquote(BlockquoteNode {
+            children: vec![node],
+        });
+    }
+    node
+}
+
+/// Content nested BEYOND `MAX_DEPTH` blockquotes is dropped (the guard fires)
+/// rather than recursed into — while shallow content still renders.
+#[test]
+fn over_deep_blockquote_content_is_dropped() {
+    // A "DEEP" paragraph buried ~50 levels past the cap, plus a top-level "TOP".
+    let buried = nest_blockquotes(super::MAX_DEPTH + 50, vec![para(vec![text("DEEP")])]);
+    let d = doc(vec![para(vec![text("TOP")]), buried]);
+    let text = open_docx(&to_docx_bytes(&d)).unwrap().text();
+    assert!(text.contains("TOP"), "shallow content rendered: {text:?}");
+    assert!(
+        !text.contains("DEEP"),
+        "over-deep content dropped by the guard: {text:?}"
+    );
+}
+
+/// Inline content nested BEYOND `MAX_DEPTH` emphasis spans is dropped; a sibling
+/// at the top level still renders.
+#[test]
+fn over_deep_emphasis_content_is_dropped() {
+    let mut inner = InlineNode::Text(TextNode {
+        value: "INNER".to_string(),
+    });
+    for _ in 0..super::MAX_DEPTH + 50 {
+        inner = InlineNode::Emphasis(EmphasisNode {
+            children: vec![inner],
+        });
+    }
+    let d = doc(vec![para(vec![inner, text("AFTER")])]);
+    let xml = body_xml(&d);
+    assert!(xml.contains("AFTER"), "top-level sibling rendered: {xml}");
+    assert!(
+        !xml.contains("INNER"),
+        "over-deep inline dropped by the guard: {xml}"
+    );
+}
+
+/// The headline DoS proof: a pathologically deep AST (50k nested blockquotes)
+/// converts to a valid `.docx` WITHOUT overflowing the stack. The walker is
+/// bounded to `MAX_DEPTH` frames regardless of input depth; the large thread
+/// stack here is only so the TEST's own construction/`Drop` of the 50k-deep tree
+/// doesn't overflow (that's a property of the test data, not the converter).
+/// Without the depth guard, the converter's recursion would follow the input to
+/// 50k frames and crash.
+#[test]
+fn deeply_nested_input_does_not_overflow() {
+    std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024)
+        .spawn(|| {
+            let buried = nest_blockquotes(50_000, vec![para(vec![text("x")])]);
+            let bytes = to_docx_bytes(&doc(vec![buried]));
+            assert_eq!(&bytes[..2], b"PK", "deep input still yields a valid .docx");
+        })
+        .unwrap()
+        .join()
+        .expect("converting a 50k-deep AST must not overflow the stack");
+}


### PR DESCRIPTION
## What

New `document-ast-to-docx` crate: renders the shared `document_ast::DocumentNode` to a real Word `.docx`, over the zero-dependency `docx-writer` (formatting landed in the preceding PR).

`to_docx_document(&DocumentNode) -> docx_writer::Document` and `to_docx_bytes(&DocumentNode) -> Vec<u8>`.

## Why

This is the bridge that makes the **Document AST the prose hub**. Composed with `commonmark-parser`/`gfm-parser` (next PR), it gives **native Markdown → .docx** with no external tooling — analogous to `spreadsheet-core` for tabular formats.

## Mappings

Headings → `Heading N`, `**bold**`/`*italic*`/`` `code` `` → run properties, lists → prefixed paragraphs (`• ` / `1. `), task items → `☑`/`☐`, blockquotes → `Quote` style, fenced code → one `Code` paragraph per line, GFM tables → `<w:tbl>`, thematic break → a rule. Raw HTML/inline is dropped (fidelity limit documented in the MD02 spec).

## Safety

Untrusted Markdown can nest arbitrarily deep (`>>>>…`, `***…`), handing a deep AST to the recursive renderer → stack-overflow DoS (CWE-674). Guarded with a `MAX_DEPTH = 256` cap threaded through every descent; past the cap the subtree is dropped. **Verified adversarially** (neutering the guard makes the boundary test fail; restored → passes). 14 tests incl. `deeply_nested_input_does_not_overflow` (50k-deep). `#![forbid(unsafe_code)]`.

Security-reviewed twice — passed.