### PR TITLE
[codex] Add sqlite-file table read API

### DIFF
--- a/code/packages/rust/sqlite-file/CHANGELOG.md
+++ b/code/packages/rust/sqlite-file/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog — sqlite-file
 
+## 0.5.0 - Unreleased
+
+Phase E4: **`sqlite_schema` lookup** and the public **`read_table(bytes, name)`**
+API. Callers no longer need to hand-walk page 1 to find a table root page before
+reading rows.
+
+### Added
+
+- New `schema` module:
+  - `read_schema(bytes)` decodes the five-column `sqlite_schema` rows into
+    `SchemaEntry` values (`type`, `name`, `tbl_name`, `rootpage`, `sql`).
+  - `table_root_page(bytes, name)` resolves a real table name to its root b-tree
+    page and reports `SqliteError::NoSuchTable` for missing tables or views.
+  - `read_table(bytes, name)` opens the pager, resolves the root page, walks the
+    table b-tree, and returns rows as `(rowid, Vec<SqlValue>)` in rowid order.
+- Root-level re-exports for the E4 API, so downstream Engram code can call
+  `sqlite_file::read_table(...)` directly.
+
+### Verified
+
+- New `rusqlite` cross-checks confirm schema roots match SQLite's own
+  `sqlite_schema` view and that `read_table` decodes named-table rows including
+  INTEGER PRIMARY KEY aliases, REAL, BLOB, NULL, and an overflow-chain TEXT row.
+- Full `cargo test --manifest-path code/packages/rust/sqlite-file/Cargo.toml`
+  passes: unit tests, cross-check tests, and doc tests.
+
+### Next
+
+- Phase E5: cut `engram-anki-package`'s V11 collection reader over from
+  `rusqlite` to `sqlite-file::read_table`.
+
 ## 0.4.0 — Unreleased
 
 Phase E3b: **overflow-chain reassembly** and the **full row round-trip gate**.

--- a/code/packages/rust/sqlite-file/Cargo.toml
+++ b/code/packages/rust/sqlite-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-file"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A small, zero-dependency reader for the SQLite on-disk file format — the read subset the Engram Anki-package importer needs — reimplemented from scratch to keep the Engram stack free of the bundled-C `rusqlite` crate."
 license = "MIT"

--- a/code/packages/rust/sqlite-file/README.md
+++ b/code/packages/rust/sqlite-file/README.md
@@ -40,19 +40,20 @@ Built leaf-to-root; this is the foundation:
 | DB header + in-memory pager | `header`, `pager` | ✅ header fields + zero-copy 1-based pages |
 | table b-tree walk (leaf + interior) | `btree` | ✅ `walk_table(root)` → `(rowid, record)` |
 | overflow chains (records spanning pages) | `btree` | ✅ reassembled inline + overflow; cycle/size guarded |
-| `sqlite_schema` + `read_table(bytes, name)` | `schema` | ⏳ Phase E4 |
+| `sqlite_schema` + `read_table(bytes, name)` | `schema` | ✅ read API |
 
 ## Usage
 
 ```rust
-use sqlite_file::record::{decode, SqlValue};
+use sqlite_file::read_table;
 
-// On-disk bytes of the row `(NULL, 42, "hi")`.
-let row = [0x04, 0x00, 0x01, 0x11, 0x2a, 0x68, 0x69];
-assert_eq!(
-    decode(&row).unwrap(),
-    vec![SqlValue::Null, SqlValue::Int(42), SqlValue::Text("hi".into())],
-);
+let rows = read_table(&db_bytes, "notes")?;
+for (rowid, columns) in rows {
+    // INTEGER PRIMARY KEY columns are stored as rowid and appear as NULL in
+    // the record payload; use `rowid` when a table aliases it.
+    println!("{rowid}: {columns:?}");
+}
+# Ok::<(), sqlite_file::SqliteError>(())
 ```
 
 ## Verification

--- a/code/packages/rust/sqlite-file/src/error.rs
+++ b/code/packages/rust/sqlite-file/src/error.rs
@@ -27,6 +27,9 @@ pub enum SqliteError {
     /// implement (named by the `&'static str`) — e.g. a text encoding other
     /// than UTF-8.
     Unsupported(&'static str),
+    /// The caller asked for a table name that does not exist as a real table in
+    /// `sqlite_schema`.
+    NoSuchTable(String),
     /// The bytes are internally inconsistent in a way a well-formed database
     /// never is — a b-tree page of an unexpected type, a cell pointer past the
     /// page, or a page-link cycle. The `&'static str` names what was wrong.
@@ -41,6 +44,7 @@ impl fmt::Display for SqliteError {
             SqliteError::BadPageSize(n) => write!(f, "invalid page size {n}"),
             SqliteError::BadPageNumber(n) => write!(f, "invalid page number {n}"),
             SqliteError::Unsupported(what) => write!(f, "unsupported SQLite feature: {what}"),
+            SqliteError::NoSuchTable(name) => write!(f, "no such table: {name}"),
             SqliteError::Corrupt(what) => write!(f, "corrupt SQLite database: {what}"),
         }
     }

--- a/code/packages/rust/sqlite-file/src/lib.rs
+++ b/code/packages/rust/sqlite-file/src/lib.rs
@@ -31,7 +31,8 @@
 //! 4. **`btree`** — walk a table b-tree (leaf + interior pages) → `(rowid, record
 //!    bytes)`, reassembling overflow chains for records too big for one page.
 //!    *(done)*
-//! 5. `sqlite_schema` + `read_table(bytes, name)` — the public read API. *(next)*
+//! 5. **`sqlite_schema` + `read_table(bytes, name)`** - the public read API.
+//!    *(done)*
 //!
 //! Each layer is cross-checked against the real `rusqlite`/C-SQLite as an
 //! independent oracle (a dev-dependency, never a runtime one) before the Anki
@@ -57,9 +58,11 @@ pub mod error;
 pub mod header;
 pub mod pager;
 pub mod record;
+pub mod schema;
 pub mod varint;
 
 pub use error::SqliteError;
 pub use header::{Header, TextEncoding};
 pub use pager::Pager;
 pub use record::SqlValue;
+pub use schema::{read_schema, read_table, table_root_page, SchemaEntry};

--- a/code/packages/rust/sqlite-file/src/schema.rs
+++ b/code/packages/rust/sqlite-file/src/schema.rs
@@ -1,0 +1,119 @@
+//! `sqlite_schema` lookup and table-by-name reads.
+//!
+//! Low-level callers can use [`crate::btree::walk_table`] directly when they
+//! already know a root page. Most import code, though, starts with a table name:
+//! `col`, `notes`, `cards`, `revlog`, or `graves`. This module is that public
+//! convenience layer. It reads the `sqlite_schema` table rooted on page 1,
+//! resolves a table name to its root page, walks that table b-tree, and decodes
+//! each row into [`SqlValue`] columns.
+
+use crate::btree;
+use crate::error::SqliteError;
+use crate::header::Header;
+use crate::pager::Pager;
+use crate::record::{self, SqlValue};
+
+/// One decoded row from `sqlite_schema`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SchemaEntry {
+    /// Object kind, such as `table`, `index`, `view`, or `trigger`.
+    pub object_type: String,
+    /// Object name.
+    pub name: String,
+    /// Table name this object belongs to.
+    pub table_name: String,
+    /// Root b-tree page for table/index objects. Views/triggers use no root.
+    pub root_page: Option<u32>,
+    /// Original SQL text, if SQLite stored one for this object.
+    pub sql: Option<String>,
+}
+
+/// Decode every row from `sqlite_schema`.
+pub fn read_schema(data: &[u8]) -> Result<Vec<SchemaEntry>, SqliteError> {
+    let (header, pager) = Pager::open(data)?;
+    read_schema_from(&pager, &header)
+}
+
+/// Return the root page for a table named `name`.
+pub fn table_root_page(data: &[u8], name: &str) -> Result<u32, SqliteError> {
+    let (header, pager) = Pager::open(data)?;
+    table_root_page_from(&pager, &header, name)
+}
+
+/// Read a table by name, returning `(rowid, decoded columns)` in rowid order.
+///
+/// For an `INTEGER PRIMARY KEY` column, SQLite stores the primary-key value as
+/// the rowid and leaves that record column as `NULL`; callers should use the
+/// returned rowid when comparing such columns.
+pub fn read_table(data: &[u8], name: &str) -> Result<Vec<(i64, Vec<SqlValue>)>, SqliteError> {
+    let (header, pager) = Pager::open(data)?;
+    let root_page = table_root_page_from(&pager, &header, name)?;
+    let rows = btree::walk_table(&pager, &header, root_page)?;
+    rows.into_iter()
+        .map(|(rowid, record)| {
+            let columns = record::decode(&record).ok_or(SqliteError::Corrupt("bad table row"))?;
+            Ok((rowid, columns))
+        })
+        .collect()
+}
+
+fn read_schema_from(pager: &Pager<'_>, header: &Header) -> Result<Vec<SchemaEntry>, SqliteError> {
+    let rows = btree::walk_table(pager, header, 1)?;
+    rows.into_iter()
+        .map(|(_rowid, record)| decode_schema_row(&record))
+        .collect()
+}
+
+fn table_root_page_from(
+    pager: &Pager<'_>,
+    header: &Header,
+    name: &str,
+) -> Result<u32, SqliteError> {
+    for entry in read_schema_from(pager, header)? {
+        if entry.object_type == "table" && entry.name == name {
+            return entry
+                .root_page
+                .ok_or(SqliteError::Corrupt("table without root page"));
+        }
+    }
+    Err(SqliteError::NoSuchTable(name.to_string()))
+}
+
+fn decode_schema_row(record: &[u8]) -> Result<SchemaEntry, SqliteError> {
+    let columns = record::decode(record).ok_or(SqliteError::Corrupt("bad schema row"))?;
+    if columns.len() != 5 {
+        return Err(SqliteError::Corrupt("bad schema column count"));
+    }
+
+    let object_type = expect_text(&columns[0], "schema type")?;
+    let name = expect_text(&columns[1], "schema name")?;
+    let table_name = expect_text(&columns[2], "schema table name")?;
+    let root_page = match &columns[3] {
+        SqlValue::Null => None,
+        SqlValue::Int(n) if *n == 0 => None,
+        SqlValue::Int(n) => {
+            Some(u32::try_from(*n).map_err(|_| SqliteError::Corrupt("bad schema root page"))?)
+        }
+        _ => return Err(SqliteError::Corrupt("bad schema root page")),
+    };
+    let sql = match &columns[4] {
+        SqlValue::Null => None,
+        SqlValue::Text(s) => Some(s.clone()),
+        _ => return Err(SqliteError::Corrupt("bad schema sql")),
+    };
+
+    Ok(SchemaEntry {
+        object_type,
+        name,
+        table_name,
+        root_page,
+        sql,
+    })
+}
+
+fn expect_text(value: &SqlValue, what: &'static str) -> Result<String, SqliteError> {
+    match value {
+        SqlValue::Text(s) => Ok(s.clone()),
+        _ => Err(SqliteError::Corrupt(what)),
+    }
+}

--- a/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
+++ b/code/packages/rust/sqlite-file/tests/cross_check_reader.rs
@@ -302,3 +302,112 @@ fn rows_round_trip_through_our_reader() {
         "the overflow row must have been reassembled in full"
     );
 }
+
+/// Phase E4: the public schema API should expose the same table root pages the
+/// low-level E3 tests hand-extracted from `sqlite_schema`.
+#[test]
+fn public_schema_api_finds_table_root_pages() {
+    let db = build_sqlite_db(&[
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)",
+        "CREATE TABLE u (x INTEGER, y INTEGER)",
+        "CREATE VIEW v AS SELECT name FROM t",
+        "INSERT INTO t VALUES (1, 'Ada'), (2, 'Grace')",
+        "INSERT INTO u VALUES (10, 20), (30, 40)",
+    ]);
+
+    let schema = sqlite_file::read_schema(&db).expect("schema should decode");
+    assert!(
+        schema.iter().any(|entry| entry.object_type == "table"
+            && entry.name == "t"
+            && entry.table_name == "t"
+            && entry.root_page.is_some()
+            && entry
+                .sql
+                .as_deref()
+                .unwrap_or("")
+                .contains("CREATE TABLE t")),
+        "table t should appear in decoded sqlite_schema"
+    );
+    assert!(
+        schema.iter().any(|entry| entry.object_type == "view"
+            && entry.name == "v"
+            && entry.root_page.is_none()),
+        "view v should appear without a root page"
+    );
+
+    let t_root = sqlite_file::table_root_page(&db, "t").expect("table t root");
+    let u_root = sqlite_file::table_root_page(&db, "u").expect("table u root");
+    assert_ne!(t_root, 0);
+    assert_ne!(u_root, 0);
+
+    static COUNTER4: AtomicU64 = AtomicU64::new(3_000_000);
+    let unique = COUNTER4.fetch_add(1, Ordering::Relaxed);
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "sqlite_file_schema_api_{}_{}",
+        std::process::id(),
+        unique
+    ));
+    std::fs::create_dir(&dir).unwrap();
+    let path = dir.join("oracle.db");
+    std::fs::write(&path, &db).unwrap();
+    let conn = rusqlite::Connection::open(&path).unwrap();
+    let theirs: Vec<(String, i64)> = conn
+        .prepare("SELECT name, rootpage FROM sqlite_schema WHERE type = 'table' ORDER BY name")
+        .unwrap()
+        .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))
+        .unwrap()
+        .map(|r| r.unwrap())
+        .collect();
+    drop(conn);
+    let _ = std::fs::remove_dir_all(&dir);
+
+    assert!(theirs.contains(&("t".to_string(), i64::from(t_root))));
+    assert!(theirs.contains(&("u".to_string(), i64::from(u_root))));
+}
+
+/// Phase E4: callers should be able to read a table by name without knowing how
+/// to walk `sqlite_schema` manually. This also keeps the overflow row gate on
+/// the public API path.
+#[test]
+fn read_table_api_decodes_named_table_rows() {
+    let big = "public api overflow ".repeat(400);
+    assert!(big.len() > 5000, "the large row must exceed one page");
+    let ins2 = format!("INSERT INTO t VALUES (2, '{big}', 2.5, x'cafe', 'kept')");
+    let db = build_sqlite_db(&[
+        "CREATE TABLE t (id INTEGER PRIMARY KEY, body TEXT, score REAL, payload BLOB, note TEXT)",
+        "INSERT INTO t VALUES (1, 'short one', 1.25, x'dead', NULL)",
+        &ins2,
+        "INSERT INTO t VALUES (3, 'short three', NULL, NULL, 'tail')",
+    ]);
+
+    let rows = sqlite_file::read_table(&db, "t").expect("read table t");
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[0].1[0], sqlite_file::SqlValue::Null);
+    assert_eq!(
+        rows[0].1[1],
+        sqlite_file::SqlValue::Text("short one".to_string())
+    );
+    assert_eq!(rows[0].1[2], sqlite_file::SqlValue::Real(1.25));
+    assert_eq!(rows[0].1[3], sqlite_file::SqlValue::Blob(vec![0xde, 0xad]));
+    assert_eq!(rows[0].1[4], sqlite_file::SqlValue::Null);
+
+    assert_eq!(rows[1].0, 2);
+    assert_eq!(rows[1].1[1], sqlite_file::SqlValue::Text(big.clone()));
+    assert_eq!(rows[1].1[2], sqlite_file::SqlValue::Real(2.5));
+    assert_eq!(rows[1].1[3], sqlite_file::SqlValue::Blob(vec![0xca, 0xfe]));
+    assert!(
+        matches!(&rows[2].1[2], sqlite_file::SqlValue::Null),
+        "NULL REAL values should decode as SqlValue::Null"
+    );
+}
+
+#[test]
+fn read_table_reports_missing_tables() {
+    let db = build_sqlite_db(&["CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"]);
+    assert_eq!(
+        sqlite_file::read_table(&db, "missing"),
+        Err(sqlite_file::SqliteError::NoSuchTable("missing".to_string()))
+    );
+}

--- a/code/specs/engram-zero-dep-plan.md
+++ b/code/specs/engram-zero-dep-plan.md
@@ -189,6 +189,9 @@ Per `code/specs/storage-sqlite.md` + the Python `storage-sqlite` port:
 - E5: cut anki-pkg **reader** over (`open_serialized_v11_collection` +
   `read_v11_*`), delete the `ffi`/`OwnedData` unsafe block. M — import runs rusqlite-free.
 
+Status update: E1-E4 are now landed in `sqlite-file`; E5 is the next reader
+milestone and can consume `sqlite_file::read_table(bytes, name)` directly.
+
 ### Phase F — sqlite-file writer (**removes rusqlite**) — L (PRs A6–A8)
 - F1: record/header/b-tree **write** — smallest-serial-type rule, leaf-insert,
   page splits → interior pages, overflow-write for large `col` JSON. L


### PR DESCRIPTION
## Summary
- Add a sqlite_file::schema layer that decodes sqlite_schema, resolves table root pages, and exposes read_table(bytes, name).
- Return decoded (rowid, Vec<SqlValue>) rows and a specific NoSuchTable error for missing table names.
- Extend the rusqlite oracle tests to cover schema roots, typed named-table rows, INTEGER PRIMARY KEY aliases, NULL/REAL/BLOB values, and overflow-chain rows through the public API.
- Update sqlite-file docs/changelog and the Engram zero-dep roadmap so E4 is landed and E5 is next.

## Validation
- cargo fmt --manifest-path code\\packages\\rust\\sqlite-file\\Cargo.toml
- cargo test --manifest-path code\\packages\\rust\\sqlite-file\\Cargo.toml -- --nocapture
- git diff --cached --check

Note: cargo test -p sqlite-file -- --nocapture is not available from this checkout root because there is no root Cargo.toml; the manifest-path test is the local gate.