### PR TITLE
feat(sir): SIR26 — Expr::Convert integer conversion node (core)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -3463,6 +3463,8 @@ enum Lowered {
 /// a closure is treated as potentially effectful.
 fn expr_may_have_effects(expr: &Expr) -> bool {
     match expr {
+        // SIR26 conversion (not currently emitted here): pure iff its value is.
+        Expr::Convert { value, .. } => expr_may_have_effects(value),
         // Provably pure leaves.
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -3628,6 +3628,8 @@ fn collect_callees_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
 
 fn collect_callees_expr(expr: &Expr, out: &mut HashSet<String>) {
     match expr {
+        // SIR26 conversion (not currently emitted by this frontend) — recurse.
+        Expr::Convert { value, .. } => collect_callees_expr(value, out),
         Expr::DirectCall { fn_name, args, .. } => {
             out.insert(fn_name.clone());
             for a in args {

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -223,6 +223,8 @@ pub fn compile(program: &GrammarASTNode, module_name: &str) -> Result<Module, Ru
 fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
     match expr {
         Expr::VarRef { name, .. } => names.contains(name),
+        // SIR26 conversion (not currently emitted by this frontend) — recurse.
+        Expr::Convert { value, .. } => expr_references_any_name(value, names),
 
         // Leaves: no children, no references possible.
         Expr::IntLit { .. }
@@ -3958,6 +3960,8 @@ impl Lowerer {
     /// `yield` inside a block literal belongs to the enclosing method).
     fn rewrite_yields_in_expr(expr: &mut Expr, block_scope: Scope) -> bool {
         match expr {
+            // SIR26 conversion (not currently emitted here) — recurse.
+            Expr::Convert { value, .. } => Self::rewrite_yields_in_expr(value, block_scope),
             Expr::BuiltinCall {
                 name,
                 args,
@@ -4658,6 +4662,8 @@ impl Lowerer {
 
     fn normalize_calls_in_expr(expr: &mut Expr, ctx: &BlockNormCtx) {
         match expr {
+            // SIR26 conversion (not currently emitted here) — recurse.
+            Expr::Convert { value, .. } => Self::normalize_calls_in_expr(value, ctx),
             // Phase Q10c — a bare, parenless reference to a known
             // block-taking method (`foo` with no `()`/args) reaches the
             // lowerer as `VarRef { scope: Local }` (the method-call parser
@@ -4948,6 +4954,8 @@ impl Lowerer {
 
     fn collect_bound_names_expr(expr: &Expr, out: &mut HashSet<String>) {
         match expr {
+            // SIR26 conversion (not currently emitted here) — recurse.
+            Expr::Convert { value, .. } => Self::collect_bound_names_expr(value, out),
             Expr::If {
                 cond,
                 then_branch,

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -80,7 +80,10 @@ pub fn emit_module(m: &Module) -> String {
     // source-controlled field — so this substitution can never inject into the
     // emitted Go.
     let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
-    out.push_str(&RUNTIME.replace("__SIR_DISPLAY_RUBY__", if display_ruby { "true" } else { "false" }));
+    out.push_str(&RUNTIME.replace(
+        "__SIR_DISPLAY_RUBY__",
+        if display_ruby { "true" } else { "false" },
+    ));
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
         out.push('\n');
@@ -847,9 +850,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MatMul { .. }
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
-        | Expr::IndexGet { .. } => {
+        | Expr::IndexGet { .. }
+        // SIR26 `Convert` — this backend does not accept `Conversions`, so a
+        // validated module never reaches here (capability check rejects it).
+        | Expr::Convert { .. } => {
             panic!(
-                "go backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                "go backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -110,7 +110,10 @@ pub fn emit_module(m: &Module) -> String {
     // source-controlled field — so this substitution can never inject into the
     // emitted JavaScript.
     let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
-    out.push_str(&RUNTIME.replace("__SIR_DISPLAY_RUBY__", if display_ruby { "true" } else { "false" }));
+    out.push_str(&RUNTIME.replace(
+        "__SIR_DISPLAY_RUBY__",
+        if display_ruby { "true" } else { "false" },
+    ));
     emit_ancestry_registration(&mut out, m);
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
@@ -834,9 +837,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MatMul { span, .. }
         | Expr::ElementwiseOp { span, .. }
         | Expr::Transpose { span, .. }
-        | Expr::IndexGet { span, .. } => {
+        | Expr::IndexGet { span, .. }
+        // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
+        // validated module (capability check rejects it).
+        | Expr::Convert { span, .. } => {
             panic!(
-                "javascript backend reached a deferred SIR22 array/matrix expression ({}) at {span} — not accepted yet",
+                "javascript backend reached a deferred SIR22/SIR26 expression ({}) at {span} — not accepted yet",
                 e.kind_name()
             );
         }

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -415,6 +415,7 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
             expr_uses_builtin(target, name)
                 || indices.iter().any(|ix| index_arg_uses_builtin(ix, name))
         }
+        Expr::Convert { value, .. } => expr_uses_builtin(value, name),
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -1238,9 +1239,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MatMul { .. }
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
-        | Expr::IndexGet { .. } => {
+        | Expr::IndexGet { .. }
+        // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
+        // validated module.
+        | Expr::Convert { .. } => {
             panic!(
-                "python backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                "python backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -64,7 +64,10 @@ pub fn emit_module(m: &Module) -> String {
     // source-controlled field — so this substitution can never inject into the
     // emitted Rust.
     let display_ruby = m.metadata.source_language.as_deref() == Some("ruby");
-    out.push_str(&RUNTIME.replace("__SIR_DISPLAY_RUBY__", if display_ruby { "true" } else { "false" }));
+    out.push_str(&RUNTIME.replace(
+        "__SIR_DISPLAY_RUBY__",
+        if display_ruby { "true" } else { "false" },
+    ));
     emit_globals(&mut out, &m.globals);
     for f in &m.functions {
         out.push('\n');
@@ -516,7 +519,8 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         | Expr::MatMul { .. }
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
-        | Expr::IndexGet { .. } => {}
+        | Expr::IndexGet { .. }
+        | Expr::Convert { .. } => {}
     }
 }
 
@@ -1099,9 +1103,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MatMul { span, .. }
         | Expr::ElementwiseOp { span, .. }
         | Expr::Transpose { span, .. }
-        | Expr::IndexGet { span, .. } => {
+        | Expr::IndexGet { span, .. }
+        // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
+        // validated module.
+        | Expr::Convert { span, .. } => {
             panic!(
-                "rust backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                "rust backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 span
             );

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -421,6 +421,7 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
             expr_uses_builtin(target, name)
                 || indices.iter().any(|idx| index_arg_uses_builtin(idx, name))
         }
+        Expr::Convert { value, .. } => expr_uses_builtin(value, name),
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -921,6 +922,7 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
                 collect_index_arg_assigned(idx, out);
             }
         }
+        Expr::Convert { value, .. } => collect_expr_assigned(value, out),
         // Leaves with no nested blocks/exprs that could hold an Assign.
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
@@ -1461,9 +1463,12 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::MatMul { .. }
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
-        | Expr::IndexGet { .. } => {
+        | Expr::IndexGet { .. }
+        // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
+        // validated module.
+        | Expr::Convert { .. } => {
             panic!(
-                "typescript backend reached a deferred SIR22 array/matrix expression ({}) at {} — not accepted yet",
+                "typescript backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -443,6 +443,10 @@ where
             walk_intrinsics_in_expr(target, f, depth + 1);
             walk_intrinsics_in_index_args(indices, f, depth + 1);
         }
+        // ── SIR26 ──────────────────────────────────────────────────
+        Expr::Convert { value, .. } => {
+            walk_intrinsics_in_expr(value, f, depth + 1);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -194,6 +194,14 @@ pub enum Feature {
     /// buffer layout and must match the same `(r, c) → c * nrows + r`
     /// indexing formula.
     ArrayColumnMajor,
+    // ── SIR26 (integer conversions) ──────────────────────────────────
+    /// The module contains an `Expr::Convert` node — an integer
+    /// narrowing / reinterpretation to a target width+signedness (a C cast
+    /// or implicit conversion).  A backend accepting this renders the
+    /// two's-complement reduction (mask + sign-fold); a `Convert`'s target
+    /// type also implies `SizedIntegers`/`Unsigned` per SIR21.  See
+    /// [SIR26](../../../../specs/SIR26-integer-conversions.md).
+    Conversions,
 }
 
 impl Feature {
@@ -236,6 +244,7 @@ impl Feature {
         Feature::Rationals,
         Feature::Complex,
         Feature::ArrayColumnMajor,
+        Feature::Conversions,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -278,6 +287,7 @@ impl Feature {
             Feature::Rationals => "rationals",
             Feature::Complex => "complex",
             Feature::ArrayColumnMajor => "array-column-major",
+            Feature::Conversions => "conversions",
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -28,7 +28,7 @@ use crate::effects::EffectSet;
 use crate::manifest::FeatureManifest;
 use crate::metadata::Metadata;
 use crate::span::Span;
-use crate::types::SirType;
+use crate::types::{IntSpec, SirType};
 
 // ---------------------------------------------------------------------------
 // Module-level structure
@@ -894,6 +894,27 @@ pub enum Expr {
         indices: Vec<IndexArg>,
         span: Span,
     },
+
+    // ── SIR26 (integer conversions) ──────────────────────────────────
+    /// Convert an integer `value` to the target integer type `to` by
+    /// two's-complement reinterpretation: reduce modulo `2^width` (mask to
+    /// the low `width` bits), then sign-extend when `to.signed` and the top
+    /// bit is set.  A target width of `Arbitrary` is the identity (a widen
+    /// into the unbounded integer — no bits lost).
+    ///
+    /// This is exactly a C integer cast / implicit conversion under
+    /// two's-complement (`-fwrapv`): `(uint8_t)300 == 44`,
+    /// `(int32_t)4_000_000_000 == −294_967_296`.  A frontend inserts a
+    /// `Convert` after each width-bounded operation and at each cast /
+    /// assignment; arithmetic stays exact, so the width enforcement here
+    /// reproduces the source's overflow behaviour at every step.  See
+    /// [SIR26](../../../specs/SIR26-integer-conversions.md).  Gated by
+    /// [`Feature::Conversions`](crate::Feature::Conversions).
+    Convert {
+        value: Box<Expr>,
+        to: IntSpec,
+        span: Span,
+    },
 }
 
 /// The five elementwise (broadcast) binary arithmetic operators
@@ -1010,6 +1031,7 @@ impl Expr {
             Expr::ElementwiseOp { span, .. } => span,
             Expr::Transpose { span, .. } => span,
             Expr::IndexGet { span, .. } => span,
+            Expr::Convert { span, .. } => span,
         }
     }
 
@@ -1046,6 +1068,7 @@ impl Expr {
             Expr::ElementwiseOp { .. } => "elementwise-op",
             Expr::Transpose { .. } => "transpose",
             Expr::IndexGet { .. } => "index-get",
+            Expr::Convert { .. } => "convert",
         }
     }
 }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -644,6 +644,14 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             print_index_args(out, indices, depth);
             out.push(')');
         }
+        // ── SIR26: integer conversion ──────────────────────────────────
+        Expr::Convert { value, to, .. } => {
+            // `(convert <to> <value>)`, where <to> is the IntSpec text form
+            // (SIR21), e.g. `(convert (int u8 wrap) (var-ref t local))`.
+            let _ = write!(out, "(convert {} ", to);
+            print_expr_inline_depth(out, value, depth + 1);
+            out.push(')');
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -1024,6 +1024,24 @@ impl<'m> ValidatorState<'m> {
                 self.check_expr(target, env, depth + 1);
                 self.check_index_args(indices, env, depth + 1);
             }
+
+            // ── SIR26: integer conversion ──────────────────────────────
+            Expr::Convert { value, to, .. } => {
+                // Observe the conversion feature plus the SIR21 type-implied
+                // features of the target type, so the manifest and capability
+                // check see exactly what a backend must support.
+                self.observed.add(Feature::Conversions);
+                if !to.is_arbitrary() {
+                    self.observed.add(Feature::SizedIntegers);
+                }
+                if !to.signed {
+                    self.observed.add(Feature::Unsigned);
+                }
+                if to.overflow != crate::types::Overflow::Arbitrary {
+                    self.observed.add(Feature::WrappingArithmetic);
+                }
+                self.check_expr(value, env, depth + 1);
+            }
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -351,6 +351,11 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
             v.visit_expr(target);
             walk_index_args(v, indices);
         }
+
+        // ── SIR26 ──────────────────────────────────────────────────
+        Expr::Convert { value, .. } => {
+            v.visit_expr(value);
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir/tests/convert_node.rs
+++ b/code/packages/rust/semantic-ir/tests/convert_node.rs
@@ -1,0 +1,127 @@
+//! Tests for the SIR26 `Expr::Convert` node: text format, feature gating, and
+//! the validator's observation of `Conversions` + the SIR21 type-implied
+//! features of the target type.
+
+use semantic_ir::effects::EffectSet;
+use semantic_ir::{
+    print_expr, validate, Block, Expr, Feature, FeatureManifest, Function, IntSpec, IntWidth,
+    Metadata, Module, Overflow, Span, CURRENT_SIR_VERSION,
+};
+
+fn u8_wrap() -> IntSpec {
+    IntSpec::sized(IntWidth::W8, false, Overflow::Wrap)
+}
+
+fn convert(to: IntSpec, inner: Expr) -> Expr {
+    Expr::Convert {
+        value: Box::new(inner),
+        to,
+        span: Span::synthetic(),
+    }
+}
+
+fn int(v: i64) -> Expr {
+    Expr::IntLit {
+        value: v,
+        span: Span::synthetic(),
+    }
+}
+
+/// A module whose `main` returns `body`, with the given manifest features.
+fn module_returning(body: Expr, features: &[Feature]) -> Module {
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: body,
+                span: Span::synthetic(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: Span::synthetic(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: Span::synthetic(),
+    }
+}
+
+#[test]
+fn prints_as_convert_with_intspec_target() {
+    let e = convert(u8_wrap(), int(300));
+    assert_eq!(print_expr(&e), "(convert (int u8 wrap) (int 300))");
+}
+
+#[test]
+fn arbitrary_target_prints_bare_int() {
+    // A widen into the unbounded integer prints its target as bare `int`.
+    let e = convert(IntSpec::arbitrary(), int(5));
+    assert_eq!(print_expr(&e), "(convert int (int 5))");
+}
+
+#[test]
+fn convert_requires_conversions_feature() {
+    // Undeclared: the validator observes `Conversions` but the manifest does
+    // not declare it → error.
+    let m = module_returning(convert(u8_wrap(), int(300)), &[]);
+    let r = validate(&m);
+    assert!(
+        !r.is_ok(),
+        "a Convert node with no manifest feature must fail"
+    );
+    assert!(
+        r.issues.iter().any(|i| i.message.contains("conversions")),
+        "the diagnostic should name the missing `conversions` feature: {:?}",
+        r.issues
+    );
+}
+
+#[test]
+fn convert_validates_with_full_manifest() {
+    // A u8-wrap target implies Conversions + SizedIntegers + Unsigned +
+    // WrappingArithmetic; declaring all of them validates.
+    let m = module_returning(
+        convert(u8_wrap(), int(300)),
+        &[
+            Feature::Conversions,
+            Feature::SizedIntegers,
+            Feature::Unsigned,
+            Feature::WrappingArithmetic,
+        ],
+    );
+    let r = validate(&m);
+    assert!(r.is_ok(), "should validate: {:?}", r.issues);
+}
+
+#[test]
+fn signed_target_does_not_observe_unsigned() {
+    // An i32-wrap target implies Conversions + SizedIntegers + Wrapping, but
+    // NOT Unsigned — so declaring those three (without Unsigned) validates.
+    let i32_wrap = IntSpec::sized(IntWidth::W32, true, Overflow::Wrap);
+    let m = module_returning(
+        convert(i32_wrap, int(5)),
+        &[
+            Feature::Conversions,
+            Feature::SizedIntegers,
+            Feature::WrappingArithmetic,
+        ],
+    );
+    assert!(validate(&m).is_ok());
+}
+
+#[test]
+fn conversions_feature_name_round_trips() {
+    assert_eq!(Feature::Conversions.name(), "conversions");
+    assert_eq!(
+        Feature::from_name("conversions"),
+        Some(Feature::Conversions)
+    );
+}

--- a/code/specs/SIR26-integer-conversions.md
+++ b/code/specs/SIR26-integer-conversions.md
@@ -1,0 +1,116 @@
+# SIR26 — Integer conversions: the `Convert` node
+
+## Status
+
+Core-IR extension.  Adds one expression node — `Expr::Convert` — and one
+feature — `Feature::Conversions` — to the narrow-waist Semantic IR
+([SIR10](SIR10-narrow-waist-semantic-ir.md)), building on the integer type
+system of [SIR21](SIR21-type-system-and-integer-semantics.md).
+
+This is the mechanism that lets SIR **carry a source language's integer
+width / wrapping / truncating behaviour** across the waist.  It is the enabling
+node for the **C → SIR → Ruby** path: a C frontend (a later spec) inserts
+`Convert` nodes per C's conversion rules, and a Ruby backend renders them as
+masking so the loose target reproduces the strict source's results exactly.
+
+This spec adds the node and its validation/traversal/text-format support in the
+`semantic-ir` crate only.  Backend *rendering* (Ruby, C) and frontend *emission*
+(C) land in follow-up PRs; until a backend accepts `Conversions`, a module
+containing a `Convert` node is cleanly rejected by the capability check — the
+node is inert and additive.
+
+## The node
+
+```rust
+// in semantic_ir::nodes::Expr
+Convert {
+    /// The integer value being converted.
+    value: Box<Expr>,
+    /// The target integer type.  Its width + signedness define the result;
+    /// the overflow mode is carried for the backend's record (see below).
+    to: IntSpec,
+    span: Span,
+}
+```
+
+## Semantics — two's-complement reinterpretation
+
+`Convert { value, to }` evaluates `value` (an integer) and reduces it to the
+target integer type `to` by **two's-complement reinterpretation**:
+
+1. Let `n = to.width` in bits.  Reduce the value modulo `2ⁿ` (mask to the low
+   `n` bits).
+2. If `to.signed` and the resulting bit `n−1` is set, subtract `2ⁿ` (sign
+   extension), giving a value in `[−2ⁿ⁻¹, 2ⁿ⁻¹−1]`; otherwise the value is in
+   `[0, 2ⁿ−1]`.
+
+When `to.width == Arbitrary`, the conversion is the **identity** (a widen into
+the unbounded integer — no bits are lost).  This is the one case that never
+narrows.
+
+This is exactly what a C cast / implicit integer conversion does under
+two's-complement (`-fwrapv` for the signed case):
+
+| example | `to` | reduces `value` … | e.g. |
+|---|---|---|---|
+| `(uint8_t)x` | `{W8, unsigned}` | mod 2⁸ | `300 → 44` |
+| `(int32_t)x` | `{W32, signed}` | mod 2³², sign-fold | `4_000_000_000 → −294_967_296` |
+| `(uint32_t)x` | `{W32, unsigned}` | mod 2³² | `−1 → 4_294_967_295` |
+| `(int64_t)small` | `{W64, signed}` | value-preserving | `200 → 200` |
+
+**Why the node instead of typed-arithmetic opcodes.** C's integer overflow is
+always modular (unsigned = defined wraparound; signed = UB, rendered as
+two's-complement wrap).  So arithmetic can stay **exact** (the existing dynamic
+`+`/`-`/`*`, which on a bignum target is precise), and a `Convert` inserted
+**after each width-bounded operation and at each cast/assignment** enforces the
+width.  Narrowing an exact intermediate to width `n` equals C's wrapped result
+at width `n` *at every operation*, so a C program and its translation agree
+bit-for-bit.  This keeps the core addition to a single node rather than a family
+of typed arithmetic ops (`add_i32_wrap`, …).
+
+**Overflow mode.** `to.overflow` is carried but, for the conversions this spec
+targets (C: `Wrap` for unsigned, `Undefined`→wrap for signed), the reduction is
+always modular — so v0 rendering ignores it.  `Trap` / `Saturate` *conversions*
+(a checked narrowing that raises, or a clamping one) are a later generalisation;
+a backend that does not implement them may reject a `Convert` whose
+`to.overflow` it cannot honour.
+
+## Feature gate
+
+A `Convert` node makes the validator observe **`Feature::Conversions`**
+(kebab: `conversions`).  Because `to` is a concrete integer type, the validator
+also observes the type-implied features already defined in
+[SIR21](SIR21-type-system-and-integer-semantics.md): `SizedIntegers` (target
+width ≠ `Arbitrary`), `Unsigned` (target `signed == false`), and
+`WrappingArithmetic` (target overflow ≠ `Arbitrary`).  A module using `Convert`
+must therefore declare all of these in its manifest, and a backend must accept
+them to compile it — so no backend silently mishandles a typed conversion.
+
+## Text format
+
+`Convert` prints as `(convert <to> <value>)`, where `<to>` is the `IntSpec`
+text form (SIR21): `(int u8 wrap)`, `(int i32 ub)`, … (and bare `int` for the
+arbitrary spec).  Example:
+
+```text
+(convert (int u8 wrap) (var-ref t3 local))
+```
+
+The printer is inline (no source positions), matching the other expression
+nodes.
+
+## How backends will render it (follow-up PRs)
+
+- **Ruby** — inlined mask helpers: `Convert{W8,unsigned}` → `(v) & 0xFF`;
+  `Convert{W32,signed}` → `sir_i32(v)` where `sir_i32(v) = ((v & 0xFFFFFFFF) ^
+  0x80000000) - 0x80000000`.  Arithmetic stays native bignum.
+- **C** — a native cast to the target type (`(uint8_t)(v)`), which already wraps
+  on the target hardware; this makes **C → SIR → C** round-trip.
+- The existing dynamic backends (Python/JS/Go/Rust) will either render the mask
+  or, until they do, simply not accept `Conversions` (clean rejection).
+
+## Out of scope (this spec)
+
+- Backend rendering and C-frontend emission (separate PRs).
+- Float ↔ integer conversions (a later `Convert`-family extension).
+- `Trap` / `Saturate` narrowing behaviour (a later generalisation).


### PR DESCRIPTION
## What

Adds one core-IR expression node — **`Expr::Convert { value, to: IntSpec }`** — and one **`Feature::Conversions`** to the Semantic IR (spec: `code/specs/SIR26-integer-conversions.md`).

`Convert` is **two's-complement reinterpretation** to a target integer width/signedness (mask to `width` bits + sign-fold; identity when the target width is `Arbitrary`) — exactly a C integer cast / implicit conversion under `-fwrapv`: `(uint8_t)300 == 44`, `(int32_t)4_000_000_000 == −294_967_296`.

## Why

This is the mechanism that carries a source language's **integer width / wrapping / truncating** behaviour across the narrow waist — the enabling node for **C → SIR → Ruby**. A C frontend will insert a `Convert` after each width-bounded operation and at each cast/assignment; arithmetic stays exact, so width enforcement reproduces the source's overflow behaviour at every step, and a backend renders `Convert` as masking so a loose (arbitrary-precision) target reproduces the strict source's results bit-for-bit. Keeping arithmetic exact + `Convert`-per-op avoids a whole family of typed-arithmetic opcodes. It's also the first thing to actually exercise SIR21's `op_select`/`IntSpec` type system end-to-end.

## Scope

Core (`semantic-ir`) only: the node + `span()`/`kind_name()`, `Feature::Conversions` (+ `ALL`/`name`), validator gating (a `Convert` observes `Conversions` plus the SIR21 type-implied `SizedIntegers`/`Unsigned`/`WrappingArithmetic` of its target), walker + intrinsic-walker traversal, and the text printer `(convert <intspec> <value>)`. Plus a `Convert` arm in every sibling crate that matches `Expr` exhaustively.

**Inert & additive:** no frontend emits `Convert` and no backend accepts `Conversions` yet, so a `Convert`-bearing module is cleanly **rejected** by the capability check (fail-closed) until a backend renders it. Backend rendering (Ruby, C) and the C frontend are follow-up PRs.

## Security

Reviewed by a security sub-agent — **passed, no vulnerabilities**. The printer's target is a closed-enum `IntSpec` Display (no source-derived free text); recursion passes through the existing depth guards; gating is fail-closed.

## Verification

- `cargo test -p semantic-ir` — **253** existing + **6** new `Convert` tests (text format, feature gating, signed-vs-unsigned observation, name round-trip).
- All backend/frontend lib tests green (ts 124, rust 130, python 427, go 97, js 109, twig 100, ruby 123, py-fe 94, js-fe 23).
- `cargo test -p sir-conformance` corpus green — the core change is behaviour-neutral for every existing module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)