### PR TITLE
docs(task-app): Phase 0 specs — general task/project engine on Mosaic

### DIFF
--- a/code/specs/task-app-architecture.md
+++ b/code/specs/task-app-architecture.md
@@ -1,0 +1,210 @@
+# task-app — Application Architecture
+
+> Part of the [task-app spec series](task-app-overview.md). Defines the crate layering, the
+> props/event contract, and the FFI/UI seams. This replicates the **Engram** architecture
+> (`engram-core` → `engram-core-wasm` → `engram-capi`+`engram-wasm` → Mosaic host adapters) exactly;
+> where a decision has a proven Engram precedent, we cite it.
+
+## The layer cake
+
+```
+task-core            pure domain: ProjectState + reduce() + CPM scheduler + formula/calendar modules
+  │                  no I/O, no clock (now: u64 injected), serde behind a feature, forbid(unsafe)
+  └ task-core-wasm   THE FACADE (platform-free, forbid(unsafe)): TaskSession = ProjectState +
+        │            view-model state; &str-in / JSON-String-out (panic-caught); dispatch() command
+        │            bus; get_props(ctx) → flat kebab slot map; handle_event() → combined envelope
+        ├ task-capi  extern "C" over TaskSession — native shells; + task-host-cli sidecar
+        └ task-wasm  linear-memory WASM ABI over TaskSession — browser / Electron; + JS loader
+```
+
+`task-capi` and `task-wasm` are **siblings**, each depending only on `task-core-wasm` and adding an
+ABI + marshalling. All behavior — every prop, every event — lives once in the facade. Porting to a
+platform is a new thin ABI/adapter, never a change to core logic. (Engram precedent:
+`engram-capi`/`engram-wasm` both wrap `engram-core-wasm`, not `engram-core`.)
+
+Only the two ABI crates contain `unsafe`; everything below `forbid(unsafe_code)`.
+
+## `task-core` — the domain core
+
+Public surface (engram-core `reducer.rs` pattern):
+
+```rust
+pub struct ProjectState { /* see data-model spec */ }
+
+pub enum TaskCommand { /* the full mutation catalog, below */ }
+
+/// Pure reducer: immutable in, new state out. Never mutates in place.
+pub fn reduce(state: &ProjectState, cmd: TaskCommand) -> ProjectState;
+
+/// Pure read-models (not commands) — the scheduler & projections:
+pub fn schedule(state: &ProjectState) -> ScheduleResult;        // CPM: dates, slack, critical, conflicts
+pub fn level_resources(state: &ProjectState, opts: LevelOpts) -> ScheduleResult;
+pub fn recompute_fields(state: &ProjectState) -> FieldValues;   // formula/rollup via symbolic-vm
+pub fn checklist_view(state, view) -> ChecklistProjection;      // flattenVisibleItems analogue
+pub fn kanban_view(state, view) -> KanbanProjection;
+pub fn gantt_view(state, view) -> GanttProjection;
+// … one per ViewShape …
+```
+
+### Command catalog (`TaskCommand`)
+
+Grouped; each variant carries typed ids/values (not strings):
+
+- **Task**: `CreateTask`, `RenameTask`, `SetNotes`, `DeleteTask`, `Reparent{task,new_parent,index}`,
+  `Reorder`, `SetKind`, `ToggleCollapsed`.
+- **Progress/workflow**: `SetStatus`, `ToggleCompleted`, `SetPercentComplete`.
+- **Schedule**: `SetDuration`, `SetWork`, `SetTaskType`, `SetConstraint`, `SetDeadline`,
+  `SetTaskCalendar`, `SetActuals`.
+- **Dependencies**: `LinkDependency{pred,succ,kind,lag}`, `UnlinkDependency`, `SetDependencyKind`,
+  `SetLag`.
+- **Generic links**: `AddLink`, `RemoveLink`.
+- **Resources/assignments**: `CreateResource`, `EditResource`, `DeleteResource`, `Assign`,
+  `SetAssignmentUnits`, `SetContour`, `Unassign`.
+- **Calendars**: `CreateCalendar`, `SetWorkWeek`, `AddException`, `RemoveException`, `SetProjectCalendar`.
+- **Fields**: `AddFieldDef`, `EditFieldDef`, `DeleteFieldDef`, `SetFieldValue`.
+- **Decision (checklist)**: `SetDecisionQuestion`, `AnswerDecision{task,answer}`, `ClearDecision`.
+- **Baselines**: `CaptureBaseline`, `DeleteBaseline`.
+- **Views**: `CreateView`, `EditView`, `DeleteView`.
+- **Bulk/state**: `LoadState`, `ImportProject`, `Undo`, `Redo` (history via snapshot stack).
+
+### Recompute triggers
+
+Each command declares what it invalidates, so the facade recomputes minimally:
+
+| Invalidates | Commands (examples) |
+|---|---|
+| **Schedule cache** (→ re-run CPM) | duration/work/type/constraint/calendar edits, link CRUD, reparent, assignment edits |
+| **Formula cache** (→ recompute affected fields) | `SetFieldValue`, any schedule change formulas read (`[finish]` etc.) |
+| **Neither** | rename, notes, view CRUD, collapse toggle |
+
+`directed-graph.affected_nodes` bounds both recomputations to the transitive impact set.
+
+## `task-core-wasm` — the facade (the contract layer)
+
+The keystone: the single place the UI contract is defined. (Engram precedent:
+`engram-core-wasm/src/lib.rs`.)
+
+```rust
+pub struct TaskSession {
+    state: ProjectState,
+    // view-model state the core doesn't track:
+    active_view: ViewId,
+    selection: Vec<TaskId>,
+    editor: Option<TaskEditorState>,
+    filters: FilterState,
+}
+impl TaskSession {
+    pub fn new() -> Self; pub fn new_demo() -> Self;
+    pub fn snapshot(&self) -> String;                 // JSON of ProjectState
+    pub fn load_snapshot(&mut self, json: &str) -> String;
+    pub fn dispatch(&mut self, command_json: &str) -> String;      // {"ok":true,"state":…}
+    pub fn get_props(&self, ctx_json: &str) -> String;             // flat kebab-case slot map
+    pub fn handle_event(&mut self, event_json: &str, now: u64) -> String; // combined envelope
+    pub fn export_backup(&self, now: u64) -> String;
+    pub fn import_backup(&mut self, json: &str) -> String;
+}
+```
+
+- **Method shape**: `&str` in, JSON `String` out, every call wrapped in a panic-catcher so a bug
+  becomes `{"ok":false,"error":…}` instead of trapping the FFI boundary. Standard success envelope
+  `{"ok":true,"<key>":<payload>}`. (Engram's `catch_json`/`ok_with`.)
+- **`dispatch`** deserializes a `FacadeCommand`, lowers it into a core `TaskCommand`, and `reduce`s.
+- **`get_props(ctx)`** builds a flat object of **kebab-case slot keys** from the current state +
+  active view + selection — e.g. `"app-title"`, `"view-shape"`, `"task-count"`,
+  `"gantt-bars"` (list), `"selected-task-name"`, `"schedule-conflicts"` (list),
+  `"kanban-columns"`. Names line up 1:1 with the Mosaic `.mil` slots.
+- **`handle_event(event, now)`** parses an event envelope into a typed `TaskAppEvent`
+  (`SelectTask`, `Toggle`, `AnswerDecision`, `MoveCard{task,to_status}`, `EditDuration`,
+  `RequestOpenFile`, `RequestSave`, …), mutates via `dispatch`/view-model, and returns **one combined
+  envelope**: `{ ok, event, hostIntent?, state, props }` — the freshly recomputed props *and* an
+  optional out-of-band host intent.
+- **`hostIntent`** is the escape hatch for things the sandbox can't do — file open/save,
+  OS dialogs. `host_intent_for_event` emits e.g. `{"type":"openProject","accept":[".taskproj",".json"]}`
+  or `{"type":"saveProject","extension":".taskproj"}`. The host performs the side effect and feeds
+  bytes back through a dedicated method. (Engram precedent: Anki import/export intents.)
+
+The facade also owns **snapshot persistence policy** (what to persist after each non-error event),
+which host adapters wrap with `storage-core` / localStorage.
+
+## `task-capi` — C ABI (native shells)
+
+(Engram precedent: `engram-capi`.) `crate-type = ["cdylib","staticlib","rlib"]`, plus a
+`[[bin]] task-host-cli`.
+
+```c
+TaskSession* task_session_new(void);
+void         task_session_free(TaskSession*);
+char*        task_dispatch(TaskSession*, const char* command_json);
+char*        task_get_props(TaskSession*, const char* ctx_json);
+char*        task_handle_event(TaskSession*, const char* event_json, uint64_t now);
+char*        task_snapshot(TaskSession*);
+char*        task_load_snapshot(TaskSession*, const char* json);
+char*        task_import_project(TaskSession*, const uint8_t* data, size_t len); // binary payloads
+void         task_string_free(char*);   // caller frees every returned string
+```
+
+Opaque handle + NUL-terminated UTF-8 strings; a `with_session` helper null-checks and maps 1:1 onto
+the facade. Binary payloads (project file import) use `(ptr,len)` byte pairs. Events flow back the
+same way any call returns — request/response, no callbacks; `hostIntent` rides inside the
+`handle_event` JSON. Ships a generated `include/task.h` for the SwiftUI module map.
+
+## `task-wasm` — WASM ABI (browser / Electron)
+
+(Engram precedent: `engram-wasm`, mirroring the repo's `spreadsheet-wasm` convention.) Hand-rolled
+`extern "C"` over `wasm32-unknown-unknown` linear memory — not wasm-bindgen:
+
+- exports `alloc(len)` / `dealloc(ptr,len)`; inputs are `(ptr,len)` byte pairs; outputs are
+  **length-prefixed** (`[u32 LE len][UTF-8 JSON]`).
+- one `thread_local! { static SESSION: RefCell<TaskSession> }`, with `reset()`/`reset_demo()`.
+- exports mirror the facade: `dispatch`, `snapshot`, `load_snapshot`, `get_props`, `handle_event`,
+  `import_project`, `export_backup`.
+- a hand-written JS loader `task-mosaic-host-wasm.mjs` (typed `.d.ts`) exposes
+  `createTaskEngine(wasmBytes, opts) → TaskEngine` with camelCase methods and, crucially,
+  `engine.createMosaicHost({now, onHostIntent}) → { platform, getProps, handleEvent }` — where the
+  Rust kebab-case slot keys are surfaced to the Mosaic host contract.
+
+## Mosaic UI package (`code/programs/mosaic/task-app`)
+
+A **UI** package — no product logic. (Engram precedent: `engram-app` package.)
+
+- `TaskApp.mil` — interface: `slot`s (props, typed) and `emit`s (events, some with typed args like
+  `onMoveCard(task:text, toStatus:text)`), names aligned to the facade's kebab-case prop keys.
+- `TaskApp.mll` + `TaskApp.touch.mll` — desktop and touch layout variants.
+- `TaskApp.light.msl` + `TaskApp.dark.msl` — theme stylesheets (`--theme` at build).
+- `mosaic-package.toml` — `exports = ["TaskApp"]`; depends on reusable
+  `code/packages/mosaic/mosaic-pkg-*` components; declares `[host_assets]` (the adapter files).
+- `scripts/build-all.ps1` — the assembly line: build `task-wasm` (→ wasm + JS loader) and
+  `cargo build -p task-capi` (→ dll/dylib/so + static lib + `task-host-cli`); then per backend run
+  `mosaic-compile pkg … --backend X --emit-project`; then install the right artifact — wasm+loader
+  for web/react/electron, `task_capi.{dll,dylib,so}` for qt/xaml/flutter/compose, static lib +
+  `task.h` + module.modulemap for swiftui.
+
+### Reusable components (`code/packages/mosaic/mosaic-pkg-*`)
+
+`checklist-runner`, `todo-list`, `task-board` (kanban), `gantt-view`, `flowchart-view`,
+`task-detail`, `field-editor`, `calendar-view`. Each is an independently-adoptable Mosaic component,
+authored once, emitted to every backend.
+
+### Host adapters (`host/{web,electron,qt,swiftui,compose,flutter,xaml}`)
+
+Thin per-backend glue. The **getProps/handleEvent contract** is the seam: Mosaic-generated UI calls
+`window.mosaicHost.getProps({component})` to fill slots and `window.mosaicHost.handleEvent(...)` on
+`emit`. The web adapter builds that host object from `engine.createMosaicHost(...)`:
+`getProps → task_get_props → {props}`; `handleEvent → task_handle_event → {props, hostIntent}`;
+re-render from `props`, and route any `hostIntent` through `onHostIntent` (file open/save), then
+persist `snapshot()` via `withSnapshotPersistence` (localStorage / `~/.task-app/snapshot.v1.json`).
+Native shells (Qt/XAML/SwiftUI/Compose/Flutter) link `task-capi` and marshal identically.
+
+## Contract-parity testing
+
+Following Engram's smoke tests: assert that every generated host shell (web/react/electron and the
+native project shells) exposes the **same** slot keys and event envelope as the `TaskSession` facade
+— i.e. the `.mil` interface stays in lockstep with `get_props`/`handle_event`. This catches drift
+between the Rust contract and the Mosaic UI at build time, on every platform.
+
+## Phase-1 seam (how the two tracks meet)
+
+Track B (facade + wasm + Mosaic + web/electron) can start against a **minimal** `task-core` (tasks +
+checklist/todo projections, no scheduling) so the pipeline is proven end-to-end early; as Track A
+lands the real CPM scheduler + resources, the facade's read-models (`schedule`, `gantt_view`, …)
+light up without changing the ABI or the UI contract. The contract-parity tests guard the seam.

--- a/code/specs/task-app-constraint-vm-enhancement.md
+++ b/code/specs/task-app-constraint-vm-enhancement.md
@@ -1,0 +1,172 @@
+# Constraint-VM Enhancement — Optimization & Scheduling-Scale Solving
+
+> Part of the [task-app spec series](task-app-overview.md), but the work lands in the **existing**
+> `constraint-*` crates, not in task-app. It fulfils the standing instruction to *"fix the constraint
+> VM so it supports all the features."* The task-app scheduler
+> ([`task-app-scheduling-engine.md`](task-app-scheduling-engine.md)) is the first consumer, but these
+> are general SMT/OMT capabilities that benefit every user of the stack.
+
+## Current state (audited)
+
+The `constraint-*` stack is a clean, SMT-LIB-style decision procedure:
+
+- `constraint-core` — `Predicate` AST (linear arithmetic), `Sort` (`Bool`/`Int`/`Real`/…),
+  `Logic` (`QF_Bool`, `QF_LIA`, `QF_LRA` declared, `free_vars`, `infer_sort`, NNF/CNF/simplify).
+- `constraint-instructions` — `ConstraintInstr` opcodes (`DeclareVar`, `Assert`, `CheckSat`,
+  `GetModel`, `GetUnsatCore`, `PushScope`/`PopScope`, `Reset`, `SetLogic`) + text parser/serializer.
+- `constraint-engine` — `Engine::check_sat() -> SolverResult::{Sat(Model), Unsat, Unknown(String)}`;
+  `Model` maps names to `Value::{Int(i128), Bool(bool)}`; a boolean CDCL core (`sat.rs`) + a
+  linear-integer tactic (`lia.rs`).
+- `constraint-vm` — `Vm` + `ProgramBuilder` fluent API (`set_logic`, `declare_int`, `assert_pred`,
+  `assert_ge_int/le_int/eq_int`, `check_sat`, `get_model`, `push_scope`/`pop_scope`, `build`) and
+  free functions `check_sat(&Program)` / `get_model(&Program)`.
+
+**Two gaps** make it unable to *drive* scheduling optimization today:
+
+1. **No objective / optimization.** The engine is satisfiability-only — `SolverResult` has no
+   `Optimal`, and there is no `Minimize`/`Maximize` opcode. `get_model` returns an *arbitrary*
+   feasible point (typically variables pushed to a lower bound), not a cost-minimal one. Resource
+   leveling and makespan minimization are inexpressible.
+2. **The LIA tactic is a bounded-search heuristic.** `lia.rs` collects per-variable bounds, picks a
+   witness, substitutes, and recurses — its own docs warn it is "potentially exponential" and may
+   return `Unknown` on many-variable coupled systems. A real scheduling network (dozens–hundreds of
+   interacting `start`/`finish` variables) is exactly that case.
+
+`adj-lang` already *parses* `minimize`/`maximize` (its `OptDir`), and `adj-constraint-solver` names
+LP/simplex as an unimplemented "track C2" — so the front-end vocabulary exists but the solver side is
+empty. We implement it.
+
+## Goals
+
+Add, without breaking existing satisfiability behavior:
+
+1. **Optimization Modulo Theories (OMT)** — minimize/maximize a linear objective, returning a
+   provably optimal model.
+2. **A difference-logic fast path** that solves the scheduling fragment in polynomial time and
+   detects infeasibility (negative cycles) exactly — making the engine robust at scheduling scale.
+3. The plumbing to expose both through instructions, the VM, the builder, and `adj-lang`.
+
+## Change 1 — Objective representation (`constraint-core`)
+
+Add a linear **objective term** type (reusing the arithmetic sub-AST already inside `Predicate`):
+
+```rust
+/// A linear term: Σ coefficient·variable + constant. (Same shape as the arithmetic already
+/// embedded in Predicate::{Add,Sub,Mul,Var,Int}; extracted here so objectives and constraints share it.)
+pub struct LinearTerm { pub terms: Vec<(i128, String)>, pub constant: i128 }
+
+pub enum Objective { Minimize(LinearTerm), Maximize(LinearTerm) }
+```
+
+`LinearTerm::free_vars`, `Display` (SMT-LIB s-expr), and a `from_predicate_arith` helper keep it
+consistent with the existing normalization/printing conventions.
+
+## Change 2 — Opcodes (`constraint-instructions`)
+
+Add two opcodes mirroring SMT-LIB `(minimize t)` / `(maximize t)`, plus `(get-objectives)`:
+
+```rust
+pub enum ConstraintInstr {
+    // …existing…
+    Minimize { term: LinearTerm },
+    Maximize { term: LinearTerm },
+    GetObjectives,          // after CheckSat: report objective value(s) of the optimal model
+}
+```
+
+Extend the text parser/serializer (`minimize`, `maximize`, `get-objectives`) and the
+`check_program` validator (objective vars must be declared; objectives require an optimizing
+`CheckSat`). Programs with no objective behave exactly as before (`CheckSat` = satisfiability).
+
+## Change 3 — The OMT loop (`constraint-engine`)
+
+Add an optimization result and an `optimize` entry point layered over the existing `check_sat`:
+
+```rust
+pub enum OptResult {
+    Optimal { model: Model, value: i128 },
+    Unbounded,                 // objective decreases without bound
+    Unsat,
+    Unknown(String),
+}
+impl Engine {
+    pub fn optimize(&mut self, obj: &Objective) -> OptResult { /* … */ }
+}
+```
+
+**Algorithm — bound-refinement OMT over the existing theory solver** (correct for `QF_LIA`, which is
+what scheduling uses):
+
+1. `check_sat()`. If `Unsat`/`Unknown`, return the same. Else take the model `m₀`, objective value `v₀`.
+2. Push a scope; assert `obj < v₀` (for minimize). `check_sat()` again.
+3. If `Sat(m₁)` with value `v₁ < v₀`: keep `m₁`, tighten again (linear descent; optionally
+   **binary search** between a known feasible `v` and a lower bound derived from the constraints to
+   cut iterations to `O(log range)`).
+4. When the tightened query is `Unsat`, the last feasible model is **optimal** → `Optimal{m, v}`.
+5. Unbounded detection: if no lower bound exists and each tighten stays `Sat`, return `Unbounded`
+   (guarded by the engine's instruction/assertion resource limits).
+
+This reuses `push_scope`/`pop_scope` (already stale-invalidate the cached result — see
+`constraint-vm` line ~336) so each refinement is incremental. It is exact for integer objectives and
+needs no new theory — it is a driver around `check_sat`.
+
+## Change 4 — Difference-logic tactic for scheduling scale (`constraint-engine/lia.rs`)
+
+Scheduling constraints are almost all **difference constraints**: `start_B − finish_A ≥ lag`,
+`finish_T − start_T = duration`, `start_T ≥ project_start`. The fragment where every assertion is
+`x − y ≤ c` (Integer Difference Logic, QF_IDL) is solvable in **polynomial time** via shortest paths
+and detects infeasibility as a **negative cycle** — precisely what over-constrained plans produce.
+
+Add a **difference-logic recognizer + Bellman-Ford solver** as a fast tactic ahead of the general
+LIA search:
+
+1. Normalize each asserted linear predicate; if *all* are two-variable difference constraints (plus
+   simple bounds `x ≤ c` via a virtual zero node), build the constraint graph (edge `y →(c) x` for
+   `x − y ≤ c`).
+2. Run Bellman-Ford from the zero node. A **negative cycle ⇒ `Unsat`** (with the cycle as an
+   unsat-core hint). Otherwise the shortest-path distances are a **feasible model** (and, for
+   scheduling, the tightest — matching CPM early dates when minimizing starts).
+3. If any assertion falls outside the fragment, fall back to the existing (now clearly-scoped) LIA
+   search. Combined with OMT bound-refinement, minimizing makespan over a pure-DL network is then
+   polynomial per iteration.
+
+This makes the engine **robust and fast on exactly the networks task-app produces**, and its
+negative-cycle detection is the feasibility check the scheduler surfaces to the UI.
+
+## Change 5 — VM & builder surface (`constraint-vm`)
+
+Extend `ProgramBuilder` and add optimizing entry points, keeping the satisfiability API untouched:
+
+```rust
+impl ProgramBuilder {
+    pub fn minimize(self, term: LinearTerm) -> Self;   // pushes Minimize
+    pub fn maximize(self, term: LinearTerm) -> Self;
+    pub fn get_objectives(self) -> Self;
+}
+/// Free function mirroring check_sat/get_model.
+pub fn optimize(program: &Program) -> Result<OptResult, VmError>;
+```
+
+`VmOutput` gains `last_opt_result()`. `adj-constraint-solver` routes `adj-lang`'s already-parsed
+`OptDir::{Minimize,Maximize}` to `optimize` instead of erroring, closing its "track C2".
+
+## Backward compatibility & safety
+
+- Every existing program (no objective) produces byte-identical results — the OMT loop and DL tactic
+  are only entered when an `Objective` is present or the pure-DL fragment is detected; the general
+  `check_sat` path is otherwise unchanged.
+- Existing resource limits (default 10k instructions / 10k assertions) bound the OMT loop; add an
+  explicit `max_optimize_iterations` to `Config`.
+- `#![forbid(unsafe_code)]` remains; no new `unsafe`.
+
+## Testing
+
+- **OMT correctness**: minimize/maximize on small linear programs with hand-computed optima; unbounded
+  and infeasible cases; binary-search vs. linear-descent agree on the optimum.
+- **Difference logic**: feasible networks return shortest-path (CPM-early) models; negative-cycle
+  networks return `Unsat` with the cycle; mixed fragments fall back correctly.
+- **Scheduling-scale**: generated CPM networks (100–500 tasks) solve within limits where the old LIA
+  path returned `Unknown` — the regression the enhancement targets.
+- **No-regression**: the entire existing `constraint-*` test suite passes unchanged; a property test
+  asserts objective-free programs give identical `SolverResult` before/after.
+- Update each touched crate's CHANGELOG and README; add worked OMT + difference-logic examples.

--- a/code/specs/task-app-data-model.md
+++ b/code/specs/task-app-data-model.md
@@ -1,0 +1,417 @@
+# task-app — Data Model
+
+> Part of the [task-app spec series](task-app-overview.md). This is the foundational document:
+> the entity model that every other spec builds on. It is deliberately comprehensive — the model is
+> designed for the *hardest* case (Microsoft Project-class scheduling) so that every simpler tool
+> (checklist, todo, kanban, flowchart) is a restriction of it, never a migration away from it.
+
+## Design goals
+
+1. **One `Task` entity, rich enough to be a superset of every task tool.** A checklist item, a
+   todo, a kanban card, a Gantt bar, and a flowchart node are all the same entity with different
+   capabilities switched on.
+2. **Comprehensive from day one.** Resources, assignments, calendars, baselines, and typed custom
+   fields are in the model now, so there is no schema migration when the UI grows into them.
+3. **Stored vs. computed is explicit.** Anything a scheduler derives (early/late dates, slack,
+   critical flag, rollups, formula values) is **never** stored as source of truth — it is recomputed
+   from stored inputs. This mirrors `computeStats` in the legacy checklist-app and `CardProgress`
+   separation in `engram-core`.
+4. **Platform-neutral and serde-friendly.** All types are plain Rust with `#[serde(rename_all =
+   "camelCase")]` (engram-core house style), `serde` behind a feature flag, no I/O, no clock.
+5. **Flexible via a typed field system.** Beyond the fixed scheduling fields, users define their own
+   columns (text/number/date/select/relation/**formula**/**rollup**) — the Notion/Airtable capability
+   — evaluated by `symbolic-vm` (see [`task-app-formula-fields.md`](task-app-formula-fields.md)).
+
+## Identifiers
+
+Every entity carries a stable `Id` = a **UUID v7** (time-sortable; from the `uuid` crate). Typed
+newtypes prevent cross-entity mixups:
+
+```rust
+pub struct TaskId(pub Uuid);
+pub struct ResourceId(pub Uuid);
+pub struct CalendarId(pub Uuid);
+pub struct FieldId(pub Uuid);
+pub struct BaselineId(pub Uuid);
+pub struct ViewId(pub Uuid);
+pub struct LinkId(pub Uuid);
+```
+
+References between entities are by id, never by nesting — the state is a flat, normalized set of
+maps, which keeps the dependency graph, undo snapshots, and incremental recalc simple.
+
+## Root state
+
+```rust
+/// The entire project. One `ProjectState` per open document.
+#[serde(rename_all = "camelCase")]
+pub struct ProjectState {
+    pub id: ProjectId,
+    pub name: String,
+    pub tasks: IndexMap<TaskId, Task>,          // insertion-ordered → stable outline order
+    pub dependencies: Vec<DependencyLink>,       // the scheduling network
+    pub links: Vec<GenericLink>,                 // non-scheduling relations
+    pub resources: IndexMap<ResourceId, Resource>,
+    pub assignments: Vec<Assignment>,
+    pub calendars: IndexMap<CalendarId, Calendar>,
+    pub project_calendar: CalendarId,            // default working time
+    pub fields: IndexMap<FieldId, FieldDef>,     // user-defined custom fields
+    pub workflows: IndexMap<WorkflowId, Workflow>,
+    pub baselines: IndexMap<BaselineId, Baseline>,
+    pub views: IndexMap<ViewId, View>,
+    pub settings: ProjectSettings,               // duration unit, week start, currency, etc.
+}
+```
+
+`IndexMap` (insertion-ordered map) gives O(1) lookup by id *and* a deterministic order for the WBS
+outline and serialization. Task hierarchy is expressed by `parent` + order, not by nesting, so a
+task can be reparented without moving data.
+
+## The Task entity
+
+The core of the model. A Task is intentionally large; most fields are optional and default to
+"unset," so a checklist item populates ~three of them while a Gantt task populates all of them.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct Task {
+    // ---- identity & hierarchy (always present) ----
+    pub id: TaskId,
+    pub name: String,
+    pub notes: String,
+    pub parent: Option<TaskId>,        // None = top level; forms the WBS tree
+    pub kind: TaskKind,                // Leaf | Summary | Milestone
+    pub collapsed: bool,               // UI: is the summary subtree collapsed
+
+    // ---- workflow (kanban / agile) ----
+    pub status: StatusId,              // references a Workflow's status; default = first status
+    pub completed: bool,               // the checklist "done" flag; kept distinct from status
+    pub percent_complete: u8,          // 0..=100
+
+    // ---- scheduling block (Gantt / CPM) — optional capability ----
+    pub schedule: Option<TaskSchedule>,
+
+    // ---- flexible typed fields ----
+    pub fields: HashMap<FieldId, FieldValue>,   // only user-set values; formula/rollup recomputed
+
+    // ---- checklist decision-tree support (legacy-parity projection) ----
+    pub decision: Option<Decision>,    // Some => this task is a yes/no branch point
+}
+
+pub enum TaskKind { Leaf, Summary, Milestone }
+```
+
+### The scheduling block
+
+Everything the CPM engine needs. Present only on tasks that participate in scheduling.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct TaskSchedule {
+    pub task_type: TaskType,           // FixedUnits | FixedDuration | FixedWork
+    pub effort_driven: bool,
+    pub duration: Duration,            // working-time span (see Duration below)
+    pub work: Work,                    // total effort (person-time)
+    pub calendar: Option<CalendarId>,  // task calendar override; else project/resource calendar
+    pub constraint: Constraint,        // one of the 8 constraint types + optional date
+    pub deadline: Option<Date>,        // soft marker; flags slippage, never forces dates
+
+    // actuals (progress tracking)
+    pub actual_start: Option<Date>,
+    pub actual_finish: Option<Date>,
+}
+
+/// The scheduling triangle:  Work = Duration × Units.
+/// `task_type` pins one leg while the scheduler recomputes the others.
+pub enum TaskType { FixedUnits, FixedDuration, FixedWork }
+```
+
+**Task types** (the recompute rule when an input changes):
+
+| Type | Pinned | Add resources ⇒ |
+|---|---|---|
+| `FixedUnits` | assignment units | duration shrinks (work constant) |
+| `FixedDuration` | duration | units drop to absorb the work |
+| `FixedWork` | work (always effort-driven) | duration shrinks |
+
+### Constraints (the 8 MS-Project types, three rigidity tiers)
+
+```rust
+pub enum Constraint {
+    Asap,                          // flexible: as soon as possible (default)
+    Alap,                          // flexible: as late as possible
+    StartNoEarlierThan(Date),      // semi-flexible
+    StartNoLaterThan(Date),
+    FinishNoEarlierThan(Date),
+    FinishNoLaterThan(Date),
+    MustStartOn(Date),             // inflexible
+    MustFinishOn(Date),
+}
+```
+
+Rigidity ordering matters to the scheduler: inflexible > semi-flexible > flexible, and an
+inflexible constraint can override a dependency. See
+[`task-app-scheduling-engine.md`](task-app-scheduling-engine.md).
+
+### Durations, work, and time units
+
+Scheduling operates in **working time**, so a duration is not wall-clock. We store durations and
+work as integer **minutes of working time** to stay exact and serde-simple; the UI renders them in
+the project's chosen unit (`ProjectSettings.duration_unit`: minutes/hours/days/weeks) using the
+calendar's hours-per-day/days-per-week.
+
+```rust
+pub struct Duration { pub working_minutes: i64, pub elapsed: bool } // elapsed=true ⇒ ignore calendar
+pub struct Work { pub minutes: i64 }
+/// A calendar date as days since the Unix epoch (matches datetime-core::Date; UTC, civil).
+pub struct Date(pub i32);
+/// A precise instant when needed (actuals with time-of-day): datetime-core wall-clock seconds.
+pub struct DateTime(pub f64);
+```
+
+Dates reuse `datetime-core`'s civil `Date` representation exactly, so calendar arithmetic (weekday,
+add-days, month math) is a direct call into that crate — no new date code.
+
+### Computed schedule outputs (never stored as source of truth)
+
+The scheduler produces a `ScheduledDates` per task on demand; it is cached in a separate
+side-table (`schedule_cache: HashMap<TaskId, ScheduledDates>`), rebuilt by the engine, and excluded
+from the canonical snapshot's "input" section (it may be serialized as a convenience but is always
+reproducible).
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct ScheduledDates {
+    pub early_start: Date, pub early_finish: Date,
+    pub late_start: Date,  pub late_finish: Date,
+    pub scheduled_start: Date, pub scheduled_finish: Date, // after constraints/calendars
+    pub total_slack: i64, pub free_slack: i64,             // working minutes
+    pub critical: bool,                                     // total_slack <= 0
+}
+```
+
+### Decision-tree support (legacy checklist parity)
+
+To preserve the checklist-app's branching semantics as a first-class projection, a task may be a
+decision point. This reuses the existing model shape (`yesBranch`/`noBranch` become child-task
+subsets gated by the answer), so `flattenVisibleItems` becomes a view over tasks:
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct Decision {
+    pub question: String,
+    pub answer: Option<bool>,          // None = unanswered → only the question shows
+    pub yes_children: Vec<TaskId>,     // subtree revealed when answer = Some(true)
+    pub no_children: Vec<TaskId>,      // subtree revealed when answer = Some(false)
+}
+```
+
+## Relations: two graphs, deliberately separate
+
+**Dependency links** drive scheduling *and* render as flowchart edges. **Generic links** capture
+non-scheduling relationships (Jira-style) and never affect dates.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct DependencyLink {
+    pub id: LinkId,
+    pub predecessor: TaskId,
+    pub successor: TaskId,
+    pub kind: DependencyKind,          // FS | SS | FF | SF
+    pub lag: Duration,                 // may be negative (lead); may be elapsed or working-time
+}
+pub enum DependencyKind { FinishToStart, StartToStart, FinishToFinish, StartToFinish }
+
+#[serde(rename_all = "camelCase")]
+pub struct GenericLink {
+    pub id: LinkId,
+    pub from: TaskId,
+    pub to: TaskId,
+    pub kind: LinkKind,                // Blocks | Relates | Duplicates | Causes | Custom(String)
+}
+```
+
+The dependency set is loaded into `directed-graph` for topological ordering and cycle detection;
+a cycle is a validation error surfaced to the UI, never an infinite loop (the crate's
+`has_cycle`/`topological_sort` give this for free).
+
+## Resources, assignments, calendars
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct Resource {
+    pub id: ResourceId,
+    pub name: String,
+    pub kind: ResourceKind,            // Work | Material | Cost
+    pub calendar: Option<CalendarId>,  // resource calendar (availability)
+    pub max_units: f64,                // e.g. 1.0 = one full-time person; 3.0 = a crew of three
+    pub std_rate: Money,               // cost per working hour (Work) or per unit (Material)
+    pub cost_per_use: Money,
+}
+pub enum ResourceKind { Work, Material, Cost }
+
+#[serde(rename_all = "camelCase")]
+pub struct Assignment {
+    pub task: TaskId,
+    pub resource: ResourceId,
+    pub units: f64,                    // % of the resource applied (1.0 = 100%)
+    pub work: Work,                    // this resource's share of the task work
+    pub contour: WorkContour,          // Flat | FrontLoaded | BackLoaded | BellShaped | ...
+}
+
+pub struct Money { pub cents: i64, pub currency: [u8; 3] }  // exact; numeric-tower if fractional rates needed
+```
+
+### Calendars (the working-time model)
+
+Four-layer resolution: **resource → task → project → base**. The first layer that specifies working
+time wins for a given instant. A calendar is a weekly template plus dated exceptions (holidays,
+overtime days).
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct Calendar {
+    pub id: CalendarId,
+    pub name: String,
+    pub base: Option<CalendarId>,      // inherit from a base calendar
+    pub work_week: [DaySchedule; 7],   // Mon..Sun working intervals
+    pub exceptions: Vec<CalendarException>, // holidays / special days override the week
+}
+pub struct DaySchedule { pub working: bool, pub intervals: Vec<MinuteInterval> } // e.g. 09:00–12:00, 13:00–17:00
+pub struct MinuteInterval { pub start_min: u16, pub end_min: u16 }               // minutes from midnight
+pub struct CalendarException { pub date: Date, pub schedule: DaySchedule }
+```
+
+Calendar arithmetic (is-this-a-working-minute, add-N-working-minutes-to-a-date,
+count-working-minutes-between) is **new code folded into `task-core`**, built on `datetime-core`
+primitives (`iso_weekday`, `add_days`). There is no working-day crate in the repo, so this small
+module is justified new code — not a standalone micro-crate.
+
+## The typed field system (flexibility layer)
+
+Users add columns beyond the built-ins. This is what lets task-app model "any kind of task
+management" — the Notion/Airtable capability — on top of the MS-Project skeleton.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct FieldDef {
+    pub id: FieldId,
+    pub name: String,
+    pub kind: FieldKind,
+}
+pub enum FieldKind {
+    Text, Number, Bool, Date, Duration, Money,
+    Select { options: Vec<String>, multi: bool },
+    Relation { target: RelationTarget },               // link to other tasks/resources
+    Formula { source: String },                        // e.g. "[work] / [duration]"
+    Rollup { over: RollupScope, field: FieldId, agg: RollupAgg }, // aggregate children/assignments
+}
+pub enum RollupScope { Children, Descendants, Assignments }
+pub enum RollupAgg { Sum, Min, Max, Average, Count }
+
+/// Per-task stored values (only for user-set, non-computed fields).
+pub enum FieldValue { Text(String), Number(f64), Bool(bool), Date(Date),
+                      Duration(Duration), Money(Money), Select(Vec<String>), Ref(Vec<Uuid>) }
+```
+
+`Formula` and `Rollup` fields are **computed**, never stored: their source is parsed to a
+`symbolic-ir` tree, the referenced fields are extracted as the dependency set, and values are
+recomputed in topological order via `directed-graph.affected_nodes` when an input changes. Full
+mechanics in [`task-app-formula-fields.md`](task-app-formula-fields.md).
+
+## Workflow (status state machine)
+
+Kanban/agile boards need configurable statuses and legal transitions.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct Workflow {
+    pub id: WorkflowId,
+    pub name: String,
+    pub statuses: IndexMap<StatusId, Status>,          // ordered → board column order
+    pub transitions: Vec<Transition>,                  // allowed status moves; empty ⇒ any→any
+    pub done_status: StatusId,                          // entering it sets completed = true
+}
+pub struct Status { pub id: StatusId, pub name: String, pub category: StatusCategory, pub color: String }
+pub enum StatusCategory { Todo, InProgress, Done }
+pub struct Transition { pub from: StatusId, pub to: StatusId }
+```
+
+## Baselines (variance)
+
+A baseline is a named immutable snapshot of the schedule inputs + computed dates, captured at a
+point in time, used to show variance (planned vs. actual). Stored compactly as a diff-free copy of
+the relevant task fields.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct Baseline {
+    pub id: BaselineId,
+    pub name: String,
+    pub captured_at: u64,                       // injected `now`
+    pub tasks: HashMap<TaskId, BaselineTask>,   // start/finish/duration/work/cost at capture
+}
+```
+
+## Views (projections)
+
+A View is a saved projection descriptor: which tasks (filter), how grouped/sorted, and the render
+shape. Views hold **no task data** — they are lenses over `tasks`.
+
+```rust
+#[serde(rename_all = "camelCase")]
+pub struct View {
+    pub id: ViewId,
+    pub name: String,
+    pub shape: ViewShape,                       // Checklist | Todo | Kanban | Gantt | Calendar | Flowchart | Table
+    pub filter: Filter,                         // status/field/date predicates
+    pub group_by: Option<FieldRef>,             // e.g. kanban groups by status
+    pub sort: Vec<SortKey>,
+    pub visible_fields: Vec<FieldRef>,          // table/gantt columns
+}
+```
+
+### How each projection restricts the model
+
+| Shape | Reads | Ignores |
+|---|---|---|
+| **Checklist** | `name`, `completed`, `decision`, hierarchy; `flattenVisibleItems` over decision answers | scheduling, resources |
+| **Todo** | `name`, `completed`, `schedule.deadline`, `percent_complete` | dependencies, resources |
+| **Kanban** | `status` (group), `name`, `percent_complete` | dates, dependencies |
+| **Gantt** | full `schedule`, `dependencies`, calendars → `ScheduledDates` | generic links |
+| **Calendar** | `ScheduledDates.scheduled_start/finish`, `deadline` | — |
+| **Flowchart** | `dependencies` + `links` as edges, tasks as nodes | dates |
+| **Table** | any `fields` + built-ins as columns | render-specific bits |
+
+## Commands (mutation surface, summarized)
+
+All mutations flow through a single `enum TaskCommand` reduced by a pure
+`reduce(&ProjectState, TaskCommand) -> ProjectState` (engram-core pattern; new state out, never
+mutate in place — cheap given `IndexMap`/`im`-style sharing where needed). The command catalog spans
+task CRUD, reparent/reorder, set-status/complete, edit-schedule (duration/work/type/constraint),
+link/unlink dependencies and generic links, resource + assignment CRUD, calendar edits, field-def
+CRUD + set-value, answer-decision, capture/clear baseline, and view CRUD. The exhaustive command
+list and the reducer's recompute triggers (which commands invalidate the schedule cache vs. only the
+formula cache) live in [`task-app-architecture.md`](task-app-architecture.md) alongside the facade.
+
+## Invariants & validation
+
+- Hierarchy is acyclic; a task's `parent` chain never includes itself. Reparent commands reject cycles.
+- The dependency network is acyclic (checked via `directed-graph.has_cycle`); a cycle is a surfaced
+  validation error, not a panic.
+- `percent_complete ∈ 0..=100`; `units ≥ 0`; `max_units ≥ 0`.
+- Every `status` references an existing `Status` in the task's board `Workflow`; deleting a status
+  requires remapping tasks off it.
+- Summary tasks derive dates/work/%-complete/cost from descendants (rollup) and are not directly
+  scheduled; setting a schedule input on a Summary is rejected.
+- Formula/rollup field graphs are acyclic; a formula referencing its own field (directly or
+  transitively) is a validation error.
+
+## Snapshot & persistence
+
+`ProjectState` serializes to JSON via `serde_json` (feature-gated), matching the engram-core /
+spreadsheet-core idiom. The snapshot is the single source of truth; computed caches
+(`schedule_cache`, formula values) are reproducible and may be omitted. Durable storage (optional)
+uses `storage-core` with one JSON record per project, following the `memory-store` shape. See the
+architecture spec for the facade's `snapshot()` / `load_snapshot()` and `hostIntent`-driven
+file I/O.

--- a/code/specs/task-app-formula-fields.md
+++ b/code/specs/task-app-formula-fields.md
@@ -1,0 +1,144 @@
+# task-app — Formula & Rollup Fields
+
+> Part of the [task-app spec series](task-app-overview.md). Specifies how the typed custom-field
+> system from [`task-app-data-model.md`](task-app-data-model.md) computes `Formula` and `Rollup`
+> fields, by **reusing** the repo's `symbolic-vm` evaluator — no new formula engine.
+
+## Why `symbolic-vm`, not spreadsheet-core
+
+Computed task fields need **named-variable** formulas — `[work] / [duration]`, `[cost] * 1.1` — not
+cell coordinates. `spreadsheet-core`'s formula language is A1-only (`B2*C2`), so it cannot express
+field references without an ugly synthetic-address shim. `symbolic-vm` (+ `symbolic-ir`) is the
+opposite: a variable *is* a named atom `IRNode::Symbol("work")`. It is Rust, mature (266 tests), has
+the arithmetic/logical/conditional operators we need, a pluggable `Backend` trait for extension, and
+a walkable AST for dependency extraction. It is the right reuse.
+
+## Confirmed API surface (what we build on)
+
+```rust
+// symbolic-ir
+enum IRNode { Symbol(String), Integer(i64), Rational(i64,i64), Float(f64), Str(String), Apply(IRApply) }
+// heads: "Add" "Sub" "Mul" "Div" "Pow" "Neg" "If" "And" "Or" "Not" comparisons, etc.
+
+// symbolic-vm
+trait Backend { fn bind(&mut self, name: &str, value: IRNode); /* … */ }
+struct StrictBackend; // "calculator mode": every name must be bound, else it errors — ideal for computed fields
+struct VM;
+impl VM { fn new(backend: Box<dyn Backend>) -> Self; fn eval(&mut self, node: IRNode) -> IRNode; }
+fn substitute(node: IRNode, mapping: &HashMap<String, IRNode>) -> IRNode;
+```
+
+## Field kinds we compute
+
+From the data model:
+
+```rust
+Formula { source: String }                              // e.g. "[work] / [duration] * 100"
+Rollup  { over: RollupScope, field: FieldId, agg: RollupAgg } // aggregate children/descendants/assignments
+```
+
+Both are **computed, never stored** — recomputed from inputs on change.
+
+## Pipeline for a `Formula` field
+
+### 1. Parse `[Field]` bracket syntax → `IRNode`
+
+We own a small surface parser (justified new code, ~150 lines) that maps our field-reference syntax
+to `symbolic-ir`. This is deliberately *our* syntax, not Wolfram/Maxima, so it matches MS-Project's
+`[Field]` custom-field convention and stays closed/safe:
+
+- `[field-name]` → `IRNode::Symbol("field-name")` (resolved to a `FieldId` or a built-in like
+  `[work]`, `[duration]`, `[cost]`, `[percent-complete]`, `[start]`, `[finish]`).
+- number literals → `Integer`/`Float`/`Rational`; strings → `Str`.
+- `+ - * / ^`, comparisons, `and/or/not`, and function calls `NAME(args…)` → the matching
+  `IRNode::Apply(sym(head), args)`.
+- Anything outside the grammar is a parse error with position — no `eval`, no injection (mirrors the
+  Mosaic/closed-grammar security posture).
+
+Built-in field names resolve to the task's scheduling/rollup values; user field names resolve to
+their `FieldId`. The parser output is cached per `FieldDef` (parse once, evaluate many).
+
+### 2. Extract the dependency set from the AST
+
+Walk the parsed `IRNode` and collect every `Symbol` (there is no packaged `free_symbols` in the
+cas-* crates — a ~10-line walker, templated on `symbolic-vm`'s `substitute` at `vm.rs:238`). The set
+of referenced fields *is* the formula's dependencies. This feeds the recalc graph (below). Rollup
+fields depend on the rolled-up field across the scope's tasks.
+
+### 3. Bind values and evaluate with `StrictBackend`
+
+For a given task, bind each referenced field to its current `IRNode` value and evaluate:
+
+```rust
+let mut vm = VM::new(Box::new(StrictBackend::new()));
+for dep in formula.deps { vm.backend.bind(dep.name, value_as_irnode(task, dep)); }
+let result = vm.eval(formula.ast.clone());     // Integer/Float/Rational/Str out → FieldValue
+```
+
+`StrictBackend` is chosen precisely because it **errors on any unbound name** — a formula that
+references a deleted field surfaces as a field error, never a silent wrong number. The result
+`IRNode` is converted back to a `FieldValue` (Number/Money/Duration per the field's declared kind).
+
+## Pipeline for a `Rollup` field
+
+A rollup aggregates a field over a scope (children / descendants / assignments). We express it as an
+`Apply` over the collected child values and evaluate with the same VM, so rollups and formulas share
+one evaluator:
+
+```
+Sum      → Apply(sym("Add"),  child_values)
+Min/Max  → Apply(sym("Min"|"Max"), child_values)
+Average  → Apply(sym("Div"), [Apply(sym("Add"), child_values), Integer(n)])
+Count    → Integer(n)
+```
+
+`Min`/`Max`/aggregation heads that `StrictBackend` doesn't ship are registered via the `Backend`
+trait's handler table (a small extension, not a fork) — the same seam we use for date functions.
+
+## Backend extensions (via the trait, not a fork)
+
+Two capability gaps in the stock backend, both closed by registering handlers on our own backend
+built atop `StrictBackend`:
+
+1. **Aggregation heads** — `Min`, `Max`, `Total`/`Sum`, `Average`, `Count` over a `List`/vararg.
+2. **Date/duration functions** — `WorkdaysBetween([start],[finish])`, `AddWorkdays([date], n)`,
+   `Year/Month/Day`, wired to `task-core`'s calendar module (which itself is built on
+   `datetime-core`). Dates are carried as `Integer` (days since epoch) inside the IR.
+
+No change to `symbolic-vm` itself — we compose a `TaskBackend { inner: StrictBackend, … }` that
+delegates unknown heads to the extra handler table. If the extensions prove broadly useful they can
+later be upstreamed into a `cas-*` crate, but they start folded into `task-core`.
+
+## Incremental recomputation (shared with the scheduler)
+
+Formula/rollup fields form a **dependency graph** (field → fields it reads; rollup → child field
+across tasks). We reuse **`directed-graph`** — the *same* crate the CPM scheduler uses:
+
+1. On any field/schedule edit, form the `changed` set (the edited fields + scheduling outputs like
+   `[finish]` that formulas may read).
+2. `graph.affected_nodes(changed)` → the transitive set of computed fields needing refresh.
+3. Recompute them in `graph.topological_sort()` order, so each formula sees fresh inputs.
+4. `graph.has_cycle()` guards against a formula that references itself transitively — a validation
+   error surfaced to the UI (matching the data-model invariant), never an infinite loop.
+
+The reducer tags each `TaskCommand` with whether it dirties the schedule cache, the formula cache,
+or both (see [`task-app-architecture.md`](task-app-architecture.md)), so a rename or a non-computed
+edit does the minimal recompute.
+
+## Safety
+
+- Closed grammar; no `eval` of arbitrary strings, no host access — the parser accepts exactly the
+  defined operators/functions, and `StrictBackend` cannot reach outside its bound environment.
+- Resource-bounded: formula depth and the recalc graph size are capped; a pathological formula fails
+  to parse rather than hanging (the `symbolic-ir` depth conventions apply).
+
+## Testing
+
+- Parser: `[field]` refs, literals, every operator, function calls, and rejection of malformed input
+  with positions.
+- Dependency extraction: the collected `Symbol` set matches the fields a formula reads (incl. nested).
+- Evaluation: arithmetic/logical/conditional formulas against hand-computed results; unit conversions
+  (Duration/Money) round-trip; unbound-field references error cleanly.
+- Rollups: Sum/Min/Max/Average/Count over children, descendants, and assignments; empty-scope edge cases.
+- Recalc: editing one input recomputes exactly its transitive dependents in topo order; a formula
+  cycle is reported, not looped; large field graphs recompute incrementally, not wholesale.

--- a/code/specs/task-app-overview.md
+++ b/code/specs/task-app-overview.md
@@ -1,0 +1,128 @@
+# task-app — A General Task & Project Engine on Mosaic
+
+> **Spec series.** This is the overview. The companion specs are:
+> - [`task-app-data-model.md`](task-app-data-model.md) — the entity model (the crown jewel)
+> - [`task-app-scheduling-engine.md`](task-app-scheduling-engine.md) — CPM, calendars, leveling
+> - [`task-app-constraint-vm-enhancement.md`](task-app-constraint-vm-enhancement.md) — optimization for the constraint VM
+> - [`task-app-formula-fields.md`](task-app-formula-fields.md) — computed/rollup fields via `symbolic-vm`
+> - [`task-app-architecture.md`](task-app-architecture.md) — core → facade → capi/wasm → Mosaic hosts
+
+## Overview
+
+**task-app** is a general-purpose task- and project-management platform. Its heart is a
+single **Rust core engine** — as flexible as Microsoft Project — that every native app *and*
+the web app consume identically: the browser and Electron through **WebAssembly**, native
+shells (Qt, SwiftUI, Compose, Flutter, WinUI/XAML) through a **C ABI**. One engine, every
+platform, identical behavior.
+
+The user interface is authored once in **Mosaic** (this repo's compile-time UI language) and
+emitted to all nine host platforms, exactly as the **Engram** app already does. task-app is,
+in effect, "Engram's architecture applied to project management."
+
+This project supersedes the exploratory TypeScript/Electron
+[`checklist-app`](../programs/typescript/checklist-app) (which remains in place, retrievable via
+git). Where checklist-app modeled one narrow thing (decision-tree checklists) in TypeScript,
+task-app models the **general case** in Rust and treats checklists as one of many *views*.
+
+## The core thesis: one model, many views
+
+Most task tools pick a shape — a flat list, a kanban board, a Gantt chart — and marry the data
+model to it. task-app inverts this. There is **one entity, the Task**, rich enough to be a strict
+superset of every shape, and each familiar tool is a **projection** of that one model:
+
+| Familiar tool | Is just a Task with… | Rendered as |
+|---|---|---|
+| Checklist item | a done-flag, no scheduling | decision-tree list |
+| Todo | a due-date / deadline | flat list |
+| Kanban card | a workflow `status` | column board |
+| Gantt bar | full scheduling (duration, dependencies, calendar) | timeline |
+| Flowchart node | membership in the dependency/relation graph | node-edge canvas |
+| Spreadsheet row | typed custom fields incl. formulas | table/grid |
+
+Because the model is the union, you never migrate data to "upgrade" a checklist into a project
+plan — you just turn on more of the same Task's capabilities and pick a different view.
+
+## Design principles
+
+1. **Model the hardest case first.** We design for Microsoft Project-class scheduling (durations,
+   work, four dependency types with lag, eight date constraints, working-time calendars, resources,
+   assignments, resource leveling, critical path, baselines). Everything simpler falls out as a
+   restriction of the general model. See [`task-app-data-model.md`](task-app-data-model.md).
+
+2. **Reuse the repo's engines; do not build micro-packages.** The scheduling graph, date math,
+   formula evaluation, and constraint solving already exist as mature crates. task-app is
+   assembled from them. New code is confined to the *domain* (the task model + scheduler) and the
+   FFI/UI seams. (Reuse map below.)
+
+3. **Pure, headless, deterministic core.** `task-core` has no I/O, no clock (time is passed in as
+   `now: u64`), and `serde` behind a feature flag — the house pattern of `engram-core` and
+   `spreadsheet-core`. The same bytes in produce the same bytes out on every platform.
+
+4. **One props/event contract, authored once.** The facade computes a flat slot map (props) and
+   handles a typed event envelope; the Mosaic `.mil` interface mirrors it; every host adapter is a
+   thin translator. Behavior is defined exactly once, in Rust.
+
+5. **Views are projections, never separate stores.** Checklist/todo/kanban/gantt/flowchart/table
+   are computed read-models over the one `ProjectState`, like `computeStats` in the legacy app.
+
+## Reuse map (assembled from existing crates)
+
+| Need | Reused crate | Notes |
+|---|---|---|
+| Dependency DAG: topo sort, cycle detection, affected-set recalc, parallel levels | `directed-graph` (on `graph`) | powers both CPM ordering and formula recalc |
+| Date math, weekday/month arithmetic, day-count, injectable clock | `datetime-core` + `wall-clock` | working-day calendars layer on top |
+| Exact/rational/decimal quantities | `numeric-tower` | where exactness matters (cost, unit math) |
+| Named-variable formula / computed / rollup fields | `symbolic-vm` + `symbolic-ir` (+ `cas-substitution`) | `StrictBackend`; the win over A1-only spreadsheet-core |
+| Feasibility validation + optimization (makespan, leveling) | `constraint-*` stack (enhanced) | see the enhancement spec |
+| Persistence | `storage-core` + a backend | copy the `memory-store` record shape |
+| Time-sortable IDs | `uuid` (v7) | |
+| FFI/WASM/host architecture | Engram pattern | `engram-core` → `engram-core-wasm` → `engram-capi`+`engram-wasm` |
+
+**Genuinely new code** (no gratuitous micro-crates): the `task-core` domain model + CPM scheduler;
+working-day/holiday calendars and time-interval types folded *into* `task-core`; the
+`task-core-wasm` facade; the `task-capi`/`task-wasm` ABI siblings; optimization enhancements inside
+the existing `constraint-*` crates; and the Mosaic UI packages + host adapters.
+
+## Component map
+
+```
+task-core            pure domain model + CPM scheduler (no I/O, no clock, forbid(unsafe))
+  └ task-core-wasm   facade: TaskSession, dispatch(), get_props(), handle_event()
+        ├ task-capi  C ABI (native shells) + task-host-cli sidecar
+        └ task-wasm  linear-memory WASM ABI (browser/Electron) + JS loader
+
+code/programs/mosaic/task-app         Mosaic product package (.mil/.mll/.msl) + host adapters
+code/packages/mosaic/mosaic-pkg-*     reusable UI components (checklist-runner, todo-list,
+                                      task-board, gantt-view, flowchart-view, task-detail, …)
+```
+
+The two ABI crates are **siblings over the facade**, adding only marshalling — all props/event
+logic lives once in `task-core-wasm`. Porting to a new platform is a new thin adapter, never a
+change to core logic. Full detail in [`task-app-architecture.md`](task-app-architecture.md).
+
+## Scope & phasing
+
+The **data model is comprehensive from day one** (so no schema migration later), and the **full
+engine** — CPM scheduling *plus* resources, assignments, and resource leveling — is in scope, not
+deferred. Implementation proceeds in phases:
+
+- **Phase 0 — Specs** (this series), committed before code, per repo mandate.
+- **Phase 1 — Two parallel tracks.** *Track A:* `task-core` model + CPM scheduler + calendars +
+  formula fields + resources; begin constraint-VM optimization. *Track B:* facade + `task-capi` +
+  `task-wasm` + Mosaic `task-app` + **web & Electron** adapters + **checklist & todo** projections,
+  proving the full core→facade→wasm→Mosaic loop.
+- **Phase 2 — Convergence.** Full engine through the facade; kanban/gantt/flowchart projections;
+  feasibility/leveling surfaced in the UI.
+- **Phase 3 — Host fan-out.** The remaining native shells (Qt, SwiftUI, Compose, Flutter, XAML) via
+  `task-capi`, matching Engram's nine-host reach.
+- **Phase 4 — Polish.** Baselines/variance, resource-leveling UI, `storage-core` persistence,
+  per-package CHANGELOG/README, security review, spec-sync.
+
+Each phase is a series of small, focused PRs on feature branches, pulling `origin/main` first.
+
+## Out of scope (noted for later)
+
+- A pure **Win32 / non-XAML Windows** Mosaic emit backend + native host — a separate Mosaic-backend
+  effort, independent of this app.
+- Portfolio/multi-project rollups, earned-value management, and Monte-Carlo risk analysis
+  (Primavera-tier features) — the data model leaves room for them; they are not v1 work.

--- a/code/specs/task-app-scheduling-engine.md
+++ b/code/specs/task-app-scheduling-engine.md
@@ -1,0 +1,171 @@
+# task-app — Scheduling Engine
+
+> Part of the [task-app spec series](task-app-overview.md). Defines how `task-core` turns the stored
+> inputs from [`task-app-data-model.md`](task-app-data-model.md) into a schedule: early/late dates,
+> slack, the critical path, summary rollups, and (via the enhanced constraint VM) resource leveling.
+
+## Principle: the Critical Path Method *is* a forward/backward pass
+
+Microsoft Project's scheduling semantics are, at their core, the classical **Critical Path Method
+(CPM)**. That is a linear-time graph algorithm, and MS-Project behavior is a near-direct
+transcription of it. So `task-core` computes the schedule directly — it does **not** hand the
+problem to a general solver. (The constraint VM is used only for the genuinely optimization-shaped
+problems: resource leveling and feasibility checking — see below and
+[`task-app-constraint-vm-enhancement.md`](task-app-constraint-vm-enhancement.md).)
+
+The dependency network is loaded into the existing **`directed-graph`** crate; we reuse
+`topological_sort`, `has_cycle`, `predecessors`, `successors`, and `affected_nodes`. We do **not**
+write a new graph.
+
+## Inputs and outputs
+
+- **Inputs** (stored): tasks with `TaskSchedule` (duration, work, type, constraint, deadline,
+  calendar), `DependencyLink`s (FS/SS/FF/SF + lag), calendars, assignments, and the project start date.
+- **Output**: a `ScheduledDates` per task (early/late start & finish, scheduled start & finish after
+  constraints, total & free slack, `critical`), cached in `schedule_cache` and recomputed on change.
+
+## Working time is the unit of measure
+
+All duration/lag/work math is in **working minutes**, resolved against calendars — never raw
+wall-clock. Three calendar primitives (new code in `task-core`, built on `datetime-core`) underpin
+everything:
+
+```rust
+fn is_working(cal, at: DateTime) -> bool;
+fn add_working(cal, from: DateTime, minutes: i64) -> DateTime;   // walk forward/back over working intervals
+fn working_between(cal, a: DateTime, b: DateTime) -> i64;        // count working minutes in [a,b)
+```
+
+Calendar resolution order per task: **task calendar → (driving resource calendar) → project
+calendar → base**. `add_working` skips non-working days/holidays and honors intra-day intervals
+(e.g. 09:00–12:00, 13:00–17:00). Elapsed durations (`Duration.elapsed = true`) bypass the calendar
+(wall-clock), for things like "wait 24h for paint to dry."
+
+## Stage 1 — Topological order & cycle check
+
+```
+graph = directed-graph from dependencies (node = TaskId, edge = predecessor → successor)
+if graph.has_cycle(): return SchedulingError::Cycle(path)   // surfaced to UI, never a panic
+order = graph.topological_sort()
+```
+
+Summary tasks are excluded from the network (they are rolled up, not scheduled — Stage 4);
+milestones participate with zero duration.
+
+## Stage 2 — Forward pass (early dates)
+
+Process tasks in topological order. A task's Early Start is the latest constraint imposed by all its
+incoming dependencies; Early Finish adds the calendar-walked duration. Per predecessor link type:
+
+| Link | Constraint on successor |
+|---|---|
+| **FS** (finish→start) | `ES_succ ≥ EF_pred + lag` |
+| **SS** (start→start) | `ES_succ ≥ ES_pred + lag` |
+| **FF** (finish→finish) | `EF_succ ≥ EF_pred + lag` |
+| **SF** (start→finish) | `EF_succ ≥ ES_pred + lag` |
+
+```
+ES = max(project_start, max over preds of the link constraint above)
+EF = add_working(task.calendar, ES, task.duration.working_minutes)
+```
+
+`lag` is added via `add_working` (or raw if the lag is elapsed). A task with no predecessors starts
+at the project start date (or its own constraint floor).
+
+## Stage 3 — Constraints (may override dependencies)
+
+After the raw early dates, apply the task's `Constraint`, honoring MS-Project rigidity precedence
+(inflexible > semi-flexible > flexible):
+
+| Constraint | Effect on scheduled dates |
+|---|---|
+| `Asap` | scheduled = early dates (default) |
+| `Alap` | scheduled = late dates (computed in Stage 5) |
+| `StartNoEarlierThan(d)` | `scheduled_start = max(ES, d)` |
+| `StartNoLaterThan(d)` | cap; flag conflict if `ES > d` |
+| `FinishNoEarlierThan(d)` | `scheduled_finish = max(EF, d)` |
+| `FinishNoLaterThan(d)` | cap; flag conflict if `EF > d` |
+| `MustStartOn(d)` | `scheduled_start = d` (overrides predecessors) |
+| `MustFinishOn(d)` | `scheduled_finish = d` (overrides predecessors) |
+
+Inflexible constraints (`MustStartOn/On`) pin the date even against a predecessor; when that
+contradicts a dependency, we record a **conflict** (surfaced in the UI) rather than silently
+choosing one — matching MS-Project's "planning wizard" warning behavior. `deadline` is *not* a
+constraint: it never moves a date; it only sets a `deadline_missed` flag when `scheduled_finish >
+deadline`.
+
+## Stage 4 — Summary rollups
+
+Walk the WBS bottom-up (reverse of the outline order): a Summary task's start = min(child starts),
+finish = max(child finishes), work = Σ child work, cost = Σ child cost, percent-complete =
+work-weighted mean of children. Summaries are read-only in the scheduler.
+
+## Stage 5 — Backward pass (late dates, slack, critical path)
+
+Process in **reverse** topological order from the project finish (or an imposed
+`FinishNoLaterThan`/deadline horizon):
+
+```
+LF = min(project_finish, min over succs of the mirror-image link constraint)
+LS = sub_working(task.calendar, LF, task.duration.working_minutes)
+total_slack = working_between(cal, ES, LS)      // == LS − ES in working minutes
+free_slack  = min over succs of (ES_succ − EF_this) honoring link type
+critical    = total_slack <= 0
+```
+
+The **critical path** is the connected chain of `critical` tasks from a start node to the project
+finish. Because CPM yields early, late, *and* slack in two linear passes, all of it comes "for free"
+— which is precisely why a hand-written pass beats routing this through a general solver (the
+constraint VM can decide feasibility but cannot produce slack or the critical path; see its spec).
+
+## Stage 6 — Effort-driven recompute (the scheduling triangle)
+
+When assignments or an input change, reconcile `Work = Duration × Units` per the task's `TaskType`
+(see the data-model table): `FixedUnits` recomputes duration, `FixedDuration` recomputes units,
+`FixedWork` recomputes duration and forces effort-driven. This runs before Stage 2 (it changes
+durations) and is the reason assignment edits trigger a full reschedule.
+
+## Incremental recomputation
+
+A naive reschedule is already linear, but for large plans we recompute only what changed:
+`directed-graph.affected_nodes(changed_set)` returns the transitive successors that need new dates.
+Formula/rollup field recomputation uses the same crate over the field-dependency graph (see
+[`task-app-formula-fields.md`](task-app-formula-fields.md)). The reducer tags each `TaskCommand`
+with what it invalidates (schedule cache, formula cache, or both) so the facade recomputes minimally.
+
+## Resource leveling & makespan optimization (the optimization layer)
+
+CPM assumes infinite resources. **Resource leveling** resolves over-allocation (a resource assigned
+>`max_units` at an instant) by delaying tasks within their slack — an *optimization* problem
+(minimize makespan / total delay subject to capacity), not a satisfiability one. This is where the
+**enhanced constraint VM** is used:
+
+- Encode task `start`/`finish` as integer variables, dependencies + constraints as linear
+  inequalities (`start_B ≥ finish_A + lag`, `MustStartOn` as equalities), and resource capacity as
+  per-time-window sums.
+- Add an **objective** (`minimize` project finish, or `minimize` total start-delay from the CPM
+  dates) — the new capability specified in
+  [`task-app-constraint-vm-enhancement.md`](task-app-constraint-vm-enhancement.md).
+- Solve for a leveled schedule; fall back to a deterministic **priority-based serial leveler**
+  (order by CPM start, then slack, then priority; greedily place respecting capacity) when the
+  network is too large for the solver or the solver returns `Unknown`.
+
+Leveling is opt-in per project and runs *after* CPM; the un-leveled CPM schedule (with its true
+critical path) always remains available.
+
+## Feasibility validation
+
+Independently of leveling, the constraint VM's `check_sat` detects **over-constrained** plans that
+CPM would silently fudge: `MustStartOn` vs. a predecessor, `FinishNoLaterThan` earlier than the
+earliest possible finish, negative-lag loops. The facade surfaces these as conflicts with the
+offending task/link ids, so the UI can explain *why* a date can't be met.
+
+## Determinism & testing
+
+The engine is pure and deterministic (calendar math is integer working-minutes; ties broken by
+outline order). Tests live in `task-core` and assert against **hand-computed** early/late/float on
+canonical CPM networks from the literature, plus: each of FS/SS/FF/SF with positive and negative
+lag; each of the 8 constraints including conflict cases; multi-interval and holiday calendars;
+summary rollups; effort-driven recompute for all three task types; and leveling on small
+known-optimal instances (solver path vs. serial-leveler path agree on makespan where the instance is
+small enough to be provably optimal).


### PR DESCRIPTION
## What

Phase 0 (specs-first, per repo mandate) for **task-app** — pivoting the legacy TS/Electron
`checklist-app` into a **Mosaic app** and expanding it into a **general task-management
platform**. The center of gravity is a shared **Rust core engine** (as flexible as Microsoft
Project) consumed identically by web (WASM) and native shells (C ABI), with a Mosaic UI emitted
to all 9 host platforms — mirroring the **Engram** architecture.

This PR is **docs-only** (six spec markdown files). No code.

## Specs

- **task-app-overview** — "one model, many views" thesis (checklist/todo/kanban/Gantt/flowchart
  are projections of one `Task`), reuse map, phasing.
- **task-app-data-model** — comprehensive MS-Project-class + flexible typed-field union model:
  Project, Task (scheduling block + typed fields + decision-tree), Dependency/Generic links,
  Resources, Assignments, 4-layer Calendars, Baselines, Workflow, Views. Stored-vs-computed explicit.
- **task-app-scheduling-engine** — direct CPM (forward/backward pass) on `directed-graph`;
  working-time calendars; the 8 constraints; summary rollups; resource leveling.
- **task-app-constraint-vm-enhancement** — concrete additions to the existing `constraint-*`
  crates: OMT optimization (makespan/leveling) + a difference-logic tactic for scheduling scale,
  grounded in the real `SolverResult`/`ProgramBuilder` API. No regression to satisfiability behavior.
- **task-app-formula-fields** — computed/rollup fields reusing `symbolic-vm` (named variables,
  `StrictBackend`, `[Field]` parser); incremental recalc via `directed-graph`.
- **task-app-architecture** — `task-core → task-core-wasm (facade) → task-capi + task-wasm →
  Mosaic host adapters`; command catalog; props/event contract; build-all wiring.

## Principle: reuse, do not build micro-packages

Assembled from existing crates — `directed-graph`, `datetime-core`/`wall-clock`, `symbolic-vm`,
`constraint-*` (enhanced), `storage-core`, `uuid`. New code is confined to the `task-core` domain
(model + CPM scheduler + working-day calendars), the FFI/UI seams, and the constraint-VM optimization.

## Next

Phase 1 — two parallel tracks: `task-core` engine ‖ facade + wasm + Mosaic `task-app` on web/Electron
with checklist + todo projections. `/security-review` runs before any code push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)