### PR TITLE
feat(sir-runtime-oop): Numeric divmod/fdiv/round(n)/clamp/between? (Python, v0.1.17)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -21,8 +21,13 @@ semantics for the N1 breadth sweep before the embedded backends mirror them:
 - `clamp(min, max)` — `min` if `recv < min`, `max` if `recv > max`, else `recv`.
 - `between?(min, max)` — `min <= recv <= max`.
 
-The `clamp`/`between?` `Range` form and `divmod`/`fdiv` on non-numeric arguments
-are deferred, matching the literal-only precedent elsewhere in the catalog.
+The `clamp`/`between?` `Range` form is deferred, matching the literal-only
+precedent elsewhere in the catalog. All arithmetic is hardened to the
+never-raise floor: `round` bounds a hostile `ndigits` (no bignum allocation),
+guards non-finite arguments, and uses all-integer rounding for large-integer
+receivers; `divmod`/`fdiv` saturate bignum operands to `±Infinity` (via
+`_sat_float`) and route a non-numeric argument to the typed `ZeroDivisionError`
+rather than an untyped `OverflowError`/`ValueError`/`TypeError`.
 
 ## [0.1.16] - 2026-07-07
 

--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.17] - 2026-07-10
+
+### Added — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
+
+Extends the `Integer`/`Float` catalog (`_numeric_method` + `_NUMERIC_METHODS`)
+with five more Ruby numeric methods — this establishes the **reference**
+semantics for the N1 breadth sweep before the embedded backends mirror them:
+
+- `round(ndigits)` — `round` gains an optional digits argument: a positive
+  `ndigits` rounds a `Float` to that many decimals (half **away from zero**, not
+  Python's banker's rounding); `ndigits <= 0` rounds to an `Integer` power of ten.
+  A non-finite `Float` returns unchanged (never-raise floor).
+- `divmod(n)` — `[quotient, remainder]` with a floored quotient and the
+  divisor-signed remainder; division by zero raises a typed `ZeroDivisionError`.
+- `fdiv(n)` — floating-point division that **never raises**: dividing by zero
+  yields `Infinity`/`-Infinity`/`NaN` (matching Ruby) rather than raising.
+- `clamp(min, max)` — `min` if `recv < min`, `max` if `recv > max`, else `recv`.
+- `between?(min, max)` — `min <= recv <= max`.
+
+The `clamp`/`between?` `Range` form and `divmod`/`fdiv` on non-numeric arguments
+are deferred, matching the literal-only precedent elsewhere in the catalog.
+
 ## [0.1.16] - 2026-07-07
 
 ### Added — String char-set methods: `tr` / `count` / `delete` / `squeeze`

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -82,8 +82,9 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`, `tr`/`count`/`delete`/`squeeze`
 *(literal char sets)*, `each_char`); and (item **M1c**) the
 **`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`, `even?`/`odd?`/`zero?`/
-`positive?`/`negative?`, `succ`/`pred`, `floor`/`ceil`/`round`, `gcd`, `pow`/`**`,
-`digits`, and block `times`/`upto`/`downto`/`step`), the **`Symbol`** catalog
+`positive?`/`negative?`, `succ`/`pred`, `floor`/`ceil`/`round` (with optional
+`ndigits`), `divmod`, `fdiv`, `clamp`, `between?`, `gcd`, `pow`/`**`, `digits`,
+and block `times`/`upto`/`downto`/`step`), the **`Symbol`** catalog
 (`to_s`/`to_sym`/`length`/`upcase`/`downcase`/`inspect`), and universal
 **`to_s`/`inspect`** Ruby display forms (so `nil`/`true`/`false` need no catalog)
 plus **`Array#join`**.

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.16"
+version = "0.1.17"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1586,26 +1586,46 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
         # a positive ``ndigits`` on a Float rounds to that many decimal places
         # (still half-away-from-zero, unlike Python's banker's rounding).  A
         # non-finite Float is returned unchanged (never-raise floor).
+        #
+        # DoS guard: ``ndigits`` is caller-controlled, so ``10 ** (-ndigits)``
+        # could build a multi-gigabyte bignum for a hostile magnitude.  Rounding
+        # to a place value that dwarfs the receiver is exactly ``0`` in Ruby
+        # (``1234.round(-10) == 0``), so we short-circuit to ``0`` once the place
+        # count clearly exceeds the receiver's decimal width instead of
+        # allocating the factor — and cap positive ``ndigits`` past a Float's
+        # precision (the value is already at full precision) to dodge the
+        # ``10.0 ** ndigits`` ``OverflowError``.
         ndigits = int(args[0]) if args and isinstance(args[0], (int, float)) else 0
         if isinstance(recv, float) and not math.isfinite(recv):
             return recv
+        # Decimal width of the integer magnitude — cheap and bounded.
+        int_width = len(str(abs(int(recv)))) if math.isfinite(recv) else 0
         if isinstance(recv, int):
             if ndigits >= 0:
                 return recv
-            # Negative ndigits: round to the nearest power of ten (half-up).
+            if -ndigits > int_width + 1:
+                return 0  # rounding place dwarfs the value ⇒ 0 (Ruby parity)
             factor = 10 ** (-ndigits)
             return int(_ruby_round(recv / factor)) * factor
         if ndigits <= 0:
-            rounded = _ruby_round(recv / (10 ** (-ndigits))) * (10 ** (-ndigits))
-            return int(rounded)
+            if -ndigits > int_width + 1:
+                return 0
+            factor = 10 ** (-ndigits)
+            return int(_ruby_round(recv / factor) * factor)
+        # A binary64 Float carries ~15–17 significant digits; rounding to more
+        # decimals than that returns the value unchanged (and avoids overflow).
+        if ndigits > 17:
+            return recv
         factor = 10.0**ndigits
         return _ruby_round(recv * factor) / factor
     if name == "divmod":
         # Ruby ``Integer#divmod`` / ``Float#divmod``: ``[quotient, remainder]``
         # where the quotient is floored and the remainder takes the divisor's
         # sign (Python's ``divmod`` matches this).  Division by zero raises a
-        # typed ``ZeroDivisionError`` so a translated ``rescue`` catches it.
-        divisor = args[0]
+        # typed ``ZeroDivisionError`` so a translated ``rescue`` catches it.  A
+        # non-numeric divisor degrades to ``0`` → the same typed error (rather
+        # than an untyped ``TypeError`` from Python's ``divmod``).
+        divisor = args[0] if args and isinstance(args[0], (int, float)) else 0
         if divisor == 0:
             raise_error("ZeroDivisionError", "divided by 0")
         quotient, remainder = divmod(recv, divisor)
@@ -1613,8 +1633,10 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
     if name == "fdiv":
         # Ruby ``fdiv``: floating-point division.  Unlike ``/``, dividing by zero
         # yields ``Infinity``/``NaN`` rather than raising (Ruby never raises on
-        # ``Float`` division), honouring the never-raise floor.
-        divisor = float(args[0])
+        # ``Float`` division), honouring the never-raise floor.  A non-numeric
+        # argument degrades to a ``0`` divisor (→ ``Infinity``/``NaN``) rather
+        # than raising an untyped ``ValueError``/``TypeError`` from ``float()``.
+        divisor = float(args[0]) if args and isinstance(args[0], (int, float)) else 0.0
         numer = float(recv)
         if divisor == 0.0:
             if numer == 0.0:

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1635,7 +1635,14 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
         if ndigits > 17:
             return recv
         factor = 10.0**ndigits
-        return _ruby_round(recv * factor) / factor
+        scaled = recv * factor
+        # A large ``recv`` can overflow the scale-up to ``inf``; ``_ruby_round``
+        # (``math.floor(inf + 0.5)``) would then raise an untyped ``OverflowError``.
+        # A value that large has no fractional part left to round, so return it
+        # unchanged — holding the never-raise floor.
+        if not math.isfinite(scaled):
+            return recv
+        return _ruby_round(scaled) / factor
     if name == "divmod":
         # Ruby ``Integer#divmod`` / ``Float#divmod``: ``[quotient, remainder]``
         # where the quotient is floored and the remainder takes the divisor's

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1506,6 +1506,17 @@ _MAX_POW_BITS = 1 << 20
 _MAX_DISPLAY_DEPTH = 100
 
 
+def _sat_float(x: Val) -> float:
+    """Coerce ``x`` to ``float``, **saturating** to ``±inf`` when it is a bignum
+    ``int`` past ``float`` range.  Plain ``float(2**5000)`` raises an untyped
+    ``OverflowError``; Ruby instead treats such a value as ``Infinity`` in
+    floating-point contexts, so saturating holds the never-raise floor."""
+    try:
+        return float(x)
+    except OverflowError:
+        return math.inf if x > 0 else -math.inf
+
+
 def _ruby_round(x: float) -> int:
     """Ruby ``Float#round`` (no digits): round half **away from zero** — unlike
     Python's banker's rounding, ``2.5.round == 3`` and ``-2.5.round == -3``."""
@@ -1653,16 +1664,25 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
         divisor = args[0] if args and isinstance(args[0], (int, float)) else 0
         if divisor == 0:
             raise_error("ZeroDivisionError", "divided by 0")
-        quotient, remainder = divmod(recv, divisor)
+        # ``divmod(int, int)`` is exact, but a mixed ``int``-receiver / ``float``-
+        # divisor coerces the (possibly bignum) receiver to ``float`` and raises
+        # an untyped ``OverflowError`` past ``float`` range.  Route any
+        # float-involving pair through saturating floats so the surface never
+        # raises (matching Ruby's floating-point ``Infinity``/``NaN`` result).
+        if isinstance(recv, float) or isinstance(divisor, float):
+            quotient, remainder = divmod(_sat_float(recv), _sat_float(divisor))
+        else:
+            quotient, remainder = divmod(recv, divisor)
         return [quotient, remainder]
     if name == "fdiv":
         # Ruby ``fdiv``: floating-point division.  Unlike ``/``, dividing by zero
         # yields ``Infinity``/``NaN`` rather than raising (Ruby never raises on
         # ``Float`` division), honouring the never-raise floor.  A non-numeric
-        # argument degrades to a ``0`` divisor (→ ``Infinity``/``NaN``) rather
-        # than raising an untyped ``ValueError``/``TypeError`` from ``float()``.
-        divisor = float(args[0]) if args and isinstance(args[0], (int, float)) else 0.0
-        numer = float(recv)
+        # argument degrades to a ``0`` divisor (→ ``Infinity``/``NaN``); a bignum
+        # receiver/arg saturates to ``±inf`` via ``_sat_float`` rather than
+        # raising an untyped ``OverflowError`` from ``float()``.
+        divisor = _sat_float(args[0]) if args and isinstance(args[0], (int, float)) else 0.0
+        numer = _sat_float(recv)
         if divisor == 0.0:
             if numer == 0.0:
                 return math.nan

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -720,6 +720,10 @@ _NUMERIC_METHODS = frozenset(
         "floor",
         "ceil",
         "round",
+        "divmod",
+        "fdiv",
+        "clamp",
+        "between?",
         "gcd",
         "pow",
         "**",
@@ -1577,9 +1581,58 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
     if name == "ceil":
         return recv if isinstance(recv, float) and not math.isfinite(recv) else math.ceil(recv)
     if name == "round":
-        if isinstance(recv, int) or (isinstance(recv, float) and not math.isfinite(recv)):
+        # Ruby ``round`` / ``round(ndigits)``.  With no argument (or ``ndigits <=
+        # 0`` on an Integer) the result is an Integer rounded half-away-from-zero;
+        # a positive ``ndigits`` on a Float rounds to that many decimal places
+        # (still half-away-from-zero, unlike Python's banker's rounding).  A
+        # non-finite Float is returned unchanged (never-raise floor).
+        ndigits = int(args[0]) if args and isinstance(args[0], (int, float)) else 0
+        if isinstance(recv, float) and not math.isfinite(recv):
             return recv
-        return _ruby_round(recv)
+        if isinstance(recv, int):
+            if ndigits >= 0:
+                return recv
+            # Negative ndigits: round to the nearest power of ten (half-up).
+            factor = 10 ** (-ndigits)
+            return int(_ruby_round(recv / factor)) * factor
+        if ndigits <= 0:
+            rounded = _ruby_round(recv / (10 ** (-ndigits))) * (10 ** (-ndigits))
+            return int(rounded)
+        factor = 10.0**ndigits
+        return _ruby_round(recv * factor) / factor
+    if name == "divmod":
+        # Ruby ``Integer#divmod`` / ``Float#divmod``: ``[quotient, remainder]``
+        # where the quotient is floored and the remainder takes the divisor's
+        # sign (Python's ``divmod`` matches this).  Division by zero raises a
+        # typed ``ZeroDivisionError`` so a translated ``rescue`` catches it.
+        divisor = args[0]
+        if divisor == 0:
+            raise_error("ZeroDivisionError", "divided by 0")
+        quotient, remainder = divmod(recv, divisor)
+        return [quotient, remainder]
+    if name == "fdiv":
+        # Ruby ``fdiv``: floating-point division.  Unlike ``/``, dividing by zero
+        # yields ``Infinity``/``NaN`` rather than raising (Ruby never raises on
+        # ``Float`` division), honouring the never-raise floor.
+        divisor = float(args[0])
+        numer = float(recv)
+        if divisor == 0.0:
+            if numer == 0.0:
+                return math.nan
+            return math.inf if numer > 0 else -math.inf
+        return numer / divisor
+    if name == "clamp":
+        # Ruby ``Comparable#clamp(min, max)``: return ``min`` if ``recv < min``,
+        # ``max`` if ``recv > max``, else ``recv``.  (The Range form is deferred.)
+        low, high = args[0], args[1]
+        if recv < low:
+            return low
+        if recv > high:
+            return high
+        return recv
+    if name == "between?":
+        # Ruby ``Comparable#between?(min, max)``: ``min <= recv <= max``.
+        return args[0] <= recv <= args[1]
     if name == "gcd":
         return math.gcd(int(recv), int(args[0]))
     if name in ("pow", "**"):

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1604,15 +1604,27 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
         )
         if isinstance(recv, float) and not math.isfinite(recv):
             return recv
-        # Decimal width of the integer magnitude — cheap and bounded.
-        int_width = len(str(abs(int(recv)))) if math.isfinite(recv) else 0
+        # Decimal width of the integer magnitude — cheap and bounded.  ``recv`` is
+        # now an int or a *finite* float (non-finite floats returned above), so we
+        # avoid ``math.isfinite(recv)``: that coerces a huge int to a float and
+        # would itself raise ``OverflowError`` (e.g. ``10**309``).
+        int_width = len(str(abs(recv if isinstance(recv, int) else int(recv))))
         if isinstance(recv, int):
             if ndigits >= 0:
                 return recv
             if -ndigits > int_width + 1:
                 return 0  # rounding place dwarfs the value ⇒ 0 (Ruby parity)
             factor = 10 ** (-ndigits)
-            return int(_ruby_round(recv / factor)) * factor
+            # Round to the nearest multiple of ``factor`` half-away-from-zero
+            # with ALL-INTEGER arithmetic.  ``recv / factor`` would be Python
+            # true division (a float) and raises ``OverflowError`` for a receiver
+            # past ~1.8e308 (e.g. ``(10**309).round(-1)``) — an untyped error;
+            # integer ``divmod`` never overflows.
+            quotient, rem = divmod(abs(recv), factor)
+            if rem * 2 >= factor:
+                quotient += 1
+            magnitude = quotient * factor
+            return -magnitude if recv < 0 else magnitude
         if ndigits <= 0:
             if -ndigits > int_width + 1:
                 return 0

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -1595,7 +1595,13 @@ def _numeric_method(recv: Val, name: str, args: list[Val]) -> Val:
         # allocating the factor — and cap positive ``ndigits`` past a Float's
         # precision (the value is already at full precision) to dodge the
         # ``10.0 ** ndigits`` ``OverflowError``.
-        ndigits = int(args[0]) if args and isinstance(args[0], (int, float)) else 0
+        # ``isfinite`` also rejects an ``inf``/``nan`` ``ndigits`` argument, whose
+        # ``int(...)`` would otherwise raise an untyped ``OverflowError``/``ValueError``.
+        ndigits = (
+            int(args[0])
+            if args and isinstance(args[0], (int, float)) and math.isfinite(args[0])
+            else 0
+        )
         if isinstance(recv, float) and not math.isfinite(recv):
             return recv
         # Decimal width of the integer magnitude — cheap and bounded.

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -696,6 +696,10 @@ def test_numeric_round_ndigits() -> None:
     # Positive ndigits past Float precision returns the value unchanged (no
     # 10.0 ** ndigits OverflowError).
     assert oop.call_method(3.14, "round", 1_000_000) == 3.14
+    # A non-finite ndigits argument degrades to 0 rather than raising an untyped
+    # int(inf)/int(nan) error.
+    assert oop.call_method(5, "round", float("inf")) == 5
+    assert oop.call_method(5, "round", float("nan")) == 5
 
 
 def test_numeric_divmod_fdiv() -> None:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -704,6 +704,10 @@ def test_numeric_round_ndigits() -> None:
     # OverflowError from `recv / factor`).
     assert oop.call_method(10**309, "round", -1) == 10**309
     assert oop.call_method(5 * 10**400, "round", -3) == 5 * 10**400
+    # A near-max Float with a positive ndigits must not overflow the scale-up
+    # (recv * 10**ndigits → inf → _ruby_round(inf) OverflowError); return as-is.
+    assert oop.call_method(1.7e308, "round", 5) == 1.7e308
+    assert oop.call_method(1e300, "round", 17) == 1e300
 
 
 def test_numeric_divmod_fdiv() -> None:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -678,6 +678,42 @@ def test_numeric_gcd_pow_digits() -> None:
     assert oop.call_method(0, "digits") == [0]
 
 
+def test_numeric_round_ndigits() -> None:
+    # A positive ndigits rounds a Float to that many decimals, half away from zero.
+    assert oop.call_method(3.14159, "round", 2) == 3.14
+    assert oop.call_method(2.675, "round", 2) == 2.68
+    assert oop.call_method(-2.5, "round", 0) == -3
+    # ndigits <= 0 rounds to an Integer power of ten.
+    assert oop.call_method(1234, "round", -2) == 1200
+    assert oop.call_method(1250, "round", -2) == 1300  # half away from zero
+    assert oop.call_method(1234.5, "round", -1) == 1230
+
+
+def test_numeric_divmod_fdiv() -> None:
+    assert oop.call_method(13, "divmod", 4) == [3, 1]
+    # Remainder takes the divisor's sign (Ruby/Python floored division).
+    assert oop.call_method(13, "divmod", -4) == [-4, -3]
+    assert oop.call_method(7, "fdiv", 2) == 3.5
+    # fdiv never raises: dividing by zero yields Infinity / NaN.
+    assert oop.call_method(1, "fdiv", 0) == float("inf")
+    assert oop.call_method(-1, "fdiv", 0) == float("-inf")
+    import math as _math
+
+    assert _math.isnan(oop.call_method(0, "fdiv", 0))
+    # divmod by zero raises a typed ZeroDivisionError.
+    with pytest.raises(SirError):
+        oop.call_method(1, "divmod", 0)
+
+
+def test_numeric_clamp_between() -> None:
+    assert oop.call_method(5, "clamp", 1, 10) == 5
+    assert oop.call_method(-3, "clamp", 1, 10) == 1
+    assert oop.call_method(99, "clamp", 1, 10) == 10
+    assert oop.call_method(5, "between?", 1, 10) is True
+    assert oop.call_method(0, "between?", 1, 10) is False
+    assert oop.call_method(10, "between?", 1, 10) is True
+
+
 def test_numeric_to_s() -> None:
     assert oop.call_method(42, "to_s") == "42"
     assert oop.call_method(3.14, "to_s") == "3.14"

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -729,6 +729,16 @@ def test_numeric_divmod_fdiv() -> None:
     with pytest.raises(SirError):
         oop.call_method(1, "divmod", "x")
     assert oop.call_method(1, "fdiv", "x") == float("inf")
+    # A bignum receiver/arg must saturate to ±inf, not raise an untyped
+    # OverflowError from float(bignum).
+    big = 2**5000
+    assert oop.call_method(big, "fdiv", 2) == float("inf")
+    assert oop.call_method(3, "fdiv", big) == 0.0
+    # Mixed int-receiver / float-divisor divmod on a bignum must not raise an
+    # untyped OverflowError; the receiver saturates to inf, so divmod degrades
+    # to NaN (never-raise floor) rather than crashing.
+    q, r = oop.call_method(big, "divmod", 0.5)
+    assert _math.isnan(q) and _math.isnan(r)
 
 
 def test_numeric_clamp_between() -> None:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -687,6 +687,15 @@ def test_numeric_round_ndigits() -> None:
     assert oop.call_method(1234, "round", -2) == 1200
     assert oop.call_method(1250, "round", -2) == 1300  # half away from zero
     assert oop.call_method(1234.5, "round", -1) == 1230
+    # A rounding place that dwarfs the value is 0 (Ruby parity).
+    assert oop.call_method(1234, "round", -10) == 0
+    assert oop.call_method(1234.5, "round", -10) == 0
+    # DoS guard: a hostile magnitude must short-circuit, not build a bignum.
+    assert oop.call_method(1234, "round", -1_000_000_000) == 0
+    assert oop.call_method(1234.5, "round", -1_000_000_000) == 0
+    # Positive ndigits past Float precision returns the value unchanged (no
+    # 10.0 ** ndigits OverflowError).
+    assert oop.call_method(3.14, "round", 1_000_000) == 3.14
 
 
 def test_numeric_divmod_fdiv() -> None:
@@ -703,6 +712,11 @@ def test_numeric_divmod_fdiv() -> None:
     # divmod by zero raises a typed ZeroDivisionError.
     with pytest.raises(SirError):
         oop.call_method(1, "divmod", 0)
+    # A non-numeric divisor degrades rather than raising an untyped error:
+    # divmod → typed ZeroDivisionError, fdiv → Infinity (0 divisor).
+    with pytest.raises(SirError):
+        oop.call_method(1, "divmod", "x")
+    assert oop.call_method(1, "fdiv", "x") == float("inf")
 
 
 def test_numeric_clamp_between() -> None:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -700,6 +700,10 @@ def test_numeric_round_ndigits() -> None:
     # int(inf)/int(nan) error.
     assert oop.call_method(5, "round", float("inf")) == 5
     assert oop.call_method(5, "round", float("nan")) == 5
+    # A huge integer receiver must round via integer arithmetic (no float
+    # OverflowError from `recv / factor`).
+    assert oop.call_method(10**309, "round", -1) == 10**309
+    assert oop.call_method(5 * 10**400, "round", -3) == 5 * 10**400
 
 
 def test_numeric_divmod_fdiv() -> None:


### PR DESCRIPTION
## Summary

Establishes the **reference** semantics for the N1 numeric-breadth sweep — the Python `sir-runtime-oop` library is the parity reference the embedded backends mirror next. Extends the `Integer`/`Float` catalog (`_numeric_method` + `_NUMERIC_METHODS`) with five Ruby numeric methods:

- **`round(ndigits)`** — `round` gains an optional digits arg: positive `ndigits` rounds a `Float` to N decimals half-away-from-zero (not banker's rounding); `ndigits <= 0` rounds to an `Integer` power of ten; non-finite `Float` unchanged.
- **`divmod(n)`** — `[floored quotient, divisor-signed remainder]`; divide-by-zero raises a typed `ZeroDivisionError`.
- **`fdiv(n)`** — float division that **never raises**: zero divisor yields `Infinity`/`-Infinity`/`NaN` (Ruby parity).
- **`clamp(min, max)`** / **`between?(min, max)`**.

## Never-raise hardening (5 security-review rounds)

The `round`/`divmod`/`fdiv` arithmetic surface is fiddly; the review found and closed several **untyped-`OverflowError`/DoS** edges — all now guarded:

- `round`: a hostile `ndigits` no longer builds a multi-GB bignum (short-circuits to `0` when the place dwarfs the value); non-finite `ndigits` arg rejected; large-integer receivers round via **all-integer** arithmetic (no `recv / factor` float overflow); `int_width` avoids `isfinite()` on huge ints; positive-`ndigits` float scale-up guarded for `inf`.
- `divmod`/`fdiv`: bignum operands (pow permits ~1M-bit ints) **saturate to `±Infinity`** via a new `_sat_float` helper instead of raising; non-numeric args degrade to the typed `ZeroDivisionError` / `Infinity`.

Dispatch stays explicit (`if name == "..."`) — no reflection.

## Testing

- **pytest: 123 pass, 97% coverage**; ruff clean.
- Tests cover: `round(ndigits)` pos/neg/dwarfing/hostile-1e9/non-finite-arg/huge-int/near-max-float; `divmod`/`fdiv` incl. zero, non-numeric, and `2**5000` bignum operands; `clamp`/`between?`.
- Security review: **PASSED** after convergence (no untyped raise, no DoS, no reflection).

Bumps `0.1.16` → `0.1.17`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)