### PR TITLE
[codex] Build authoritative package parity inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           go-version: '1.23'
 
+      - name: Test package parity reporter
+        run: |
+          python3 -m unittest discover -s scripts/tests -p 'test_package_parity_report.py'
+          python3 scripts/package_parity_report.py --format json > /tmp/package-parity-report.json
+
       - name: Determine diff base
         id: diff-base
         shell: bash

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -2,286 +2,307 @@
 
 ## Goal
 
-Close package gaps intelligently across language buckets without pretending
-that directory equality is the same as useful parity.
+Close package gaps across implementation languages without confusing directory
+equality with useful parity. Every deterministic, language-agnostic package
+should have a pure implementation in each established language when practical.
+Platform, ABI, browser, firmware, and accelerator packages should instead have
+honest native implementations or thin tested wrappers.
 
-The repo should aim for portable API parity where a package is naturally
-language-agnostic, and for honest native or web specialization where the
-package is tied to a runtime, operating system, browser API, or FFI boundary.
+This roadmap is the durable work queue for the autonomous package-parity PR
+loop. It is ordered by leverage: repair the inventory, finish nearly complete
+families, then classify and port sparse families in dependency-shaped waves.
 
-## Current Baseline
+## Canonical Inventory
 
-The most useful baseline today is not "everything everywhere." It is:
-
-- **Portable core:** packages present in both Rust and Python.
-- **Native source of truth:** Rust packages that expose platform, FFI, graphics,
-  runtime, or C ABI behavior.
-- **Python prototyping/runtime lane:** Python packages that carry language
-  runtime experiments, compiler tracks, and native-wrapper facades.
-- **Web lane:** TypeScript and WASM packages that depend on browser, DOM,
-  Canvas, IndexedDB, Vite, or Web Audio behavior.
-
-After normalizing folder naming conventions, the current inventory is:
-
-| Baseline | Count |
-|---|---:|
-| All normalized package names, excluding Starlark | 540 |
-| Rust/Python union | 493 |
-| Rust/Python shared core | 261 |
-| Rust packages | 377 |
-| Python packages | 377 |
-| Rust-only packages | 116 |
-| Python-only packages | 116 |
-| Packages outside Rust/Python | 47 |
-
-Core parity coverage against the Rust/Python shared core:
-
-| Language | Missing Core | Coverage |
-|---|---:|---:|
-| TypeScript | 19 | 92.7% |
-| Go | 23 | 91.2% |
-| Ruby | 23 | 91.2% |
-| Elixir | 32 | 87.7% |
-| Perl | 56 | 78.5% |
-| Lua | 57 | 78.2% |
-| Swift | 136 | 47.9% |
-| Haskell | 138 | 47.1% |
-| Java | 192 | 26.4% |
-| Kotlin | 193 | 26.1% |
-| WASM | 200 | 23.4% |
-| F# | 209 | 19.9% |
-| C# | 210 | 19.5% |
-| Dart | 228 | 12.6% |
-
-Regenerate the numbers with:
+Run:
 
 ```sh
 python scripts/package_parity_report.py --format markdown
+python scripts/package_parity_report.py --format json
+python scripts/package_parity_report.py --format csv
 ```
 
-## Parity Rules
+The reporter reads Git-visible files: tracked files plus untracked files that
+are not ignored. It therefore sees newly scaffolded packages without treating
+`target`, `node_modules`, `.pytest_cache`, or other ignored build output as
+packages.
 
-### Portable Packages Should Converge
+Package identity is case- and punctuation-insensitive. `directed-graph`,
+`directed_graph`, and `Directed.Graph` are one identity. The reporter retains
+the original directories and reports collisions when one language contains
+multiple directories for the same identity.
 
-Packages should converge across all serious implementation languages when they
-are pure algorithms, data structures, grammar frontends, codecs, IR models,
-validators, encoders, simulators, or deterministic transforms.
+### Established implementation lanes
 
-Examples:
-
-- `hash-functions`
-- `trie`
-- `bloom-filter`
-- `lexer`
-- `parser`
-- `wasm-module-encoder`
-- `json-value`
-- `zip`
-
-### Native Packages Should Not Be Reimplemented Blindly
-
-Rust should remain the implementation source of truth for packages that are
-really platform or ABI surfaces. Other languages should usually receive thin,
-tested wrappers instead of independent reimplementations.
-
-Examples:
-
-- `python-bridge`, `ruby-bridge`, `node-bridge`, `lua-bridge`
-- `epoll`, `kqueue`, `iocp`
-- `audio-device-coreaudio`
-- `paint-vm-direct2d`, `paint-vm-gdi`, `paint-metal`
-- `cuda-compute`, `metal-compute`
-- `*-c`, `*-native`, and runtime extension packages
-
-### Web Packages Stay Web-First
-
-Browser and app-shell packages should not become parity blockers for backend
-languages.
-
-Examples:
-
-- `indexeddb`
-- `ui-components`
-- `vite-plugin-lattice`
-- `paint-vm-canvas`
-- `window-canvas`
-- `web-audio-sink`
-- `browser-extension-toolkit`
-
-### Runtime-Specific Compiler Backends Need Dependency Readiness
-
-Compiler and VM packages should be ported in dependency waves, not one package
-at a time. A backend package is only ready when its local lexer, parser, IR,
-validator, encoder, and runtime dependencies are already present or included in
-the same wave.
-
-## Optimal Implementation Order
-
-### Phase 0: Keep the Map Fresh
-
-Status: started by this roadmap and `scripts/package_parity_report.py`.
-
-- Keep `scripts/package_parity_report.py` as the canonical quick inventory.
-- Use the Rust/Python shared core as the portable parity target.
-- Classify every apparent gap before implementing it.
-- Do not count Starlark as an implementation language; it is a build/config
-  rule lane.
-
-### Phase 1: Close Near-Parity Languages First
-
-Target languages:
-
-- TypeScript
-- Go
-- Ruby
+- C#
+- Dart
 - Elixir
+- F#
+- Go
+- Haskell
+- Java
+- Kotlin
+- Lua
+- Perl
+- Python
+- Ruby
+- Rust
+- Swift
+- TypeScript
 
-These buckets are already above 87% core coverage. Closing them first gives the
-repo fast wins and creates templates for Lua, Perl, Swift, and Haskell.
+### Separately classified lanes
 
-Recommended first wave:
+- C++ is an emerging implementation lane. It needs package/scaffold maturity
+  before it can join the all-language completion denominator.
+- WASM is an execution-target lane, not a requirement for every source package.
+- Mosaic and Twig are domain/source-language lanes.
+- Starlark is a build/configuration lane.
 
-| Package | Languages | Why first |
+## July 10, 2026 Baseline
+
+The tracked tree at `8efcb2d5b` contains:
+
+| Metric | Count |
+|---|---:|
+| Established implementation languages | 15 |
+| Tracked package directories in those languages | 4,096 |
+| Distinct normalized package identities | 1,102 |
+| Package/language slots after identity normalization | 4,094 |
+| Missing slots for literal all-language parity | 12,436 |
+| Rust identities | 873 |
+| Python identities | 494 |
+| TypeScript identities | 436 |
+| Rust singletons | 465 |
+| Python singletons | 88 |
+| TypeScript singletons | 81 |
+| Packages present in all 15 languages | 34 |
+
+Rust drift is recent as well as cumulative. From June 10 to July 10, Rust added
+127 package directories out of 185 total net additions across the 15 lanes.
+Rust-only identities grew from 373 to 465.
+
+The previous April baseline had 377 Rust and 377 Python packages. It is no
+longer a useful current planning baseline.
+
+## Parity Classes
+
+Every sparse package must receive one of these classifications before a porting
+wave treats it as a gap:
+
+| Class | Meaning | Expected action |
 |---|---|---|
-| `hash-functions` | TypeScript, Go, Ruby, Elixir | Leaf-like utility used by later structures |
-| `trie` | TypeScript, Go, Ruby, Elixir | Pure data structure with clear tests |
-| `bloom-filter` | TypeScript, Go, Ruby, Elixir | Depends naturally on hash behavior |
+| `portable` | Pure algorithm, data structure, IR, codec, validator, deterministic transform, simulator, or grammar frontend | Pure implementation in every established language |
+| `native-source` | The package directly owns OS, ABI, GPU, firmware, or hardware behavior | Keep the appropriate native implementation |
+| `wrapper` | Thin language-facing binding to a native source of truth | Test the wrapper; do not count it as a missing pure port |
+| `web-only` | Browser, DOM, Canvas, IndexedDB, Vite, or Web Audio behavior | Keep in web-capable lanes |
+| `target-specific` | Compiler backend or artifact writer meaningful only for a particular target | Port only where the target is supported |
+| `not-applicable` | The package has no coherent role in the language lane | Document the exception |
 
-The `hash-functions` row is implemented in this branch. The next best cut is
-`trie`, followed by `bloom-filter`.
+Directory presence is not completion. A completed pure port needs matching API
+semantics, shared fixtures or reference vectors, package-native tests, README,
+CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 
-Recommended second wave:
+## Work Inventory
 
-| Package | Languages | Why second |
-|---|---|---|
-| `css-lexer` | TypeScript, Go | Grammar-generated and browser-relevant |
-| `css-parser` | TypeScript, Go, Elixir | Completes the CSS frontend pair |
-| `haskell-lexer` | Go, Perl | Follow existing grammar-generated package pattern |
-| `haskell-parser` | Go, Perl | Follows lexer support |
+The missing matrix is heavily concentrated in singleton packages:
 
-Hold for classification:
+| Current breadth | Packages | Missing slots to all 15 |
+|---|---:|---:|
+| Present in 10-15 languages | 171 | 411 |
+| Present in 5-9 languages | 122 | 917 |
+| Present in 2-4 languages | 153 | 1,924 |
+| Present in one language | 656 | 9,184 |
 
-- `audio-device-sink`: likely portable facade plus native backends.
-- `tcp-server`: portable contract, but runtime behavior must be shaped per
-  language.
-- `ml-framework-*`: probably educational facades; confirm desired depth before
-  porting.
-- `jit-compiler`, `lisp-*`, `starlark-compiler`: port as compiler waves after
-  dependency checks.
+The loop must not start by attempting 9,184 singleton ports. It should finish
+the broadly established portable core, then classify the sparse majority.
 
-### Phase 2: Bring Lua and Perl to Near-Parity
+## Priority 0: Inventory And Identity Integrity
 
-Lua and Perl are around 78% core coverage and share many missing packages. Use
-the Phase 1 implementations as templates after they pass in TypeScript, Go,
-Ruby, and Elixir.
+1. Make the parity reporter use Git-visible files rather than filesystem
+   directories.
+2. Emit Markdown summary, JSON detail, and a full CSV package/language matrix.
+3. Classify implementation, emerging, target, domain-language, and build lanes.
+4. Report within-language canonical identity collisions.
+5. Add unit tests and run them in the CI detect job.
+6. Resolve the current Ruby collisions:
+   - `ruby/b-tree` versus `ruby/b_tree`
+   - `ruby/b-plus-tree` versus `ruby/b_plus_tree`
+7. Once collisions are fixed, enable `--fail-on-collisions` in CI.
 
-Prioritize:
+## Priority 1: Complete The 14-Of-15 Set
 
-- `hash-functions`
-- `bloom-filter`
-- `fenwick-tree`
-- `hash-map`
-- `hyperloglog`
-- `radix-tree`
-- `skip-list`
-- `tree-set`
-- `trie`
-- `resp-protocol`
-- `tcp-server`
+Twenty-one package/language slots turn 21 nearly complete packages into fully
+covered packages.
 
-Then continue with compiler/runtime packages from the existing convergence
-specs.
+### Dart: 13 ports
 
-### Phase 3: Treat Haskell and Swift as Medium Catch-Up Tracks
+- `algol-lexer`
+- `algol-parser`
+- `bitset`
+- `b-plus-tree`
+- `b-tree`
+- `heap`
+- `image-geometric-transforms`
+- `image-point-ops`
+- `logic-gates`
+- `mosaic-lexer`
+- `mosaic-parser`
+- `pixel-container`
+- `toml-lexer`
 
-Haskell and Swift sit near 47% core coverage, so their next work should be
-dependency-shaped rather than gap-count-shaped.
+### Haskell: 5 ports
 
-Haskell:
+- `huffman-compression`
+- `huffman-tree`
+- `lz77`
+- `lzss`
+- `lzw`
 
-- Refresh `haskell-catch-up-survey.md` with the new merged baseline.
-- Prioritize tooling/core packages that make future Haskell package creation
-  cheaper.
-- Continue the Brainfuck/Nib/WASM convergence wave in
-  `04n-haskell-wasm-convergence.md`.
-- Be strict about `cabal.project` transitive local dependencies.
+### Swift: 3 ports
 
-Swift:
+- `cli-builder`
+- `sql-execution-engine`
+- `wasm-simulator`
 
-- Add a Swift catch-up survey similar to the Haskell one.
-- Prioritize portable algorithm/data-structure packages before native app
-  surfaces.
-- Port grammar frontends only after package scaffolding and build support are
-  predictable.
+Port dependency families together when doing so avoids temporary broken package
+graphs. Grammar-generated lexer/parser pairs should be generated from the shared
+grammar sources rather than independently handwritten.
 
-### Phase 4: Work in Paired Ecosystems
+## Priority 2: Complete The High-Consensus Core
 
-Java and Kotlin should move together. C# and F# should move together.
+The 171 packages present in at least ten implementation languages need 411
+ports to reach all 15. After Priority 1, select work in this order:
 
-The best initial paired waves are:
+| Language lane | Current high-consensus gaps | Pairing rule |
+|---|---:|---|
+| Python | 3 | Pair `in-memory-data-store` packages; classify self-hosted `python-parser` carefully |
+| Elixir | 1 | Complete alongside the Python parser/frontend decision |
+| Lua | 16 | Pair with Perl data-structure/storage wave |
+| Perl | 16 | Pair with Lua data-structure/storage wave |
+| C# | 17 | Move with F# |
+| F# | 17 | Move with C# |
+| Haskell | 41 | Dependency-shaped compression, graphics, ML, and protocol waves |
+| Swift | 56 | Data structures and generated frontends before native app surfaces |
+| Java | 60 | Move with Kotlin |
+| Kotlin | 60 | Move with Java |
+| Dart | 124 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
 
-- generated lexer/parser packages
-- data structures
-- crypto and compression primitives
-- WASM encoder/runtime slices
-- existing Brainfuck/Nib convergence specs
+Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
+consensus set. They remain reference/template lanes for these waves.
 
-Avoid one-off ports that make Java diverge from Kotlin or C# diverge from F#.
+Recommended family order:
 
-### Phase 5: Keep Dart and WASM Selective
+1. Leaf algorithms and data structures.
+2. Hashing, crypto, compression, and deterministic codecs.
+3. Shared JSON/document/IR models and serializers.
+4. Grammar-generated lexer/parser pairs.
+5. SQL/storage packages in dependency order.
+6. Compiler and VM families with their local IR, validator, encoder, and runtime
+   dependencies in the same wave.
 
-Dart has low coverage but should not blindly mirror systems packages. Favor
-portable packages that fit the Dart ecosystem:
+## Priority 3: Expand The Portable Core
 
-- data structures
-- codecs
-- QR/barcode work
-- grammar frontends
-- document and paint transforms
+After the high-consensus set is complete:
 
-WASM packages should stay focused on wrappers, runtime targets, and browser or
-portable execution units. They do not need to mirror every source-language
-package.
+1. Complete packages already present in 8-9 languages.
+2. Complete packages present in 5-7 languages.
+3. Recompute the matrix after every merged wave.
+4. Prefer families with existing cross-language fixtures and low dependency
+   fan-out.
+5. Add missing shared conformance fixtures before porting when current tests are
+   language-specific and cannot prove equivalent behavior.
 
-## First Implementation Tranche
+This phase covers 122 package identities and 917 current missing slots.
 
-Start with 12 packages:
+## Priority 4: Classify Sparse And Singleton Families
 
-- `code/packages/typescript/hash-functions` - done in this branch
-- `code/packages/go/hash-functions` - done in this branch
-- `code/packages/ruby/hash_functions` - done in this branch
-- `code/packages/elixir/hash_functions` - done in this branch
-- `code/packages/typescript/trie`
-- `code/packages/go/trie`
-- `code/packages/ruby/trie`
-- `code/packages/elixir/trie`
-- `code/packages/typescript/bloom-filter`
-- `code/packages/go/bloom-filter`
-- `code/packages/ruby/bloom_filter`
-- `code/packages/elixir/bloom_filter`
+The singleton inventory is led by 465 Rust, 88 Python, and 81 TypeScript
+packages. Classify families before opening implementation PRs.
 
-Build order:
+### Likely portable Rust-led families
 
-1. `hash-functions`
-2. `trie`
-3. `bloom-filter`
+- `closure-*` compiler passes
+- `dsp-*` algorithms
+- `iir-*` IR passes and deterministic target emitters
+- portable `image-codec-*` packages
+- `state-machine-*` tokenization, serialization, and compilation
+- language runtimes and frontends such as `r-*` and `twig-*`, when their
+  dependency stacks are ready
+- deterministic portions of `vault-*`, `adjudication-*`, and `smart-home-*`
 
-Validation rules:
+### Likely native, wrapper, or target-specific Rust-led families
 
-- Each package needs `BUILD`, README, CHANGELOG, package metadata, and tests.
-- BUILD files must install transitive local dependencies in leaf-to-root order.
-- Ruby requires dependency `require` ordering before local modules.
-- Elixir implementations must avoid reserved words as variables.
-- Go packages must run `go mod tidy` after adding local module dependencies.
-- TypeScript packages must avoid committing generated `.js`, `.d.ts`, or source
-  map outputs.
+- `*-bridge`, `*-capi`, `*-jni`, `*-napi`, and `*-native`
+- `silicon-rust-*` bindings
+- board firmware and physical transport packages
+- OS paint/window backends
+- CUDA, Metal, Vulkan, Direct2D, GDI, OpenCL, and similar accelerator/platform
+  implementations
+
+### Python-led families requiring classification
+
+- CPU/ISA simulators and gate-level models
+- JVM/CLR/BEAM artifact and runtime packages
+- Prolog and logic-runtime stacks
+- Tetrad, Twig, and Oct compiler backends
+- native data-structure wrappers
+
+### TypeScript-led families requiring classification
+
+- the 57-package `forme-*` web/static-site family
+- browser, IndexedDB, Vite, Canvas, Web Audio, and UI packages
+- layout and document-to-paint packages
+- Mosaic web emitters
+
+For each family, add or identify a portable contract spec, dependency order,
+reference implementation, shared fixtures, and explicit exception list before
+the first port PR.
+
+## Priority 5: Conformance And Regression Prevention
+
+1. Give each portable family a language-neutral fixture corpus or oracle.
+2. Add package-level conformance runners where directory presence currently
+   masks API or semantic drift.
+3. Extend the parity reporter with explicit applicability data rather than
+   hard-coding exceptions in reporting logic.
+4. Fail CI on unclassified new package buckets.
+5. After identity cleanup, fail CI on canonical collisions.
+6. Add a policy check: a new portable singleton must include either another
+   language implementation or a declared parity work item/classification.
+7. Track package maturity separately from structural presence: manifest,
+   source, tests, BUILD, README, CHANGELOG, conformance status, and last verified
+   revision.
+
+## Autonomous Loop Protocol
+
+Only one parity PR should be active at a time.
+
+1. Fetch `origin/main` and verify the prior PR state.
+2. If CI fails, inspect the actual GitHub Actions logs, make a focused fix, run
+   local verification, and push to the same PR.
+3. If the branch conflicts with `main`, update it carefully and verify the full
+   PR diff contains only intended work.
+4. If checks are pending, keep monitoring.
+5. If the PR is merged, regenerate the report from the new `origin/main`, update
+   priorities with any newly discovered work, and select the highest-impact
+   unblocked item.
+6. Create a fresh `codex/` branch, implement one coherent dependency-shaped
+   work item, validate it, push it, and open the next PR.
+7. Continue until the report has no unclassified or eligible portable gaps.
+
+Every PR must state what changed, why the selected slice is next, tests run,
+remaining gaps, and any packages deliberately classified as non-portable.
 
 ## Completion Definition
 
-This roadmap is working when:
+The parity program is complete when:
 
-- the parity report can be regenerated after every major merge;
-- near-parity language gaps shrink in coherent waves;
-- native and web-only packages are classified instead of treated as failures;
-- new implementations follow existing package conventions;
-- specs, READMEs, CHANGELOGs, and tests move together.
+- every package identity is classified;
+- every `portable` package has a tested pure implementation in every established
+  implementation language, or an explicit reviewed `not-applicable` exception;
+- native, wrapper, web-only, and target-specific packages have honest tested
+  coverage in their applicable lanes;
+- canonical identity collisions are zero;
+- the reporter and conformance checks run in CI;
+- adding a new package cannot silently create an unplanned singleton;
+- the generated matrix contains no eligible unowned gap.

--- a/scripts/package_parity_report.py
+++ b/scripts/package_parity_report.py
@@ -1,20 +1,91 @@
 #!/usr/bin/env python3
-"""Report package parity across language buckets.
+"""Report package parity across the repository's language buckets.
 
-The report intentionally normalizes only folder-name conventions. It does not
-try to decide that every package should exist in every language. That judgment
-belongs in the roadmap/spec layer.
+The inventory is built from Git-visible files (tracked plus untracked and not
+ignored), rather than raw filesystem directories. That keeps build outputs such
+as ``target``, ``node_modules``, and ``.pytest_cache`` out of the report while
+still allowing a newly scaffolded package to appear before its first commit.
+
+Directory presence is structural evidence, not proof of API or behavioural
+parity. The roadmap/spec layer decides which package identities are portable.
 """
 
 from __future__ import annotations
 
 import argparse
+import csv
+import io
 import json
+import re
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
-from typing import Iterable
+from typing import Any
 
 
-NORMALIZATION_OVERRIDES = {
+IMPLEMENTATION_LANGUAGES = (
+    "csharp",
+    "dart",
+    "elixir",
+    "fsharp",
+    "go",
+    "haskell",
+    "java",
+    "kotlin",
+    "lua",
+    "perl",
+    "python",
+    "ruby",
+    "rust",
+    "swift",
+    "typescript",
+)
+
+BUCKET_CLASSES = {
+    "implementation": IMPLEMENTATION_LANGUAGES,
+    "emerging_implementation": ("cpp",),
+    "execution_target": ("wasm",),
+    "domain_language": ("mosaic", "twig"),
+    "build_language": ("starlark",),
+}
+
+ALL_BUCKETS = tuple(bucket for buckets in BUCKET_CLASSES.values() for bucket in buckets)
+
+DISPLAY_PRIORITY = (
+    "rust",
+    "python",
+    "typescript",
+    "go",
+    "ruby",
+    "elixir",
+    "csharp",
+    "fsharp",
+    "haskell",
+    "java",
+    "kotlin",
+    "lua",
+    "perl",
+    "dart",
+    "swift",
+    "cpp",
+    "wasm",
+    "mosaic",
+    "twig",
+    "starlark",
+)
+
+HIGH_CONSENSUS_MIN_LANGUAGES = 10
+
+IGNORED_PACKAGE_DIRS = {
+    ".cargo",
+    ".pytest_cache",
+    "node_modules",
+    "target",
+}
+
+# PascalCase Swift packages predate the current kebab-case convention. These
+# overrides preserve their established cross-language display names.
+DISPLAY_OVERRIDES = {
     "barcode1d": "barcode-1d",
     "barcode2d": "barcode-2d",
     "barcodelayout1d": "barcode-layout-1d",
@@ -32,159 +103,400 @@ NORMALIZATION_OVERRIDES = {
     "upca": "upc-a",
 }
 
-IGNORED_PACKAGE_DIRS = {
-    ".cargo",
-}
 
-IGNORED_LANGUAGE_BUCKETS = {
-    "starlark",
-}
+def package_identity(name: str) -> str:
+    """Return a punctuation- and case-insensitive package identity key."""
+
+    return re.sub(r"[^a-z0-9]", "", name.lower())
 
 
-def normalize_package_name(name: str) -> str | None:
-    if name in IGNORED_PACKAGE_DIRS:
-        return None
-    normalized = name.lower().replace("_", "-")
-    return NORMALIZATION_OVERRIDES.get(normalized, normalized)
+def package_display_name(name: str) -> str:
+    """Return the preferred human-readable spelling for a directory name."""
+
+    identity = package_identity(name)
+    if identity in DISPLAY_OVERRIDES:
+        return DISPLAY_OVERRIDES[identity]
+
+    # Split acronym/PascalCase boundaries before normalizing separators.
+    value = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1-\2", name)
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", value)
+    value = re.sub(r"[_.]+", "-", value)
+    value = re.sub(r"-+", "-", value)
+    return value.lower().strip("-")
 
 
-def discover_packages(root: Path) -> dict[str, set[str]]:
-    package_root = root / "code" / "packages"
-    language_packages: dict[str, set[str]] = {}
+def parse_package_paths(
+    paths: Iterable[str],
+) -> tuple[dict[str, dict[str, set[str]]], set[str]]:
+    """Parse Git-visible paths into bucket/identity/directory mappings."""
 
-    for language_dir in sorted(package_root.iterdir()):
-        if not language_dir.is_dir() or language_dir.name in IGNORED_LANGUAGE_BUCKETS:
+    packages: dict[str, dict[str, set[str]]] = {bucket: {} for bucket in ALL_BUCKETS}
+    unknown_buckets: set[str] = set()
+
+    for raw_path in paths:
+        parts = raw_path.strip().replace("\\", "/").split("/")
+        if len(parts) < 5 or parts[:2] != ["code", "packages"]:
             continue
 
-        packages: set[str] = set()
-        for package_dir in sorted(language_dir.iterdir()):
-            if not package_dir.is_dir():
-                continue
-            normalized = normalize_package_name(package_dir.name)
-            if normalized:
-                packages.add(normalized)
+        bucket, directory = parts[2], parts[3]
+        if bucket not in packages:
+            unknown_buckets.add(bucket)
+            continue
+        if directory.startswith(".") or directory in IGNORED_PACKAGE_DIRS:
+            continue
 
-        language_packages[language_dir.name] = packages
+        identity = package_identity(directory)
+        if not identity:
+            continue
+        packages[bucket].setdefault(identity, set()).add(directory)
 
-    return language_packages
-
-
-def sorted_list(values: Iterable[str]) -> list[str]:
-    return sorted(values)
+    return packages, unknown_buckets
 
 
-def build_report(root: Path) -> dict[str, object]:
-    language_packages = discover_packages(root)
-    if "rust" not in language_packages or "python" not in language_packages:
-        raise SystemExit("package parity report requires rust and python buckets")
+def git_visible_package_paths(root: Path) -> list[str]:
+    """Return tracked plus untracked, non-ignored paths under code/packages."""
 
-    all_packages: set[str] = set()
-    for packages in language_packages.values():
-        all_packages.update(packages)
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            "code/packages",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return [
+        path
+        for raw_path in result.stdout.split(b"\0")
+        if raw_path
+        for path in [raw_path.decode("utf-8", errors="surrogateescape")]
+        if (root / Path(path)).is_file()
+    ]
 
-    rust_packages = language_packages["rust"]
-    python_packages = language_packages["python"]
+
+def discover_packages(
+    root: Path,
+) -> tuple[dict[str, dict[str, set[str]]], set[str]]:
+    return parse_package_paths(git_visible_package_paths(root))
+
+
+def identity_sets(
+    packages: Mapping[str, Mapping[str, set[str]]],
+) -> dict[str, set[str]]:
+    return {bucket: set(entries) for bucket, entries in packages.items()}
+
+
+def preferred_display_name(
+    identity: str, packages: Mapping[str, Mapping[str, set[str]]]
+) -> str:
+    for bucket in DISPLAY_PRIORITY:
+        directories = packages.get(bucket, {}).get(identity)
+        if directories:
+            return package_display_name(sorted(directories)[0])
+    return identity
+
+
+def display_names(
+    identities: Iterable[str], packages: Mapping[str, Mapping[str, set[str]]]
+) -> list[str]:
+    return sorted(preferred_display_name(identity, packages) for identity in identities)
+
+
+def completion_band(language_count: int) -> str:
+    if language_count >= 10:
+        return "10-15"
+    if language_count >= 5:
+        return "5-9"
+    if language_count >= 2:
+        return "2-4"
+    return "1"
+
+
+def build_report(
+    packages: dict[str, dict[str, set[str]]], unknown_buckets: set[str]
+) -> dict[str, Any]:
+    sets = identity_sets(packages)
+    implementation_union: set[str] = set().union(
+        *(sets[language] for language in IMPLEMENTATION_LANGUAGES)
+    )
+    all_reported_union: set[str] = set().union(
+        *(sets[bucket] for bucket in ALL_BUCKETS)
+    )
+
+    rust_packages = sets["rust"]
+    python_packages = sets["python"]
     rust_python_core = rust_packages & python_packages
     rust_python_union = rust_packages | python_packages
 
-    coverage = []
-    for language, packages in sorted(language_packages.items()):
-        missing_core = rust_python_core - packages
-        present_core = len(rust_python_core) - len(missing_core)
+    implementation_frequency = {
+        identity: sum(
+            identity in sets[language] for language in IMPLEMENTATION_LANGUAGES
+        )
+        for identity in implementation_union
+    }
+    high_consensus = {
+        identity
+        for identity, count in implementation_frequency.items()
+        if count >= HIGH_CONSENSUS_MIN_LANGUAGES
+    }
+
+    coverage: list[dict[str, Any]] = []
+    for language in IMPLEMENTATION_LANGUAGES:
+        language_set = sets[language]
+        missing_core = rust_python_core - language_set
+        missing_high_consensus = high_consensus - language_set
+        rust_overlap = rust_packages & language_set
         coverage.append(
             {
                 "language": language,
-                "present": len(packages),
+                "present": len(language_set),
+                "union_coverage": (
+                    len(language_set) / len(implementation_union)
+                    if implementation_union
+                    else 1.0
+                ),
+                "rust_overlap": len(rust_overlap),
+                "missing_from_rust_set": len(rust_packages - language_set),
                 "missing_core": len(missing_core),
-                "core_coverage": present_core / len(rust_python_core),
-                "missing_core_packages": sorted_list(missing_core),
+                "core_coverage": (
+                    (len(rust_python_core) - len(missing_core)) / len(rust_python_core)
+                    if rust_python_core
+                    else 1.0
+                ),
+                "missing_core_packages": display_names(missing_core, packages),
+                "missing_high_consensus": len(missing_high_consensus),
+                "missing_high_consensus_packages": display_names(
+                    missing_high_consensus, packages
+                ),
             }
         )
 
-    package_frequency = []
-    for package in sorted(all_packages):
-        languages = [
+    package_frequency: list[dict[str, Any]] = []
+    for identity in sorted(all_reported_union):
+        languages = [bucket for bucket in ALL_BUCKETS if identity in sets[bucket]]
+        implementation_languages = [
             language
-            for language, packages in sorted(language_packages.items())
-            if package in packages
+            for language in IMPLEMENTATION_LANGUAGES
+            if identity in sets[language]
         ]
         package_frequency.append(
             {
-                "package": package,
-                "language_count": len(languages),
+                "identity": identity,
+                "package": preferred_display_name(identity, packages),
+                "language_count": len(implementation_languages),
                 "languages": languages,
+                "implementation_languages": implementation_languages,
             }
         )
 
+    collisions: list[dict[str, Any]] = []
+    for bucket in ALL_BUCKETS:
+        for identity, directories in packages[bucket].items():
+            if len(directories) > 1:
+                collisions.append(
+                    {
+                        "language": bucket,
+                        "identity": identity,
+                        "package": preferred_display_name(identity, packages),
+                        "directories": sorted(directories),
+                    }
+                )
+
+    breadth: dict[str, dict[str, int]] = {
+        "10-15": {"packages": 0, "missing_slots": 0},
+        "5-9": {"packages": 0, "missing_slots": 0},
+        "2-4": {"packages": 0, "missing_slots": 0},
+        "1": {"packages": 0, "missing_slots": 0},
+    }
+    for language_count in implementation_frequency.values():
+        band = completion_band(language_count)
+        breadth[band]["packages"] += 1
+        breadth[band]["missing_slots"] += len(IMPLEMENTATION_LANGUAGES) - language_count
+
+    singleton_by_language = {
+        language: sum(
+            implementation_frequency[identity] == 1 for identity in sets[language]
+        )
+        for language in IMPLEMENTATION_LANGUAGES
+    }
+
     return {
+        "schema_version": 2,
+        "bucket_classes": {key: list(value) for key, value in BUCKET_CLASSES.items()},
         "package_count": {
-            "all_languages_union": len(all_packages),
+            "all_reported_union": len(all_reported_union),
+            "implementation_union": len(implementation_union),
+            "implementation_directories": sum(
+                len(directories)
+                for language in IMPLEMENTATION_LANGUAGES
+                for directories in packages[language].values()
+            ),
+            "implementation_package_slots": sum(
+                len(sets[language]) for language in IMPLEMENTATION_LANGUAGES
+            ),
+            "high_consensus": len(high_consensus),
             "rust_python_union": len(rust_python_union),
             "rust_python_core": len(rust_python_core),
             "rust": len(rust_packages),
             "python": len(python_packages),
         },
-        "rust_only": sorted_list(rust_packages - python_packages),
-        "python_only": sorted_list(python_packages - rust_packages),
-        "outside_rust_python": sorted_list(all_packages - rust_python_union),
-        "coverage": sorted(coverage, key=lambda row: (row["missing_core"], row["language"])),
+        # Backwards-compatible Rust/Python delta fields.
+        "rust_only": display_names(rust_packages - python_packages, packages),
+        "python_only": display_names(python_packages - rust_packages, packages),
+        "outside_rust_python": display_names(
+            all_reported_union - rust_python_union, packages
+        ),
+        "rust_singletons": display_names(
+            {
+                identity
+                for identity in rust_packages
+                if implementation_frequency[identity] == 1
+            },
+            packages,
+        ),
+        "singleton_by_language": singleton_by_language,
+        "completion_bands": breadth,
+        "coverage": coverage,
         "package_frequency": package_frequency,
+        "collisions": collisions,
+        "unknown_language_buckets": sorted(unknown_buckets),
+        "special_buckets": [
+            {
+                "language": bucket,
+                "class": class_name,
+                "present": len(sets[bucket]),
+                "packages": display_names(sets[bucket], packages),
+            }
+            for class_name, buckets in BUCKET_CLASSES.items()
+            if class_name != "implementation"
+            for bucket in buckets
+        ],
     }
 
 
-def render_markdown(report: dict[str, object]) -> str:
+def render_markdown(report: Mapping[str, Any]) -> str:
     counts = report["package_count"]
-    assert isinstance(counts, dict)
     lines = [
         "# Package Parity Report",
+        "",
+        "The report inventories Git-visible package files. It measures structural",
+        "presence only; portable/native applicability remains a roadmap decision.",
         "",
         "## Summary",
         "",
         "| Baseline | Count |",
         "|---|---:|",
-        f"| All normalized package names | {counts['all_languages_union']} |",
-        f"| Rust/Python union | {counts['rust_python_union']} |",
-        f"| Rust/Python shared core | {counts['rust_python_core']} |",
+        f"| Established implementation languages | {len(IMPLEMENTATION_LANGUAGES)} |",
+        f"| Implementation package directories | {counts['implementation_directories']} |",
+        f"| Distinct implementation package identities | {counts['implementation_union']} |",
+        f"| Packages present in at least {HIGH_CONSENSUS_MIN_LANGUAGES} languages | {counts['high_consensus']} |",
         f"| Rust packages | {counts['rust']} |",
         f"| Python packages | {counts['python']} |",
+        f"| Rust/Python shared core | {counts['rust_python_core']} |",
         "",
-        "## Core Coverage",
+        "## Implementation Coverage",
         "",
-        "| Language | Present | Missing Core | Core Coverage |",
+        "| Language | Packages | Union Coverage | High-Consensus Gaps |",
         "|---|---:|---:|---:|",
     ]
 
-    coverage = report["coverage"]
-    assert isinstance(coverage, list)
-    for row in coverage:
-        assert isinstance(row, dict)
+    for row in sorted(report["coverage"], key=lambda item: item["language"]):
         lines.append(
-            "| {language} | {present} | {missing_core} | {core_coverage:.1%} |".format(
-                **row
-            )
+            "| {language} | {present} | {union_coverage:.1%} | "
+            "{missing_high_consensus} |".format(**row)
         )
 
     lines.extend(
         [
             "",
-            "## Rust Only",
+            "## Completion Bands",
             "",
-            ", ".join(report["rust_only"]),  # type: ignore[arg-type]
+            "| Present In | Packages | Missing Slots To All 15 |",
+            "|---|---:|---:|",
+        ]
+    )
+    for band in ("10-15", "5-9", "2-4", "1"):
+        row = report["completion_bands"][band]
+        language_label = "language" if band == "1" else "languages"
+        lines.append(
+            f"| {band} {language_label} | {row['packages']} | {row['missing_slots']} |"
+        )
+
+    lines.extend(
+        [
             "",
-            "## Python Only",
+            "## Singleton Packages",
             "",
-            ", ".join(report["python_only"]),  # type: ignore[arg-type]
+            "| Language | Singletons |",
+            "|---|---:|",
+        ]
+    )
+    for language, count in report["singleton_by_language"].items():
+        lines.append(f"| {language} | {count} |")
+
+    lines.extend(
+        [
             "",
-            "## Outside Rust/Python",
+            "## Special Buckets",
             "",
-            ", ".join(report["outside_rust_python"]),  # type: ignore[arg-type]
+            "| Bucket | Class | Packages |",
+            "|---|---|---:|",
+        ]
+    )
+    for row in report["special_buckets"]:
+        lines.append(f"| {row['language']} | {row['class']} | {row['present']} |")
+
+    lines.extend(["", "## Identity Findings", ""])
+    if report["collisions"]:
+        for collision in report["collisions"]:
+            directories = ", ".join(f"`{name}`" for name in collision["directories"])
+            lines.append(
+                f"- `{collision['language']}/{collision['package']}`: {directories}"
+            )
+    else:
+        lines.append("- No within-language canonical identity collisions.")
+
+    if report["unknown_language_buckets"]:
+        unknown = ", ".join(
+            f"`{bucket}`" for bucket in report["unknown_language_buckets"]
+        )
+        lines.append(f"- Unclassified package buckets: {unknown}")
+    else:
+        lines.append("- No unclassified package buckets.")
+
+    lines.extend(
+        [
+            "",
+            "Use `--format json` for complete gap lists and `--format csv` for the",
+            "full package-by-language presence matrix.",
             "",
         ]
     )
     return "\n".join(lines)
 
 
-def main() -> int:
+def render_csv(report: Mapping[str, Any]) -> str:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(["package", *ALL_BUCKETS])
+    for row in report["package_frequency"]:
+        present = set(row["languages"])
+        writer.writerow(
+            [
+                row["package"],
+                *("1" if bucket in present else "0" for bucket in ALL_BUCKETS),
+            ]
+        )
+    return output.getvalue()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--root",
@@ -194,17 +506,31 @@ def main() -> int:
     )
     parser.add_argument(
         "--format",
-        choices=("json", "markdown"),
+        choices=("json", "markdown", "csv"),
         default="markdown",
         help="output format",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--fail-on-collisions",
+        action="store_true",
+        help="exit non-zero when two directories normalize to one identity",
+    )
+    args = parser.parse_args(argv)
 
-    report = build_report(args.root)
+    packages, unknown_buckets = discover_packages(args.root.resolve())
+    report = build_report(packages, unknown_buckets)
+
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "csv":
+        print(render_csv(report), end="")
     else:
         print(render_markdown(report))
+
+    if report["unknown_language_buckets"]:
+        return 2
+    if args.fail_on_collisions and report["collisions"]:
+        return 3
     return 0
 
 

--- a/scripts/tests/test_package_parity_report.py
+++ b/scripts/tests/test_package_parity_report.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import csv
+import io
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import package_parity_report as parity  # noqa: E402
+
+
+def package_path(language: str, package: str) -> str:
+    return f"code/packages/{language}/{package}/src/source.txt"
+
+
+class PackageIdentityTests(unittest.TestCase):
+    def test_identity_ignores_case_and_punctuation(self) -> None:
+        variants = ("directed-graph", "directed_graph", "Directed.Graph")
+        self.assertEqual(
+            {parity.package_identity(variant) for variant in variants},
+            {"directedgraph"},
+        )
+
+    def test_display_normalizes_pascal_case_and_known_swift_names(self) -> None:
+        self.assertEqual(
+            parity.package_display_name("IrcServerNative"), "irc-server-native"
+        )
+        self.assertEqual(parity.package_display_name("Barcode1D"), "barcode-1d")
+        self.assertEqual(parity.package_display_name("Mosaic.Flux"), "mosaic-flux")
+
+
+class PackageInventoryTests(unittest.TestCase):
+    def test_parser_uses_only_known_package_buckets(self) -> None:
+        packages, unknown = parity.parse_package_paths(
+            [
+                package_path("rust", "heap"),
+                package_path("python", "heap"),
+                package_path("python", ".pytest_cache"),
+                package_path("rust", "target"),
+                package_path("mystery", "heap"),
+                "code/programs/rust/not-a-package/src/main.rs",
+            ]
+        )
+
+        self.assertEqual(set(packages["rust"]), {"heap"})
+        self.assertEqual(set(packages["python"]), {"heap"})
+        self.assertEqual(unknown, {"mystery"})
+
+    def test_parser_reports_within_language_identity_collisions(self) -> None:
+        paths = [
+            package_path("ruby", "b-tree"),
+            package_path("ruby", "b_tree"),
+            package_path("rust", "b-tree"),
+            package_path("python", "b-tree"),
+        ]
+        packages, unknown = parity.parse_package_paths(paths)
+        report = parity.build_report(packages, unknown)
+
+        self.assertEqual(len(report["collisions"]), 1)
+        self.assertEqual(report["collisions"][0]["language"], "ruby")
+        self.assertEqual(report["collisions"][0]["directories"], ["b-tree", "b_tree"])
+
+    def test_report_builds_completion_bands_and_gap_lists(self) -> None:
+        paths: list[str] = []
+        for language in parity.IMPLEMENTATION_LANGUAGES:
+            paths.append(package_path(language, "universal"))
+            if language != "dart":
+                paths.append(package_path(language, "near-complete"))
+        paths.extend(
+            [
+                package_path("rust", "rust-only"),
+                package_path("python", "python-only"),
+                package_path("wasm", "universal"),
+            ]
+        )
+
+        packages, unknown = parity.parse_package_paths(paths)
+        report = parity.build_report(packages, unknown)
+        coverage = {row["language"]: row for row in report["coverage"]}
+
+        self.assertEqual(report["package_count"]["implementation_union"], 4)
+        self.assertEqual(report["package_count"]["high_consensus"], 2)
+        self.assertEqual(report["completion_bands"]["10-15"]["packages"], 2)
+        self.assertEqual(report["completion_bands"]["10-15"]["missing_slots"], 1)
+        self.assertEqual(coverage["dart"]["missing_high_consensus"], 1)
+        self.assertEqual(
+            coverage["dart"]["missing_high_consensus_packages"], ["near-complete"]
+        )
+        self.assertEqual(report["singleton_by_language"]["rust"], 1)
+        self.assertEqual(report["singleton_by_language"]["python"], 1)
+
+    def test_csv_is_a_complete_presence_matrix(self) -> None:
+        packages, unknown = parity.parse_package_paths(
+            [
+                package_path("rust", "heap"),
+                package_path("python", "heap"),
+                package_path("starlark", "builtins"),
+            ]
+        )
+        report = parity.build_report(packages, unknown)
+        rows = list(csv.DictReader(io.StringIO(parity.render_csv(report))))
+
+        self.assertEqual(len(rows), 2)
+        by_package = {row["package"]: row for row in rows}
+        self.assertEqual(by_package["heap"]["rust"], "1")
+        self.assertEqual(by_package["heap"]["python"], "1")
+        self.assertEqual(by_package["heap"]["dart"], "0")
+        self.assertEqual(by_package["builtins"]["starlark"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- rebuild the package parity inventory from Git-visible files instead of raw filesystem directories
- normalize package identities across case, punctuation, and Swift naming conventions
- classify implementation, emerging, execution-target, domain-language, and build-language buckets
- emit Markdown, JSON, and a full CSV package-by-language matrix
- report canonical identity collisions and unclassified language buckets
- add unit coverage and run the reporter in the CI detect job
- refresh the parity roadmap with the July 2026 baseline and the autonomous work queue

## Why

The previous April inventory was being contaminated by ignored build outputs and generated directories, and its Rust/Python baseline had drifted substantially. The parity loop needs a reproducible tracked-tree inventory before it begins creating hundreds of ports.

## Validation

- `python -m unittest discover -s scripts/tests -p 'test_package_parity_report.py' -v`
- `ruff check scripts/package_parity_report.py scripts/tests/test_package_parity_report.py`
- `ruff format --check scripts/package_parity_report.py scripts/tests/test_package_parity_report.py`
- live Markdown, JSON, and CSV report generation
- `git diff --check`

## Current findings encoded in the roadmap

- 1,102 implementation package identities across 15 established languages
- 171 high-consensus packages with 411 missing language slots
- 465 Rust singletons
- two Ruby canonical identity collisions to resolve next
