### PR TITLE
feat(latex): LTXDOC03 S32 unresolved_citation_count (dangling \cite total)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.68.0] — 2026-07-09
+
+### Added — single-integer TOTAL of the unresolved (dangling) citations (LTXDOC03 S32)
+
+A **new** public method `Document::unresolved_citation_count(&self) -> String` that renders the decimal
+**COUNT** of the unresolved (dangling) citations — the `\cite` keys **no** `\bibitem` defines — as one
+integer line. It is the *count-total* companion of S17's `unresolved_citations_by_source` (which renders
+the dangling keys grouped by their source `\cite`): S17 and S32 are two *views* of the one `unresolved`
+list `resolve_citations()` produces — S32 collapses the whole list to a single `.len()` tally. It is the
+exact unresolved-**citation-side twin** of S27's `unresolved_reference_count`, and the **dangling sibling**
+of S31's resolved `citation_count`. Together S31 and S32 **partition** every per-key `\cite` record:
+`citation_count + unresolved_citation_count` equals the total number of cited keys, because
+`resolve_citations()` routes each key into exactly one of `resolved`/`unresolved`. It reads only
+`resolve_citations().unresolved.len()` — a resolved `\cite{a}` lives in `resolved` (S15/S31's domain) and is
+excluded by construction — never a `cite_span`/dangling `key`, no source slicing at all, so every dangling
+key folds into one total. Being a COUNT renderer, its empty case (every cited key resolving, or none at
+all) is the honest number `"0"` — **not** a `(no unresolved citations)` marker (that discipline belongs to
+the *list* renderer S17; this mirrors S27/S28/S29/S30/S31). One line, no trailing newline. E.g. `\cite{a,b}`
+(both defined) + `\cite{c,ghost}` (only `c` defined) → `1`. It is a read-only view over
+`resolve_citations()`; every S1–S31 output is left **byte-for-byte unchanged**; S32 is purely additive and
+leaves the `to_latex()` round-trip fixed point intact. Total & panic-free.
+
+---
+
 ## [0.67.0] — 2026-07-09
 
 ### Added — single-integer TOTAL of the resolved citations (LTXDOC03 S31)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.67.0"
+version = "0.68.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -79,6 +79,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S29 — single-integer total of the label definitions** | `Document::label_definition_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning label definitions — the distinct `\label` keys the document defines — as one integer line. It is the **count-total companion of S22's** `label_definitions` **and S23's** `label_definitions_by_kind` (which render one `\label{key}` *line per winning definition*, flat in source order or grouped by kind): S22/S23 and S29 are two views of the one winning `definitions` list; S29 collapses the whole list to a single `.len()` tally. It is the exact label-definition-side **analogue** of the reference-side totals S27's `unresolved_reference_count` and S28's `resolved_reference_count`, and the count-total sibling of the census family (S25 `label_kind_counts`) but over the *whole* definition list rather than per-kind. It reads only `resolve_references().definitions.len()` (a later duplicate `\label{dup}` lives in `duplicates`, S20's domain, and is excluded by construction — the count is exactly the number of lines S22 lists) — never a `kind`, no source slicing at all, so section/figure/equation/inline labels all fold into one total. Being a COUNT renderer, its empty case (no `\label` at all) is the honest number `"0"` — **not** a `(no label definitions)` marker (that discipline belongs to the *list* renderers; this mirrors S27/S28). One line, no trailing newline. E.g. `sec:intro` (section) + `eq:main` (equation) + a re-used `sec:intro` (duplicate) → `2`. Every S1–S28 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S30 — single-integer total of the bibliography entries** | `Document::bibliography_entry_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning bibliography entries — the distinct `\bibitem` keys the document defines inside a `thebibliography` environment — as one integer line. It is the **count-total companion of S19's** `bibliography_entries` (which renders one `[n] key` *line per winning entry*, 1-based in source order): S19 and S30 are two views of the one winning `entries` list; S30 collapses the whole list to a single `.len()` tally. It is the exact **citation-side analogue of S29's** `label_definition_count`, completing the *totals family* — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, and S30 counts the bibliography entries. It reads only `resolve_citations().entries.len()` (a later duplicate `\bibitem{dup}` lives in `duplicate_entries`, S16's domain, and is excluded by construction — the count is exactly the number of lines S19 lists) — no source slicing at all. Being a COUNT renderer, its empty case (no `\bibitem` at all) is the honest number `"0"` — **not** a `(no bibliography entries)` marker (that discipline belongs to the *list* renderer S19; this mirrors S27/S28/S29). One line, no trailing newline. E.g. `a` + `b` + `c` + a re-used `a` (duplicate) → `3`. Every S1–S29 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S31 — single-integer total of the resolved citations** | `Document::citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\cite` keys — the ones some `\bibitem` defines — as one integer line. It is the **count-total companion of S15's** `citations_by_source` (which renders the resolved keys *grouped by their source `\cite`*): S15 and S31 are two views of the one `resolved` list; S31 collapses the whole list to a single `.len()` tally. It is the exact resolved-**citation-side twin of S28's** `resolved_reference_count`, extending the *totals family* onto the resolved-citation table — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, S30 counts the bibliography entries, and S31 counts the resolved citations. It reads only `resolve_citations().resolved.len()` (a dangling `\cite{ghost}` lives in `unresolved`, S17's domain, and is excluded by construction) — never a `cite_span`/`entry_span`, no source slicing at all, so every resolved key folds into one total. Being a COUNT renderer, its empty case (every cited key dangling, or none at all) is the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to the *list* renderer S15; this mirrors S27/S28/S29/S30). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `3`. Every S1–S30 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S32 — single-integer total of the unresolved (dangling) citations** | `Document::unresolved_citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\cite` keys — the ones **no** `\bibitem` defines — as one integer line. It is the **count-total companion of S17's** `unresolved_citations_by_source` (which renders the dangling keys *grouped by their source `\cite`*): S17 and S32 are two views of the one `unresolved` list; S32 collapses the whole list to a single `.len()` tally. It is the exact unresolved-**citation-side twin of S27's** `unresolved_reference_count`, and the **dangling sibling of S31's** resolved `citation_count`. Together S31 and S32 **partition** every per-key `\cite` record — `citation_count + unresolved_citation_count` equals the number of cited keys, because `resolve_citations()` routes each key into exactly one of `resolved`/`unresolved`. It reads only `resolve_citations().unresolved.len()` (a resolved `\cite{a}` lives in `resolved`, S15/S31's domain, and is excluded by construction) — never a `cite_span`/dangling `key`, no source slicing at all, so every dangling key folds into one total. Being a COUNT renderer, its empty case (every cited key resolving, or none at all) is the honest number `"0"` — **not** a `(no unresolved citations)` marker (that discipline belongs to the *list* renderer S17; this mirrors S27/S28/S29/S30/S31). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `1`. Every S1–S31 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1231,6 +1232,39 @@ Being a COUNT renderer, a document with no resolved citations at all (every cite
 all) renders the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to
 the *list* renderer S15, whose empty case has no lines to show; this mirrors S27/S28/S29/S30). Purely
 additive — reuses `resolve_citations`, mutates nothing, leaves every S1–S30 output and the `to_latex()` fixed
+point unchanged.
+
+### single-integer total of the unresolved (dangling) citations (LTXDOC03 S32)
+
+The decimal **COUNT** of the unresolved (dangling) `\cite` keys — the ones **no** `\bibitem` defines — as one
+integer line. It is the **count-total companion of S17's** `unresolved_citations_by_source` (which renders
+the dangling keys *grouped by their source `\cite`*): S17 and S32 are two *views* of the one `unresolved`
+list `resolve_citations()` produces; S32 collapses the whole list to a single `.len()` tally. It is the exact
+unresolved-**citation-side twin of S27's** `unresolved_reference_count`, and the **dangling sibling of S31's**
+resolved `citation_count`. Together S31 and S32 **partition** every per-key `\cite` record —
+`citation_count + unresolved_citation_count` is exactly the number of cited keys, because
+`resolve_citations()` routes each key into exactly one of `resolved`/`unresolved`. `unresolved_citation_count`
+reads only `resolve_citations().unresolved.len()` — a resolved `\cite{a}` lives in `resolved` (S15/S31's
+domain) and is excluded by construction — never a `cite_span`/dangling `key`, no source slicing at all, so
+every dangling key folds into one total.
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}See \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\bibitem{c} C.\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.unresolved_citation_count(),
+    // one key dangles (`ghost`); the three resolved keys `a`, `b`, `c` are excluded (they are S31's "3")
+    "1",
+);
+```
+
+Being a COUNT renderer, a document with no dangling citations at all (every cited key resolving, or none at
+all) renders the honest number `"0"` — **not** a `(no unresolved citations)` marker (that discipline belongs
+to the *list* renderer S17, whose empty case has no lines to show; this mirrors S27/S28/S29/S30/S31). Purely
+additive — reuses `resolve_citations`, mutates nothing, leaves every S1–S31 output and the `to_latex()` fixed
 point unchanged.
 
 ## Usage

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -3063,6 +3063,77 @@ impl Document {
         // into a single total, the resolved-citation-side twin of S28's resolved-reference count.
         self.resolve_citations().resolved.len().to_string()
     }
+
+    /// The **single-integer TOTAL of the unresolved (dangling) citations** (LTXDOC03 S32) — the exact
+    /// **citation-side** twin of S27's [`unresolved_reference_count`](Document::unresolved_reference_count),
+    /// and the **dangling sibling** of S31's resolved-citation total
+    /// [`citation_count`](Document::citation_count).
+    ///
+    /// This closes the totals family over the citation family the way S27/S28 close it over the
+    /// reference family. S27's [`unresolved_reference_count`](Document::unresolved_reference_count) counts
+    /// the *dangling* `\ref`s and S28's [`resolved_reference_count`](Document::resolved_reference_count)
+    /// the *resolved* ones; on the citation side S31's [`citation_count`](Document::citation_count) counts
+    /// the *resolved* `\cite` keys and S32 counts the *dangling* ones. Together S31 and S32 **partition**
+    /// every per-key `\cite` record S2 produced: `citation_count + unresolved_citation_count` is exactly
+    /// the number of citation keys in the body, because [`Document::resolve_citations`] routes each key
+    /// into exactly one of `resolved` or `unresolved`. S32 is to S17's
+    /// [`unresolved_citations_by_source`](Document::unresolved_citations_by_source) exactly what S27 is to
+    /// S18's per-source dangling-reference list: a numeric summary over the *same* list — here the
+    /// **dangling** `\cite` keys — so a reader sees "how many citations dangle" without scanning the keys.
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] walks every `\cite` in body pre-order and splits its keys (a
+    /// multi-key `\cite{a,b}` yields one record per key) into the **resolved** citations — those a
+    /// `\bibitem` defines ([`CitationResolution::resolved`], S15's domain) — and the **unresolved**
+    /// (dangling) ones ([`CitationResolution::unresolved`] as [`UnresolvedCite`]s, S17's domain). S17
+    /// renders that `unresolved` list grouped by source `\cite`; S32 collapses the whole list to a
+    /// **single count line** — the decimal `.len()` of `unresolved`. It reads only the length, never a
+    /// `cite_span` or a dangling `key`, so every unresolved key — regardless of which `\cite` it came
+    /// from — folds into one total. Only the **dangling** keys are counted; a resolved `\cite{a}` lives
+    /// in [`CitationResolution::resolved`] (S15/S31), never in `unresolved`, so it is excluded by
+    /// construction.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`CitationResolution::unresolved`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no dangling citations is the number `0` — the string `"0"`, **not** a
+    /// `(no unresolved citations)` marker (a total count of zero *is* a number; the `(no …)` marker
+    /// discipline belongs to the *list* renderer S17, whose empty case has no lines to show). This
+    /// mirrors S27/S28/S29/S30/S31 exactly, which emit `"0"` for their empty lists. There is no source
+    /// slicing — only `.len()` is taken.
+    ///
+    /// Concretely, for a body `\cite{a,b}` (both defined) then `\cite{c,ghost}` (only `c` defined),
+    /// against a bibliography defining `a`, `b`, `c`:
+    ///
+    /// ```text
+    /// 1
+    /// ```
+    ///
+    /// (one key dangles — `ghost`; the three resolved keys `a`, `b`, `c` are excluded, and are the "3"
+    /// S31 reports). A document with no dangling citations — every cited key resolves, or none at all —
+    /// returns `"0"`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S32 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1–S31 output (they are byte-for-byte unchanged) and leaves the
+    /// `to_latex` round-trip fixed point intact. It is a *second view* of the same `unresolved` list S17
+    /// renders per-source — counting never adds, drops, or reorders the dangling citations relative to
+    /// what `resolve_citations` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read); a single read of the already-bounded `unresolved` list's length. Borrows
+    /// `self` immutably and returns owned `String` data, so the result outlives any borrow of the
+    /// source.
+    pub fn unresolved_citation_count(&self) -> String {
+        // S2 already flattened every `\cite` into per-key records, routing the ones NO `\bibitem`
+        // defines into `unresolved` (in body pre-order; the resolved keys went to `resolved`, S15/S31).
+        // We only read that list's length. No `cite_span`/`key` is read — every dangling key folds into
+        // a single total, the unresolved-citation-side twin of S27's unresolved-reference count.
+        self.resolve_citations().unresolved.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -7624,5 +7695,134 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         // And S31 itself: exactly THREE citation keys resolve (`a`, `b`, `c`); the one dangling `ghost`
         // is in `unresolved` (S17), not counted here.
         assert_eq!(doc.citation_count(), "3");
+    }
+
+    // LTXDOC03 S32 — single-integer TOTAL of the unresolved (dangling) citations
+    // (`unresolved_citation_count`). The exact unresolved-CITATION-side twin of S27's
+    // `unresolved_reference_count`, and the dangling sibling of S31's resolved `citation_count`: one
+    // decimal line = `.len()` of the SAME dangling `\cite`-key list S17's `unresolved_citations_by_source`
+    // renders grouped by source. S31 + S32 PARTITION every per-key `\cite` record (each key routes to
+    // exactly one of `resolved`/`unresolved`). Being a COUNT renderer, its empty value is the honest
+    // number "0", NOT a `(no …)` marker. A resolved `\cite{a}` is in `resolved` (S15/S31), never
+    // `unresolved`, so it is excluded.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s32_multiple_dangling_citations_count_the_integer() {
+        // `\cite{ghost, phantom}` then `\cite{spook}` against a bibliography defining only `real` →
+        // three keys dangle, so the count is exactly "3".
+        let src = r"\begin{document}See \cite{ghost, phantom} and \cite{spook}.
+\begin{thebibliography}{9}\bibitem{real} R.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citation_count(), "3");
+    }
+
+    #[test]
+    fn s32_one_dangling_citation_counts_one() {
+        // A single dangling `\cite{ghost}` (no matching `\bibitem`) → "1".
+        let src = r"\begin{document}See \cite{ghost}.
+\begin{thebibliography}{9}\bibitem{real} R.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citation_count(), "1");
+    }
+
+    #[test]
+    fn s32_resolved_citation_excluded_from_count() {
+        // `\cite{a, ghost}`: `a` is defined (resolves, S15/S31's domain), `ghost` is not (dangles). Only
+        // the ONE dangling key is counted; the resolved `a` is excluded by construction.
+        let src = r"\begin{document}See \cite{a, ghost}.
+\begin{thebibliography}{9}\bibitem{a} A.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citation_count(), "1");
+    }
+
+    #[test]
+    fn s32_no_dangling_citations_counts_zero() {
+        // A document with NO `\cite` at all → "0" (the count of an empty `unresolved` list). A COUNT
+        // renderer's honest value for an empty list is the number "0", never a `(no …)` marker.
+        let src = r"\begin{document}Just some text with no citations.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citation_count(), "0");
+        // And S17 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(doc.unresolved_citations_by_source(), "(no unresolved citations)");
+    }
+
+    #[test]
+    fn s32_every_citation_resolved_counts_zero() {
+        // Every cited key resolves (a matching `\bibitem` for each) → all go to `resolved` (S15/S31), so
+        // the dangling-citation count is "0", the same honest-zero as the "no `\cite` at all" case.
+        let src = r"\begin{document}See \cite{a, b}.
+\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citation_count(), "0");
+    }
+
+    #[test]
+    fn s32_mixed_partitions_with_s31_over_the_cite_keys() {
+        // `\cite{a,b}` (both defined) then `\cite{c,ghost}` (only `c` defined) → `a`,`b`,`c` resolve
+        // (three) and `ghost` dangles (one). S32 counts the dangling ONE; and S31 + S32 partition the
+        // four total keys — proving each `\cite` key routes to exactly one of `resolved`/`unresolved`.
+        let src = r"\begin{document}See \cite{a,b} then \cite{c,ghost}.
+\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\bibitem{c} C.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.unresolved_citation_count(), "1");
+        // S31 still reports the three resolved keys — unchanged by S32.
+        assert_eq!(doc.citation_count(), "3");
+        // The two totals partition all four cited keys.
+        let resolved: usize = doc.citation_count().parse().unwrap();
+        let dangling: usize = doc.unresolved_citation_count().parse().unwrap();
+        assert_eq!(resolved + dangling, 4);
+    }
+
+    #[test]
+    fn s32_is_additive_leaves_s1_s31_outputs_unchanged() {
+        // Same representative doc as the S31 additive test. S32 changes NONE of the S1-S31 outputs — it
+        // only reads `resolve_citations`. Its count is a second view of the SAME `unresolved` list S17
+        // renders per-source; pinned here alongside S27/S28/S29/S30/S31 to show S32 neither adds, drops,
+        // nor reorders. The body cites `\cite{a,b}` and `\cite{c,ghost}` against a bibliography defining
+        // a, b, c — so `a`, `b`, `c` resolve (three) and `ghost` dangles (one).
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A couple of representative earlier *list* renderers — byte-for-byte unchanged.
+        // S19 flat winning bibliography entries (three distinct keys; the later `\bibitem{a}` loses).
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S22 flat winning label definitions (four distinct keys, first-definition-wins on `dup`).
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+
+        // Prior totals-family renderers — byte-for-byte unchanged.
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // S28 resolved-reference count — exactly two (`\ref{sec:intro}`, `\eqref{eq:e}`).
+        assert_eq!(doc.resolved_reference_count(), "2");
+        // S29 label-definition count — exactly four distinct label keys.
+        assert_eq!(doc.label_definition_count(), "4");
+        // S30 bibliography-entry count — exactly three distinct `\bibitem` keys (`a`, `b`, `c`).
+        assert_eq!(doc.bibliography_entry_count(), "3");
+        // S31 resolved-citation count — exactly three keys resolve (`a`, `b`, `c`).
+        assert_eq!(doc.citation_count(), "3");
+
+        // And S32 itself: exactly ONE citation key dangles (`ghost`); the three resolved keys `a`, `b`,
+        // `c` are in `resolved` (S15/S31), not counted here.
+        assert_eq!(doc.unresolved_citation_count(), "1");
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2550,3 +2550,78 @@ the prior totals-family renderers — S27's `unresolved_reference_count`, S28's 
 S29's `label_definition_count`, and S30's `bibliography_entry_count` — all still produce their exact prior
 strings, with S31 returning `"3"` for `\cite{a,b}` plus `\cite{c,ghost}`). All prior S1–S30 tests pass
 unchanged. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 38. S32 — single-integer total of the unresolved (dangling) citations (`unresolved_citation_count`)
+
+### 38.1 Motivation
+
+S17 (`unresolved_citations_by_source`) enumerates the **unresolved** (dangling) citations — the `\cite` keys
+**no** `\bibitem` defines — grouped by their source `\cite`. But a reader often wants not the enumeration but
+the **total** — "how many citations dangle in this document?" — a single number answered at a glance, without
+scanning the individual keys. S27 (`unresolved_reference_count`) gave that single-total discipline to the
+*dangling* side of the reference family, and S31 (`citation_count`) gave it to the *resolved* side of the
+citation family; S32 is the exact unresolved-**citation-side twin** of S27, and the **dangling sibling** of
+S31, closing the totals family over the citation family: it collapses the whole `unresolved` list to its
+decimal `.len()`. Where S27 counts the dangling references, S32 counts the dangling citations. Together S31
+and S32 **partition** every per-key `\cite` record — the resolved count plus the dangling count equals the
+total number of cited keys, because S2's `resolve_citations` routes each key into exactly one of
+`resolved`/`unresolved`.
+
+### 38.2 Why a new method — additive by construction
+
+S32 adds a **new public method** `Document::unresolved_citation_count(&self) -> String`. It is a pure,
+read-only render of `resolve_citations().unresolved.len()` — a *second view* of the exact list S17 renders
+per-source. It reuses that list verbatim (never re-walking the body or re-resolving), so the report can never
+drift from the S2 resolution it summarises, and counting never adds, drops, or reorders citations relative to
+what `resolve_citations` produced. It mutates nothing and changes no S1–S31 output — including `to_latex()`'s
+round-trip fixed point — byte-for-byte. Like S11–S31 it is a method the caller invokes directly.
+
+### 38.3 The rendering rule
+
+The output is the decimal `.len()` of the `unresolved` list, rendered as its `String`, **always** on a single
+line with **no** trailing newline. There is no ordering question (a single integer has no order) — only
+`.len()` is read, with **no** source slicing at all. Being a **count** renderer, its empty case is the honest
+number `"0"` — **not** a `(no unresolved citations)` marker, mirroring S27/S28/S29/S30/S31 exactly. The
+`(no …)` marker discipline belongs to the *list* renderer S17, whose empty case has no lines to show; a total
+count of zero *is* a number, so `"0"` is its truthful value.
+
+### 38.4 The exact rendering contract — `Document::unresolved_citation_count(&self) -> String`
+
+- Read `resolve_citations().unresolved.len()` and render it with `.to_string()` → the decimal count, one
+  line, no trailing newline. There is **no** source slicing at all, so the render needs no source borrow and
+  can never index out of bounds.
+- Only the **dangling** keys are counted. A resolved `\cite{a}` (a matching `\bibitem` defines it) lives in
+  `resolve_citations().resolved` (S15/S31's domain), never in `unresolved`, so it is excluded by
+  construction. A multi-key `\cite{a,b}` contributes one record per dangling key; the `cite_span` and the
+  dangling `key` are never read.
+- The empty case (every cited key resolving, or no `\cite` at all) returns the honest number `"0"` — **not** a
+  `(no unresolved citations)` marker, because S32 is a count renderer (mirroring S27/S28/S29/S30/S31).
+
+Example (a body `\cite{a,b}` (both defined) then `\cite{c,ghost}` (only `c` defined), against a bibliography
+defining `a`, `b`, `c`):
+
+```text
+1
+```
+
+One key dangles (`ghost`); the three resolved keys `a`, `b`, `c` are excluded (they are the `3` S31 reports).
+This is the count-total companion of S17's per-source list — a second view of the one `unresolved` list.
+
+### 38.5 Public API (added in S32)
+
+One new method: `Document::unresolved_citation_count(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_citations` and every S1–S31 method are unchanged; no AST or grammar change; no
+new dependency, no `unsafe`, no I/O.
+
+### 38.6 Verification (S32)
+
+`cargo test -p latex` green (7 new S32 tests: a multiple-dangling case returning `"3"`; a single-dangling
+case returning `"1"`; a mixed-key case where `\cite{a, ghost}` counts only the one dangling key `"1"` (the
+resolved `a` excluded, S15/S31's domain); a no-citations case returning `"0"` (cross-checked against S17's
+`(no unresolved citations)` marker); an every-key-resolving case returning `"0"`; a partition check that S31
++ S32 sum to the total cited keys; and an additivity check that the prior totals-family renderers — S27's
+`unresolved_reference_count`, S28's `resolved_reference_count`, S29's `label_definition_count`, S30's
+`bibliography_entry_count`, and S31's `citation_count` — together with two representative earlier *list*
+renderers (S19's `bibliography_entries` and S22's `label_definitions`) all still produce their exact prior
+strings, with S32 returning `"1"` for `\cite{a,b}` plus `\cite{c,ghost}`). All prior S1–S31 tests pass
+unchanged. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S32 — `unresolved_citation_count` (dangling `\cite` total)

Adds the next read-only `String` renderer slice to the `latex` crate: **S32 `unresolved_citation_count`**, the dangling-`\cite` total — the citation keys that did **not** resolve to a `\bibitem` (the "undefined" warnings). It completes the **unresolved axis for citations**.

```rust
pub fn unresolved_citation_count(&self) -> String {
    self.resolve_citations().unresolved.len().to_string()
}
```

### Where it sits in the totals family
| slice | renderer | counts |
|-------|----------|--------|
| S27 | `unresolved_reference_count` | dangling `\ref`/`\eqref` |
| S28 | `resolved_reference_count` | resolved `\ref` |
| S29 | `label_definition_count` | `\label` defs |
| S30 | `bibliography_entry_count` | `\bibitem` entries |
| S31 | `citation_count` | **resolved** `\cite` keys |
| **S32** | **`unresolved_citation_count`** | **dangling `\cite` keys** |

S32 is the unresolved-citation-side **twin of S27** and the dangling **sibling of S31**: **S31 (resolved) + S32 (unresolved) partition every per-key `\cite` record.** It reads only `resolve_citations().unresolved.len()`, reusing the citation-resolution pass the crate already runs (S2/S17/S31) — no new recursion or re-parse. The zero case emits `"0"` (mirroring S27–S31 count renderers, not a `(no …)` marker). Total & panic-free (no `unwrap`/`expect`, no indexing, only `.len()`), borrows `&self` immutably, returns owned `String`.

### Purely additive
S1–S31 outputs are **byte-for-byte unchanged** — proven by a dedicated additivity/regression test that pins the S19/S22 list renderers and the S27–S31 totals family byte-for-byte while S32 returns its value.

### Tests (7)
- multiple / one dangling `\cite` → the integer
- resolved citation excluded from the count
- two zero-cases: every citation resolved, and no `\cite` at all → `"0"`
- an **S31+S32 partition** check over the cite keys (resolved + unresolved = total)
- the **additivity** test above

### Verification (all from the worktree `code/packages/rust`)
- `cargo test -p latex` → **479 passed** (+1 doctest)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green
- `cargo build -p latex --no-default-features` → compiles
- Inline security review → **PASSED**

Bumps latex `0.67.0` → `0.68.0`; updates CHANGELOG.md, README.md, and the LTXDOC03 spec (appends §38 for S32; prior sections byte-for-byte unchanged). Exactly 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
