### PR TITLE
feat(sir-js): Hash fetch/clear/[]= (breadth parity, v0.24.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.24.0 — Hash breadth: `fetch` / `clear` / `[]=`
+
+Closes the JavaScript-backend Hash parity gap (the Python/TS reference and the
+Go/Rust runtimes already carry these) by adding three Ruby `Hash` methods to the
+inlined runtime's `hashMethod` switch and the `HASH_METHODS` `respond_to?` set:
+
+- `fetch(k[, default])` — returns the value for `k` if present; a **missing** key
+  with no default raises a typed `KeyError` (unlike `hash[k]`, which returns
+  `nil`), so a translated `rescue KeyError` catches it; a second argument
+  supplies a default returned instead of raising. (The block form is deferred.)
+- `clear` — mutates, removing every pair, and returns the now-empty receiver.
+- `[]=` — wired as an explicit alias of `store` (`recv.set(k, v)`; returns `v`).
+
+Dispatch stays an explicit `switch` on the literal method name (never
+`recv[name]`). Exec-proven end-to-end under Node (the `hash_catalog_methods`
+test now also covers `[]=`, `fetch` present/default, and `clear`; the
+missing-key `KeyError` path remains covered by
+`t3_hash_fetch_missing_raises_key_error`).
+
 ## 0.23.0 — String char-set methods: `tr` / `count` / `delete` / `squeeze`
 
 Adds four non-block Ruby String methods to the inlined runtime's `stringMethod`

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -879,8 +879,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   const HASH_METHODS = new Set([
     "keys", "values", "size", "length", "empty?", "has_key?", "key?",
     "include?", "member?", "has_value?", "value?", "to_a", "merge", "dig",
-    "invert", "delete", "store", "each", "each_pair", "map", "select",
-    "filter", "reject",
+    "invert", "delete", "store", "[]=", "fetch", "clear", "each", "each_pair",
+    "map", "select", "filter", "reject",
   ]);
   function hashMethod(recv, name, args) {
     switch (name) {
@@ -928,10 +928,27 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         if (recv.has(args[0])) { const v = recv.get(args[0]); recv.delete(args[0]); return v; }
         return null;
       }
-      case "store": {
+      case "store": case "[]=": {
         // Ruby `store(k, v)` (alias `[]=`): mutates, returns the value.
         recv.set(args[0], args[1]);
         return args[1];
+      }
+      case "fetch": {
+        // Ruby `Hash#fetch(k)`: returns the value for `k` if present; a MISSING
+        // key with no default raises `KeyError` (unlike `hash[k]`, which returns
+        // nil).  A second argument supplies a default returned instead of
+        // raising.  Typed `SirError` so a translated `rescue KeyError` catches it.
+        // (The block form is out of v0 scope.)
+        if (recv.has(args[0])) { return recv.get(args[0]); }
+        if (args.length > 1) { return args[1]; }
+        raiseError("KeyError", "key not found: " + format(args[0]));
+        return null; // unreachable — raiseError throws
+      }
+      case "clear": {
+        // Ruby `Hash#clear`: MUTATES, removing every pair, and returns the
+        // (now-empty) receiver.
+        recv.clear();
+        return recv;
       }
       case "each": case "each_pair": {
         // Yields (key, value); returns the receiver.

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2447,11 +2447,20 @@ fn hash_catalog_methods() {
         )), // [a, b, c]
         print(method(local("m"), "delete", vec![str_("a")])), // 1 (mutates m)
         print(method(local("m"), "keys", vec![])),            // [b]
+        // `[]=` (store alias): mutate, returns the stored value.
+        print(method(local("m"), "[]=", vec![str_("z"), int(9)])), // 9
+        // `fetch` present key → value; with a default arg on a missing key →
+        // the default (no raise).  (The missing-no-default KeyError path is
+        // proven separately in `t3_hash_fetch_missing_raises_key_error`.)
+        print(method(local("m"), "fetch", vec![str_("z")])), // 9
+        print(method(local("m"), "fetch", vec![str_("nope"), int(0)])), // 0
+        // `clear` empties the receiver and returns it (size 0 afterwards).
+        print(method(method(local("m"), "clear", vec![]), "size", vec![])), // 0
     ];
     let module =
         module_with_main(stmts, Expr::NilLit { span: sp() }, &[Feature::Maps, Feature::Strings]);
     if let Some(stdout) = run_module(&module, "hashcatalog") {
-        assert_eq!(stdout, "[a, b]\n[1, 2]\n2\n[[a, 1], [b, 2]]\n2\n[a, b, c]\n1\n[b]");
+        assert_eq!(stdout, "[a, b]\n[1, 2]\n2\n[[a, 1], [b, 2]]\n2\n[a, b, c]\n1\n[b]\n9\n9\n0\n0");
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the **JavaScript-backend Hash parity gap**. The Python/TS `sir-runtime-oop` reference and the Go/Rust runtimes already carry these; the JS backend's `hashMethod` switch lacked them. Adds three Ruby `Hash` methods to the inlined runtime + the `HASH_METHODS` `respond_to?` set:

- **`fetch(k[, default])`** — value for `k` if present; a **missing** key with no default raises a typed **`KeyError`** (unlike `hash[k]`, which returns `nil`), so a translated `rescue KeyError` catches it; a second argument supplies a default returned instead of raising. Block form deferred.
- **`clear`** — mutates, removing every pair, returns the now-empty receiver.
- **`[]=`** — wired as an explicit alias of `store` (`recv.set(k, v)`; returns `v`).

## Design invariants held

- **Explicit dispatch** — `switch` on the literal method name; no `recv[name]`/reflection.
- **Typed errors** — the only throw is the intended `KeyError` SirError.
- **No prototype pollution** — keys go through `Map.set`, not object indexing.

## Testing

- **Exec-proof under Node**: `hash_catalog_methods` now also covers `[]=`, `fetch` (present + default), and `clear`; the missing-key `KeyError` path stays covered by `t3_hash_fetch_missing_raises_key_error`. Both pass.
- Security review: **PASSED** (no pollution, no reflection, no unbounded allocation, typed-error contract intact).

Bumps `0.23.0` → `0.24.0`; CHANGELOG updated. (README is architectural prose with no per-method hash catalog, so no README change needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)