### PR TITLE
feat(sir-go): String tr / count / delete / squeeze (char sets, v0.24.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.24.0 — String char-set methods: `tr` / `count` / `delete` / `squeeze`
+
+Adds four non-block Ruby String methods to the emitted runtime's
+`_sir_string_method` switch and the `_sir_string_responds` catalog, mirroring
+the Python `sir-runtime-oop` reference semantics (rune-based, so multibyte
+strings are never split mid-codepoint):
+
+- `tr(from, to)` — position-wise rune translation; a shorter `to` repeats its
+  last rune, an empty `to` deletes matching runes, and a repeated rune in `from`
+  keeps the last mapping.
+- `count(*sets)` / `delete(*sets)` / `squeeze(*sets)` — char-set methods:
+  `count` tallies runes of the receiver in the set, `delete` removes them, and
+  `squeeze` collapses consecutive runs (of set runes, or of *all* runes when no
+  set is given). Multiple set arguments intersect (Ruby's rule).
+
+Each `set`/`from`/`to` argument is treated **literally** — the range (`"a-z"`)
+and negation (`"^abc"`) forms are a follow-up, matching the literal-only
+`sub`/`gsub` precedent. Exec-proven end-to-end via `go run`. Second backend of
+the String char-set sweep (Python landed in `sir-runtime-oop` v0.1.16).
+
 ## 0.23.0 — slice-selection Array methods: `take` / `drop` / `values_at`
 
 Extends the emitted Go runtime's non-block `Array` catalog (and the

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1659,7 +1659,8 @@ func _sir_string_responds(name string) bool {
 		"strip", "lstrip", "rstrip", "chomp", "empty?", "include?",
 		"start_with?", "end_with?", "split", "chars", "bytes", "index",
 		"replace", "sub", "gsub", "to_i", "to_f", "to_sym",
-		"ljust", "rjust", "center", "swapcase":
+		"ljust", "rjust", "center", "swapcase",
+		"tr", "count", "delete", "squeeze":
 		return true
 	}
 	return false
@@ -2747,6 +2748,109 @@ func _sir_string_method(recv string, name string, args []Value) (Value, bool) {
 			}
 		}
 		return string(r), true
+	case "tr":
+		// Ruby String#tr(from, to): position-wise rune translation.  A shorter
+		// `to` repeats its last rune; an empty `to` deletes matching runes; a
+		// repeated rune in `from` keeps the last mapping.  Literal only — the
+		// range (`"a-z"`) and negation (`"^abc"`) forms are a follow-up, matching
+		// the literal-only sub/gsub precedent here.
+		if len(args) < 2 {
+			return recv, true
+		}
+		from, fok := args[0].(string)
+		to, tok := args[1].(string)
+		if !fok || !tok {
+			return recv, true
+		}
+		toR := []rune(to)
+		table := make(map[rune]rune)
+		del := make(map[rune]bool)
+		for i, c := range []rune(from) {
+			if len(toR) == 0 {
+				del[c] = true
+				delete(table, c)
+			} else if i < len(toR) {
+				table[c] = toR[i]
+				delete(del, c)
+			} else {
+				table[c] = toR[len(toR)-1]
+				delete(del, c)
+			}
+		}
+		out := make([]rune, 0, len(recv))
+		for _, c := range recv {
+			if del[c] {
+				continue
+			}
+			if r, ok := table[c]; ok {
+				out = append(out, r)
+			} else {
+				out = append(out, c)
+			}
+		}
+		return string(out), true
+	case "count", "delete", "squeeze":
+		// Char-set methods.  Each `set` argument is treated LITERALLY — the runes
+		// it contains (ranges/negation are a follow-up).  `count` tallies runes of
+		// `recv` in the set; `delete` removes them; `squeeze` collapses consecutive
+		// runs (of set runes, or of ALL runes when no set is given).  Multiple set
+		// args intersect (Ruby's rule).
+		sets := make([]map[rune]bool, 0, len(args))
+		for _, a := range args {
+			if s, ok := a.(string); ok {
+				m := make(map[rune]bool)
+				for _, c := range s {
+					m[c] = true
+				}
+				sets = append(sets, m)
+			}
+		}
+		inAll := func(c rune) bool {
+			if len(sets) == 0 {
+				return false
+			}
+			for _, m := range sets {
+				if !m[c] {
+					return false
+				}
+			}
+			return true
+		}
+		if name == "squeeze" && len(sets) == 0 {
+			out := make([]rune, 0, len(recv))
+			for _, c := range recv {
+				if len(out) == 0 || out[len(out)-1] != c {
+					out = append(out, c)
+				}
+			}
+			return string(out), true
+		}
+		if name == "count" {
+			n := int64(0)
+			for _, c := range recv {
+				if inAll(c) {
+					n++
+				}
+			}
+			return n, true
+		}
+		if name == "delete" {
+			out := make([]rune, 0, len(recv))
+			for _, c := range recv {
+				if !inAll(c) {
+					out = append(out, c)
+				}
+			}
+			return string(out), true
+		}
+		out := make([]rune, 0, len(recv))
+		for _, c := range recv {
+			if len(out) > 0 && out[len(out)-1] == c && inAll(c) {
+				continue
+			}
+			out = append(out, c)
+		}
+		return string(out), true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_string_methods.rs
@@ -191,6 +191,71 @@ fn ilit(v: i64) -> Expr {
     Expr::IntLit { value: v, span: s() }
 }
 
+/// The v0.24.0 **char-set** String methods: `tr`, `count`, `delete`, `squeeze`.
+/// Each `set`/`from`/`to` argument is treated LITERALLY (the runes it contains);
+/// range/negation forms are a follow-up, matching the literal-only sub/gsub
+/// precedent.  Mirrors the Python `sir-runtime-oop` reference semantics.
+fn charset_module() -> Module {
+    let stmts = vec![
+        // tr: position-wise translate; shorter `to` repeats its last rune
+        print_stmt(method(slit("hello"), "tr", vec![slit("el"), slit("ip")])), // hippo
+        print_stmt(method(slit("hello"), "tr", vec![slit("aeiou"), slit("*")])), // h*ll*
+        // tr with empty `to` deletes matching runes
+        print_stmt(method(slit("hello"), "tr", vec![slit("l"), slit("")])), // heo
+        // count / delete over a literal set
+        print_stmt(method(slit("hello"), "count", vec![slit("lo")])), // 3
+        print_stmt(method(slit("hello"), "delete", vec![slit("aeiou")])), // hll
+        // squeeze: no arg collapses every run; a set squeezes only those runes
+        print_stmt(method(slit("mississippi"), "squeeze", vec![])), // misisipi
+        print_stmt(method(slit("aaabbbccc"), "squeeze", vec![slit("a")])), // abbbccc
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![main])
+}
+
+#[test]
+fn string_charset_methods_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&charset_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "charset");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "hippo",    // "hello".tr("el", "ip")
+            "h*ll*",    // "hello".tr("aeiou", "*") — shorter `to` repeats last
+            "heo",      // "hello".tr("l", "") — empty `to` deletes
+            "3",        // "hello".count("lo")
+            "hll",      // "hello".delete("aeiou")
+            "misisipi", // "mississippi".squeeze
+            "abbbccc",  // "aaabbbccc".squeeze("a")
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}
+
 /// The v0.22.0 **justify / swapcase** String methods: `ljust`, `rjust`,
 /// `center`, `swapcase`.  Width is counted in RUNES; center puts an odd extra
 /// pad rune on the RIGHT; an omitted pad defaults to a space.  Assertions use a


### PR DESCRIPTION
## What

Mirrors the Python reference String **char-set** sweep onto the **Go backend** (follows #7863 which landed it in `sir-runtime-oop` v0.1.16). Adds four non-block Ruby String methods to the emitted runtime's `_sir_string_method` switch + `_sir_string_responds` catalog, **rune-based** so multibyte strings are never split mid-codepoint:

- **`tr(from, to)`** — position-wise rune translation; a shorter `to` repeats its last rune, an empty `to` deletes matching runes, and a repeated rune in `from` keeps the last mapping.
- **`count(*sets)` / `delete(*sets)` / `squeeze(*sets)`** — char-set methods: `count` tallies receiver runes in the set, `delete` removes them, `squeeze` collapses consecutive runs (of set runes, or of *all* runes when no set is given). Multiple set args intersect (Ruby's rule).

Each `set`/`from`/`to` arg is treated **literally** — range (`"a-z"`) and negation (`"^abc"`) forms are a follow-up, matching the literal-only `sub`/`gsub` precedent.

## Verification

- Full crate suite green incl. new `string_charset_methods_compile_and_run` (compiles + runs the emitted Go under `go run`, diffs stdout).
- `cargo clippy` clean.
- Security review: **PASSED** — bounded rune transforms, no unbounded allocation / overflow / panic / reflection surface.

Bumps `0.23.0 → 0.24.0`; CHANGELOG updated. Sweep order remaining: Rust → JS → TS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)