### PR TITLE
feat(sir-go): Numeric divmod/fdiv/round(n)/clamp/between? (v0.25.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.25.0 — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
+
+Mirrors the Python `sir-runtime-oop` v0.1.17 reference into the Go backend's
+emitted runtime (`_sir_numeric_method` + `_sir_numeric_responds`), adding five
+Ruby numeric methods:
+
+- `round(ndigits)` — `round` gains an optional digits argument: a positive
+  `ndigits` rounds a Float to that many decimals (half **away from zero**, via
+  `_sir_ruby_round`); `ndigits <= 0` rounds to a power of ten.  Go's `int64`/
+  `float64` are FIXED width, so the Python bignum→float `OverflowError` pitfall
+  does not apply — the only guards are a place count past int64's ~18 decimal
+  digits (dwarfs the value ⇒ `0`, Ruby parity) and a positive `ndigits` past
+  Float precision / an overflowing scale-up (returns the value unchanged).
+- `divmod(n)` — `[quotient, remainder]` with a floored quotient (`_sir_floor_div`)
+  and the divisor-signed remainder; a zero divisor raises a typed
+  `ZeroDivisionError`.
+- `fdiv(n)` — floating-point division that never panics: a zero divisor yields
+  `±Inf`/`NaN` (Go float division already produces these).
+- `clamp(min, max)` / `between?(min, max)` — compared numerically.
+
+Dispatch stays an explicit `switch` on the interned method name (never
+reflection).  Exec-proven end-to-end via `go run` (the numeric exec-proof test
+now covers `round(2)`/`round(-2)`, `divmod` incl. the divisor-signed remainder,
+`fdiv` incl. the divide-by-zero `Infinity`, and `clamp`/`between?`).
+
 ## 0.24.0 — String char-set methods: `tr` / `count` / `delete` / `squeeze`
 
 Adds four non-block Ruby String methods to the emitted runtime's

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -188,7 +188,8 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 **String** `length`/`size`, `upcase`, `downcase`, `reverse`, `strip`/`lstrip`/
 `rstrip`, `empty?`, `include?`, `start_with?`, `end_with?`, `split`, `chars`,
 `to_i`, `to_f`, `to_sym`; **Numeric** `abs`, `to_i`, `to_f`, `even?`, `odd?`,
-`zero?`, `positive?`, `negative?`, `succ`/`next`, `pred`, `times`; **Symbol**
+`zero?`, `positive?`, `negative?`, `succ`/`next`, `pred`, `round` (with optional
+`ndigits`), `divmod`, `fdiv`, `clamp`, `between?`, `times`; **Symbol**
 `to_s`, `to_sym`, `length`/`size`, `upcase`, `downcase`, `empty?`; **universal**
 `nil?`, `==`, `!=`, `class`, `to_s`, `itself`.
 

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1683,7 +1683,8 @@ func _sir_numeric_responds(name string) bool {
 	// `_sir_numeric_method` switch above).
 	case "abs", "to_i", "to_int", "to_f", "even?", "odd?", "zero?",
 		"positive?", "negative?", "succ", "next", "pred",
-		"floor", "ceil", "round", "gcd", "pow", "**", "digits":
+		"floor", "ceil", "round", "divmod", "fdiv", "clamp", "between?",
+		"gcd", "pow", "**", "digits":
 		return true
 	}
 	return false
@@ -3094,19 +3095,111 @@ func _sir_numeric_method(recv Value, name string, args []Value) (Value, bool) {
 		}
 		return int64(math.Ceil(f)), true
 	case "round":
-		// Ruby `Float#round` (no digits) rounds half AWAY from zero — unlike
-		// Go's `math.Round` which also rounds half away, but we route through
-		// the explicit helper to stay in lockstep with the Python/TS
-		// `_ruby_round` (`2.5.round == 3`, `(-2.5).round == -3`).  An integer
-		// receiver is the identity; a non-finite float degrades to 0.
+		// Ruby `round` / `round(ndigits)` — half AWAY from zero (unlike Go's
+		// `math.Round`, routed through `_sir_ruby_round` to stay in lockstep
+		// with the Python/TS reference: `2.5.round == 3`, `(-2.5).round == -3`).
+		// With no argument (or `ndigits >= 0` on an Integer) the result is an
+		// integer; a positive `ndigits` on a Float rounds to that many decimals;
+		// `ndigits <= 0` rounds to a power of ten.  A non-finite float degrades
+		// to the receiver/0.  Go's int64/float64 are FIXED width (no bignum), so
+		// the only guard needed is against `10^k` overflowing int64: a place
+		// count past int64's ~18 decimal digits dwarfs the value ⇒ 0 (Ruby
+		// `1234.round(-30) == 0`), and a large positive `ndigits` past float
+		// precision returns the value unchanged.
+		ndigits := int64(0)
+		if len(args) > 0 {
+			ndigits = _sir_as_int_trunc(args[0])
+		}
 		if isInt {
-			return _sir_as_int(recv), true
+			iv := _sir_as_int(recv)
+			if ndigits >= 0 {
+				return iv, true
+			}
+			if -ndigits > 18 {
+				return int64(0), true
+			}
+			factor := _sir_pow10(-ndigits)
+			return _sir_round_int_to_multiple(iv, factor), true
 		}
 		f := _sir_as_float(recv)
 		if math.IsNaN(f) || math.IsInf(f, 0) {
 			return int64(0), true
 		}
-		return _sir_ruby_round(f), true
+		if ndigits <= 0 {
+			if -ndigits > 18 {
+				return int64(0), true
+			}
+			factor := _sir_pow10(-ndigits)
+			return _sir_round_int_to_multiple(_sir_ruby_round(f), factor), true
+		}
+		if ndigits > 17 {
+			return f, true // already at full Float precision
+		}
+		scale := math.Pow(10, float64(ndigits))
+		scaled := f * scale
+		if math.IsInf(scaled, 0) {
+			return f, true // overflow guard: no fractional part left to round
+		}
+		return float64(_sir_ruby_round(scaled)) / scale, true
+	case "divmod":
+		// Ruby `divmod(n)` → `[quotient, remainder]` with a FLOORED quotient and
+		// the divisor-signed remainder.  Division by zero raises a typed
+		// `ZeroDivisionError` (so a translated `rescue` matches).  Int/int uses
+		// exact integer math; a float operand promotes to float64 (Go float
+		// division of a nonzero-divided-by-nonzero never panics).
+		if len(args) < 1 {
+			return nil, false
+		}
+		divIsInt := _sir_is_int(args[0])
+		if isInt && divIsInt {
+			d := _sir_as_int(args[0])
+			if d == 0 {
+				panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
+			}
+			n := _sir_as_int(recv)
+			q := _sir_floor_div(n, d)
+			r := n - q*d
+			return &Seq{Items: []Value{q, r}}, true
+		}
+		df := _sir_as_float(args[0])
+		if df == 0 {
+			panic(_sir_new_error("ZeroDivisionError", Value("divided by 0")))
+		}
+		nf := _sir_as_float(recv)
+		q := math.Floor(nf / df)
+		r := nf - q*df
+		return &Seq{Items: []Value{q, r}}, true
+	case "fdiv":
+		// Ruby `fdiv(n)`: floating-point division that NEVER raises — dividing
+		// by zero yields ±Infinity/NaN (Go float division already produces these
+		// rather than panicking), honouring the never-raise floor.
+		if len(args) < 1 {
+			return nil, false
+		}
+		return _sir_as_float(recv) / _sir_as_float(args[0]), true
+	case "clamp":
+		// Ruby `Comparable#clamp(min, max)`: `min` if recv < min, `max` if
+		// recv > max, else recv.  Compared numerically (float view) so mixed
+		// int/float bounds behave; the original receiver value is returned
+		// unchanged when in range.  (The Range form is deferred.)
+		if len(args) < 2 {
+			return nil, false
+		}
+		rv := _sir_as_float(recv)
+		if rv < _sir_as_float(args[0]) {
+			return args[0], true
+		}
+		if rv > _sir_as_float(args[1]) {
+			return args[1], true
+		}
+		return recv, true
+	case "between?":
+		// Ruby `Comparable#between?(min, max)`: `min <= recv <= max`.
+		if len(args) < 2 {
+			return nil, false
+		}
+		rv := _sir_as_float(recv)
+		return rv >= _sir_as_float(args[0]) && rv <= _sir_as_float(args[1]), true
 	case "gcd":
 		// `a.gcd(b)` is the (non-negative) greatest common divisor, via
 		// Euclid on the truncated magnitudes (matching Python `math.gcd` and
@@ -3161,6 +3254,52 @@ func _sir_ruby_round(x float64) int64 {
 		return int64(math.Floor(x + 0.5))
 	}
 	return int64(math.Ceil(x - 0.5))
+}
+
+// _sir_is_int reports whether a runtime Value is an integer (not a float).
+func _sir_is_int(v Value) bool {
+	_, ok := _sir_int_val(v)
+	return ok
+}
+
+// _sir_floor_div is Ruby's integer division: the quotient FLOORED toward −∞
+// (`-7 / 2 == -4`), unlike Go's truncating `/`.  Callers guarantee `b != 0`.
+func _sir_floor_div(a, b int64) int64 {
+	q := a / b
+	if (a%b != 0) && ((a < 0) != (b < 0)) {
+		q--
+	}
+	return q
+}
+
+// _sir_pow10 returns 10**n for a small non-negative n.  Callers bound n ≤ 18
+// (int64 holds ≤ ~9.2e18), so the result never overflows int64.
+func _sir_pow10(n int64) int64 {
+	result := int64(1)
+	for i := int64(0); i < n; i++ {
+		result *= 10
+	}
+	return result
+}
+
+// _sir_round_int_to_multiple rounds `v` to the nearest multiple of `factor`
+// half-AWAY-from-zero using all-integer arithmetic (`Integer#round(-n)` /
+// `Float#round(<=0)` parity).  `factor >= 1`.
+func _sir_round_int_to_multiple(v, factor int64) int64 {
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	q := v / factor
+	rem := v - q*factor
+	if rem*2 >= factor {
+		q++
+	}
+	magnitude := q * factor
+	if neg {
+		return -magnitude
+	}
+	return magnitude
 }
 
 func _sir_gcd(a, b int64) int64 {

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -3284,8 +3284,16 @@ func _sir_pow10(n int64) int64 {
 
 // _sir_round_int_to_multiple rounds `v` to the nearest multiple of `factor`
 // half-AWAY-from-zero using all-integer arithmetic (`Integer#round(-n)` /
-// `Float#round(<=0)` parity).  `factor >= 1`.
+// `Float#round(<=0)` parity).  `factor >= 1`.  Ruby's result is a bignum that
+// may not fit int64; rather than return a two's-complement-wrapped (sign-
+// flipped) garbage value, we DEGRADE to the un-rounded receiver when the
+// rounded multiple would overflow int64 (the closest representable answer),
+// holding the never-surprise floor.  `math.MinInt64` cannot be negated, so it
+// takes the same degrade path.
 func _sir_round_int_to_multiple(v, factor int64) int64 {
+	if v == math.MinInt64 {
+		return v
+	}
 	neg := v < 0
 	if neg {
 		v = -v
@@ -3294,6 +3302,13 @@ func _sir_round_int_to_multiple(v, factor int64) int64 {
 	rem := v - q*factor
 	if rem*2 >= factor {
 		q++
+	}
+	// Guard `q*factor` against int64 overflow (q, factor both non-negative).
+	if factor != 0 && q > math.MaxInt64/factor {
+		if neg {
+			return -v
+		}
+		return v
 	}
 	magnitude := q * factor
 	if neg {

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
@@ -148,6 +148,23 @@ fn catalog_module() -> Module {
         print_stmt(method(flit(3.7), "floor", vec![])),
         print_stmt(method(flit(3.2), "ceil", vec![])),
         print_stmt(method(flit(2.5), "round", vec![])),
+        // Numeric breadth (N1): round(ndigits) / divmod / fdiv / clamp / between?
+        // 3.14159.round(2) → 3.14 ; 1250.round(-2) → 1300 (half away from zero)
+        print_stmt(method(flit(3.14159), "round", vec![ilit(2)])),
+        print_stmt(method(ilit(1250), "round", vec![ilit(-2)])),
+        // 13.divmod(4) → [3, 1] ; 13.divmod(-4) → [-4, -3] (divisor-signed rem)
+        print_stmt(method(ilit(13), "divmod", vec![ilit(4)])),
+        print_stmt(method(ilit(13), "divmod", vec![ilit(-4)])),
+        // 7.fdiv(2) → 3.5 ; 1.fdiv(0) → Infinity (never raises)
+        print_stmt(method(ilit(7), "fdiv", vec![ilit(2)])),
+        print_stmt(method(ilit(1), "fdiv", vec![ilit(0)])),
+        // 5.clamp(1, 10) → 5 ; (-3).clamp(1, 10) → 1 ; 99.clamp(1, 10) → 10
+        print_stmt(method(ilit(5), "clamp", vec![ilit(1), ilit(10)])),
+        print_stmt(method(ilit(-3), "clamp", vec![ilit(1), ilit(10)])),
+        print_stmt(method(ilit(99), "clamp", vec![ilit(1), ilit(10)])),
+        // 5.between?(1, 10) → #t ; 0.between?(1, 10) → #f
+        print_stmt(method(ilit(5), "between?", vec![ilit(1), ilit(10)])),
+        print_stmt(method(ilit(0), "between?", vec![ilit(1), ilit(10)])),
         // 1.upto(3) { |i| print i } → 1,2,3 (three lines).  The block itself
         // prints; the iterator's return value (the receiver) is discarded, so
         // this is a bare ExprStmt, NOT wrapped in another print.
@@ -236,6 +253,17 @@ fn numeric_methods_compile_and_run() {
             "3",         // 3.7.floor
             "4",         // 3.2.ceil
             "3",         // 2.5.round
+            "3.14",      // 3.14159.round(2)
+            "1300",      // 1250.round(-2) — half away from zero
+            "[3, 1]",    // 13.divmod(4)
+            "[-4, -3]",  // 13.divmod(-4) — divisor-signed remainder
+            "3.5",       // 7.fdiv(2)
+            "inf",       // 1.fdiv(0) — never raises
+            "5",         // 5.clamp(1, 10)
+            "1",         // (-3).clamp(1, 10)
+            "10",        // 99.clamp(1, 10)
+            "#t",        // 5.between?(1, 10)
+            "#f",        // 0.between?(1, 10)
             "1", "2", "3", // 1.upto(3)
             "3", "2", "1", // 3.downto(1)
             "0", "2", "4", // 0.step(4, 2)

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_numeric_methods.rs
@@ -165,6 +165,10 @@ fn catalog_module() -> Module {
         // 5.between?(1, 10) → #t ; 0.between?(1, 10) → #f
         print_stmt(method(ilit(5), "between?", vec![ilit(1), ilit(10)])),
         print_stmt(method(ilit(0), "between?", vec![ilit(1), ilit(10)])),
+        // Overflow guard: rounding int64::MAX to a multiple that would overflow
+        // degrades to the un-rounded value (closest int64) instead of wrapping
+        // to a sign-flipped garbage number.
+        print_stmt(method(ilit(9223372036854775807), "round", vec![ilit(-1)])),
         // 1.upto(3) { |i| print i } → 1,2,3 (three lines).  The block itself
         // prints; the iterator's return value (the receiver) is discarded, so
         // this is a bare ExprStmt, NOT wrapped in another print.
@@ -264,6 +268,7 @@ fn numeric_methods_compile_and_run() {
             "10",        // 99.clamp(1, 10)
             "#t",        // 5.between?(1, 10)
             "#f",        // 0.between?(1, 10)
+            "9223372036854775807", // int64::MAX.round(-1) — overflow-degrade to self
             "1", "2", "3", // 1.upto(3)
             "3", "2", "1", // 3.downto(1)
             "0", "2", "4", // 0.step(4, 2)


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.17 **reference** (the N1 numeric-breadth item) into the Go backend's emitted runtime — first backend of the N1 sweep. Adds five Ruby numeric methods to `_sir_numeric_method` + `_sir_numeric_responds`:

- **`round(ndigits)`** — `round` gains an optional digits arg: positive `ndigits` rounds a Float to N decimals half-away-from-zero; `ndigits <= 0` rounds to a power of ten.
- **`divmod(n)`** — `[floored quotient, divisor-signed remainder]` (returned as a `*Seq` so it prints `[3, 1]`); zero divisor → typed `ZeroDivisionError`.
- **`fdiv(n)`** — float division; never panics (zero divisor → `±Inf`/`NaN`).
- **`clamp(min, max)`** / **`between?(min, max)`**.

## Fixed-width simplification + hardening

Go's `int64`/`float64` are **fixed 64-bit**, so the Python bignum→float `OverflowError` pitfall (which took 5 review rounds there) does **not** apply. The guards needed are narrow:
- `round(-n)`: place count > 18 int64 digits ⇒ `0` (Ruby parity); positive `ndigits` past Float precision / overflowing scale-up ⇒ value unchanged.
- **Security-review LOW hardening**: `round(-n)` on `int64::MAX`/`MinInt64` could two's-complement wrap to a sign-flipped garbage number — now degrades to the un-rounded receiver (closest representable int64). (The one remaining note — `divmod` at `MinInt64/-1` — is a genuinely unrepresentable int64 result, an inherent fixed-width limit.)

## Design invariants

- **Explicit `switch` dispatch** — no reflection.
- **Never-panic floor** — only the intended typed `ZeroDivisionError` panics.

## Testing

- **Exec-proof via `go run`**: the numeric test now covers `round(2)`/`round(-2)`, `divmod` (incl. divisor-signed remainder), `fdiv` (incl. divide-by-zero `Infinity`), `clamp`/`between?`, and the `int64::MAX.round(-1)` overflow-degrade. Passes.
- Security review: **no HIGH/MED**; two LOW int64-wrap parity notes (one hardened, one inherent).

New helpers: `_sir_is_int`, `_sir_floor_div`, `_sir_pow10`, `_sir_round_int_to_multiple`. Bumps `0.24.0` → `0.25.0`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)