### PR TITLE
feat(sir-runtime-oop): Array rotate / zip (Python parity, v0.1.15)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.15] - 2026-07-07
+
+### Added — Array reorder/combine methods: `rotate` / `zip`
+
+Closes the parity gap with the Go/Rust runtimes (which already carry these) by
+adding two more non-block Ruby Array methods to `_array_method` and the
+`_ARRAY_METHODS` `respond_to?` catalog:
+
+- `rotate(n=1)` — rotate left by `n` (a negative `n` rotates right); the modulo
+  wraps so any magnitude terminates, and an empty array stays `[]`. No argument
+  defaults to `1`; a non-numeric argument degrades to `0` (never raises).
+- `zip(*others)` — an Array of tuples `[self[i], others..[i]]` of length
+  `len(self)`; a shorter operand pads with `nil` (`None`), a longer one is
+  truncated, and a non-array operand is treated as empty (pad-only).
+
 ## [0.1.14] - 2026-07-07
 
 ### Added — Array slice-selection methods: `take` / `drop` / `values_at`

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -65,7 +65,7 @@ The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
-`take`/`drop`/`values_at` — and the
+`take`/`drop`/`values_at`, `rotate`/`zip` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`, plus the **Kernel
 flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.14"
+version = "0.1.15"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -574,6 +574,8 @@ _ARRAY_METHODS = frozenset(
         "take",
         "drop",
         "values_at",
+        "rotate",
+        "zip",
     }
 )
 
@@ -986,6 +988,34 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
                 idx += length
             out.append(recv[idx] if 0 <= idx < length else None)
         return out
+    if name == "rotate":
+        # Ruby ``Array#rotate(n=1)``: rotate left by ``n`` (a negative ``n`` rotates
+        # right).  The modulo wraps so any ``n`` terminates; an empty array is ``[]``.
+        # No arg defaults to 1; a non-numeric arg degrades to 0 (never raises),
+        # matching the Go/Rust runtimes.
+        length = len(recv)
+        if length == 0:
+            return []
+        if not args:
+            n = 1
+        elif isinstance(args[0], (int, float)):
+            n = int(args[0])
+        else:
+            n = 0
+        shift = n % length  # Python ``%`` folds negatives into ``[0, length)``
+        return recv[shift:] + recv[:shift]
+    if name == "zip":
+        # Ruby ``Array#zip(*others)``: an Array of tuples ``[self[i], others..[i]]``
+        # of length ``len(self)``.  A shorter operand pads with ``nil`` (``None``);
+        # a non-array operand is treated as empty (pad-only), never raising.
+        others = [o if isinstance(o, list) else [] for o in args]
+        zipped: list[Val] = []
+        for i, x in enumerate(recv):
+            row: list[Val] = [x]
+            for o in others:
+                row.append(o[i] if i < len(o) else None)
+            zipped.append(row)
+        return zipped
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -222,6 +222,28 @@ def test_array_values_at_selects_and_folds_negatives() -> None:
     assert oop.call_method([10, 20, 30], "values_at") == []
 
 
+def test_array_rotate_wraps_left_and_right() -> None:
+    # ``rotate(n=1)`` rotates left by ``n``; a negative ``n`` rotates right and the
+    # modulo wraps any magnitude.  Empty array stays empty.
+    assert oop.call_method([1, 2, 3, 4], "rotate") == [2, 3, 4, 1]
+    assert oop.call_method([1, 2, 3, 4], "rotate", 2) == [3, 4, 1, 2]
+    assert oop.call_method([1, 2, 3, 4], "rotate", -1) == [4, 1, 2, 3]
+    assert oop.call_method([1, 2, 3, 4], "rotate", 6) == [3, 4, 1, 2]
+    assert oop.call_method([1, 2, 3], "rotate", 0) == [1, 2, 3]
+    assert oop.call_method([], "rotate", 3) == []
+
+
+def test_array_zip_pads_and_truncates_to_receiver_length() -> None:
+    # ``zip(*others)`` yields one tuple per receiver element; a shorter operand pads
+    # with ``None`` and a longer one is truncated to the receiver length.
+    assert oop.call_method([1, 2, 3], "zip", [4, 5, 6]) == [[1, 4], [2, 5], [3, 6]]
+    assert oop.call_method([1, 2, 3], "zip", [4, 5]) == [[1, 4], [2, 5], [3, None]]
+    assert oop.call_method([1, 2], "zip", [3, 4, 5]) == [[1, 3], [2, 4]]
+    assert oop.call_method([1, 2], "zip", [3, 4], [5, 6]) == [[1, 3, 5], [2, 4, 6]]
+    assert oop.call_method([1, 2], "zip", 99) == [[1, None], [2, None]]
+    assert oop.call_method([1, 2], "zip") == [[1], [2]]
+
+
 def test_array_mutating_push_pop_shift_unshift() -> None:
     a = [1, 2]
     assert oop.call_method(a, "push", 3) == [1, 2, 3]


### PR DESCRIPTION
## What

Closes the parity gap where the **Go & Rust** runtimes already carry `rotate`/`zip` but the **Python** OOP runtime did not. Adds both non-block Ruby Array methods to `_array_method` and the `_ARRAY_METHODS` `respond_to?` catalog, matching the Go reference semantics byte-for-byte.

- **`rotate(n=1)`** — rotate left by `n` (a negative `n` rotates right). Python `%` folds the shift into `[0, len)` so any magnitude terminates; empty array → `[]`; no arg → `1`; a non-numeric arg degrades to `0` (never raises).
- **`zip(*others)`** — an Array of tuples `[self[i], others..[i]]` of length `len(self)`; a shorter operand pads with `nil` (`None`), a longer one is truncated, and a non-array operand is treated as empty (pad-only).

## Discipline

- Explicit literal-name dispatch (no reflection); never-raise floor preserved.

## Verification

- `pytest` — **118 passed**, `oop.py` coverage **97%**. New specs cover wrap (left/right/over-length), zero, empty-array, pad, truncate, multi-operand, and non-array-operand cases.
- `ruff` clean.
- Security review: **PASSED — no vulnerabilities found**.

Bumps `0.1.14 → 0.1.15`; CHANGELOG + README updated.

> Discovered follow-up (not in this PR): the **JS backend** (`semantic-ir-to-javascript`) lags the others on the non-block Array surface (`flatten`/`compact`/`join`/`fetch`/`rotate`/`zip` absent from its `arrayMethod` switch). Tracking for a dedicated catch-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)