### PR TITLE
feat(sqlite-file): table b-tree walk — leaf + interior pages (Phase E3a)

### DIFF
--- a/code/packages/rust/sqlite-file/CHANGELOG.md
+++ b/code/packages/rust/sqlite-file/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog — sqlite-file
 
+## 0.3.0 — Unreleased
+
+Phase E3a: the **table b-tree walk** — reads every row of a table given its
+root page. Overflow-chain reassembly (for records too big for one page) and the
+public `read_table(bytes, name)` API follow in E3b/E4.
+
+### Added
+
+- **`btree::walk_table(pager, header, root_page)`** — walks a table b-tree and
+  returns `Vec<(rowid, record bytes)>` in rowid order. Handles **leaf** table
+  pages (`0x0D`) and **interior** table pages (`0x05`, descending every child
+  cell plus the right-most child in the page header), the page-1 offset-100
+  quirk, and the cell-pointer array. Fully bounds- and cycle-checked: a corrupt
+  tree (unexpected page type, cell pointer past the page, or a child-pointer
+  cycle) returns a `SqliteError`, never a panic, out-of-bounds read, or infinite
+  loop — the walk uses an explicit stack (no recursion) and a visited-page set.
+- **`SqliteError::Corrupt(&str)`** — for structurally-inconsistent bytes a
+  well-formed database never produces.
+
+### Not yet included
+
+- **Overflow chains**: a record larger than the inline maximum (`usable_size −
+  35`) currently returns `Unsupported("overflow chain")` rather than truncating.
+  Reassembly is Phase E3b, which also flips on the full row round-trip gate.
+
+### Verified
+
+- 5 new unit tests (single-leaf walk in rowid order, empty leaf, an interior
+  page over two leaves, unknown-page-type reject, child-pointer-cycle detect).
+  New cross-check: our reader walks the **real `sqlite_schema` b-tree** of a
+  genuine `rusqlite`-built file and its `(name, rootpage)` set matches
+  `SELECT name, rootpage FROM sqlite_schema` exactly — the first end-to-end row
+  read against real SQLite. Full suite green (`#![forbid(unsafe_code)]`); clippy
+  + fmt clean.
+
 ## 0.2.0 — Unreleased
 
 Phase E2: the **database header** parser and a read-only **pager**, on the way

--- a/code/packages/rust/sqlite-file/Cargo.toml
+++ b/code/packages/rust/sqlite-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-file"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A small, zero-dependency reader for the SQLite on-disk file format — the read subset the Engram Anki-package importer needs — reimplemented from scratch to keep the Engram stack free of the bundled-C `rusqlite` crate."
 license = "MIT"

--- a/code/packages/rust/sqlite-file/README.md
+++ b/code/packages/rust/sqlite-file/README.md
@@ -38,7 +38,7 @@ Built leaf-to-root; this is the foundation:
 | varint (1–9 byte integers) | `varint` | ✅ read + write, golden-vector + sweep tests |
 | record / serial types → `SqlValue` | `record` | ✅ decode, golden-row tests |
 | DB header + in-memory pager | `header`, `pager` | ✅ header fields + zero-copy 1-based pages |
-| table b-tree walk + overflow | `btree` | ⏳ Phase E3 |
+| table b-tree walk (leaf + interior) | `btree` | ✅ `walk_table(root)` → `(rowid, record)`; overflow chains next |
 | `sqlite_schema` + `read_table(bytes, name)` | `schema` | ⏳ Phase E4 |
 
 ## Usage

--- a/code/packages/rust/sqlite-file/src/btree.rs
+++ b/code/packages/rust/sqlite-file/src/btree.rs
@@ -1,0 +1,355 @@
+//! # Walking a table b-tree
+//!
+//! A SQLite *table* stores its rows in a **b-tree** keyed by `rowid`. This
+//! module walks that tree from its root page and yields every `(rowid, record
+//! bytes)` pair, in rowid order — the raw material [`crate::record::decode`]
+//! turns into typed columns.
+//!
+//! ## Two kinds of page
+//!
+//! Every b-tree page starts with a one-byte **type**:
+//!
+//! - **`0x0D` — leaf table page.** Holds the actual rows. Each cell is
+//!   `[payload-length varint] [rowid varint] [record bytes…]`.
+//! - **`0x05` — interior table page.** Holds no rows, only pointers: each cell
+//!   is `[left-child page (u32-be)] [rowid varint]`, and the page header carries
+//!   one extra **right-most child** pointer. Walking one means descending into
+//!   every child.
+//!
+//! (Index b-trees use `0x0A`/`0x02`; this reader is table-only and rejects them.)
+//!
+//! ## The page-1 quirk, again
+//!
+//! Page 1 opens with the 100-byte database header, so a b-tree rooted on page 1
+//! (the `sqlite_schema` table) puts its page header at offset **100**, not 0.
+//! Every other page's header is at offset 0. Cell-pointer values, however, are
+//! always offsets from the start of the page. `header_offset` below captures
+//! exactly this.
+//!
+//! ## Page-header byte layout
+//!
+//! ```text
+//! offset  size  field
+//!    0     1    page type (0x0D leaf / 0x05 interior)
+//!    1     2    first freeblock (unused here)
+//!    3     2    number of cells on the page (u16-be)
+//!    5     2    cell content area start (unused here)
+//!    7     1    fragmented free bytes (unused here)
+//!    8     4    right-most child pointer (u32-be) — INTERIOR pages only
+//! ```
+//!
+//! The cell-pointer array (two bytes per cell, each a u16-be offset into the
+//! page) begins right after the header: offset 8 on a leaf, 12 on an interior
+//! page.
+//!
+//! ## Overflow — deferred
+//!
+//! A row whose record is too big for one page spills into an *overflow chain*.
+//! That is Phase E3b; here, a cell that would overflow returns
+//! `Unsupported("overflow chain")` rather than silently truncating the record.
+//! The tables Engram reads whose rows all fit inline work today.
+
+use crate::error::SqliteError;
+use crate::header::Header;
+use crate::pager::Pager;
+use crate::varint;
+
+const LEAF_TABLE: u8 = 0x0D;
+const INTERIOR_TABLE: u8 = 0x05;
+
+/// Read the big-endian `u16` at `off` (bounds-checked).
+fn be_u16(page: &[u8], off: usize) -> Option<u16> {
+    let hi = *page.get(off)?;
+    let lo = *page.get(off + 1)?;
+    Some(u16::from_be_bytes([hi, lo]))
+}
+
+/// Read the big-endian `u32` at `off` (bounds-checked).
+fn be_u32(page: &[u8], off: usize) -> Option<u32> {
+    let b0 = *page.get(off)?;
+    let b1 = *page.get(off + 1)?;
+    let b2 = *page.get(off + 2)?;
+    let b3 = *page.get(off + 3)?;
+    Some(u32::from_be_bytes([b0, b1, b2, b3]))
+}
+
+/// Walk the table b-tree rooted at `root_page` and return every row as
+/// `(rowid, record bytes)`, sorted by rowid.
+///
+/// `root_page` is typically obtained from `sqlite_schema` (the `rootpage`
+/// column); for `sqlite_schema` itself it is page 1. Bounds- and cycle-checked
+/// throughout: a corrupt tree (bad page type, cell pointer past the page, or a
+/// child-pointer cycle) yields an `Err`, never a panic, an out-of-bounds read,
+/// or an infinite loop.
+pub fn walk_table<'a>(
+    pager: &Pager<'a>,
+    header: &Header,
+    root_page: u32,
+) -> Result<Vec<(i64, Vec<u8>)>, SqliteError> {
+    // The largest record that fits inline on a leaf page, per the format's
+    // table-leaf formula: usable_size - 35. A larger payload spills to overflow
+    // (Phase E3b) — for now we detect it and refuse rather than truncate.
+    let max_local = header.usable_size().saturating_sub(35) as usize;
+
+    let mut rows: Vec<(i64, Vec<u8>)> = Vec::new();
+
+    // Explicit stack instead of recursion: a deep or maliciously-nested tree
+    // cannot overflow the call stack. A `visited` set bounds total work and
+    // turns any child-pointer cycle into a clean `Corrupt` error.
+    let mut stack: Vec<u32> = vec![root_page];
+    let mut visited: std::collections::HashSet<u32> = std::collections::HashSet::new();
+
+    while let Some(page_no) = stack.pop() {
+        if !visited.insert(page_no) {
+            return Err(SqliteError::Corrupt("b-tree page cycle"));
+        }
+        let page = pager.page(page_no)?;
+
+        // Page 1 carries the 100-byte database header before its b-tree header.
+        let header_off = if page_no == 1 { 100 } else { 0 };
+
+        let page_type = *page
+            .get(header_off)
+            .ok_or(SqliteError::Truncated("b-tree page"))?;
+        let cell_count =
+            be_u16(page, header_off + 3).ok_or(SqliteError::Truncated("b-tree page"))? as usize;
+
+        match page_type {
+            LEAF_TABLE => {
+                let ptr_array = header_off + 8;
+                for i in 0..cell_count {
+                    let cell_off = cell_pointer(page, ptr_array, i)?;
+                    let (rowid, record) = read_leaf_cell(page, cell_off, max_local)?;
+                    rows.push((rowid, record));
+                }
+            }
+            INTERIOR_TABLE => {
+                // Each interior cell points at a left child; the page header
+                // holds the extra right-most child.
+                let ptr_array = header_off + 12;
+                for i in 0..cell_count {
+                    let cell_off = cell_pointer(page, ptr_array, i)?;
+                    let child = be_u32(page, cell_off)
+                        .ok_or(SqliteError::Corrupt("interior cell past page"))?;
+                    stack.push(child);
+                }
+                let rightmost = be_u32(page, header_off + 8)
+                    .ok_or(SqliteError::Truncated("interior page header"))?;
+                stack.push(rightmost);
+            }
+            _ => return Err(SqliteError::Corrupt("unexpected b-tree page type")),
+        }
+    }
+
+    // A table scan yields rows in rowid order; collecting across a DFS and
+    // sorting by the unique rowid gives that same order deterministically.
+    rows.sort_by_key(|(rowid, _)| *rowid);
+    Ok(rows)
+}
+
+/// The `i`-th cell's byte offset within the page, read from the cell-pointer
+/// array at `ptr_array`.
+fn cell_pointer(page: &[u8], ptr_array: usize, i: usize) -> Result<usize, SqliteError> {
+    let entry = ptr_array
+        .checked_add(
+            i.checked_mul(2)
+                .ok_or(SqliteError::Corrupt("cell index overflow"))?,
+        )
+        .ok_or(SqliteError::Corrupt("cell index overflow"))?;
+    let off = be_u16(page, entry).ok_or(SqliteError::Corrupt("cell pointer past page"))?;
+    Ok(off as usize)
+}
+
+/// Decode one leaf-table cell at `cell_off`: `[payload-len varint] [rowid
+/// varint] [record bytes]`. Returns `(rowid, record bytes)`.
+fn read_leaf_cell(
+    page: &[u8],
+    cell_off: usize,
+    max_local: usize,
+) -> Result<(i64, Vec<u8>), SqliteError> {
+    let cell = page
+        .get(cell_off..)
+        .ok_or(SqliteError::Corrupt("cell pointer past page"))?;
+
+    let (payload_len, n1) = varint::read(cell).ok_or(SqliteError::Corrupt("bad payload length"))?;
+    let payload_len =
+        usize::try_from(payload_len).map_err(|_| SqliteError::Corrupt("bad payload length"))?;
+
+    let after_len = cell
+        .get(n1..)
+        .ok_or(SqliteError::Corrupt("truncated cell"))?;
+    let (rowid, n2) = varint::read(after_len).ok_or(SqliteError::Corrupt("bad rowid"))?;
+
+    // A payload larger than the inline maximum spills into an overflow chain,
+    // which this layer does not yet reassemble (Phase E3b).
+    if payload_len > max_local {
+        return Err(SqliteError::Unsupported("overflow chain"));
+    }
+
+    let record_start = n1 + n2;
+    let record = after_len
+        .get(n2..)
+        .and_then(|s| s.get(..payload_len))
+        .ok_or(SqliteError::Corrupt("record past page"))?;
+    let _ = record_start; // documented offset; the slice above is what we return
+    Ok((rowid, record.to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::header::MAGIC;
+
+    /// Build a one-page database (page size `ps`) whose page 1 is a *leaf* table
+    /// b-tree holding `rows` as `(rowid, record-bytes)`. Cells are packed from
+    /// the end of the page downward, exactly as SQLite lays them out.
+    fn one_leaf_page_db(ps: usize, rows: &[(i64, Vec<u8>)]) -> Vec<u8> {
+        let mut page = vec![0u8; ps];
+        // DB header on page 1.
+        page[0..16].copy_from_slice(MAGIC);
+        page[16..18].copy_from_slice(&(ps as u16).to_be_bytes());
+        page[56..60].copy_from_slice(&1u32.to_be_bytes()); // UTF-8
+        page[28..32].copy_from_slice(&1u32.to_be_bytes()); // 1 page
+
+        // B-tree header at offset 100 (page 1).
+        let h = 100;
+        page[h] = LEAF_TABLE;
+        page[h + 3..h + 5].copy_from_slice(&(rows.len() as u16).to_be_bytes());
+
+        // Write each cell from the end of the page down; record its offset.
+        let mut content_top = ps;
+        let ptr_array = h + 8;
+        for (i, (rowid, record)) in rows.iter().enumerate() {
+            let mut cell = Vec::new();
+            varint::write(record.len() as i64, &mut cell);
+            varint::write(*rowid, &mut cell);
+            cell.extend_from_slice(record);
+            content_top -= cell.len();
+            page[content_top..content_top + cell.len()].copy_from_slice(&cell);
+            let ptr = (content_top as u16).to_be_bytes();
+            page[ptr_array + i * 2..ptr_array + i * 2 + 2].copy_from_slice(&ptr);
+        }
+        page[h + 5..h + 7].copy_from_slice(&(content_top as u16).to_be_bytes());
+        page
+    }
+
+    #[test]
+    fn walks_a_single_leaf_page_in_rowid_order() {
+        // Rows inserted out of rowid order; walk must return them sorted.
+        let db = one_leaf_page_db(
+            512,
+            &[
+                (2, vec![0xAA, 0xBB]),
+                (1, vec![0x01]),
+                (3, vec![0xCC, 0xDD, 0xEE]),
+            ],
+        );
+        let (header, pager) = Pager::open(&db).unwrap();
+        let rows = walk_table(&pager, &header, 1).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                (1, vec![0x01]),
+                (2, vec![0xAA, 0xBB]),
+                (3, vec![0xCC, 0xDD, 0xEE]),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_leaf_page_yields_no_rows() {
+        let db = one_leaf_page_db(512, &[]);
+        let (header, pager) = Pager::open(&db).unwrap();
+        assert_eq!(walk_table(&pager, &header, 1).unwrap(), vec![]);
+    }
+
+    /// Build a two-level tree: page 1 is an *interior* page pointing at two leaf
+    /// pages (2 and 3), each holding rows. Exercises interior descent + the
+    /// right-most child pointer.
+    fn interior_over_two_leaves_db() -> Vec<u8> {
+        let ps = 512usize;
+        let mut data = vec![0u8; ps * 3];
+
+        // --- Page 1: interior table page with one cell (left child = 2) and
+        //     right-most child = 3.
+        data[0..16].copy_from_slice(MAGIC);
+        data[16..18].copy_from_slice(&(ps as u16).to_be_bytes());
+        data[56..60].copy_from_slice(&1u32.to_be_bytes());
+        data[28..32].copy_from_slice(&3u32.to_be_bytes()); // 3 pages
+        let h = 100;
+        data[h] = INTERIOR_TABLE;
+        data[h + 3..h + 5].copy_from_slice(&1u16.to_be_bytes()); // 1 cell
+        data[h + 8..h + 12].copy_from_slice(&3u32.to_be_bytes()); // right child = page 3
+                                                                  // One interior cell at the end of the page: [left child = 2][rowid = 2].
+        let mut cell = Vec::new();
+        cell.extend_from_slice(&2u32.to_be_bytes()); // left child = page 2
+        varint::write(2, &mut cell); // divider rowid
+        let cell_off = ps - cell.len();
+        data[cell_off..cell_off + cell.len()].copy_from_slice(&cell);
+        data[h + 12..h + 14].copy_from_slice(&(cell_off as u16).to_be_bytes());
+
+        // --- Page 2: leaf with rowid 1.  --- Page 3: leaf with rowids 2, 3.
+        for (page_no, rows) in [
+            (2u32, vec![(1i64, vec![0x11])]),
+            (3, vec![(2, vec![0x22]), (3, vec![0x33])]),
+        ] {
+            let base = (page_no as usize - 1) * ps;
+            data[base] = LEAF_TABLE;
+            data[base + 3..base + 5].copy_from_slice(&(rows.len() as u16).to_be_bytes());
+            let mut top = base + ps;
+            for (i, (rowid, record)) in rows.iter().enumerate() {
+                let mut c = Vec::new();
+                varint::write(record.len() as i64, &mut c);
+                varint::write(*rowid, &mut c);
+                c.extend_from_slice(record);
+                top -= c.len();
+                data[top..top + c.len()].copy_from_slice(&c);
+                let ptr = ((top - base) as u16).to_be_bytes();
+                data[base + 8 + i * 2..base + 8 + i * 2 + 2].copy_from_slice(&ptr);
+            }
+        }
+        data
+    }
+
+    #[test]
+    fn walks_interior_page_descending_into_children() {
+        let db = interior_over_two_leaves_db();
+        let (header, pager) = Pager::open(&db).unwrap();
+        let rows = walk_table(&pager, &header, 1).unwrap();
+        assert_eq!(
+            rows,
+            vec![(1, vec![0x11]), (2, vec![0x22]), (3, vec![0x33])]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_page_type() {
+        let mut db = one_leaf_page_db(512, &[(1, vec![0x00])]);
+        db[100] = 0x0A; // index leaf — unsupported
+        let (header, pager) = Pager::open(&db).unwrap();
+        assert_eq!(
+            walk_table(&pager, &header, 1),
+            Err(SqliteError::Corrupt("unexpected b-tree page type"))
+        );
+    }
+
+    #[test]
+    fn detects_a_child_pointer_cycle() {
+        // An interior page whose right-most child points back at itself (page 1).
+        let ps = 512usize;
+        let mut data = vec![0u8; ps];
+        data[0..16].copy_from_slice(MAGIC);
+        data[16..18].copy_from_slice(&(ps as u16).to_be_bytes());
+        data[56..60].copy_from_slice(&1u32.to_be_bytes());
+        data[28..32].copy_from_slice(&1u32.to_be_bytes());
+        let h = 100;
+        data[h] = INTERIOR_TABLE;
+        data[h + 3..h + 5].copy_from_slice(&0u16.to_be_bytes()); // 0 cells
+        data[h + 8..h + 12].copy_from_slice(&1u32.to_be_bytes()); // right child = page 1 (self!)
+        let (header, pager) = Pager::open(&data).unwrap();
+        assert_eq!(
+            walk_table(&pager, &header, 1),
+            Err(SqliteError::Corrupt("b-tree page cycle"))
+        );
+    }
+}

--- a/code/packages/rust/sqlite-file/src/btree.rs
+++ b/code/packages/rust/sqlite-file/src/btree.rs
@@ -91,6 +91,18 @@ pub fn walk_table<'a>(
     // (Phase E3b) — for now we detect it and refuse rather than truncate.
     let max_local = header.usable_size().saturating_sub(35) as usize;
 
+    // Anti-amplification budget. The cell-pointer array is attacker-controlled
+    // and pointers need not be distinct: a hostile page could point all of its
+    // (up to 65535) cells at one full-size cell, making us copy that record
+    // thousands of times — gigabytes out of a single small page, an OOM DoS.
+    // Every record byte a *well-formed* database emits is physically stored in
+    // some page, and pages do not overlap, so the total record bytes can never
+    // exceed the file's byte length. Cap the running total there: a valid file
+    // is always under it, and the aliasing attack trips it after copying at most
+    // one page's worth of bytes.
+    let file_bytes = pager.page_count().saturating_mul(pager.page_size());
+    let mut emitted_bytes: usize = 0;
+
     let mut rows: Vec<(i64, Vec<u8>)> = Vec::new();
 
     // Explicit stack instead of recursion: a deep or maliciously-nested tree
@@ -120,6 +132,10 @@ pub fn walk_table<'a>(
                 for i in 0..cell_count {
                     let cell_off = cell_pointer(page, ptr_array, i)?;
                     let (rowid, record) = read_leaf_cell(page, cell_off, max_local)?;
+                    emitted_bytes = emitted_bytes
+                        .checked_add(record.len())
+                        .filter(|total| *total <= file_bytes)
+                        .ok_or(SqliteError::Corrupt("row data exceeds file size"))?;
                     rows.push((rowid, record));
                 }
             }
@@ -350,6 +366,43 @@ mod tests {
         assert_eq!(
             walk_table(&pager, &header, 1),
             Err(SqliteError::Corrupt("b-tree page cycle"))
+        );
+    }
+
+    #[test]
+    fn rejects_aliased_cell_pointer_amplification() {
+        // Anti-DoS: a hostile page pointing many cells at ONE full-size cell
+        // must not copy that record thousands of times. Build a 512-byte page
+        // (file = 512 bytes) claiming 20 cells that all alias one ~400-byte
+        // record — replaying it would emit ~8 KB, well over the 512-byte file.
+        let ps = 512usize;
+        let mut page = vec![0u8; ps];
+        page[0..16].copy_from_slice(MAGIC);
+        page[16..18].copy_from_slice(&(ps as u16).to_be_bytes());
+        page[56..60].copy_from_slice(&1u32.to_be_bytes());
+        page[28..32].copy_from_slice(&1u32.to_be_bytes());
+        let h = 100;
+        page[h] = LEAF_TABLE;
+        page[h + 3..h + 5].copy_from_slice(&20u16.to_be_bytes()); // 20 cells claimed
+
+        // One real cell near the end: a ~400-byte record.
+        let record = vec![0x5A; 400];
+        let mut cell = Vec::new();
+        varint::write(record.len() as i64, &mut cell);
+        varint::write(1, &mut cell); // rowid
+        cell.extend_from_slice(&record);
+        let cell_off = ps - cell.len();
+        page[cell_off..cell_off + cell.len()].copy_from_slice(&cell);
+        // Point ALL 20 cell pointers at that same cell.
+        for i in 0..20 {
+            page[h + 8 + i * 2..h + 8 + i * 2 + 2]
+                .copy_from_slice(&(cell_off as u16).to_be_bytes());
+        }
+
+        let (header, pager) = Pager::open(&page).unwrap();
+        assert_eq!(
+            walk_table(&pager, &header, 1),
+            Err(SqliteError::Corrupt("row data exceeds file size"))
         );
     }
 }

--- a/code/packages/rust/sqlite-file/src/error.rs
+++ b/code/packages/rust/sqlite-file/src/error.rs
@@ -27,6 +27,10 @@ pub enum SqliteError {
     /// implement (named by the `&'static str`) — e.g. a text encoding other
     /// than UTF-8.
     Unsupported(&'static str),
+    /// The bytes are internally inconsistent in a way a well-formed database
+    /// never is — a b-tree page of an unexpected type, a cell pointer past the
+    /// page, or a page-link cycle. The `&'static str` names what was wrong.
+    Corrupt(&'static str),
 }
 
 impl fmt::Display for SqliteError {
@@ -37,6 +41,7 @@ impl fmt::Display for SqliteError {
             SqliteError::BadPageSize(n) => write!(f, "invalid page size {n}"),
             SqliteError::BadPageNumber(n) => write!(f, "invalid page number {n}"),
             SqliteError::Unsupported(what) => write!(f, "unsupported SQLite feature: {what}"),
+            SqliteError::Corrupt(what) => write!(f, "corrupt SQLite database: {what}"),
         }
     }
 }

--- a/code/packages/rust/sqlite-file/src/lib.rs
+++ b/code/packages/rust/sqlite-file/src/lib.rs
@@ -27,8 +27,9 @@
 //! 1. **`varint`** — the 1–9 byte integer encoding used everywhere. *(done)*
 //! 2. **`record`** — decode a row's bytes into typed [`SqlValue`]s. *(done)*
 //! 3. **`header` + `pager`** — parse the 100-byte DB header; borrow pages from
-//!    `&[u8]` (read-only, zero-copy, no journal/cache). *(here)*
-//! 4. b-tree walk — leaf + interior pages + overflow chains → `(rowid, row)`.
+//!    `&[u8]` (read-only, zero-copy, no journal/cache). *(done)*
+//! 4. **`btree`** — walk a table b-tree (leaf + interior pages) → `(rowid, record
+//!    bytes)`. *(here; overflow-chain reassembly is the next step)*
 //! 5. `sqlite_schema` + `read_table(bytes, name)` — the public read API.
 //!
 //! Each layer is cross-checked against the real `rusqlite`/C-SQLite as an
@@ -50,6 +51,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod btree;
 pub mod error;
 pub mod header;
 pub mod pager;

--- a/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
+++ b/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
@@ -142,6 +142,79 @@ fn our_header_matches_a_real_sqlite_file() {
     assert_eq!(&pager.page(1).unwrap()[0..16], sqlite_file::header::MAGIC);
 }
 
+/// Walk the **real `sqlite_schema` b-tree** (rooted on page 1) with our reader
+/// and confirm the object name + rootpage of every table/index matches what
+/// SQLite reports via `SELECT name, rootpage FROM sqlite_schema`. This exercises
+/// the whole leaf/interior walk + record-decode pipeline against genuine SQLite
+/// output — the first end-to-end row read.
+#[test]
+fn sqlite_schema_walk_matches_the_oracle() {
+    let db = build_sqlite_db(&[
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)",
+        "CREATE TABLE u (x INTEGER, y INTEGER)",
+        "CREATE INDEX idx_u_x ON u (x)",
+        "INSERT INTO t VALUES (1, 'Ada'), (2, 'Grace')",
+        "INSERT INTO u VALUES (10, 20), (30, 40)",
+    ]);
+
+    // Our reader: walk page 1 (the sqlite_schema root) and decode each 5-column
+    // row (type, name, tbl_name, rootpage, sql).
+    let (header, pager) = sqlite_file::Pager::open(&db).unwrap();
+    let rows = sqlite_file::btree::walk_table(&pager, &header, 1).unwrap();
+    let mut ours: Vec<(String, i64)> = Vec::new();
+    for (_rowid, record) in &rows {
+        let cols = sqlite_file::record::decode(record).expect("schema row decodes");
+        assert_eq!(cols.len(), 5, "sqlite_schema has five columns");
+        let name = match &cols[1] {
+            sqlite_file::SqlValue::Text(s) => s.clone(),
+            other => panic!("name column should be TEXT, got {other:?}"),
+        };
+        // rootpage is 0 for views/triggers; tables and indexes have a real page.
+        let rootpage = match &cols[3] {
+            sqlite_file::SqlValue::Int(n) => *n,
+            sqlite_file::SqlValue::Null => 0,
+            other => panic!("rootpage should be INTEGER, got {other:?}"),
+        };
+        ours.push((name, rootpage));
+    }
+    ours.sort();
+
+    // The oracle: the same view straight out of bundled-C SQLite.
+    let conn = {
+        // Reopen the bytes we already built by writing them to a fresh temp file
+        // and querying — simplest independent path to the same rows.
+        static COUNTER2: AtomicU64 = AtomicU64::new(1_000_000);
+        let unique = COUNTER2.fetch_add(1, Ordering::Relaxed);
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "sqlite_file_schema_{}_{}",
+            std::process::id(),
+            unique
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("oracle.db");
+        std::fs::write(&path, &db).unwrap();
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        // Leak the tempdir cleanup to the OS reboot is fine, but tidy up anyway
+        // after reading.
+        (conn, dir)
+    };
+    let mut theirs: Vec<(String, i64)> = conn
+        .0
+        .prepare("SELECT name, rootpage FROM sqlite_schema")
+        .unwrap()
+        .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    theirs.sort();
+    drop(conn.0);
+    let _ = std::fs::remove_dir_all(&conn.1);
+
+    assert_eq!(ours, theirs, "our sqlite_schema walk must match SQLite's");
+    assert!(!ours.is_empty(), "expected some schema objects");
+}
+
 /// The full round-trip gate: decode every row straight out of the file bytes
 /// and confirm it equals what SQLite reports over SQL. It needs the table
 /// b-tree walk to locate record bytes, which lands in Phase E3 — this staged


### PR DESCRIPTION
## Phase E3a — the b-tree walk (reads rows out of a table)

Third layer of the zero-dep SQLite reader (Engram zero-dependency program,
Phase E — the arc that removes `rusqlite` from engram-anki-package). Reads every
row of a table given its root page.

- **`btree::walk_table(pager, header, root_page) -> Vec<(rowid, record bytes)>`**
  in rowid order. Handles **leaf** table pages (`0x0D`) and **interior** table
  pages (`0x05`, descending each child cell + the right-most child in the page
  header), the page-1 offset-100 quirk, and the cell-pointer array.
- Fully bounds- and cycle-checked: unexpected page type, cell pointer past the
  page, or a child-pointer cycle return `SqliteError`, never a panic, OOB read,
  or infinite loop — explicit stack (no recursion) + a visited-page set.
- **`SqliteError::Corrupt(&str)`** for structurally-inconsistent bytes.
- Records too big for one page (`> usable_size − 35`) return
  `Unsupported("overflow chain")` rather than truncating; overflow reassembly +
  the full row round-trip gate are Phase E3b.

### Verification
- 28 unit tests (single/empty leaf, interior over two leaves, unknown-page-type
  reject, cycle detect, **aliased-cell-pointer amplification reject**).
- New interop cross-check: our reader walks a **real `rusqlite`-built file's
  `sqlite_schema` b-tree** and its `(name, rootpage)` set matches
  `SELECT name, rootpage FROM sqlite_schema` exactly — the first end-to-end row
  read against genuine SQLite. (`rusqlite` dev-dep only; runtime is zero-dep.)
- clippy 0, fmt clean, `#![forbid(unsafe_code)]`, v0.3.0.
- **Security review (Rust, hostile-input threat model): PASSED after one fix.**
  The reviewer caught a HIGH memory-amplification DoS — the leaf cell-pointer
  array is attacker-controlled and pointers need not be distinct, so a page could
  alias 65535 pointers at one full-size cell → ~4 GB of copies from a 64 KiB page
  (OOM-abort). Fixed by capping cumulative emitted record bytes at the file's
  byte length (record bytes can never exceed the non-overlapping pages that hold
  them, so valid files always pass; the attack trips a clean `Corrupt` after
  ~one page's worth). Regression test included; re-review confirmed the finding
  closed with no new issues.

### Next in the arc
E3b overflow chains + activate the full row round-trip gate · E4 `read_table`
API · E5 cut the Anki importer over and delete the `rusqlite` FFI/`OwnedData`
`unsafe` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)