### PR TITLE
feat(javascript-ast): ClassDeclaration node + emit + all pass arms (CLOC12.174 PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.38.0] - 2026-07-10
+
+### Added — CLOC12.174 PR1: emit `ClassDeclaration` (`class C [extends S] {…}`)
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. New
+`emit_class_declaration` prints `class <id>[ extends S]{members}`, reusing
+`emit_class_member` for each member. The shared `[ extends S]{members}` tail was
+factored into a new `emit_class_tail` helper used by **both** `emit_class` (the
+expression form) and `emit_class_declaration`.
+
+Three deliberate differences from the class *expression*, each the exact mirror
+of the `FunctionDeclaration` vs `FunctionExpression` split:
+
+1. **`id` always prints** (it is non-optional), with a `required_ws()` after
+   `class`, like `emit_function_declaration` after `function`.
+2. **No precedence wrap / no statement-start parenthesis** — a class expression
+   is `PREC_UNARY` and wrapped in statement position (`(class{});`) because a
+   leading `class` parses as a declaration, which is precisely what this node
+   *is*. So the declaration form has no `expr_prec` entry and is never wrapped.
+3. **No trailing `;`** — `emit_function_declaration` appends a normalising `;`
+   (gap-030 part B); a class declaration terminates with its `}` alone (upstream
+   Closure).
+
+5 hand-constructed AST unit tests: empty (bare, no `;`), heritage, members
+(method / static / get / set), `constructor` + computed key, and the full
+`class C extends B{m(){}}` shape. Reachable end-to-end once the PR2 bridge
+produces the node.
+
 ## [0.37.1] - 2026-07-08
 
 ### Added — CLOC12.173 PR3: CodePrinter class-expression conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.37.1"
+version = "0.38.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -73,7 +73,7 @@ use coding_adventures_javascript_ast::{
     MethodDefinition, MethodKind,
     EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
-    FunctionDeclaration, FunctionExpression,
+    ClassDeclaration, FunctionDeclaration, FunctionExpression,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem, SequenceExpression,
     ObjectMember, Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
@@ -783,6 +783,7 @@ impl<'a> Emitter<'a> {
                 self.emit_variable_declaration(v, /*top_level=*/ true);
             }
             Declaration::FunctionDeclaration(f) => self.emit_function_declaration(f),
+            Declaration::ClassDeclaration(c) => self.emit_class_declaration(c),
         }
     }
 
@@ -947,7 +948,62 @@ impl<'a> Emitter<'a> {
             self.required_ws();
             self.emit_identifier(id);
         }
-        if let Some(sup) = &c.super_class {
+        self.emit_class_tail(&c.super_class, &c.body);
+    }
+
+    /// Emit a [`ClassDeclaration`] — `class <id>[ extends S]{members}`.
+    ///
+    /// The *statement* form of a class. Byte-identical to [`Self::emit_class`]
+    /// (the expression form) for the `[ extends S]{members}` tail — both call
+    /// [`Self::emit_class_tail`] — with three deliberate differences, each the
+    /// exact mirror of the [`FunctionDeclaration`] vs `FunctionExpression`
+    /// split:
+    ///
+    /// 1. **`id` always prints.** A declaration's `id` is non-optional (a class
+    ///    written as a statement must bind a name — `class {}` in statement
+    ///    position is a syntax error), so — unlike the expression form's
+    ///    `if let Some(id)` — the name is emitted unconditionally, with a
+    ///    `required_ws()` after `class` exactly as
+    ///    [`Self::emit_function_declaration`] does after `function`.
+    /// 2. **No precedence wrap / no statement-start parenthesis.** A class
+    ///    *expression* is tagged `PREC_UNARY` and
+    ///    [`Self::emit_expression_statement`] wraps a leading one (`(class{});`)
+    ///    because a statement-position `class` would otherwise parse as a
+    ///    *declaration* — which is precisely what this node **is**. So the
+    ///    declaration form has no `expr_prec` entry and is never wrapped.
+    /// 3. **No trailing `;`.** [`Self::emit_function_declaration`] appends a
+    ///    normalising `;` after its `}` (gap-030 part B); a **class**
+    ///    declaration does not — upstream Closure terminates a class declaration
+    ///    with its `}` alone (a class body is self-delimiting and, unlike a bare
+    ///    `function(){}` value, subject to no ASI hazard). The PR3 conformance
+    ///    port validates this against `CodePrinterTest`.
+    fn emit_class_declaration(&mut self, c: &ClassDeclaration) {
+        self.maybe_map(&c.cv);
+        self.write_str("class");
+        // `id` is required for a declaration — always emit it (with the
+        // mandatory `class C` separating space).
+        self.required_ws();
+        self.emit_identifier(&c.id);
+        self.emit_class_tail(&c.super_class, &c.body);
+    }
+
+    /// Emit the shared `[ extends S]{members}` tail of a class — the part after
+    /// the `class[ id]` head that is identical for the expression
+    /// ([`Self::emit_class`]) and declaration ([`Self::emit_class_declaration`])
+    /// forms.
+    ///
+    /// The `extends` operand is emitted at `PREC_PRIMARY`: a `LeftHandSide`
+    /// superclass (identifier `extends B`, member `extends ns.B`, call
+    /// `extends mixin(B)`) stays bare, while anything looser (a conditional
+    /// `extends (a?b:c)`) is wrapped — exactly the grammar's requirement.
+    /// Members print back-to-back with no separators (each carries its own
+    /// `{…}`).
+    fn emit_class_tail(
+        &mut self,
+        super_class: &Option<Box<Expression>>,
+        body: &[ClassMember],
+    ) {
+        if let Some(sup) = super_class {
             self.required_ws();
             self.write_str("extends");
             self.required_ws();
@@ -956,7 +1012,7 @@ impl<'a> Emitter<'a> {
         // No space before the brace even in pretty mode — Closure prints
         // `class C{...}` (the members carry their own layout).
         self.write_str("{");
-        for member in &c.body {
+        for member in body {
             match member {
                 ClassMember::Method(m) => self.emit_class_member(m),
             }
@@ -3609,6 +3665,95 @@ mod tests {
         // after the function-declaration's closing `}` to
         // match upstream Closure v20240317.
         assert_eq!(out.code, "function f(x){return x};");
+    }
+
+    // ---- class declarations (CLOC12.174 PR1) ----------------
+    //
+    // The *statement* form of a class. Emitted at top level via
+    // `ProgramItem::Declaration` (not `emit_expr`, which is for expression
+    // position). Contrast with the ClassExpression tests above: a class
+    // *expression* in statement position is parenthesised (`(class C{});`),
+    // whereas the declaration is emitted bare with no wrap and — crucially —
+    // NO trailing `;` (unlike `function f(){};`, gap-030 part B).
+
+    /// Build a top-level `class <id>[ extends S]{members}` program and emit it
+    /// in the default (minified) mode, returning the output code.
+    fn emit_class_decl(id: &str, super_class: Option<Expression>, body: Vec<ClassMember>) -> String {
+        let d = Declaration::ClassDeclaration(ClassDeclaration {
+            cv: None,
+            id: Identifier { cv: None, name: id.to_string() },
+            super_class: super_class.map(Box::new),
+            body,
+        });
+        emit_default(program().with_body(vec![ProgramItem::Declaration(d)])).code
+    }
+
+    #[test]
+    fn class_declaration_empty_is_bare_and_unterminated() {
+        // `class C {}` — bare (no wrapping paren, unlike the expression form's
+        // `(class C{});`) and NO trailing `;` (unlike `function f(){};`).
+        assert_eq!(emit_class_decl("C", None, vec![]), "class C{}");
+    }
+
+    #[test]
+    fn class_declaration_heritage() {
+        // `class C extends B {}` — the `extends` operand prints bare (an
+        // identifier is a LeftHandSide, tighter than the class body).
+        assert_eq!(
+            emit_class_decl("C", Some(ident("B")), vec![]),
+            "class C extends B{}"
+        );
+    }
+
+    #[test]
+    fn class_declaration_members_reuse_emit_class_member() {
+        // A method, a static method, and get/set accessors — each printed by
+        // the shared `emit_class_member` (the same helper the expression form
+        // uses), back-to-back with no separators.
+        assert_eq!(
+            emit_class_decl("C", None, vec![method("m", MethodKind::Method, false)]),
+            "class C{m(){}}"
+        );
+        assert_eq!(
+            emit_class_decl("C", None, vec![method("m", MethodKind::Method, true)]),
+            "class C{static m(){}}"
+        );
+        assert_eq!(
+            emit_class_decl("C", None, vec![method("x", MethodKind::Get, false)]),
+            "class C{get x(){}}"
+        );
+        assert_eq!(
+            emit_class_decl("C", None, vec![method("x", MethodKind::Set, false)]),
+            "class C{set x(){}}"
+        );
+    }
+
+    #[test]
+    fn class_declaration_constructor_and_computed_key() {
+        // The constructor prints with no keyword prefix (its `kind` only
+        // matters to the passes). A computed key `[k]` is bracketed.
+        assert_eq!(
+            emit_class_decl("C", None, vec![method("constructor", MethodKind::Constructor, false)]),
+            "class C{constructor(){}}"
+        );
+        let computed = ClassMember::Method(MethodDefinition {
+            cv: None,
+            key: PropertyKey::Expression(Box::new(ident("k"))),
+            kind: MethodKind::Method,
+            value: method_fn(),
+            computed: true,
+            is_static: false,
+        });
+        assert_eq!(emit_class_decl("C", None, vec![computed]), "class C{[k](){}}");
+    }
+
+    #[test]
+    fn class_declaration_full_shape_named_heritage_and_member() {
+        // `class C extends B { m() {} }` — the whole shape in one assertion.
+        assert_eq!(
+            emit_class_decl("C", Some(ident("B")), vec![method("m", MethodKind::Method, false)]),
+            "class C extends B{m(){}}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` fold arm
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant, making
+this crate's exhaustive `Declaration` match non-exhaustive. Added a
+`fold_class_declaration` arm that folds inside the `extends` operand and each
+method body — identical to `fold_class` for the expression form. The shared
+member-folding logic was factored into a new `#[inline(never)] fold_class_body`
+helper used by both. Reachable once the CLOC12.174 PR2 bridge produces the node.
+
 ## [0.85.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: fold inside a `ClassExpression`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.13"
+version = "0.85.14"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -95,7 +95,7 @@ use coding_adventures_javascript_ast::{
     Declaration, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
-    ClassExpression, ClassMember, MethodDefinition,
+    ClassDeclaration, ClassExpression, ClassMember, MethodDefinition,
     FunctionDeclaration, FunctionExpression, Identifier,
     ChainExpression, IfStatement, LogicalExpression, LogicalOperator, MemberExpression, NullLiteral, NumericLiteral, OptionalCallExpression, OptionalMemberExpression,
     ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey, PropertyKind, ReturnStatement, Statement,
@@ -465,7 +465,27 @@ fn fold_declaration(decl: &Declaration, st: &mut FoldState) -> Declaration {
                 is_async: f.is_async,
             })
         }
+        // A class *declaration* (`class C { … }`) folds identically to a class
+        // *expression* inside its heritage + member bodies — only the outer node
+        // type and the required `id` differ. Both route through the shared
+        // `fold_class_body` helper.
+        Declaration::ClassDeclaration(c) => fold_class_declaration(c, st),
     }
+}
+
+/// Fold a class *declaration* (`class C [extends S] { … }`): the `extends`
+/// operand and each method body, via the shared [`fold_class_body`] helper.
+/// Mirrors [`fold_class`] (the expression form); `#[inline(never)]` keeps its
+/// locals off the caller's frame (DoS lesson).
+#[inline(never)]
+fn fold_class_declaration(c: &ClassDeclaration, st: &mut FoldState) -> Declaration {
+    let (super_class, body) = fold_class_body(&c.super_class, &c.body, st);
+    Declaration::ClassDeclaration(ClassDeclaration {
+        cv: c.cv.clone(),
+        id: c.id.clone(),
+        super_class,
+        body,
+    })
 }
 
 fn fold_variable_declaration(v: &VariableDeclaration, st: &mut FoldState) -> VariableDeclaration {
@@ -488,48 +508,65 @@ fn fold_variable_declaration(v: &VariableDeclaration, st: &mut FoldState) -> Var
 // Expressions — the actual folding
 // =====================================================================
 
-/// Fold inside a class expression: the `extends` operand (an expression) and
-/// each method's body (statements). Kept `#[inline(never)]` so its locals do
-/// not inflate `fold_expression`'s frame — see the call site.
+/// Fold the shared `[extends S] { members }` tail of a class — the heritage
+/// operand (an expression) and each method's body (statements). Reused by both
+/// the class *expression* ([`fold_class`]) and the class *declaration*
+/// ([`fold_class_declaration`]), since the two node forms share their body
+/// shape and differ only in the outer node type + whether `id` is optional.
+/// Kept `#[inline(never)]` so its locals do not inflate the caller's frame —
+/// see the DoS lesson.
+#[inline(never)]
+fn fold_class_body(
+    super_class: &Option<Box<Expression>>,
+    body: &[ClassMember],
+    st: &mut FoldState,
+) -> (Option<Box<Expression>>, Vec<ClassMember>) {
+    let super_class = super_class
+        .as_ref()
+        .map(|s| Box::new(fold_expression(s, st)));
+    let body = body
+        .iter()
+        .map(|m| match m {
+            ClassMember::Method(md) => ClassMember::Method(MethodDefinition {
+                cv: md.cv.clone(),
+                key: md.key.clone(),
+                kind: md.kind,
+                value: FunctionExpression {
+                    cv: md.value.cv.clone(),
+                    id: md.value.id.clone(),
+                    params: md.value.params.clone(),
+                    body: BlockStatement {
+                        cv: md.value.body.cv.clone(),
+                        body: md
+                            .value
+                            .body
+                            .body
+                            .iter()
+                            .map(|s| fold_statement(s, st))
+                            .collect(),
+                    },
+                    generator: md.value.generator,
+                    is_async: md.value.is_async,
+                },
+                computed: md.computed,
+                is_static: md.is_static,
+            }),
+        })
+        .collect();
+    (super_class, body)
+}
+
+/// Fold inside a class expression: delegates to [`fold_class_body`] for the
+/// heritage + method bodies. Kept `#[inline(never)]` so its locals do not
+/// inflate `fold_expression`'s frame — see the call site.
 #[inline(never)]
 fn fold_class(c: &ClassExpression, st: &mut FoldState) -> Expression {
+    let (super_class, body) = fold_class_body(&c.super_class, &c.body, st);
     Expression::ClassExpression(ClassExpression {
         cv: c.cv.clone(),
         id: c.id.clone(),
-        super_class: c
-            .super_class
-            .as_ref()
-            .map(|s| Box::new(fold_expression(s, st))),
-        body: c
-            .body
-            .iter()
-            .map(|m| match m {
-                ClassMember::Method(md) => ClassMember::Method(MethodDefinition {
-                    cv: md.cv.clone(),
-                    key: md.key.clone(),
-                    kind: md.kind,
-                    value: FunctionExpression {
-                        cv: md.value.cv.clone(),
-                        id: md.value.id.clone(),
-                        params: md.value.params.clone(),
-                        body: BlockStatement {
-                            cv: md.value.body.cv.clone(),
-                            body: md
-                                .value
-                                .body
-                                .body
-                                .iter()
-                                .map(|s| fold_statement(s, st))
-                                .collect(),
-                        },
-                        generator: md.value.generator,
-                        is_async: md.value.is_async,
-                    },
-                    computed: md.computed,
-                    is_static: md.is_static,
-                }),
-            })
-            .collect(),
+        super_class,
+        body,
     })
 }
 

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+arms at each of this crate's exhaustive `Declaration` match sites: the transform
+(`dce_class_declaration` runs DCE inside the heritage operand and method bodies,
+mirroring `dce_class`), and two conservative predicates — `tail_is_safe_to_truncate`
+and `block_is_scope_safe_to_flatten` both return `false` for a class declaration
+(a name-binding, block-scoped node, like a function declaration; preserving it is
+never a miscompile). Reachable once the CLOC12.174 PR2 bridge produces the node.
+
 ## [0.20.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.13"
+version = "0.20.14"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -76,7 +76,7 @@ use coding_adventures_javascript_ast::{
     ForOfStatement,
     ForStatement,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
-    ClassExpression, ClassMember, MethodDefinition,
+    ClassDeclaration, ClassExpression, ClassMember, MethodDefinition,
     ChainExpression, FunctionDeclaration, FunctionExpression, IfStatement, LogicalExpression, MemberExpression, NullLiteral, OptionalCallExpression, OptionalMemberExpression,
     NumericLiteral, ObjectExpression, ObjectMember, Program, ProgramItem, Property, PropertyKey,
     ReturnStatement, Statement, StringLiteral, UnaryExpression, UndefinedLiteral, UpdateExpression, VarKind,
@@ -862,6 +862,10 @@ fn tail_is_safe_to_truncate(stmts: &[Statement]) -> bool {
         Statement::Declaration(Declaration::VariableDeclaration(vd)) => vd.kind != VarKind::Var,
         // A `function` declaration is itself a hoisted binding — unsafe.
         Statement::Declaration(Declaration::FunctionDeclaration(_)) => false,
+        // A `class` declaration binds a name too — treated as unsafe like a
+        // function declaration (conservative: preserving it is never a
+        // miscompile, and a genuinely-unused one is removed downstream).
+        Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
     })
 }
 
@@ -1014,6 +1018,10 @@ fn block_is_scope_safe_to_flatten(b: &BlockStatement) -> bool {
             matches!(v.kind, VarKind::Var)
         }
         Statement::Declaration(Declaration::FunctionDeclaration(_)) => false,
+        // A `class` declaration is block-scoped (per the doc above) — hoisting
+        // it out of an inner block would leak the binding, so it is never safe
+        // to flatten, exactly like a nested function declaration.
+        Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
         // Tagged statements never introduce a new lexical binding
         // by themselves. `ExpressionStatement`, control flow,
         // `EmptyStatement`, etc. are all safe.
@@ -1129,6 +1137,43 @@ fn dce_declaration(decl: &Declaration, st: &mut DceState) -> Declaration {
                 is_async: f.is_async,
             })
         }
+        // A class *declaration* runs DCE inside its heritage operand and each
+        // method body, exactly as `dce_class` does for a class *expression* —
+        // only the outer node type and the required `id` differ.
+        Declaration::ClassDeclaration(c) => {
+            Declaration::ClassDeclaration(dce_class_declaration(c, st))
+        }
+    }
+}
+
+/// DCE inside a class *declaration*: the `extends` operand and each method
+/// body. Mirrors `dce_class` (the expression form).
+fn dce_class_declaration(c: &ClassDeclaration, st: &mut DceState) -> ClassDeclaration {
+    ClassDeclaration {
+        cv: c.cv.clone(),
+        id: c.id.clone(),
+        super_class: c.super_class.as_ref().map(|s| Box::new(dce_expression(s, st))),
+        body: c
+            .body
+            .iter()
+            .map(|m| match m {
+                ClassMember::Method(md) => ClassMember::Method(MethodDefinition {
+                    cv: md.cv.clone(),
+                    key: md.key.clone(),
+                    kind: md.kind,
+                    value: FunctionExpression {
+                        cv: md.value.cv.clone(),
+                        id: md.value.id.clone(),
+                        params: md.value.params.clone(),
+                        body: dce_block_statement(&md.value.body, st),
+                        generator: md.value.generator,
+                        is_async: md.value.is_async,
+                    },
+                    computed: md.computed,
+                    is_static: md.is_static,
+                }),
+            })
+            .collect(),
     }
 }
 

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+the transform arm to `fold_declaration` (folds control flow inside the heritage
+operand and method bodies via a new shared `#[inline(never)] fold_class_body`
+helper, also refactored out of `fold_class`), and a `false` arm to
+`block_is_scope_safe_to_hoist` (a block-scoped class declaration must not be
+hoisted out of an `else`, like a nested function declaration). Reachable once the
+CLOC12.174 PR2 bridge produces the node.
+
 ## [0.20.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.13"
+version = "0.20.14"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -59,7 +59,7 @@ use coding_adventures_javascript_ast::{
     AssignmentTarget, BinaryExpression, BindingTarget, BlockStatement, CallExpression, NewExpression, SequenceExpression, SpreadElement, YieldExpression, AwaitExpression, ImportExpression,
     ConditionalExpression, Declaration, EmptyStatement, Expression, ExpressionStatement, ForInit,
     ArrowBody, ArrowFunctionExpression, TaggedTemplateExpression, TemplateLiteral,
-    ClassExpression, ClassMember, MethodDefinition,
+    ClassDeclaration, ClassExpression, ClassMember, MethodDefinition,
     ForInStatement, ForOfStatement, ForStatement, FunctionDeclaration, FunctionExpression, Identifier, IfStatement,
     LogicalExpression,
     LogicalOperator,
@@ -641,6 +641,10 @@ fn block_is_scope_safe_to_hoist(b: &BlockStatement) -> bool {
             matches!(v.kind, VarKind::Var)
         }
         Statement::Declaration(Declaration::FunctionDeclaration(_)) => false,
+        // A `class` declaration is block-scoped, so hoisting it out of the
+        // `else` block would leak or collide its binding — unsafe, like a
+        // nested function declaration.
+        Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
         // Tagged statements introduce no lexical binding of their own.
         Statement::Tagged(_) => true,
     })
@@ -1068,6 +1072,19 @@ fn fold_declaration(decl: &Declaration, st: &mut FoldState) -> Declaration {
                 is_async: f.is_async,
             })
         }
+        // A class *declaration* folds inside its heritage + method bodies, like
+        // `fold_class` for the expression form. Unlike a function declaration
+        // it hoists no `var`s of its own — a class body is not a `var` scope in
+        // the hoisting sense — so no `hoist_function_body_vars` step applies.
+        Declaration::ClassDeclaration(c) => {
+            let (super_class, body) = fold_class_body(&c.super_class, &c.body, st);
+            Declaration::ClassDeclaration(ClassDeclaration {
+                cv: c.cv.clone(),
+                id: c.id.clone(),
+                super_class,
+                body,
+            })
+        }
     }
 }
 
@@ -1360,45 +1377,60 @@ fn fold_variable_declaration(
 // a literal test IS folded for robustness when this pass runs solo.
 // =====================================================================
 
-/// Fold control flow inside a class expression: the `extends` operand is a
-/// plain value-position expression, and each method's function *value* body is
-/// folded and its `var`s hoisted exactly like the `FunctionExpression` arm
-/// (fold the body, then hoist to the function top). `#[inline(never)]` so it
-/// does not inflate `fold_expression`'s frame (stack-overflow DoS guard).
+/// Fold control flow inside the shared `[extends S] { members }` tail of a
+/// class — the heritage operand (a value-position expression) and each method's
+/// function *value* body (folded, then its `var`s hoisted, exactly like the
+/// `FunctionExpression` arm). Reused by both the class *expression*
+/// ([`fold_class`]) and the class *declaration* (the `fold_declaration` arm),
+/// which share their body shape. `#[inline(never)]` so it does not inflate the
+/// caller's frame (stack-overflow DoS guard).
+#[inline(never)]
+fn fold_class_body(
+    super_class: &Option<Box<Expression>>,
+    body: &[ClassMember],
+    st: &mut FoldState,
+) -> (Option<Box<Expression>>, Vec<ClassMember>) {
+    let super_class = super_class
+        .as_ref()
+        .map(|s| Box::new(fold_expression(s, st)));
+    let body = body
+        .iter()
+        .map(|m| match m {
+            ClassMember::Method(md) => {
+                let folded_body = fold_block_statement(&md.value.body, st);
+                let hoisted_body = hoist_function_body_vars(&folded_body, st);
+                ClassMember::Method(MethodDefinition {
+                    cv: md.cv.clone(),
+                    key: md.key.clone(),
+                    kind: md.kind,
+                    value: FunctionExpression {
+                        cv: md.value.cv.clone(),
+                        id: md.value.id.clone(),
+                        params: md.value.params.clone(),
+                        body: hoisted_body,
+                        generator: md.value.generator,
+                        is_async: md.value.is_async,
+                    },
+                    computed: md.computed,
+                    is_static: md.is_static,
+                })
+            }
+        })
+        .collect();
+    (super_class, body)
+}
+
+/// Fold control flow inside a class expression: delegates to
+/// [`fold_class_body`] for the heritage + method bodies. `#[inline(never)]` so
+/// it does not inflate `fold_expression`'s frame (stack-overflow DoS guard).
 #[inline(never)]
 fn fold_class(c: &ClassExpression, st: &mut FoldState) -> Expression {
+    let (super_class, body) = fold_class_body(&c.super_class, &c.body, st);
     Expression::ClassExpression(ClassExpression {
         cv: c.cv.clone(),
         id: c.id.clone(),
-        super_class: c
-            .super_class
-            .as_ref()
-            .map(|s| Box::new(fold_expression(s, st))),
-        body: c
-            .body
-            .iter()
-            .map(|m| match m {
-                ClassMember::Method(md) => {
-                    let folded_body = fold_block_statement(&md.value.body, st);
-                    let hoisted_body = hoist_function_body_vars(&folded_body, st);
-                    ClassMember::Method(MethodDefinition {
-                        cv: md.cv.clone(),
-                        key: md.key.clone(),
-                        kind: md.kind,
-                        value: FunctionExpression {
-                            cv: md.value.cv.clone(),
-                            id: md.value.id.clone(),
-                            params: md.value.params.clone(),
-                            body: hoisted_body,
-                            generator: md.value.generator,
-                            is_async: md.value.is_async,
-                        },
-                        computed: md.computed,
-                        is_static: md.is_static,
-                    })
-                }
-            })
-            .collect(),
+        super_class,
+        body,
     })
 }
 

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.11.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+arms at each exhaustive `Declaration` match site: `decl_is_inert` returns `false`
+(a class declaration runs code — its `extends` heritage is evaluated at the
+declaration site, unlike a hoisted function declaration); `count_decl_names_decl`
+counts the class name + method-body names; and `count_uses_decl` / `propagate_in_decl`
+recurse the heritage operand + method bodies in lockstep (missing a use would let
+a still-referenced const be inlined away — a miscompile). Reachable once the
+CLOC12.174 PR2 bridge produces the node.
+
 ## [0.11.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.11.13"
+version = "0.11.14"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -380,6 +380,11 @@ fn decl_is_inert(decl: &Declaration) -> bool {
         // function is called, which (given every preceding item is inert)
         // cannot happen before a later `const` initializes.
         Declaration::FunctionDeclaration(_) => true,
+        // A class declaration is NOT inert: evaluating its `extends` heritage
+        // (`class C extends f() {}`) and creating the class runs code at the
+        // declaration site — unlike a function declaration, which only hoists.
+        // Conservatively (and correctly) treat it as running code.
+        Declaration::ClassDeclaration(_) => false,
         Declaration::VariableDeclaration(vd) => vd.declarations.iter().all(|d| match &d.init {
             None => true,
             Some(init) => is_literal(init),
@@ -457,6 +462,19 @@ fn count_decl_names_decl(
             }
             for s in &fd.body.body {
                 count_decl_names_stmt(s, out, nodes_touched);
+            }
+        }
+        // A class declaration binds its name (`cd.id`), and its method bodies
+        // declare their own locals — count both, mirroring the function
+        // declaration arm (name + body-declared names). Counting more names is
+        // conservative: it only ever prevents an unsafe inline, never causes one.
+        Declaration::ClassDeclaration(cd) => {
+            *out.entry(cd.id.name.clone()).or_insert(0) += 1;
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &m.value.body.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
             }
         }
     }
@@ -592,6 +610,22 @@ fn count_uses_decl(decl: &Declaration, name: &str, count: &mut usize) {
         Declaration::FunctionDeclaration(fd) => {
             for s in &fd.body.body {
                 count_uses_stmt(s, name, count);
+            }
+        }
+        // A class declaration can USE `name` in its `extends` operand
+        // (`class C extends name {}`) and inside its method bodies. We MUST
+        // count every such use — missing one would let the pass inline/remove
+        // `name` while the class still references it (a miscompile). Mirrors the
+        // `Expression::ClassExpression` arm of `count_uses_expr`.
+        Declaration::ClassDeclaration(cd) => {
+            if let Some(sup) = &cd.super_class {
+                count_uses_expr(sup, name, count);
+            }
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &m.value.body.body {
+                    count_uses_stmt(s, name, count);
+                }
             }
         }
     }
@@ -929,6 +963,21 @@ fn propagate_in_decl(decl: &mut Declaration, cand: &ConstCandidate) -> bool {
         Declaration::FunctionDeclaration(fd) => {
             for s in &mut fd.body.body {
                 changed |= propagate_in_stmt(s, cand);
+            }
+        }
+        // Substitute the const into the same positions `count_uses_decl`
+        // inspects — the `extends` operand and each method body — so the count
+        // and the rewrite stay in lockstep. Mirrors the
+        // `Expression::ClassExpression` arm of `propagate_in_expr`.
+        Declaration::ClassDeclaration(cd) => {
+            if let Some(sup) = &mut cd.super_class {
+                changed |= propagate_in_expr(sup, cand);
+            }
+            for member in &mut cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &mut m.value.body.body {
+                    changed |= propagate_in_stmt(s, cand);
+                }
             }
         }
     }

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.25.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+arms at every exhaustive `Declaration` match site: `count_decl_names_decl`
+(class name + method params + bodies), `tally_decl` and `inline_in_decl` (recurse
+the heritage operand + method bodies, kept in lockstep so a candidate use inside
+a class is never missed then wrongly inlined), `collect_top_level_decl_names`
+(a top-level `class C` binds `C`), `splice_void_in_decl` / `splice_valued_in_decl`
+(splice into each method body), and `collect_used_idents_decl`. All mirror the
+existing `Expression::ClassExpression` handling. Reachable once the CLOC12.174
+PR2 bridge produces the node.
+
 ## [0.25.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.25.13"
+version = "0.25.14"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -669,6 +669,22 @@ fn count_decl_names_decl(
                 count_decl_names_stmt(s, out, nodes_touched);
             }
         }
+        // A class declaration binds its name, and each method's params + locals
+        // are declared names — count all, mirroring the function arm. Counting
+        // method params keeps inline-collision detection conservative.
+        Declaration::ClassDeclaration(cd) => {
+            *out.entry(cd.id.name.clone()).or_insert(0) += 1;
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                for p in &m.value.params {
+                    let FunctionParam::Identifier(id) = p;
+                    *out.entry(id.name.clone()).or_insert(0) += 1;
+                }
+                for s in &m.value.body.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
+            }
+        }
     }
 }
 
@@ -1001,6 +1017,21 @@ fn tally_decl(decl: &Declaration, cand: &InlineCandidate, t: &mut Tally) {
         Declaration::FunctionDeclaration(fd) => {
             for s in &fd.body.body {
                 tally_stmt(s, cand, t);
+            }
+        }
+        // Tally candidate uses inside a class declaration's heritage operand
+        // and method bodies — missing one would let the pass inline a callee
+        // that is still called from inside the class (a miscompile). Mirrors the
+        // `Expression::ClassExpression` arm of `tally_expr`.
+        Declaration::ClassDeclaration(cd) => {
+            if let Some(sup) = &cd.super_class {
+                tally_expr(sup, cand, t);
+            }
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &m.value.body.body {
+                    tally_stmt(s, cand, t);
+                }
             }
         }
     }
@@ -1365,6 +1396,20 @@ fn inline_in_decl(decl: &mut Declaration, cand: &InlineCandidate) -> bool {
         Declaration::FunctionDeclaration(fd) => {
             for s in &mut fd.body.body {
                 changed |= inline_in_stmt(s, cand);
+            }
+        }
+        // Perform the inline substitution inside a class declaration's heritage
+        // operand and method bodies, kept in lockstep with `tally_decl` above.
+        // Mirrors the `Expression::ClassExpression` arm of `inline_in_expr`.
+        Declaration::ClassDeclaration(cd) => {
+            if let Some(sup) = &mut cd.super_class {
+                changed |= inline_in_expr(sup, cand);
+            }
+            for member in &mut cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &mut m.value.body.body {
+                    changed |= inline_in_stmt(s, cand);
+                }
             }
         }
     }
@@ -2105,6 +2150,11 @@ fn collect_top_level_decl_names(program: &Program) -> HashSet<String> {
         Declaration::FunctionDeclaration(fd) => {
             out.insert(fd.id.name.clone());
         }
+        // A top-level `class C {}` binds `C` in the program scope, exactly like
+        // a top-level function name.
+        Declaration::ClassDeclaration(cd) => {
+            out.insert(cd.id.name.clone());
+        }
         Declaration::VariableDeclaration(vd) => {
             for decl in &vd.declarations {
                 let BindingTarget::Identifier(id) = &decl.id;
@@ -2823,6 +2873,17 @@ fn splice_void_in_decl(
         // A function body is a `Vec<Statement>` the call may live in.
         Declaration::FunctionDeclaration(fd) => {
             splice_void_in_stmt_vec(&mut fd.body.body, cand, avoid, nodes_touched)
+        }
+        // Each class method body is a `Vec<Statement>` a void call may live in
+        // — splice into every method, mirroring the function-body arm.
+        Declaration::ClassDeclaration(cd) => {
+            let mut changed = false;
+            for member in &mut cd.body {
+                let ClassMember::Method(m) = member;
+                changed |=
+                    splice_void_in_stmt_vec(&mut m.value.body.body, cand, avoid, nodes_touched);
+            }
+            changed
         }
         // Variable initializers are expressions — a call there is a value
         // position, declined by this slice.
@@ -3649,6 +3710,17 @@ fn splice_valued_in_decl(
         Declaration::FunctionDeclaration(fd) => {
             splice_valued_in_stmt_vec(&mut fd.body.body, cand, avoid, nodes_touched)
         }
+        // Each class method body is a `Vec<Statement>` a valued call may live
+        // in — splice into every method, mirroring the function-body arm.
+        Declaration::ClassDeclaration(cd) => {
+            let mut changed = false;
+            for member in &mut cd.body {
+                let ClassMember::Method(m) = member;
+                changed |=
+                    splice_valued_in_stmt_vec(&mut m.value.body.body, cand, avoid, nodes_touched);
+            }
+            changed
+        }
         // A variable initializer is a value position; the call must be the
         // ENTIRE init (handled at the list level by `try_capture_in_stmt` /
         // `capture_splice_for_vardecl`), so there is nothing to descend into
@@ -3974,6 +4046,20 @@ fn collect_used_idents_decl(decl: &Declaration, out: &mut HashSet<String>) {
         Declaration::FunctionDeclaration(fd) => {
             for s in &fd.body.body {
                 collect_used_idents_stmt(s, out);
+            }
+        }
+        // Collect identifiers used in a class declaration's heritage operand and
+        // method bodies, so an inline never mints a fresh name that collides
+        // with one referenced inside the class.
+        Declaration::ClassDeclaration(cd) => {
+            if let Some(sup) = &cd.super_class {
+                collect_binding_idents_expr(sup, out);
+            }
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &m.value.body.body {
+                    collect_used_idents_stmt(s, out);
+                }
             }
         }
     }

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.10.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+arms at each exhaustive `Declaration` match site: `count_decl_names_decl` (class
+name + method params + bodies — counting params upholds the rename invariant that
+a global shadowed by a method param is disqualified), `collect_all_idents_decl`
+(class name + heritage + member keys/params/bodies), and `rename_apply_decl`
+(rename the class's own name as a global binding, the `extends` operand as a use,
+and recurse each method body with the full map). Reachable once the CLOC12.174
+PR2 bridge produces the node.
+
 ## [0.10.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.10.13"
+version = "0.10.14"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -352,6 +352,25 @@ fn count_decl_names_decl(
                 count_decl_names_stmt(s, out, nodes_touched);
             }
         }
+        // A class declaration binds its name (`cd.id`) as a global, and each
+        // method's params + body-locals are declared names too. Counting the
+        // method params here is what upholds the rename invariant used by
+        // `rename_apply_decl`: a method param that shares a global name pushes
+        // that name's count past 1, disqualifying it from renaming — so a
+        // later body walk with the full map can never rewrite a shadowed use.
+        Declaration::ClassDeclaration(cd) => {
+            *out.entry(cd.id.name.clone()).or_insert(0) += 1;
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                for p in &m.value.params {
+                    let FunctionParam::Identifier(id) = p;
+                    *out.entry(id.name.clone()).or_insert(0) += 1;
+                }
+                for s in &m.value.body.body {
+                    count_decl_names_stmt(s, out, nodes_touched);
+                }
+            }
+        }
     }
 }
 
@@ -470,6 +489,31 @@ fn collect_all_idents_decl(decl: &Declaration, out: &mut HashSet<String>) {
                 out.insert(id.name.clone());
                 if let Some(init) = &d.init {
                     collect_all_idents_expr(init, out);
+                }
+            }
+        }
+        Declaration::ClassDeclaration(cd) => {
+            // Mirror the `Expression::ClassExpression` arm of
+            // `collect_all_idents_expr`: the class name, the heritage operand's
+            // identifiers, and each method's key / value-name / params / body.
+            out.insert(cd.id.name.clone());
+            if let Some(sup) = &cd.super_class {
+                collect_all_idents_expr(sup, out);
+            }
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                if let PropertyKey::Identifier(id) = &m.key {
+                    out.insert(id.name.clone());
+                }
+                if let Some(id) = &m.value.id {
+                    out.insert(id.name.clone());
+                }
+                for p in &m.value.params {
+                    let FunctionParam::Identifier(id) = p;
+                    out.insert(id.name.clone());
+                }
+                for s in &m.value.body.body {
+                    collect_all_idents_stmt(s, out);
                 }
             }
         }
@@ -870,6 +914,27 @@ fn rename_apply_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
             // so it would not be in `map`.
             for s in &mut fd.body.body {
                 rename_apply_stmt(s, map);
+            }
+        }
+        Declaration::ClassDeclaration(cd) => {
+            // Rename the class's own name (a top-level binding, a rename
+            // target) and the `extends` operand (a use position). Then recurse
+            // each method body with the full `map` — mirroring the function
+            // declaration arm. This is safe for the same reason: a method param
+            // (or local) sharing a global name would be counted more than once
+            // by `count_decl_names_decl` (which tallies method params), so that
+            // name is excluded from `map` and a shadowed use is never rewritten.
+            if let Some(new) = map.get(&cd.id.name) {
+                cd.id.name = new.clone();
+            }
+            if let Some(sup) = &mut cd.super_class {
+                rename_apply_expr(sup, map);
+            }
+            for member in &mut cd.body {
+                let ClassMember::Method(m) = member;
+                for s in &mut m.value.body.body {
+                    rename_apply_stmt(s, map);
+                }
             }
         }
     }

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.12.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+arms to `classify_decl` and `rewrite_decl` that treat a class declaration's
+members exactly like a class expression's — each non-computed method key is a
+renameable property name (with `constructor` pinned as never-renameable). The
+shared member logic was factored into `classify_class_members` /
+`rewrite_class_members` helpers used by both the expression and declaration arms,
+so classification and rewrite stay in lockstep. The class's own name is a
+variable, not a property, so it is untouched. Reachable once the CLOC12.174 PR2
+bridge produces the node.
+
 ## [0.12.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.12.13"
+version = "0.12.14"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1015,6 +1015,59 @@ fn classify_decl(decl: &Declaration, cls: &mut Classify, nodes_touched: &mut u32
                 classify_stmt(s, cls, nodes_touched);
             }
         }
+        // A class *declaration* classifies its members exactly like a class
+        // *expression* — the class name is a variable binding, not a property,
+        // so only the member keys + bodies matter.
+        Declaration::ClassDeclaration(cd) => classify_class_members(&cd.super_class, &cd.body, cls),
+    }
+}
+
+/// Classify the property names inside the shared `[extends S] { members }` tail
+/// of a class — reused by the class *expression* arm of [`classify_expr`] and
+/// the class *declaration* arm of [`classify_decl`], which share their body
+/// shape. Each non-computed method key is recorded as a property name (with the
+/// `constructor` keyword pinned as un-renameable), computed-key expressions are
+/// recursed, and each method body is classified. The class's own name is a
+/// variable, not a property, so it never enters here.
+fn classify_class_members(
+    super_class: &Option<Box<Expression>>,
+    body: &[ClassMember],
+    cls: &mut Classify,
+) {
+    if let Some(sup) = super_class {
+        classify_expr(sup, cls);
+    }
+    for member in body {
+        match member {
+            ClassMember::Method(m) => {
+                if !m.computed {
+                    match &m.key {
+                        // `constructor` is a class-semantic keyword-as-key, NOT
+                        // an ordinary property: renaming it would turn the
+                        // constructor into a plain prototype method and the
+                        // class would silently get an implicit ctor — `new C(x)`
+                        // would stop initialising (miscompile). Pin it via the
+                        // same channel as a quoted key so it is never eligible
+                        // for renaming anywhere.
+                        PropertyKey::Identifier(id) if id.name == "constructor" => {
+                            cls.see_quoted("constructor")
+                        }
+                        PropertyKey::Identifier(id) => cls.see_dotted(&id.name),
+                        PropertyKey::StringLiteral(s) => cls.see_quoted(&s.value),
+                        _ => {}
+                    }
+                } else if let PropertyKey::Expression(e) = &m.key {
+                    // A computed key `[expr]` is a dynamic access — no static
+                    // name recorded, but recurse for nested property accesses
+                    // inside the key expression.
+                    classify_expr(e, cls);
+                }
+                let mut nested = 0u32;
+                for s in &m.value.body.body {
+                    classify_stmt(s, cls, &mut nested);
+                }
+            }
+        }
     }
 }
 
@@ -1275,43 +1328,7 @@ fn classify_expr(expr: &Expression, cls: &mut Classify) {
         //     property names.
         //
         // The `extends` operand is an ordinary expression — recurse into it.
-        Expression::ClassExpression(ce) => {
-            if let Some(sup) = &ce.super_class {
-                classify_expr(sup, cls);
-            }
-            for member in &ce.body {
-                match member {
-                    ClassMember::Method(m) => {
-                        if !m.computed {
-                            match &m.key {
-                                // `constructor` is a class-semantic keyword-as-key,
-                                // NOT an ordinary property: renaming it would turn
-                                // the constructor into a plain prototype method and
-                                // the class would silently get an implicit ctor —
-                                // `new C(x)` would stop initialising (miscompile).
-                                // Pin it via the same channel as a quoted key so it
-                                // is never eligible for renaming anywhere.
-                                PropertyKey::Identifier(id) if id.name == "constructor" => {
-                                    cls.see_quoted("constructor")
-                                }
-                                PropertyKey::Identifier(id) => cls.see_dotted(&id.name),
-                                PropertyKey::StringLiteral(s) => cls.see_quoted(&s.value),
-                                _ => {}
-                            }
-                        } else if let PropertyKey::Expression(e) = &m.key {
-                            // A computed key `[expr]` is a dynamic access — no
-                            // static name recorded, but recurse for nested
-                            // property accesses inside the key expression.
-                            classify_expr(e, cls);
-                        }
-                        let mut nested = 0u32;
-                        for s in &m.value.body.body {
-                            classify_stmt(s, cls, &mut nested);
-                        }
-                    }
-                }
-            }
-        }
+        Expression::ClassExpression(ce) => classify_class_members(&ce.super_class, &ce.body, cls),
         // Classify property accesses inside an arrow-value's body too —
         // a quoted `o["foo"]` written there must still disable renaming
         // of `foo`. Params are variable names, never property names, so
@@ -1387,6 +1404,53 @@ fn rewrite_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
         Declaration::FunctionDeclaration(fd) => {
             for s in &mut fd.body.body {
                 rewrite_stmt(s, map);
+            }
+        }
+        // A class *declaration* rewrites its members exactly like a class
+        // *expression* (the class name is a variable, untouched by property
+        // renaming) — same shared helper, kept in lockstep with `classify_decl`.
+        Declaration::ClassDeclaration(cd) => {
+            rewrite_class_members(&mut cd.super_class, &mut cd.body, map)
+        }
+    }
+}
+
+/// Rewrite the property keys inside the shared `[extends S] { members }` tail of
+/// a class — the mirror of [`classify_class_members`], reused by both the class
+/// *expression* and *declaration* arms so the classification and the rewrite
+/// cover exactly the same positions. Renames each non-computed method key found
+/// in `map` (never `constructor`), recurses computed-key expressions, and
+/// rewrites each method body.
+fn rewrite_class_members(
+    super_class: &mut Option<Box<Expression>>,
+    body: &mut [ClassMember],
+    map: &HashMap<String, String>,
+) {
+    if let Some(sup) = super_class {
+        rewrite_expr(sup, map);
+    }
+    for member in body {
+        match member {
+            ClassMember::Method(m) => {
+                if m.computed {
+                    if let PropertyKey::Expression(e) = &mut m.key {
+                        rewrite_expr(e, map);
+                    }
+                } else if let PropertyKey::Identifier(id) = &mut m.key {
+                    // Never rewrite a `constructor` key (see classify: it is
+                    // `see_quoted`-pinned, so it is not in `map` anyway — this
+                    // guard is belt-and-braces against a future map that might
+                    // contain it, since renaming it is a construction-semantics
+                    // miscompile).
+                    if id.name != "constructor" {
+                        if let Some(new) = map.get(&id.name) {
+                            id.name = new.clone();
+                        }
+                    }
+                }
+                for s in &mut m.value.body.body {
+                    rewrite_stmt(s, map);
+                }
             }
         }
     }
@@ -1624,36 +1688,7 @@ fn rewrite_expr(expr: &mut Expression, map: &HashMap<String, String>) {
         // `map`, so it is left alone); each method VALUE body is walked for
         // nested property accesses like a `FunctionExpression` body; and the
         // `extends` operand recurses as an ordinary expression.
-        Expression::ClassExpression(ce) => {
-            if let Some(sup) = &mut ce.super_class {
-                rewrite_expr(sup, map);
-            }
-            for member in &mut ce.body {
-                match member {
-                    ClassMember::Method(m) => {
-                        if m.computed {
-                            if let PropertyKey::Expression(e) = &mut m.key {
-                                rewrite_expr(e, map);
-                            }
-                        } else if let PropertyKey::Identifier(id) = &mut m.key {
-                            // Never rewrite a `constructor` key (see classify:
-                            // it is `see_quoted`-pinned, so it is not in `map`
-                            // anyway — this guard is belt-and-braces against a
-                            // future map that might contain it, since renaming
-                            // it is a construction-semantics miscompile).
-                            if id.name != "constructor" {
-                                if let Some(new) = map.get(&id.name) {
-                                    id.name = new.clone();
-                                }
-                            }
-                        }
-                        for s in &mut m.value.body.body {
-                            rewrite_stmt(s, map);
-                        }
-                    }
-                }
-            }
-        }
+        Expression::ClassExpression(ce) => rewrite_class_members(&mut ce.super_class, &mut ce.body, map),
         // Rewrite property accesses inside an arrow-value's body, the
         // mirror of classifying them above.
         Expression::ArrowFunctionExpression(ae) => match &mut ae.body {

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.14.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` match arms
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+arms at each exhaustive match site: `process_stmt` → `false` (a class is not a
+leaf top-level function this pass renames); `stmt_has_function` → `true`
+(a class carries method functions, so the leaf-binding rename is conservatively
+disabled in its presence); `collect_decl_occurrences_stmt` marks the class name
+ineligible (like a function name); and the soundness-critical
+`collect_all_idents_stmt` / `rewrite_uses_stmt` recurse the class name, heritage,
+and every method body (over-collect + shadow-aware rewrite, mirroring the
+`Expression::ClassExpression` arms). Reachable once the CLOC12.174 PR2 bridge
+produces the node.
+
 ## [0.14.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.14.13"
+version = "0.14.14"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -301,6 +301,11 @@ fn process_stmt(
             process_function(fd, nodes_touched, renames)
         }
         Statement::Declaration(Declaration::VariableDeclaration(_)) => false,
+        // A class declaration is not a leaf top-level function whose params
+        // this pass renames — treat it like a variable declaration (no work
+        // here). Its method bodies are separate scopes; leaving them unrenamed
+        // is safe (a missed optimisation, never unsound).
+        Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
         Statement::Tagged(t) => process_tagged(t, nodes_touched, renames),
     }
 }
@@ -427,6 +432,11 @@ fn stmt_has_function(stmt: &Statement) -> bool {
     match stmt {
         Statement::Declaration(Declaration::FunctionDeclaration(_)) => true,
         Statement::Declaration(Declaration::VariableDeclaration(_)) => false,
+        // A class declaration carries method *functions*. Report `true` so the
+        // leaf-binding rename is conservatively disabled in its presence — a
+        // method could capture/re-scope a name, which would make the leaf
+        // rename unsound (see this function's doc comment).
+        Statement::Declaration(Declaration::ClassDeclaration(_)) => true,
         Statement::Tagged(t) => match t {
             TaggedStatement::BlockStatement(b) => b.body.iter().any(stmt_has_function),
             TaggedStatement::IfStatement(is) => {
@@ -650,6 +660,13 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
             out.push((fd.id.name.clone(), false));
             // Do NOT recurse into fd.body — separate scope.
         }
+        Statement::Declaration(Declaration::ClassDeclaration(cd)) => {
+            // A class declaration binds a name — mark it ineligible for local
+            // renaming, like a nested function name (renaming a class name
+            // needs its own care). Do NOT recurse into the method bodies —
+            // separate scopes.
+            out.push((cd.id.name.clone(), false));
+        }
         Statement::Tagged(t) => match t {
             // Anything below this point is inside an inner block → nested.
             TaggedStatement::BlockStatement(b) => collect_decl_occurrences(b, out, true),
@@ -775,6 +792,33 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
                 out.insert(id.name.clone());
             }
             collect_all_idents_block(&fd.body, out);
+        }
+        Statement::Declaration(Declaration::ClassDeclaration(cd)) => {
+            // Soundness-critical: collect EVERY identifier the class introduces
+            // or references — its name, the heritage operand, and each method's
+            // key / value-name / params / body — so a freshly-minted short name
+            // never collides with one. Mirrors the `Expression::ClassExpression`
+            // arm of `collect_all_idents_expr` plus the required class name.
+            out.insert(cd.id.name.clone());
+            if let Some(sup) = &cd.super_class {
+                collect_all_idents_expr(sup, out);
+            }
+            for member in &cd.body {
+                let ClassMember::Method(m) = member;
+                if let PropertyKey::Identifier(id) = &m.key {
+                    out.insert(id.name.clone());
+                }
+                if let Some(id) = &m.value.id {
+                    out.insert(id.name.clone());
+                }
+                for p in &m.value.params {
+                    let FunctionParam::Identifier(id) = p;
+                    out.insert(id.name.clone());
+                }
+                for s in &m.value.body.body {
+                    collect_all_idents_stmt(s, out);
+                }
+            }
         }
         Statement::Tagged(t) => match t {
             TaggedStatement::ExpressionStatement(es) => {
@@ -1142,6 +1186,33 @@ fn rewrite_uses_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
         // A leaf function has no nested function declarations, so this arm
         // is unreachable in practice; leave nested functions untouched.
         Statement::Declaration(Declaration::FunctionDeclaration(_)) => {}
+        Statement::Declaration(Declaration::ClassDeclaration(cd)) => {
+            // Rewrite renamed outer locals used in the heritage operand and
+            // inside each method body. The class's own name is marked
+            // ineligible during collection (never in `map`); each method's
+            // id/params SHADOW outer locals, so they are dropped from the active
+            // map before recursing — mirroring the `Expression::ClassExpression`
+            // arm of `rewrite_uses_expr`.
+            if let Some(sup) = &mut cd.super_class {
+                rewrite_uses_expr(sup, map);
+            }
+            let mut class_inner = map.clone();
+            class_inner.remove(&cd.id.name);
+            for member in &mut cd.body {
+                let ClassMember::Method(m) = member;
+                let mut inner = class_inner.clone();
+                if let Some(id) = &m.value.id {
+                    inner.remove(&id.name);
+                }
+                for p in &m.value.params {
+                    let FunctionParam::Identifier(id) = p;
+                    inner.remove(&id.name);
+                }
+                for s in &mut m.value.body.body {
+                    rewrite_uses_stmt(s, &inner);
+                }
+            }
+        }
         Statement::Tagged(t) => rewrite_uses_tagged(t, map),
     }
 }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.14] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `Declaration::ClassDeclaration` walk arm
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` variant. Added
+`walk_class_declaration` to the exhaustive `walk_declaration` match: it emits a
+`BindingKind::Class` binding for the class name in the current scope (the lexical
+analogue of the `Function`-kind binding a function declaration hoists — the
+`Class` kind was already reserved for exactly this), then resolves references in
+the `extends` heritage (enclosing scope) and each method value (its own function
+scope). Reachable once the CLOC12.174 PR2 bridge produces the node.
+
 ## [0.12.13] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` match arm (mirrors `FunctionExpression`)

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.13"
+version = "0.12.14"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -68,7 +68,7 @@
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use coding_adventures_javascript_ast::{
     ArrowBody, ArrowFunctionExpression,
-    AssignmentTarget, BindingTarget, BlockStatement, ClassMember, CvId, Declaration, Expression, ForInit,
+    AssignmentTarget, BindingTarget, BlockStatement, ClassDeclaration, ClassMember, CvId, Declaration, Expression, ForInit,
     FunctionDeclaration, FunctionExpression, FunctionParam, ObjectMember, Program, ProgramItem, Property, PropertyKey, Statement,
     VarKind, VariableDeclaration,
 };
@@ -495,6 +495,43 @@ fn walk_declaration(
     match decl {
         Declaration::VariableDeclaration(vd) => walk_variable_declaration(vd, ctx, analysis, pending),
         Declaration::FunctionDeclaration(fd) => walk_function_declaration(fd, ctx, analysis, pending),
+        Declaration::ClassDeclaration(cd) => walk_class_declaration(cd, ctx, analysis, pending),
+    }
+}
+
+/// Walk a class *declaration* (`class C [extends S] { … }`). Two jobs, mirroring
+/// the split between [`walk_function_declaration`] (the name binding) and the
+/// `Expression::ClassExpression` arm of [`walk_expression`] (the body):
+///
+/// 1. **Bind the class name.** A class declaration introduces a
+///    [`BindingKind::Class`] binding for `cd.id` in the current scope — the
+///    lexical analogue of the `Function`-kind binding a function declaration
+///    hoists. This is what lets a later reference to `C` resolve (and a renaming
+///    pass rename the class consistently).
+/// 2. **Resolve inside the body.** The `extends` heritage is an ordinary
+///    expression evaluated in the enclosing scope; each method `value` is a
+///    function expression walked as its own function scope — identical to the
+///    class-expression handling.
+fn walk_class_declaration(
+    cd: &ClassDeclaration,
+    ctx: WalkCtx,
+    analysis: &mut ScopeAnalysis,
+    pending: &mut Vec<PendingReference>,
+) {
+    emit_binding(
+        cd.id.name.clone(),
+        BindingKind::Class,
+        ctx.current,
+        cd.id.cv.clone(),
+        analysis,
+    );
+    if let Some(sup) = &cd.super_class {
+        walk_expression(sup, ctx, analysis, pending);
+    }
+    for member in &cd.body {
+        match member {
+            ClassMember::Method(m) => walk_function_expression(&m.value, ctx, analysis, pending),
+        }
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.33.0] - 2026-07-10
+
+### Added — CLOC12.174 PR1: `ClassDeclaration` node (the class *statement*)
+
+The declaration half of the class arc whose *expression* form shipped in 0.32.0
+(CLOC12.173). New `Declaration` variant `ClassDeclaration(ClassDeclaration)`:
+
+- `ClassDeclaration { cv, id: Identifier, super_class: Option<Box<Expression>>, body: Vec<ClassMember> }`
+  — `class C [extends S] { members }` in statement position.
+- **Reuses** `ClassMember` / `MethodDefinition` / `MethodKind` from the expression
+  form — no new member modelling.
+- The one structural difference from `ClassExpression`: `id` is `Identifier`
+  (required), not `Option<Identifier>` — a class declaration must bind a name
+  (`class {}` in statement position is a syntax error), exactly as
+  `FunctionDeclaration.id` is required where `FunctionExpression.id` is optional.
+
+Round-trip tests cover the `ClassDeclaration` type tag and the ESTree
+`superClass` camelCase field (present with heritage, omitted without).
+
 ## [0.32.0] - 2026-07-08
 
 ### Added — CLOC12.173 PR1: `ClassExpression` node + class member sub-AST

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/declaration.rs
+++ b/code/packages/rust/javascript-ast/src/declaration.rs
@@ -16,7 +16,7 @@
 //! in [`crate::statement`] lets a declaration appear anywhere a
 //! statement does — matching ESTree's flatter shape on the JSON wire.
 
-use crate::expression::{Expression, Identifier};
+use crate::expression::{ClassMember, Expression, Identifier};
 use crate::statement::BlockStatement;
 use crate::CvId;
 use serde::{Deserialize, Serialize};
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 pub enum Declaration {
     VariableDeclaration(VariableDeclaration),
     FunctionDeclaration(FunctionDeclaration),
+    ClassDeclaration(ClassDeclaration),
 }
 
 /// `var x = 1, y = 2;`, `let i = 0;`, `const PI = 3.14;`. The `kind`
@@ -101,6 +102,46 @@ pub struct FunctionDeclaration {
 #[serde(untagged)]
 pub enum FunctionParam {
     Identifier(Identifier),
+}
+
+/// `class C { … }`, `class C extends B { … }` — a class written in
+/// **statement** position. This is the *declaration* form: it binds the name
+/// `C` in the enclosing scope, exactly as [`FunctionDeclaration`] binds a
+/// function name.
+///
+/// # How it differs from [`crate::expression::ClassExpression`]
+///
+/// The class *expression* (`x = class {}`, `f(class C {})`) and the class
+/// *declaration* (`class C {}` as a statement) share their entire body shape —
+/// the `extends` heritage and the `{ … }` member list — and so reuse the same
+/// [`ClassMember`] sub-AST. The **one** structural difference is the name:
+///
+/// | node                | `id`                    | why                                    |
+/// |---------------------|-------------------------|----------------------------------------|
+/// | `ClassExpression`   | `Option<Identifier>`    | may be anonymous (`x = class {}`)      |
+/// | `ClassDeclaration`  | `Identifier` (required) | `class {}` in statement position is a  |
+/// |                     |                         | syntax error — a declaration must name |
+/// |                     |                         | its binding                            |
+///
+/// This mirrors exactly the `FunctionExpression` (optional `id`) vs
+/// `FunctionDeclaration` (required `id`) split — a value may be anonymous, a
+/// statement that introduces a binding cannot be.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClassDeclaration {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    /// The bound class name. Required — see the type-level doc for why a
+    /// declaration's `id` is not optional.
+    pub id: Identifier,
+    /// The `extends <expr>` operand, if any — same shape as
+    /// [`crate::expression::ClassExpression::super_class`] (a boxed
+    /// [`Expression`], so an identifier / member / call heritage is all legal).
+    #[serde(skip_serializing_if = "Option::is_none", default, rename = "superClass")]
+    pub super_class: Option<Box<Expression>>,
+    /// The class body — the ordered member list between the braces. May be
+    /// empty (`class C {}`). Reuses [`ClassMember`] from the expression form.
+    pub body: Vec<ClassMember>,
 }
 
 #[cfg(test)]
@@ -281,5 +322,82 @@ mod tests {
         let back: FunctionDeclaration =
             serde_json::from_str(&json).expect("deserialize");
         assert!(back.generator);
+    }
+
+    #[test]
+    fn class_declaration_roundtrips_with_type_tag() {
+        // `class C extends B { m() {} }` — a named declaration with heritage and
+        // one member, exercising the required `id`, the `superClass` operand,
+        // and the reused `ClassMember` body.
+        use crate::expression::{
+            ClassMember, FunctionExpression, MethodDefinition, MethodKind, PropertyKey,
+        };
+        let d = Declaration::ClassDeclaration(ClassDeclaration {
+            cv: Some("cd.1".to_string()),
+            id: Identifier {
+                cv: None,
+                name: "C".to_string(),
+            },
+            super_class: Some(Box::new(Expression::Identifier(Identifier {
+                cv: None,
+                name: "B".to_string(),
+            }))),
+            body: vec![ClassMember::Method(MethodDefinition {
+                cv: None,
+                key: PropertyKey::Identifier(Identifier {
+                    cv: None,
+                    name: "m".to_string(),
+                }),
+                kind: MethodKind::Method,
+                value: FunctionExpression {
+                    cv: None,
+                    id: None,
+                    params: vec![],
+                    body: BlockStatement {
+                        cv: None,
+                        body: vec![],
+                    },
+                    generator: false,
+                    is_async: false,
+                },
+                computed: false,
+                is_static: false,
+            })],
+        });
+        assert_eq!(type_tag(&d), "ClassDeclaration");
+        assert_eq!(roundtrip(d.clone()), d);
+    }
+
+    #[test]
+    fn class_declaration_serializes_superclass_camelcase() {
+        // The heritage field must serialize as ESTree `superClass`, not
+        // `super_class`, and be omitted entirely when there is no heritage.
+        let with = Declaration::ClassDeclaration(ClassDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "C".to_string(),
+            },
+            super_class: Some(Box::new(Expression::Identifier(Identifier {
+                cv: None,
+                name: "B".to_string(),
+            }))),
+            body: vec![],
+        });
+        let json = serde_json::to_string(&with).expect("serialize");
+        assert!(json.contains("\"superClass\""), "got {}", json);
+        assert!(!json.contains("super_class"), "got {}", json);
+
+        let without = Declaration::ClassDeclaration(ClassDeclaration {
+            cv: None,
+            id: Identifier {
+                cv: None,
+                name: "C".to_string(),
+            },
+            super_class: None,
+            body: vec![],
+        });
+        let json = serde_json::to_string(&without).expect("serialize");
+        assert!(!json.contains("superClass"), "heritage omitted; got {}", json);
     }
 }

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -128,7 +128,7 @@ mod es_version_serde {
 // `use coding_adventures_javascript_ast::{Program, IfStatement,
 // BinaryOperator}` without learning the module layout.
 pub use declaration::{
-    BindingTarget, Declaration, FunctionDeclaration, FunctionParam, VarKind,
+    BindingTarget, ClassDeclaration, Declaration, FunctionDeclaration, FunctionParam, VarKind,
     VariableDeclaration, VariableDeclarator,
 };
 pub use expression::{

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2138,6 +2138,128 @@ shipped node + emit + conformance-port ahead of the parser. `emit_await` is thus
 fully covered; only the parser→typed-AST reachability remains, tracked here.
 
 
+## CLOC12.174 — `ClassDeclaration` (`class C [extends S] { … }`): the class *statement* arc (design)
+
+CLOC12.173 shipped the class **expression** (a value: `x = class {}`, `f(class C {})`).
+Its closing note flagged the remaining half explicitly: *"The bridge for a class
+**declaration** (a `ProgramItem`, not an `Expression`) is a separate future arc…
+The two share the member sub-AST once PR1 lands."* That arc is CLOC12.174, and the
+member sub-AST (`ClassMember` / `MethodDefinition` / `MethodKind`) now exists, so
+this is a **small, additive** arc — no new member modelling, only a new
+*declaration-position* node that reuses it.
+
+A class declaration is the **statement** form: `class C { … }` written where a
+statement is expected, binding the name `C` in the enclosing scope. It mirrors
+`FunctionDeclaration` (the `function f(){}` statement) exactly as `ClassExpression`
+mirrors `FunctionExpression`.
+
+### Model (ESTree-aligned)
+
+```rust
+// javascript-ast/src/declaration.rs — a new variant of the `Declaration` enum
+pub enum Declaration {
+    VariableDeclaration(VariableDeclaration),
+    FunctionDeclaration(FunctionDeclaration),
+    ClassDeclaration(ClassDeclaration),          // NEW
+}
+
+pub struct ClassDeclaration {
+    pub cv: Option<CvId>,
+    pub id: Identifier,                          // REQUIRED — a declaration always binds a name
+    pub super_class: Option<Box<Expression>>,    // `extends <expr>` heritage (reused shape)
+    pub body: Vec<ClassMember>,                  // reuse ClassMember from expression.rs
+}
+```
+
+**The one structural difference from `ClassExpression`: `id` is `Identifier`, not
+`Option<Identifier>`.** A class *expression* may be anonymous (`x = class {}`); a
+class *declaration* must name its binding (`class {}` in statement position is a
+syntax error), exactly as `FunctionDeclaration.id` is required where
+`FunctionExpression.id` is optional. `super_class` and `body` are byte-identical
+in shape to `ClassExpression` and reuse the same `ClassMember` / `MethodDefinition`
+/ `MethodKind` types (imported from `expression.rs`) — no new member modelling.
+
+### Emit (`closure-emitter`)
+
+`class <id>[ extends S]{members}` — the same body shape as `emit_class`, with three
+deliberate differences from a class *expression*, all mirroring the
+declaration/expression split already established for functions:
+
+1. **No precedence wrap and no statement-start parenthesisation.** A class
+   expression is tagged `PREC_UNARY` and `emit_expression_statement` wraps a
+   leading one (`(class{});`) because a statement-position `class` would otherwise
+   parse as a *declaration* — which is precisely what a `ClassDeclaration` **is**.
+   So the declaration form is emitted bare, with no `expr_prec` entry and no
+   wrap-set membership.
+2. **`id` always prints** (it is non-optional), with a `required_ws()` after
+   `class` exactly as `emit_function_declaration` does after `function`.
+3. **No trailing `;`.** `emit_function_declaration` appends a normalising `;`
+   after its `}` (gap-030 part B). A **class** declaration does *not* — upstream
+   Closure terminates a `ClassDeclaration` with its `}` alone (a class body is
+   self-delimiting and never subject to ASI hazards the way a bare
+   `function(){}` value is). PR3's conformance port validates this against
+   `CodePrinterTest`.
+
+Implementation reuses `emit_class_member` unchanged. The shared
+`[ extends S]{members}` tail is factored into a small helper used by **both**
+`emit_class` (after its optional-id head) and the new `emit_class_declaration`
+(after its required-id head), so the heritage-precedence + member-loop logic lives
+in one place.
+
+### Pass arms — the atomic-PR1 blast radius
+
+Adding a variant to the `Declaration` enum makes **every exhaustive `match` on
+`Declaration` fail to compile** until an arm is added — that is the point of the
+atomic PR1 (enum + emit + all arms in ONE commit, workspace green). The
+`Declaration` match sites are: `closure-emitter`, `closure-pass-constant-fold`,
+`closure-pass-dce`, `closure-pass-fold-control-flow`, `closure-pass-inline`,
+`closure-pass-inline-variables`, `closure-pass-rename`, `closure-pass-rename-globals`,
+`closure-pass-rename-properties`, `closure-pass-treeshake`,
+`closure-pass-remove-unused-vars`, `closure-scope-analyzer`, plus `bridge.rs` /
+`run.rs` (touched in PR2, not PR1). Each new arm **mirrors that crate's existing
+`Expression::ClassExpression` handling** — which already knows how to walk
+`super_class` and each method `value` (a nested function scope) — since 173 PR1
+added exactly that machinery. So the arm is "recurse into the heritage operand and
+each member body," reusing the same helper the ClassExpression arm calls. Rebuild
+/ transform arms delegate to an `#[inline(never)]` helper (frame-size DoS lesson,
+per 173). The declared *name* `C` is a binding a variable-renaming pass may rename
+(like `FunctionDeclaration.id`), unlike a method key (a property name) — the arm
+follows the `FunctionDeclaration` arm's treatment of `.id`, not the method-key
+treatment. Non-exhaustive matches with a catch-all (`treeshake` /
+`remove-unused-vars` may already absorb it) need no arm; the per-crate CI
+build-tool is the source of truth for which do (a compile error there — NOT a
+green `grep -c "test result: FAILED"`, the flawed check called out in 173 — is
+what proves the arm was needed).
+
+### PR breakdown
+
+- **PR1 (atomic node + emit + all pass arms, ONE commit).** `javascript-ast`
+  (MINOR) adds `ClassDeclaration` + the `Declaration::ClassDeclaration` variant;
+  `closure-emitter` (MINOR) adds `emit_class_declaration` + the shared class-tail
+  helper + the `Declaration::ClassDeclaration` emit arm; every pass crate that
+  matches `Declaration` exhaustively gets its mirror-of-FunctionDeclaration arm.
+  Hand-constructed emitter unit tests (named class, `extends`, one method,
+  `static`/`get`/`set`, computed key, `constructor` — asserting **no** trailing
+  `;` and **no** wrapping paren).
+- **PR2 (bridge-enable).** `javascript-parser` (MINOR) + `closurec` (PATCH):
+  convert the grammar's `class_declaration` node → `Declaration::ClassDeclaration`,
+  reusing the `convert_class_heritage` / `convert_class_element` /
+  `convert_method_definition` converters that 173 PR2 already built for the
+  expression form (only the top-level node kind and the required-`id` differ).
+  Dump the parse-tree shape first. Add a `closurec` e2e diff fixture
+  (`tests/diff/simple-class-decl/`). Same decline-to-WHITESPACE_ONLY safety for
+  the member shapes the grammar can't yet cleanly bridge (generator / async /
+  computed / multi-member), never a miscompile.
+- **PR3 (CodePrinter conformance port).** `closure-emitter` (PATCH): new
+  `tests/upstream/code_printer_class_declaration_test.rs` mirroring upstream
+  `CodePrinterTest`'s class-**declaration** printing cases (statement position, no
+  wrap, no trailing `;`, heritage, members) — hand-constructed AST, so it also
+  covers the member shapes the grammar cannot yet parse.
+
+Serialised after 173 (shares the member sub-AST it introduced). Fields
+(`PropertyDefinition`) and static blocks remain deferred to their own additive
+slices, identical to the ClassExpression deferral.
+
 ## CLOC12.173 — `ClassExpression` (`class [id] [extends S] { … }`): the class arc (design)
 
 `ClassExpression` is the next `Expression` node, and unlike every arc since

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2260,6 +2260,30 @@ Serialised after 173 (shares the member sub-AST it introduced). Fields
 (`PropertyDefinition`) and static blocks remain deferred to their own additive
 slices, identical to the ClassExpression deferral.
 
+**PR1 (DONE).** `javascript-ast` 0.33.0 adds `ClassDeclaration` + the
+`Declaration::ClassDeclaration` variant exactly as modelled; `closure-emitter`
+0.38.0 adds `emit_class_declaration` + the shared `emit_class_tail` helper
+(factored out of `emit_class`), with 5 unit tests asserting the bare, no-`;`,
+no-wrap shape. The atomic pass-arm set turned out **larger than the design note's
+match-site list**: the note named 12 crates but only enumerated the ones with a
+central `fn *_declaration`; in fact `closure-pass-inline` (7 sites) and
+`closure-pass-rename` (5 sites) ALSO match `Declaration` exhaustively at many
+predicate/collect/rewrite helpers, and both needed arms — the per-crate CI
+build-tool (a compile error, the ground truth) is what surfaced them, exactly the
+lesson 173 recorded. Final arm-bearing crates: `constant-fold` 0.85.14, `dce`
+0.20.14, `fold-control-flow` 0.20.14, `inline` 0.25.14, `inline-variables`
+0.11.14, `rename` 0.14.14, `rename-globals` 0.10.14, `rename-properties` 0.12.14,
+`scope-analyzer` 0.12.14. `treeshake` / `remove-unused-vars` route through
+catch-alls (no arm). Each arm mirrors the crate's existing
+`Expression::ClassExpression` handling plus the required class-name binding;
+soundness-critical passes (`inline` tally/inline, `inline-variables`
+count-uses/propagate, `rename` collect/rewrite) recurse the heritage + every
+method body so a class use is never missed. Where a class-body walk was
+duplicated between the expression and declaration forms it was factored into a
+shared helper (`fold_class_body`, `classify_class_members` /
+`rewrite_class_members`). Reachable end-to-end once the PR2 bridge produces the
+node.
+
 ## CLOC12.173 — `ClassExpression` (`class [id] [extends S] { … }`): the class arc (design)
 
 `ClassExpression` is the next `Expression` node, and unlike every arc since


### PR DESCRIPTION
## CLOC12.174 PR1 — `ClassDeclaration` atomic node

The **declaration** half of the class arc — `class C [extends S] {…}` in statement position — whose *expression* form shipped in CLOC12.173. Atomic node PR1: enum variant + emit + **every** exhaustive-match pass arm in ONE commit, workspace green.

### What's here
- **javascript-ast 0.33.0** — new `Declaration::ClassDeclaration` variant + `ClassDeclaration { cv, id: Identifier (required), super_class, body: Vec<ClassMember> }`, reusing the `ClassMember` sub-AST from 173. The one structural difference from `ClassExpression` is the **required `id`** (a declaration must bind a name), mirroring `FunctionDeclaration` vs `FunctionExpression`. +2 round-trip tests.
- **closure-emitter 0.38.0** — `emit_class_declaration` prints `class <id>[ extends S]{members}` via a shared `emit_class_tail` helper (factored out of `emit_class`). Three deliberate differences from the expression form, each the mirror of the function decl/expr split: **id always prints**; **no precedence wrap / no statement-start paren**; **no trailing `;`**. +5 emitter unit tests.
- **9 pass crates** get `Declaration::ClassDeclaration` arms, each mirroring the crate's existing `Expression::ClassExpression` handling plus the class-name binding: constant-fold, dce, fold-control-flow, inline, inline-variables, rename, rename-globals, rename-properties, scope-analyzer. Soundness-critical passes recurse the heritage operand + every method body so a class use is never missed. Duplicated class-body walks were factored into shared helpers (`fold_class_body`, `classify`/`rewrite_class_members`).

### Notes
- The atomic set was **larger than the design note's match-site list**: `inline` (7 sites) and `rename` (5 sites) also match `Declaration` exhaustively at many predicate/collect/rewrite helpers — the per-crate build-tool surfaced them (a compile error is the ground truth, per the CLOC12.173 lesson). `treeshake` / `remove-unused-vars` route through catch-alls (no arm).
- Spec (`code/specs/CLOC12-gaps.md`) authored first (specs-before-code) and updated with a PR1-DONE note recording the divergence.
- Reachable end-to-end once the **PR2** bridge produces the node.
- Security review: PASSED (in-memory AST transforms; recursion bounded by the same limits as the mirrored ClassExpression handling; no `unsafe`, no reachable panics on valid AST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)