### PR TITLE
feat(sir-ruby,sir-c): render SIR26 Expr::Convert (integer conversions)

### DIFF
--- a/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-c/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.2.0 — render SIR26 integer conversions
+
+Accepts `Feature::Conversions` (plus the SIR21 type-implied `SizedIntegers`,
+`Unsigned`, `WrappingArithmetic`) and renders `Expr::Convert`, so C→SIR→C
+round-trips a source language's integer width/wrapping/truncating semantics.
+
+- A conversion emits the portable runtime helper `_sir_convert(v, bits, signed)`
+  (with `_sir_mask_to` doing a two's-complement reduction over `int64`/`uint64`
+  — mask then sign-fold — no reliance on native fixed-width casts, so it behaves
+  identically on MSVC/GCC/Clang).  A target width of `Arbitrary` is the identity
+  and emits no wrapper.  `bits >= 64` is the `int64` storage floor (u64 above
+  2^63 is the documented bignum frontier, shared with the Go/Rust backends).
+- Verified on **clang, gcc, and MSVC**: `(uint8_t)300==44`, `(int8_t)200==-56`,
+  `(uint16_t)70000==4464`, `(uint32_t)-1==4294967295`,
+  `(int32_t)4e9==-294967296`, arbitrary-width identity.
+
 ## 0.1.0 — v0 core (SIR24)
 
 First release of the sixth SIR backend: lowers a `semantic_ir::Module` to a

--- a/code/packages/rust/semantic-ir-to-c/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-c"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained C source code (SIR24). Sixth backend for the SIR10 narrow-waist IR — gives Ruby→C (and Python/JS/Twig→C) through the shared waist."
 

--- a/code/packages/rust/semantic-ir-to-c/examples/dump_convert.rs
+++ b/code/packages/rust/semantic-ir-to-c/examples/dump_convert.rs
@@ -1,0 +1,71 @@
+//! Dev helper: emit a self-contained C program that prints several
+//! `Expr::Convert` results, for portability checking on clang/gcc/MSVC.
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, IntSpec, IntWidth, Metadata,
+    Module, Overflow, Span, Stmt, CURRENT_SIR_VERSION,
+};
+
+fn conv(v: i64, w: IntWidth, signed: bool) -> Expr {
+    Expr::Convert {
+        value: Box::new(Expr::IntLit {
+            value: v,
+            span: Span::synthetic(),
+        }),
+        to: IntSpec::sized(w, signed, Overflow::Wrap),
+        span: Span::synthetic(),
+    }
+}
+
+fn puts(e: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "puts".into(),
+            args: vec![e],
+            effects: EffectSet::PURE,
+            span: Span::synthetic(),
+        },
+        span: Span::synthetic(),
+    }
+}
+
+fn main() {
+    let stmts = vec![
+        puts(conv(300, IntWidth::W8, false)),           // 44
+        puts(conv(200, IntWidth::W8, true)),            // -56
+        puts(conv(70_000, IntWidth::W16, false)),       // 4464
+        puts(conv(-1, IntWidth::W32, false)),           // 4294967295
+        puts(conv(4_000_000_000, IntWidth::W32, true)), // -294967296
+    ];
+    let module = Module {
+        name: "conv".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Conversions,
+            Feature::SizedIntegers,
+            Feature::Unsigned,
+            Feature::WrappingArithmetic,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit {
+                    span: Span::synthetic(),
+                },
+                span: Span::synthetic(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: Span::synthetic(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: Span::synthetic(),
+    };
+    print!("{}", semantic_ir_to_c::compile(&module).unwrap().source);
+}

--- a/code/packages/rust/semantic-ir-to-c/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/emit.rs
@@ -13,7 +13,7 @@
 use std::cell::Cell;
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, Module, Scope, Span, Stmt};
+use semantic_ir::{Block, Expr, Function, Global, IntSpec, IntWidth, Module, Scope, Span, Stmt};
 
 use crate::runtime::RUNTIME;
 
@@ -403,6 +403,18 @@ fn emit_assign(out: &mut String, dst: &str, e: &Expr, indent: usize) {
             emit_assign(out, dst, &args[1], indent + 1);
             let _ = writeln!(out, "{pad}}}");
         }
+        // SIR26 conversion with a compound value: compute the value into `dst`,
+        // then reduce it to the target width in place.
+        Expr::Convert { value, to, .. } => {
+            emit_assign(out, dst, value, indent);
+            if let IntWidth::Arbitrary = to.width {
+                // identity widen — nothing to mask
+            } else {
+                let bits = to.width.bits().expect("non-arbitrary width has bits");
+                let signed = if to.signed { 1 } else { 0 };
+                let _ = writeln!(out, "{pad}{dst} = _sir_convert({dst}, {bits}, {signed});");
+            }
+        }
         // A call whose arguments contain control flow: hoist every argument
         // into a temp (left-to-right), then make the call.
         _ => emit_compound_call(out, dst, e, indent),
@@ -530,6 +542,8 @@ fn is_simple(e: &Expr) -> bool {
         | Expr::IndirectCall { args, .. }
         | Expr::BuiltinCall { args, .. } => args.iter().all(is_simple),
         Expr::MakeClosure { captures, .. } => captures.iter().all(|c| is_simple(&c.value)),
+        // SIR26: a conversion is as simple as its value.
+        Expr::Convert { value, .. } => is_simple(value),
         // SIR16+ nodes / Intrinsic are not accepted in v0 → unreachable after
         // the capability check.  Treat as non-simple defensively.
         _ => false,
@@ -587,7 +601,24 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
             // Simple only when stmts empty (guaranteed by is_simple).
             emit_expr(out, &b.value, indent);
         }
+        Expr::Convert { value, to, .. } => emit_convert(out, value, to, indent),
         other => unreachable!("emit_expr on compound/unsupported node: {other:?}"),
+    }
+}
+
+/// SIR26 integer conversion → the portable `_sir_convert(v, bits, signed)`
+/// runtime helper (two's-complement reduction), or the identity when the
+/// target width is `Arbitrary` (a widen into the unbounded integer).
+fn emit_convert(out: &mut String, value: &Expr, to: &IntSpec, indent: usize) {
+    match to.width {
+        IntWidth::Arbitrary => emit_expr(out, value, indent),
+        w => {
+            let bits = w.bits().expect("non-arbitrary width has bits");
+            let signed = if to.signed { 1 } else { 0 };
+            out.push_str("_sir_convert(");
+            emit_expr(out, value, indent);
+            let _ = write!(out, ", {bits}, {signed})");
+        }
     }
 }
 
@@ -753,6 +784,7 @@ fn scan_expr_for_builtin(e: &Expr) -> Option<(String, Span)> {
         Expr::MakeClosure { captures, .. } => captures
             .iter()
             .find_map(|c| scan_expr_for_builtin(&c.value)),
+        Expr::Convert { value, .. } => scan_expr_for_builtin(value),
         _ => None,
     }
 }

--- a/code/packages/rust/semantic-ir-to-c/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/lib.rs
@@ -57,6 +57,15 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // ── SIR26 integer conversions ────────────────────────────────────
+    // `Expr::Convert` renders as the portable `_sir_convert(v, bits, signed)`
+    // runtime helper (two's-complement reduction over int64/uint64).  A
+    // Convert's target type also makes the validator observe these SIR21
+    // type-implied features, so the C backend must accept them.
+    Feature::Conversions,
+    Feature::SizedIntegers,
+    Feature::Unsigned,
+    Feature::WrappingArithmetic,
 ];
 
 impl Backend for CBackend {

--- a/code/packages/rust/semantic-ir-to-c/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-c/src/runtime.rs
@@ -142,6 +142,32 @@ const char *_sir_str_of(SirValue v) {
     return (v.tag == SIR_STR || v.tag == SIR_SYM) ? v.as.s : "";
 }
 
+/* ---- SIR26 integer conversions ------------------------------ */
+
+/* Reduce an int64 to `bits` (8/16/32/64/128) by two's-complement
+ * reinterpretation: mask to the low `bits`, then sign-fold when `is_signed`.
+ * Pure int64/uint64 arithmetic (no reliance on native fixed-width casts), so it
+ * behaves identically on every compiler.  For bits >= 64 the value is the int64
+ * identity — the u64/i64 storage floor, where u64 values above 2^63 are the
+ * documented bignum frontier shared with the Go/Rust backends. */
+int64_t _sir_mask_to(int64_t v, int bits, int is_signed) {
+    uint64_t mask, m;
+    if (bits >= 64) return v;
+    mask = ((uint64_t)1 << bits) - 1u;
+    m = (uint64_t)v & mask;
+    if (is_signed && (m & ((uint64_t)1 << (bits - 1)))) {
+        return (int64_t)(m - ((uint64_t)1 << bits)); /* sign-extend */
+    }
+    return (int64_t)m;
+}
+
+/* The rendering of Expr::Convert: reduce an integer SirValue to the target
+ * width/signedness (a non-integer passes through, defensively). */
+SirValue _sir_convert(SirValue v, int bits, int is_signed) {
+    if (v.tag != SIR_INT) return v;
+    return _sir_int(_sir_mask_to(v.as.i, bits, is_signed));
+}
+
 /* Collect varargs into a heap array (freed by the caller).  Returns NULL
  * for n == 0. */
 SirValue *_sir_va_collect(int n, va_list ap) {

--- a/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_conversions.rs
+++ b/code/packages/rust/semantic-ir-to-c/tests/compile_and_run_conversions.rs
@@ -1,0 +1,167 @@
+//! Execution proof for SIR26 `Expr::Convert` rendering — build a module whose
+//! `main` prints `convert(to, IntLit(v))`, emit C, compile it with a real
+//! gcc/clang-style compiler, run it, and assert stdout.
+//!
+//! Compiler discovery mirrors `compile_and_run.rs`: `SIR_CC` first, then
+//! `cc`/`clang`/`gcc` on `PATH`; when none is present every case **skips**.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, IntSpec, IntWidth, Metadata,
+    Module, Overflow, Span, CURRENT_SIR_VERSION,
+};
+
+fn find_cc() -> Option<String> {
+    if let Ok(cc) = std::env::var("SIR_CC") {
+        if !cc.trim().is_empty() {
+            return Some(cc);
+        }
+    }
+    for cand in ["cc", "clang", "gcc"] {
+        let ok = Command::new(cand)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if ok {
+            return Some(cand.to_string());
+        }
+    }
+    None
+}
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn compile_and_run(cc: &str, module: &Module) -> String {
+    let artifact = semantic_ir_to_c::compile(module).expect("C backend compile");
+    let dir = std::env::temp_dir();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = format!("sirc_conv_{}_{}", std::process::id(), n);
+    let cpath: PathBuf = dir.join(format!("{stem}.c"));
+    let exe: PathBuf = dir.join(format!("{stem}{}", std::env::consts::EXE_SUFFIX));
+    std::fs::File::create(&cpath)
+        .and_then(|mut f| f.write_all(artifact.source.as_bytes()))
+        .expect("write .c");
+    let out = Command::new(cc)
+        .arg("-std=c99")
+        .arg("-o")
+        .arg(&exe)
+        .arg(&cpath)
+        .output()
+        .expect("spawn C compiler");
+    assert!(
+        out.status.success(),
+        "compile failed:\n{}\n--- source ---\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        artifact.source
+    );
+    let run = Command::new(&exe).output().expect("run emitted program");
+    assert!(
+        run.status.success(),
+        "run failed (exit {:?})",
+        run.status.code()
+    );
+    let _ = std::fs::remove_file(&cpath);
+    let _ = std::fs::remove_file(&exe);
+    String::from_utf8_lossy(&run.stdout).replace("\r\n", "\n")
+}
+
+/// A module whose `main` does `puts(convert(to, IntLit(v)))`.
+fn convert_module(v: i64, to: IntSpec) -> Module {
+    let conv = Expr::Convert {
+        value: Box::new(Expr::IntLit {
+            value: v,
+            span: Span::synthetic(),
+        }),
+        to,
+        span: Span::synthetic(),
+    };
+    let puts = Expr::BuiltinCall {
+        name: "puts".into(),
+        args: vec![conv],
+        effects: EffectSet::PURE,
+        span: Span::synthetic(),
+    };
+    Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Conversions,
+            Feature::SizedIntegers,
+            Feature::Unsigned,
+            Feature::WrappingArithmetic,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: puts,
+                span: Span::synthetic(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: Span::synthetic(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: Span::synthetic(),
+    }
+}
+
+fn sized(w: IntWidth, signed: bool) -> IntSpec {
+    IntSpec::sized(w, signed, Overflow::Wrap)
+}
+
+#[test]
+fn convert_cases_compile_and_run() {
+    let Some(cc) = find_cc() else {
+        eprintln!("skip: no C compiler (set SIR_CC or install cc/clang/gcc)");
+        return;
+    };
+    // (value, target, expected stdout) — the canonical wraparound/truncation set.
+    let cases: &[(i64, IntSpec, &str)] = &[
+        (300, sized(IntWidth::W8, false), "44\n"), // (uint8_t)300
+        (200, sized(IntWidth::W8, true), "-56\n"), // (int8_t)200
+        (-1, sized(IntWidth::W32, false), "4294967295\n"), // (uint32_t)-1
+        (4_000_000_000, sized(IntWidth::W32, true), "-294967296\n"), // (int32_t)4e9
+        (65_535, sized(IntWidth::W16, false), "65535\n"), // fits u16
+        (70_000, sized(IntWidth::W16, false), "4464\n"), // 70000 mod 65536
+        (4_000_000_000, IntSpec::arbitrary(), "4000000000\n"), // identity widen
+    ];
+    for (v, to, expected) in cases {
+        let got = compile_and_run(&cc, &convert_module(*v, *to));
+        assert_eq!(&got, expected, "convert({v}, {to:?})");
+    }
+}
+
+#[test]
+fn convert_emit_shape_uses_the_runtime_helper() {
+    let src = semantic_ir_to_c::compile(&convert_module(300, sized(IntWidth::W8, false)))
+        .unwrap()
+        .source;
+    // uint8 → _sir_convert(<value>, 8, 0); the runtime helper is present.
+    assert!(
+        src.contains("_sir_convert(_sir_int(300LL), 8, 0)"),
+        "emit:\n{src}"
+    );
+    assert!(
+        src.contains("int64_t _sir_mask_to("),
+        "runtime helper present"
+    );
+    // An arbitrary-width target is the identity (no _sir_convert wrapper).
+    let arb = semantic_ir_to_c::compile(&convert_module(5, IntSpec::arbitrary()))
+        .unwrap()
+        .source;
+    assert!(
+        arb.contains("_sir_puts(1, _sir_int(5LL))"),
+        "arbitrary is identity:\n{arb}"
+    );
+}

--- a/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-ruby/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.2.0 — render SIR26 integer conversions
+
+Accepts `Feature::Conversions` (plus the SIR21 type-implied `SizedIntegers`,
+`Unsigned`, `WrappingArithmetic`) and renders `Expr::Convert` — the C→SIR→Ruby
+payoff.
+
+- A conversion emits an inlined mask helper chosen by target width + signedness:
+  `sir_u8`/`sir_u16`/`sir_u32`/`sir_u64`/`sir_u128` (mask) and
+  `sir_i8`/`sir_i16`/`sir_i32`/`sir_i64`/`sir_i128` (mask then two's-complement
+  sign-fold).  A target width of `Arbitrary` is the identity (a widen into
+  Ruby's already-unbounded `Integer`) and emits no wrapper.
+- The masking is exact for every width because Ruby's `Integer` is arbitrary
+  precision and its bitwise ops use a two's-complement model — so `sir_u8(-1)
+  == 255`, `sir_i32(4_000_000_000) == -294_967_296`.
+- Verified end-to-end through a real `ruby`: `sir_u8(300)==44`,
+  `sir_i32(4e9)==-294_967_296`, `(uint32_t)-1==4_294_967_295`,
+  `(int8_t)200==-56`, arbitrary-width identity.
+
 ## 0.1.0 — v0 core (SIR25)
 
 First release of the Ruby backend — the seventh SIR backend and the first Ruby

--- a/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-ruby"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Semantic IR → self-contained Ruby source code (SIR25). Seventh backend for the SIR10 narrow-waist IR — the first Ruby target (Ruby was previously only a frontend)."
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/emit.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::Write;
 
-use semantic_ir::{Block, Expr, Function, Global, Module, Scope, Stmt};
+use semantic_ir::{Block, Expr, Function, Global, IntWidth, Module, Scope, Stmt};
 
 use crate::runtime::RUNTIME;
 
@@ -149,6 +149,7 @@ fn scan_expr(e: &Expr) -> Option<(String, semantic_ir::Span)> {
             args.iter().find_map(scan_expr)
         }
         Expr::MakeClosure { captures, .. } => captures.iter().find_map(|c| scan_expr(&c.value)),
+        Expr::Convert { value, .. } => scan_expr(value),
         _ => None,
     }
 }
@@ -269,7 +270,18 @@ fn emit_expr(e: &Expr) -> String {
                 fixed.join(", ")
             )
         }
-        other => unreachable!("v0 Ruby backend reached unsupported expr: {other:?}"),
+        // SIR26: integer conversion → a mask helper chosen by target width +
+        // signedness.  A target width of `Arbitrary` is the identity (a widen
+        // into Ruby's already-unbounded Integer), so no helper wraps it.
+        Expr::Convert { value, to, .. } => match to.width {
+            IntWidth::Arbitrary => emit_expr(value),
+            w => {
+                let bits = w.bits().expect("non-arbitrary width has bits");
+                let sign = if to.signed { 'i' } else { 'u' };
+                format!("sir_{sign}{bits}({})", emit_expr(value))
+            }
+        },
+        other => unreachable!("Ruby backend reached unsupported expr: {other:?}"),
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/lib.rs
@@ -53,6 +53,16 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     Feature::OptionalTypeAnnotations,
     Feature::MutualRecursion,
     Feature::Globals,
+    // ── SIR26 integer conversions ────────────────────────────────────
+    // `Expr::Convert` renders as an inlined mask helper (`sir_u8`/`sir_i32`/…);
+    // a Convert's target type also makes the validator observe these SIR21
+    // type-implied features, so the Ruby backend must accept them to compile a
+    // conversion-bearing module.  Ruby's arbitrary-precision Integer makes the
+    // masking exact for every width (its bitwise ops use two's complement).
+    Feature::Conversions,
+    Feature::SizedIntegers,
+    Feature::Unsigned,
+    Feature::WrappingArithmetic,
 ];
 
 impl Backend for RubyBackend {

--- a/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/src/runtime.rs
@@ -56,6 +56,39 @@ def sir_eq(a, b) = a == b
 # Call a closure value (a Ruby lambda) with the given arguments.
 def sir_apply(target, *args) = target.call(*args)
 
+# ── SIR26 integer conversions ──
+# Reduce an Integer to a fixed width by two's-complement reinterpretation — the
+# rendering of an Expr::Convert.  Ruby's Integer is arbitrary precision and its
+# bitwise ops use an (infinite) two's-complement model, so `v & mask` is exact
+# even when v is negative (e.g. sir_u8(-1) == 255).  Unsigned masks; signed
+# masks then folds the sign bit.  (A target width of Arbitrary is the identity
+# and is emitted with no helper.)
+def sir_u8(v)   = v & 0xFF
+def sir_u16(v)  = v & 0xFFFF
+def sir_u32(v)  = v & 0xFFFFFFFF
+def sir_u64(v)  = v & 0xFFFFFFFFFFFFFFFF
+def sir_u128(v) = v & ((1 << 128) - 1)
+def sir_i8(v)
+  m = v & 0xFF
+  m >= 0x80 ? m - 0x100 : m
+end
+def sir_i16(v)
+  m = v & 0xFFFF
+  m >= 0x8000 ? m - 0x10000 : m
+end
+def sir_i32(v)
+  m = v & 0xFFFFFFFF
+  m >= 0x80000000 ? m - 0x100000000 : m
+end
+def sir_i64(v)
+  m = v & 0xFFFFFFFFFFFFFFFF
+  m >= 0x8000000000000000 ? m - 0x10000000000000000 : m
+end
+def sir_i128(v)
+  m = v & ((1 << 128) - 1)
+  m >= (1 << 127) ? m - (1 << 128) : m
+end
+
 # The key is normalised with to_s so a name that arrives as a Symbol (how the
 # _init function's global_set passes it) and the same name as a String (how a
 # VarRef Global reads it) hit the same entry.

--- a/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
+++ b/code/packages/rust/semantic-ir-to-ruby/tests/emit_tests.rs
@@ -166,3 +166,150 @@ fn e2e_tail_if_both_branches() {
         None => eprintln!("skip: no ruby on PATH"),
     }
 }
+
+// ── SIR26 integer conversions (Expr::Convert) ───────────────────────────────
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, IntSpec, IntWidth, Metadata,
+    Module, Overflow, Span, CURRENT_SIR_VERSION,
+};
+
+/// Build a module whose `main` prints `convert(to, IntLit(v))`, emit Ruby, run
+/// it, and return stdout (or `None` when `ruby` is absent).
+fn run_convert(v: i64, to: IntSpec) -> Option<String> {
+    let inner = Expr::IntLit {
+        value: v,
+        span: Span::synthetic(),
+    };
+    let conv = Expr::Convert {
+        value: Box::new(inner),
+        to,
+        span: Span::synthetic(),
+    };
+    let puts = Expr::BuiltinCall {
+        name: "puts".into(),
+        args: vec![conv],
+        effects: EffectSet::PURE,
+        span: Span::synthetic(),
+    };
+    let module = Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Conversions,
+            Feature::SizedIntegers,
+            Feature::Unsigned,
+            Feature::WrappingArithmetic,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: puts,
+                span: Span::synthetic(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: Span::synthetic(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: Span::synthetic(),
+    };
+    let rb = compile(&module).expect("ruby emit").source;
+    run_ruby(&rb)
+}
+
+fn sized(w: IntWidth, signed: bool) -> IntSpec {
+    IntSpec::sized(w, signed, Overflow::Wrap)
+}
+
+#[test]
+fn convert_emit_shape_picks_the_right_helper() {
+    let inner = Expr::IntLit {
+        value: 300,
+        span: Span::synthetic(),
+    };
+    let m = Module {
+        name: "prog".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Conversions,
+            Feature::SizedIntegers,
+            Feature::Unsigned,
+            Feature::WrappingArithmetic,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::Convert {
+                    value: Box::new(inner),
+                    to: sized(IntWidth::W8, false),
+                    span: Span::synthetic(),
+                },
+                span: Span::synthetic(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: Span::synthetic(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new().with_sir_version(CURRENT_SIR_VERSION),
+        span: Span::synthetic(),
+    };
+    assert!(compile(&m).unwrap().source.contains("sir_u8(300)"));
+}
+
+#[test]
+fn e2e_convert_u8_wraps() {
+    // 300 mod 256 == 44 (the canonical uint8 overflow).
+    match run_convert(300, sized(IntWidth::W8, false)) {
+        Some(out) => assert_eq!(out, "44"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_convert_i32_overflow() {
+    // (int32_t)4_000_000_000 == -294_967_296 under two's complement.
+    match run_convert(4_000_000_000, sized(IntWidth::W32, true)) {
+        Some(out) => assert_eq!(out, "-294967296"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_convert_u32_of_negative_one() {
+    // (uint32_t)(-1) == 4_294_967_295.
+    match run_convert(-1, sized(IntWidth::W32, false)) {
+        Some(out) => assert_eq!(out, "4294967295"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_convert_i8_of_200() {
+    // (int8_t)200 == -56.
+    match run_convert(200, sized(IntWidth::W8, true)) {
+        Some(out) => assert_eq!(out, "-56"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}
+
+#[test]
+fn e2e_convert_arbitrary_is_identity() {
+    // A widen into the unbounded integer keeps the value exactly.
+    match run_convert(4_000_000_000, IntSpec::arbitrary()) {
+        Some(out) => assert_eq!(out, "4000000000"),
+        None => eprintln!("skip: no ruby on PATH"),
+    }
+}


### PR DESCRIPTION
## What

Teaches the **Ruby** and **C** backends to render the SIR26 `Expr::Convert` node (merged in #7875) — the mechanism that carries a source language's integer **width / wrapping / truncating** semantics across the narrow waist. This lights up the payoff of the C→SIR→Ruby initiative (and makes C→SIR→C round-trip conversions).

Both backends now accept `Feature::Conversions` (+ the SIR21 type-implied `SizedIntegers`/`Unsigned`/`WrappingArithmetic`).

## Ruby (`semantic-ir-to-ruby` 0.2.0)

A conversion emits an inlined mask helper chosen by target width + signedness — `sir_u8`/`u16`/`u32`/`u64`/`u128` (mask) and `sir_i8`/`i16`/`i32`/`i64`/`i128` (mask then two's-complement sign-fold). `Arbitrary` width is the identity (a widen into Ruby's unbounded `Integer`). Exact for every width because Ruby's `Integer` is arbitrary-precision with two's-complement bitwise ops (`sir_u8(-1)==255`).

## C (`semantic-ir-to-c` 0.2.0)

A conversion emits the **portable** runtime helper `_sir_convert(v, bits, signed)` — `_sir_mask_to` does a two's-complement reduction over `int64`/`uint64` (mask + sign-fold, no native fixed-width casts), so it behaves identically on MSVC/GCC/Clang. `Arbitrary` is the identity; `bits >= 64` is the `int64` storage floor (u64 above 2⁶³ is the shared bignum frontier).

## Verification

- **Ruby:** 16 tests incl. real `ruby` runs — `sir_u8(300)==44`, `sir_i32(4e9)==−294967296`, `(uint32_t)-1==4294967295`, `(int8_t)200==−56`, arbitrary identity.
- **C:** new `compile_and_run_conversions` (7 cases) + emit-shape. The emitted C **compiles and runs identically on clang, gcc, AND MSVC** (44 / −56 / 4464 / 4294967295 / −294967296 / identity).
- Security review: **passed** (no injection — helper name/bits/signed are closed-enum/bool; `_sir_mask_to` shift-UB guarded; Ruby helpers pure arithmetic).

## Next

The final step of the initiative is the **`c-to-semantic-ir` frontend** (integer-core C subset) that emits `Convert` nodes per C's promotion rules — completing C→SIR→Ruby with bit-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)