### PR TITLE
feat(sqlite-file): zero-dep SQLite reader scaffold + varint/record codec (Phase E1)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -292,6 +292,7 @@ members = [
     "s-runtime",
     "sql-lexer",
     "sql-parser",
+    "sqlite-file",
     "smt-lib-format",
     "starlark-ast-to-bytecode-compiler",
     "starlark-compiler",

--- a/code/packages/rust/sqlite-file/BUILD
+++ b/code/packages/rust/sqlite-file/BUILD
@@ -1,0 +1,1 @@
+cargo test -p sqlite-file -- --nocapture

--- a/code/packages/rust/sqlite-file/CHANGELOG.md
+++ b/code/packages/rust/sqlite-file/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog — sqlite-file
+
+## 0.1.0 — Unreleased
+
+Initial scaffold of a zero-dependency reader for the SQLite on-disk file format,
+created to remove the third-party `rusqlite` crate (and its bundled C SQLite +
+`unsafe` FFI) from the Engram Anki-package **read** path (Engram
+zero-dependency program, `code/specs/engram-zero-dep-plan.md`, Phase E; byte
+layout per `code/specs/storage-sqlite.md`).
+
+### Added
+
+- **`varint`** — the SQLite 1–9 byte big-endian variable-length integer used
+  throughout the format. `read` (bounds-checked, returns `None` on truncation
+  rather than panicking) and `write` (minimal-length encoding, needed later for
+  the Phase F writer and for round-trip testing now). Verified by golden vectors
+  from the format spec, a 50 000-value encode→decode round-trip sweep, and
+  truncation cases.
+- **`record`** — decode a record's bytes (header-length varint, serial-type
+  varints, back-to-back payloads) into typed `SqlValue`s (`Null` / `Int` /
+  `Real` / `Text` / `Blob`). Implements the full serial-type table including the
+  zero-payload integers 0 and 1 (serial types 8/9), signed big-endian widths
+  (1/2/3/4/6/8 bytes with sign extension), IEEE-754 f64, and even/odd BLOB/TEXT
+  lengths. Corrupt or truncated records return `None` — no panics, no
+  out-of-bounds reads. `#![forbid(unsafe_code)]`.
+
+### Verified
+
+- Cross-check harness (`tests/cross_check_reader.rs`) wired to the real
+  bundled-C SQLite via `rusqlite` (**dev-dependency only** — no runtime link).
+  It builds genuine `.sqlite` files and, at this layer, confirms the format
+  constants the reader assumes (magic string, power-of-two page size, in-header
+  page count vs. file length, schema format 1–4, UTF-8 text encoding). The
+  full row-level round-trip gate is staged (`#[ignore]`) and turns on with the
+  b-tree walk in Phase E3.
+
+### Not yet included
+
+- **Header + pager** (Phase E2), **table b-tree walk + overflow chains**
+  (Phase E3), and the **`sqlite_schema` + `read_table(bytes, name)`** public API
+  (Phase E4). Only after those does the Anki importer switch off `rusqlite`
+  (Phase E5). Writing databases is Phase F.

--- a/code/packages/rust/sqlite-file/Cargo.toml
+++ b/code/packages/rust/sqlite-file/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sqlite-file"
+version = "0.1.0"
+edition = "2021"
+description = "A small, zero-dependency reader for the SQLite on-disk file format — the read subset the Engram Anki-package importer needs — reimplemented from scratch to keep the Engram stack free of the bundled-C `rusqlite` crate."
+license = "MIT"
+
+[dependencies]
+
+# `rusqlite` (bundled C SQLite) is a DEV-dependency only: it is the independent
+# oracle the cross-check tests measure this zero-dep reader against. It builds
+# real `.sqlite` files (and reads rows back via SQL) so the interop gate can
+# confirm our reader decodes the exact same bytes. No runtime code path depends
+# on it — that is the whole point of this crate (Engram zero-dependency program,
+# `code/specs/engram-zero-dep-plan.md`, Phase E).
+[dev-dependencies]
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/code/packages/rust/sqlite-file/README.md
+++ b/code/packages/rust/sqlite-file/README.md
@@ -1,0 +1,68 @@
+# sqlite-file — zero-dependency reader for the SQLite on-disk format
+
+A from-scratch, pure-Rust reader for the subset of the [SQLite file
+format](https://www.sqlite.org/fileformat2.html) that the Engram Anki-package
+importer needs. It exists so the Engram stack can read `.anki2` collection
+databases **without linking the third-party `rusqlite` crate** (which bundles
+the entire C SQLite library behind an `unsafe` FFI boundary).
+
+This is part of the Engram zero-dependency program
+(`code/specs/engram-zero-dep-plan.md`, Phase E). The byte layout it tracks is
+specified in `code/specs/storage-sqlite.md`.
+
+## Why
+
+Engram imports `.apkg` decks; inside each is a real SQLite database from which
+Engram reads a few tables (`col`, `notes`, `cards`, `revlog`, `graves`). That
+was the last thing forcing `rusqlite` (and bundled C SQLite) into the graph.
+This crate replaces the **read** path with a small, auditable, dependency-free
+byte parser. (Writing SQLite files — the reverse direction — is the separate,
+larger Phase F.)
+
+## Scope
+
+Read-only, and only what Engram's collections use:
+
+- **Table** b-trees (leaf `0x0D` + interior `0x05`) — no index b-trees.
+- **Overflow chains** for records too large for one page.
+- Standard page sizes and **UTF-8** text (encoding = 1).
+
+Out of scope: writing, WAL, index b-trees, encryption, non-UTF-8 encodings.
+
+## Status
+
+Built leaf-to-root; this is the foundation:
+
+| Layer | Module | State |
+|-------|--------|-------|
+| varint (1–9 byte integers) | `varint` | ✅ read + write, golden-vector + sweep tests |
+| record / serial types → `SqlValue` | `record` | ✅ decode, golden-row tests |
+| DB header + in-memory pager | `header` | ⏳ Phase E2 |
+| table b-tree walk + overflow | `btree` | ⏳ Phase E3 |
+| `sqlite_schema` + `read_table(bytes, name)` | `schema` | ⏳ Phase E4 |
+
+## Usage
+
+```rust
+use sqlite_file::record::{decode, SqlValue};
+
+// On-disk bytes of the row `(NULL, 42, "hi")`.
+let row = [0x04, 0x00, 0x01, 0x11, 0x2a, 0x68, 0x69];
+assert_eq!(
+    decode(&row).unwrap(),
+    vec![SqlValue::Null, SqlValue::Int(42), SqlValue::Text("hi".into())],
+);
+```
+
+## Verification
+
+Every layer is cross-checked against the real bundled-C SQLite (`rusqlite`, a
+**dev-dependency only**) as an independent oracle: the gate builds genuine
+`.sqlite` files and confirms this reader decodes the exact bytes SQLite wrote,
+before the Anki importer is ever cut over. See `tests/cross_check_reader.rs`.
+
+## Testing
+
+```
+cargo test -p sqlite-file
+```

--- a/code/packages/rust/sqlite-file/src/lib.rs
+++ b/code/packages/rust/sqlite-file/src/lib.rs
@@ -1,0 +1,56 @@
+//! # sqlite-file — a zero-dependency reader for the SQLite on-disk format
+//!
+//! Engram imports Anki `.apkg` decks. Inside an `.apkg` is a `collection.anki2`
+//! (or a serialized `.anki21` blob) — a **real SQLite database** — and Engram
+//! needs to read a handful of tables out of it (`col`, `notes`, `cards`,
+//! `revlog`, `graves`). Historically that meant linking the third-party
+//! `rusqlite` crate, which bundles the entire C SQLite library and an `unsafe`
+//! FFI boundary.
+//!
+//! This crate replaces that read path with a small, pure-Rust, **zero-dependency**
+//! decoder for exactly the subset of the [SQLite file format][fmt] Engram reads:
+//! it parses the bytes directly. It is part of the Engram zero-dependency
+//! program (`code/specs/engram-zero-dep-plan.md`, Phase E); the byte layout it
+//! tracks is documented in `code/specs/storage-sqlite.md`.
+//!
+//! [fmt]: https://www.sqlite.org/fileformat2.html
+//!
+//! ## Scope
+//!
+//! Read-only, and only the format features Engram's collections actually use:
+//! table b-trees (no index b-trees), overflow chains, the standard 4 KiB-and-up
+//! page sizes, UTF-8 text. Writing a database is a separate, larger effort
+//! (Phase F) and lives elsewhere.
+//!
+//! ## Build order (this crate grows leaf-to-root)
+//!
+//! 1. **`varint`** — the 1–9 byte integer encoding used everywhere. *(here)*
+//! 2. **`record`** — decode a row's bytes into typed [`SqlValue`]s. *(here)*
+//! 3. `header` + pager — parse the 100-byte DB header, borrow pages from `&[u8]`.
+//! 4. b-tree walk — leaf + interior pages + overflow chains → `(rowid, row)`.
+//! 5. `sqlite_schema` + `read_table(bytes, name)` — the public read API.
+//!
+//! Steps 1–2 land in this first change; the rest follow as their own reviewable
+//! pieces. Each is cross-checked against the real `rusqlite`/C-SQLite as an
+//! independent oracle (a dev-dependency, never a runtime one) before the Anki
+//! importer is cut over to this crate.
+//!
+//! ## Example
+//!
+//! ```
+//! use sqlite_file::record::{decode, SqlValue};
+//!
+//! // The on-disk bytes of the row `(NULL, 42, "hi")`.
+//! let row = [0x04, 0x00, 0x01, 0x11, 0x2a, 0x68, 0x69];
+//! assert_eq!(
+//!     decode(&row).unwrap(),
+//!     vec![SqlValue::Null, SqlValue::Int(42), SqlValue::Text("hi".into())],
+//! );
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod record;
+pub mod varint;
+
+pub use record::SqlValue;

--- a/code/packages/rust/sqlite-file/src/record.rs
+++ b/code/packages/rust/sqlite-file/src/record.rs
@@ -1,0 +1,229 @@
+//! # SQLite record format (rows as bytes)
+//!
+//! Every row SQLite stores — a table row, a `sqlite_schema` entry — is a
+//! **record**: a self-describing sequence of column values. This module decodes
+//! one record's bytes into a `Vec<SqlValue>`. (The *encoder* is a separate,
+//! larger concern — writing byte-identical records is Phase F. This crate is a
+//! reader, so it only needs to decode.)
+//!
+//! ## Anatomy of a record
+//!
+//! ```text
+//!   ┌───────────────┬───────────────────────────┬──────────────────────┐
+//!   │ header length │ serial type per column     │ column payloads      │
+//!   │  (varint)     │  (varint each)             │  (back-to-back)      │
+//!   └───────────────┴───────────────────────────┴──────────────────────┘
+//!   └────────────── header ─────────────────────┘
+//! ```
+//!
+//! The **header length** varint counts itself plus all the serial-type varints,
+//! so the payload begins exactly `header_length` bytes into the record. We read
+//! serial types until we reach that boundary, then peel each column's bytes off
+//! the payload in order.
+//!
+//! ## Serial types — the type/size table
+//!
+//! A column's *serial type* varint says both what the value is and how many
+//! payload bytes it occupies:
+//!
+//! | serial type   | value                 | payload bytes    |
+//! |---------------|-----------------------|------------------|
+//! | 0             | NULL                  | 0                |
+//! | 1             | signed 8-bit int      | 1                |
+//! | 2             | signed 16-bit int BE  | 2                |
+//! | 3             | signed 24-bit int BE  | 3                |
+//! | 4             | signed 32-bit int BE  | 4                |
+//! | 5             | signed 48-bit int BE  | 6                |
+//! | 6             | signed 64-bit int BE  | 8                |
+//! | 7             | IEEE-754 f64 BE       | 8                |
+//! | 8             | integer 0             | 0 (value inline) |
+//! | 9             | integer 1             | 0 (value inline) |
+//! | 10, 11        | reserved (unused)     | —                |
+//! | N ≥ 12, even  | BLOB, `(N−12)/2` long | `(N−12)/2`       |
+//! | N ≥ 13, odd   | TEXT, `(N−13)/2` long | `(N−13)/2`       |
+//!
+//! Serial types 8 and 9 are a neat trick: the integers 0 and 1 are so common
+//! (booleans, flags) that SQLite spends *zero* payload bytes on them — the value
+//! lives entirely in the serial type.
+
+use crate::varint;
+
+/// A single decoded column value — the five storage classes SQLite has.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SqlValue {
+    /// SQL `NULL`.
+    Null,
+    /// An integer (serial types 1–6, 8, 9), always widened to `i64`.
+    Int(i64),
+    /// An IEEE-754 double (serial type 7).
+    Real(f64),
+    /// UTF-8 text (odd serial types ≥ 13). SQLite databases we read use the
+    /// UTF-8 encoding (header text-encoding = 1), so the bytes are decoded as
+    /// UTF-8; any stray invalid byte is replaced rather than rejected, matching
+    /// how `rusqlite`/`sqlite3` hand back text.
+    Text(String),
+    /// Opaque bytes (even serial types ≥ 12).
+    Blob(Vec<u8>),
+}
+
+/// How many payload bytes a column of the given `serial` type occupies.
+fn content_size(serial: u64) -> usize {
+    match serial {
+        0 | 8 | 9 | 10 | 11 => 0,
+        1 => 1,
+        2 => 2,
+        3 => 3,
+        4 => 4,
+        5 => 6,
+        6 | 7 => 8,
+        // For N ≥ 12, integer division `(N-12)/2` yields the byte length for
+        // both BLOB (even) and TEXT (odd): e.g. 14→1, 15→1, 16→2, 17→2.
+        n => ((n - 12) / 2) as usize,
+    }
+}
+
+/// Read a big-endian, two's-complement signed integer out of `bytes`
+/// (1, 2, 3, 4, 6, or 8 bytes) and widen it to `i64`, sign-extending from the
+/// top bit of the most-significant byte.
+fn read_int_be(bytes: &[u8]) -> i64 {
+    let mut v: u64 = 0;
+    for &b in bytes {
+        v = (v << 8) | u64::from(b);
+    }
+    let bits = bytes.len() * 8;
+    // Sign-extend: if the value's top bit is set and it is narrower than 64
+    // bits, fill the high bits with ones so the `i64` keeps the same value.
+    if bits < 64 && (v & (1u64 << (bits - 1))) != 0 {
+        v |= !((1u64 << bits) - 1);
+    }
+    v as i64
+}
+
+/// Turn one `(serial type, its payload bytes)` pair into a [`SqlValue`].
+/// Returns `None` only for the reserved serial types 10/11 (which never occur
+/// in a well-formed file) or a truncated float.
+fn decode_value(serial: u64, content: &[u8]) -> Option<SqlValue> {
+    let value = match serial {
+        0 => SqlValue::Null,
+        1..=6 => SqlValue::Int(read_int_be(content)),
+        7 => {
+            let arr: [u8; 8] = content.try_into().ok()?;
+            SqlValue::Real(f64::from_be_bytes(arr))
+        }
+        8 => SqlValue::Int(0),
+        9 => SqlValue::Int(1),
+        10 | 11 => return None, // reserved — corrupt file
+        n if n % 2 == 0 => SqlValue::Blob(content.to_vec()),
+        _ => SqlValue::Text(String::from_utf8_lossy(content).into_owned()),
+    };
+    Some(value)
+}
+
+/// Decode a complete record (header + payload) into its column values.
+///
+/// Returns `None` on any inconsistency — a header that overruns the record, a
+/// truncated payload, a reserved serial type — so a corrupt or maliciously
+/// crafted database surfaces an error to the caller instead of panicking or
+/// reading out of bounds.
+pub fn decode(record: &[u8]) -> Option<Vec<SqlValue>> {
+    let (header_len, mut header_off) = varint::read(record)?;
+    let header_len = usize::try_from(header_len).ok()?;
+    if header_len > record.len() {
+        return None;
+    }
+
+    let mut values = Vec::new();
+    let mut payload_off = header_len;
+    // Walk serial types until we hit the payload boundary...
+    while header_off < header_len {
+        let (serial, n) = varint::read(record.get(header_off..)?)?;
+        header_off += n;
+        let serial = u64::try_from(serial).ok()?;
+        let size = content_size(serial);
+        // ...peeling `size` payload bytes off for each, bounds-checked.
+        let end = payload_off.checked_add(size)?;
+        let content = record.get(payload_off..end)?;
+        payload_off = end;
+        values.push(decode_value(serial, content)?);
+    }
+    Some(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_null_int_text_row() {
+        // Row [NULL, 42, "hi"]:
+        //   serial types 0, 1, 17(=13+2·2)  →  header = [len=4, 0, 1, 17]
+        //   payload      (none), 0x2a, "hi"
+        let record = [0x04, 0x00, 0x01, 0x11, 0x2a, 0x68, 0x69];
+        assert_eq!(
+            decode(&record).unwrap(),
+            vec![
+                SqlValue::Null,
+                SqlValue::Int(42),
+                SqlValue::Text("hi".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn zero_and_one_carry_no_payload_bytes() {
+        // Row [0, 1, 1.5]: serial types 8, 9, 7. The 0 and 1 use no payload;
+        // the float is eight big-endian bytes (0x3ff8_0000_0000_0000 = 1.5).
+        let record = [
+            0x04, 0x08, 0x09, 0x07, 0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        assert_eq!(
+            decode(&record).unwrap(),
+            vec![SqlValue::Int(0), SqlValue::Int(1), SqlValue::Real(1.5)]
+        );
+    }
+
+    #[test]
+    fn negative_integers_sign_extend() {
+        // Row [-2] as a 16-bit int (serial type 2): payload 0xff 0xfe.
+        let record = [0x02, 0x02, 0xff, 0xfe];
+        assert_eq!(decode(&record).unwrap(), vec![SqlValue::Int(-2)]);
+
+        // Row [-1] as an 8-bit int (serial type 1): payload 0xff.
+        let record = [0x02, 0x01, 0xff];
+        assert_eq!(decode(&record).unwrap(), vec![SqlValue::Int(-1)]);
+    }
+
+    #[test]
+    fn decodes_blob() {
+        // Row [x'DEAD'] — a 2-byte blob is serial type 12 + 2·2 = 16.
+        let record = [0x02, 0x10, 0xde, 0xad];
+        assert_eq!(
+            decode(&record).unwrap(),
+            vec![SqlValue::Blob(vec![0xde, 0xad])]
+        );
+    }
+
+    #[test]
+    fn wide_integer_widths_round_out_the_table() {
+        // 24-bit (serial 3): 0x010000 = 65536.
+        assert_eq!(
+            decode(&[0x02, 0x03, 0x01, 0x00, 0x00]).unwrap(),
+            vec![SqlValue::Int(65536)]
+        );
+        // 64-bit (serial 6): 0x0000_0001_0000_0000 = 2^32.
+        assert_eq!(
+            decode(&[0x02, 0x06, 0, 0, 0, 1, 0, 0, 0, 0]).unwrap(),
+            vec![SqlValue::Int(1 << 32)]
+        );
+    }
+
+    #[test]
+    fn corrupt_records_return_none_not_panic() {
+        // Header claims 4 bytes but the record is only 1 long.
+        assert_eq!(decode(&[0x04]), None);
+        // Serial type 6 (needs 8 payload bytes) but payload is short.
+        assert_eq!(decode(&[0x02, 0x06, 0x00]), None);
+        // Reserved serial type 10.
+        assert_eq!(decode(&[0x02, 0x0a]), None);
+    }
+}

--- a/code/packages/rust/sqlite-file/src/varint.rs
+++ b/code/packages/rust/sqlite-file/src/varint.rs
@@ -1,0 +1,179 @@
+//! # SQLite variable-length integers ("varints")
+//!
+//! A *varint* is how SQLite squeezes a 64-bit integer into as few bytes as it
+//! can. It appears everywhere in the file format — record header lengths,
+//! serial types, rowids, b-tree child pointers — so getting it exactly right is
+//! the foundation everything else stands on.
+//!
+//! ## The encoding, one byte at a time
+//!
+//! A varint is **big-endian, base-128**, 1 to 9 bytes long. For the first eight
+//! bytes, the high bit (`0x80`) is a *continuation flag* and the low seven bits
+//! (`0x7f`) are payload:
+//!
+//! ```text
+//!   byte:  1ppppppp  1ppppppp  0ppppppp        (high bit set ⇒ "more follows")
+//!          └── keep reading ──┘ └ last byte ┘   (high bit clear ⇒ "stop")
+//! ```
+//!
+//! The ninth byte is special: if we have already read eight continuation bytes
+//! (7 bits × 8 = 56 bits) we still need 8 more bits to reach a full 64, so the
+//! **ninth byte contributes all eight of its bits**, not seven.
+//!
+//! ## Worked examples
+//!
+//! | value        | bytes (hex)        | why                                   |
+//! |--------------|--------------------|---------------------------------------|
+//! | `0`          | `00`               | fits in 7 bits, high bit clear        |
+//! | `127`        | `7f`               | largest 1-byte varint                 |
+//! | `128`        | `81 00`            | `1` in the high group, `0` in the low |
+//! | `300`        | `82 2c`            | `0b10_0101100` split 7+7              |
+//! | `2^64 - 1`   | `ff ff … ff` (9)   | all nine bytes, last uses 8 bits      |
+//!
+//! ## Signedness
+//!
+//! On disk a varint carries a raw 64-bit pattern. SQLite *interprets* it as a
+//! signed two's-complement `i64` (rowids and the small-int serial types are
+//! signed). We therefore decode into a `u64` bit pattern and hand back an `i64`
+//! via a bit cast — the caller decides whether the value is a length (always
+//! non-negative in practice) or a signed integer.
+
+/// Read a varint from the front of `buf`.
+///
+/// Returns `(value, len)` where `value` is the decoded integer (as the raw
+/// two's-complement `i64`) and `len` is how many bytes were consumed (1..=9).
+/// Returns `None` if `buf` ends before the varint does — a truncated /
+/// corrupt file, which the reader surfaces rather than panicking on.
+pub fn read(buf: &[u8]) -> Option<(i64, usize)> {
+    let mut result: u64 = 0;
+    // Bytes 1..=8 carry seven payload bits each behind a continuation flag.
+    for i in 0..8 {
+        let byte = *buf.get(i)?;
+        result = (result << 7) | u64::from(byte & 0x7f);
+        if byte & 0x80 == 0 {
+            return Some((result as i64, i + 1));
+        }
+    }
+    // Byte 9 (index 8) is reached only when the first eight all had the
+    // continuation bit set; it donates all eight of its bits to fill out 64.
+    let ninth = *buf.get(8)?;
+    result = (result << 8) | u64::from(ninth);
+    Some((result as i64, 9))
+}
+
+/// Encode `value` (a raw two's-complement `i64`) into its minimal varint form,
+/// appending the bytes to `out`. Returns the number of bytes written.
+///
+/// "Minimal" is not cosmetic: SQLite always uses the shortest encoding, so to
+/// round-trip a file byte-for-byte (Phase F, the writer) we must too. The
+/// reader ships this alongside `read` so the two can be property-tested against
+/// each other — every value must survive `read(write(v)) == v`.
+pub fn write(value: i64, out: &mut Vec<u8>) -> usize {
+    let v = value as u64;
+
+    // How many of the low bits are actually significant? A varint of the first
+    // eight bytes holds 7 bits each (max 56 bits); if the value needs a 57th
+    // bit we must fall back to the full nine-byte form.
+    if v > 0x00ff_ffff_ffff_ffff {
+        // Nine-byte form: eight 7-bit groups (bits 63..8) then a final full byte
+        // (bits 7..0).
+        for shift in (8..=57).rev().step_by(7) {
+            out.push(0x80 | ((v >> shift) & 0x7f) as u8);
+        }
+        out.push((v & 0xff) as u8);
+        return 9;
+    }
+
+    // Fewer than 57 significant bits: standard 7-bits-per-byte form. Find the
+    // highest non-empty 7-bit group, then emit groups high→low with the
+    // continuation bit set on every byte except the last.
+    let mut len = 1;
+    let mut shift = 7;
+    while shift < 63 && (v >> shift) != 0 {
+        len += 1;
+        shift += 7;
+    }
+    for i in (0..len).rev() {
+        let group = ((v >> (i * 7)) & 0x7f) as u8;
+        // Continuation bit on all but the least-significant group.
+        let cont = if i == 0 { 0 } else { 0x80 };
+        out.push(cont | group);
+    }
+    len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Golden vectors taken from the SQLite file-format spec and hand-computed.
+    /// `(value, encoded-bytes)`.
+    const GOLDEN: &[(i64, &[u8])] = &[
+        (0, &[0x00]),
+        (1, &[0x01]),
+        (127, &[0x7f]),
+        (128, &[0x81, 0x00]),
+        (129, &[0x81, 0x01]),
+        (255, &[0x81, 0x7f]),
+        (256, &[0x82, 0x00]),
+        (300, &[0x82, 0x2c]),
+        (16383, &[0xff, 0x7f]),
+        (16384, &[0x81, 0x80, 0x00]),
+        (2097151, &[0xff, 0xff, 0x7f]),
+    ];
+
+    #[test]
+    fn golden_vectors_read_and_write() {
+        for &(value, bytes) in GOLDEN {
+            let mut out = Vec::new();
+            let n = write(value, &mut out);
+            assert_eq!(out, bytes, "encoding {value}");
+            assert_eq!(n, bytes.len(), "length for {value}");
+
+            let (decoded, consumed) = read(bytes).expect("golden decodes");
+            assert_eq!(decoded, value, "decoding {bytes:?}");
+            assert_eq!(consumed, bytes.len(), "consumed for {bytes:?}");
+        }
+    }
+
+    #[test]
+    fn max_u64_uses_nine_bytes_with_full_last_byte() {
+        // 2^64 - 1 is the widest varint: nine bytes, and the last one carries a
+        // full eight bits (0xff), not seven.
+        let value = -1i64; // all ones == u64::MAX bit pattern
+        let mut out = Vec::new();
+        let n = write(value, &mut out);
+        assert_eq!(n, 9);
+        assert_eq!(out, &[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+        let (decoded, consumed) = read(&out).unwrap();
+        assert_eq!(decoded, value);
+        assert_eq!(consumed, 9);
+    }
+
+    #[test]
+    fn round_trips_across_a_wide_sweep() {
+        // Deterministic LCG — no rng dependency (zero-dep crate).
+        let mut state: u64 = 0x1234_5678_9abc_def1;
+        for _ in 0..50_000 {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let value = state as i64;
+            let mut out = Vec::new();
+            let n = write(value, &mut out);
+            let (decoded, consumed) = read(&out).expect("sweep decodes");
+            assert_eq!(decoded, value, "round-trip value");
+            assert_eq!(consumed, n, "round-trip length");
+            assert!((1..=9).contains(&n), "length in range");
+        }
+    }
+
+    #[test]
+    fn truncated_input_returns_none_not_panic() {
+        // A lone continuation byte promises more that never arrives.
+        assert_eq!(read(&[0x81]), None);
+        assert_eq!(read(&[]), None);
+        // Eight continuation bytes but no ninth.
+        assert_eq!(read(&[0x80; 8]), None);
+    }
+}

--- a/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
+++ b/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
@@ -1,0 +1,111 @@
+//! Interop gate for the zero-dependency `sqlite-file` reader, measured against
+//! the real bundled-C SQLite via `rusqlite` (a **dev-dependency only** — the
+//! whole point of this crate is that nothing at runtime links it).
+//!
+//! The gate builds genuine `.sqlite` files with `rusqlite`, then asserts our
+//! from-scratch decoder reads back exactly what SQLite wrote. It grows in
+//! lockstep with the reader:
+//!
+//!   * **now (varint + record codec):** confirm the oracle is wired and that a
+//!     real SQLite file matches the format constants the reader is built to
+//!     assume (page size, text encoding, schema format). This is what pins the
+//!     fixtures every later phase parses.
+//!   * **with the b-tree walk (Phase E3):** locate each row's record bytes in
+//!     the file and assert `record::decode` yields the same values `rusqlite`
+//!     returns over SQL — the full round-trip gate. Staged below as an
+//!     `#[ignore]`d placeholder so the intent is visible and testable the moment
+//!     the walk lands.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Build a real SQLite database by running `statements` through bundled-C
+/// SQLite (`rusqlite`) and return its on-disk bytes. This is the reusable
+/// oracle fixture-builder the whole cross-check suite is built on.
+///
+/// A unique temp path keeps parallel test threads from colliding without
+/// pulling in a `tempfile` dependency (this is a zero-dep crate; even the test
+/// oracle stays lean).
+fn build_sqlite_db(statements: &[&str]) -> Vec<u8> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "sqlite_file_xcheck_{}_{}.db",
+        std::process::id(),
+        unique
+    ));
+
+    {
+        let conn = rusqlite::Connection::open(&path).expect("open sqlite db");
+        for stmt in statements {
+            conn.execute_batch(stmt).expect("run statement");
+        }
+    } // connection dropped → file flushed and closed
+
+    let bytes = std::fs::read(&path).expect("read db file");
+    let _ = std::fs::remove_file(&path);
+    bytes
+}
+
+/// A real SQLite file must open with the format's magic string and expose the
+/// header fields the reader is built around. Validating them here means every
+/// fixture the later phases parse is known-good, and proves the `rusqlite`
+/// oracle is available in this environment.
+#[test]
+fn oracle_produces_wellformed_sqlite_header() {
+    let db = build_sqlite_db(&[
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, score REAL, blob BLOB)",
+        "INSERT INTO t VALUES (1, 'Ada', 1.5, x'dead'), (2, 'Grace', NULL, NULL)",
+    ]);
+
+    // The 100-byte database header lives at the start of page 1.
+    assert!(db.len() >= 100, "file too small to hold a header");
+    assert_eq!(&db[0..16], b"SQLite format 3\0", "magic string");
+
+    // Offset 16: page size, u16 big-endian. SQLite encodes 65536 as the value
+    // 1; every other legal size is a power of two in 512..=32768.
+    let raw_page_size = u16::from_be_bytes([db[16], db[17]]);
+    let page_size: u32 = if raw_page_size == 1 {
+        65536
+    } else {
+        u32::from(raw_page_size)
+    };
+    assert!(
+        page_size >= 512 && page_size.is_power_of_two(),
+        "page size {page_size} must be a power of two ≥ 512"
+    );
+
+    // Offset 28: in-header database size in pages (u32-be). Must cover the file.
+    let page_count = u32::from_be_bytes([db[28], db[29], db[30], db[31]]);
+    assert_eq!(
+        u64::from(page_count) * u64::from(page_size),
+        db.len() as u64,
+        "in-header page count must match the file length"
+    );
+
+    // Offset 44: schema format number (1..=4). Offset 56: text encoding
+    // (1 = UTF-8) — the reader decodes TEXT as UTF-8, so this must hold.
+    let schema_format = u32::from_be_bytes([db[44], db[45], db[46], db[47]]);
+    assert!(
+        (1..=4).contains(&schema_format),
+        "schema format {schema_format} out of range"
+    );
+    let text_encoding = u32::from_be_bytes([db[56], db[57], db[58], db[59]]);
+    assert_eq!(text_encoding, 1, "reader assumes UTF-8 (encoding = 1)");
+}
+
+/// The full round-trip gate: decode every row straight out of the file bytes
+/// and confirm it equals what SQLite reports over SQL. It needs the table
+/// b-tree walk to locate record bytes, which lands in Phase E3 — this staged
+/// placeholder documents the gate and turns green the moment `read_table`
+/// exists.
+#[test]
+#[ignore = "activates in Phase E3 once the b-tree walk can locate row records"]
+fn rows_round_trip_through_our_reader() {
+    let _db = build_sqlite_db(&[
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)",
+        "INSERT INTO t VALUES (1, 'Ada'), (2, 'Grace')",
+    ]);
+    // TODO(E3): let rows = sqlite_file::read_table(&_db, "t").unwrap();
+    //           assert_eq!(rows, [(1, [Int(1), Text("Ada")]), (2, [Int(2), Text("Grace")])]);
+}

--- a/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
+++ b/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
@@ -22,18 +22,23 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// SQLite (`rusqlite`) and return its on-disk bytes. This is the reusable
 /// oracle fixture-builder the whole cross-check suite is built on.
 ///
-/// A unique temp path keeps parallel test threads from colliding without
-/// pulling in a `tempfile` dependency (this is a zero-dep crate; even the test
-/// oracle stays lean).
+/// The fixture is written inside a freshly-`create_dir`'d per-run subdirectory
+/// rather than a predictably-named file placed straight in the shared temp dir:
+/// `create_dir` fails if the path already exists (including a planted symlink),
+/// which sidesteps the classic `/tmp` symlink-swap hazard without pulling in a
+/// `tempfile` dependency (this is a zero-dep crate; even the test oracle stays
+/// lean). A per-run counter keeps parallel test threads from colliding.
 fn build_sqlite_db(statements: &[&str]) -> Vec<u8> {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "sqlite_file_xcheck_{}_{}.db",
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "sqlite_file_xcheck_{}_{}",
         std::process::id(),
         unique
     ));
+    std::fs::create_dir(&dir).expect("create fresh fixture dir");
+    let path = dir.join("oracle.db");
 
     {
         let conn = rusqlite::Connection::open(&path).expect("open sqlite db");
@@ -43,7 +48,7 @@ fn build_sqlite_db(statements: &[&str]) -> Vec<u8> {
     } // connection dropped → file flushed and closed
 
     let bytes = std::fs::read(&path).expect("read db file");
-    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir_all(&dir);
     bytes
 }
 


### PR DESCRIPTION
## Phase E1 — first step toward removing `rusqlite` from engram-anki-package

Begins Phase E of the Engram zero-dependency program: a from-scratch, pure-Rust
**reader** for the subset of the [SQLite on-disk format](https://www.sqlite.org/fileformat2.html)
the Anki-package importer needs, so the read path can eventually drop the
third-party `rusqlite` crate (bundled C SQLite + `unsafe` FFI). Byte layout per
`code/specs/storage-sqlite.md`; plan per `code/specs/engram-zero-dep-plan.md` (Phase E).

Built leaf-to-root — this PR lays the two foundation codecs:

- **`varint`** — the SQLite 1–9 byte big-endian variable-length integer used
  throughout the format. `read` (bounds-checked; returns `None` on truncation,
  never panics) + `write` (minimal-length encoding; reused by the Phase F writer
  and for round-trip testing). Verified by spec golden vectors, a 50k
  encode→decode sweep, and truncation cases.
- **`record`** — decode a record (header-length varint, serial-type varints,
  back-to-back payloads) into typed `SqlValue`s (`Null`/`Int`/`Real`/`Text`/`Blob`).
  Full serial-type table incl. zero-payload 0/1 (types 8/9), signed BE widths
  with sign extension, IEEE-754 f64, even/odd BLOB/TEXT. Corrupt/truncated input
  returns `None` — no panics, no OOB. `#![forbid(unsafe_code)]`.

### Interop gate
`tests/cross_check_reader.rs` is wired to real bundled-C SQLite via `rusqlite`
(**dev-dependency only** — no runtime link; the runtime crate is genuinely
zero-dep). At this layer it builds genuine `.sqlite` files and confirms the
format constants the reader assumes (magic string, power-of-two page size,
in-header page count vs file length, schema format 1–4, UTF-8 encoding). The
full row-level round-trip gate is staged (`#[ignore]`) and turns on with the
b-tree walk in **Phase E3**.

### Verification
- 10 unit tests + doctest + oracle cross-check green; the E3 row gate correctly ignored.
- clippy 0, fmt clean. Registered in the workspace members.
- Security review (Rust, hostile-input threat model): **PASSED** — every buffer
  access is `get(..)?`-guarded, no reachable panics/OOB/overflow (`content_size`
  underflow, `read_int_be` shifts, varint accumulation, `payload_off` checked-add
  all verified safe). One INFO note (test-harness temp-file predictability) was
  addressed by writing the fixture inside a freshly-`create_dir`'d per-run
  subdirectory.

### Next in the arc
E2 header + pager · E3 table b-tree walk + overflow (activates the row gate) ·
E4 `sqlite_schema` + `read_table(bytes, name)` · E5 cut the Anki importer over
and delete the `rusqlite` read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)