### PR TITLE
feat(latex): LTXDOC03 S29 — label_definition_count report renderer

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.65.0] — 2026-07-08
+
+### Added — single-integer TOTAL of the label definitions (LTXDOC03 S29)
+
+A **new** public method `Document::label_definition_count(&self) -> String` that renders the decimal
+**COUNT** of the winning label definitions — the distinct `\label` keys the document defines — as one
+integer line. It is the *count-total* companion of S22's `label_definitions` and S23's
+`label_definitions_by_kind` (which render one `\label{key}` **line per winning definition**, flat in
+source order or grouped by kind): S22/S23 and S29 are two *views* of the one winning `definitions` list
+`resolve_references()` produces — S29 collapses the whole list to a single `.len()` tally. It is the exact
+label-definition-side **analogue** of the reference-side totals S27's `unresolved_reference_count` and
+S28's `resolved_reference_count`, and the count-total sibling of the census family (S25 `label_kind_counts`)
+but for the *whole* definition list rather than per-kind. It is a read-only view over
+`resolve_references()`; every S1–S28 output is left **byte-for-byte unchanged**; S29 is purely additive and
+leaves the `to_latex()` round-trip fixed point intact.
+
+- **Counts the WINNING definitions only.** S29 reads `resolve_references().definitions.len()` — each entry
+  a `LabelDef` for the first `\label` of a distinct key. A later re-definition `\label{dup}` lives in
+  `resolve_references().duplicates` (S20's domain), never in `definitions`, so it is excluded by
+  construction — the count is exactly the number of lines S22 lists.
+- **A single decimal line, always.** The output is the decimal `.len()` of the `definitions` list — one
+  line, no trailing newline. There is **no** source slicing and **no** `kind` read at all (unlike S25's
+  per-kind census); section, figure, equation, and inline labels all fold into one total — only `.len()`
+  is taken.
+- **Zero is the honest value `"0"`.** Being a COUNT renderer, its empty case (no `\label` at all) is the
+  number `"0"` — **not** a `(no label definitions)` marker. This mirrors S27/S28 exactly. The `(no …)`
+  marker discipline belongs to the *list* renderers S22/S23, whose empty case has no lines to show; a
+  total count of zero *is* a number.
+- **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing, no source slicing; a single read of
+  the already-bounded `definitions` list's length. Borrows `self` immutably, returns owned `String`.
+- **Tests.** Added `s29_multiple_definitions_count_the_integer`,
+  `s29_duplicate_label_counted_once_matching_s22` (cross-checking that a later `\label{dup}` is a
+  duplicate — S20's domain — not a second definition), `s29_no_labels_counts_zero`,
+  `s29_mixed_document_counts_only_label_definitions` (the count is unaffected by refs/citations),
+  `s29_count_equals_number_of_s22_lines` (cross-checking the total against the number of lines S22
+  enumerates), and `s29_is_additive_leaves_s1_s28_outputs_unchanged` (which pins a handful of prior
+  S1–S28 outputs byte-for-byte — including S22's `label_definitions`, S25's `label_kind_counts`, S27's
+  `unresolved_reference_count`, and S28's `resolved_reference_count` — alongside the new count).
+
 ## [0.64.0] — 2026-07-08
 
 ### Added — single-integer TOTAL of the resolved references (LTXDOC03 S28)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -76,6 +76,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S26 — per-kind census (counts) of the resolved references** | `Document::resolved_reference_kind_counts() -> String` — a **new**, read-only method that renders a **per-kind CENSUS** of the RESOLVED `\ref`/`\eqref`/`\pageref` references: one `<kind>: <n>` line per `LabelKind` that has at least one resolved ref, carrying the integer **count** (not a list) — the **count companion of S24's** `resolved_references_by_kind` (which renders one `[kind] \<command>{key}` *line per resolved ref*). S21's flat `resolved_references_by_source`, S24's grouped list, and S26's counts are three views of the one `resolved` list; S26 collapses each kind's group to a single tally line (it is to S24 what S25's `label_kind_counts` is to S23). It reads only `resolve_references().resolved` (each a `ResolvedRef` carrying the `target_kind` — the kind of the label it bound to; a dangling `\ref` lives in `unresolved`, S18's domain, and is excluded by construction — never a spurious `<kind>: 0`) and counts by `target_kind` in a **fixed, document-independent order** (the enum declaration order: `Section`, `Table`, `Figure`, `Equation`, `Inline` — the SAME slice S23/S24/S25 use, iterated explicitly, not a hash map, so the order is deterministic). Each line is `<kind>: <n>` — `<kind>` from `LabelKind::as_str()` (the SAME tag S24 renders: `"section"`/`"table"`/`"figure"`/`"equation"`/`"inline"`), `<n>` the decimal count (no source slicing). A kind with a zero count contributes no line (no bare `table: 0`). Lines joined by `\n`, no trailing newline. A document with **no** resolved references → the **same** fixed marker `(no resolved references)` S21/S24 use. E.g. `\ref{sec:a}`, `\ref{sec:b}` (two sections), `\eqref{eq:e}` (equation) → `section: 2\nequation: 1`. Every S1–S25 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S27 — single-integer total of the unresolved (dangling) references** | `Document::unresolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\ref`/`\eqref`/`\pageref` references — the ones no `\label` defines (LaTeX's *"Reference `key' undefined"*, the `??`) — as one integer line. It is the **count-total companion of S18's** `unresolved_references_by_source` (which renders one `\<command>{key}` *line per dangling ref*): S18 and S27 are two views of the one `unresolved` list; S27 collapses the whole list to a single `.len()` tally. It is the count-total sibling of the census family (S25 `label_kind_counts`, S26 `resolved_reference_kind_counts`), but for the UNRESOLVED refs — which carry **no** `target_kind` (a dangling ref bound to nothing), so a per-kind census is not viable and a single total is the clean move. It reads only `resolve_references().unresolved.len()` (a resolved `\ref{sec:i}` lives in `resolved`, S21's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all. Being a COUNT renderer, its empty case (every ref resolves, or none at all) is the honest number `"0"` — **not** a `(no …)` marker (that discipline belongs to the *list* renderers). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\ref{nope}` + `\ref{gone}` (both dangle) → `2`. Every S1–S26 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S28 — single-integer total of the resolved references** | `Document::resolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — the ones some `\label` defines — as one integer line. It is the **count-total companion of S21's** `resolved_references_by_source` **and S24's** `resolved_references_by_kind` (which render one `\<command>{key}` *line per resolved ref*, flat in source order or grouped by target kind): S21/S24 and S28 are two views of the one `resolved` list; S28 collapses the whole list to a single `.len()` tally. It is the exact resolved-side **twin of S27's** `unresolved_reference_count` — together S28 + S27 split every reference into the pair (resolved, dangling), so their totals sum to the total reference count. It reads only `resolve_references().resolved.len()` (a dangling `\ref{nope}` lives in `unresolved`, S18/S27's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all, so section/table/equation references all fold into one total. Being a COUNT renderer, its empty case (every ref dangles, or none at all) is the honest number `"0"` — **not** a `(no resolved references)` marker (that discipline belongs to the *list* renderers; this mirrors S27). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\pageref{sec:i}` (resolves) + `\ref{nope}` (dangles) → `2`. Every S1–S27 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S29 — single-integer total of the label definitions** | `Document::label_definition_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning label definitions — the distinct `\label` keys the document defines — as one integer line. It is the **count-total companion of S22's** `label_definitions` **and S23's** `label_definitions_by_kind` (which render one `\label{key}` *line per winning definition*, flat in source order or grouped by kind): S22/S23 and S29 are two views of the one winning `definitions` list; S29 collapses the whole list to a single `.len()` tally. It is the exact label-definition-side **analogue** of the reference-side totals S27's `unresolved_reference_count` and S28's `resolved_reference_count`, and the count-total sibling of the census family (S25 `label_kind_counts`) but over the *whole* definition list rather than per-kind. It reads only `resolve_references().definitions.len()` (a later duplicate `\label{dup}` lives in `duplicates`, S20's domain, and is excluded by construction — the count is exactly the number of lines S22 lists) — never a `kind`, no source slicing at all, so section/figure/equation/inline labels all fold into one total. Being a COUNT renderer, its empty case (no `\label` at all) is the honest number `"0"` — **not** a `(no label definitions)` marker (that discipline belongs to the *list* renderers; this mirrors S27/S28). One line, no trailing newline. E.g. `sec:intro` (section) + `eq:main` (equation) + a re-used `sec:intro` (duplicate) → `2`. Every S1–S28 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1133,6 +1134,39 @@ renders the honest number `"0"` — **not** a `(no resolved references)` marker 
 the *list* renderers S21/S24, whose empty case has no lines to show; this mirrors S27). Purely additive —
 reuses `resolve_references`, mutates nothing, leaves every S1–S27 output and the `to_latex()` fixed point
 unchanged.
+
+### single-integer total of the label definitions (LTXDOC03 S29)
+
+The decimal **COUNT** of the winning label definitions — the distinct `\label` keys the document defines —
+as one integer line. It is the **count-total companion of S22's** `label_definitions` **and S23's**
+`label_definitions_by_kind` (which render one `\label{key}` line *per winning definition*, flat in source
+order or grouped by kind): S22/S23 and S29 are two *views* of the one winning `definitions` list
+`resolve_references()` produces; S29 collapses the whole list to a single `.len()` tally. It is the exact
+label-definition-side **analogue** of the reference-side totals S27's `unresolved_reference_count` and
+S28's `resolved_reference_count`, and the count-total sibling of the census family (S25 `label_kind_counts`)
+but over the *whole* definition list rather than per-kind. `label_definition_count` reads only
+`resolve_references().definitions.len()` — a later duplicate `\label{dup}` lives in `duplicates` (S20's
+domain) and is excluded by construction, so the count is exactly the number of lines S22 lists — never a
+`kind`, with no source slicing at all, so section/figure/equation/inline labels all fold into one total.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\section{Intro}\label{sec:intro}
+\begin{equation}\label{eq:main}x=1\end{equation}
+\subsection{Dup}\label{sec:intro}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.label_definition_count(),
+    // two distinct keys defined (`sec:intro`, `eq:main`); the later `\label{sec:intro}` is a duplicate
+    "2",
+);
+```
+
+Being a COUNT renderer, a document with no label definitions at all renders the honest number `"0"` —
+**not** a `(no label definitions)` marker (that discipline belongs to the *list* renderers S22/S23, whose
+empty case has no lines to show; this mirrors S27/S28). Purely additive — reuses `resolve_references`,
+mutates nothing, leaves every S1–S28 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2866,6 +2866,73 @@ impl Document {
         // equation references all fold into a single total, the resolved-side twin of S27's count.
         self.resolve_references().resolved.len().to_string()
     }
+
+    /// The **single-integer TOTAL of the label definitions** (LTXDOC03 S29) — the *count-total*
+    /// companion of S22's [`label_definitions`](Document::label_definitions) and S23's
+    /// [`label_definitions_by_kind`](Document::label_definitions_by_kind). Where S22/S23 render one
+    /// **line per winning label definition** (a `\label{key}` list, flat in pre-order or grouped by
+    /// kind), S29 renders one **line** carrying just the decimal **count** of those definitions — the
+    /// number of distinct `\label` keys the document defines. It is the exact label-definition-side
+    /// analogue of the reference-side totals S27's
+    /// [`unresolved_reference_count`](Document::unresolved_reference_count) and S28's
+    /// [`resolved_reference_count`](Document::resolved_reference_count) provide for the two reference
+    /// tables. It is to S22/S23 what S25's [`label_kind_counts`](Document::label_kind_counts) is: a
+    /// numeric summary over the *same* list — here the **winning** label definitions — so a reader
+    /// sees "how many labels are defined" without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] splits every `\label` into the **winning** first
+    /// definition of each key ([`ReferenceResolution::definitions`] — one row per distinct key, in
+    /// [`Document::walk`] pre-order) and the **losing** later re-definitions
+    /// ([`ReferenceResolution::duplicates`] — LaTeX's *"Label `key' multiply defined"* warning, S20's
+    /// domain). S22/S23 render that `definitions` list as one line per winning definition; S29
+    /// collapses the whole list to a **single count line** — the decimal `.len()` of `definitions`.
+    /// Unlike S25 (which *can* census the definitions by [`LabelKind`]), S29 takes no per-kind view at
+    /// all: it reads only the length, never a `kind`, so section, figure, equation, and inline labels
+    /// all fold into one total. Only the **winning** definitions are counted; a later duplicate
+    /// `\label{dup}` lives in [`ReferenceResolution::duplicates`] (S20), never in `definitions`, so it
+    /// is excluded by construction — the count is exactly the number of lines S22 lists.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`ReferenceResolution::definitions`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no label definitions is the number `0` — the string `"0"`, **not**
+    /// a `(no label definitions)` marker (a total count of zero *is* a number; the `(no …)` marker
+    /// discipline belongs to the *list* renderers S22/S23, whose empty case has no lines to show). This
+    /// mirrors S27/S28 exactly, which emit `"0"` for their empty lists. There is no source slicing and
+    /// no `kind` read at all — only `.len()` is taken.
+    ///
+    /// Concretely, for a body defining `\label{sec:intro}` (a section), `\label{eq:main}` (an
+    /// equation), and then re-using `\label{sec:intro}` on a later subsection (a duplicate):
+    ///
+    /// ```text
+    /// 2
+    /// ```
+    ///
+    /// (two distinct keys are defined; the later duplicate `\label{sec:intro}` is excluded). A document
+    /// with no label definitions at all returns `"0"`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S29 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1–S28 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *second view* of the same `definitions`
+    /// list S22/S23 render flat and per-kind — counting never adds, drops, or reorders the definitions
+    /// relative to what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read, never a `kind`); a single read of the already-bounded `definitions`
+    /// list's length. Borrows `self` immutably and returns owned `String` data, so the result outlives
+    /// any borrow of the source.
+    pub fn label_definition_count(&self) -> String {
+        // S1 already collected the winning definitions — the first `\label` of each distinct key, in
+        // body pre-order (later re-definitions went to `duplicates`, S20, not here). We only read that
+        // list's length. No `kind` is read — section, figure, equation, and inline labels all fold into
+        // a single total, the label-definition-side analogue of S27/S28's reference-side counts.
+        self.resolve_references().definitions.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -7064,6 +7131,153 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.resolved_reference_count(),
             doc.resolved_references_by_source().lines().count().to_string()
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S29 — single-integer TOTAL of the label definitions (`label_definition_count`). The
+    // count-total companion of S22's `label_definitions` / S23's `label_definitions_by_kind`: one
+    // decimal line = `.len()` of the SAME winning `definitions` list. It is the label-definition-side
+    // analogue of S27/S28's reference-side totals. No `kind` is read, so all kinds fold into one
+    // total. Being a COUNT renderer, its empty value is the honest number "0", NOT a `(no …)` marker.
+    // A later duplicate `\label` is in `duplicates` (S20), never `definitions`, so it is excluded —
+    // the count is exactly the number of lines S22 lists.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s29_multiple_definitions_count_the_integer() {
+        // Three distinct label keys defined (a section, an equation, an inline label) → the count is
+        // exactly "3".
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+Some \label{inl} text.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definition_count(), "3");
+        // Cross-check: the three winning definitions are exactly what S22 enumerates.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:i}\n\\label{eq:e}\n\\label{inl}"
+        );
+    }
+
+    #[test]
+    fn s29_duplicate_label_counted_once_matching_s22() {
+        // A key `\label{dup}` defined twice: only the FIRST (winning) definition is in `definitions`;
+        // the later one is a DUPLICATE (S20's domain), never a second `definitions` row. So the count
+        // is the number of DISTINCT keys, exactly matching the number of lines S22 lists.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+First \label{dup} here.
+Second \label{dup} there.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        // Two distinct keys: `sec:i` and `dup`.
+        assert_eq!(doc.label_definition_count(), "2");
+        // The later `\label{dup}` is a duplicate, surfaced by S20, not counted here.
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // The count MUST equal the number of lines S22 lists (two views of the SAME list).
+        assert_eq!(
+            doc.label_definition_count(),
+            doc.label_definitions().lines().count().to_string()
+        );
+        assert_eq!(doc.label_definitions(), "\\label{sec:i}\n\\label{dup}");
+    }
+
+    #[test]
+    fn s29_no_labels_counts_zero() {
+        // A document with NO `\label` at all → "0" (the count of an empty `definitions` list). A COUNT
+        // renderer's honest value for an empty list is the number "0", never a `(no …)` marker.
+        let src = r"\begin{document}Just some text with no labels.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definition_count(), "0");
+        // And S22 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(doc.label_definitions(), "(no label definitions)");
+    }
+
+    #[test]
+    fn s29_mixed_document_counts_only_label_definitions() {
+        // A mixed doc — labels + refs + citations. S29 counts ONLY the label-definition total; the
+        // `\ref`s and `\cite`s do not perturb it. Three distinct label keys are defined, so the answer
+        // is "3" regardless of how many references or citations appear.
+        let src = r"\begin{document}\section{Intro}\label{sec:i}
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+\begin{figure}\caption{P}\label{fig:p}\end{figure}
+See \ref{sec:i}, \eqref{eq:e}, \ref{ghost} and \cite{a,b}.
+\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.label_definition_count(), "3");
+        // Unaffected by the refs (2 resolve, 1 dangles) or the citations.
+        assert_eq!(doc.resolved_reference_count(), "2");
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // Still equals the number of lines S22 lists.
+        assert_eq!(
+            doc.label_definition_count(),
+            doc.label_definitions().lines().count().to_string()
+        );
+    }
+
+    #[test]
+    fn s29_count_equals_number_of_s22_lines() {
+        // Cross-check the total against S22's flat list: the count S29 returns MUST equal the number of
+        // lines S22 enumerates (they are two views of the SAME winning `definitions` list).
+        let src = r"\begin{document}\section{A}\label{a}
+\section{B}\label{b}
+\begin{equation}\label{c}x=1\end{equation}
+\label{a}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        let s22 = doc.label_definitions();
+        let s22_line_count = s22.lines().count();
+        assert_eq!(s22_line_count, 3);
+        assert_eq!(doc.label_definition_count(), s22_line_count.to_string());
+        assert_eq!(doc.label_definition_count(), "3");
+    }
+
+    #[test]
+    fn s29_is_additive_leaves_s1_s28_outputs_unchanged() {
+        // Same representative doc as the S24/S25/S26/S27/S28 additive tests. S29 changes NONE of the
+        // S1-S28 outputs — it only reads `resolve_references`. Its count is a second view of the SAME
+        // `definitions` list S22/S23 render flat and per-kind; pinned here to show S29 neither adds,
+        // drops, nor reorders, and that its total agrees with the number of lines S22 enumerates.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A handful of prior renderers — byte-for-byte unchanged.
+        // S22 flat winning label definitions.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S25 per-kind label-definition counts.
+        assert_eq!(
+            doc.label_kind_counts(),
+            "section: 1\nfigure: 1\nequation: 1\ninline: 1"
+        );
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // S28 resolved-reference count — exactly two (`\ref{sec:intro}`, `\eqref{eq:e}`).
+        assert_eq!(doc.resolved_reference_count(), "2");
+
+        // And S29 itself: exactly FOUR distinct label keys are defined (`sec:intro`, `fig:p`, `eq:e`,
+        // `dup`), so the count is "4" — agreeing with the four lines S22 enumerates for the same doc.
+        // The later `\label{dup}` is a duplicate (S20), not a fifth definition.
+        assert_eq!(doc.label_definition_count(), "4");
+        assert_eq!(
+            doc.label_definition_count(),
+            doc.label_definitions().lines().count().to_string()
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2328,3 +2328,80 @@ renderers — `list_summary`, `label_definitions`, `resolved_references_by_sourc
 S26's `resolved_reference_kind_counts`, and S27's `unresolved_reference_count` — all still produce their
 exact prior strings, with S28 returning `"2"` (agreeing with the two lines S21 enumerates)). All prior
 S1–S27 tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 35. S29 — single-integer total of the label definitions (`label_definition_count`)
+
+### 35.1 Motivation
+
+S22 (`label_definitions`) and S23 (`label_definitions_by_kind`) enumerate the **winning** label
+definitions — the distinct `\label` keys the document defines, the table `\ref`/`\eqref`/`\pageref`
+resolve against — one **line per winning definition** (`\label{key}`, flat in body pre-order or grouped by
+the `LabelKind` each label defines). But a reader often wants not the enumeration but the **total** — "how
+many labels does this document define?" — a single number answered at a glance, without scanning the
+individual keys. S27 (`unresolved_reference_count`) and S28 (`resolved_reference_count`) gave that
+single-total discipline to the two *reference* tables; S29 is their label-definition-side **analogue**: it
+collapses the whole winning `definitions` list to its decimal `.len()`. Unlike S25 (`label_kind_counts`,
+which *can* census the definitions by the `LabelKind` each defines), S29 takes no per-kind view: section,
+figure, equation, and inline labels all fold into one total — a single number is the clean move.
+
+### 35.2 Why a new method — additive by construction
+
+S29 adds a **new public method** `Document::label_definition_count(&self) -> String`. It is a pure,
+read-only render of `resolve_references().definitions.len()` — a *second view* of the exact list S22/S23
+render flat and per-kind. It reuses that list verbatim (never re-walking the body or re-resolving), so the
+report can never drift from the S1 resolution it summarises, and counting never adds, drops, or reorders
+definitions relative to what `resolve_references` produced. It mutates nothing and changes no S1–S28
+output — including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S28 it is a method the
+caller invokes directly.
+
+### 35.3 The rendering rule
+
+The output is the decimal `.len()` of the winning `definitions` list, rendered as its `String`, **always**
+on a single line with **no** trailing newline. There is no ordering question (a single integer has no
+order) and no per-kind grouping (S29 reads only the length, never a `kind`) — only `.len()` is read, with
+**no** source slicing at all. Being a **count** renderer, its empty case is the honest number `"0"` —
+**not** a `(no label definitions)` marker, mirroring S27/S28 exactly. The `(no …)` marker discipline
+belongs to the *list* renderers S22/S23, whose empty case has no lines to show; a total count of zero *is*
+a number, so `"0"` is its truthful value.
+
+### 35.4 The exact rendering contract — `Document::label_definition_count(&self) -> String`
+
+- Read `resolve_references().definitions.len()` and render it with `.to_string()` → the decimal count, one
+  line, no trailing newline. There is **no** source slicing and **no** `kind` read at all, so the render
+  needs no source borrow and can never index out of bounds.
+- Only the **winning** definitions are counted. A later re-definition `\label{dup}` of an already-defined
+  key lives in `resolve_references().duplicates` (S20's domain), never in `definitions`, so it is excluded
+  by construction — the count is exactly the number of lines S22 lists.
+- The empty case (no `\label` at all) returns the honest number `"0"` — **not** a `(no label definitions)`
+  marker, because S29 is a count renderer (mirroring S27/S28).
+
+Example (body defining `\label{sec:intro}` (a section), `\label{eq:main}` (an equation), and then re-using
+`\label{sec:intro}` on a later subsection (a duplicate)):
+
+```text
+2
+```
+
+Two distinct keys are defined; the later duplicate `\label{sec:intro}` is excluded. This is the
+count-total companion of S22's flat list and S23's per-kind grouping — a second view of the one winning
+`definitions` list; the count equals the number of lines S22 would enumerate.
+
+### 35.5 Public API (added in S29)
+
+One new method: `Document::label_definition_count(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_references` and every S1–S28 method are unchanged; no AST or grammar change; no
+new dependency, no `unsafe`, no I/O.
+
+### 35.6 Verification (S29)
+
+`cargo test -p latex` green (6 new S29 tests: a multiple-definitions case returning `"3"` (cross-checked
+against S22's `label_definitions`); a duplicate-label case where the later `\label{dup}` is a duplicate
+(S20's domain), not a second definition, so the count is the number of distinct keys `"2"` (cross-checked
+against S20's `duplicate_label_definitions` and against the number of lines S22 lists); a no-labels case
+returning `"0"` (cross-checked against S22's `(no label definitions)` marker); a mixed-document case
+(labels + refs + citations) where the count `"3"` counts only the label definitions, unaffected by the
+refs/citations; a cross-check that the count equals the number of lines S22 enumerates (`"3"`); and an
+additivity check that a handful of prior renderers — S22's `label_definitions`, S25's `label_kind_counts`,
+S27's `unresolved_reference_count`, and S28's `resolved_reference_count` — all still produce their exact
+prior strings, with S29 returning `"4"` (agreeing with the four lines S22 enumerates)). All prior S1–S28
+tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S29 — `label_definition_count` (the label-definition-side total)

Adds the **S29** report renderer `label_definition_count` to the `latex` crate's cross-reference module — the total count of label definitions, as a decimal-integer string. It is the **label-def-side total**: the single-integer companion to the S22 `label_definitions` list and the S23/S25 by-kind censuses, and the definition-side twin of the two reference-side totals shipped last round (S27 `unresolved_reference_count`, S28 `resolved_reference_count`).

### What's new

```rust
/// S29 — total count of label definitions …
pub fn label_definition_count(&self) -> String {
    self.resolve_references().definitions.len().to_string()
}
```

- Counts one row per **distinct winning `\label` key** — exactly the set S22 `label_definitions` lists. A later duplicate `\label{k}` is routed to the duplicates channel (S20's domain), **not** a second `definitions` row, so `label_definition_count` == number of rows S22 emits.
- **Zero case**: a document with no `\label` → `definitions.len() == 0` → emits the plain string `"0"` (a count, **not** a `(no …)` marker) — mirroring S27/S28.
- Pure read-only accessor over the already-parsed `ReferenceResolution { definitions: Vec<LabelDef>, … }`: no I/O, no `unsafe`, no new deps.

### Tests (6, all green)

`s29_multiple_definitions_count_the_integer`, `s29_duplicate_label_counted_once_matching_s22`, `s29_no_labels_counts_zero`, `s29_mixed_document_counts_only_label_definitions`, `s29_count_equals_number_of_s22_lines`, plus the **additivity/regression** test `s29_is_additive_leaves_s1_s28_outputs_unchanged` which pins S22 `label_definitions`, S25 `label_kind_counts`, S27 `unresolved_reference_count`, and S28 `resolved_reference_count` byte-for-byte alongside the new S29 output — proving S29 is purely additive.

### Verification

- `cargo test -p latex` → **461 passed** (+ 1 doctest), 0 failed
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review: PASSED (pure counting accessor; no panic/DoS/unsafe/injection surface)

### Docs & version

`latex` 0.64.0 → **0.65.0**; CHANGELOG.md + README.md updated; LTXDOC03 spec gains a new appended S29 section (S1–S28 byte-for-byte unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
