### PR TITLE
feat(sir-runtime-oop): String tr / count / delete / squeeze (Python, char sets)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.16] - 2026-07-07
+
+### Added — String char-set methods: `tr` / `count` / `delete` / `squeeze`
+
+Extends `_string_method` (and the `_STRING_METHODS` `respond_to?` catalog) with
+four more non-block Ruby String methods:
+
+- `tr(from, to)` — position-wise character translation; a shorter `to` repeats
+  its last char, an empty `to` deletes matching chars, and the last mapping wins
+  when `from` repeats a char.
+- `count(*sets)` / `delete(*sets)` / `squeeze(*sets)` — char-set methods:
+  `count` tallies chars of the receiver in the set, `delete` removes them, and
+  `squeeze` collapses consecutive runs (of set chars, or of *all* chars when no
+  set is given). Multiple set arguments intersect (Ruby's rule).
+
+Each `set`/`from`/`to` argument is treated **literally** — the character-range
+(`"a-z"`) and negation (`"^abc"`) forms are a follow-up, matching the existing
+literal-only `sub`/`gsub` precedent. First backend of the String char-set sweep
+(reference; the Go/Rust/JS/TS backends follow).
+
 ## [0.1.15] - 2026-07-07
 
 ### Added — Array reorder/combine methods: `rotate` / `zip`

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -79,7 +79,8 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 **M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
 `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,
 `include?`/`start_with?`/`end_with?`/`index`, `replace`, `sub`/`gsub` *literal*,
-`to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`); and (item **M1c**) the
+`to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `tr`/`count`/`delete`/`squeeze`
+*(literal char sets)*, `each_char`); and (item **M1c**) the
 **`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`, `even?`/`odd?`/`zero?`/
 `positive?`/`negative?`, `succ`/`pred`, `floor`/`ceil`/`round`, `gcd`, `pow`/`**`,
 `digits`, and block `times`/`upto`/`downto`/`step`), the **`Symbol`** catalog

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.15"
+version = "0.1.16"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -690,6 +690,10 @@ _STRING_METHODS = frozenset(
         "rjust",
         "center",
         "swapcase",
+        "tr",
+        "count",
+        "delete",
+        "squeeze",
     }
 )
 
@@ -1351,6 +1355,47 @@ def _string_method(recv: str, name: str, args: list[Val]) -> Val:
                 out.append(chr(code - 32))
             else:
                 out.append(ch)
+        return "".join(out)
+    if name == "tr":
+        # Ruby ``String#tr(from, to)``: translate each char that appears in
+        # ``from`` to the char at the same position in ``to``.  A shorter ``to``
+        # repeats its LAST char; an empty ``to`` deletes matching chars; when
+        # ``from`` repeats a char the last mapping wins.
+        # NOTE: the char-RANGE (``"a-z"``) and NEGATION (``"^abc"``) forms are a
+        # follow-up, matching the literal-only ``sub``/``gsub`` precedent here.
+        if len(args) < 2 or not isinstance(args[0], str) or not isinstance(args[1], str):
+            return recv
+        frm, to = args[0], args[1]
+        table: dict[str, str] = {}
+        for i, ch in enumerate(frm):
+            table[ch] = (to[i] if i < len(to) else to[-1]) if to else ""
+        return "".join(table.get(ch, ch) for ch in recv)
+    if name in ("count", "delete", "squeeze"):
+        # Char-set methods.  Each ``set`` argument is treated LITERALLY — the set
+        # of characters it contains (ranges/negation are a follow-up).  ``count``
+        # returns how many chars of ``recv`` lie in the set; ``delete`` removes
+        # them; ``squeeze`` collapses consecutive runs (of set chars, or of ALL
+        # chars when no set is given).  Multiple set args intersect (Ruby's rule).
+        str_sets = [set(a) for a in args if isinstance(a, str)]
+        if name == "squeeze" and not str_sets:
+            squeezed: list[str] = []
+            for ch in recv:
+                if not squeezed or squeezed[-1] != ch:
+                    squeezed.append(ch)
+            return "".join(squeezed)
+
+        def in_all(ch: str) -> bool:
+            return bool(str_sets) and all(ch in s for s in str_sets)
+
+        if name == "count":
+            return sum(1 for ch in recv if in_all(ch))
+        if name == "delete":
+            return "".join(ch for ch in recv if not in_all(ch))
+        out = []
+        for ch in recv:
+            if out and out[-1] == ch and in_all(ch):
+                continue
+            out.append(ch)
         return "".join(out)
     return _MISS
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -599,6 +599,26 @@ def test_string_repeat_and_concat() -> None:
     assert len(oop.call_method("ab", "*", 10**9)) <= 100_000_000
 
 
+def test_string_tr_translates_and_deletes() -> None:
+    # `tr(from, to)`: position-wise char map; a shorter `to` repeats its last
+    # char; an empty `to` deletes matching chars; last mapping wins on a repeat.
+    assert oop.call_method("hello", "tr", "el", "ip") == "hippo"
+    assert oop.call_method("hello", "tr", "aeiou", "*") == "h*ll*"
+    assert oop.call_method("hello", "tr", "l", "") == "heo"
+    assert oop.call_method("hello", "tr", "xyz", "abc") == "hello"
+
+
+def test_string_count_delete_squeeze_char_sets() -> None:
+    assert oop.call_method("hello", "count", "l") == 2
+    assert oop.call_method("hello", "count", "lo") == 3
+    assert oop.call_method("hello", "count", "xyz") == 0
+    assert oop.call_method("hello", "delete", "l") == "heo"
+    assert oop.call_method("hello", "delete", "aeiou") == "hll"
+    # squeeze: no arg collapses every run; with a set, only those chars
+    assert oop.call_method("mississippi", "squeeze") == "misisipi"
+    assert oop.call_method("aaabbbccc", "squeeze", "a") == "abbbccc"
+
+
 def test_string_each_char_block() -> None:
     seen: list[Val] = []
     result = oop.call_method("abc", "each_char", Closure(seen.append))


### PR DESCRIPTION
## What

Starts the **String char-set breadth sweep** on the reference (Python) backend. Adds four non-block Ruby String methods to `_string_method` and the `_STRING_METHODS` `respond_to?` catalog:

- **`tr(from, to)`** — position-wise character translation; a shorter `to` repeats its last char, an empty `to` deletes matching chars, and the last mapping wins when `from` repeats a char.
- **`count(*sets)` / `delete(*sets)` / `squeeze(*sets)`** — char-set methods: `count` tallies receiver chars in the set, `delete` removes them, `squeeze` collapses consecutive runs (of set chars, or of *all* chars when no set is given). Multiple set args intersect (Ruby's rule).

Each `set`/`from`/`to` argument is treated **literally** — the char-range (`"a-z"`) and negation (`"^abc"`) forms are a follow-up, matching the existing literal-only `sub`/`gsub` precedent.

## Discipline

- Explicit literal-name dispatch (no reflection); never-raise floor preserved (bad arity / non-str args degrade rather than raise).

## Verification

- `pytest` — **120 passed**, `oop.py` coverage **97%**. New specs cover translate/repeat-last/delete, count (single + multi-char sets + miss), delete, and squeeze (no-arg + set).
- `ruff` clean.
- Security review: **PASSED** — no injection / ReDoS / unbounded-allocation surface (all four are bounded literal transforms, no regex).

Bumps `0.1.15 → 0.1.16`; CHANGELOG + README updated. First of the sweep; Go/Rust/JS/TS backends follow in later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)