### PR TITLE
feat(sir-js): Ruby value-equality for Array#include? / index (v0.22.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.22.0 — Ruby value-equality for `Array#include?` / `Array#index`
+
+Fixes two native-alias semantic divergences on Array receivers, routed through
+the explicit `arrayMethod` switch (never `recv[name]`) with a new `valEq` helper
+that mirrors the Go/Python reference `_sir_value_eq` (scalars by `===`, Symbols
+by name, Arrays element-wise, Maps entry-wise):
+
+- **`index`** was previously **absent** for arrays (`index` ≠ native `indexOf`,
+  not aliased, not on the allowlist) → `[1, 2, 3].index(2)` raised NoMethodError.
+  It now returns the first index whose element `== x` by **value**, or **`nil`**
+  when absent (native `indexOf` returns `-1` and uses identity).
+- **`include?`** previously used native `Array#includes` (SameValueZero /
+  identity), so a nested Array or Symbol wrongly missed. It now compares by
+  **value**, so `[[1, 2]].include?([1, 2])` is `true`, matching Ruby and the
+  sibling backends. (String `include?` is unaffected — strings resolve via
+  `stringMethod`/the native alias before the Array path.)
+
+Exec-proven end-to-end under Node.
+
+> Deferred (display-frontier entanglement): `Array#join`'s default separator
+> (Ruby `""` vs native JS `","`) and element `to_s` rendering intersect the
+> in-progress source-language display-convention work, so they are left to that
+> effort rather than fixed here.
+
 ## 0.21.0 — non-block Array catch-up: `flatten` / `compact` / `rotate` / `zip`
 
 Closes the JS backend's remaining gap on the reference (Go/Rust/Python/TS)

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -957,10 +957,51 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "each_with_object", "sum", "uniq", "first", "last", "empty?", "to_a",
     "take", "drop", "values_at",
     "flatten", "compact", "rotate", "zip",
+    "include?", "index",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
   function arrCmp(a, b) { return a < b ? -1 : a > b ? 1 : 0; }
+  // Ruby value equality (`==`) for `Array#include?` / `Array#index`.  Ruby
+  // compares by VALUE, not identity: `[[1,2]].include?([1, 2])` is `true` and
+  // `[1,2,3].index(9)` is `nil`.  Native JS `Array#includes` / `indexOf` use
+  // SameValueZero (identity for objects), so a nested Array or Symbol would
+  // wrongly miss — this mirrors the Go/Python reference (`_sir_value_eq`):
+  // scalars by `===`, Symbols by name, Arrays element-wise, Maps entry-wise.
+  // (`NaN !== NaN`, matching Ruby's `Float::NAN == Float::NAN == false`.)
+  // `seen` is a path-set of the `a`-side containers currently being compared; a
+  // cyclic array (`a = []; a << a`, which this runtime explicitly supports) would
+  // otherwise recurse forever.  Re-encountering `a` on the path means the two
+  // structures have matched identically all the way down to the back-edge, so we
+  // return `true` — exactly Ruby's recursive-`==` rule — mirroring the `seen` set
+  // the display path (`formatSeen`) carries for the same cyclic values.
+  function valEq(a, b, seen) {
+    if (a === b) { return true; }
+    if (a instanceof Sym && b instanceof Sym) { return a.name === b.name; }
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) { return false; }
+      if (seen === undefined) { seen = new Set(); }
+      if (seen.has(a)) { return true; }
+      seen.add(a);
+      for (let i = 0; i < a.length; i++) {
+        if (!valEq(a[i], b[i], seen)) { seen.delete(a); return false; }
+      }
+      seen.delete(a);
+      return true;
+    }
+    if (a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) { return false; }
+      if (seen === undefined) { seen = new Set(); }
+      if (seen.has(a)) { return true; }
+      seen.add(a);
+      for (const [k, v] of a) {
+        if (!b.has(k) || !valEq(b.get(k), v, seen)) { seen.delete(a); return false; }
+      }
+      seen.delete(a);
+      return true;
+    }
+    return false;
+  }
   function arrayMethod(recv, name, args) {
     // A trailing function positional is the block (`arr.map { … }`).
     const blk = args.length > 0 && typeof args[args.length - 1] === "function"
@@ -1150,6 +1191,23 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           zipped.push(row);
         }
         return zipped;
+      }
+      case "include?": {
+        // Ruby `Array#include?(x)` — VALUE equality (see `valEq`), so a nested
+        // Array/Symbol matches structurally.  Overrides the native `includes`
+        // alias (SameValueZero), matching the Go/Python reference.
+        for (const x of recv) { if (valEq(x, args[0])) { return true; } }
+        return false;
+      }
+      case "index": {
+        // Ruby `Array#index(x)` — the first index whose element `== x` (value
+        // equality), or `nil` when absent.  Native JS `indexOf` returns `-1`
+        // and uses identity; this returns `null` and matches Ruby / the Go
+        // reference.  (The block form `index { … }` is out of v0 scope.)
+        for (let i = 0; i < recv.length; i++) {
+          if (valEq(recv[i], args[0])) { return i; }
+        }
+        return null;
       }
       case "to_a": return recv;
     }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2372,6 +2372,31 @@ fn array_flatten_compact_rotate_zip_methods() {
     }
 }
 
+// v0.22.0 native-alias divergence fixes: `include?` and `index` now use Ruby
+// VALUE equality (`valEq`) via the explicit `arrayMethod` switch, not native
+// `Array#includes`/`indexOf` (which use identity and return `-1`).  So a nested
+// Array matches structurally, and a missing element yields `nil` (not `-1`).
+// `index` was previously ABSENT for arrays (NoMethodError).  Booleans render
+// `#t`/`#f` here because the module's source language is non-Ruby ("handbuilt").
+#[test]
+fn array_include_and_index_value_equality() {
+    let pair = |a, b| seq(vec![int(a), int(b)]);
+    let stmts = vec![
+        print(method(seq(vec![int(10), int(20), int(30)]), "include?", vec![int(20)])), // #t
+        print(method(seq(vec![int(10), int(20), int(30)]), "include?", vec![int(99)])), // #f
+        // structural: a nested Array matches by value, not identity
+        print(method(seq(vec![pair(1, 2), pair(3, 4)]), "include?", vec![pair(1, 2)])), // #t
+        print(method(seq(vec![int(10), int(20), int(30)]), "index", vec![int(20)])), // 1
+        print(method(seq(vec![int(10), int(20), int(30)]), "index", vec![int(99)])), // nil
+        print(method(seq(vec![pair(1, 2), pair(3, 4)]), "index", vec![pair(3, 4)])), // 1
+    ];
+    let module =
+        module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Sequences, Feature::Strings]);
+    if let Some(stdout) = run_module(&module, "arrincludeindex") {
+        assert_eq!(stdout, "#t\n#f\n#t\n1\nnil\n1");
+    }
+}
+
 // ── Ruby Hash method catalog (hand-implemented, explicit dispatch) ──
 //
 // Exercises the `hashMethod` catalog end-to-end under Node: `keys`/`values`/


### PR DESCRIPTION
## What

Fixes two native-alias semantic divergences on **Array** receivers in the JS backend, via the explicit `arrayMethod` switch (never `recv[name]`) with a new `valEq` helper mirroring the Go/Python reference `_sir_value_eq` (scalars `===`, Symbols by name, Arrays element-wise, Maps entry-wise):

- **`index`** was **absent** for arrays (`index` ≠ native `indexOf`, not aliased, not on the allowlist) → `[1,2,3].index(2)` raised **NoMethodError**. Now returns the first index whose element `== x` by **value**, or **`nil`** when absent (native `indexOf` returns `-1` and uses identity).
- **`include?`** used native `Array#includes` (SameValueZero / identity), so a nested Array or Symbol wrongly missed. Now compares by **value** — `[[1,2]].include?([1,2])` is `true` — matching Ruby and the sibling backends. String `include?` is unaffected (strings resolve via `stringMethod`/the native alias before the Array path).

`valEq` carries a `seen` path-set **cycle guard** (mirroring `formatSeen`) so a cyclic array terminates as equal on the back-edge — Ruby's recursive-`==` rule — instead of overflowing the stack (security-review hardening).

## Verification

- Full crate suite green (**109 unit + 70 Node exec-proof**), incl. new `array_include_and_index_value_equality` (runs emitted JS under `node`, exercises scalar + structural-nested cases).
- Security review: **PASSED** — no injection / prototype-pollution / reflection surface; the flagged cyclic-recursion self-DoS is closed by the cycle guard.

Bumps `0.21.0 → 0.22.0`; CHANGELOG updated.

> Deferred (display-frontier entanglement): `Array#join`'s default separator (Ruby `""` vs native JS `","`) and element `to_s` rendering intersect the in-progress source-language display-convention work, so they're left to that effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)