### PR TITLE
feat(task-core): data model for the task-app engine (Phase 1, Track A)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -875,4 +875,5 @@ members = [
     "spreadsheet-io",
   "document-ast-to-docx",
   "markdown-docx",
+  "task-core",
 ]

--- a/code/packages/rust/task-core/BUILD
+++ b/code/packages/rust/task-core/BUILD
@@ -1,0 +1,4 @@
+# Test both configurations: the zero-dependency default model, and the serde
+# feature that host-facing crates enable for JSON (de)serialisation.
+cargo test -p task-core -- --nocapture
+cargo test -p task-core --all-features -- --nocapture

--- a/code/packages/rust/task-core/CHANGELOG.md
+++ b/code/packages/rust/task-core/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to `task-core` are documented here.
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- **The data model** — the foundational entity set for a Microsoft Project-class,
+  "one model, many views" task engine:
+  - `Task` — the central entity, with an optional `TaskSchedule` block (task-type
+    triangle, the 8 date constraints, deadline, calendar, actuals), workflow status,
+    completion + percent-complete, typed custom-field values, and decision-tree
+    support (`Decision`) for checklist parity.
+  - `DependencyLink` (FS/SS/FF/SF + lag) driving the CPM network *and* flowchart
+    edges; `GenericLink` (blocks/relates/…) for non-scheduling relations.
+  - `Resource`, `Assignment` (units + work contour), and a four-layer working-time
+    `Calendar` model (weekly pattern + dated exceptions).
+  - Typed custom fields: `FieldDef`/`FieldKind` (text/number/bool/date/duration/
+    money/select/relation/**formula**/**rollup**) and `FieldValue`.
+  - `Workflow` (status state machine), `Baseline` (variance snapshot), and `View`
+    (projection descriptor: checklist/todo/kanban/gantt/calendar/flowchart/table).
+  - `ProjectState` — the flat, normalised root (entities stored by id, relationships
+    by id, never by nesting).
+- **Primitives** — `Date` (sharing `datetime-core`'s civil representation, with
+  arithmetic delegated to it), `Duration` (working minutes), `Work` (person-minutes),
+  and `Money` (exact minor units).
+- **Typed string-backed ids** — `TaskId`, `ResourceId`, `CalendarId`, etc.; ids are
+  minted by the facade (this core is clock-free and id-free), serialised as bare
+  strings so they round-trip losslessly through JavaScript/JSON.
+- **serde behind a feature flag** — the default model has zero external dependencies;
+  the `serde` feature emits camelCase JSON. A JSON round-trip test proves the wire
+  contract (camelCase field names, transparent string ids).
+
+### Notes
+
+- Design principle: everything a scheduler derives is computed, never stored — this
+  release is the *input* model; the CPM scheduler and reducer land next.
+- Reuses `directed-graph` (declared; consumed by the forthcoming scheduler) and
+  `datetime-core` (date arithmetic) rather than reimplementing them.

--- a/code/packages/rust/task-core/Cargo.toml
+++ b/code/packages/rust/task-core/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "task-core"
+version = "0.1.0"
+edition = "2021"
+description = "Headless task and project scheduling core (MS-Project-class CPM) for task-app and Mosaic frontends."
+
+# `serde` is optional (engram-core house style): the pure model has zero
+# external deps by default; JSON (de)serialisation is opt-in for the facade.
+[features]
+default = []
+serde = ["dep:serde"]
+
+[dependencies]
+# Reused, not rebuilt. directed-graph powers the CPM dependency network
+# (topological order, cycle detection, affected-set recompute); datetime-core
+# provides civil-date arithmetic (weekday/add-days) for the working-time model.
+directed-graph = { path = "../directed-graph" }
+datetime-core = { path = "../datetime-core" }
+serde = { version = "1", features = ["derive"], optional = true }
+
+# `serde_json` is a dev-only oracle: the JSON round-trip tests (gated on the
+# `serde` feature) use it to prove the wire contract (camelCase, transparent ids).
+[dev-dependencies]
+serde_json = "1"

--- a/code/packages/rust/task-core/README.md
+++ b/code/packages/rust/task-core/README.md
@@ -1,0 +1,77 @@
+# task-core
+
+The headless engine behind **task-app**: a general task- and project-management
+model in Rust, designed for the *hardest* case — Microsoft Project-class scheduling —
+so that every simpler tool is a *restriction* of one rich `Task` entity rather than a
+separate data model.
+
+- A **checklist item** is a task with a done-flag and no scheduling.
+- A **todo** is a task with a deadline.
+- A **kanban card** is a task with a workflow status.
+- A **Gantt bar** is a fully-scheduled task.
+- A **flowchart node** is a task in the relation graph.
+
+One model, many views. See the full design in
+[`code/specs/task-app-data-model.md`](../../../specs/task-app-data-model.md) and the
+series overview in [`task-app-overview.md`](../../../specs/task-app-overview.md).
+
+## Where this sits in the stack
+
+`task-core` is the bottom of the task-app layer cake, mirroring Engram:
+
+```
+task-core            ← you are here: pure model + (soon) CPM scheduler
+  └ task-core-wasm   facade: JSON in / JSON out, props + events
+        ├ task-capi  C ABI for native shells
+        └ task-wasm  WASM ABI for web / Electron
+```
+
+It is **pure and headless**: no I/O, no system clock (the current time is passed in
+as `now: u64`), and no id generation (ids are minted by the facade and passed in).
+`serde` is behind a feature flag, so the model has zero external dependencies by
+default. This matches the house style of `engram-core` and `spreadsheet-core`.
+
+Everything a scheduler *derives* — early/late dates, slack, the critical flag,
+rollups, formula values — is **computed, never stored as source of truth**.
+
+## Reuse, not rebuild
+
+`task-core` is assembled from existing repo crates rather than duplicating them:
+
+- [`directed-graph`](../directed-graph) — the CPM dependency network: topological
+  order, cycle detection, and affected-set recompute.
+- [`datetime-core`](../datetime-core) — civil-date arithmetic (weekday, add-days) for
+  the working-time calendar model. `task-core`'s `Date` shares its exact
+  representation (days since the Unix epoch).
+
+## What's implemented
+
+- **The data model** (this release): `Task` (with an optional scheduling block, typed
+  custom fields, and decision-tree support), dependency and generic links, resources,
+  assignments, working-time calendars, workflows, baselines, views, and the root
+  `ProjectState`. Typed string-backed ids; serde-optional; JSON round-trip tested.
+
+Landing next (per the specs): the CPM scheduler (forward/backward pass over
+`directed-graph`), working-time calendar math, formula/rollup fields (via
+`symbolic-vm`), and the `TaskCommand` reducer.
+
+## Usage
+
+```rust
+use task_core::{ProjectState, ProjectId, Task, TaskId};
+
+// The facade mints ids; here we use fixed strings.
+let mut project = ProjectState::empty(ProjectId::from_raw("p1"));
+let task = Task::new(TaskId::from_raw("t1"), "Write the spec");
+project.tasks.insert(task.id.clone(), task);
+```
+
+With the `serde` feature, `ProjectState` (and every entity) serialises to camelCase
+JSON with ids as bare strings — the wire contract the host adapters consume.
+
+## Testing
+
+```bash
+cargo test -p task-core                 # zero-dependency default model
+cargo test -p task-core --all-features  # + serde JSON round-trip
+```

--- a/code/packages/rust/task-core/required_capabilities.json
+++ b/code/packages/rust/task-core/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/task-core",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/rust/task-core/src/ids.rs
+++ b/code/packages/rust/task-core/src/ids.rs
@@ -1,0 +1,99 @@
+//! Typed entity identifiers.
+//!
+//! Every entity is addressed by a stable, string-backed id. We use **strings**
+//! (canonical UUID-v7 text, minted by the facade) rather than a 128-bit integer for
+//! one deliberate reason: this core is consumed from JavaScript through WebAssembly,
+//! and JSON numbers larger than 2^53 lose precision in JS. A string id round-trips
+//! losslessly on every platform.
+//!
+//! **Ids are not generated here.** Generating a UUID v7 needs a clock and a random
+//! source; this crate is intentionally clock-free and deterministic, so the *facade*
+//! (`task-core-wasm`, which the host feeds `now` and entropy) mints ids and passes
+//! them in on the create-commands. Within the core an id is just an opaque, ordered
+//! key — see [`TaskId::from_raw`].
+//!
+//! Each entity gets its *own* newtype (`TaskId`, `ResourceId`, …) so the compiler
+//! rejects passing a resource id where a task id is expected.
+
+/// Define a string-backed id newtype with the standard trait set and optional serde.
+///
+/// `serde(transparent)` makes the id serialise as a bare string (`"018f…"`), not a
+/// wrapper object, keeping the JSON contract clean for host adapters.
+macro_rules! id_type {
+    ($(#[$doc:meta])* $name:ident) => {
+        $(#[$doc])*
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(transparent))]
+        pub struct $name(pub String);
+
+        impl $name {
+            /// Wrap an externally-minted id string (the facade mints UUID v7s).
+            pub fn from_raw(s: impl Into<String>) -> Self {
+                Self(s.into())
+            }
+            /// Borrow the id as a string slice.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl core::fmt::Display for $name {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                Self(s.to_string())
+            }
+        }
+        impl From<String> for $name {
+            fn from(s: String) -> Self {
+                Self(s)
+            }
+        }
+    };
+}
+
+id_type!(
+    /// Identifies a whole project (one open document).
+    ProjectId
+);
+id_type!(
+    /// Identifies a task — the central entity.
+    TaskId
+);
+id_type!(
+    /// Identifies a resource (a person, machine, material, or cost).
+    ResourceId
+);
+id_type!(
+    /// Identifies a working-time calendar.
+    CalendarId
+);
+id_type!(
+    /// Identifies a user-defined custom field.
+    FieldId
+);
+id_type!(
+    /// Identifies a captured baseline (a schedule snapshot).
+    BaselineId
+);
+id_type!(
+    /// Identifies a saved view (a projection descriptor).
+    ViewId
+);
+id_type!(
+    /// Identifies a dependency or generic link.
+    LinkId
+);
+id_type!(
+    /// Identifies a workflow (a status state machine).
+    WorkflowId
+);
+id_type!(
+    /// Identifies a status within a workflow.
+    StatusId
+);

--- a/code/packages/rust/task-core/src/lib.rs
+++ b/code/packages/rust/task-core/src/lib.rs
@@ -1,0 +1,184 @@
+#![forbid(unsafe_code)]
+//! # task-core
+//!
+//! The headless engine behind **task-app**: a general task- and project-management
+//! model, designed for the *hardest* case (Microsoft Project-class scheduling) so
+//! that every simpler tool — a checklist, a todo list, a kanban board, a Gantt
+//! chart, a flowchart — is a *restriction* of one rich `Task` entity rather than a
+//! separate data model.
+//!
+//! ## What lives here
+//!
+//! This crate is **pure**: no I/O, no system clock (the current time is always
+//! passed in as `now: u64`), and no id generation (ids are minted by the facade and
+//! passed in — see the note on [`ids`]). `serde` is behind a feature flag, so the
+//! model has zero external dependencies by default. This mirrors the house style of
+//! `engram-core` and `spreadsheet-core`.
+//!
+//! Everything a scheduler *derives* (early/late dates, slack, the critical flag,
+//! rollups, formula values) is **computed, never stored as source of truth** — the
+//! stored state is the minimal set of inputs, and the schedule is reproducible from
+//! it. See `code/specs/task-app-data-model.md` for the full design.
+//!
+//! ## Module map
+//!
+//! - [`ids`] — typed, string-backed entity identifiers.
+//! - [`primitives`] — `Date`, `Duration`, `Work`, `Money`: the units the model
+//!   measures in, with civil-date arithmetic delegated to `datetime-core`.
+//! - [`model`] — the entities: `Task`, links, resources, calendars, fields,
+//!   workflow, baselines, views, and the root `ProjectState`.
+//!
+//! The CPM scheduler (a forward/backward pass over `directed-graph`) and the
+//! command/reducer surface land in follow-up modules; this module defines the
+//! *shape* of the world they operate on.
+
+mod ids;
+mod model;
+mod primitives;
+
+pub use ids::*;
+pub use model::*;
+pub use primitives::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_a_minimal_project() {
+        // A project with one task — the smallest meaningful state.
+        let mut project = ProjectState::empty(ProjectId::from_raw("p1"));
+        let task = Task::new(TaskId::from_raw("t1"), "Write the spec");
+        project.tasks.insert(task.id.clone(), task);
+
+        assert_eq!(project.tasks.len(), 1);
+        let t = project.tasks.get(&TaskId::from_raw("t1")).unwrap();
+        assert_eq!(t.name, "Write the spec");
+        assert!(!t.completed);
+        assert_eq!(t.kind, TaskKind::Leaf);
+        assert!(t.schedule.is_none(), "a bare task carries no scheduling");
+    }
+
+    #[test]
+    fn empty_project_seeds_a_standard_calendar() {
+        let project = ProjectState::empty(ProjectId::from_raw("p1"));
+        let cal = project
+            .calendars
+            .get(&project.project_calendar)
+            .expect("project calendar exists");
+        // Monday (index 0) is a working day; Sunday (index 6) is not.
+        assert!(cal.work_week[0].working);
+        assert!(!cal.work_week[6].working);
+        assert_eq!(cal.work_week[0].intervals[0].start_min, 9 * 60);
+        assert_eq!(cal.work_week[0].intervals[0].end_min, 17 * 60);
+    }
+
+    #[test]
+    fn date_arithmetic_delegates_to_datetime_core() {
+        // 2026-07-10 is a Friday (ISO weekday 5).
+        let d = Date::from_ymd(2026, 7, 10).unwrap();
+        assert_eq!(d.weekday(), 5);
+        assert_eq!(d.to_ymd(), (2026, 7, 10));
+        // Adding one day lands on Saturday.
+        assert_eq!(d.add_days(1).weekday(), 6);
+        assert_eq!(d.days_until(d.add_days(7)), 7);
+        assert!(
+            Date::from_ymd(2026, 13, 1).is_none(),
+            "invalid month rejected"
+        );
+    }
+
+    #[test]
+    fn primitive_helpers() {
+        assert!(Duration::zero().is_zero());
+        assert_eq!(Duration::minutes(480).working_minutes, 480);
+        assert!(!Duration::minutes(1).elapsed);
+        assert_eq!(Work::minutes(960).minutes, 960);
+        assert_eq!(Work::zero().minutes, 0);
+        let m = Money::zero("USD");
+        assert_eq!(m.minor_units, 0);
+        assert_eq!(m.currency, "USD");
+    }
+
+    #[test]
+    fn a_fully_scheduled_task_carries_the_whole_model() {
+        // Exercise the scheduling block, a decision, a dependency, and an assignment
+        // together — the shapes a Gantt/flowchart projection reads.
+        let mut project = ProjectState::empty(ProjectId::from_raw("p1"));
+
+        let mut design = Task::new(TaskId::from_raw("t1"), "Design");
+        design.schedule = Some(TaskSchedule {
+            duration: Duration::minutes(3 * 8 * 60),
+            work: Work::minutes(3 * 8 * 60),
+            constraint: Constraint::StartNoEarlierThan(Date::from_ymd(2026, 7, 13).unwrap()),
+            deadline: Some(Date::from_ymd(2026, 7, 20).unwrap()),
+            ..TaskSchedule::default()
+        });
+        let build = Task::new(TaskId::from_raw("t2"), "Build");
+
+        project.tasks.insert(design.id.clone(), design);
+        project.tasks.insert(build.id.clone(), build);
+        project.dependencies.push(DependencyLink {
+            id: LinkId::from_raw("l1"),
+            predecessor: TaskId::from_raw("t1"),
+            successor: TaskId::from_raw("t2"),
+            kind: DependencyKind::FinishToStart,
+            lag: Duration::zero(),
+        });
+
+        let dev = Resource {
+            id: ResourceId::from_raw("r1"),
+            name: "Dev".into(),
+            kind: ResourceKind::Work,
+            calendar: None,
+            max_units: 1.0,
+            std_rate: Money::zero("USD"),
+            cost_per_use: Money::zero("USD"),
+        };
+        project.resources.insert(dev.id.clone(), dev);
+        project.assignments.push(Assignment {
+            task: TaskId::from_raw("t1"),
+            resource: ResourceId::from_raw("r1"),
+            units: 1.0,
+            work: Work::minutes(3 * 8 * 60),
+            contour: WorkContour::Flat,
+        });
+
+        assert_eq!(project.tasks.len(), 2);
+        assert_eq!(project.dependencies[0].kind, DependencyKind::FinishToStart);
+        let sched = project.tasks[&TaskId::from_raw("t1")]
+            .schedule
+            .as_ref()
+            .unwrap();
+        assert!(matches!(
+            sched.constraint,
+            Constraint::StartNoEarlierThan(_)
+        ));
+        assert_eq!(project.assignments[0].units, 1.0);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn project_json_round_trips_with_camelcase_and_string_ids() {
+        let mut project = ProjectState::empty(ProjectId::from_raw("p1"));
+        let mut t = Task::new(TaskId::from_raw("t1"), "Ship it");
+        t.percent_complete = 40;
+        t.schedule = Some(TaskSchedule {
+            task_type: TaskType::FixedWork,
+            ..TaskSchedule::default()
+        });
+        project.tasks.insert(t.id.clone(), t);
+
+        let json = serde_json::to_string(&project).unwrap();
+        // Wire contract: camelCase field names …
+        assert!(json.contains("\"percentComplete\":40"));
+        assert!(json.contains("\"taskType\":\"fixedWork\""));
+        // … and ids serialise as bare strings (serde transparent), so the tasks map
+        // is keyed by the plain id string.
+        assert!(json.contains("\"t1\":{"));
+
+        // And it deserialises back to an equal value.
+        let back: ProjectState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, project);
+    }
+}

--- a/code/packages/rust/task-core/src/model.rs
+++ b/code/packages/rust/task-core/src/model.rs
@@ -1,0 +1,868 @@
+//! The entities.
+//!
+//! One [`Task`] is a strict superset of every task tool: a checklist item is a task
+//! with a done-flag and no scheduling; a todo is a task with a deadline; a kanban
+//! card is a task with a workflow status; a Gantt bar is a fully-scheduled task; a
+//! flowchart node is a task in the relation graph. The remaining types
+//! ([`Resource`], [`Calendar`], [`FieldDef`], [`Workflow`], [`Baseline`], [`View`])
+//! surround the task, and [`ProjectState`] is the flat, normalised root that holds
+//! them all.
+
+use crate::ids::*;
+use crate::primitives::*;
+use std::collections::BTreeMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The central entity. Most fields are optional and default to "unset", so a
+/// checklist item populates a handful while a scheduled Gantt task populates all.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Task {
+    /// Stable identity (minted by the facade).
+    pub id: TaskId,
+    /// Human-facing title.
+    pub name: String,
+    /// Free-form notes / description.
+    pub notes: String,
+    /// Parent in the work-breakdown structure; `None` for a top-level task.
+    pub parent: Option<TaskId>,
+    /// Sibling ordering key (lower sorts first). Reordering reassigns this, never
+    /// moves data.
+    pub order: i64,
+    /// Leaf, summary (rolls up its children), or milestone (zero-duration marker).
+    pub kind: TaskKind,
+    /// UI: is this summary's subtree collapsed.
+    pub collapsed: bool,
+
+    /// Workflow status (kanban/agile). `None` uses the board's default status.
+    pub status: Option<StatusId>,
+    /// The checklist "done" flag — kept distinct from `status` so a board and a
+    /// checklist can coexist over the same task.
+    pub completed: bool,
+    /// Progress, 0..=100.
+    pub percent_complete: u8,
+
+    /// The scheduling block — present only on tasks that participate in CPM.
+    pub schedule: Option<TaskSchedule>,
+
+    /// User-set values for custom fields. Formula/rollup fields are *not* stored
+    /// here; they are recomputed.
+    pub fields: BTreeMap<FieldId, FieldValue>,
+
+    /// Decision-tree branch point (checklist parity). `Some` makes this task a
+    /// yes/no question whose answer reveals one child subtree.
+    pub decision: Option<Decision>,
+}
+
+impl Task {
+    /// A bare leaf task: no scheduling, no status, not done.
+    pub fn new(id: TaskId, name: impl Into<String>) -> Task {
+        Task {
+            id,
+            name: name.into(),
+            notes: String::new(),
+            parent: None,
+            order: 0,
+            kind: TaskKind::Leaf,
+            collapsed: false,
+            status: None,
+            completed: false,
+            percent_complete: 0,
+            schedule: None,
+            fields: BTreeMap::new(),
+            decision: None,
+        }
+    }
+}
+
+/// What kind of node a task is in the outline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum TaskKind {
+    /// An ordinary task with its own duration/work.
+    Leaf,
+    /// A container whose dates/work/cost roll up from its descendants.
+    Summary,
+    /// A zero-duration marker (a deadline or a phase gate).
+    Milestone,
+}
+
+/// Everything the CPM scheduler needs. Present only on scheduled tasks.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct TaskSchedule {
+    /// Which leg of `Work = Duration × Units` is pinned when inputs change.
+    pub task_type: TaskType,
+    /// When true, changing assignments changes duration but never total work.
+    pub effort_driven: bool,
+    /// Working-time span of the task.
+    pub duration: Duration,
+    /// Total effort.
+    pub work: Work,
+    /// Task calendar override; falls back to resource/project/base calendars.
+    pub calendar: Option<CalendarId>,
+    /// The date constraint (default `Asap`).
+    pub constraint: Constraint,
+    /// A soft deadline: flags slippage, never forces a date.
+    pub deadline: Option<Date>,
+    /// Actual start once progress is recorded.
+    pub actual_start: Option<Date>,
+    /// Actual finish once complete.
+    pub actual_finish: Option<Date>,
+}
+
+impl Default for TaskSchedule {
+    fn default() -> Self {
+        TaskSchedule {
+            task_type: TaskType::FixedUnits,
+            effort_driven: true,
+            duration: Duration::minutes(0),
+            work: Work::zero(),
+            calendar: None,
+            constraint: Constraint::Asap,
+            deadline: None,
+            actual_start: None,
+            actual_finish: None,
+        }
+    }
+}
+
+/// Which quantity a task holds fixed while the scheduler recomputes the others.
+///
+/// | Type            | Pinned            | Add resources ⇒               |
+/// |-----------------|-------------------|-------------------------------|
+/// | `FixedUnits`    | assignment units  | duration shrinks (work const) |
+/// | `FixedDuration` | duration          | units drop to absorb the work |
+/// | `FixedWork`     | work (effort-driven) | duration shrinks           |
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum TaskType {
+    /// Units fixed.
+    FixedUnits,
+    /// Duration fixed.
+    FixedDuration,
+    /// Work fixed (always effort-driven).
+    FixedWork,
+}
+
+/// A date constraint. Rigidity increases down the list; an inflexible constraint can
+/// override a dependency (the scheduler records a conflict when they disagree).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum Constraint {
+    /// As soon as possible (flexible, default).
+    Asap,
+    /// As late as possible (flexible).
+    Alap,
+    /// Start no earlier than this date (semi-flexible).
+    StartNoEarlierThan(Date),
+    /// Start no later than this date (semi-flexible).
+    StartNoLaterThan(Date),
+    /// Finish no earlier than this date (semi-flexible).
+    FinishNoEarlierThan(Date),
+    /// Finish no later than this date (semi-flexible).
+    FinishNoLaterThan(Date),
+    /// Must start exactly on this date (inflexible).
+    MustStartOn(Date),
+    /// Must finish exactly on this date (inflexible).
+    MustFinishOn(Date),
+}
+
+/// Scheduler output for one task — **computed, never stored as truth**. Cached
+/// alongside the state and rebuilt by the engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ScheduledDates {
+    /// Earliest the task can start (forward pass).
+    pub early_start: Date,
+    /// Earliest the task can finish.
+    pub early_finish: Date,
+    /// Latest the task can start without delaying the project (backward pass).
+    pub late_start: Date,
+    /// Latest the task can finish.
+    pub late_finish: Date,
+    /// Start after constraints and calendars are applied.
+    pub scheduled_start: Date,
+    /// Finish after constraints and calendars are applied.
+    pub scheduled_finish: Date,
+    /// Total slack in working minutes (`late_start − early_start`).
+    pub total_slack: i64,
+    /// Free slack in working minutes.
+    pub free_slack: i64,
+    /// On the critical path (`total_slack <= 0`).
+    pub critical: bool,
+}
+
+/// A yes/no branch point, preserving the checklist app's decision-tree semantics.
+/// Until answered, only the question shows; the answer reveals one child subtree.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Decision {
+    /// The yes/no question shown for this branch point.
+    pub question: String,
+    /// The answer; `None` while unanswered.
+    pub answer: Option<bool>,
+    /// Child tasks revealed when the answer is `true`.
+    pub yes_children: Vec<TaskId>,
+    /// Child tasks revealed when the answer is `false`.
+    pub no_children: Vec<TaskId>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Relations: two graphs, deliberately separate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A scheduling dependency. Drives the CPM network *and* renders as a flowchart
+/// edge.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct DependencyLink {
+    /// Link identity.
+    pub id: LinkId,
+    /// The task that must (partly) precede.
+    pub predecessor: TaskId,
+    /// The task that (partly) follows.
+    pub successor: TaskId,
+    /// Which endpoints are related.
+    pub kind: DependencyKind,
+    /// Delay (positive) or lead (negative) between the linked endpoints.
+    pub lag: Duration,
+}
+
+/// The four precedence relationships.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum DependencyKind {
+    /// Successor starts after predecessor finishes (the default).
+    FinishToStart,
+    /// Successor starts after predecessor starts.
+    StartToStart,
+    /// Successor finishes after predecessor finishes.
+    FinishToFinish,
+    /// Successor finishes after predecessor starts.
+    StartToFinish,
+}
+
+/// A non-scheduling relationship (Jira-style). Never affects dates; renders in the
+/// flowchart alongside dependencies.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct GenericLink {
+    /// Link identity.
+    pub id: LinkId,
+    /// Source task.
+    pub from: TaskId,
+    /// Target task.
+    pub to: TaskId,
+    /// The relationship type.
+    pub kind: LinkKind,
+}
+
+/// The type of a non-scheduling link.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum LinkKind {
+    /// This task blocks the other.
+    Blocks,
+    /// Loosely related.
+    Relates,
+    /// A duplicate of the other.
+    Duplicates,
+    /// Causes the other.
+    Causes,
+    /// A user-named relationship.
+    Custom(String),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resources & assignments
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Something that can be assigned to a task: a person, a machine, a material, or a
+/// flat cost.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Resource {
+    /// Resource identity.
+    pub id: ResourceId,
+    /// Display name.
+    pub name: String,
+    /// Work, material, or cost.
+    pub kind: ResourceKind,
+    /// Availability calendar; falls back to the project calendar.
+    pub calendar: Option<CalendarId>,
+    /// Capacity: `1.0` = one full-time unit, `3.0` = a crew of three.
+    pub max_units: f64,
+    /// Standard rate (per working hour for `Work`, per unit for `Material`).
+    pub std_rate: Money,
+    /// A fixed cost incurred each time the resource is used.
+    pub cost_per_use: Money,
+}
+
+/// The nature of a resource.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum ResourceKind {
+    /// People or equipment measured in time (drives duration).
+    Work,
+    /// Consumables measured in quantity.
+    Material,
+    /// A pure cost line with no time dimension.
+    Cost,
+}
+
+/// A resource applied to a task.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Assignment {
+    /// The task being worked.
+    pub task: TaskId,
+    /// The resource doing the work.
+    pub resource: ResourceId,
+    /// Fraction of the resource applied (`1.0` = 100%).
+    pub units: f64,
+    /// This resource's share of the task's work.
+    pub work: Work,
+    /// How the work is distributed across the task's span.
+    pub contour: WorkContour,
+}
+
+/// How assigned work is spread over a task's duration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum WorkContour {
+    /// Even distribution (the default).
+    Flat,
+    /// Heavier at the start.
+    FrontLoaded,
+    /// Heavier at the end.
+    BackLoaded,
+    /// Ramps up then down.
+    BellShaped,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Calendars (the working-time model)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A working-time template: a weekly pattern plus dated exceptions. Resolution
+/// layers resource → task → project → base; the first that specifies a time wins.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Calendar {
+    /// Calendar identity.
+    pub id: CalendarId,
+    /// Display name.
+    pub name: String,
+    /// Optional base calendar to inherit unspecified days from.
+    pub base: Option<CalendarId>,
+    /// The weekly working pattern, indexed Monday (0) … Sunday (6).
+    pub work_week: [DaySchedule; 7],
+    /// Holidays and special days that override the weekly pattern.
+    pub exceptions: Vec<CalendarException>,
+}
+
+impl Calendar {
+    /// A standard Monday–Friday, 09:00–17:00 calendar.
+    pub fn standard(id: CalendarId, name: impl Into<String>) -> Calendar {
+        let workday = DaySchedule {
+            working: true,
+            intervals: vec![MinuteInterval {
+                start_min: 9 * 60,
+                end_min: 17 * 60,
+            }],
+        };
+        let off = DaySchedule {
+            working: false,
+            intervals: Vec::new(),
+        };
+        Calendar {
+            id,
+            name: name.into(),
+            base: None,
+            // Mon, Tue, Wed, Thu, Fri, Sat, Sun
+            work_week: [
+                workday.clone(),
+                workday.clone(),
+                workday.clone(),
+                workday.clone(),
+                workday,
+                off.clone(),
+                off,
+            ],
+            exceptions: Vec::new(),
+        }
+    }
+}
+
+/// One day's working intervals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct DaySchedule {
+    /// Whether any work happens on this day.
+    pub working: bool,
+    /// The working windows (e.g. 09:00–12:00, 13:00–17:00).
+    pub intervals: Vec<MinuteInterval>,
+}
+
+/// A half-open working window `[start_min, end_min)` in minutes from midnight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct MinuteInterval {
+    /// Inclusive start, minutes from midnight.
+    pub start_min: u16,
+    /// Exclusive end, minutes from midnight.
+    pub end_min: u16,
+}
+
+/// A dated override of the weekly pattern (a holiday, or an overtime day).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct CalendarException {
+    /// The affected date.
+    pub date: Date,
+    /// The schedule that applies on that date.
+    pub schedule: DaySchedule,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Typed custom fields (the flexibility layer)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A user-defined column. `Formula` and `Rollup` fields are computed by the formula
+/// engine (`symbolic-vm`), not stored per task.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct FieldDef {
+    /// Field identity.
+    pub id: FieldId,
+    /// Column name.
+    pub name: String,
+    /// The field's type and behavior.
+    pub kind: FieldKind,
+}
+
+/// The type of a custom field.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum FieldKind {
+    /// Free text.
+    Text,
+    /// A number.
+    Number,
+    /// A boolean.
+    Bool,
+    /// A date.
+    Date,
+    /// A working-time duration.
+    Duration,
+    /// A monetary amount.
+    Money,
+    /// A single- or multi-select from a fixed option set.
+    Select {
+        /// The allowed options.
+        options: Vec<String>,
+        /// Whether more than one option may be chosen.
+        multi: bool,
+    },
+    /// A link to other entities.
+    Relation {
+        /// What the relation points at.
+        target: RelationTarget,
+    },
+    /// A computed value, e.g. `[work] / [duration]`.
+    Formula {
+        /// The formula source in `[field]` bracket syntax.
+        source: String,
+    },
+    /// An aggregate over related tasks.
+    Rollup {
+        /// Which set of tasks to aggregate over.
+        over: RollupScope,
+        /// The field being aggregated.
+        field: FieldId,
+        /// The aggregation function.
+        agg: RollupAgg,
+    },
+}
+
+/// What a `Relation` field points at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum RelationTarget {
+    /// Links to other tasks.
+    Task,
+    /// Links to resources.
+    Resource,
+}
+
+/// The set a rollup aggregates over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum RollupScope {
+    /// Direct children only.
+    Children,
+    /// All descendants.
+    Descendants,
+    /// Assignments on the task.
+    Assignments,
+}
+
+/// A rollup aggregation function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum RollupAgg {
+    /// Sum of the values.
+    Sum,
+    /// Smallest value.
+    Min,
+    /// Largest value.
+    Max,
+    /// Arithmetic mean.
+    Average,
+    /// Count of non-empty values.
+    Count,
+}
+
+/// A stored value for a non-computed custom field.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum FieldValue {
+    /// Text value.
+    Text(String),
+    /// Numeric value.
+    Number(f64),
+    /// Boolean value.
+    Bool(bool),
+    /// Date value.
+    Date(Date),
+    /// Duration value.
+    Duration(Duration),
+    /// Money value.
+    Money(Money),
+    /// One or more selected options.
+    Select(Vec<String>),
+    /// Referenced entity ids.
+    Ref(Vec<String>),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Workflow (status state machine)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A configurable set of statuses and legal transitions — the engine behind kanban
+/// and agile boards.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Workflow {
+    /// Workflow identity.
+    pub id: WorkflowId,
+    /// Display name.
+    pub name: String,
+    /// Statuses in board-column order.
+    pub statuses: BTreeMap<StatusId, Status>,
+    /// Allowed status moves; empty means any status may move to any other.
+    pub transitions: Vec<Transition>,
+    /// Entering this status marks a task `completed`.
+    pub done_status: StatusId,
+}
+
+/// One status (a board column).
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Status {
+    /// Status identity.
+    pub id: StatusId,
+    /// Display name.
+    pub name: String,
+    /// Which lifecycle bucket it belongs to.
+    pub category: StatusCategory,
+    /// A display color (hex).
+    pub color: String,
+}
+
+/// The lifecycle bucket a status belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum StatusCategory {
+    /// Not started.
+    Todo,
+    /// Underway.
+    InProgress,
+    /// Finished.
+    Done,
+}
+
+/// A legal status move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Transition {
+    /// The status moved from.
+    pub from: StatusId,
+    /// The status moved to.
+    pub to: StatusId,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Baselines (variance)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A named, immutable snapshot of the schedule at a point in time, used to show
+/// planned-vs-actual variance.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Baseline {
+    /// Baseline identity.
+    pub id: BaselineId,
+    /// Display name (e.g. "Baseline 1").
+    pub name: String,
+    /// When it was captured (the injected `now`, epoch millis).
+    pub captured_at: u64,
+    /// Per-task captured values.
+    pub tasks: BTreeMap<TaskId, BaselineTask>,
+}
+
+/// The captured values for one task in a baseline.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct BaselineTask {
+    /// Planned start at capture.
+    pub start: Option<Date>,
+    /// Planned finish at capture.
+    pub finish: Option<Date>,
+    /// Planned duration at capture.
+    pub duration: Duration,
+    /// Planned work at capture.
+    pub work: Work,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Views (projections)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A saved projection: which tasks, how grouped/sorted, and the render shape. A view
+/// holds no task data — it is a lens over `ProjectState::tasks`.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct View {
+    /// View identity.
+    pub id: ViewId,
+    /// Display name.
+    pub name: String,
+    /// How the tasks are rendered.
+    pub shape: ViewShape,
+    /// Which tasks are included.
+    pub filter: Filter,
+    /// Optional grouping column (e.g. kanban groups by status).
+    pub group_by: Option<FieldRef>,
+    /// Sort order.
+    pub sort: Vec<SortKey>,
+    /// Columns shown (table/gantt).
+    pub visible_fields: Vec<FieldRef>,
+}
+
+/// The render shape of a view — each is a restriction of the one task model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum ViewShape {
+    /// Decision-tree checklist.
+    Checklist,
+    /// Flat todo list.
+    Todo,
+    /// Status-column board.
+    Kanban,
+    /// Timeline with dependency bars.
+    Gantt,
+    /// Date grid.
+    Calendar,
+    /// Node-edge graph of dependencies and links.
+    Flowchart,
+    /// Spreadsheet-style grid.
+    Table,
+}
+
+/// A predicate set selecting which tasks a view shows. Kept intentionally small for
+/// now; richer field/date predicates are a follow-up.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Filter {
+    /// Only tasks in these statuses (empty = any).
+    pub statuses: Vec<StatusId>,
+    /// Filter by completion (`None` = either).
+    pub completed: Option<bool>,
+    /// Case-insensitive substring match on the task name.
+    pub search: Option<String>,
+}
+
+/// A reference to a column, either a built-in field or a custom one.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum FieldRef {
+    /// A built-in column, named (e.g. "name", "start", "finish", "percentComplete").
+    Builtin(String),
+    /// A user-defined field.
+    Custom(FieldId),
+}
+
+/// A sort key.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct SortKey {
+    /// The column to sort on.
+    pub field: FieldRef,
+    /// Ascending when true.
+    pub ascending: bool,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Project settings & the root state
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Project-wide conventions.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ProjectSettings {
+    /// The unit durations are entered and displayed in.
+    pub duration_unit: DurationUnit,
+    /// First day of the week (ISO: Monday = 1).
+    pub week_start: u8,
+    /// Default currency (ISO-4217).
+    pub currency: String,
+    /// Working hours in a standard day (for unit conversion).
+    pub hours_per_day: u16,
+    /// Working days in a standard week (for unit conversion).
+    pub days_per_week: u8,
+}
+
+impl Default for ProjectSettings {
+    fn default() -> Self {
+        ProjectSettings {
+            duration_unit: DurationUnit::Days,
+            week_start: 1,
+            currency: "USD".to_string(),
+            hours_per_day: 8,
+            days_per_week: 5,
+        }
+    }
+}
+
+/// The unit durations are displayed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum DurationUnit {
+    /// Minutes.
+    Minutes,
+    /// Hours.
+    Hours,
+    /// Days.
+    Days,
+    /// Weeks.
+    Weeks,
+}
+
+/// The entire project — the flat, normalised root. Every entity is stored by id in a
+/// map (deterministic iteration for stable serialization); relationships are by id,
+/// never by nesting, which keeps the dependency graph, snapshots, and incremental
+/// recompute simple.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct ProjectState {
+    /// Project identity.
+    pub id: ProjectId,
+    /// Project name.
+    pub name: String,
+    /// All tasks, by id.
+    pub tasks: BTreeMap<TaskId, Task>,
+    /// The scheduling network.
+    pub dependencies: Vec<DependencyLink>,
+    /// Non-scheduling relations.
+    pub links: Vec<GenericLink>,
+    /// All resources, by id.
+    pub resources: BTreeMap<ResourceId, Resource>,
+    /// Resource assignments.
+    pub assignments: Vec<Assignment>,
+    /// All calendars, by id.
+    pub calendars: BTreeMap<CalendarId, Calendar>,
+    /// The default working-time calendar.
+    pub project_calendar: CalendarId,
+    /// User-defined custom fields, by id.
+    pub fields: BTreeMap<FieldId, FieldDef>,
+    /// Status workflows, by id.
+    pub workflows: BTreeMap<WorkflowId, Workflow>,
+    /// Captured baselines, by id.
+    pub baselines: BTreeMap<BaselineId, Baseline>,
+    /// Saved views, by id.
+    pub views: BTreeMap<ViewId, View>,
+    /// Project-wide settings.
+    pub settings: ProjectSettings,
+}
+
+impl ProjectState {
+    /// An empty project seeded with a standard Monday–Friday calendar.
+    pub fn empty(id: ProjectId) -> ProjectState {
+        let cal_id = CalendarId::from_raw("calendar-standard");
+        let mut calendars = BTreeMap::new();
+        calendars.insert(
+            cal_id.clone(),
+            Calendar::standard(cal_id.clone(), "Standard"),
+        );
+        ProjectState {
+            id,
+            name: String::new(),
+            tasks: BTreeMap::new(),
+            dependencies: Vec::new(),
+            links: Vec::new(),
+            resources: BTreeMap::new(),
+            assignments: Vec::new(),
+            calendars,
+            project_calendar: cal_id,
+            fields: BTreeMap::new(),
+            workflows: BTreeMap::new(),
+            baselines: BTreeMap::new(),
+            views: BTreeMap::new(),
+            settings: ProjectSettings::default(),
+        }
+    }
+}

--- a/code/packages/rust/task-core/src/primitives.rs
+++ b/code/packages/rust/task-core/src/primitives.rs
@@ -1,0 +1,124 @@
+//! The units the model measures in: calendar dates, working-time durations, effort,
+//! and money.
+//!
+//! ## Why durations are integers of *working* minutes
+//!
+//! A project schedule does not run in wall-clock time. "3 days" of work spans a
+//! weekend as five, not three, calendar days; an 8-hour task on a half-day Friday
+//! finishes Monday. So the model stores durations and effort as integer **minutes of
+//! working time** and resolves them to real dates against a [`crate::Calendar`]
+//! during scheduling. Integers keep the arithmetic exact and the JSON simple.
+
+/// A calendar date, stored as **days since the Unix epoch (1970-01-01)** in UTC —
+/// exactly `datetime_core::Date`'s representation, so all civil-date arithmetic is a
+/// direct delegation to that crate (no date math is reinvented here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Date(pub i32);
+
+impl Date {
+    /// Construct from a civil year/month/day, or `None` if the date is invalid.
+    pub fn from_ymd(year: i32, month: u32, day: u32) -> Option<Date> {
+        datetime_core::Date::from_ymd(year, month, day)
+            .ok()
+            .map(|d| Date(d.0))
+    }
+
+    /// Decompose into `(year, month, day)`.
+    pub fn to_ymd(self) -> (i32, u8, u8) {
+        datetime_core::Date(self.0).to_ymd()
+    }
+
+    /// ISO weekday: Monday = 1 … Sunday = 7.
+    pub fn weekday(self) -> u8 {
+        datetime_core::Date(self.0).iso_weekday()
+    }
+
+    /// This date shifted by `days` (negative moves backward).
+    pub fn add_days(self, days: i32) -> Date {
+        Date(datetime_core::Date(self.0).add_days(days).0)
+    }
+
+    /// Number of days from `self` to `end` (negative if `end` precedes `self`).
+    pub fn days_until(self, end: Date) -> i32 {
+        datetime_core::Date(self.0).days_until(datetime_core::Date(end.0))
+    }
+}
+
+/// A span of scheduled time.
+///
+/// `working_minutes` is measured against a calendar unless `elapsed` is set, in
+/// which case it is raw wall-clock (e.g. "wait 24h for concrete to cure" ignores
+/// weekends). A milestone is a task whose `duration` is zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Duration {
+    /// Minutes of time this span covers.
+    pub working_minutes: i64,
+    /// When true, the span ignores the calendar and is measured in wall-clock time.
+    pub elapsed: bool,
+}
+
+impl Duration {
+    /// A working-time duration of `minutes`.
+    pub fn minutes(minutes: i64) -> Duration {
+        Duration {
+            working_minutes: minutes,
+            elapsed: false,
+        }
+    }
+    /// Zero duration — the definition of a milestone.
+    pub fn zero() -> Duration {
+        Duration::minutes(0)
+    }
+    /// True if this is a zero-length span.
+    pub fn is_zero(self) -> bool {
+        self.working_minutes == 0
+    }
+}
+
+/// Total effort required, in person-minutes. Distinct from [`Duration`]: five people
+/// working one day is `Work` = 5 days but `Duration` = 1 day (`Work = Duration ×
+/// Units`, the scheduling triangle).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Work {
+    /// Effort in person-minutes.
+    pub minutes: i64,
+}
+
+impl Work {
+    /// `minutes` of effort.
+    pub fn minutes(minutes: i64) -> Work {
+        Work { minutes }
+    }
+    /// Zero effort.
+    pub fn zero() -> Work {
+        Work { minutes: 0 }
+    }
+}
+
+/// An exact monetary amount: integer minor units (e.g. cents) plus an ISO-4217
+/// currency code. Integers avoid floating-point rounding in cost rollups.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Money {
+    /// Amount in minor units (cents for USD/EUR, etc.).
+    pub minor_units: i64,
+    /// ISO-4217 currency code, e.g. "USD".
+    pub currency: String,
+}
+
+impl Money {
+    /// Zero in the given `currency`.
+    pub fn zero(currency: impl Into<String>) -> Money {
+        Money {
+            minor_units: 0,
+            currency: currency.into(),
+        }
+    }
+}


### PR DESCRIPTION
## What

Phase 1, Track A — the first implementation slice of **task-app**: the pure, headless
`task-core` data model, turning the crown-jewel design in
[`task-app-data-model.md`](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/task-app-data-model.md)
into compilable Rust. "One model, many views": a checklist item, todo, kanban card,
Gantt bar, and flowchart node are all *restrictions* of one rich `Task` entity.

## Contents

- **`Task`** — optional `TaskSchedule` block (task-type triangle, the 8 date
  constraints, deadline, calendar, actuals), workflow status, completion +
  percent-complete, typed custom-field values, and `Decision` (checklist
  decision-tree parity).
- **Relations** — `DependencyLink` (FS/SS/FF/SF + lag, drives CPM *and* flowchart
  edges) and `GenericLink` (blocks/relates/…).
- **Resources** — `Resource`, `Assignment` (units + contour), and a four-layer
  working-time `Calendar` (weekly pattern + dated exceptions).
- **Flexibility** — typed custom fields (`FieldDef`/`FieldKind` incl. formula/rollup)
  and `FieldValue`; `Workflow` (status state machine); `Baseline`; `View` (7
  projection shapes).
- **Root** — `ProjectState`, flat and normalized (by-id maps, relations by id).
- **Primitives** — `Date` (shares `datetime-core`'s civil representation; arithmetic
  delegated to it), `Duration` (working minutes), `Work`, `Money` (exact minor units).
- **Ids** — typed, string-backed, minted by the facade (this core is clock-free and
  id-free), serialized as bare strings for lossless JS/JSON round-trips.

## Design & quality

- **Pure and headless**: no I/O, no clock, `#![forbid(unsafe_code)]`. `serde` behind a
  feature flag (engram-core house style) — a JSON round-trip test proves the camelCase
  + transparent-string-id wire contract.
- **Reuse over rebuild**: depends on `directed-graph` (for the forthcoming scheduler)
  and `datetime-core` (date math); no new micro-crates.
- **Tests**: 6 pass (5 default + serde round-trip). BUILD runs both feature configs.
- **Security review passed** (Rust sub-agent): no unsafe, no library panics, flat
  model → no deserialization-depth DoS.

## Next (per the specs)

CPM scheduler (forward/backward pass over `directed-graph`), working-time calendar
math, formula/rollup fields (via `symbolic-vm`), and the `TaskCommand` reducer —
then Track B (facade + WASM + Mosaic on web/Electron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)