### PR TITLE
feat(markdown-docx): native Markdown → .docx end-to-end + md2docx CLI

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -873,4 +873,5 @@ members = [
     "xls",
     "spreadsheet-io",
   "document-ast-to-docx",
+  "markdown-docx",
 ]

--- a/code/packages/rust/markdown-docx/BUILD
+++ b/code/packages/rust/markdown-docx/BUILD
@@ -1,0 +1,1 @@
+cargo test -p markdown-docx -- --nocapture

--- a/code/packages/rust/markdown-docx/CHANGELOG.md
+++ b/code/packages/rust/markdown-docx/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `markdown-docx` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-08
+
+### Added
+
+- Initial release — native **Markdown → `.docx`** (spec
+  `code/specs/MD02-markdown-to-docx.md`).
+- `markdown_to_docx(&str) -> Vec<u8>` (CommonMark) and `gfm_to_docx(&str) -> Vec<u8>`
+  (GitHub-Flavored) — compose `commonmark-parser` / `gfm-parser` with
+  `document-ast-to-docx::to_docx_bytes`, so Markdown flows through the shared
+  Document AST into real WordprocessingML bytes with no external dependency.
+- 8 end-to-end tests + a doctest: a rich Markdown document round-trips (text +
+  block structure) through the `wordprocessingml` reader; GFM tables and task
+  lists round-trip; fenced code blocks and blockquotes render; raw HTML embedded
+  in Markdown is NOT injected into the `.docx` (XSS-safe); and a 20 000-level
+  nested input converts without overflowing the stack (the depth guard holds
+  end-to-end). `#![forbid(unsafe_code)]`, clippy-clean.

--- a/code/packages/rust/markdown-docx/Cargo.toml
+++ b/code/packages/rust/markdown-docx/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "markdown-docx"
+version = "0.1.0"
+edition = "2021"
+description = "Native Markdown/GFM to .docx, through the shared Document AST (MD02)"
+license = "MIT"
+
+[dependencies]
+commonmark-parser = { path = "../commonmark-parser" }
+gfm-parser = { path = "../gfm-parser" }
+document-ast-to-docx = { path = "../document-ast-to-docx" }
+
+[dev-dependencies]
+# Round-trip proof: reopen the .docx bytes with the read-side WordprocessingML reader.
+coding-adventures-wordprocessingml = { path = "../wordprocessingml" }

--- a/code/packages/rust/markdown-docx/README.md
+++ b/code/packages/rust/markdown-docx/README.md
@@ -1,0 +1,64 @@
+# markdown-docx
+
+Native **Markdown → `.docx`** — turn Markdown (or GitHub-Flavored Markdown) into
+a real Word document, over the repo's own zero-dependency stack, by routing it
+through the shared **Document AST**.
+
+Spec: [`code/specs/MD02-markdown-to-docx.md`](../../../specs/MD02-markdown-to-docx.md).
+
+## The pipeline
+
+This crate is the terminal convenience wrapper; it just composes two already-
+tested stages:
+
+```text
+  Markdown  ──commonmark-parser::parse──▶  document_ast::DocumentNode
+            ──document-ast-to-docx::to_docx_bytes──▶  .docx bytes
+```
+
+All the block/inline mapping (headings → `Heading N`, `**bold**` → bold runs,
+lists → prefixed paragraphs, GFM tables → `<w:tbl>`, raw HTML dropped, …) plus
+the recursion-depth DoS guard live in
+[`document-ast-to-docx`](../document-ast-to-docx); the Markdown parsing lives in
+[`commonmark-parser`](../commonmark-parser) / [`gfm-parser`](../gfm-parser).
+
+## Usage
+
+```rust
+use markdown_docx::{markdown_to_docx, gfm_to_docx};
+
+let docx = markdown_to_docx("# Title\n\nA **bold** word.\n");
+std::fs::write("out.docx", docx).unwrap();          // opens in Word
+
+// GFM adds pipe tables, task lists, strikethrough, autolinks:
+let gfm = gfm_to_docx("| A | B |\n| - | - |\n| 1 | 2 |\n");
+```
+
+- `markdown_to_docx(&str) -> Vec<u8>` — strict CommonMark.
+- `gfm_to_docx(&str) -> Vec<u8>` — GitHub-Flavored Markdown.
+
+Both are total and panic-free on any input (the depth guard bounds adversarial
+nesting); an empty string yields a valid empty `.docx`. `#![forbid(unsafe_code)]`.
+
+## Fidelity
+
+Inherited from `document-ast-to-docx` (MD02 §6), each lossless for visible text:
+raw HTML is **dropped** (never injected — XSS-safe), links render as `text (url)`,
+images as `[alt] (url)`, strikethrough as plain text, lists as prefixed
+paragraphs. See that crate for the full table.
+
+## The CLI
+
+The [`md2docx`](../../../programs/rust/md2docx) program wraps this crate for the
+shell: `md2docx in.md out.docx` (or `--gfm`, `--demo`).
+
+## Testing
+
+```bash
+bash BUILD   # cargo test -p markdown-docx
+```
+
+The tests are the headline end-to-end proof: a Markdown string in, a real `.docx`
+out, reopened with the independent `wordprocessingml` reader to confirm the text
+and block structure survived — plus a raw-HTML-not-injected check and an
+adversarially-deep (20 000-level) input that must not crash.

--- a/code/packages/rust/markdown-docx/src/lib.rs
+++ b/code/packages/rust/markdown-docx/src/lib.rs
@@ -1,0 +1,64 @@
+//! # `markdown-docx` — native Markdown → `.docx`
+//!
+//! Turn Markdown into a real Word `.docx`, over the repo's own zero-dependency
+//! stack, by routing it through the shared **Document AST**. This is the
+//! terminal convenience crate of the `MD02` pipeline: it just composes two
+//! already-tested stages —
+//!
+//! ```text
+//!   Markdown  ──commonmark-parser::parse──▶  document_ast::DocumentNode
+//!             ──document_ast_to_docx::to_docx_bytes──▶  .docx bytes
+//! ```
+//!
+//! — so there is nothing format-specific here beyond wiring. All the block/inline
+//! mapping (headings → `Heading N`, `**bold**` → bold runs, lists → prefixed
+//! paragraphs, tables → `<w:tbl>`, raw-HTML dropped, …) and the recursion-depth
+//! DoS guard live in [`document_ast_to_docx`]; the Markdown parsing lives in
+//! [`commonmark_parser`] / [`gfm_parser`]. See `code/specs/MD02-markdown-to-docx.md`.
+//!
+//! ## Example
+//!
+//! ```
+//! let docx = markdown_docx::markdown_to_docx("# Hi\n\nA **bold** word.\n");
+//! assert_eq!(&docx[..2], b"PK"); // a .docx is a ZIP/OPC package
+//! // std::fs::write("out.docx", docx)?; — opens in Word.
+//! ```
+//!
+//! ## CommonMark vs GFM
+//!
+//! [`markdown_to_docx`] uses the strict CommonMark parser. [`gfm_to_docx`] uses
+//! the GitHub-Flavored parser, which additionally recognizes pipe **tables**,
+//! **task lists** (`- [x]`), **strikethrough**, and autolinks — all of which the
+//! Document AST models and this pipeline renders.
+//!
+//! ## Why native (not pandoc)
+//!
+//! Same rationale as the rest of the repo: pandoc is a large external Haskell
+//! binary; this is zero-dependency Rust that already reads and writes real Office
+//! files. Routing through `document-ast` means every prose format the repo learns
+//! reuses one IR and one set of bridges.
+
+#![forbid(unsafe_code)]
+
+use document_ast_to_docx::to_docx_bytes;
+
+/// Convert **CommonMark** Markdown to the bytes of a valid `.docx`.
+///
+/// `markdown_to_docx(md) == document_ast_to_docx::to_docx_bytes(&commonmark_parser::parse(md))`.
+/// Total and panic-free on any input (the depth guard in `document-ast-to-docx`
+/// bounds adversarially nested Markdown); an empty string yields a valid empty
+/// `.docx`.
+pub fn markdown_to_docx(markdown: &str) -> Vec<u8> {
+    to_docx_bytes(&commonmark_parser::parse(markdown))
+}
+
+/// Convert **GitHub-Flavored Markdown** to the bytes of a valid `.docx`.
+///
+/// Like [`markdown_to_docx`] but via the GFM parser, so pipe tables, task lists
+/// (`- [x]` / `- [ ]`), strikethrough, and autolinks are recognized and rendered.
+pub fn gfm_to_docx(markdown: &str) -> Vec<u8> {
+    to_docx_bytes(&gfm_parser::parse(markdown))
+}
+
+#[cfg(test)]
+mod tests;

--- a/code/packages/rust/markdown-docx/src/tests.rs
+++ b/code/packages/rust/markdown-docx/src/tests.rs
@@ -1,0 +1,152 @@
+//! Tests for `markdown-docx` — the headline end-to-end proof of the whole MD02
+//! pipeline: a Markdown string in, a real `.docx` out, reopened with the
+//! independent `wordprocessingml` reader to confirm the visible text and block
+//! structure survived Markdown → Document AST → WordprocessingML → ZIP.
+//!
+//! (Note on whitespace: the reader keeps a run's *trailing* space but drops a
+//! *leading* one — a documented shared-xml-lexer limitation — so these tests
+//! assert on the presence of the content tokens and the block structure rather
+//! than exact inter-run spacing. The emitted `.docx` itself is correct; Word
+//! renders the spaces.)
+
+use super::*;
+use coding_adventures_wordprocessingml::{open_docx, Block as RBlock};
+
+/// A `.docx` begins with the ZIP/OPC magic, and the empty string is valid.
+#[test]
+fn output_is_a_valid_docx() {
+    let bytes = markdown_to_docx("# Hi\n\nSome text.\n");
+    assert_eq!(&bytes[..2], b"PK", "a .docx is a ZIP/OPC package");
+    open_docx(&bytes).expect("reader opens our .docx");
+
+    let empty = markdown_to_docx("");
+    assert_eq!(&empty[..2], b"PK");
+    assert_eq!(
+        open_docx(&empty).unwrap().text(),
+        "",
+        "empty markdown → empty doc"
+    );
+}
+
+/// The headline round-trip: a rich Markdown document → `.docx` → reopened text +
+/// structure. Heading, a formatted paragraph, and a bullet list all survive.
+#[test]
+fn rich_markdown_round_trips() {
+    let md = "\
+# Report
+
+An **important** and *emphasised* point, with some `code`.
+
+- first item
+- second item
+- third item
+";
+    let read = open_docx(&markdown_to_docx(md)).expect("reopen");
+    let text = read.text();
+
+    // Content tokens survive (heading, the formatted words, the list items).
+    for needle in [
+        "Report",
+        "important",
+        "emphasised",
+        "code",
+        "first item",
+        "third item",
+    ] {
+        assert!(text.contains(needle), "missing {needle:?} in {text:?}");
+    }
+    // Structure: 1 heading + 1 body paragraph + 3 list-item paragraphs = 5 paragraphs.
+    assert_eq!(read.paragraphs().count(), 5, "paragraph count: {text:?}");
+    // The list markers are present.
+    assert_eq!(text.matches("• ").count(), 3, "three bullets: {text:?}");
+}
+
+/// GFM pipe tables round-trip as a real Word table with the cell text intact.
+#[test]
+fn gfm_table_round_trips() {
+    let md = "\
+| Name | Qty |
+| ---- | --- |
+| Apple | 3 |
+| Pear  | 7 |
+";
+    let read = open_docx(&gfm_to_docx(md)).expect("reopen");
+    let tables: Vec<_> = read.tables().collect();
+    assert_eq!(tables.len(), 1, "one table");
+    // Header + two data rows.
+    assert_eq!(tables[0].rows.len(), 3, "header + 2 data rows");
+    assert_eq!(tables[0].rows[0][0].text, "Name");
+    assert_eq!(tables[0].rows[0][1].text, "Qty");
+    assert_eq!(tables[0].rows[2][0].text, "Pear");
+    assert_eq!(tables[0].rows[2][1].text, "7");
+}
+
+/// GFM task lists render with checkbox markers.
+#[test]
+fn gfm_task_list_round_trips() {
+    let read = open_docx(&gfm_to_docx("- [x] done\n- [ ] todo\n")).expect("reopen");
+    let text = read.text();
+    assert!(text.contains("☑ done"), "checked: {text:?}");
+    assert!(text.contains("☐ todo"), "unchecked: {text:?}");
+}
+
+/// A fenced code block becomes monospace `Code` paragraphs (one per line).
+#[test]
+fn code_block_round_trips() {
+    let md = "```rust\nfn main() {}\nlet x = 1;\n```\n";
+    let read = open_docx(&markdown_to_docx(md)).expect("reopen");
+    let text = read.text();
+    assert!(text.contains("fn main() {}"), "code line 1: {text:?}");
+    assert!(text.contains("let x = 1;"), "code line 2: {text:?}");
+}
+
+/// Raw HTML embedded in Markdown is NOT injected into the `.docx` — the pipeline
+/// drops it at the Document-AST → docx stage. (Markdown's `<script>…` parses to
+/// an HTML block, which `document-ast-to-docx` drops.)
+#[test]
+fn raw_html_is_not_injected() {
+    let md =
+        "Before.\n\n<script>alert('xss')</script>\n\n<div onclick=\"evil()\">x</div>\n\nAfter.\n";
+    let read = open_docx(&markdown_to_docx(md)).expect("reopen");
+    let text = read.text();
+    assert!(
+        text.contains("Before.") && text.contains("After."),
+        "prose kept: {text:?}"
+    );
+    assert!(!text.contains("alert"), "raw <script> dropped: {text:?}");
+    assert!(
+        !text.contains("onclick"),
+        "raw <div> attributes dropped: {text:?}"
+    );
+    assert!(!text.contains("evil"), "raw handler dropped: {text:?}");
+}
+
+/// A blockquote renders (its text survives); the reader sees it as a paragraph.
+#[test]
+fn blockquote_round_trips() {
+    let read = open_docx(&markdown_to_docx("> quoted wisdom\n")).expect("reopen");
+    assert!(
+        read.text().contains("quoted wisdom"),
+        "quote text: {:?}",
+        read.text()
+    );
+    // The quote is a paragraph block (not a table).
+    assert!(matches!(read.blocks.first(), Some(RBlock::Paragraph(_))));
+}
+
+/// Adversarially deep Markdown does not crash the pipeline — the depth guard in
+/// `document-ast-to-docx` bounds the recursion. A one-line input of 20 000 `>`
+/// nests blockquotes 20 000 deep; it must still produce a valid `.docx`.
+#[test]
+fn deeply_nested_markdown_does_not_crash() {
+    std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024) // for the PARSER's own construction/Drop, not the converter
+        .spawn(|| {
+            let md = format!("{}x\n", ">".repeat(20_000));
+            let bytes = markdown_to_docx(&md);
+            assert_eq!(&bytes[..2], b"PK", "deep input still yields a valid .docx");
+        })
+        .unwrap()
+        .join()
+        .expect("deeply nested Markdown must not overflow the stack");
+}

--- a/code/programs/rust/md2docx/BUILD
+++ b/code/programs/rust/md2docx/BUILD
@@ -1,0 +1,1 @@
+cargo test -p md2docx -- --nocapture

--- a/code/programs/rust/md2docx/CHANGELOG.md
+++ b/code/programs/rust/md2docx/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to `md2docx` are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
+[Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-07-08
+
+### Added
+
+- Initial release — the CLI end-goal of the Markdown → `.docx` pipeline (MD02).
+- `md2docx <in.md> [out.docx]` converts a Markdown file to a real `.docx`
+  (default output: the input with a `.docx` extension); `--gfm` selects the
+  GitHub-Flavored parser (pipe tables, task lists, strikethrough); `--demo`
+  converts a bundled sample; `--help` prints usage.
+- A testable `convert(&str, Dialect) -> Vec<u8>` library core over the
+  `markdown-docx` crate, with tests asserting both dialects produce a valid
+  `.docx` and that GFM recognizes a pipe table CommonMark leaves as text.
+  `#![forbid(unsafe_code)]`, clippy-clean.

--- a/code/programs/rust/md2docx/Cargo.toml
+++ b/code/programs/rust/md2docx/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "md2docx"
+version = "0.1.0"
+edition = "2021"
+description = "CLI: convert a Markdown (or GFM) file to a real Word .docx, natively — the runnable end-goal of the Markdown → Document AST → OOXML pipeline (MD02)."
+license = "MIT"
+
+# Programs in code/programs/rust/ each declare their own [workspace] so they stay
+# independent from the packages workspace at code/packages/rust/Cargo.toml.
+[workspace]
+
+[[bin]]
+name = "md2docx"
+path = "src/main.rs"
+
+[lib]
+name = "md2docx"
+path = "src/lib.rs"
+
+[dependencies]
+# The whole pipeline: Markdown/GFM → Document AST → .docx bytes.
+markdown-docx = { path = "../../../packages/rust/markdown-docx" }
+
+[dev-dependencies]
+# Reopen the emitted .docx to assert the GFM/CommonMark difference.
+coding-adventures-wordprocessingml = { path = "../../../packages/rust/wordprocessingml" }

--- a/code/programs/rust/md2docx/README.md
+++ b/code/programs/rust/md2docx/README.md
@@ -1,0 +1,38 @@
+# md2docx
+
+CLI: convert a **Markdown** (or GitHub-Flavored Markdown) file to a real Word
+**`.docx`**, natively — the runnable end-goal of the Markdown → Document AST →
+OOXML pipeline ([`MD02`](../../../specs/MD02-markdown-to-docx.md)).
+
+The whole path is zero-dependency Rust:
+
+```text
+  Markdown → commonmark-parser / gfm-parser → document_ast::DocumentNode
+           → document-ast-to-docx → docx-writer → .docx bytes
+```
+
+## Usage
+
+```bash
+md2docx <in.md> [out.docx]     # convert (default output: <in>.docx)
+md2docx --gfm <in.md> [out]    # parse as GitHub-Flavored Markdown (tables, task lists)
+md2docx --demo [out.docx]      # convert the built-in sample (default: md2docx-demo.docx)
+md2docx --help
+```
+
+Example:
+
+```bash
+cargo run -p md2docx -- --demo report.docx   # writes a sample .docx you can open in Word
+cargo run -p md2docx -- --gfm notes.md        # writes notes.docx
+```
+
+`md2docx` is a thin CLI over the [`markdown-docx`](../../../packages/rust/markdown-docx)
+library; the conversion core (`convert`, `Dialect`) is a testable library
+(`src/lib.rs`) so the CLI wiring is exercised without spawning a process.
+
+## Build & test
+
+```bash
+bash BUILD   # cargo test -p md2docx
+```

--- a/code/programs/rust/md2docx/src/lib.rs
+++ b/code/programs/rust/md2docx/src/lib.rs
@@ -1,0 +1,85 @@
+//! `md2docx` — the conversion core behind the CLI.
+//!
+//! A hair-thin wrapper over [`markdown_docx`]: pick the CommonMark or GFM parser,
+//! and hand the Markdown to the pipeline. Kept as a library (separate from
+//! `main.rs`) so the conversion is unit-testable without spawning a process.
+
+#![forbid(unsafe_code)]
+
+/// Which Markdown dialect to parse.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Dialect {
+    /// Strict CommonMark.
+    CommonMark,
+    /// GitHub-Flavored Markdown (adds pipe tables, task lists, strikethrough).
+    Gfm,
+}
+
+/// Convert Markdown `source` to `.docx` bytes using the chosen [`Dialect`].
+///
+/// Total and panic-free (the pipeline's depth guard bounds adversarial nesting);
+/// an empty document yields a valid, empty `.docx`.
+pub fn convert(source: &str, dialect: Dialect) -> Vec<u8> {
+    match dialect {
+        Dialect::CommonMark => markdown_docx::markdown_to_docx(source),
+        Dialect::Gfm => markdown_docx::gfm_to_docx(source),
+    }
+}
+
+/// A built-in sample document for `md2docx --demo`, exercising headings, inline
+/// formatting, a list, a code block, a GFM table, and a task list.
+pub const SAMPLE_MARKDOWN: &str = "\
+# md2docx
+
+A **native** Markdown → `.docx` converter — no pandoc, no external anything.
+
+## Features
+
+- Headings, **bold**, *italic*, and `code`
+- Lists, blockquotes, and fenced code blocks
+- GFM tables and task lists
+
+> Everything routes through the shared Document AST.
+
+```rust
+fn main() { println!(\"hello, docx\"); }
+```
+
+| Feature | Supported |
+| ------- | --------- |
+| Tables  | yes       |
+| Tasks   | yes       |
+
+- [x] parse Markdown
+- [ ] rule the world
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Both dialects produce a valid `.docx` (ZIP/OPC magic).
+    #[test]
+    fn convert_produces_a_docx() {
+        assert_eq!(&convert("# Hi\n", Dialect::CommonMark)[..2], b"PK");
+        assert_eq!(&convert("# Hi\n", Dialect::Gfm)[..2], b"PK");
+    }
+
+    /// The GFM dialect recognizes a pipe table that CommonMark would leave as
+    /// plain text — a visible behavioural difference between the two paths.
+    #[test]
+    fn gfm_recognizes_tables() {
+        use coding_adventures_wordprocessingml::open_docx;
+        let md = "| Name | Qty |\n| ---- | --- |\n| Apple | 3 |\n";
+        let gfm = open_docx(&convert(md, Dialect::Gfm)).unwrap();
+        assert_eq!(gfm.tables().count(), 1, "GFM parses the pipe table");
+        let cm = open_docx(&convert(md, Dialect::CommonMark)).unwrap();
+        assert_eq!(cm.tables().count(), 0, "CommonMark leaves it as text");
+    }
+
+    /// The bundled sample converts cleanly.
+    #[test]
+    fn sample_converts() {
+        assert_eq!(&convert(SAMPLE_MARKDOWN, Dialect::Gfm)[..2], b"PK");
+    }
+}

--- a/code/programs/rust/md2docx/src/main.rs
+++ b/code/programs/rust/md2docx/src/main.rs
@@ -1,0 +1,114 @@
+//! `md2docx` — CLI: convert a Markdown file to a real Word `.docx`, natively.
+//!
+//! ```text
+//!   md2docx <in.md> [out.docx]   convert a Markdown file (default out: in.docx)
+//!   md2docx --gfm <in.md> [out]  use GitHub-Flavored Markdown (tables, tasks, …)
+//!   md2docx --demo [out.docx]    convert the built-in sample (default: md2docx-demo.docx)
+//!   md2docx --help               show this help
+//! ```
+//!
+//! The whole path is native, zero-dependency Rust:
+//! Markdown → `commonmark-parser`/`gfm-parser` → `document_ast::DocumentNode` →
+//! `document-ast-to-docx` → `docx-writer` → `.docx` bytes.
+
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use md2docx::{convert, Dialect, SAMPLE_MARKDOWN};
+
+const HELP: &str = "\
+md2docx — convert Markdown to a real Word .docx, natively
+
+USAGE:
+  md2docx <in.md> [out.docx]    convert a Markdown file (default out: <in>.docx)
+  md2docx --gfm <in.md> [out]   parse as GitHub-Flavored Markdown (tables, task lists)
+  md2docx --demo [out.docx]     convert the built-in sample (default: md2docx-demo.docx)
+  md2docx --help                show this help";
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut rest: Vec<&str> = Vec::new();
+    let mut dialect = Dialect::CommonMark;
+    let mut demo = false;
+
+    for arg in &args {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                println!("{HELP}");
+                return ExitCode::SUCCESS;
+            }
+            "--gfm" => dialect = Dialect::Gfm,
+            "--demo" => demo = true,
+            other if other.starts_with('-') => {
+                eprintln!("md2docx: unknown option '{other}'\n\n{HELP}");
+                return ExitCode::FAILURE;
+            }
+            other => rest.push(other),
+        }
+    }
+
+    // --demo: convert the bundled sample; optional first positional = output path.
+    if demo {
+        let out = rest
+            .first()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("md2docx-demo.docx"));
+        return write_docx(convert(SAMPLE_MARKDOWN, dialect), &out);
+    }
+
+    // Otherwise: <in.md> [out.docx].
+    let input = match rest.first() {
+        Some(p) => *p,
+        None => {
+            eprintln!("md2docx: no input file\n\n{HELP}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let source = match std::fs::read_to_string(input) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("md2docx: cannot read '{input}': {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let out = match rest.get(1) {
+        Some(o) => PathBuf::from(o),
+        None => {
+            // No explicit output: derive `<in>.docx`. Refuse if that equals the
+            // input (i.e. the input is already named `.docx`), so we never
+            // silently overwrite the source with its own conversion — the caller
+            // must name an output path in that case.
+            let derived = default_output(input);
+            if derived == Path::new(input) {
+                eprintln!(
+                    "md2docx: input '{input}' is already .docx — specify an output path \
+                     (`md2docx {input} out.docx`) so the input isn't overwritten"
+                );
+                return ExitCode::FAILURE;
+            }
+            derived
+        }
+    };
+    write_docx(convert(&source, dialect), &out)
+}
+
+/// The default output path: the input with its extension swapped to `.docx`.
+fn default_output(input: &str) -> PathBuf {
+    Path::new(input).with_extension("docx")
+}
+
+/// Write the `.docx` bytes, reporting the result.
+fn write_docx(bytes: Vec<u8>, out: &Path) -> ExitCode {
+    match std::fs::write(out, &bytes) {
+        Ok(()) => {
+            println!("md2docx: wrote {} ({} bytes)", out.display(), bytes.len());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("md2docx: cannot write '{}': {e}", out.display());
+            ExitCode::FAILURE
+        }
+    }
+}


### PR DESCRIPTION
## What

The terminal deliverable of **MD02**: native Markdown → real Word `.docx`, end-to-end, over the repo's own zero-dependency stack.

- **`markdown-docx`** crate: `markdown_to_docx(&str) -> Vec<u8>` (CommonMark) and `gfm_to_docx(&str) -> Vec<u8>` (GFM). Each composes the already-merged stages: `commonmark-parser`/`gfm-parser` → `document_ast::DocumentNode` → `document-ast-to-docx` → `.docx` bytes.
- **`md2docx`** CLI (standalone program): `md2docx <in.md> [out.docx]`, `--gfm`, `--demo`, `--help`. Derives `<in>.docx`, refuses to overwrite a `.docx` input.

## Why

Completes the pipeline whose spec (MD02) and stages (docx-writer formatting #7835, document-ast-to-docx bridge #7839) already merged. **The document-ast is now the prose-format hub** — analogous to `spreadsheet-core` for tabular — so every prose format the repo learns reuses one IR and one set of bridges. No pandoc, no external Haskell binary.

## Tests

**8 end-to-end round-trip tests** that reopen the emitted `.docx` with the independent `wordprocessingml` reader and assert the visible text + block structure survived Markdown → AST → WordprocessingML → ZIP:

- `output_is_a_valid_docx`, `rich_markdown_round_trips`, `gfm_table_round_trips`, `gfm_task_list_round_trips`, `code_block_round_trips`, `blockquote_round_trips`
- **`raw_html_is_not_injected`** — `<script>`/`<div onclick>` in Markdown is dropped at the AST→docx stage, never reaches the output
- **`deeply_nested_markdown_does_not_crash`** — 20 000-deep blockquotes still yield a valid `.docx` (the depth guard from #7839 holds)

The `md2docx` CLI was **verified live** — `--demo` wrote a real 2416-byte `.docx`.

Security-reviewed — passed.