### PR TITLE
feat(sir-rust): Numeric divmod/fdiv/round(n)/clamp/between? (v0.26.0)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.26.0 — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
+
+Mirrors the Python `sir-runtime-oop` v0.1.17 reference (and the Go backend
+v0.25.0) into the Rust backend's emitted runtime (`numeric_method` +
+`responds_to`), adding five Ruby numeric methods:
+
+- `round(ndigits)` — `round` gains an optional digits argument: a positive
+  `ndigits` rounds a Float to that many decimals (half **away from zero**, via
+  `ruby_round`); `ndigits <= 0` rounds to a power of ten. Rust's `i64`/`f64` are
+  FIXED width, so the Python bignum→float `OverflowError` pitfall does not apply
+  — the only guards are a place count past i64's ~18 decimal digits (dwarfs the
+  value ⇒ `0`, Ruby parity), a positive `ndigits` past Float precision / an
+  overflowing scale-up (returns the value unchanged), and an `i64::MAX`/`MIN`
+  overflow-degrade in `round_int_to_multiple` (returns the un-rounded value
+  rather than a sign-flipped wrap).
+- `divmod(n)` — `[quotient, remainder]` with a floored quotient (`floor_div_i64`)
+  and the divisor-signed remainder (a `Seq`, so it prints `[3, 1]`); a zero
+  divisor raises a typed `ZeroDivisionError`.
+- `fdiv(n)` — floating-point division that never panics: a zero divisor yields
+  `±Inf`/`NaN` (f64 division already produces these).
+- `clamp(min, max)` / `between?(min, max)` — compared numerically.
+
+Dispatch stays an explicit `match` on the interned method name (never
+reflection). Exec-proven end-to-end via `rustc` (the numeric exec-proof test now
+covers `round(2)`/`round(-2)`, `divmod` incl. the divisor-signed remainder,
+`fdiv` incl. the divide-by-zero `Infinity`, `clamp`/`between?`, and the
+`i64::MAX.round(-1)` overflow-degrade). Completes the numeric breadth on the Rust
+backend.
+
 ## 0.25.0 — String justify methods: `ljust` / `rjust` / `center` / `swapcase`
 
 Closes the last String parity gap with the Python/Go/JS/TS runtimes (which

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -149,7 +149,8 @@ rather than panicking:
     sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`
     puts any odd extra pad char on the RIGHT, Ruby's rule).
   - **Numeric** (`Int`/`Float`): `abs`, `to_i`, `to_f`, `even?`, `odd?`,
-    `zero?`, `times`; plus a universal `to_s`.
+    `zero?`, `round` (with optional `ndigits`), `divmod`, `fdiv`, `clamp`,
+    `between?`, `times`; plus a universal `to_s`.
   - Block-taking methods apply the trailing closure via `apply_closure`;
     `sym_to_proc` implements `Symbol#to_proc` (`&:sym`).
   - **Strict vs. lenient reads** — `Array#[]` / `Hash#[]` are lenient (out of

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -2880,8 +2880,13 @@ pub const RUNTIME: &str = r##"mod __sir {
     // Ruby's integer division: the quotient FLOORED toward −∞ (`-7 / 2 == -4`),
     // unlike Rust's truncating `/`.  Callers guarantee `b != 0`.
     fn floor_div_i64(a: i64, b: i64) -> i64 {
+        // `wrapping_rem` (like `wrapping_div`) avoids the `i64::MIN % -1` panic —
+        // plain `%` traps on that case in BOTH debug and release, which would
+        // escape the typed-error floor.  It yields `0` there (the correct
+        // remainder), so the sign-correction branch is skipped and `q` (=
+        // `i64::MIN` from `wrapping_div`) is returned — Ruby parity.
         let q = a.wrapping_div(b);
-        if (a % b != 0) && ((a < 0) != (b < 0)) {
+        if (a.wrapping_rem(b) != 0) && ((a < 0) != (b < 0)) {
             q - 1
         } else {
             q

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -2700,7 +2700,12 @@ pub const RUNTIME: &str = r##"mod __sir {
                             raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
                         }
                         let q = floor_div_i64(*n, *d);
-                        let r = n - q.wrapping_mul(*d);
+                        // `wrapping_sub`/`wrapping_mul`: for `n == i64::MIN` with a
+                        // non-dividing `d`, the FLOORED quotient rounds away from
+                        // zero so the true `q*d` exceeds i64 range; a checked `-`
+                        // would panic in debug.  The true remainder always fits
+                        // in i64, so wrapping recovers it exactly in both profiles.
+                        let r = n.wrapping_sub(q.wrapping_mul(*d));
                         Value::Seq(Rc::new(RefCell::new(vec![Value::Int(q), Value::Int(r)])))
                     }
                     _ => {

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1495,7 +1495,8 @@ pub const RUNTIME: &str = r##"mod __sir {
                     name,
                     "abs" | "to_i" | "to_int" | "to_f" | "even?" | "odd?" | "zero?"
                         | "positive?" | "negative?" | "succ" | "next" | "pred" | "floor"
-                        | "ceil" | "round" | "gcd" | "pow" | "**" | "digits" | "times"
+                        | "ceil" | "round" | "divmod" | "fdiv" | "clamp" | "between?"
+                        | "gcd" | "pow" | "**" | "digits" | "times"
                         | "upto" | "downto" | "step"
                 )
             }
@@ -2644,11 +2645,104 @@ pub const RUNTIME: &str = r##"mod __sir {
                 Value::Float(x) if x.is_finite() => Value::Int(x.ceil() as i64),
                 _ => Value::Int(0),
             },
-            "round" => match &recv {
-                Value::Int(_) => recv,
-                Value::Float(x) if x.is_finite() => Value::Int(ruby_round(*x)),
-                _ => Value::Int(0),
-            },
+            // `round` / `round(ndigits)` — half AWAY from zero (via `ruby_round`,
+            // matching the Python/Go reference: `2.5.round == 3`).  A positive
+            // `ndigits` on a Float rounds to that many decimals; `ndigits <= 0`
+            // rounds to a power of ten.  Rust's i64/f64 are FIXED width (no
+            // bignum), so the only guards are a place count past i64's ~18
+            // decimal digits (dwarfs the value ⇒ 0, Ruby parity) and a positive
+            // `ndigits` past Float precision / an overflowing scale-up (returns
+            // the value unchanged).
+            "round" => {
+                let ndigits = pos.first().map(as_i64_lenient).unwrap_or(0);
+                match &recv {
+                    Value::Int(iv) => {
+                        if ndigits >= 0 {
+                            recv
+                        } else if -ndigits > 18 {
+                            Value::Int(0)
+                        } else {
+                            Value::Int(round_int_to_multiple(*iv, pow10(-ndigits)))
+                        }
+                    }
+                    Value::Float(x) if x.is_finite() => {
+                        if ndigits <= 0 {
+                            if -ndigits > 18 {
+                                Value::Int(0)
+                            } else {
+                                Value::Int(round_int_to_multiple(ruby_round(*x), pow10(-ndigits)))
+                            }
+                        } else if ndigits > 17 {
+                            recv // already at full Float precision
+                        } else {
+                            let scale = 10f64.powi(ndigits as i32);
+                            let scaled = *x * scale;
+                            if scaled.is_finite() {
+                                Value::Float(ruby_round(scaled) as f64 / scale)
+                            } else {
+                                recv // overflow guard: no fractional part left
+                            }
+                        }
+                    }
+                    _ => Value::Int(0),
+                }
+            }
+            // `divmod(n)` → `[quotient, remainder]` with a FLOORED quotient and
+            // the divisor-signed remainder.  Division by zero raises a typed
+            // `ZeroDivisionError`.  Int/int uses exact integer math; a Float
+            // operand promotes to f64 (f64 division of nonzero/nonzero never
+            // panics).
+            "divmod" => {
+                let arg = pos.first().cloned().unwrap_or(Value::Int(0));
+                match (&recv, &arg) {
+                    (Value::Int(n), Value::Int(d)) => {
+                        if *d == 0 {
+                            raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
+                        }
+                        let q = floor_div_i64(*n, *d);
+                        let r = n - q.wrapping_mul(*d);
+                        Value::Seq(Rc::new(RefCell::new(vec![Value::Int(q), Value::Int(r)])))
+                    }
+                    _ => {
+                        let df = as_f64_lenient(&arg);
+                        if df == 0.0 {
+                            raise("ZeroDivisionError", Value::Str(Rc::from("divided by 0")));
+                        }
+                        let nf = as_f64_lenient(&recv);
+                        let q = (nf / df).floor();
+                        let r = nf - q * df;
+                        Value::Seq(Rc::new(RefCell::new(vec![Value::Float(q), Value::Float(r)])))
+                    }
+                }
+            }
+            // `fdiv(n)` — floating-point division that NEVER raises: dividing by
+            // zero yields `±Infinity`/`NaN` (f64 division already produces these
+            // rather than panicking), honouring the never-raise floor.
+            "fdiv" => {
+                let arg = pos.first().cloned().unwrap_or(Value::Int(0));
+                Value::Float(as_f64_lenient(&recv) / as_f64_lenient(&arg))
+            }
+            // `clamp(min, max)` — `min` if recv < min, `max` if recv > max, else
+            // recv.  Compared numerically (Range form deferred).
+            "clamp" => {
+                let lo = pos.first().cloned().unwrap_or(Value::Int(0));
+                let hi = pos.get(1).cloned().unwrap_or(Value::Int(0));
+                let rv = as_f64_lenient(&recv);
+                if rv < as_f64_lenient(&lo) {
+                    lo
+                } else if rv > as_f64_lenient(&hi) {
+                    hi
+                } else {
+                    recv
+                }
+            }
+            // `between?(min, max)` — `min <= recv <= max`.
+            "between?" => {
+                let lo = pos.first().map(|v| as_f64_lenient(v)).unwrap_or(0.0);
+                let hi = pos.get(1).map(|v| as_f64_lenient(v)).unwrap_or(0.0);
+                let rv = as_f64_lenient(&recv);
+                Value::Bool(rv >= lo && rv <= hi)
+            }
             // `gcd(other)` — the integer greatest common divisor, always
             // non-negative (Ruby: `(-12).gcd(8) == 4`).  Both receiver and
             // argument are truncated to i64 via the lenient coercion.
@@ -2780,6 +2874,60 @@ pub const RUNTIME: &str = r##"mod __sir {
             (x + 0.5).floor() as i64
         } else {
             (x - 0.5).ceil() as i64
+        }
+    }
+
+    // Ruby's integer division: the quotient FLOORED toward −∞ (`-7 / 2 == -4`),
+    // unlike Rust's truncating `/`.  Callers guarantee `b != 0`.
+    fn floor_div_i64(a: i64, b: i64) -> i64 {
+        let q = a.wrapping_div(b);
+        if (a % b != 0) && ((a < 0) != (b < 0)) {
+            q - 1
+        } else {
+            q
+        }
+    }
+
+    // `10.pow(n)` for a small non-negative `n`.  Callers bound `n <= 18` (an i64
+    // holds ≤ ~9.2e18), so the result never overflows i64.
+    fn pow10(n: i64) -> i64 {
+        let mut result = 1i64;
+        let mut i = 0;
+        while i < n {
+            result = result.saturating_mul(10);
+            i += 1;
+        }
+        result
+    }
+
+    // Round `v` to the nearest multiple of `factor` (>= 1) half-AWAY-from-zero
+    // with ALL-INTEGER arithmetic (`Integer#round(-n)` / `Float#round(<=0)`
+    // parity).  Ruby's result is a bignum that may not fit i64; rather than
+    // return a two's-complement-wrapped (sign-flipped) garbage value, we DEGRADE
+    // to the un-rounded value when the rounded multiple would overflow i64 (the
+    // closest representable answer).  `i64::MIN` cannot be negated, so it takes
+    // the same degrade path.
+    fn round_int_to_multiple(v: i64, factor: i64) -> i64 {
+        if v == i64::MIN {
+            return v;
+        }
+        let neg = v < 0;
+        let mag = v.unsigned_abs();
+        let f = factor as u64;
+        let mut q = mag / f;
+        let rem = mag - q * f;
+        if rem.saturating_mul(2) >= f {
+            q += 1;
+        }
+        // Guard `q * factor` against i64 overflow.
+        if q > (i64::MAX as u64) / f {
+            return v; // rounded multiple overflows ⇒ degrade to the value
+        }
+        let magnitude = (q * f) as i64;
+        if neg {
+            -magnitude
+        } else {
+            magnitude
         }
     }
 

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
@@ -112,6 +112,9 @@ fn numeric_demo() -> Module {
         // both debug and release); wrapping_rem yields 0 so the quotient wraps
         // to i64::MIN and the remainder is 0.
         print_stmt(method(ilit(i64::MIN), "divmod", vec![ilit(-1)])),
+        // i64::MIN.divmod(3): the floored quotient makes the true q*d exceed i64
+        // range, so the remainder reconstruction must wrap (not a checked `-`).
+        print_stmt(method(ilit(i64::MIN), "divmod", vec![ilit(3)])),
     ];
 
     Module {
@@ -239,6 +242,7 @@ fn numeric_methods_compile_and_run() {
             "#f",        // 0.between?(1, 10)
             "9223372036854775807", // i64::MAX.round(-1) — overflow-degrade to self
             "[-9223372036854775808, 0]", // i64::MIN.divmod(-1) — no panic (wrapping_rem)
+            "[-3074457345618258603, 1]", // i64::MIN.divmod(3) — no panic (wrapping_sub)
         ],
         "unexpected program output; full stdout:\n{stdout}"
     );

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
@@ -108,6 +108,10 @@ fn numeric_demo() -> Module {
         print_stmt(method(ilit(0), "between?", vec![ilit(1), ilit(10)])), // #f
         // overflow-degrade: i64::MAX.round(-1) returns self, not a wrapped garbage value.
         print_stmt(method(ilit(9223372036854775807), "round", vec![ilit(-1)])),
+        // i64::MIN.divmod(-1) must NOT panic (plain `%` traps on MIN % -1 in
+        // both debug and release); wrapping_rem yields 0 so the quotient wraps
+        // to i64::MIN and the remainder is 0.
+        print_stmt(method(ilit(i64::MIN), "divmod", vec![ilit(-1)])),
     ];
 
     Module {
@@ -234,6 +238,7 @@ fn numeric_methods_compile_and_run() {
             "#t",        // 5.between?(1, 10)
             "#f",        // 0.between?(1, 10)
             "9223372036854775807", // i64::MAX.round(-1) — overflow-degrade to self
+            "[-9223372036854775808, 0]", // i64::MIN.divmod(-1) — no panic (wrapping_rem)
         ],
         "unexpected program output; full stdout:\n{stdout}"
     );

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_numeric_methods.rs
@@ -94,6 +94,20 @@ fn numeric_demo() -> Module {
         print_stmt(method(ilit(2), "pow", vec![ilit(10)])),  // 1024
         print_stmt(method(ilit(2), "**", vec![ilit(8)])),    // 256
         print_stmt(method(ilit(123), "digits", vec![])),     // [3, 2, 1]
+        // numeric breadth (N1) ----------------------------------------
+        print_stmt(method(flit(3.14159), "round", vec![ilit(2)])), // 3.14
+        print_stmt(method(ilit(1250), "round", vec![ilit(-2)])),   // 1300 (half away)
+        print_stmt(method(ilit(13), "divmod", vec![ilit(4)])),     // [3, 1]
+        print_stmt(method(ilit(13), "divmod", vec![ilit(-4)])),    // [-4, -3]
+        print_stmt(method(ilit(7), "fdiv", vec![ilit(2)])),        // 3.5
+        print_stmt(method(ilit(1), "fdiv", vec![ilit(0)])),        // inf (never raises)
+        print_stmt(method(ilit(5), "clamp", vec![ilit(1), ilit(10)])),   // 5
+        print_stmt(method(ilit(-3), "clamp", vec![ilit(1), ilit(10)])),  // 1
+        print_stmt(method(ilit(99), "clamp", vec![ilit(1), ilit(10)])),  // 10
+        print_stmt(method(ilit(5), "between?", vec![ilit(1), ilit(10)])), // #t
+        print_stmt(method(ilit(0), "between?", vec![ilit(1), ilit(10)])), // #f
+        // overflow-degrade: i64::MAX.round(-1) returns self, not a wrapped garbage value.
+        print_stmt(method(ilit(9223372036854775807), "round", vec![ilit(-1)])),
     ];
 
     Module {
@@ -208,6 +222,18 @@ fn numeric_methods_compile_and_run() {
             "1024",      // 2.pow(10)
             "256",       // 2 ** 8
             "[3, 2, 1]", // 123.digits
+            "3.14",      // 3.14159.round(2)
+            "1300",      // 1250.round(-2) — half away from zero
+            "[3, 1]",    // 13.divmod(4)
+            "[-4, -3]",  // 13.divmod(-4) — divisor-signed remainder
+            "3.5",       // 7.fdiv(2)
+            "inf",       // 1.fdiv(0) — never raises
+            "5",         // 5.clamp(1, 10)
+            "1",         // (-3).clamp(1, 10)
+            "10",        // 99.clamp(1, 10)
+            "#t",        // 5.between?(1, 10)
+            "#f",        // 0.between?(1, 10)
+            "9223372036854775807", // i64::MAX.round(-1) — overflow-degrade to self
         ],
         "unexpected program output; full stdout:\n{stdout}"
     );


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.17 **reference** (and Go backend #7885) into the Rust backend's emitted runtime — second backend of the N1 numeric-breadth sweep. Adds five Ruby numeric methods to `numeric_method` + `responds_to`:

- **`round(ndigits)`** — optional digits arg: positive `ndigits` rounds a Float to N decimals half-away-from-zero; `ndigits <= 0` rounds to a power of ten.
- **`divmod(n)`** — `[floored quotient, divisor-signed remainder]` as a `Seq` (prints `[3, 1]`); zero divisor → typed `ZeroDivisionError`.
- **`fdiv(n)`** — f64 division; never panics (zero divisor → `±Inf`/`NaN`).
- **`clamp(min, max)`** / **`between?(min, max)`**.

Rust's `i64`/`f64` are **fixed width**, so the Python bignum→float `OverflowError` pitfall does not apply.

## Security-review hardening (never-panic floor)

The `divmod` integer path took **three review rounds** to fully harden against the `i64::MIN` panic class — Rust integer division/remainder **trap unconditionally** on `i64::MIN op -1`, and checked `+`/`-`/`*` trap in **debug** (which `cargo test` uses):

- `round(-n)`: place count > 18 i64 digits ⇒ `0`; `round_int_to_multiple` degrades an `i64::MAX/MIN` overflow to the un-rounded value (no sign-flip wrap).
- **HIGH fixed**: `floor_div_i64` used a plain `a % b` → panics on `i64::MIN % -1` (both profiles). Now `a.wrapping_rem(b)`.
- **residual fixed**: `n - q.wrapping_mul(d)` used a checked `-` → panics in debug for `i64::MIN.divmod(3)` (floored quotient makes true `q*d` exceed i64 range). Now `n.wrapping_sub(...)`.

Final review: **PASSED** — divmod/`floor_div_i64` is now panic-free for all `(n, d)` with `d != 0`.

## Testing

- **Exec-proof via `rustc`** (`SIR_TEST_RUSTC_LINKER=rust-lld`): the numeric test now covers `round(2)`/`round(-2)`, `divmod` (incl. divisor-signed remainder), `fdiv` (incl. divide-by-zero `Infinity`), `clamp`/`between?`, `i64::MAX.round(-1)` overflow-degrade, and both `i64::MIN.divmod(-1)`/`i64::MIN.divmod(3)` no-panic cases. Passes.

New helpers: `floor_div_i64`, `pow10`, `round_int_to_multiple`. Explicit `match` dispatch — no reflection. Bumps `0.25.0` → `0.26.0`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)