### PR TITLE
feat(task-core): working-time calendar engine (Phase 1, Track A)

### DIFF
--- a/code/packages/rust/task-core/CHANGELOG.md
+++ b/code/packages/rust/task-core/CHANGELOG.md
@@ -32,9 +32,22 @@ All notable changes to `task-core` are documented here.
   the `serde` feature emits camelCase JSON. A JSON round-trip test proves the wire
   contract (camelCase field names, transparent string ids).
 
+- **The working-time engine** (`calendar` module) — the unit the CPM scheduler
+  measures in. Represents time as **instants** (integer minutes since the epoch) for
+  clean half-open interval arithmetic, and provides:
+  - `is_working_day` — calendar-aware working-day test (weekly pattern + holiday/
+    overtime exceptions).
+  - `next_working` — snap an instant forward to the next working minute.
+  - `add_working` — advance an instant by a `Duration` in working time (skipping
+    weekends/holidays/off-hours), with elapsed-duration and zero-duration handling.
+  - `working_between` — count working minutes in a half-open interval (for slack).
+  - Built on `datetime-core` weekday math; an absent calendar safely degrades to 24/7;
+    walks are bounded so a no-working-time calendar can never hang.
+
 ### Notes
 
 - Design principle: everything a scheduler derives is computed, never stored — this
-  release is the *input* model; the CPM scheduler and reducer land next.
+  release is the *input* model plus the working-time engine; the CPM scheduler
+  (forward/backward pass) and the reducer land next.
 - Reuses `directed-graph` (declared; consumed by the forthcoming scheduler) and
   `datetime-core` (date arithmetic) rather than reimplementing them.

--- a/code/packages/rust/task-core/src/calendar.rs
+++ b/code/packages/rust/task-core/src/calendar.rs
@@ -1,0 +1,350 @@
+//! The working-time engine.
+//!
+//! A project schedule does not run in wall-clock time: "one working day" of effort
+//! skips weekends and holidays, and an eight-hour task started at 15:00 on a
+//! nine-to-five Friday does not finish until Monday. Everything the CPM scheduler
+//! does — placing a task, honouring lag, measuring slack — is expressed in **working
+//! minutes** resolved against a [`Calendar`]. This module is that resolver.
+//!
+//! ## Instants
+//!
+//! We work in **instants**: integer minutes since the Unix epoch, computed as
+//! `date_days × 1440 + minute_of_day`. Instants make interval arithmetic clean and
+//! half-open — a task occupies `[start, finish)` and "finish-to-start" is simply
+//! `successor.start ≥ predecessor.finish`, with none of the inclusive-date
+//! off-by-one bookkeeping that day-granularity scheduling suffers from.
+//!
+//! ## Calendar resolution
+//!
+//! For a given date we resolve the applicable [`DaySchedule`] as: a matching
+//! [`CalendarException`] (a holiday or overtime day) if one exists, otherwise the
+//! weekly pattern entry for that weekday. If the referenced calendar is *absent*
+//! entirely we fall back to treating all time as working (24/7) — a safe default
+//! that never hangs the walk. (Base-calendar inheritance and resource calendars are
+//! layered in a follow-up; today the scheduler resolves task-or-project calendars.)
+
+use crate::ids::CalendarId;
+use crate::model::{Calendar, DaySchedule, ProjectState};
+use crate::primitives::{Date, Duration};
+
+/// Minutes in a day.
+const MINUTES_PER_DAY: i64 = 1440;
+
+/// Safety bound on how many days a working-time walk may traverse before giving up
+/// (≈50 years). Prevents an infinite loop if a calendar defines no working time.
+const MAX_DAYS_WALK: i64 = 366 * 50;
+
+/// An instant: integer minutes since the Unix epoch.
+pub type Instant = i64;
+
+/// Compose an instant from a date and a minute-of-day offset.
+pub fn instant_of(date: Date, minute_of_day: i64) -> Instant {
+    date.0 as i64 * MINUTES_PER_DAY + minute_of_day
+}
+
+/// The calendar date an instant falls on (floor division, so it is correct for
+/// pre-epoch negative instants too).
+pub fn date_of(inst: Instant) -> Date {
+    Date(inst.div_euclid(MINUTES_PER_DAY) as i32)
+}
+
+/// The minute-of-day (0..1440) of an instant.
+pub fn minute_of_day(inst: Instant) -> i64 {
+    inst.rem_euclid(MINUTES_PER_DAY)
+}
+
+/// The calendar to use, falling back to the project calendar when `cal` is missing.
+/// Returns `None` only when neither exists — the caller then treats time as 24/7.
+fn resolve_calendar<'a>(project: &'a ProjectState, cal: &CalendarId) -> Option<&'a Calendar> {
+    project
+        .calendars
+        .get(cal)
+        .or_else(|| project.calendars.get(&project.project_calendar))
+}
+
+/// The [`DaySchedule`] that applies to `date` on `cal`: an exception if one matches,
+/// otherwise the weekday's entry in the weekly pattern.
+fn day_schedule<'a>(cal: &'a Calendar, date: Date) -> &'a DaySchedule {
+    for ex in &cal.exceptions {
+        if ex.date == date {
+            return &ex.schedule;
+        }
+    }
+    // `weekday()` is ISO: Monday = 1 … Sunday = 7; the pattern is indexed from 0.
+    let idx = (date.weekday() - 1) as usize;
+    &cal.work_week[idx]
+}
+
+/// Whether `date` is a working day on the calendar named by `cal`.
+pub fn is_working_day(project: &ProjectState, cal: &CalendarId, date: Date) -> bool {
+    match resolve_calendar(project, cal) {
+        None => true, // no calendar ⇒ every day works
+        Some(c) => {
+            let sched = day_schedule(c, date);
+            sched.working && !sched.intervals.is_empty()
+        }
+    }
+}
+
+/// The first working instant at or after `start`. Returns `start` unchanged if it is
+/// already within a working interval. Returns `None` only if no working time is found
+/// within [`MAX_DAYS_WALK`] days (a calendar with no working time at all).
+pub fn next_working(project: &ProjectState, cal: &CalendarId, start: Instant) -> Option<Instant> {
+    let Some(c) = resolve_calendar(project, cal) else {
+        return Some(start); // 24/7
+    };
+    let mut date = date_of(start);
+    let mut from_min = minute_of_day(start);
+    for _ in 0..MAX_DAYS_WALK {
+        let sched = day_schedule(c, date);
+        if sched.working {
+            for iv in &sched.intervals {
+                let end = iv.end_min as i64;
+                if end > from_min {
+                    let s = from_min.max(iv.start_min as i64);
+                    return Some(instant_of(date, s));
+                }
+            }
+        }
+        // Nothing left today ⇒ jump to the start of the next day.
+        date = date.add_days(1);
+        from_min = 0;
+    }
+    None
+}
+
+/// Advance `start` by a [`Duration`], returning the finish instant.
+///
+/// - An **elapsed** duration is raw wall-clock: `start + minutes`, ignoring the
+///   calendar (e.g. "wait 24h for paint to dry").
+/// - A **working** duration consumes `minutes` of working time, snapping the start
+///   forward into working time first and skipping every non-working interval.
+/// - A **zero** duration returns `start` unchanged (a milestone is a point in time).
+pub fn add_working(
+    project: &ProjectState,
+    cal: &CalendarId,
+    start: Instant,
+    dur: Duration,
+) -> Instant {
+    if dur.elapsed {
+        return start + dur.working_minutes;
+    }
+    if dur.working_minutes <= 0 {
+        return start;
+    }
+    let Some(c) = resolve_calendar(project, cal) else {
+        return start + dur.working_minutes; // 24/7
+    };
+
+    let mut remaining = dur.working_minutes;
+    // Snap into working time before consuming.
+    let snapped = match next_working(project, cal, start) {
+        Some(i) => i,
+        None => return start + dur.working_minutes, // degenerate calendar
+    };
+    let mut date = date_of(snapped);
+    let mut from_min = minute_of_day(snapped);
+
+    for _ in 0..MAX_DAYS_WALK {
+        let sched = day_schedule(c, date);
+        if sched.working {
+            for iv in &sched.intervals {
+                let end = iv.end_min as i64;
+                let seg_start = from_min.max(iv.start_min as i64);
+                if end > seg_start {
+                    let avail = end - seg_start;
+                    if remaining <= avail {
+                        return instant_of(date, seg_start + remaining);
+                    }
+                    remaining -= avail;
+                }
+            }
+        }
+        date = date.add_days(1);
+        from_min = 0;
+    }
+    // Degenerate calendar: best effort.
+    instant_of(date, 0)
+}
+
+/// Count the working minutes in the half-open interval `[a, b)`. Zero if `b <= a`.
+/// Used for slack (`total_slack = working_between(early_start, late_start)`).
+pub fn working_between(project: &ProjectState, cal: &CalendarId, a: Instant, b: Instant) -> i64 {
+    if b <= a {
+        return 0;
+    }
+    let Some(c) = resolve_calendar(project, cal) else {
+        return b - a; // 24/7
+    };
+    let mut total = 0;
+    let mut date = date_of(a);
+    let last_date = date_of(b - 1);
+    let mut guard = 0;
+    while date <= last_date && guard < MAX_DAYS_WALK {
+        let sched = day_schedule(c, date);
+        if sched.working {
+            let day_start = instant_of(date, 0);
+            for iv in &sched.intervals {
+                let iv_lo = day_start + iv.start_min as i64;
+                let iv_hi = day_start + iv.end_min as i64;
+                let lo = iv_lo.max(a);
+                let hi = iv_hi.min(b);
+                if hi > lo {
+                    total += hi - lo;
+                }
+            }
+        }
+        date = date.add_days(1);
+        guard += 1;
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::{CalendarId, ProjectId};
+
+    fn project_with_standard_calendar() -> (ProjectState, CalendarId) {
+        let p = ProjectState::empty(ProjectId::from_raw("p1"));
+        let cal = p.project_calendar.clone();
+        (p, cal)
+    }
+
+    #[test]
+    fn instant_round_trips_through_date_and_minute() {
+        let d = Date::from_ymd(2026, 7, 10).unwrap();
+        let inst = instant_of(d, 9 * 60);
+        assert_eq!(date_of(inst), d);
+        assert_eq!(minute_of_day(inst), 9 * 60);
+    }
+
+    #[test]
+    fn standard_calendar_marks_weekends_non_working() {
+        let (p, cal) = project_with_standard_calendar();
+        // 2026-07-10 is Friday, 07-11 Saturday, 07-13 Monday.
+        assert!(is_working_day(
+            &p,
+            &cal,
+            Date::from_ymd(2026, 7, 10).unwrap()
+        ));
+        assert!(!is_working_day(
+            &p,
+            &cal,
+            Date::from_ymd(2026, 7, 11).unwrap()
+        ));
+        assert!(!is_working_day(
+            &p,
+            &cal,
+            Date::from_ymd(2026, 7, 12).unwrap()
+        ));
+        assert!(is_working_day(
+            &p,
+            &cal,
+            Date::from_ymd(2026, 7, 13).unwrap()
+        ));
+    }
+
+    #[test]
+    fn next_working_snaps_out_of_the_weekend_and_off_hours() {
+        let (p, cal) = project_with_standard_calendar();
+        // Saturday 10:00 → Monday 09:00.
+        let sat = instant_of(Date::from_ymd(2026, 7, 11).unwrap(), 10 * 60);
+        let got = next_working(&p, &cal, sat).unwrap();
+        assert_eq!(date_of(got), Date::from_ymd(2026, 7, 13).unwrap());
+        assert_eq!(minute_of_day(got), 9 * 60);
+
+        // Friday 07:00 (before the workday) → Friday 09:00.
+        let early = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 7 * 60);
+        let got = next_working(&p, &cal, early).unwrap();
+        assert_eq!(minute_of_day(got), 9 * 60);
+
+        // Friday 18:00 (after the workday) → Monday 09:00.
+        let late = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 18 * 60);
+        let got = next_working(&p, &cal, late).unwrap();
+        assert_eq!(date_of(got), Date::from_ymd(2026, 7, 13).unwrap());
+    }
+
+    #[test]
+    fn add_working_consumes_a_full_eight_hour_day() {
+        let (p, cal) = project_with_standard_calendar();
+        // A one-day (8h) task starting Friday 09:00 finishes Friday 17:00.
+        let fri_9 = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 9 * 60);
+        let finish = add_working(&p, &cal, fri_9, Duration::minutes(8 * 60));
+        assert_eq!(date_of(finish), Date::from_ymd(2026, 7, 10).unwrap());
+        assert_eq!(minute_of_day(finish), 17 * 60);
+    }
+
+    #[test]
+    fn add_working_spills_across_the_weekend() {
+        let (p, cal) = project_with_standard_calendar();
+        // 12 working hours from Friday 09:00: 8h fills Friday, the remaining 4h lands
+        // Monday 09:00–13:00.
+        let fri_9 = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 9 * 60);
+        let finish = add_working(&p, &cal, fri_9, Duration::minutes(12 * 60));
+        assert_eq!(date_of(finish), Date::from_ymd(2026, 7, 13).unwrap());
+        assert_eq!(minute_of_day(finish), 13 * 60);
+    }
+
+    #[test]
+    fn elapsed_duration_ignores_the_calendar() {
+        let (p, cal) = project_with_standard_calendar();
+        let fri_9 = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 9 * 60);
+        let finish = add_working(
+            &p,
+            &cal,
+            fri_9,
+            Duration {
+                working_minutes: MINUTES_PER_DAY,
+                elapsed: true,
+            },
+        );
+        // Exactly 24h later, weekend or not.
+        assert_eq!(finish, fri_9 + MINUTES_PER_DAY);
+    }
+
+    #[test]
+    fn zero_duration_is_a_point() {
+        let (p, cal) = project_with_standard_calendar();
+        let fri_9 = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 9 * 60);
+        assert_eq!(add_working(&p, &cal, fri_9, Duration::zero()), fri_9);
+    }
+
+    #[test]
+    fn working_between_counts_only_working_minutes() {
+        let (p, cal) = project_with_standard_calendar();
+        // Friday 09:00 to Monday 13:00 = 8h (Fri) + 4h (Mon) = 12h of working time,
+        // the weekend contributing nothing.
+        let a = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 9 * 60);
+        let b = instant_of(Date::from_ymd(2026, 7, 13).unwrap(), 13 * 60);
+        assert_eq!(working_between(&p, &cal, a, b), 12 * 60);
+        assert_eq!(
+            working_between(&p, &cal, b, a),
+            0,
+            "reversed interval is empty"
+        );
+    }
+
+    #[test]
+    fn holiday_exception_makes_a_weekday_non_working() {
+        let mut p = ProjectState::empty(ProjectId::from_raw("p1"));
+        let cal_id = p.project_calendar.clone();
+        let holiday = Date::from_ymd(2026, 7, 10).unwrap(); // a Friday
+        p.calendars
+            .get_mut(&cal_id)
+            .unwrap()
+            .exceptions
+            .push(crate::model::CalendarException {
+                date: holiday,
+                schedule: DaySchedule {
+                    working: false,
+                    intervals: Vec::new(),
+                },
+            });
+        assert!(!is_working_day(&p, &cal_id, holiday));
+        // A task that would have started Friday 09:00 now snaps to Monday.
+        let fri_9 = instant_of(holiday, 9 * 60);
+        let got = next_working(&p, &cal_id, fri_9).unwrap();
+        assert_eq!(date_of(got), Date::from_ymd(2026, 7, 13).unwrap());
+    }
+}

--- a/code/packages/rust/task-core/src/calendar.rs
+++ b/code/packages/rust/task-core/src/calendar.rs
@@ -127,20 +127,20 @@ pub fn add_working(
     dur: Duration,
 ) -> Instant {
     if dur.elapsed {
-        return start + dur.working_minutes;
+        return start.saturating_add(dur.working_minutes);
     }
     if dur.working_minutes <= 0 {
         return start;
     }
     let Some(c) = resolve_calendar(project, cal) else {
-        return start + dur.working_minutes; // 24/7
+        return start.saturating_add(dur.working_minutes); // 24/7
     };
 
     let mut remaining = dur.working_minutes;
     // Snap into working time before consuming.
     let snapped = match next_working(project, cal, start) {
         Some(i) => i,
-        None => return start + dur.working_minutes, // degenerate calendar
+        None => return start.saturating_add(dur.working_minutes), // degenerate calendar
     };
     let mut date = date_of(snapped);
     let mut from_min = minute_of_day(snapped);
@@ -301,6 +301,19 @@ mod tests {
         );
         // Exactly 24h later, weekend or not.
         assert_eq!(finish, fri_9 + MINUTES_PER_DAY);
+    }
+
+    #[test]
+    fn add_working_saturates_instead_of_overflowing() {
+        // A hostile project (e.g. from untrusted JSON) with an enormous duration must
+        // not panic (debug) or wrap to a negative finish (release) — it saturates.
+        let (p, cal) = project_with_standard_calendar();
+        let start = instant_of(Date::from_ymd(2026, 7, 10).unwrap(), 9 * 60);
+        let huge = Duration {
+            working_minutes: i64::MAX,
+            elapsed: true,
+        };
+        assert_eq!(add_working(&p, &cal, start, huge), i64::MAX);
     }
 
     #[test]

--- a/code/packages/rust/task-core/src/lib.rs
+++ b/code/packages/rust/task-core/src/lib.rs
@@ -27,11 +27,15 @@
 //!   measures in, with civil-date arithmetic delegated to `datetime-core`.
 //! - [`model`] — the entities: `Task`, links, resources, calendars, fields,
 //!   workflow, baselines, views, and the root `ProjectState`.
+//! - [`calendar`] — the working-time engine: resolve calendars, snap into working
+//!   time, add working durations, and count working minutes. The unit the scheduler
+//!   measures in.
 //!
-//! The CPM scheduler (a forward/backward pass over `directed-graph`) and the
-//! command/reducer surface land in follow-up modules; this module defines the
-//! *shape* of the world they operate on.
+//! The CPM scheduler (a forward/backward pass over `directed-graph`, built on
+//! [`calendar`]) and the command/reducer surface land in follow-up modules; the
+//! types here define the *shape* of the world they operate on.
 
+pub mod calendar;
 mod ids;
 mod model;
 mod primitives;


### PR DESCRIPTION
## What

The **working-time engine** for `task-core` — the unit the forthcoming CPM scheduler
measures in. A project schedule runs in working time, not wall-clock: durations skip
weekends, holidays, and off-hours. Per
[`task-app-scheduling-engine.md`](https://github.com/adhithyan15/coding-adventures/blob/main/code/specs/task-app-scheduling-engine.md).

## The engine (`calendar` module)

- **Instants** — integer minutes since the epoch (`date_days × 1440 + minute`), for
  clean half-open interval math: finish-to-start becomes `succ.start ≥ pred.finish`,
  with none of the inclusive-date off-by-one bookkeeping of day-granularity scheduling.
- `is_working_day` — weekly pattern + holiday/overtime exceptions.
- `next_working` — snap an instant forward to the next working minute.
- `add_working` — advance by a `Duration` in working time (weekend/holiday/off-hours
  aware); handles elapsed and zero durations.
- `working_between` — count working minutes in `[a, b)` (for slack).

Built on `datetime-core` weekday math. An absent calendar safely degrades to 24/7;
all walks are bounded so a no-working-time calendar can never hang.

## Quality

- 9 calendar tests (weekend spill, holiday exception, elapsed, slack counting,
  snap-out-of-off-hours) + overflow saturation; **15 tests pass** total.
- Pure, `#![forbid(unsafe_code)]`.
- **Security review**: found + fixed a MEDIUM (integer overflow on an unbounded
  duration from untrusted JSON → now `saturating_add`, test added). One LOW
  (crafted-calendar interval amplification) deferred to input validation at the
  deserialization/facade trust boundary, tracked for `task-core-wasm`.

## Next

The CPM forward/backward pass builds directly on this — early/late dates, slack, and
the critical path over `directed-graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)