### PR TITLE
feat(latex): LTXDOC03 S31 citation_count (resolved-citation total)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.67.0] — 2026-07-09
+
+### Added — single-integer TOTAL of the resolved citations (LTXDOC03 S31)
+
+A **new** public method `Document::citation_count(&self) -> String` that renders the decimal **COUNT** of
+the resolved citations — the `\cite` keys some `\bibitem` defines — as one integer line. It is the
+*count-total* companion of S15's `citations_by_source` (which renders the resolved keys grouped by their
+source `\cite`): S15 and S31 are two *views* of the one `resolved` list `resolve_citations()` produces —
+S31 collapses the whole list to a single `.len()` tally. It is the exact resolved-**citation-side twin** of
+S28's `resolved_reference_count`, extending the *totals family* onto the resolved-citation table: S27
+`unresolved_reference_count` and S28 `resolved_reference_count` count the two reference tables, S29
+`label_definition_count` counts the label definitions, S30 `bibliography_entry_count` counts the
+bibliography entries, and S31 counts the resolved citations. It reads only
+`resolve_citations().resolved.len()` — a dangling `\cite{ghost}` lives in `unresolved` (S17's domain) and is
+excluded by construction — never a `cite_span`/`entry_span`, no source slicing at all, so every resolved key
+folds into one total. Being a COUNT renderer, its empty case (every cited key dangling, or none at all) is
+the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to the *list*
+renderer S15; this mirrors S27/S28/S29/S30). One line, no trailing newline. E.g. `\cite{a,b}` (both defined)
++ `\cite{c,ghost}` (only `c` defined) → `3`. It is a read-only view over `resolve_citations()`; every
+S1–S30 output is left **byte-for-byte unchanged**; S31 is purely additive and leaves the `to_latex()`
+round-trip fixed point intact. Total & panic-free.
+
+---
+
 ## [0.66.0] — 2026-07-09
 
 ### Added — single-integer TOTAL of the bibliography entries (LTXDOC03 S30)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.66.0"
+version = "0.67.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -78,6 +78,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S28 — single-integer total of the resolved references** | `Document::resolved_reference_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\ref`/`\eqref`/`\pageref` references — the ones some `\label` defines — as one integer line. It is the **count-total companion of S21's** `resolved_references_by_source` **and S24's** `resolved_references_by_kind` (which render one `\<command>{key}` *line per resolved ref*, flat in source order or grouped by target kind): S21/S24 and S28 are two views of the one `resolved` list; S28 collapses the whole list to a single `.len()` tally. It is the exact resolved-side **twin of S27's** `unresolved_reference_count` — together S28 + S27 split every reference into the pair (resolved, dangling), so their totals sum to the total reference count. It reads only `resolve_references().resolved.len()` (a dangling `\ref{nope}` lives in `unresolved`, S18/S27's domain, and is excluded by construction) — never a `target_kind`, no source slicing at all, so section/table/equation references all fold into one total. Being a COUNT renderer, its empty case (every ref dangles, or none at all) is the honest number `"0"` — **not** a `(no resolved references)` marker (that discipline belongs to the *list* renderers; this mirrors S27). One line, no trailing newline. E.g. `\ref{sec:i}` (resolves) + `\pageref{sec:i}` (resolves) + `\ref{nope}` (dangles) → `2`. Every S1–S27 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S29 — single-integer total of the label definitions** | `Document::label_definition_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning label definitions — the distinct `\label` keys the document defines — as one integer line. It is the **count-total companion of S22's** `label_definitions` **and S23's** `label_definitions_by_kind` (which render one `\label{key}` *line per winning definition*, flat in source order or grouped by kind): S22/S23 and S29 are two views of the one winning `definitions` list; S29 collapses the whole list to a single `.len()` tally. It is the exact label-definition-side **analogue** of the reference-side totals S27's `unresolved_reference_count` and S28's `resolved_reference_count`, and the count-total sibling of the census family (S25 `label_kind_counts`) but over the *whole* definition list rather than per-kind. It reads only `resolve_references().definitions.len()` (a later duplicate `\label{dup}` lives in `duplicates`, S20's domain, and is excluded by construction — the count is exactly the number of lines S22 lists) — never a `kind`, no source slicing at all, so section/figure/equation/inline labels all fold into one total. Being a COUNT renderer, its empty case (no `\label` at all) is the honest number `"0"` — **not** a `(no label definitions)` marker (that discipline belongs to the *list* renderers; this mirrors S27/S28). One line, no trailing newline. E.g. `sec:intro` (section) + `eq:main` (equation) + a re-used `sec:intro` (duplicate) → `2`. Every S1–S28 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S30 — single-integer total of the bibliography entries** | `Document::bibliography_entry_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning bibliography entries — the distinct `\bibitem` keys the document defines inside a `thebibliography` environment — as one integer line. It is the **count-total companion of S19's** `bibliography_entries` (which renders one `[n] key` *line per winning entry*, 1-based in source order): S19 and S30 are two views of the one winning `entries` list; S30 collapses the whole list to a single `.len()` tally. It is the exact **citation-side analogue of S29's** `label_definition_count`, completing the *totals family* — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, and S30 counts the bibliography entries. It reads only `resolve_citations().entries.len()` (a later duplicate `\bibitem{dup}` lives in `duplicate_entries`, S16's domain, and is excluded by construction — the count is exactly the number of lines S19 lists) — no source slicing at all. Being a COUNT renderer, its empty case (no `\bibitem` at all) is the honest number `"0"` — **not** a `(no bibliography entries)` marker (that discipline belongs to the *list* renderer S19; this mirrors S27/S28/S29). One line, no trailing newline. E.g. `a` + `b` + `c` + a re-used `a` (duplicate) → `3`. Every S1–S29 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S31 — single-integer total of the resolved citations** | `Document::citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\cite` keys — the ones some `\bibitem` defines — as one integer line. It is the **count-total companion of S15's** `citations_by_source` (which renders the resolved keys *grouped by their source `\cite`*): S15 and S31 are two views of the one `resolved` list; S31 collapses the whole list to a single `.len()` tally. It is the exact resolved-**citation-side twin of S28's** `resolved_reference_count`, extending the *totals family* onto the resolved-citation table — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, S30 counts the bibliography entries, and S31 counts the resolved citations. It reads only `resolve_citations().resolved.len()` (a dangling `\cite{ghost}` lives in `unresolved`, S17's domain, and is excluded by construction) — never a `cite_span`/`entry_span`, no source slicing at all, so every resolved key folds into one total. Being a COUNT renderer, its empty case (every cited key dangling, or none at all) is the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to the *list* renderer S15; this mirrors S27/S28/S29/S30). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `3`. Every S1–S30 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1199,6 +1200,38 @@ Being a COUNT renderer, a document with no bibliography entries at all renders t
 **not** a `(no bibliography entries)` marker (that discipline belongs to the *list* renderer S19, whose empty
 case has no lines to show; this mirrors S27/S28/S29). Purely additive — reuses `resolve_citations`, mutates
 nothing, leaves every S1–S29 output and the `to_latex()` fixed point unchanged.
+
+### single-integer total of the resolved citations (LTXDOC03 S31)
+
+The decimal **COUNT** of the resolved `\cite` keys — the ones some `\bibitem` defines — as one integer line.
+It is the **count-total companion of S15's** `citations_by_source` (which renders the resolved keys *grouped
+by their source `\cite`*): S15 and S31 are two *views* of the one `resolved` list `resolve_citations()`
+produces; S31 collapses the whole list to a single `.len()` tally. It is the exact resolved-**citation-side
+twin of S28's** `resolved_reference_count`, extending the *totals family* onto the resolved-citation table —
+S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29
+counts the label definitions, S30 counts the bibliography entries, and S31 counts the resolved citations.
+`citation_count` reads only `resolve_citations().resolved.len()` — a dangling `\cite{ghost}` lives in
+`unresolved` (S17's domain) and is excluded by construction — never a `cite_span`/`entry_span`, no source
+slicing at all, so every resolved key folds into one total.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}See \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\bibitem{c} C.\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.citation_count(),
+    // three keys resolve (`a`, `b`, `c`); the dangling `ghost` is excluded
+    "3",
+);
+```
+
+Being a COUNT renderer, a document with no resolved citations at all (every cited key dangling, or none at
+all) renders the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to
+the *list* renderer S15, whose empty case has no lines to show; this mirrors S27/S28/S29/S30). Purely
+additive — reuses `resolve_citations`, mutates nothing, leaves every S1–S30 output and the `to_latex()` fixed
+point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -2998,6 +2998,71 @@ impl Document {
         // and completes the totals family (S27/S28 references, S29 labels, S30 bibliography).
         self.resolve_citations().entries.len().to_string()
     }
+
+    /// The **single-integer TOTAL of the resolved citations** (LTXDOC03 S31) — the exact
+    /// **citation-side** twin of S28's [`resolved_reference_count`](Document::resolved_reference_count).
+    ///
+    /// This extends the *totals family* onto the resolved-citation table: S27's
+    /// [`unresolved_reference_count`](Document::unresolved_reference_count) and S28's
+    /// [`resolved_reference_count`](Document::resolved_reference_count) count the two reference tables,
+    /// S29's [`label_definition_count`](Document::label_definition_count) counts the winning label
+    /// definitions, S30's [`bibliography_entry_count`](Document::bibliography_entry_count) counts the
+    /// winning bibliography entries, and S31 counts the **resolved** citations. It is to S15's
+    /// [`citations_by_source`](Document::citations_by_source) exactly what S28 is to S21/S24's resolved-
+    /// reference lists: a numeric summary over the *same* list — here the **resolved** `\cite` keys — so
+    /// a reader sees "how many citations resolve" without scanning the individual keys.
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] walks every `\cite` in body pre-order and splits its keys
+    /// (a multi-key `\cite{a,b}` yields one record per key) into the **resolved** citations — those a
+    /// `\bibitem` defines ([`CitationResolution::resolved`] as [`ResolvedCite`]s, S15's domain) — and the
+    /// **unresolved** (dangling) ones ([`CitationResolution::unresolved`], S17's domain). S15 renders
+    /// that `resolved` list grouped by source `\cite`; S31 collapses the whole list to a **single count
+    /// line** — the decimal `.len()` of `resolved`. It reads only the length, never a `cite_span` or
+    /// `entry_span`, so every resolved key — regardless of which `\cite` it came from — folds into one
+    /// total. Only the **resolved** keys are counted; a dangling `\cite{ghost}` lives in
+    /// [`CitationResolution::unresolved`] (S17), never in `resolved`, so it is excluded by construction.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`CitationResolution::resolved`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no resolved citations is the number `0` — the string `"0"`, **not**
+    /// a `(no resolved citations)` marker (a total count of zero *is* a number; the `(no …)` marker
+    /// discipline belongs to the *list* renderer S15, whose empty case has no lines to show). This
+    /// mirrors S27/S28/S29/S30 exactly, which emit `"0"` for their empty lists. There is no source
+    /// slicing — only `.len()` is taken.
+    ///
+    /// Concretely, for a body `\cite{a,b}` (both defined) then `\cite{c,ghost}` (only `c` defined),
+    /// against a bibliography defining `a`, `b`, `c`:
+    ///
+    /// ```text
+    /// 3
+    /// ```
+    ///
+    /// (three keys resolve — `a`, `b`, `c`; the one dangling `ghost` is excluded). A document with no
+    /// resolved citations — every cited key dangling, or none at all — returns `"0"`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S31 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1–S30 output (they are byte-for-byte unchanged) and leaves the
+    /// `to_latex` round-trip fixed point intact. It is a *second view* of the same `resolved` list S15
+    /// renders per-source — counting never adds, drops, or reorders the resolved citations relative to
+    /// what `resolve_citations` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read); a single read of the already-bounded `resolved` list's length. Borrows
+    /// `self` immutably and returns owned `String` data, so the result outlives any borrow of the
+    /// source.
+    pub fn citation_count(&self) -> String {
+        // S2 already flattened every `\cite` into per-key records, routing the ones a `\bibitem`
+        // defines into `resolved` (in body pre-order; the dangling keys went to `unresolved`, S17). We
+        // only read that list's length. No `cite_span`/`entry_span` is read — every resolved key folds
+        // into a single total, the resolved-citation-side twin of S28's resolved-reference count.
+        self.resolve_citations().resolved.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -7459,5 +7524,105 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
             doc.bibliography_entry_count(),
             doc.bibliography_entries().lines().count().to_string()
         );
+    }
+
+    // LTXDOC03 S31 — single-integer TOTAL of the resolved citations (`citation_count`). The exact
+    // resolved-CITATION-side twin of S28's `resolved_reference_count`: one decimal line = `.len()` of
+    // the SAME resolved `\cite`-key list S15's `citations_by_source` renders grouped by source. It
+    // extends the totals family onto the resolved-citation table — S27/S28 count the two reference
+    // tables, S29 the label definitions, S30 the bibliography entries, S31 the resolved citations.
+    // Being a COUNT renderer, its empty value is the honest number "0", NOT a `(no …)` marker. A
+    // dangling `\cite{ghost}` is in `unresolved` (S17), never `resolved`, so it is excluded.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s31_multiple_resolved_citations_count_the_integer() {
+        // `\cite{a,b}` then `\cite{c}` against a bibliography defining a, b, c → three keys resolve,
+        // so the count is exactly "3".
+        let src = r"\begin{document}See \cite{a,b} and \cite{c}.
+\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\bibitem{c} C.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citation_count(), "3");
+    }
+
+    #[test]
+    fn s31_one_resolved_citation_counts_one() {
+        // A single resolved `\cite{only}` → "1".
+        let src = r"\begin{document}See \cite{only}.
+\begin{thebibliography}{9}\bibitem{only} Solo.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citation_count(), "1");
+    }
+
+    #[test]
+    fn s31_dangling_citation_excluded_from_count() {
+        // `\cite{a, ghost}`: `a` is defined (resolves), `ghost` is not (dangles, S17's domain). Only
+        // the ONE resolved key is counted; the dangling `ghost` is excluded by construction.
+        let src = r"\begin{document}See \cite{a, ghost}.
+\begin{thebibliography}{9}\bibitem{a} A.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citation_count(), "1");
+    }
+
+    #[test]
+    fn s31_no_resolved_citations_counts_zero() {
+        // A document with NO `\cite` at all → "0" (the count of an empty `resolved` list). A COUNT
+        // renderer's honest value for an empty list is the number "0", never a `(no …)` marker.
+        let src = r"\begin{document}Just some text with no citations.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citation_count(), "0");
+        // And S15 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(doc.citations_by_source(), "(no resolved citations)");
+    }
+
+    #[test]
+    fn s31_every_citation_dangling_counts_zero() {
+        // Every cited key dangles (no matching `\bibitem`) → all go to `unresolved` (S17), so the
+        // resolved-citation count is "0", the same honest-zero as the "no `\cite` at all" case.
+        let src = r"\begin{document}See \cite{ghost, phantom}.
+\begin{thebibliography}{9}\bibitem{real} R.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.citation_count(), "0");
+    }
+
+    #[test]
+    fn s31_is_additive_leaves_s1_s30_outputs_unchanged() {
+        // Same representative doc as the S30 additive test. S31 changes NONE of the S1-S30 outputs — it
+        // only reads `resolve_citations`. Its count is a second view of the SAME `resolved` list S15
+        // renders per-source; pinned here alongside S27/S28/S29/S30 to show S31 neither adds, drops, nor
+        // reorders. The body cites `\cite{a,b}` and `\cite{c,ghost}` against a bibliography defining a,
+        // b, c — so `a`, `b`, `c` resolve (three) and `ghost` dangles.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // Prior totals-family renderers — byte-for-byte unchanged.
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // S28 resolved-reference count — exactly two (`\ref{sec:intro}`, `\eqref{eq:e}`).
+        assert_eq!(doc.resolved_reference_count(), "2");
+        // S29 label-definition count — exactly four distinct label keys.
+        assert_eq!(doc.label_definition_count(), "4");
+        // S30 bibliography-entry count — exactly three distinct `\bibitem` keys (`a`, `b`, `c`).
+        assert_eq!(doc.bibliography_entry_count(), "3");
+
+        // And S31 itself: exactly THREE citation keys resolve (`a`, `b`, `c`); the one dangling `ghost`
+        // is in `unresolved` (S17), not counted here.
+        assert_eq!(doc.citation_count(), "3");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2480,3 +2480,73 @@ and an additivity check that a handful of prior renderers — S19's `bibliograph
 `label_definition_count` — all still produce their exact prior strings, with S30 returning `"3"` (agreeing
 with the three lines S19 enumerates)). All prior S1–S29 tests pass unchanged. No `cargo fmt`, no grammar
 regen, no new dependencies.
+
+## 37. S31 — single-integer total of the resolved citations (`citation_count`)
+
+### 37.1 Motivation
+
+S15 (`citations_by_source`) enumerates the **resolved** citations — the `\cite` keys some `\bibitem` defines
+— grouped by their source `\cite`. But a reader often wants not the enumeration but the **total** — "how many
+citations resolve in this document?" — a single number answered at a glance, without scanning the individual
+keys. S27 (`unresolved_reference_count`) and S28 (`resolved_reference_count`) gave that single-total
+discipline to the two *reference* tables, S29 (`label_definition_count`) to the label-definition table, and
+S30 (`bibliography_entry_count`) to the bibliography table; S31 is the exact resolved-**citation-side twin**
+of S28, extending the *totals family* onto the resolved-citation table: it collapses the whole `resolved`
+list to its decimal `.len()`. Where S28 counts the resolved references, S31 counts the resolved citations —
+the citation-side analogue that pairs with S30 (bibliography entries) to summarise the two citation tables.
+
+### 37.2 Why a new method — additive by construction
+
+S31 adds a **new public method** `Document::citation_count(&self) -> String`. It is a pure, read-only render
+of `resolve_citations().resolved.len()` — a *second view* of the exact list S15 renders per-source. It
+reuses that list verbatim (never re-walking the body or re-resolving), so the report can never drift from the
+S2 resolution it summarises, and counting never adds, drops, or reorders citations relative to what
+`resolve_citations` produced. It mutates nothing and changes no S1–S30 output — including `to_latex()`'s
+round-trip fixed point — byte-for-byte. Like S11–S30 it is a method the caller invokes directly.
+
+### 37.3 The rendering rule
+
+The output is the decimal `.len()` of the `resolved` list, rendered as its `String`, **always** on a single
+line with **no** trailing newline. There is no ordering question (a single integer has no order) — only
+`.len()` is read, with **no** source slicing at all. Being a **count** renderer, its empty case is the honest
+number `"0"` — **not** a `(no resolved citations)` marker, mirroring S27/S28/S29/S30 exactly. The `(no …)`
+marker discipline belongs to the *list* renderer S15, whose empty case has no lines to show; a total count of
+zero *is* a number, so `"0"` is its truthful value.
+
+### 37.4 The exact rendering contract — `Document::citation_count(&self) -> String`
+
+- Read `resolve_citations().resolved.len()` and render it with `.to_string()` → the decimal count, one line,
+  no trailing newline. There is **no** source slicing at all, so the render needs no source borrow and can
+  never index out of bounds.
+- Only the **resolved** keys are counted. A dangling `\cite{ghost}` (no matching `\bibitem`) lives in
+  `resolve_citations().unresolved` (S17's domain), never in `resolved`, so it is excluded by construction. A
+  multi-key `\cite{a,b}` contributes one record per resolved key; `cite_span`/`entry_span` are never read.
+- The empty case (every cited key dangling, or no `\cite` at all) returns the honest number `"0"` — **not** a
+  `(no resolved citations)` marker, because S31 is a count renderer (mirroring S27/S28/S29/S30).
+
+Example (a body `\cite{a,b}` (both defined) then `\cite{c,ghost}` (only `c` defined), against a bibliography
+defining `a`, `b`, `c`):
+
+```text
+3
+```
+
+Three keys resolve (`a`, `b`, `c`); the one dangling `ghost` is excluded. This is the count-total companion
+of S15's per-source list — a second view of the one `resolved` list.
+
+### 37.5 Public API (added in S31)
+
+One new method: `Document::citation_count(&self) -> String`. No existing type, field, counter, or signature
+changes; `resolve_citations` and every S1–S30 method are unchanged; no AST or grammar change; no new
+dependency, no `unsafe`, no I/O.
+
+### 37.6 Verification (S31)
+
+`cargo test -p latex` green (6 new S31 tests: a multiple-resolved case returning `"3"`; a single-resolved
+case returning `"1"`; a dangling-key case where `\cite{a, ghost}` counts only the one resolved key `"1"` (the
+`ghost` excluded, S17's domain); a no-citations case returning `"0"` (cross-checked against S15's
+`(no resolved citations)` marker); an every-key-dangling case returning `"0"`; and an additivity check that
+the prior totals-family renderers — S27's `unresolved_reference_count`, S28's `resolved_reference_count`,
+S29's `label_definition_count`, and S30's `bibliography_entry_count` — all still produce their exact prior
+strings, with S31 returning `"3"` for `\cite{a,b}` plus `\cite{c,ghost}`). All prior S1–S30 tests pass
+unchanged. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S31 — `citation_count` (resolved-citation total)

Completes the LTXDOC03 **totals family** with the resolved-**citation** side. The family now pairs both resolution axes symmetrically:

| slice | renderer | counts |
|-------|----------|--------|
| S27 | `unresolved_reference_count` | dangling `\ref` keys |
| S28 | `resolved_reference_count` | resolved `\ref` keys |
| S29 | `label_definition_count` | `\label` definitions |
| S30 | `bibliography_entry_count` | bibliography entries |
| **S31** | **`citation_count`** | **resolved `\cite` keys** |

### What's new
`citation_count` is the resolved-citation twin of S28's resolved-reference total. Body:
```rust
self.resolve_citations().resolved.len().to_string()
```
`resolve_citations()` returns `CitationResolution { entries, duplicate_entries, resolved, unresolved }`; S2 already flattened every `\cite` into per-key records, routing keys a `\bibitem` defines into `resolved` (dangling keys go to `unresolved`, surfaced by S17). We only read that list's length — a single integer total, the resolved-citation-side twin of S28. Pure, read-only, emits `"0"` for the zero case (mirroring S30, **not** a `(no ...)` marker).

### Tests (+6)
- `s31_multiple_resolved_citations_count_the_integer` → `"3"`
- `s31_one_resolved_citation_counts_one` → `"1"`
- `s31_dangling_citation_excluded_from_count` → `"1"` (a `ghost` key excluded)
- `s31_no_resolved_citations_counts_zero` → `"0"`
- `s31_every_citation_dangling_counts_zero` → `"0"`
- `s31_is_additive_leaves_s1_s30_outputs_unchanged` → pins S27=`"1"`, S28=`"2"`, S29=`"4"`, S30=`"3"`, S31=`"3"` **byte-for-byte** (proves S31 is purely additive)

### Scope & verification
- **Exactly 5 files**: `references.rs`, `Cargo.toml` (0.66.0 → **0.67.0**), `CHANGELOG.md`, `README.md`, `LTXDOC03-cross-reference-resolution.md` (new S31 section appended; prior sections byte-for-byte unchanged).
- `cargo test -p latex` → **472 passed** (+6) + doctest 1 passed
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green (downstream consumers unaffected)
- `cargo build -p latex --no-default-features` → compiles
- No new deps, no `unsafe`, no file I/O, no grammar regen, no `cargo fmt`.
- Inline security review: **PASSED** (pure read-only counting of an in-memory `Vec`; no unwrap/overflow/injection/unsafe vectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
