### PR TITLE
feat(latex): LTXDOC03 S30 bibliography_entry_count — citation-side total

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.66.0] — 2026-07-09
+
+### Added — single-integer TOTAL of the bibliography entries (LTXDOC03 S30)
+
+A **new** public method `Document::bibliography_entry_count(&self) -> String` that renders the decimal
+**COUNT** of the winning bibliography entries — the distinct `\bibitem` keys the document defines inside a
+`thebibliography` environment — as one integer line. It is the *count-total* companion of S19's
+`bibliography_entries` (which renders one `[n] key` **line per winning entry**, 1-based in source order):
+S19 and S30 are two *views* of the one winning `entries` list `resolve_citations()` produces — S30
+collapses the whole list to a single `.len()` tally. It is the exact **citation-side analogue** of S29's
+`label_definition_count`, completing the *totals family*: S27 `unresolved_reference_count` and S28
+`resolved_reference_count` count the two reference tables, S29 `label_definition_count` counts the label
+definitions, and S30 counts the bibliography entries. It reads only `resolve_citations().entries.len()` — a
+later duplicate `\bibitem{dup}` lives in `duplicate_entries` (S16's domain) and is excluded by construction,
+so the count is exactly the number of lines S19 lists. Being a COUNT renderer, its empty case (no `\bibitem`
+at all) is the honest number `"0"` — **not** a `(no bibliography entries)` marker (that discipline belongs
+to the *list* renderer S19; this mirrors S27/S28/S29). One line, no trailing newline. It is a read-only view
+over `resolve_citations()`; every S1–S29 output is left **byte-for-byte unchanged**; S30 is purely additive
+and leaves the `to_latex()` round-trip fixed point intact. Total & panic-free.
+
+---
+
 ## [0.65.0] — 2026-07-08
 
 ### Added — single-integer TOTAL of the label definitions (LTXDOC03 S29)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -77,6 +77,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S27 — single-integer total of the unresolved (dangling) references** | `Document::unresolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\ref`/`\eqref`/`\pageref` references — the ones no `\label` defines (LaTeX's *"Reference `key' undefined"*, the `??`) — as one integer line. It is the **count-total companion of S18's** `unresolved_references_by_source` (which renders one `\<command>{key}` *line per dangling ref*): S18 and S27 are two views of the one `unresolved` list; S27 collapses the whole list to a single `.len()` tally. It is the count-total sibling of the census family (S25 `label_kind_counts`, S26 `resolved_reference_kind_counts`), but for the UNRESOLVED refs — which carry **no** `target_kind` (a dangling ref bound to nothing), so a per-kind census is not viable and a single total is the clean move. It reads only `resolve_references().unresolved.len()` (a resolved `\ref{sec:i}` lives in `resolved`, S21's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all. Being a COUNT renderer, its empty case (every ref resolves, or none at all) is the honest number `"0"` — **not** a `(no …)` marker (that discipline belongs to the *list* renderers). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\ref{nope}` + `\ref{gone}` (both dangle) → `2`. Every S1–S26 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S28 — single-integer total of the resolved references** | `Document::resolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — the ones some `\label` defines — as one integer line. It is the **count-total companion of S21's** `resolved_references_by_source` **and S24's** `resolved_references_by_kind` (which render one `\<command>{key}` *line per resolved ref*, flat in source order or grouped by target kind): S21/S24 and S28 are two views of the one `resolved` list; S28 collapses the whole list to a single `.len()` tally. It is the exact resolved-side **twin of S27's** `unresolved_reference_count` — together S28 + S27 split every reference into the pair (resolved, dangling), so their totals sum to the total reference count. It reads only `resolve_references().resolved.len()` (a dangling `\ref{nope}` lives in `unresolved`, S18/S27's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all, so section/table/equation references all fold into one total. Being a COUNT renderer, its empty case (every ref dangles, or none at all) is the honest number `"0"` — **not** a `(no resolved references)` marker (that discipline belongs to the *list* renderers; this mirrors S27). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\pageref{sec:i}` (resolves) + `\ref{nope}` (dangles) → `2`. Every S1–S27 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S29 — single-integer total of the label definitions** | `Document::label_definition_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning label definitions — the distinct `\label` keys the document defines — as one integer line. It is the **count-total companion of S22's** `label_definitions` **and S23's** `label_definitions_by_kind` (which render one `\label{key}` *line per winning definition*, flat in source order or grouped by kind): S22/S23 and S29 are two views of the one winning `definitions` list; S29 collapses the whole list to a single `.len()` tally. It is the exact label-definition-side **analogue** of the reference-side totals S27's `unresolved_reference_count` and S28's `resolved_reference_count`, and the count-total sibling of the census family (S25 `label_kind_counts`) but over the *whole* definition list rather than per-kind. It reads only `resolve_references().definitions.len()` (a later duplicate `\label{dup}` lives in `duplicates`, S20's domain, and is excluded by construction — the count is exactly the number of lines S22 lists) — never a `kind`, no source slicing at all, so section/figure/equation/inline labels all fold into one total. Being a COUNT renderer, its empty case (no `\label` at all) is the honest number `"0"` — **not** a `(no label definitions)` marker (that discipline belongs to the *list* renderers; this mirrors S27/S28). One line, no trailing newline. E.g. `sec:intro` (section) + `eq:main` (equation) + a re-used `sec:intro` (duplicate) → `2`. Every S1–S28 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S30 — single-integer total of the bibliography entries** | `Document::bibliography_entry_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning bibliography entries — the distinct `\bibitem` keys the document defines inside a `thebibliography` environment — as one integer line. It is the **count-total companion of S19's** `bibliography_entries` (which renders one `[n] key` *line per winning entry*, 1-based in source order): S19 and S30 are two views of the one winning `entries` list; S30 collapses the whole list to a single `.len()` tally. It is the exact **citation-side analogue of S29's** `label_definition_count`, completing the *totals family* — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, and S30 counts the bibliography entries. It reads only `resolve_citations().entries.len()` (a later duplicate `\bibitem{dup}` lives in `duplicate_entries`, S16's domain, and is excluded by construction — the count is exactly the number of lines S19 lists) — no source slicing at all. Being a COUNT renderer, its empty case (no `\bibitem` at all) is the honest number `"0"` — **not** a `(no bibliography entries)` marker (that discipline belongs to the *list* renderer S19; this mirrors S27/S28/S29). One line, no trailing newline. E.g. `a` + `b` + `c` + a re-used `a` (duplicate) → `3`. Every S1–S29 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1167,6 +1168,37 @@ Being a COUNT renderer, a document with no label definitions at all renders the 
 **not** a `(no label definitions)` marker (that discipline belongs to the *list* renderers S22/S23, whose
 empty case has no lines to show; this mirrors S27/S28). Purely additive — reuses `resolve_references`,
 mutates nothing, leaves every S1–S28 output and the `to_latex()` fixed point unchanged.
+
+### single-integer total of the bibliography entries (LTXDOC03 S30)
+
+The decimal **COUNT** of the winning bibliography entries — the distinct `\bibitem` keys the document defines
+inside a `thebibliography` environment — as one integer line. It is the **count-total companion of S19's**
+`bibliography_entries` (which renders one `[n] key` line *per winning entry*, 1-based in source order): S19
+and S30 are two *views* of the one winning `entries` list `resolve_citations()` produces; S30 collapses the
+whole list to a single `.len()` tally. It is the exact **citation-side analogue of S29's**
+`label_definition_count`, completing the *totals family* — S27's `unresolved_reference_count` and S28's
+`resolved_reference_count` count the two reference tables, S29 counts the label definitions, and S30 counts
+the bibliography entries. `bibliography_entry_count` reads only `resolve_citations().entries.len()` — a later
+duplicate `\bibitem{dup}` lives in `duplicate_entries` (S16's domain) and is excluded by construction, so the
+count is exactly the number of lines S19 lists, with no source slicing at all.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{a} Author A.\bibitem{b} Author B.\bibitem{a} Author A again.\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.bibliography_entry_count(),
+    // two distinct keys defined (`a`, `b`); the later `\bibitem{a}` is a duplicate
+    "2",
+);
+```
+
+Being a COUNT renderer, a document with no bibliography entries at all renders the honest number `"0"` —
+**not** a `(no bibliography entries)` marker (that discipline belongs to the *list* renderer S19, whose empty
+case has no lines to show; this mirrors S27/S28/S29). Purely additive — reuses `resolve_citations`, mutates
+nothing, leaves every S1–S29 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2933,6 +2933,71 @@ impl Document {
         // a single total, the label-definition-side analogue of S27/S28's reference-side counts.
         self.resolve_references().definitions.len().to_string()
     }
+
+    /// The single-integer TOTAL of the winning bibliography entries (LTXDOC03 S30) — the
+    /// **citation-side** twin of S29's [`label_definition_count`](Document::label_definition_count).
+    ///
+    /// This is the last member of the *totals family*: S27's
+    /// [`unresolved_reference_count`](Document::unresolved_reference_count) and S28's
+    /// [`resolved_reference_count`](Document::resolved_reference_count) count the two reference tables,
+    /// S29's [`label_definition_count`](Document::label_definition_count) counts the winning label
+    /// definitions, and S30 counts the winning bibliography entries. It is to S19's
+    /// [`bibliography_entries`](Document::bibliography_entries) exactly what S29 is to S22's
+    /// [`label_definitions`](Document::label_definitions): a numeric summary over the *same* list — here
+    /// the **winning** `\bibitem` entries — so a reader sees "how many bibliography entries there are"
+    /// without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] splits every `\bibitem` inside a `thebibliography`
+    /// environment into the **winning** first entry of each key ([`CitationResolution::entries`] — one
+    /// row per distinct key, in [`Document::walk`] pre-order) and the **losing** later re-definitions
+    /// ([`CitationResolution::duplicate_entries`] — LaTeX's *"Citation `key' multiply defined"*
+    /// warning, S16's domain). S19 renders that `entries` list as one numbered line per winning entry;
+    /// S30 collapses the whole list to a **single count line** — the decimal `.len()` of `entries`.
+    /// Only the **winning** entries are counted; a later duplicate `\bibitem{dup}` lives in
+    /// [`CitationResolution::duplicate_entries`] (S16), never in `entries`, so it is excluded by
+    /// construction — the count is exactly the number of lines S19 lists.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`CitationResolution::entries`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no bibliography entries is the number `0` — the string `"0"`,
+    /// **not** a `(no bibliography entries)` marker (a total count of zero *is* a number; the `(no …)`
+    /// marker discipline belongs to the *list* renderer S19, whose empty case has no lines to show).
+    /// This mirrors S27/S28/S29 exactly, which emit `"0"` for their empty lists. There is no source
+    /// slicing — only `.len()` is taken.
+    ///
+    /// Concretely, for a `thebibliography` with `\bibitem{a}`, `\bibitem{b}`, `\bibitem{c}`, and then a
+    /// re-used `\bibitem{a}` (a duplicate):
+    ///
+    /// ```text
+    /// 3
+    /// ```
+    ///
+    /// (three distinct keys are defined; the later duplicate `\bibitem{a}` is excluded). A document
+    /// with no `\bibitem` at all returns `"0"`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S30 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1–S29 output (they are byte-for-byte unchanged) and leaves
+    /// the `to_latex` round-trip fixed point intact. It is a *second view* of the same `entries` list
+    /// S19 renders flat — counting never adds, drops, or reorders the entries relative to what
+    /// `resolve_citations` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read); a single read of the already-bounded `entries` list's length. Borrows
+    /// `self` immutably and returns owned `String` data, so the result outlives any borrow of the
+    /// source.
+    pub fn bibliography_entry_count(&self) -> String {
+        // S2 already collected the winning entries — the first `\bibitem` of each distinct key, in
+        // body pre-order (later re-definitions went to `duplicate_entries`, S16, not here). We only
+        // read that list's length. This is the citation-side analogue of S29's label-definition count
+        // and completes the totals family (S27/S28 references, S29 labels, S30 bibliography).
+        self.resolve_citations().entries.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -7278,6 +7343,121 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         assert_eq!(
             doc.label_definition_count(),
             doc.label_definitions().lines().count().to_string()
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // LTXDOC03 S30 — single-integer TOTAL of the bibliography entries (`bibliography_entry_count`).
+    // The CITATION-side twin of S29's `label_definition_count`: one decimal line = `.len()` of the
+    // SAME winning `entries` list S19's `bibliography_entries` renders flat. It completes the totals
+    // family — S27/S28 count the two reference tables, S29 counts the label definitions, S30 counts
+    // the bibliography entries. Being a COUNT renderer, its empty value is the honest number "0", NOT
+    // a `(no …)` marker. A later duplicate `\bibitem` is in `duplicate_entries` (S16), never
+    // `entries`, so it is excluded — the count is exactly the number of lines S19 lists.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s30_multiple_entries_count_the_integer() {
+        // Three distinct `\bibitem` keys → the count is exactly "3".
+        let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{a} Author A.\bibitem{b} Author B.\bibitem{c} Author C.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entry_count(), "3");
+        // Cross-check: the count equals the number of lines S19 enumerates (two views of the SAME
+        // winning `entries` list).
+        assert_eq!(
+            doc.bibliography_entry_count(),
+            doc.bibliography_entries().lines().count().to_string()
+        );
+    }
+
+    #[test]
+    fn s30_one_entry_counts_one() {
+        // A single `\bibitem` → "1".
+        let src = r"\begin{document}\begin{thebibliography}{9}\bibitem{only} Solo.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entry_count(), "1");
+        assert_eq!(doc.bibliography_entries(), "[1] only");
+    }
+
+    #[test]
+    fn s30_duplicate_bibitem_counted_once_matching_s19() {
+        // A key `\bibitem{dup}` defined twice: only the FIRST (winning) entry is in `entries`; the
+        // later one is a DUPLICATE (S16's domain), never a second `entries` row. So the count is the
+        // number of DISTINCT keys, exactly matching the number of lines S19 lists.
+        let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{a} Author A.\bibitem{dup} First.\bibitem{dup} Second.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        // Two distinct keys: `a` and `dup`.
+        assert_eq!(doc.bibliography_entry_count(), "2");
+        // The later `\bibitem{dup}` is a duplicate, surfaced by S16, not counted here.
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{dup}");
+        // The count MUST equal the number of lines S19 lists (two views of the SAME list).
+        assert_eq!(
+            doc.bibliography_entry_count(),
+            doc.bibliography_entries().lines().count().to_string()
+        );
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] dup");
+    }
+
+    #[test]
+    fn s30_no_entries_counts_zero() {
+        // A document with NO `\bibitem` at all → "0" (the count of an empty `entries` list). A COUNT
+        // renderer's honest value for an empty list is the number "0", never a `(no …)` marker.
+        let src = r"\begin{document}Just some text with no bibliography.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.bibliography_entry_count(), "0");
+        // And S19 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(doc.bibliography_entries(), "(no bibliography entries)");
+    }
+
+    #[test]
+    fn s30_is_additive_leaves_s1_s29_outputs_unchanged() {
+        // Same representative doc as the S29 additive test. S30 changes NONE of the S1-S29 outputs —
+        // it only reads `resolve_citations`. Its count is a second view of the SAME `entries` list S19
+        // renders flat; pinned here alongside S19/S22/S27/S28/S29 to show S30 neither adds, drops, nor
+        // reorders, and that its total agrees with the number of lines S19 enumerates.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A handful of prior renderers — byte-for-byte unchanged.
+        // S19 flat winning bibliography entries (three distinct keys; the later `\bibitem{a}` loses).
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S22 flat winning label definitions.
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // S28 resolved-reference count — exactly two (`\ref{sec:intro}`, `\eqref{eq:e}`).
+        assert_eq!(doc.resolved_reference_count(), "2");
+        // S29 label-definition count — exactly four distinct label keys.
+        assert_eq!(doc.label_definition_count(), "4");
+
+        // And S30 itself: exactly THREE distinct `\bibitem` keys are defined (`a`, `b`, `c`), so the
+        // count is "3" — agreeing with the three lines S19 enumerates for the same doc. The later
+        // `\bibitem{a}` is a duplicate (S16), not a fourth entry.
+        assert_eq!(doc.bibliography_entry_count(), "3");
+        assert_eq!(
+            doc.bibliography_entry_count(),
+            doc.bibliography_entries().lines().count().to_string()
         );
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2405,3 +2405,78 @@ additivity check that a handful of prior renderers — S22's `label_definitions`
 S27's `unresolved_reference_count`, and S28's `resolved_reference_count` — all still produce their exact
 prior strings, with S29 returning `"4"` (agreeing with the four lines S22 enumerates)). All prior S1–S28
 tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 36. S30 — single-integer total of the bibliography entries (`bibliography_entry_count`)
+
+### 36.1 Motivation
+
+S19 (`bibliography_entries`) enumerates the **winning** bibliography entries — the distinct `\bibitem` keys
+the document defines inside a `thebibliography` environment, the table `\cite` resolves against — one
+**line per winning entry** (`[n] key`, 1-based in body pre-order). But a reader often wants not the
+enumeration but the **total** — "how many bibliography entries does this document define?" — a single
+number answered at a glance, without scanning the individual keys. S27 (`unresolved_reference_count`) and
+S28 (`resolved_reference_count`) gave that single-total discipline to the two *reference* tables, and S29
+(`label_definition_count`) gave it to the label-definition table; S30 is the **citation-side analogue** of
+S29, completing the *totals family*: it collapses the whole winning `entries` list to its decimal `.len()`.
+Where S29 counts the label definitions, S30 counts the bibliography entries — the last of the four total
+renderers (S27/S28 references, S29 labels, S30 bibliography).
+
+### 36.2 Why a new method — additive by construction
+
+S30 adds a **new public method** `Document::bibliography_entry_count(&self) -> String`. It is a pure,
+read-only render of `resolve_citations().entries.len()` — a *second view* of the exact list S19 renders
+flat. It reuses that list verbatim (never re-walking the body or re-resolving), so the report can never
+drift from the S2 resolution it summarises, and counting never adds, drops, or reorders entries relative to
+what `resolve_citations` produced. It mutates nothing and changes no S1–S29 output — including
+`to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S29 it is a method the caller invokes
+directly.
+
+### 36.3 The rendering rule
+
+The output is the decimal `.len()` of the winning `entries` list, rendered as its `String`, **always** on a
+single line with **no** trailing newline. There is no ordering question (a single integer has no order) —
+only `.len()` is read, with **no** source slicing at all. Being a **count** renderer, its empty case is the
+honest number `"0"` — **not** a `(no bibliography entries)` marker, mirroring S27/S28/S29 exactly. The
+`(no …)` marker discipline belongs to the *list* renderer S19, whose empty case has no lines to show; a
+total count of zero *is* a number, so `"0"` is its truthful value.
+
+### 36.4 The exact rendering contract — `Document::bibliography_entry_count(&self) -> String`
+
+- Read `resolve_citations().entries.len()` and render it with `.to_string()` → the decimal count, one line,
+  no trailing newline. There is **no** source slicing at all, so the render needs no source borrow and can
+  never index out of bounds.
+- Only the **winning** entries are counted. A later re-definition `\bibitem{dup}` of an already-defined key
+  lives in `resolve_citations().duplicate_entries` (S16's domain), never in `entries`, so it is excluded by
+  construction — the count is exactly the number of lines S19 lists.
+- The empty case (no `\bibitem` at all) returns the honest number `"0"` — **not** a
+  `(no bibliography entries)` marker, because S30 is a count renderer (mirroring S27/S28/S29).
+
+Example (a `thebibliography` with `\bibitem{a}`, `\bibitem{b}`, `\bibitem{c}`, and then a re-used
+`\bibitem{a}` (a duplicate)):
+
+```text
+3
+```
+
+Three distinct keys are defined; the later duplicate `\bibitem{a}` is excluded. This is the count-total
+companion of S19's flat list — a second view of the one winning `entries` list; the count equals the number
+of lines S19 would enumerate.
+
+### 36.5 Public API (added in S30)
+
+One new method: `Document::bibliography_entry_count(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_citations` and every S1–S29 method are unchanged; no AST or grammar change; no
+new dependency, no `unsafe`, no I/O.
+
+### 36.6 Verification (S30)
+
+`cargo test -p latex` green (5 new S30 tests: a multiple-entries case returning `"3"` (cross-checked against
+S19's `bibliography_entries`); a single-entry case returning `"1"`; a duplicate-bibitem case where the later
+`\bibitem{dup}` is a duplicate (S16's domain), not a second entry, so the count is the number of distinct
+keys `"2"` (cross-checked against S16's `duplicate_bibliography_entries` and against the number of lines S19
+lists); a no-entries case returning `"0"` (cross-checked against S19's `(no bibliography entries)` marker);
+and an additivity check that a handful of prior renderers — S19's `bibliography_entries`, S22's
+`label_definitions`, S27's `unresolved_reference_count`, S28's `resolved_reference_count`, and S29's
+`label_definition_count` — all still produce their exact prior strings, with S30 returning `"3"` (agreeing
+with the three lines S19 enumerates)). All prior S1–S29 tests pass unchanged. No `cargo fmt`, no grammar
+regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S30 — `bibliography_entry_count` (citation-side total, completes the totals family)

Adds one small additive, read-only String renderer to the `latex` crate: **`Document::bibliography_entry_count()`** — the total number of winning `\bibitem` bibliography entries, as a decimal integer string.

### What it is

`bibliography_entry_count()` returns `self.resolve_citations().entries.len().to_string()` — the **citation-side single-integer total**, the exact analog of S29's `label_definition_count()` (which counts label *definitions*). With S27 `unresolved_reference_count` (dangling refs) and S28 `resolved_reference_count` (resolved refs) already covering the reference side, and S29 covering labels, **S30 completes the totals family** with the bibliography side:

| slice | renderer | counts |
|-------|----------|--------|
| S27 | `unresolved_reference_count` | dangling `\ref`/`\pageref`… |
| S28 | `resolved_reference_count` | resolved references |
| S29 | `label_definition_count` | winning `\label` definitions |
| **S30** | **`bibliography_entry_count`** | **winning `\bibitem` entries** |

### Semantics (mirrors S29 exactly)

- Counts the winning entries in `resolve_citations().entries` — the first `\bibitem` of each distinct key, in body pre-order. Later re-definitions of a key are **excluded** (they belong to S16's `duplicate_bibliography_entries`), so `.entries` already holds only winners.
- **Count renderer**: emits `"0"` when there are no entries — a total of zero *is* a number, not a `(no …)` marker (that discipline belongs to the *list* renderer S19). Matches S27/S28/S29's empty case exactly.
- Pure and panic-free: borrows `&self`, no `unwrap`/`expect`, no indexing/slicing (only `.len()`), no I/O, no `unsafe`.

### Additive by construction

S30 is a brand-new second view of the same `entries` list S19 renders flat; it mutates nothing and changes **no** S1–S29 output. A dedicated **additivity test** pins S19/S22/S27/S28/S29 byte-for-byte alongside the new S30 output, proving the addition is purely additive and the `to_latex` round-trip fixed point is intact.

### Tests (5 new, in the S27/S28/S29 module)

zero entries → `"0"`; one `\bibitem` → `"1"`; three → `"3"`; duplicate-key collapse (4 `\bibitem`s, one repeated key) → `"3"` winners; plus the byte-for-byte additivity test.

### Verification (all from the worktree)

- `cargo test -p latex` → **466 passed** (461 prior + 5 new) + 1 doctest
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- Inline security review → **PASSED** (read-only, depth-bounded via parser `MAX_DEPTH`, no unsafe/unwrap/overflow)

Bumps `latex` 0.65.0 → 0.66.0; CHANGELOG.md, README.md, and the LTXDOC03 spec updated (new S30 section appended; S1–S29 sections byte-for-byte unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
