### PR TITLE
feat(sir-rust): String ljust/rjust/center/swapcase (justify, v0.25.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.25.0 — String justify methods: `ljust` / `rjust` / `center` / `swapcase`
+
+Closes the last String parity gap with the Python/Go/JS/TS runtimes (which
+already carry these) by adding four more non-block Ruby String methods to the
+emitted runtime's `string_method` `match` and the `responds_to` catalog. All are
+**char-based** (`chars().count()` / a rune-cyclic `str_pad`), so a multibyte
+receiver and a multibyte pad are never split mid-codepoint:
+
+- `ljust(width, pad = " ")` / `rjust(width, pad = " ")` / `center(width, pad = " ")`
+  — pad to `width` **characters** using `pad` cyclically. `width <= the current
+  char length` returns the string unchanged; `center` puts any odd extra pad
+  char on the **RIGHT** (Ruby's rule). An empty `pad` degrades to a single space
+  rather than raising, and the fill count is clamped to a DoS bound
+  (`100_000_000`) so a hostile `width` cannot drive an unbounded allocation —
+  holding the never-raise floor.
+- `swapcase` — flip the case of each ASCII letter, leaving non-letters and
+  non-ASCII characters untouched (byte-for-byte identical to the other four
+  runtimes).
+
+Dispatch stays an **explicit** `match` on the interned method name (never
+reflection over a host method table). Exec-proven end-to-end via `rustc`
+(emitted Rust compiled and run; stdout diffed against the Ruby/Python/Go
+reference, including the odd-extra-pad-on-the-right `center` case). Completes the
+String justify group across all five backends.
+
 ## 0.24.0 — String char-set methods: `tr` / `count` / `delete` / `squeeze`
 
 Adds four non-block Ruby String methods to the emitted runtime's `string_method`

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -145,7 +145,9 @@ rather than panicking:
   - **Hash** (`Map`): `keys`, `values`, `size`, `has_key?`, `each`, `map`,
     `select`.
   - **String** (`Str`): `length`, `upcase`, `downcase`, `reverse`, `strip`,
-    `include?`, `split`.
+    `include?`, `split`, char-set `tr`/`count`/`delete`/`squeeze` (literal
+    sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`
+    puts any odd extra pad char on the RIGHT, Ruby's rule).
   - **Numeric** (`Int`/`Float`): `abs`, `to_i`, `to_f`, `even?`, `odd?`,
     `zero?`, `times`; plus a universal `to_s`.
   - Block-taking methods apply the trailing closure via `apply_closure`;

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1483,6 +1483,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                     | "lstrip" | "rstrip" | "chomp" | "chars" | "bytes" | "split" | "include?"
                     | "start_with?" | "end_with?" | "index" | "replace" | "sub" | "gsub" | "to_i"
                     | "to_f" | "to_sym" | "empty?" | "tr" | "count" | "delete" | "squeeze"
+                    | "ljust" | "rjust" | "center" | "swapcase"
             ),
             Value::Sym(_) => matches!(
                 name,
@@ -2399,6 +2400,59 @@ pub const RUNTIME: &str = r##"mod __sir {
             "to_f" => Value::Float(str_to_f(&s)),
             "to_sym" => intern(&s),
             "empty?" => Value::Bool(s.is_empty()),
+            "ljust" | "rjust" | "center" => {
+                // Ruby `String#ljust`/`#rjust`/`#center(width, pad = " ")`: pad to
+                // `width` CHARS (not bytes) using `pad` cyclically.  `width <= the
+                // current char length` returns the string unchanged; `center` puts
+                // any odd extra pad char on the RIGHT (Ruby's rule).  An empty pad
+                // degrades to a single space rather than raising, holding the
+                // never-raise floor.  Char-based (`chars().count()` / `str_pad`) so
+                // a multibyte receiver is never split mid-codepoint.
+                let width = args.first().map(as_i64).unwrap_or(0);
+                let pad = match args.get(1) {
+                    Some(Value::Str(p)) if !p.is_empty() => p.to_string(),
+                    _ => " ".to_string(),
+                };
+                let cur = s.chars().count() as i64;
+                if width <= cur {
+                    return Value::Str(s);
+                }
+                // Clamp the fill count to a DoS bound so a hostile width (e.g.
+                // `"".ljust(10**12)`) cannot drive an unbounded allocation — the
+                // same ceiling `String#*` guards, but degrade-not-panic here since
+                // justify is a formatting method.
+                const MAX_PAD: i64 = 100_000_000;
+                let total = (width - cur).min(MAX_PAD) as usize;
+                let result = match name {
+                    "ljust" => format!("{}{}", s, str_pad(&pad, total)),
+                    "rjust" => format!("{}{}", str_pad(&pad, total), s),
+                    _ => {
+                        // center: any odd extra pad char goes on the RIGHT.
+                        let left = total / 2;
+                        format!("{}{}{}", str_pad(&pad, left), s, str_pad(&pad, total - left))
+                    }
+                };
+                Value::Str(Rc::from(result.as_str()))
+            }
+            "swapcase" => {
+                // Ruby `String#swapcase`: flip the case of each ASCII letter
+                // (leaving non-letters and non-ASCII chars untouched), matching the
+                // Python/Go/JS/TS runtimes byte-for-byte.  Iterating `chars()` keeps
+                // a multibyte receiver intact.
+                let swapped: String = s
+                    .chars()
+                    .map(|c| {
+                        if c.is_ascii_uppercase() {
+                            c.to_ascii_lowercase()
+                        } else if c.is_ascii_lowercase() {
+                            c.to_ascii_uppercase()
+                        } else {
+                            c
+                        }
+                    })
+                    .collect();
+                Value::Str(Rc::from(swapped.as_str()))
+            }
             "tr" => {
                 // Ruby `String#tr(from, to)`: position-wise char translation.  A
                 // shorter `to` repeats its last char; an empty `to` deletes
@@ -2488,6 +2542,23 @@ pub const RUNTIME: &str = r##"mod __sir {
             }
             _ => no_method_error(&recv, name),
         }
+    }
+
+    // Build a padding string of exactly `n` CHARS by repeating `pad`
+    // cyclically (truncating the final repeat).  `n == 0` or an empty `pad`
+    // yields `""` — the `ljust`/`rjust`/`center` callers guarantee a non-empty
+    // pad, so the empty-pad guard is purely defensive.  Char-based so a
+    // multibyte pad (e.g. `"ab…"`) is never split mid-codepoint.
+    fn str_pad(pad: &str, n: usize) -> String {
+        if n == 0 || pad.is_empty() {
+            return String::new();
+        }
+        let pad_chars: Vec<char> = pad.chars().collect();
+        let mut out = String::with_capacity(n);
+        for i in 0..n {
+            out.push(pad_chars[i % pad_chars.len()]);
+        }
+        out
     }
 
     // Ruby `String#to_i`: parse the longest leading `[+-]?\d+` prefix,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_string_methods.rs
@@ -51,6 +51,10 @@ fn slit(v: &str) -> Expr {
     Expr::StrLit { value: v.into(), span: s() }
 }
 
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
 /// `recv.meth(args…)` — the `__method__` dispatch envelope.
 fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
     let mut all = vec![recv, slit(name)];
@@ -145,6 +149,21 @@ fn full_demo() -> Module {
         print_stmt(method(slit("mississippi"), "squeeze", vec![])),
         // "aaabbbccc".squeeze("a")  → "abbbccc"
         print_stmt(method(slit("aaabbbccc"), "squeeze", vec![slit("a")])),
+        // ── justify group (v0.25.0): ljust / rjust / center / swapcase ──
+        // "hi".ljust(5, "*")  → "hi***"
+        print_stmt(method(slit("hi"), "ljust", vec![ilit(5), slit("*")])),
+        // "hi".rjust(5, "*")  → "***hi"
+        print_stmt(method(slit("hi"), "rjust", vec![ilit(5), slit("*")])),
+        // "hi".center(6, "*")  → "**hi**"  (even split)
+        print_stmt(method(slit("hi"), "center", vec![ilit(6), slit("*")])),
+        // "hi".center(5, "*")  → "*hi**"  (odd extra pad on the RIGHT)
+        print_stmt(method(slit("hi"), "center", vec![ilit(5), slit("*")])),
+        // "abc".ljust(1)  → "abc"  (width <= length: unchanged)
+        print_stmt(method(slit("abc"), "ljust", vec![ilit(1)])),
+        // "hi".ljust(5)  → "hi   "  (default pad is a space)
+        print_stmt(method(slit("hi"), "ljust", vec![ilit(5)])),
+        // "Hello World".swapcase  → "hELLO wORLD"
+        print_stmt(method(slit("Hello World"), "swapcase", vec![])),
     ];
 
     demo_module(main_stmts)
@@ -237,6 +256,13 @@ fn string_methods_compile_and_run() {
             "hll",           // delete("aeiou")
             "misisipi",      // squeeze (no arg)
             "abbbccc",       // squeeze("a")
+            "hi***",         // ljust(5, "*")
+            "***hi",         // rjust(5, "*")
+            "**hi**",        // center(6, "*") — even split
+            "*hi**",         // center(5, "*") — odd extra pad on the RIGHT
+            "abc",           // ljust(1) — width <= length, unchanged
+            "hi   ",         // ljust(5) — default space pad
+            "hELLO wORLD",   // swapcase
         ],
         "unexpected program output; full stdout:\n{stdout}"
     );


### PR DESCRIPTION
## Summary

Closes the **last String parity gap in the Rust backend**. The Python/Go/JS/TS runtimes all carry the justify group, but `semantic-ir-to-rust`'s `string_method` + `responds_to` catalog lacked it. Adds four non-block Ruby `String` methods to the emitted RUNTIME:

- **`ljust`/`rjust`/`center(width, pad = " ")`** — pad to `width` **characters** (char-based, not bytes) using `pad` cyclically. `width <= the current char length` returns the string unchanged; `center` puts any odd extra pad char on the **RIGHT** (Ruby's rule); an empty pad degrades to a single space; the fill count is clamped to a DoS bound (`100_000_000`) so a hostile `width` cannot drive an unbounded allocation.
- **`swapcase`** — flip each ASCII letter, leaving non-letters / non-ASCII untouched.

Adds a rune-cyclic `str_pad` helper (mirrors Go `_sir_str_pad`) so a multibyte pad is never split mid-codepoint.

## Design invariants held

- **Explicit dispatch** — `match` on the interned method name; no reflection.
- **Never-raise floor** — missing/non-string args degrade; DoS-clamped width; no panic path (verified: `pad.is_empty()` early-return, `width <= cur` guard rules out the subtract-underflow and the cast).
- **Codepoint-safe** — `chars().count()` / char-based `str_pad`.

## Testing

- **Exec-proof via `rustc`** (`SIR_TEST_RUSTC_LINKER=rust-lld`): the emitted Rust compiles and runs; stdout diffed against the Ruby/Python/Go reference, including the odd-extra-pad-on-the-right `center(5, "*") == "*hi**"` case. Test passes.
- Security review: **PASSED** (no unbounded allocation, no overflow/underflow, no panic path, no reflection).

Completes the String justify group across all five backends. Bumps `0.24.0` → `0.25.0`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)