### PR TITLE
feat(sir-runtime-oop): String tr/count/delete/squeeze (TS, char sets, v0.1.16)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.16] - 2026-07-10
+
+### Added — String char-set methods: `tr` / `count` / `delete` / `squeeze`
+
+Completes the char-set string sweep across all five backends (Python
+`sir-runtime-oop` is the reference; Go/Rust/JS backends already landed) by adding
+four more non-block Ruby `String` methods to `stringMethod` and the
+`STRING_METHODS` `respond_to?` catalog:
+
+- `tr(from, to)` — positional translate: each char of `from` maps to the char at
+  the same index in `to`. A shorter `to` repeats its **last** char; an empty `to`
+  **deletes** matching chars; a repeated `from` char takes its **last** mapping.
+  A missing/non-string argument is a no-op (never raises).
+- `count(*sets)` — how many chars of the receiver lie in the set(s).
+- `delete(*sets)` — the receiver with all set chars removed.
+- `squeeze(*sets)` — collapse consecutive runs: of set chars when a set is given,
+  or of **all** identical runs when no set is given.
+
+Multiple set arguments **intersect** (Ruby's rule — a char must appear in every
+set). All iteration is over whole code points (`for…of` / `[...str]`) so astral
+runes are never split mid-surrogate. The char-**range** (`"a-z"`) and
+**negation** (`"^abc"`) forms are a documented follow-up, matching the
+literal-only `sub`/`gsub` precedent.
+
 ## [0.1.15] - 2026-07-07
 
 ### Added — Array reorder/combine methods: `rotate` / `zip`

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -77,7 +77,9 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `select`/…); and (item **M1c**) the **`String`** catalog (`length`,
 `upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
 `chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,
-`sub`/`gsub` *literal*, `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `each_char`);
+`sub`/`gsub` *literal*, `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`,
+`ljust`/`rjust`/`center`, `swapcase`, `tr`/`count`/`delete`/`squeeze` *literal
+char sets*, `each_char`);
 and (item **M1c**) the **`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`,
 `even?`/`odd?`/`zero?`/`positive?`/`negative?`, `succ`/`pred`,
 `floor`/`ceil`/`round`, `gcd`, `pow`/`**`, `digits`, and block

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -660,6 +660,10 @@ const STRING_METHODS = new Set<string>([
   "rjust",
   "center",
   "swapcase",
+  "tr",
+  "count",
+  "delete",
+  "squeeze",
 ]);
 
 // Block-taking `String` methods (M1c); `each_char` yields one character.
@@ -1386,6 +1390,92 @@ function stringMethod(recv: string, name: string, args: Val[]): Val | typeof MIS
         if (c >= 65 && c <= 90) out += String.fromCodePoint(c + 32);
         else if (c >= 97 && c <= 122) out += String.fromCodePoint(c - 32);
         else out += ch;
+      }
+      return out;
+    }
+    case "tr": {
+      // Ruby `String#tr(from, to)`: translate each char that appears in `from`
+      // to the char at the same position in `to`.  A shorter `to` repeats its
+      // LAST char; an empty `to` deletes matching chars; when `from` repeats a
+      // char the last mapping wins.
+      //
+      //   "hello".tr("el", "ip") == "hippo"   (e→i, l→p)
+      //   "hello".tr("l", "r")   == "herro"   (single mapping)
+      //   "hello".tr("aeiou", "*") == "h*ll*" (shorter `to` repeats "*")
+      //   "hello".tr("l", "")    == "heo"     (empty `to` deletes)
+      //
+      // NOTE: the char-RANGE (`"a-z"`) and NEGATION (`"^abc"`) forms are a
+      // follow-up, matching the literal-only `sub`/`gsub` precedent here.  We
+      // iterate whole code points (`[...s]` / `for…of`) so astral runes are
+      // never split mid-surrogate.
+      const from = typeof args[0] === "string" ? (args[0] as string) : null;
+      const to = typeof args[1] === "string" ? (args[1] as string) : null;
+      if (from === null || to === null) return recv;
+      const toC = [...to];
+      const fromC = [...from];
+      // Map each `from` code point to its replacement (or `null` = delete).
+      const table = new Map<string, string | null>();
+      for (let i = 0; i < fromC.length; i++) {
+        if (toC.length === 0) table.set(fromC[i], null);
+        else table.set(fromC[i], i < toC.length ? toC[i] : toC[toC.length - 1]);
+      }
+      let out = "";
+      for (const ch of recv) {
+        if (table.has(ch)) {
+          const r = table.get(ch) as string | null;
+          if (r !== null) out += r;
+        } else {
+          out += ch;
+        }
+      }
+      return out;
+    }
+    case "count":
+    case "delete":
+    case "squeeze": {
+      // Char-set methods.  Each `string` argument is treated LITERALLY — the set
+      // of characters it contains (ranges/negation are a follow-up).  `count`
+      // returns how many chars of `recv` lie in the set; `delete` removes them;
+      // `squeeze` collapses consecutive runs (of set chars, or of ALL chars when
+      // no set is given).  Multiple set args INTERSECT (Ruby's rule).
+      //
+      //   "hello".count("l")        == 2
+      //   "hello".delete("l")       == "heo"
+      //   "mississippi".squeeze     == "misisipi"   (no set: all runs)
+      //   "aaabbbccc".squeeze("a")  == "abbbccc"    (only "a" runs collapse)
+      const sets: Array<Set<string>> = [];
+      for (const a of args) if (typeof a === "string") sets.push(new Set([...a]));
+      // A char is "in the set" only when it is present in EVERY set argument.
+      const inAll = (ch: string): boolean => sets.length > 0 && sets.every((set) => set.has(ch));
+      if (name === "squeeze" && sets.length === 0) {
+        // Bare `squeeze` collapses every run of identical characters.
+        let out = "";
+        let last: string | null = null;
+        for (const ch of recv) {
+          if (ch !== last) {
+            out += ch;
+            last = ch;
+          }
+        }
+        return out;
+      }
+      if (name === "count") {
+        let n = 0;
+        for (const ch of recv) if (inAll(ch)) n++;
+        return n;
+      }
+      if (name === "delete") {
+        let out = "";
+        for (const ch of recv) if (!inAll(ch)) out += ch;
+        return out;
+      }
+      // squeeze(set): collapse only runs of characters that lie in the set.
+      let out = "";
+      let last: string | null = null;
+      for (const ch of recv) {
+        if (ch === last && inAll(ch)) continue;
+        out += ch;
+        last = ch;
       }
       return out;
     }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -572,6 +572,26 @@ describe("built-in method catalog: String (M1c)", () => {
     expect(callMethod("a1B!c", "swapcase")).toBe("A1b!C");
   });
 
+  it("char-set methods (tr / count / delete / squeeze)", () => {
+    // tr: positional translate; shorter `to` repeats its last char; empty `to`
+    // deletes; last mapping wins on repeated `from` chars.
+    expect(callMethod("hello", "tr", "el", "ip")).toBe("hippo");
+    expect(callMethod("hello", "tr", "l", "r")).toBe("herro");
+    expect(callMethod("hello", "tr", "aeiou", "*")).toBe("h*ll*");
+    expect(callMethod("hello", "tr", "l", "")).toBe("heo");
+    // A non-string arg (or missing `to`) is a no-op, holding the never-raise floor.
+    expect(callMethod("hello", "tr", "l")).toBe("hello");
+    // count / delete over a literal char set.
+    expect(callMethod("hello", "count", "l")).toBe(2);
+    expect(callMethod("hello", "count", "lo")).toBe(3);
+    expect(callMethod("hello", "delete", "l")).toBe("heo");
+    // Multiple set args INTERSECT (only chars in every set count/delete).
+    expect(callMethod("hello", "count", "lo", "o")).toBe(1);
+    // squeeze: bare form collapses every run; with a set only those runs.
+    expect(callMethod("mississippi", "squeeze")).toBe("misisipi");
+    expect(callMethod("aaabbbccc", "squeeze", "a")).toBe("abbbccc");
+  });
+
   it("strip family and chomp", () => {
     expect(callMethod("  hi  ", "strip")).toBe("hi");
     expect(callMethod("  hi  ", "lstrip")).toBe("hi  ");


### PR DESCRIPTION
## Summary

Completes the **char-set String sweep across all five backends**. Python (`sir-runtime-oop`) is the reference; Go (#7868), Rust (#7871), and JS (#7874) already landed — this is the final backend, TypeScript.

Adds four non-block Ruby `String` methods to `stringMethod` and the `STRING_METHODS` `respond_to?` catalog:

- **`tr(from, to)`** — positional translate: each char of `from` maps to the char at the same index in `to`. A shorter `to` repeats its **last** char; an empty `to` **deletes** matching chars; a repeated `from` char takes its **last** mapping. A missing/non-string argument is a no-op.
- **`count(*sets)`** — how many receiver chars lie in the set(s).
- **`delete(*sets)`** — the receiver with all set chars removed.
- **`squeeze(*sets)`** — collapse consecutive runs of set chars, or of **all** identical runs when no set is given.

Multiple set arguments **intersect** (Ruby's rule). All iteration is over whole code points (`for…of` / `[...str]`) so astral runes are never split mid-surrogate. The char-**range** (`"a-z"`) and **negation** (`"^abc"`) forms are a documented follow-up, matching the literal-only `sub`/`gsub` precedent.

## Design invariants held

- **Explicit dispatch** — `switch` on the literal method name; no reflection / `recv[name]`.
- **Never-raise floor** — non-string / missing args degrade (no-op or empty set) rather than throw.
- **No DoS amplification** — every output is bounded by `recv.length` (unlike `String#*`).

## Testing

- `vitest run`: **112 tests pass** (new `char-set methods (tr / count / delete / squeeze)` case added).
- Security review: **PASSED** (no reflection, no unbounded allocation, `Map`/`Set` keys immune to prototype pollution).

Bumps `0.1.15` → `0.1.16`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)