### PR TITLE
feat(latex): LTXDOC03 S33 duplicate_bibliography_count ("multiply defined" \bibitem total)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.69.0] — 2026-07-10
+
+### Added — single-integer TOTAL of the duplicate ("multiply defined") `\bibitem`s (LTXDOC03 S33)
+
+A **new** public method `Document::duplicate_bibliography_count(&self) -> String` that renders the decimal
+**COUNT** of the duplicate (later, losing) `\bibitem`s — the `\bibitem`s of already-defined keys, which
+LaTeX flags with *"Citation `key' multiply defined"* — as one integer line. It is the *count-total*
+companion of S16's `duplicate_bibliography_entries` (which renders one `\bibitem{key}` warning line per
+losing duplicate): S16 and S33 are two *views* of the one `duplicate_entries` list `resolve_citations()`
+produces — S33 collapses the whole list to a single `.len()` tally. It is the **warning-side companion**
+of the resolved (S30/S31) and unresolved (S32) citation totals, completing the *totals family* over the
+citation tables. S30 counts the winning `entries` and S33 the losing `duplicate_entries`; together they
+**partition** every `\bibitem` inside a `thebibliography` — `bibliography_entry_count +
+duplicate_bibliography_count` equals the total number of `\bibitem`s, because `resolve_citations()` routes
+each `\bibitem` into exactly one of `entries`/`duplicate_entries`. It reads only
+`resolve_citations().duplicate_entries.len()` — the winning first `\bibitem` of a key lives in `entries`
+(S19/S30's domain) and is excluded by construction — never a `key`/`span`, no source slicing at all, so
+every losing `\bibitem` folds into one total. We do **not** de-duplicate: a key defined *three* times
+contributes *two* losing duplicates, exactly the two warning lines S16 emits. Being a COUNT renderer, its
+empty case (no bibliography, or every key defined exactly once) is the honest number `"0"` — **not** a
+`(no duplicate bibliography entries)` marker (that discipline belongs to the *list* renderer S16; this
+mirrors S27/S28/S29/S30/S31/S32). One line, no trailing newline. E.g. `\bibitem{smith}` twice +
+`\bibitem{jones}` once → `1`. It is a read-only view over `resolve_citations()`; every S1–S32 output is
+left **byte-for-byte unchanged**; S33 is purely additive and leaves the `to_latex()` round-trip fixed
+point intact. Total & panic-free.
+
+---
+
 ## [0.68.0] — 2026-07-09
 
 ### Added — single-integer TOTAL of the unresolved (dangling) citations (LTXDOC03 S32)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.68.0"
+version = "0.69.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -80,6 +80,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S30 — single-integer total of the bibliography entries** | `Document::bibliography_entry_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the winning bibliography entries — the distinct `\bibitem` keys the document defines inside a `thebibliography` environment — as one integer line. It is the **count-total companion of S19's** `bibliography_entries` (which renders one `[n] key` *line per winning entry*, 1-based in source order): S19 and S30 are two views of the one winning `entries` list; S30 collapses the whole list to a single `.len()` tally. It is the exact **citation-side analogue of S29's** `label_definition_count`, completing the *totals family* — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, and S30 counts the bibliography entries. It reads only `resolve_citations().entries.len()` (a later duplicate `\bibitem{dup}` lives in `duplicate_entries`, S16's domain, and is excluded by construction — the count is exactly the number of lines S19 lists) — no source slicing at all. Being a COUNT renderer, its empty case (no `\bibitem` at all) is the honest number `"0"` — **not** a `(no bibliography entries)` marker (that discipline belongs to the *list* renderer S19; this mirrors S27/S28/S29). One line, no trailing newline. E.g. `a` + `b` + `c` + a re-used `a` (duplicate) → `3`. Every S1–S29 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S31 — single-integer total of the resolved citations** | `Document::citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\cite` keys — the ones some `\bibitem` defines — as one integer line. It is the **count-total companion of S15's** `citations_by_source` (which renders the resolved keys *grouped by their source `\cite`*): S15 and S31 are two views of the one `resolved` list; S31 collapses the whole list to a single `.len()` tally. It is the exact resolved-**citation-side twin of S28's** `resolved_reference_count`, extending the *totals family* onto the resolved-citation table — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, S30 counts the bibliography entries, and S31 counts the resolved citations. It reads only `resolve_citations().resolved.len()` (a dangling `\cite{ghost}` lives in `unresolved`, S17's domain, and is excluded by construction) — never a `cite_span`/`entry_span`, no source slicing at all, so every resolved key folds into one total. Being a COUNT renderer, its empty case (every cited key dangling, or none at all) is the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to the *list* renderer S15; this mirrors S27/S28/S29/S30). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `3`. Every S1–S30 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S32 — single-integer total of the unresolved (dangling) citations** | `Document::unresolved_citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\cite` keys — the ones **no** `\bibitem` defines — as one integer line. It is the **count-total companion of S17's** `unresolved_citations_by_source` (which renders the dangling keys *grouped by their source `\cite`*): S17 and S32 are two views of the one `unresolved` list; S32 collapses the whole list to a single `.len()` tally. It is the exact unresolved-**citation-side twin of S27's** `unresolved_reference_count`, and the **dangling sibling of S31's** resolved `citation_count`. Together S31 and S32 **partition** every per-key `\cite` record — `citation_count + unresolved_citation_count` equals the number of cited keys, because `resolve_citations()` routes each key into exactly one of `resolved`/`unresolved`. It reads only `resolve_citations().unresolved.len()` (a resolved `\cite{a}` lives in `resolved`, S15/S31's domain, and is excluded by construction) — never a `cite_span`/dangling `key`, no source slicing at all, so every dangling key folds into one total. Being a COUNT renderer, its empty case (every cited key resolving, or none at all) is the honest number `"0"` — **not** a `(no unresolved citations)` marker (that discipline belongs to the *list* renderer S17; this mirrors S27/S28/S29/S30/S31). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `1`. Every S1–S31 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S33 — single-integer total of the duplicate ("multiply defined") `\bibitem`s** | `Document::duplicate_bibliography_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the DUPLICATE (later, losing) `\bibitem`s — the ones of already-defined keys, which LaTeX flags *"Citation `key' multiply defined"* — as one integer line. It is the **count-total companion of S16's** `duplicate_bibliography_entries` (which renders one `\bibitem{key}` *warning line per losing duplicate*): S16 and S33 are two views of the one `duplicate_entries` list; S33 collapses the whole list to a single `.len()` tally. It is the **warning-side companion** of the resolved (S30/S31) and unresolved (S32) citation totals, completing the *totals family* over the citation tables. S30 counts the winning `entries` and S33 the losing `duplicate_entries` — together they **partition** every `\bibitem` inside a `thebibliography`: `bibliography_entry_count + duplicate_bibliography_count` equals the number of `\bibitem`s, because `resolve_citations()` routes each `\bibitem` into exactly one of `entries`/`duplicate_entries`. It reads only `resolve_citations().duplicate_entries.len()` (the winning first `\bibitem` of a key lives in `entries`, S19/S30's domain, and is excluded by construction) — never a `key`/`span`, no source slicing at all, so every losing `\bibitem` folds into one total (not de-duplicated: a key defined *three* times contributes *two* losing duplicates, exactly the two S16 warning lines). Being a COUNT renderer, its empty case (no bibliography, or every key defined exactly once) is the honest number `"0"` — **not** a `(no duplicate bibliography entries)` marker (that discipline belongs to the *list* renderer S16; this mirrors S27/S28/S29/S30/S31/S32). One line, no trailing newline. E.g. `\bibitem{smith}` twice + `\bibitem{jones}` once → `1`. Every S1–S32 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1266,6 +1267,42 @@ all) renders the honest number `"0"` — **not** a `(no unresolved citations)` m
 to the *list* renderer S17, whose empty case has no lines to show; this mirrors S27/S28/S29/S30/S31). Purely
 additive — reuses `resolve_citations`, mutates nothing, leaves every S1–S31 output and the `to_latex()` fixed
 point unchanged.
+
+### single-integer total of the duplicate ("multiply defined") `\bibitem`s (LTXDOC03 S33)
+
+The decimal **COUNT** of the duplicate (later, losing) `\bibitem`s — the ones of already-defined keys, which
+LaTeX flags *"Citation `key' multiply defined"* — as one integer line. It is the **count-total companion of
+S16's** `duplicate_bibliography_entries` (which renders one `\bibitem{key}` *warning line per losing
+duplicate*): S16 and S33 are two *views* of the one `duplicate_entries` list `resolve_citations()` produces;
+S33 collapses the whole list to a single `.len()` tally. It is the **warning-side companion** of the
+resolved (S30/S31) and unresolved (S32) citation totals, completing the *totals family* over the citation
+tables. S30 counts the winning `entries` and S33 the losing `duplicate_entries` — together they **partition**
+every `\bibitem` inside a `thebibliography`: `bibliography_entry_count + duplicate_bibliography_count` is
+exactly the number of `\bibitem`s, because `resolve_citations()` routes each `\bibitem` into exactly one of
+`entries`/`duplicate_entries`. `duplicate_bibliography_count` reads only
+`resolve_citations().duplicate_entries.len()` — the winning first `\bibitem` of a key lives in `entries`
+(S19/S30's domain) and is excluded by construction — never a `key`/`span`, no source slicing at all, so every
+losing `\bibitem` folds into one total (not de-duplicated: a key defined *three* times contributes *two*
+losing duplicates, exactly the two S16 warning lines).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{smith} First Smith.\bibitem{jones} Jones.\bibitem{smith} Second Smith.\end{thebibliography}\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.duplicate_bibliography_count(),
+    // one `\bibitem` loses (the second `smith`); the winning first `smith` and lone `jones` are excluded
+    "1",
+);
+```
+
+Being a COUNT renderer, a document with no duplicate `\bibitem`s at all (no bibliography, or every key
+defined exactly once) renders the honest number `"0"` — **not** a `(no duplicate bibliography entries)`
+marker (that discipline belongs to the *list* renderer S16, whose empty case has no lines to show; this
+mirrors S27/S28/S29/S30/S31/S32). Purely additive — reuses `resolve_citations`, mutates nothing, leaves every
+S1–S32 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -3134,6 +3134,93 @@ impl Document {
         // a single total, the unresolved-citation-side twin of S27's unresolved-reference count.
         self.resolve_citations().unresolved.len().to_string()
     }
+
+    /// The **single-integer TOTAL of the duplicate ("multiply defined") `\bibitem`s** (LTXDOC03 S33) —
+    /// the count of the *later, losing* `\bibitem`s of already-defined keys, the **warning-side**
+    /// companion of the resolved (S30/S31) and unresolved (S32) citation totals.
+    ///
+    /// This extends the *totals family* onto the last citation-family table it had not yet summarized.
+    /// S30's [`bibliography_entry_count`](Document::bibliography_entry_count) counts the *winning*
+    /// bibliography entries, S31's [`citation_count`](Document::citation_count) the *resolved* `\cite`
+    /// keys, and S32's [`unresolved_citation_count`](Document::unresolved_citation_count) the *dangling*
+    /// ones; S33 counts the *duplicate* `\bibitem`s — the `\bibitem`s LaTeX would flag with
+    /// *"Citation `key' multiply defined"*. It is to S16's
+    /// [`duplicate_bibliography_entries`](Document::duplicate_bibliography_entries) exactly what S30 is to
+    /// S19's `bibliography_entries`: a numeric summary over the *same* list — here the **losing**
+    /// duplicate `\bibitem`s — so a reader sees "how many `\bibitem`s are multiply defined" without
+    /// scanning the individual warning lines.
+    ///
+    /// ## What it does
+    ///
+    /// S2's [`Document::resolve_citations`] collects every `\bibitem{key}` inside a `thebibliography` in
+    /// [`Document::walk`] pre-order. The **first** `\bibitem` of each key wins (it becomes a row in
+    /// [`CitationResolution::entries`], S19/S30's domain); every **later** `\bibitem` of an
+    /// already-defined key is a *losing* duplicate, routed to
+    /// [`CitationResolution::duplicate_entries`] (S16's domain). S16 renders that list as one
+    /// `\bibitem{key}` warning line per losing duplicate; S33 collapses the whole list to a **single
+    /// count line** — the decimal `.len()` of `duplicate_entries`. It reads only the length, never a
+    /// `key` or a `span`, so every losing `\bibitem` — regardless of key — folds into one total. Only the
+    /// **losing** `\bibitem`s are counted; the winning first `\bibitem` of a key lives in `entries`
+    /// (S19/S30), never in `duplicate_entries`, so it is excluded by construction. We do **not**
+    /// de-duplicate: a key defined *three* times contributes *two* losing duplicates (one per
+    /// *"multiply defined"* warning LaTeX would raise), exactly the two `\bibitem{key}` lines S16 emits.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`CitationResolution::duplicate_entries`] and render it as its decimal
+    /// `String`, **always** on a single line with **no** trailing newline. This is a **count** renderer,
+    /// so its honest value when there are no duplicate `\bibitem`s is the number `0` — the string `"0"`,
+    /// **not** a `(no duplicate bibliography entries)` marker (a total count of zero *is* a number; the
+    /// `(no …)` marker discipline belongs to the *list* renderer S16, whose empty case has no lines to
+    /// show). This mirrors S27/S28/S29/S30/S31/S32 exactly, which emit `"0"` for their empty lists. There
+    /// is no source slicing — only `.len()` is taken.
+    ///
+    /// Concretely, for a `thebibliography` that defines `smith` twice and `jones` once:
+    ///
+    /// ```text
+    /// \begin{thebibliography}{9}
+    /// \bibitem{smith} First Smith. 1990.
+    /// \bibitem{jones} Jones. 1991.
+    /// \bibitem{smith} Second Smith. 1992.
+    /// \end{thebibliography}
+    /// ```
+    ///
+    /// only the *second* `\bibitem{smith}` loses, so S33 reports:
+    ///
+    /// ```text
+    /// 1
+    /// ```
+    ///
+    /// (one losing duplicate — the second `\bibitem{smith}`; the winning first `\bibitem{smith}` and the
+    /// lone `\bibitem{jones}` are in `entries`, the "2" S30 reports). A document with **no** duplicate
+    /// `\bibitem`s — no bibliography, or every key defined exactly once — returns `"0"`.
+    ///
+    /// **Partition note.** S30 counts `entries` (one per distinct key, the winners) and S33 counts
+    /// `duplicate_entries` (the losers); together they **partition** every `\bibitem` inside a
+    /// `thebibliography` — `bibliography_entry_count + duplicate_bibliography_count` is exactly the number
+    /// of `\bibitem`s, because [`Document::resolve_citations`] routes each `\bibitem` into exactly one of
+    /// `entries` or `duplicate_entries`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S33 is a brand-new, read-only method that reuses [`resolve_citations`](Document::resolve_citations)
+    /// and mutates nothing; it changes no S1–S32 output (they are byte-for-byte unchanged) and leaves the
+    /// `to_latex` round-trip fixed point intact. It is a *second view* of the same `duplicate_entries`
+    /// list S16 renders per-source — counting never adds, drops, or reorders the duplicate `\bibitem`s
+    /// relative to what `resolve_citations` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read); a single read of the already-bounded `duplicate_entries` list's length.
+    /// Borrows `self` immutably and returns owned `String` data, so the result outlives any borrow of the
+    /// source.
+    pub fn duplicate_bibliography_count(&self) -> String {
+        // S2 already routed every later `\bibitem` of an already-defined key into `duplicate_entries`,
+        // in body pre-order (first-entry-wins; the winning first `\bibitem`s went to `entries`, S19/S30).
+        // We only read that list's length. No `key`/`span` is read — every losing `\bibitem` folds into a
+        // single total, the "multiply defined" warning-side companion of S30/S31/S32 and the numeric
+        // summary of S16's per-source duplicate list.
+        self.resolve_citations().duplicate_entries.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -7824,5 +7911,145 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         // And S32 itself: exactly ONE citation key dangles (`ghost`); the three resolved keys `a`, `b`,
         // `c` are in `resolved` (S15/S31), not counted here.
         assert_eq!(doc.unresolved_citation_count(), "1");
+    }
+
+    // LTXDOC03 S33 — single-integer TOTAL of the duplicate ("multiply defined") `\bibitem`s
+    // (`duplicate_bibliography_count`). The warning-side companion of S30/S31/S32: one decimal line =
+    // `.len()` of the SAME losing-duplicate `\bibitem` list S16's `duplicate_bibliography_entries`
+    // renders as one `\bibitem{key}` warning line each. S30 counts the winning `entries` and S33 the
+    // losing `duplicate_entries` — together they PARTITION every `\bibitem` inside a `thebibliography`
+    // (each `\bibitem` routes to exactly one of `entries`/`duplicate_entries`). Being a COUNT renderer,
+    // its empty value is the honest number "0", NOT a `(no …)` marker. The winning first `\bibitem` of a
+    // key is in `entries` (S19/S30), never `duplicate_entries`, so it is excluded.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s33_multiple_duplicate_bibitems_count_the_integer() {
+        // `\bibitem{a}` defined three times and `\bibitem{b}` twice → the 2nd and 3rd `a` lose (two)
+        // and the 2nd `b` loses (one) → three losing duplicates, so the count is exactly "3".
+        let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{a} First A.\bibitem{b} First B.\bibitem{a} Second A.\bibitem{a} Third A.\bibitem{b} Second B.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_count(), "3");
+    }
+
+    #[test]
+    fn s33_no_duplicates_all_distinct_counts_zero() {
+        // Every `\bibitem` key is distinct → no duplicate wins → "0" (the count of an empty
+        // `duplicate_entries` list). A COUNT renderer's honest value for an empty list is "0".
+        let src = r"\begin{document}\begin{thebibliography}{9}\bibitem{a} A.\bibitem{b} B.\bibitem{c} C.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_count(), "0");
+        // And S16 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(
+            doc.duplicate_bibliography_entries(),
+            "(no duplicate bibliography entries)"
+        );
+    }
+
+    #[test]
+    fn s33_no_bibitems_at_all_counts_zero() {
+        // A document with NO `\bibitem` at all → "0", the same honest-zero as the "all distinct" case.
+        let src = r"\begin{document}Just some text with no bibliography.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_count(), "0");
+    }
+
+    #[test]
+    fn s33_one_duplicate_counts_one() {
+        // A single key `\bibitem{smith}` defined twice → only the SECOND loses → "1".
+        let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{smith} First Smith.\bibitem{jones} Jones.\bibitem{smith} Second Smith.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_count(), "1");
+        // The count MUST equal the number of warning lines S16 lists (two views of the SAME list).
+        assert_eq!(
+            doc.duplicate_bibliography_count(),
+            doc.duplicate_bibliography_entries().lines().count().to_string()
+        );
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{smith}");
+    }
+
+    #[test]
+    fn s33_partitions_with_s30_over_the_bibitems() {
+        // `a` twice, `b` once, `c` twice → winners are the three distinct keys (S30 = "3"); losers are
+        // the 2nd `a` and 2nd `c` (S33 = "2"). Together they partition all FIVE `\bibitem`s — proving
+        // each `\bibitem` routes to exactly one of `entries`/`duplicate_entries`. Also cross-checked
+        // against the number of warning lines S16 emits.
+        let src = r"\begin{document}\begin{thebibliography}{9}
+\bibitem{a} A1.\bibitem{b} B.\bibitem{a} A2.\bibitem{c} C1.\bibitem{c} C2.\end{thebibliography}\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_bibliography_count(), "2");
+        // S30 winners — unchanged by S33.
+        assert_eq!(doc.bibliography_entry_count(), "3");
+        // S33 == number of S16 warning lines (two views of the SAME `duplicate_entries` list).
+        assert_eq!(
+            doc.duplicate_bibliography_count(),
+            doc.duplicate_bibliography_entries().lines().count().to_string()
+        );
+        // Winners + losers partition all five `\bibitem`s.
+        let winners: usize = doc.bibliography_entry_count().parse().unwrap();
+        let losers: usize = doc.duplicate_bibliography_count().parse().unwrap();
+        assert_eq!(winners + losers, 5);
+    }
+
+    #[test]
+    fn s33_is_additive_leaves_s1_s32_outputs_unchanged() {
+        // Same representative doc as the S32 additive test. S33 changes NONE of the S1-S32 outputs — it
+        // only reads `resolve_citations`. Its count is a second view of the SAME `duplicate_entries` list
+        // S16 renders per-source; pinned here alongside S16/S19/S22/S27/S28/S29/S30/S31/S32 to show S33
+        // neither adds, drops, nor reorders. The bibliography defines a, b, c once each and `a` a second
+        // time — so `a` has exactly ONE losing duplicate.
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A couple of representative earlier *list* renderers — byte-for-byte unchanged.
+        // S16 duplicate `\bibitem` warnings (the later `\bibitem{a}` is the sole losing duplicate).
+        assert_eq!(doc.duplicate_bibliography_entries(), "\\bibitem{a}");
+        // S19 flat winning bibliography entries (three distinct keys; the later `\bibitem{a}` loses).
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+        // S22 flat winning label definitions (four distinct keys, first-definition-wins on `dup`).
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+
+        // Prior totals-family renderers — byte-for-byte unchanged.
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // S28 resolved-reference count — exactly two (`\ref{sec:intro}`, `\eqref{eq:e}`).
+        assert_eq!(doc.resolved_reference_count(), "2");
+        // S29 label-definition count — exactly four distinct label keys.
+        assert_eq!(doc.label_definition_count(), "4");
+        // S30 bibliography-entry count — exactly three distinct `\bibitem` keys (`a`, `b`, `c`).
+        assert_eq!(doc.bibliography_entry_count(), "3");
+        // S31 resolved-citation count — exactly three keys resolve (`a`, `b`, `c`).
+        assert_eq!(doc.citation_count(), "3");
+        // S32 unresolved-citation count — exactly one key dangles (`ghost`).
+        assert_eq!(doc.unresolved_citation_count(), "1");
+
+        // And S33 itself: exactly ONE `\bibitem` is a losing duplicate (the later `\bibitem{a}`); the
+        // three winning first `\bibitem`s `a`, `b`, `c` are in `entries` (S19/S30), not counted here.
+        assert_eq!(doc.duplicate_bibliography_count(), "1");
+        // S30 winners + S33 losers partition all four `\bibitem`s in the bibliography.
+        let winners: usize = doc.bibliography_entry_count().parse().unwrap();
+        let losers: usize = doc.duplicate_bibliography_count().parse().unwrap();
+        assert_eq!(winners + losers, 4);
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2625,3 +2625,84 @@ resolved `a` excluded, S15/S31's domain); a no-citations case returning `"0"` (c
 renderers (S19's `bibliography_entries` and S22's `label_definitions`) all still produce their exact prior
 strings, with S32 returning `"1"` for `\cite{a,b}` plus `\cite{c,ghost}`). All prior S1–S31 tests pass
 unchanged. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 39. S33 — single-integer total of the duplicate ("multiply defined") `\bibitem`s (`duplicate_bibliography_count`)
+
+### 39.1 Motivation
+
+S16 (`duplicate_bibliography_entries`) enumerates the **duplicate** (later, losing) `\bibitem`s — the
+`\bibitem`s of already-defined keys, which LaTeX flags with *"Citation `key' multiply defined"* — rendering
+one `\bibitem{key}` warning line each. But a reader often wants not the enumeration but the **total** — "how
+many `\bibitem`s are multiply defined in this document?" — a single number answered at a glance, without
+scanning the individual warning lines. S30 (`bibliography_entry_count`) gave that single-total discipline to
+the *winning* bibliography entries, S31 (`citation_count`) to the *resolved* citations, and S32
+(`unresolved_citation_count`) to the *dangling* citations; S33 is the **warning-side companion** of those
+totals, closing the totals family over the last citation-family table it had not summarized: it collapses the
+whole `duplicate_entries` list to its decimal `.len()`. Where S30 counts the winning `\bibitem`s, S33 counts
+the losing ones. Together S30 and S33 **partition** every `\bibitem` inside a `thebibliography` — the winner
+count plus the duplicate count equals the total number of `\bibitem`s, because S2's `resolve_citations`
+routes each `\bibitem` into exactly one of `entries`/`duplicate_entries`.
+
+### 39.2 Why a new method — additive by construction
+
+S33 adds a **new public method** `Document::duplicate_bibliography_count(&self) -> String`. It is a pure,
+read-only render of `resolve_citations().duplicate_entries.len()` — a *second view* of the exact list S16
+renders per-source. It reuses that list verbatim (never re-walking the body or re-collecting the
+bibliography), so the report can never drift from the S2 resolution it summarises, and counting never adds,
+drops, or reorders duplicates relative to what `resolve_citations` produced. It mutates nothing and changes
+no S1–S32 output — including `to_latex()`'s round-trip fixed point — byte-for-byte. Like S11–S32 it is a
+method the caller invokes directly.
+
+### 39.3 The rendering rule
+
+The output is the decimal `.len()` of the `duplicate_entries` list, rendered as its `String`, **always** on a
+single line with **no** trailing newline. There is no ordering question (a single integer has no order) —
+only `.len()` is read, with **no** source slicing at all. We do **not** de-duplicate: a key defined *three*
+times contributes *two* losing duplicates, exactly the two warning lines S16 emits. Being a **count**
+renderer, its empty case is the honest number `"0"` — **not** a `(no duplicate bibliography entries)` marker,
+mirroring S27/S28/S29/S30/S31/S32 exactly. The `(no …)` marker discipline belongs to the *list* renderer
+S16, whose empty case has no lines to show; a total count of zero *is* a number, so `"0"` is its truthful
+value.
+
+### 39.4 The exact rendering contract — `Document::duplicate_bibliography_count(&self) -> String`
+
+- Read `resolve_citations().duplicate_entries.len()` and render it with `.to_string()` → the decimal count,
+  one line, no trailing newline. There is **no** source slicing at all, so the render needs no source borrow
+  and can never index out of bounds.
+- Only the **losing** duplicates are counted. The winning first `\bibitem` of a key lives in
+  `resolve_citations().entries` (S19/S30's domain), never in `duplicate_entries`, so it is excluded by
+  construction. Every later `\bibitem` of an already-defined key contributes one record; the `key` and the
+  `span` are never read.
+- The empty case (no bibliography, or every key defined exactly once) returns the honest number `"0"` —
+  **not** a `(no duplicate bibliography entries)` marker, because S33 is a count renderer (mirroring
+  S27/S28/S29/S30/S31/S32).
+
+Example (a `thebibliography` defining `smith` twice and `jones` once):
+
+```text
+1
+```
+
+Only the *second* `\bibitem{smith}` loses (`1`); the winning first `\bibitem{smith}` and the lone
+`\bibitem{jones}` are in `entries` (the `2` S30 reports). This is the count-total companion of S16's
+per-source warning list — a second view of the one `duplicate_entries` list.
+
+### 39.5 Public API (added in S33)
+
+One new method: `Document::duplicate_bibliography_count(&self) -> String`. No existing type, field, counter,
+or signature changes; `resolve_citations` and every S1–S32 method are unchanged; no AST or grammar change; no
+new dependency, no `unsafe`, no I/O.
+
+### 39.6 Verification (S33)
+
+`cargo test -p latex` green (6 new S33 tests: a multiple-duplicate case (`a` thrice + `b` twice) returning
+`"3"`; a no-duplicates all-distinct case returning `"0"` (cross-checked against S16's `(no duplicate
+bibliography entries)` marker); a no-`\bibitem` case returning `"0"`; a single-duplicate case returning `"1"`
+(cross-checked against the number of S16 warning lines and the literal `\bibitem{smith}` line); a partition
+check that S30 winners + S33 losers sum to the total `\bibitem`s (also cross-checked against S16's line
+count); and an additivity check that S16's `duplicate_bibliography_entries`, S19's `bibliography_entries`,
+S22's `label_definitions`, and the totals-family renderers S27's `unresolved_reference_count`, S28's
+`resolved_reference_count`, S29's `label_definition_count`, S30's `bibliography_entry_count`, S31's
+`citation_count`, and S32's `unresolved_citation_count` all still produce their exact prior strings, with S33
+returning `"1"` for a bibliography defining `a`, `b`, `c` once each and `a` a second time). All prior S1–S32
+tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S33 — `duplicate_bibliography_count` ("multiply defined" `\bibitem` total)

Adds the next read-only `String` renderer slice to the `latex` crate: **S33 `duplicate_bibliography_count`**, the count of duplicate (later, losing) `\bibitem`s of already-defined keys — the bibliography "multiply defined" **warning** total.

```rust
pub fn duplicate_bibliography_count(&self) -> String {
    self.resolve_citations().duplicate_entries.len().to_string()
}
```

### Where it sits in the totals family
| slice | renderer | counts |
|-------|----------|--------|
| S27 | `unresolved_reference_count` | dangling `\ref` |
| S28 | `resolved_reference_count` | resolved `\ref` |
| S29 | `label_definition_count` | `\label` defs |
| S30 | `bibliography_entry_count` | **winning** `\bibitem`s |
| S31 | `citation_count` | resolved `\cite` |
| S32 | `unresolved_citation_count` | dangling `\cite` |
| **S33** | **`duplicate_bibliography_count`** | **duplicate ("multiply defined") `\bibitem`s** |

S33 is the warning-side companion of the resolved (S30/S31) and unresolved (S32) totals. **S30 winners + S33 losers partition every `\bibitem`.** It reads only `resolve_citations().duplicate_entries.len()`, reusing the citation-resolution pass the crate already runs (S16/S30/S31/S32) — no new recursion or re-parse. The zero case emits `"0"` (mirroring S27–S32 count renderers, not a `(no …)` marker). Total & panic-free (no `unwrap`/`expect`, no indexing, only `.len()`), borrows `&self` immutably, returns owned `String`.

### Purely additive
S1–S32 outputs are **byte-for-byte unchanged** — proven by a dedicated additivity/regression test that pins the S16/S19/S22 list renderers and the S27–S32 totals byte-for-byte while S33 returns its value.

### Tests (6)
- multiple / one duplicate `\bibitem` → the integer
- two zero-cases: all-distinct keys, and no `\bibitem` at all → `"0"`
- a **partition** check: S30 winners + S33 losers = total `\bibitem`s (also == S16's "multiply defined" line count)
- the **additivity** test above

### Verification (all from the worktree `code/packages/rust`)
- `cargo test -p latex` → **485 passed** (+1 doctest)
- `cargo clippy -p latex --all-targets -- -D warnings` → clean
- `cargo test -p adj-lang -p adj-lang-cli` → green
- `cargo build -p latex --no-default-features` → compiles
- Inline security review → **PASSED**

Bumps latex `0.68.0` → `0.69.0`; updates CHANGELOG.md, README.md, and the LTXDOC03 spec (appends §39 for S33; prior sections byte-for-byte unchanged). Exactly 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
