### PR TITLE
feat(sir-runtime-oop): Array rotate / zip (TS parity, v0.1.15)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.15] - 2026-07-07
+
+### Added — Array reorder/combine methods: `rotate` / `zip`
+
+Closes the parity gap with the Go/Rust runtimes (which already carry these) by
+adding two more non-block Ruby Array methods to `arrayMethod` and the
+`ARRAY_METHODS` `respond_to?` catalog:
+
+- `rotate(n=1)` — rotate left by `n` (a negative `n` rotates right); the shift is
+  re-folded into `[0, len)` (JS `%` keeps the dividend's sign) so any magnitude
+  terminates, and an empty array stays `[]`. No argument defaults to `1`; a
+  non-numeric argument degrades to `0` (never raises).
+- `zip(*others)` — an Array of tuples `[self[i], others..[i]]` of length
+  `recv.length`; a shorter operand pads with `nil` (`null`), a longer one is
+  truncated, and a non-array operand is treated as empty (pad-only).
+
 ## [0.1.14] - 2026-07-07
 
 ### Added — Array slice-selection methods: `take` / `drop` / `values_at`

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -63,7 +63,7 @@ The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
-`take`/`drop`/`values_at` — and the
+`take`/`drop`/`values_at`, `rotate`/`zip` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a` (`include?`/`index`/`==` use
 deep value equality), plus the **Kernel flow-control** group

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -553,6 +553,8 @@ const ARRAY_METHODS = new Set<string>([
   "take",
   "drop",
   "values_at",
+  "rotate",
+  "zip",
 ]);
 
 // Block-taking `Array`/`Enumerable` methods (M1b); each invokes a trailing
@@ -974,6 +976,36 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
         out.push(idx >= 0 && idx < recv.length ? recv[idx] : null);
       }
       return out;
+    }
+    case "rotate": {
+      // Ruby `Array#rotate(n=1)`: rotate left by `n` (a negative `n` rotates
+      // right).  The modulo wraps so any magnitude terminates; an empty array is
+      // `[]`.  No arg defaults to 1; a non-numeric arg degrades to 0 — matching
+      // the Go/Rust runtimes.
+      const length = recv.length;
+      if (length === 0) return [];
+      let n = args.length === 0
+        ? 1
+        : typeof args[0] === "number" ? Math.trunc(args[0] as number) : 0;
+      // JS `%` keeps the sign of the dividend, so re-add `length` to fold right
+      // rotations (negative `n`) back into `[0, length)`.
+      const shift = ((n % length) + length) % length;
+      return recv.slice(shift).concat(recv.slice(0, shift));
+    }
+    case "zip": {
+      // Ruby `Array#zip(*others)`: an Array of tuples `[self[i], others..[i]]` of
+      // length `recv.length`.  A shorter operand pads with `nil` (`null`); a
+      // non-array operand is treated as empty (pad-only), never raising.
+      const others: Val[][] = args.map((o) => (Array.isArray(o) ? o : []));
+      const zipped: Val[] = [];
+      for (let i = 0; i < recv.length; i++) {
+        const row: Val[] = [recv[i]];
+        for (const o of others) {
+          row.push(i < o.length ? o[i] : null);
+        }
+        zipped.push(row);
+      }
+      return zipped;
     }
     default:
       return MISS;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -274,6 +274,24 @@ describe("built-in method catalog: non-block Array (M1a)", () => {
     expect(callMethod([10, 20, 30], "values_at", 5, -9)).toEqual([null, null]);
     expect(callMethod([10, 20, 30], "values_at")).toEqual([]);
   });
+
+  it("rotate wraps left (default 1) and right (negative n), any magnitude", () => {
+    expect(callMethod([1, 2, 3, 4], "rotate")).toEqual([2, 3, 4, 1]);
+    expect(callMethod([1, 2, 3, 4], "rotate", 2)).toEqual([3, 4, 1, 2]);
+    expect(callMethod([1, 2, 3, 4], "rotate", -1)).toEqual([4, 1, 2, 3]);
+    expect(callMethod([1, 2, 3, 4], "rotate", 6)).toEqual([3, 4, 1, 2]);
+    expect(callMethod([1, 2, 3], "rotate", 0)).toEqual([1, 2, 3]);
+    expect(callMethod([], "rotate", 3)).toEqual([]);
+  });
+
+  it("zip pads a shorter operand with nil and truncates to receiver length", () => {
+    expect(callMethod([1, 2, 3], "zip", [4, 5, 6])).toEqual([[1, 4], [2, 5], [3, 6]]);
+    expect(callMethod([1, 2, 3], "zip", [4, 5])).toEqual([[1, 4], [2, 5], [3, null]]);
+    expect(callMethod([1, 2], "zip", [3, 4, 5])).toEqual([[1, 3], [2, 4]]);
+    expect(callMethod([1, 2], "zip", [3, 4], [5, 6])).toEqual([[1, 3, 5], [2, 4, 6]]);
+    expect(callMethod([1, 2], "zip", 99)).toEqual([[1, null], [2, null]]);
+    expect(callMethod([1, 2], "zip")).toEqual([[1], [2]]);
+  });
 });
 
 describe("built-in method catalog: universal Object (M1a)", () => {


### PR DESCRIPTION
## What

Closes the parity gap where the **Go & Rust** runtimes already carry `rotate`/`zip` but the **TypeScript** OOP runtime did not. Adds both non-block Ruby Array methods to `arrayMethod` and the `ARRAY_METHODS` `respond_to?` catalog, matching the Go reference semantics byte-for-byte. Companion to the Python parity PR #7856.

- **`rotate(n=1)`** — rotate left by `n` (a negative `n` rotates right). The shift is re-folded into `[0, len)` (JS `%` keeps the dividend's sign) so any magnitude terminates; empty array → `[]`; no arg → `1`; a non-numeric arg degrades to `0` (never raises).
- **`zip(*others)`** — an Array of tuples `[self[i], others..[i]]` of length `recv.length`; a shorter operand pads with `nil` (`null`), a longer one is truncated, and a non-array operand is treated as empty (pad-only).

## Discipline

- Explicit literal-name `switch` dispatch (no reflection); never-raise floor preserved. Writes only into fresh local arrays; numeric-index reads only — no prototype-pollution surface.

## Verification

- `vitest run` — **111 passed** (new specs cover left/right/over-length wrap, zero, empty-array, pad, truncate, multi-operand, non-array-operand).
- New code is `tsc`-clean; the only `tsc` diagnostics are the pre-existing `min_by` strict-null gaps, untouched here.
- Security review: **PASSED — no vulnerabilities found**.

Bumps `0.1.14 → 0.1.15`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)