### PR TITLE
feat(sir-js): non-block Array catch-up — flatten / compact / rotate / zip (v0.21.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.21.0 — non-block Array catch-up: `flatten` / `compact` / `rotate` / `zip`
+
+Closes the JS backend's remaining gap on the reference (Go/Rust/Python/TS)
+non-block Array surface. Adds four methods to the inlined runtime's `arrayMethod`
+switch and the `ARRAY_METHODS` `respond_to?` set — all Ruby-correct and routed
+through the explicit switch (never `recv[name]`):
+
+- `flatten` — fully flattens nested Arrays (`flatten(n)` to depth `n`, a negative
+  `n` meaning no limit). Handled explicitly rather than via the native `flat`
+  alias, so the no-arg form is full-depth (not JS `flat`'s default depth 1). Only
+  Array elements flatten; strings and other values stay intact, matching Ruby.
+- `compact` — a copy with every `nil` (`null`) removed.
+- `rotate(n=1)` — rotate left by `n` (a negative `n` rotates right); the modulo
+  wraps so any magnitude terminates, and an empty array stays `[]`. A non-numeric
+  arg degrades to `0`.
+- `zip(*others)` — an Array of tuples `[self[i], others..[i]]` of length
+  `recv.length`; a shorter operand pads with `nil` (`null`), a longer one is
+  truncated, and a non-array operand is treated as empty (pad-only).
+
+Exec-proven end-to-end under Node.
+
 ## 0.20.0 — slice-selection Array methods: `take` / `drop` / `values_at`
 
 Extends the inlined JS runtime's `arrayMethod` switch (and the `ARRAY_METHODS`

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -956,6 +956,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "partition", "flat_map", "collect_concat", "take_while", "drop_while",
     "each_with_object", "sum", "uniq", "first", "last", "empty?", "to_a",
     "take", "drop", "values_at",
+    "flatten", "compact", "rotate", "zip",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
@@ -1110,6 +1111,45 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           out.push(idx >= 0 && idx < recv.length ? recv[idx] : null);
         }
         return out;
+      }
+      case "flatten": {
+        // Ruby `flatten` fully flattens nested Arrays; `flatten(n)` flattens to
+        // depth `n` (a negative `n` means no limit).  Only Array elements are
+        // flattened — strings and other values stay intact — matching Ruby and
+        // the sibling backends.  (`Array#flat` is deliberately handled here, not
+        // via the native alias, so the no-arg case is full-depth, not depth 1.)
+        let depth = typeof args[0] === "number" ? Math.trunc(args[0]) : Infinity;
+        if (depth < 0) { depth = Infinity; }
+        return recv.flat(depth);
+      }
+      case "compact": {
+        // Ruby `compact` returns a copy with every `nil` (`null`) removed.
+        return recv.filter((x) => x !== null && x !== undefined);
+      }
+      case "rotate": {
+        // `a.rotate(n=1)` — elements rotated left by `n` (a negative `n` rotates
+        // right).  The modulo wraps so any magnitude terminates; an empty array
+        // is `[]`.  No arg defaults to 1; a non-numeric arg degrades to 0.
+        const length = recv.length;
+        if (length === 0) { return []; }
+        const n = args.length === 0
+          ? 1
+          : (typeof args[0] === "number" ? Math.trunc(args[0]) : 0);
+        const shift = ((n % length) + length) % length;
+        return recv.slice(shift).concat(recv.slice(0, shift));
+      }
+      case "zip": {
+        // `a.zip(b, c, ...)` — an Array of tuples `[a[i], b[i], ...]` of length
+        // `a.length`.  A shorter operand pads with `null`; a non-array operand
+        // is treated as empty (pad-only), never raising.
+        const others = args.map((o) => (Array.isArray(o) ? o : []));
+        const zipped = [];
+        for (let i = 0; i < recv.length; i++) {
+          const row = [recv[i]];
+          for (const o of others) { row.push(i < o.length ? o[i] : null); }
+          zipped.push(row);
+        }
+        return zipped;
       }
       case "to_a": return recv;
     }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2331,6 +2331,47 @@ fn array_take_drop_values_at_methods() {
     }
 }
 
+// v0.21.0 non-block Array catch-up: `flatten`, `compact`, `rotate`, `zip` — the
+// last of the reference (Go/Rust/Python/TS) non-block surface the JS backend was
+// missing.  All route through the explicit `arrayMethod` switch (never `recv[name]`
+// and never the depth-1 native `flat`).  Proven end-to-end under Node.
+#[test]
+fn array_flatten_compact_rotate_zip_methods() {
+    let nil = || Expr::NilLit { span: sp() };
+    let stmts = vec![
+        // flatten fully flattens nested Arrays (not the depth-1 native `flat`)
+        print(method(
+            seq(vec![int(1), seq(vec![int(2), seq(vec![int(3)])])]),
+            "flatten",
+            vec![],
+        )), // [1, 2, 3]
+        // compact drops every nil
+        print(method(
+            seq(vec![int(1), nil(), int(2), nil()]),
+            "compact",
+            vec![],
+        )), // [1, 2]
+        // rotate: default 1, explicit 2, negative rotates right
+        print(method(seq(vec![int(1), int(2), int(3), int(4)]), "rotate", vec![])), // [2, 3, 4, 1]
+        print(method(seq(vec![int(1), int(2), int(3), int(4)]), "rotate", vec![int(2)])), // [3, 4, 1, 2]
+        print(method(seq(vec![int(1), int(2), int(3), int(4)]), "rotate", vec![int(-1)])), // [4, 1, 2, 3]
+        // zip pads a shorter operand with nil, keeps receiver length
+        print(method(
+            seq(vec![int(1), int(2), int(3)]),
+            "zip",
+            vec![seq(vec![int(4), int(5)])],
+        )), // [[1, 4], [2, 5], [3, nil]]
+    ];
+    let module =
+        module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Sequences, Feature::Strings]);
+    if let Some(stdout) = run_module(&module, "arrflattenrotate") {
+        assert_eq!(
+            stdout,
+            "[1, 2, 3]\n[1, 2]\n[2, 3, 4, 1]\n[3, 4, 1, 2]\n[4, 1, 2, 3]\n[[1, 4], [2, 5], [3, nil]]"
+        );
+    }
+}
+
 // ── Ruby Hash method catalog (hand-implemented, explicit dispatch) ──
 //
 // Exercises the `hashMethod` catalog end-to-end under Node: `keys`/`values`/


### PR DESCRIPTION
Closes the JS backend's last gap on the reference (Go/Rust/Python/TS) non-block Array surface: adds `flatten`/`compact`/`rotate`/`zip` to the inlined runtime's `arrayMethod` switch + `ARRAY_METHODS` set, routed through the explicit switch (never recv[name]).

- flatten: full-depth flatten (flatten(n) to depth n, negative = no limit); explicit, not the native flat alias.
- compact: copy with every nil (null) removed.
- rotate(n=1): left-rotate by n (negative rotates right); modulo wraps; empty -> []; non-numeric arg -> 0.
- zip(*others): tuples [self[i], others..[i]] of length recv.length; shorter pads with null, longer truncates, non-array treated as empty.

Full crate suite green (109 unit + 69 Node exec-proof incl. new array_flatten_compact_rotate_zip_methods). clippy clean. Security review PASSED. Bump 0.20.0 -> 0.21.0.

Follow-up (tracked): JS native-alias table (include?/join/index) has latent Ruby semantic divergences worth an explicit-case audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)