### PR TITLE
feat(sir-js): String tr / count / delete / squeeze (char sets, v0.23.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.23.0 — String char-set methods: `tr` / `count` / `delete` / `squeeze`
+
+Adds four non-block Ruby String methods to the inlined runtime's `stringMethod`
+switch and the `STRING_METHODS` `respond_to?` set, iterating by code point
+(`for..of` / `[...str]`) so a multibyte receiver is never split, mirroring the
+Python/Go/Rust reference:
+
+- `tr(from, to)` — position-wise code-point translation; a shorter `to` repeats
+  its last code point, an empty `to` deletes matching code points, and a
+  repeated code point in `from` keeps the last mapping.
+- `count(*sets)` / `delete(*sets)` / `squeeze(*sets)` — char-set methods:
+  `count` tallies receiver code points in the set, `delete` removes them, and
+  `squeeze` collapses consecutive runs (of set code points, or of *all* when no
+  set is given). Multiple set arguments intersect (Ruby's rule).
+
+Each `set`/`from`/`to` argument is treated **literally** — the range (`"a-z"`)
+and negation (`"^abc"`) forms are a follow-up, matching the literal-only
+`sub`/`gsub` precedent. Exec-proven end-to-end under Node. Fourth backend of the
+String char-set sweep (Python, Go, Rust already landed).
+
 ## 0.22.0 — Ruby value-equality for `Array#include?` / `Array#index`
 
 Fixes two native-alias semantic divergences on Array receivers, routed through

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -684,6 +684,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "capitalize", "chomp", "chars", "bytes", "sub", "gsub", "to_i", "to_f",
     "to_sym", "to_s", "empty?", "index", "reverse", "size",
     "ljust", "rjust", "center", "swapcase",
+    "tr", "count", "delete", "squeeze",
   ]);
   // Ruby `String#to_i` / `#to_f`: parse a LEADING numeric prefix (optional
   // sign, digits, and — for to_f — a fractional/exponent part), yielding 0 when
@@ -795,6 +796,69 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           if (c >= 65 && c <= 90) { out += String.fromCodePoint(c + 32); }
           else if (c >= 97 && c <= 122) { out += String.fromCodePoint(c - 32); }
           else { out += ch; }
+        }
+        return out;
+      }
+      case "tr": {
+        // Ruby `String#tr(from, to)`: position-wise code-point translation.  A
+        // shorter `to` repeats its last code point; an empty `to` deletes
+        // matching code points; a repeated code point in `from` keeps the last
+        // mapping.  Iterates by code point (`[...str]`/`for..of`) so a multibyte
+        // receiver is never split.  Literal only — the range (`"a-z"`) and
+        // negation (`"^abc"`) forms are a follow-up, matching the literal-only
+        // sub/gsub precedent here.
+        const from = typeof args[0] === "string" ? args[0] : null;
+        const to = typeof args[1] === "string" ? args[1] : null;
+        if (from === null || to === null) { return recv; }
+        const toC = [...to];
+        const table = new Map();
+        const fromC = [...from];
+        for (let i = 0; i < fromC.length; i++) {
+          if (toC.length === 0) { table.set(fromC[i], null); }
+          else { table.set(fromC[i], i < toC.length ? toC[i] : toC[toC.length - 1]); }
+        }
+        let out = "";
+        for (const ch of recv) {
+          if (table.has(ch)) {
+            const r = table.get(ch);
+            if (r !== null) { out += r; }
+          } else { out += ch; }
+        }
+        return out;
+      }
+      case "count": case "delete": case "squeeze": {
+        // Char-set methods.  Each `set` argument is treated LITERALLY — the code
+        // points it contains (ranges/negation are a follow-up).  `count` tallies
+        // code points of the receiver in the set; `delete` removes them;
+        // `squeeze` collapses consecutive runs (of set code points, or of ALL
+        // when no set is given).  Multiple set args intersect (Ruby's rule).
+        const sets = [];
+        for (const a of args) {
+          if (typeof a === "string") { sets.push(new Set([...a])); }
+        }
+        const inAll = (ch) => sets.length > 0 && sets.every((set) => set.has(ch));
+        if (name === "squeeze" && sets.length === 0) {
+          let out = "";
+          let last = null;
+          for (const ch of recv) { if (ch !== last) { out += ch; last = ch; } }
+          return out;
+        }
+        if (name === "count") {
+          let n = 0;
+          for (const ch of recv) { if (inAll(ch)) { n++; } }
+          return n;
+        }
+        if (name === "delete") {
+          let out = "";
+          for (const ch of recv) { if (!inAll(ch)) { out += ch; } }
+          return out;
+        }
+        let out = "";
+        let last = null;
+        for (const ch of recv) {
+          if (ch === last && inAll(ch)) { continue; }
+          out += ch;
+          last = ch;
         }
         return out;
       }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2308,6 +2308,27 @@ fn string_justify_swapcase_methods() {
     }
 }
 
+// v0.23.0 char-set String methods: `tr`, `count`, `delete`, `squeeze`.  Each
+// `set`/`from`/`to` arg is a LITERAL code-point set (ranges/negation deferred);
+// all route through the explicit `stringMethod` switch (never `recv[name]`),
+// matching the Python/Go/Rust reference.
+#[test]
+fn string_charset_methods() {
+    let stmts = vec![
+        print(method(str_("hello"), "tr", vec![str_("el"), str_("ip")])),   // hippo
+        print(method(str_("hello"), "tr", vec![str_("aeiou"), str_("*")])), // h*ll*
+        print(method(str_("hello"), "tr", vec![str_("l"), str_("")])),      // heo (empty `to` deletes)
+        print(method(str_("hello"), "count", vec![str_("lo")])),            // 3
+        print(method(str_("hello"), "delete", vec![str_("aeiou")])),        // hll
+        print(method(str_("mississippi"), "squeeze", vec![])),              // misisipi
+        print(method(str_("aaabbbccc"), "squeeze", vec![str_("a")])),       // abbbccc
+    ];
+    let module = module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Strings]);
+    if let Some(stdout) = run_module(&module, "strcharset") {
+        assert_eq!(stdout, "hippo\nh*ll*\nheo\n3\nhll\nmisisipi\nabbbccc");
+    }
+}
+
 // v0.20.0 slice-selection Array methods: `take`, `drop`, `values_at`.  All are
 // index-clamped / bounds-guarded and route through the explicit `arrayMethod`
 // switch (never `recv[name]`).


### PR DESCRIPTION
## What

Mirrors the Python/Go/Rust reference String **char-set** sweep onto the **JS backend** (fourth backend; only TS remains). Adds four non-block Ruby String methods to the inlined runtime's `stringMethod` switch + `STRING_METHODS` `respond_to?` set, iterating **by code point** (`for..of` / `[...str]`) so a multibyte receiver is never split:

- **`tr(from, to)`** — position-wise code-point translation; a shorter `to` repeats its last code point, an empty `to` deletes matching code points, and a repeated code point in `from` keeps the last mapping.
- **`count(*sets)` / `delete(*sets)` / `squeeze(*sets)`** — char-set methods: `count` tallies receiver code points in the set, `delete` removes them, `squeeze` collapses consecutive runs (of set code points, or of *all* when no set is given). Multiple set args intersect (Ruby's rule).

Each `set`/`from`/`to` arg is treated **literally** — range (`"a-z"`) and negation (`"^abc"`) forms are a follow-up, matching the literal-only `sub`/`gsub` precedent.

## Verification

- Full crate suite green (**109 unit + 71 Node exec-proof**), incl. new `string_charset_methods` (runs emitted JS under `node`, diffs stdout).
- Security review: **PASSED** — real `Map`/`Set` (no prototype-pollution), no regex/eval/reflection, bounded allocation.

Bumps `0.22.0 → 0.23.0`; CHANGELOG updated. **TS is the last backend** in this sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)