### PR TITLE
fix(directed_graph_native): add missing build wiring so CI builds/tests it

### DIFF
--- a/code/packages/ruby/directed_graph_native/BUILD
+++ b/code/packages/ruby/directed_graph_native/BUILD
@@ -1,0 +1,1 @@
+bundle install --quiet && bundle exec rake compile && bundle exec rake test

--- a/code/packages/ruby/directed_graph_native/CHANGELOG.md
+++ b/code/packages/ruby/directed_graph_native/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to `coding_adventures_directed_graph_native` will be
 documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Package is now built and tested by the repo build tool. Added the build
+  infrastructure that every other Ruby native extension already ships and
+  that this package was missing:
+  - `ext/directed_graph_native/build.rs` — emits the platform link flags a
+    Ruby `cdylib` needs (`-undefined dynamic_lookup` on macOS; a synthesized
+    MSVC import library on Windows). Without it the extension failed to link
+    on macOS.
+  - `BUILD` — `bundle install && rake compile && rake test`, so the build
+    tool actually compiles and exercises the extension instead of skipping it.
+  - `Gemfile` — required by the `bundle install` step in `BUILD`.
+  - Brings the package in line with its sibling `graph_native` and the ten
+    other Ruby native extensions.
+
 ## [0.1.0] - 2026-03-21
 
 ### Added

--- a/code/packages/ruby/directed_graph_native/Gemfile
+++ b/code/packages/ruby/directed_graph_native/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/code/packages/ruby/directed_graph_native/ext/directed_graph_native/build.rs
+++ b/code/packages/ruby/directed_graph_native/ext/directed_graph_native/build.rs
@@ -1,0 +1,178 @@
+// build.rs -- Link configuration for the Ruby native extension
+// ============================================================
+//
+// A Ruby C extension is a `cdylib` that calls `rb_*` functions exported by the
+// running interpreter. Those symbols are **not** available at link time — they
+// only exist inside the `ruby` process that will later `require` this library.
+// Each platform needs a different nudge to accept that:
+//
+//   - macOS: the Mach-O linker rejects undefined symbols by default. We pass
+//     `-undefined dynamic_lookup` so `rb_*` symbols are resolved lazily when
+//     Ruby loads the bundle. Without this, `cargo build` fails to link.
+//     (See lessons.md: "N-API cdylib link flags must come from the cdylib
+//     crate's own build.rs" — the same rule applies to Ruby extensions.)
+//
+//   - Windows (MSVC): the linker needs an import library for `libruby`. We
+//     synthesize one from a `.def` listing the `rb_*` symbols we call, using
+//     `lib.exe`, and fall back to `/FORCE:UNRESOLVED` if that is unavailable.
+//
+//   - Linux/other ELF: undefined symbols in a shared object are allowed by
+//     default, so no special flags are required.
+//
+// This file is intentionally identical in spirit to the sibling
+// `graph_native` extension's build script — the linking problem is the same
+// for every ruby-bridge extension.
+
+use std::path::PathBuf;
+
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    match target_os.as_str() {
+        "macos" => {
+            println!("cargo:rustc-cdylib-link-arg=-undefined");
+            println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        }
+        "windows" => {
+            if let Some(ruby) = find_ruby() {
+                if let (Some(bin_dir), Some(lib_dir), Some(so_name)) = (
+                    get_ruby_config(&ruby, "bindir"),
+                    get_ruby_config(&ruby, "libdir"),
+                    get_ruby_config(&ruby, "RUBY_SO_NAME"),
+                ) {
+                    let out_dir = std::env::var("OUT_DIR").unwrap();
+                    let dll_name = format!("{}.dll", so_name);
+
+                    println!("cargo:rustc-link-search=native={}", lib_dir);
+                    println!("cargo:rustc-link-search=native={}", bin_dir);
+
+                    if generate_msvc_lib(&dll_name, &so_name, &out_dir) {
+                        println!("cargo:rustc-link-search=native={}", out_dir);
+                        println!("cargo:rustc-link-lib={}", so_name);
+                    } else {
+                        println!("cargo:rustc-link-lib=dylib={}", so_name);
+                    }
+
+                    println!("cargo:rustc-cdylib-link-arg=/FORCE:UNRESOLVED");
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Build an MSVC import library (`.lib`) from a `.def` that lists the exact
+/// `rb_*` symbols this extension references. Returns `true` on success.
+fn generate_msvc_lib(dll_name: &str, so_name: &str, out_dir: &str) -> bool {
+    // Data symbols (Ruby's well-known class/exception globals) must be marked
+    // `DATA` in the `.def`; everything else is a function.
+    let symbols: &[(&str, bool)] = &[
+        ("rb_define_module", false),
+        ("rb_define_module_under", false),
+        ("rb_define_class_under", false),
+        ("rb_define_method", false),
+        ("rb_define_module_function", false),
+        ("rb_define_alloc_func", false),
+        ("rb_path2class", false),
+        ("rb_utf8_str_new", false),
+        ("rb_str_new", false),
+        ("rb_string_value_cstr", false),
+        ("rb_string_value_ptr", false),
+        ("rb_ary_new", false),
+        ("rb_ary_push", false),
+        ("rb_ary_entry", false),
+        ("rb_intern", false),
+        ("rb_funcallv", false),
+        ("rb_num2long", false),
+        ("rb_int2inum", false),
+        ("rb_float_new", false),
+        ("rb_num2dbl", false),
+        ("rb_hash_new", false),
+        ("rb_hash_aset", false),
+        ("rb_data_object_wrap", false),
+        ("rb_raise", false),
+        ("rb_str_strlen", false),
+        ("rb_eval_string", false),
+        ("rb_cObject", true),
+        ("rb_eStandardError", true),
+        ("rb_eArgError", true),
+        ("rb_eRuntimeError", true),
+    ];
+
+    let def_path = PathBuf::from(out_dir).join(format!("{}.def", so_name));
+    let mut def_content = format!("LIBRARY {}\nEXPORTS\n", dll_name);
+    for (sym, is_data) in symbols {
+        if *is_data {
+            def_content.push_str(&format!("    {} DATA\n", sym));
+        } else {
+            def_content.push_str(&format!("    {}\n", sym));
+        }
+    }
+    if std::fs::write(&def_path, &def_content).is_err() {
+        return false;
+    }
+
+    let lib_path = PathBuf::from(out_dir).join(format!("{}.lib", so_name));
+
+    for command in ["lib.exe", "lib"] {
+        if let Ok(output) = std::process::Command::new(command)
+            .args([
+                &format!("/def:{}", def_path.display()),
+                &format!("/out:{}", lib_path.display()),
+                "/machine:x64",
+                "/nologo",
+            ])
+            .output()
+        {
+            if output.status.success() && lib_path.exists() {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Read a value out of the target Ruby's `RbConfig::CONFIG` table.
+fn get_ruby_config(ruby: &str, key: &str) -> Option<String> {
+    let script = format!("require 'rbconfig'; print RbConfig::CONFIG['{}']", key);
+    let output = std::process::Command::new(ruby)
+        .args(["-e", &script])
+        .output()
+        .ok()?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+/// Locate the `ruby` executable on `PATH` (via `where` on Windows, `which`
+/// elsewhere).
+fn find_ruby() -> Option<String> {
+    for name in ["ruby"] {
+        if let Ok(output) = std::process::Command::new("where").arg(name).output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+        if let Ok(output) = std::process::Command::new("which").arg(name).output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Summary

While taking a repo-wide inventory toward porting the Rust ecosystem to every language and exposing the Rust cores over FFI, I found that the **`directed_graph_native`** Ruby extension — a Rust-backed binding of the `directed-graph` crate via `ruby-bridge` — was fully implemented but **missing its build infrastructure**. As a result the repo build tool skipped it, so it never compiled or ran its tests in CI.

It was the **single outlier** among 12 Ruby `*_native` packages: every sibling (`graph_native`, `bitset_native`, `polynomial_native`, …) already ships `BUILD` + `build.rs` + `Gemfile`; this one shipped none of them.

## Changes

- **`ext/directed_graph_native/build.rs`** — emits the platform link flags a Ruby `cdylib` requires: `-undefined dynamic_lookup` on macOS (without it the extension fails to link because `rb_*` symbols resolve only inside the host `ruby` process), and a synthesized MSVC import library on Windows. Copied in spirit from the green `graph_native` sibling. Aligns with the lessons.md rule that cdylib link flags must come from the crate's own `build.rs`.
- **`BUILD`** — `bundle install --quiet && bundle exec rake compile && bundle exec rake test`, so the build tool actually compiles and exercises the extension.
- **`Gemfile`** — required by the `bundle install` step.
- **`CHANGELOG.md`** — records the fix.

No changes to the existing Rust binding or tests — this is purely the build wiring that was missing.

## Verification

- `cargo check --release` compiles the binding cleanly against the current `ruby-bridge` and `directed-graph` crates (no API drift).
- Full compile + `rake test` is CI's job (no Ruby toolchain in the authoring environment), exactly as for the other Ruby native extensions.
- Security review passed (no vulnerabilities): the `build.rs` spawns processes only with fixed program names + hardcoded args and reads config solely from the local trusted Ruby toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)