### PR TITLE
feat(sir-rust): String tr / count / delete / squeeze (char sets, v0.24.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.24.0 — String char-set methods: `tr` / `count` / `delete` / `squeeze`
+
+Adds four non-block Ruby String methods to the emitted runtime's `string_method`
+`match` and the `responds_to` catalog, mirroring the Python/Go reference
+semantics (char-based, so a multibyte receiver is never sliced mid-codepoint):
+
+- `tr(from, to)` — position-wise char translation; a shorter `to` repeats its
+  last char, an empty `to` deletes matching chars, and a repeated char in `from`
+  keeps the last mapping.
+- `count(*sets)` / `delete(*sets)` / `squeeze(*sets)` — char-set methods:
+  `count` tallies chars of the receiver in the set, `delete` removes them, and
+  `squeeze` collapses consecutive runs (of set chars, or of *all* chars when no
+  set is given). Multiple set arguments intersect (Ruby's rule).
+
+Each `set`/`from`/`to` argument is treated **literally** — the range (`"a-z"`)
+and negation (`"^abc"`) forms are a follow-up, matching the literal-only
+`sub`/`gsub` precedent. Exec-proven end-to-end via `rustc`. Third backend of the
+String char-set sweep (Python `sir-runtime-oop` v0.1.16, Go v0.24.0).
+
 ## 0.23.0 — slice-selection Array methods: `take` / `drop` / `values_at`
 
 Extends the emitted Rust runtime's `array_method` catalog (and the `Value::Seq`

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1482,7 +1482,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                 "length" | "size" | "upcase" | "downcase" | "capitalize" | "reverse" | "strip"
                     | "lstrip" | "rstrip" | "chomp" | "chars" | "bytes" | "split" | "include?"
                     | "start_with?" | "end_with?" | "index" | "replace" | "sub" | "gsub" | "to_i"
-                    | "to_f" | "to_sym" | "empty?"
+                    | "to_f" | "to_sym" | "empty?" | "tr" | "count" | "delete" | "squeeze"
             ),
             Value::Sym(_) => matches!(
                 name,
@@ -2399,6 +2399,93 @@ pub const RUNTIME: &str = r##"mod __sir {
             "to_f" => Value::Float(str_to_f(&s)),
             "to_sym" => intern(&s),
             "empty?" => Value::Bool(s.is_empty()),
+            "tr" => {
+                // Ruby `String#tr(from, to)`: position-wise char translation.  A
+                // shorter `to` repeats its last char; an empty `to` deletes
+                // matching chars; a repeated char in `from` keeps the last
+                // mapping.  Char-based so a multibyte receiver is never sliced
+                // mid-codepoint.  Literal only — the range (`"a-z"`) and negation
+                // (`"^abc"`) forms are a follow-up, matching the literal-only
+                // sub/gsub precedent here.
+                let from = match args.first() {
+                    Some(Value::Str(f)) => f.clone(),
+                    _ => return Value::Str(s.clone()),
+                };
+                let to = match args.get(1) {
+                    Some(Value::Str(t)) => t.clone(),
+                    _ => return Value::Str(s.clone()),
+                };
+                let to_chars: Vec<char> = to.chars().collect();
+                let mut table: HashMap<char, Option<char>> = HashMap::new();
+                for (i, c) in from.chars().enumerate() {
+                    if to_chars.is_empty() {
+                        table.insert(c, None);
+                    } else if i < to_chars.len() {
+                        table.insert(c, Some(to_chars[i]));
+                    } else {
+                        table.insert(c, Some(*to_chars.last().unwrap()));
+                    }
+                }
+                let out: String = s
+                    .chars()
+                    .filter_map(|c| match table.get(&c) {
+                        Some(Some(r)) => Some(*r),
+                        Some(None) => None,
+                        None => Some(c),
+                    })
+                    .collect();
+                Value::Str(Rc::from(out.as_str()))
+            }
+            "count" | "delete" | "squeeze" => {
+                // Char-set methods.  Each `set` argument is treated LITERALLY —
+                // the chars it contains (ranges/negation are a follow-up).
+                // `count` tallies chars of the receiver in the set; `delete`
+                // removes them; `squeeze` collapses consecutive runs (of set
+                // chars, or of ALL chars when no set is given).  Multiple set
+                // args intersect (Ruby's rule).  Char-based throughout.
+                let sets: Vec<std::collections::HashSet<char>> = args
+                    .iter()
+                    .filter_map(|a| {
+                        if let Value::Str(t) = a {
+                            Some(t.chars().collect())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                let in_all =
+                    |c: char| !sets.is_empty() && sets.iter().all(|set| set.contains(&c));
+                if name == "squeeze" && sets.is_empty() {
+                    let mut out = String::new();
+                    let mut last: Option<char> = None;
+                    for c in s.chars() {
+                        if last != Some(c) {
+                            out.push(c);
+                            last = Some(c);
+                        }
+                    }
+                    return Value::Str(Rc::from(out.as_str()));
+                }
+                match name {
+                    "count" => Value::Int(s.chars().filter(|c| in_all(*c)).count() as i64),
+                    "delete" => {
+                        let out: String = s.chars().filter(|c| !in_all(*c)).collect();
+                        Value::Str(Rc::from(out.as_str()))
+                    }
+                    _ => {
+                        let mut out = String::new();
+                        let mut last: Option<char> = None;
+                        for c in s.chars() {
+                            if last == Some(c) && in_all(c) {
+                                continue;
+                            }
+                            out.push(c);
+                            last = Some(c);
+                        }
+                        Value::Str(Rc::from(out.as_str()))
+                    }
+                }
+            }
             _ => no_method_error(&recv, name),
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
@@ -132,6 +132,19 @@ fn full_demo() -> Module {
         print_stmt(method(slit("foo"), "replace", vec![slit("bar")])),
         // "".empty?  → #t
         print_stmt(method(slit(""), "empty?", vec![])),
+        // ── char-set methods (v0.24.0): tr / count / delete / squeeze ──
+        // "hello".tr("el", "ip")  → "hippo"
+        print_stmt(method(slit("hello"), "tr", vec![slit("el"), slit("ip")])),
+        // "hello".tr("l", "")  → "heo"  (empty `to` deletes)
+        print_stmt(method(slit("hello"), "tr", vec![slit("l"), slit("")])),
+        // "hello".count("lo")  → 3
+        print_stmt(method(slit("hello"), "count", vec![slit("lo")])),
+        // "hello".delete("aeiou")  → "hll"
+        print_stmt(method(slit("hello"), "delete", vec![slit("aeiou")])),
+        // "mississippi".squeeze  → "misisipi"
+        print_stmt(method(slit("mississippi"), "squeeze", vec![])),
+        // "aaabbbccc".squeeze("a")  → "abbbccc"
+        print_stmt(method(slit("aaabbbccc"), "squeeze", vec![slit("a")])),
     ];
 
     demo_module(main_stmts)
@@ -218,6 +231,12 @@ fn string_methods_compile_and_run() {
             "x  ",           // lstrip
             "bar",           // replace
             "#t",            // "".empty?
+            "hippo",         // tr("el", "ip")
+            "heo",           // tr("l", "") — empty `to` deletes
+            "3",             // count("lo")
+            "hll",           // delete("aeiou")
+            "misisipi",      // squeeze (no arg)
+            "abbbccc",       // squeeze("a")
         ],
         "unexpected program output; full stdout:\n{stdout}"
     );


### PR DESCRIPTION
## What

Mirrors the Python/Go reference String **char-set** sweep onto the **Rust backend** (third backend; follows Python `sir-runtime-oop` v0.1.16 + Go v0.24.0). Adds four non-block Ruby String methods to the emitted runtime's `string_method` match + `responds_to` catalog, **char-based** so a multibyte receiver is never sliced mid-codepoint:

- **`tr(from, to)`** — position-wise char translation; a shorter `to` repeats its last char, an empty `to` deletes matching chars, and a repeated char in `from` keeps the last mapping.
- **`count(*sets)` / `delete(*sets)` / `squeeze(*sets)`** — char-set methods: `count` tallies receiver chars in the set, `delete` removes them, `squeeze` collapses consecutive runs (of set chars, or of *all* chars when no set is given). Multiple set args intersect (Ruby's rule).

Each `set`/`from`/`to` arg is treated **literally** — range (`"a-z"`) and negation (`"^abc"`) forms are a follow-up, matching the literal-only `sub`/`gsub` precedent.

## Verification

- Full crate suite green incl. `string_methods_compile_and_run` (compiles + runs the emitted Rust under `rustc`, diffs stdout).
- No new `clippy` warnings (the 4 are pre-existing in `semantic-ir` core + `emit.rs`).
- Security review: **PASSED** — no `unsafe`, no reachable panic (`unwrap` guarded), bounded allocation, char-boundary-safe, no reflection.

Bumps `0.23.0 → 0.24.0`; CHANGELOG updated. Sweep remaining: JS → TS.

> Discovered (not in this PR): the **Rust backend lacks `ljust`/`rjust`/`center`/`swapcase`** (all other backends carry them) — tracked for a Rust string catch-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)