### PR TITLE
feat(semantic-ir): SIR23 symbolic/pattern Expr/SirType/Feature variants

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -3538,6 +3538,24 @@ fn expr_may_have_effects(expr: &Expr) -> bool {
         | Expr::BuiltinCall { .. }
         | Expr::MakeClosure { .. }
         | Expr::Intrinsic { .. } => true,
+
+        // SIR23 symbolic-expression/pattern nodes: the spec's "Effects"
+        // section marks every one of these `Pure` too — same treatment as
+        // the SIR22 array/matrix nodes above.
+        Expr::SymSymbol { .. } | Expr::SymRational { .. } => false,
+        Expr::SymApply { head, args, .. } => {
+            expr_may_have_effects(head) || args.iter().any(expr_may_have_effects)
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            head.as_deref().is_some_and(expr_may_have_effects)
+        }
+        Expr::SymPatternNamed { pattern, .. } => expr_may_have_effects(pattern),
+        Expr::SymRule { lhs, rhs, .. } => {
+            expr_may_have_effects(lhs) || expr_may_have_effects(rhs)
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            expr_may_have_effects(expr) || rules.iter().any(expr_may_have_effects)
+        }
     }
 }
 

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -3742,6 +3742,32 @@ fn collect_callees_expr(expr: &Expr, out: &mut HashSet<String>) {
                 }
             }
         }
+        // SIR23 symbolic-expression/pattern nodes: the Python frontend never
+        // emits these either, but recurse into every child `Expr` slot for
+        // the same reason as the SIR22 nodes above.
+        Expr::SymSymbol { .. } | Expr::SymRational { .. } => {}
+        Expr::SymApply { head, args, .. } => {
+            collect_callees_expr(head, out);
+            for a in args {
+                collect_callees_expr(a, out);
+            }
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            if let Some(h) = head {
+                collect_callees_expr(h, out);
+            }
+        }
+        Expr::SymPatternNamed { pattern, .. } => collect_callees_expr(pattern, out),
+        Expr::SymRule { lhs, rhs, .. } => {
+            collect_callees_expr(lhs, out);
+            collect_callees_expr(rhs, out);
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            collect_callees_expr(expr, out);
+            for r in rules {
+                collect_callees_expr(r, out);
+            }
+        }
         // Atoms and references bind nothing.
         Expr::IntLit { .. }
         | Expr::BoolLit { .. }

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -319,6 +319,29 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
                     .iter()
                     .any(|idx| index_arg_references_any_name(idx, names))
         }
+
+        // SIR23 compile-compat stubs: same rationale as the SIR22 stubs
+        // above — the Ruby frontend never produces any symbolic-expression
+        // or pattern/rewrite node today, but every arm still recurses
+        // structurally so the swap-safety check keeps scanning every child
+        // `Expr` for `VarRef`s if a future lowering path starts emitting
+        // them.
+        Expr::SymSymbol { .. } | Expr::SymRational { .. } => false,
+        Expr::SymApply { head, args, .. } => {
+            expr_references_any_name(head, names)
+                || args.iter().any(|a| expr_references_any_name(a, names))
+        }
+        Expr::SymPatternBlank { head, .. } => head
+            .as_ref()
+            .is_some_and(|h| expr_references_any_name(h, names)),
+        Expr::SymPatternNamed { pattern, .. } => expr_references_any_name(pattern, names),
+        Expr::SymRule { lhs, rhs, .. } => {
+            expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            expr_references_any_name(expr, names)
+                || rules.iter().any(|r| expr_references_any_name(r, names))
+        }
     }
 }
 
@@ -4149,6 +4172,39 @@ impl Lowerer {
                 }
                 found
             }
+
+            // SIR23 compile-compat stubs: same rationale as the SIR22 stubs
+            // above — this frontend never emits any symbolic-expression or
+            // pattern/rewrite node today, but every arm still recurses into
+            // its children so a nested `yield` would still be found if such
+            // a node were ever produced.
+            Expr::SymSymbol { .. } | Expr::SymRational { .. } => false,
+            Expr::SymApply { head, args, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(head, block_scope);
+                for a in args.iter_mut() {
+                    found |= Self::rewrite_yields_in_expr(a, block_scope);
+                }
+                found
+            }
+            Expr::SymPatternBlank { head, .. } => head
+                .as_mut()
+                .map(|h| Self::rewrite_yields_in_expr(h, block_scope))
+                .unwrap_or(false),
+            Expr::SymPatternNamed { pattern, .. } => {
+                Self::rewrite_yields_in_expr(pattern, block_scope)
+            }
+            Expr::SymRule { lhs, rhs, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(lhs, block_scope);
+                found |= Self::rewrite_yields_in_expr(rhs, block_scope);
+                found
+            }
+            Expr::SymReplaceAll { expr, rules, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(expr, block_scope);
+                for r in rules.iter_mut() {
+                    found |= Self::rewrite_yields_in_expr(r, block_scope);
+                }
+                found
+            }
         }
     }
 
@@ -4821,6 +4877,35 @@ impl Lowerer {
                     Self::normalize_calls_in_index_arg(idx, ctx);
                 }
             }
+            // SIR23 compile-compat stubs (never emitted by this frontend):
+            // recurse into every child `Expr`, matching the SIR22 stubs
+            // above, so a parenless block-method call nested inside one of
+            // these would still be normalized.
+            Expr::SymSymbol { .. } | Expr::SymRational { .. } => {}
+            Expr::SymApply { head, args, .. } => {
+                Self::normalize_calls_in_expr(head, ctx);
+                for a in args.iter_mut() {
+                    Self::normalize_calls_in_expr(a, ctx);
+                }
+            }
+            Expr::SymPatternBlank { head, .. } => {
+                if let Some(h) = head {
+                    Self::normalize_calls_in_expr(h, ctx);
+                }
+            }
+            Expr::SymPatternNamed { pattern, .. } => {
+                Self::normalize_calls_in_expr(pattern, ctx);
+            }
+            Expr::SymRule { lhs, rhs, .. } => {
+                Self::normalize_calls_in_expr(lhs, ctx);
+                Self::normalize_calls_in_expr(rhs, ctx);
+            }
+            Expr::SymReplaceAll { expr, rules, .. } => {
+                Self::normalize_calls_in_expr(expr, ctx);
+                for r in rules.iter_mut() {
+                    Self::normalize_calls_in_expr(r, ctx);
+                }
+            }
             // Atomic literals and a non-rewritten VarRef carry no
             // sub-expressions.
             Expr::IntLit { .. }
@@ -5053,6 +5138,35 @@ impl Lowerer {
                 Self::collect_bound_names_expr(target, out);
                 for idx in indices {
                     Self::collect_bound_names_expr_in_index_arg(idx, out);
+                }
+            }
+            // SIR23 compile-compat stubs (never emitted by this frontend):
+            // recurse into every child `Expr`, matching the SIR22 stubs
+            // above, so a name bound inside a nested closure would still be
+            // collected.
+            Expr::SymSymbol { .. } | Expr::SymRational { .. } => {}
+            Expr::SymApply { head, args, .. } => {
+                Self::collect_bound_names_expr(head, out);
+                for a in args {
+                    Self::collect_bound_names_expr(a, out);
+                }
+            }
+            Expr::SymPatternBlank { head, .. } => {
+                if let Some(h) = head {
+                    Self::collect_bound_names_expr(h, out);
+                }
+            }
+            Expr::SymPatternNamed { pattern, .. } => {
+                Self::collect_bound_names_expr(pattern, out);
+            }
+            Expr::SymRule { lhs, rhs, .. } => {
+                Self::collect_bound_names_expr(lhs, out);
+                Self::collect_bound_names_expr(rhs, out);
+            }
+            Expr::SymReplaceAll { expr, rules, .. } => {
+                Self::collect_bound_names_expr(expr, out);
+                for r in rules {
+                    Self::collect_bound_names_expr(r, out);
                 }
             }
             Expr::IntLit { .. }

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -860,6 +860,26 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 e.span()
             );
         }
+        // ── SIR23 (symbolic expression + pattern/rewrite IR) ──────────
+        // `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+        // `SymPatternNamed`/`SymRule`/`SymReplaceAll` observe
+        // `Feature::SymbolicExpr` and/or `Feature::PatternMatching`, neither
+        // of which `ACCEPTED_FEATURES` declares, so the SIR10 capability
+        // gate rejects any module using one of these nodes before it ever
+        // reaches emit — mirrors the SIR22/SIR26 deferred-node panic above.
+        Expr::SymSymbol { .. }
+        | Expr::SymRational { .. }
+        | Expr::SymApply { .. }
+        | Expr::SymPatternBlank { .. }
+        | Expr::SymPatternNamed { .. }
+        | Expr::SymRule { .. }
+        | Expr::SymReplaceAll { .. } => {
+            panic!(
+                "go backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                e.span()
+            );
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -846,6 +846,28 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 e.kind_name()
             );
         }
+        // ── SIR23: symbolic expression + pattern/rewrite nodes (deferred) ──
+        // Neither `Feature::SymbolicExpr` nor `Feature::PatternMatching` is
+        // in `ACCEPTED_FEATURES` (see lib.rs), so `check_module` rejects any
+        // module using these nodes before lowering reaches this emitter —
+        // per the SIR23 spec's "Backend impact": real codegen (a tagged
+        // term-tree value built/consumed via `sir-runtime-symbolic`'s
+        // `__SirSym.apply`/`replaceAll`/`replaceRepeated`) is a follow-up PR
+        // once that runtime package exists, not required for this spec to
+        // land safely. These panics only guard against the capability check
+        // ever drifting, exactly like the SIR22/SIR26 arm above.
+        Expr::SymSymbol { span, .. }
+        | Expr::SymRational { span, .. }
+        | Expr::SymApply { span, .. }
+        | Expr::SymPatternBlank { span, .. }
+        | Expr::SymPatternNamed { span, .. }
+        | Expr::SymRule { span, .. }
+        | Expr::SymReplaceAll { span, .. } => {
+            panic!(
+                "javascript backend reached a deferred SIR23 expression ({}) at {span} — not accepted yet",
+                e.kind_name()
+            );
+        }
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -416,6 +416,24 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
                 || indices.iter().any(|ix| index_arg_uses_builtin(ix, name))
         }
         Expr::Convert { value, .. } => expr_uses_builtin(value, name),
+        // SIR23 symbolic-expression/pattern nodes are not accepted by this
+        // backend yet (see `ACCEPTED_FEATURES` in `lib.rs`), so a validated
+        // module never contains them in practice — same rationale as the
+        // SIR22 arms above; recurse into every sub-expression regardless.
+        Expr::SymSymbol { .. } | Expr::SymRational { .. } => false,
+        Expr::SymApply { head, args, .. } => {
+            expr_uses_builtin(head, name) || args.iter().any(|a| expr_uses_builtin(a, name))
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            head.as_deref().is_some_and(|h| expr_uses_builtin(h, name))
+        }
+        Expr::SymPatternNamed { pattern, .. } => expr_uses_builtin(pattern, name),
+        Expr::SymRule { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            expr_uses_builtin(expr, name) || rules.iter().any(|r| expr_uses_builtin(r, name))
+        }
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -1245,6 +1263,24 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::Convert { .. } => {
             panic!(
                 "python backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                e.span()
+            );
+        }
+        // SIR23 symbolic-expression/pattern nodes. This backend does not
+        // declare `Feature::SymbolicExpr`/`Feature::PatternMatching` in
+        // `ACCEPTED_FEATURES` (see `lib.rs`), so `Backend::check_module`
+        // rejects any module using these nodes before emission is ever
+        // reached — matching the SIR22/SIR26 guard above.
+        Expr::SymSymbol { .. }
+        | Expr::SymRational { .. }
+        | Expr::SymApply { .. }
+        | Expr::SymPatternBlank { .. }
+        | Expr::SymPatternNamed { .. }
+        | Expr::SymRule { .. }
+        | Expr::SymReplaceAll { .. } => {
+            panic!(
+                "python backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -521,6 +521,16 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         | Expr::Transpose { .. }
         | Expr::IndexGet { .. }
         | Expr::Convert { .. } => {}
+        // SIR23 symbolic-expression/pattern nodes: same rationale as the
+        // SIR22 nodes above — rejected before emit, so none of these carry
+        // a reachable `Assign` for this backend.
+        Expr::SymSymbol { .. }
+        | Expr::SymRational { .. }
+        | Expr::SymApply { .. }
+        | Expr::SymPatternBlank { .. }
+        | Expr::SymPatternNamed { .. }
+        | Expr::SymRule { .. }
+        | Expr::SymReplaceAll { .. } => {}
     }
 }
 
@@ -1109,6 +1119,24 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::Convert { span, .. } => {
             panic!(
                 "rust backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                span
+            );
+        }
+        // SIR23 symbolic-expression/pattern nodes — `Feature::SymbolicExpr` /
+        // `Feature::PatternMatching` are not in this backend's accepted-
+        // features list, so `check_module` rejects any module using them
+        // before it ever reaches emit.  Defensive panic covers internal
+        // bugs only (matches the SIR22/SIR26 arm above).
+        Expr::SymSymbol { span, .. }
+        | Expr::SymRational { span, .. }
+        | Expr::SymApply { span, .. }
+        | Expr::SymPatternBlank { span, .. }
+        | Expr::SymPatternNamed { span, .. }
+        | Expr::SymRule { span, .. }
+        | Expr::SymReplaceAll { span, .. } => {
+            panic!(
+                "rust backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 span
             );

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -422,6 +422,25 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
                 || indices.iter().any(|idx| index_arg_uses_builtin(idx, name))
         }
         Expr::Convert { value, .. } => expr_uses_builtin(value, name),
+        // SIR23 compile-compat stubs: this backend does not accept
+        // `Feature::SymbolicExpr`/`Feature::PatternMatching` (see
+        // `accepts_features` in lib.rs), so `check_module` rejects any
+        // module using these nodes before emission — same rationale as the
+        // SIR22 stubs above.
+        Expr::SymSymbol { .. } | Expr::SymRational { .. } => false,
+        Expr::SymApply { head, args, .. } => {
+            expr_uses_builtin(head, name) || args.iter().any(|a| expr_uses_builtin(a, name))
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            head.as_deref().is_some_and(|h| expr_uses_builtin(h, name))
+        }
+        Expr::SymPatternNamed { pattern, .. } => expr_uses_builtin(pattern, name),
+        Expr::SymRule { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            expr_uses_builtin(expr, name) || rules.iter().any(|r| expr_uses_builtin(r, name))
+        }
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
         | Expr::BoolLit { .. }
@@ -923,6 +942,33 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
             }
         }
         Expr::Convert { value, .. } => collect_expr_assigned(value, out),
+        // SIR23 compile-compat stubs: rejected by `check_module` before this
+        // backend ever emits (no `Feature::SymbolicExpr`/`Feature::PatternMatching`
+        // in `accepts_features`), but recurse into every operand so the scan
+        // stays faithful regardless.
+        Expr::SymSymbol { .. } | Expr::SymRational { .. } => {}
+        Expr::SymApply { head, args, .. } => {
+            collect_expr_assigned(head, out);
+            for a in args {
+                collect_expr_assigned(a, out);
+            }
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            if let Some(h) = head {
+                collect_expr_assigned(h, out);
+            }
+        }
+        Expr::SymPatternNamed { pattern, .. } => collect_expr_assigned(pattern, out),
+        Expr::SymRule { lhs, rhs, .. } => {
+            collect_expr_assigned(lhs, out);
+            collect_expr_assigned(rhs, out);
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            collect_expr_assigned(expr, out);
+            for r in rules {
+                collect_expr_assigned(r, out);
+            }
+        }
         // Leaves with no nested blocks/exprs that could hold an Assign.
         Expr::IntLit { .. }
         | Expr::FloatLit { .. }
@@ -1469,6 +1515,25 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::Convert { .. } => {
             panic!(
                 "typescript backend reached a deferred SIR22/SIR26 expression ({}) at {} — not accepted yet",
+                e.kind_name(),
+                e.span()
+            );
+        }
+        // SIR23 symbolic-expression/pattern nodes.  This backend does not
+        // declare `Feature::SymbolicExpr`/`Feature::PatternMatching` in
+        // `accepts_features` (see lib.rs), so `Backend::check_module` rejects
+        // any module using these nodes before it ever reaches emission.
+        // Panic here to catch a backend/validator drift (mirrors the
+        // SIR22/SIR26 guard above).
+        Expr::SymSymbol { .. }
+        | Expr::SymRational { .. }
+        | Expr::SymApply { .. }
+        | Expr::SymPatternBlank { .. }
+        | Expr::SymPatternNamed { .. }
+        | Expr::SymRule { .. }
+        | Expr::SymReplaceAll { .. } => {
+            panic!(
+                "typescript backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
                 e.kind_name(),
                 e.span()
             );

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,123 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.22.0 — SIR23: symbolic expression + pattern/rewrite IR extension
+
+Implements [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md) —
+the narrow-waist vocabulary for symbolic-CAS math languages (the substrate
+for `wolfram-to-semantic-ir`, `macsyma-to-semantic-ir`,
+`maxima-to-semantic-ir`). Additive only, following the exact discipline
+SIR22 used for the array/matrix extension: every existing SIR10/SIR16/
+SIR17/SIR18/SIR21/SIR22/SIR26 module remains valid; no existing `Expr`/
+`Stmt`/`SirType`/`Feature` variant, validator rule, or backend behaviour
+changed. Every new node kind maps 1:1 onto `symbolic_ir::IRNode`'s existing
+five-variant shape (`Symbol`/`Integer`/`Rational`/`Float`/`Str`/`Apply`);
+`IntLit`/`FloatLit`/`StrLit` already cover `Integer`/`Float`/`Str` (SIR10/
+SIR16), so no new literal nodes were needed for those three.
+
+**New `SirType` variant** (`types.rs`):
+- `SymExpr` — an opaque symbolic-expression handle; carries no static shape
+  (the shape lives in the `Expr` tree, not the type carrier). Prints
+  `sym-expr`.
+
+**New `Expr` variants** (`nodes.rs`):
+- `SymSymbol { name: String, span }` — a bare symbolic-expression symbol
+  (Wolfram `x`, `Plus`, `f`) used as *data*, distinct from `VarRef` (a
+  host-language variable lookup) and `SymLit` (a Ruby-style interned
+  `:symbol`).
+- `SymRational { numer: i64, denom: i64, span }` — an exact rational scalar
+  in reduced form; the IR carries but does not itself reduce the fraction.
+- `SymApply { head: Box<Expr>, args: Vec<Expr>, span }` — `head[args…]` /
+  `head(args…)` as data. `head` is a full `Expr` (not a bare `String`)
+  because a *computed* head is legal Wolfram (`f[x][y]`) — the one place
+  this spec's node shapes deliberately diverge from SIR22's simpler
+  bare-name shapes.
+- `SymPatternBlank { head: Option<Box<Expr>>, span }` — Wolfram `_`
+  (`head: None`) or `_h` (head-constrained, `head: Some(SymSymbol("h"))`).
+- `SymPatternNamed { name: String, pattern: Box<Expr>, span }` — a named
+  pattern variable, Wolfram `x_` / `x_h`.
+- `SymRule { lhs: Box<Expr>, rhs: Box<Expr>, delayed: bool, span }` — a
+  rewrite rule; `delayed: false` is `->` (`Rule`), `true` is `:>`
+  (`RuleDelayed`).
+- `SymReplaceAll { expr: Box<Expr>, rules: Vec<Expr>, repeated: bool, span }`
+  — rule application; `repeated: false` is `/.` (one pass), `true` is `//.`
+  (fixed point). The full binding/traversal/iteration-cap contract every
+  backend implementing this node must honour lives in the spec's "Matcher
+  semantics" section, not in the IR shape itself.
+
+**No new `Stmt` variant** — unlike SIR22's `IndexSet`, every SIR23 node is
+`Expr`-shaped and `Pure` (see "Effects" below); `effects.rs` needed zero
+changes.
+
+**New `Feature` flags** (`manifest.rs`): `SymbolicExpr` (`SymSymbol`/
+`SymApply`) and `PatternMatching` (`SymPatternBlank`/`SymPatternNamed`/
+`SymRule`/`SymReplaceAll`). `SymRational` reuses SIR22's existing
+`Rationals` feature rather than adding a new one, per the spec's explicit
+"share, don't duplicate" instruction for `Rational`/`Complex`.
+
+**Effects** (`validator.rs`): every new `Expr` variant is `Pure` — building,
+matching, and substituting a symbolic term has no observable side effect
+distinct from the value it computes. The validator's `check_expr` observes
+the matching `Feature`(s) for each new node and recurses into every child
+`Expr` (`SymApply`'s `head`+`args`, `SymPatternBlank`'s optional `head`,
+`SymPatternNamed`'s `pattern`, `SymRule`'s `lhs`+`rhs`, `SymReplaceAll`'s
+`expr`+`rules`), so a module using these nodes without declaring the
+feature is a validator error, exactly like every other feature-observation
+rule in this crate.
+
+**Walker** (`walker.rs`, `backend.rs`): both the public `Visitor` traversal
+and `backend.rs`'s internal `walk_intrinsics_in_expr` recurse into every new
+node's children, including the computed-head case (`SymApply`'s `head` may
+itself be a `SymApply`, e.g. `f[x][y]`).
+
+**Printer** (`text/printer.rs`): new S-expression forms, each `sym-`
+prefixed so none collides with an existing head keyword (notably the
+pre-existing `(sym name)` form is `Expr::SymLit`, a different concept) —
+`(sym-symbol name)`, `(sym-rational numer denom)`, `(sym-apply head arg...)`,
+`(sym-pattern-blank [head])`, `(sym-pattern-named name pattern)`,
+`(sym-rule lhs rhs eager|delayed)`, `(sym-replace-all expr (rules rule...)
+once|repeated)`.
+
+**Backend capability rejection**: no backend changes are required for this
+spec to land safely, per the SIR23 spec's "Backend impact" — a backend that
+doesn't declare `SymbolicExpr`/`PatternMatching` in `accepts_features()`
+cleanly rejects any module using these nodes via the existing SIR10
+capability-check mechanism (`Backend::check_module`), proven with new
+`backend.rs` tests constructing a real module whose body nests
+`SymReplaceAll` around a `SymApply` and a `SymRule` with a
+`SymPatternNamed`/`SymPatternBlank` left-hand side — the full symbolic +
+pattern-matching vocabulary in one tree. All five existing Rust-workspace
+backends (`semantic-ir-to-{javascript,typescript,rust,go,python}`) and
+three frontends (`{javascript,ruby,python}-to-semantic-ir`) had exhaustive
+`match` statements over `Expr` that would otherwise fail to compile; each
+gained the minimal compile-compat arm needed to keep `cargo build
+--workspace` green — panic guards in the five backends (unreachable because
+`ACCEPTED_FEATURES` never lists `SymbolicExpr`/`PatternMatching`), and
+faithful structural recursion in the three frontends (none of which emit
+these nodes today), following the exact precedent SIR22 set for its own
+five-backend/three-frontend rollout. Per the spec's own rollout, JS/TS real
+codegen against a `sir-runtime-symbolic` runtime package is explicitly
+future work — that package does not exist yet, so even the JS/TS backends
+get only the compile-compat panic guard in this PR, mirroring how SIR22's
+core PR didn't ship `sir-runtime-array` codegen either. `c-to-semantic-ir`
+and `semantic-ir-to-c` required no changes (no exhaustive `Expr` match).
+
+**Versioning** (`metadata.rs`): `CURRENT_SIR_VERSION` bumped `"2"` → `"3"`,
+following the same "adding a feature is a v.bump" policy that moved `"1"`
+→ `"2"` in SIR22. A frontend lowering a Wolfram/Macsyma/Maxima-family CAS
+language sets `metadata.sir_version` to `"3"` when its module uses any
+SIR23 node. The two `v2`-asserting golden tests (`lib.rs`,
+`text/printer.rs`) were updated to `v3`.
+
+Extensive unit tests added for every new node kind (construction, span
+handling, printer round-trip, walker traversal, validator
+feature-observation) plus new `backend.rs`/`validator.rs` tests proving the
+capability-rejection path against real `SymApply`/`SymPatternBlank`/
+`SymRule`/`SymReplaceAll` node usage — both a validator-level test per node
+kind (rejected undeclared, accepted declared) and an end-to-end test
+through the actual `Backend::check_module` path — not just a hand-set
+manifest flag or a unit assertion on the validator's internal state.
+
 ## 0.21.0 — SIR22: array/matrix IR extension
 
 Implements [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md) — the

--- a/code/packages/rust/semantic-ir/Cargo.toml
+++ b/code/packages/rust/semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Narrow-waist Semantic IR (SIR10): a language-neutral intermediate representation between frontends and backends."
 

--- a/code/packages/rust/semantic-ir/README.md
+++ b/code/packages/rust/semantic-ir/README.md
@@ -51,6 +51,11 @@ use semantic_ir::{
     print_module, print_expr,
     // SIR22: array/matrix IR extension
     ElementwiseOpKind, IndexArg,
+    // SIR23 (symbolic expression + pattern/rewrite IR extension) adds no
+    // new standalone type — its seven nodes are `Expr` variants
+    // (`SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+    // `SymPatternNamed`/`SymRule`/`SymReplaceAll`), already covered by the
+    // `Expr` re-export above.
 };
 ```
 
@@ -82,12 +87,14 @@ What's covered:
 - MakeClosure
 - Intrinsic with escape-hatch discipline
 - SirType (Dynamic, Int(IntSpec), Bool, Nil, Symbol, Str, Pair, Closure, Fn, Float, Seq, Map, Ptr, Struct, Optional,
-  NDArray, Rational, Complex)
+  NDArray, Rational, Complex, SymExpr)
   — SIR21: `Int` carries an `IntSpec { width, signed, overflow }`; `Dynamic` (was `Any`) is the top type;
   `Ptr`/`Struct`/`Optional` (T1b) are source-fidelity types for typed frontends
   — SIR22: `NDArray { elem, rank }` is a dense N-D numeric array (rank `None` = unknown/dynamic);
-  `Rational`/`Complex` are exact-rational and complex scalar carriers, shared with the future SIR23
+  `Rational`/`Complex` are exact-rational and complex scalar carriers, shared with the SIR23
   symbolic-math extension
+  — SIR23: `SymExpr` is an opaque symbolic-expression handle with no static shape (the shape lives
+  in the `Expr` tree, not the type carrier)
 - SIR22 array/matrix nodes (additive, numeric-array languages — MATLAB/Octave and future
   APL/J/K/Scilab/IDL frontends): `Expr::ArrayLit` (matrix literal `[1 2; 3 4]`), `Expr::Range`
   (`1:5`, `0:2:10`), `Expr::MatMul`, `Expr::ElementwiseOp` (the five dotted ops `.+ .- .* ./ .^`
@@ -97,6 +104,16 @@ What's covered:
   `NDArrays`/`MatrixOps`/`Rationals`/`Complex`/`ArrayColumnMajor`. Every new node kind maps 1:1 onto
   an `array_runtime::execute()` op shape — see
   [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md).
+- SIR23 symbolic expression + pattern/rewrite nodes (additive, symbolic-CAS math languages —
+  Wolfram/Macsyma/Maxima and future Reduce/Derive/Maple frontends): `Expr::SymSymbol` (a bare
+  symbol used as data), `Expr::SymRational` (exact rational scalar), `Expr::SymApply`
+  (`head[args…]` as data — `head` is a full `Expr`, since a *computed* head like `f[x][y]` is
+  legal Wolfram), `Expr::SymPatternBlank` (`_` / `_h`), `Expr::SymPatternNamed` (`x_` / `x_h`),
+  `Expr::SymRule` (`->` / `:>` via a `delayed` flag), `Expr::SymReplaceAll` (`/.` / `//.` via a
+  `repeated` flag). No new `Stmt` — every node is `Pure`. New features: `SymbolicExpr`/
+  `PatternMatching` (`Rationals` is reused from SIR22). Every node maps 1:1 onto
+  `symbolic_ir::IRNode`'s five-variant shape — see
+  [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md).
 - `int_const` — the `int.max`/`int.min`/`int.width` reflection const-intrinsics (T3a);
   pure, const-folding functions of an `IntSpec` (`IntConst::eval`), `None` for arbitrary-precision
 - `op_select` — type-directed op selection (T3c): `resolve_binary(op, lhs, rhs)` chooses
@@ -113,10 +130,14 @@ What's deferred to later versions:
 - Ownership / borrow markers
 - Async / await / coroutines
 - Exception handling (Raise / Try / Catch)
-- Pattern matching (Match)
 - Records / unions / type aliases
 - The stdlib primitive set beyond Twig needs
 - Text format parser (round-trip via printer only in v0)
+- Symbolic pattern-matching / rewrite-rule **execution**: SIR23 lands the
+  IR vocabulary (`Expr::SymPatternBlank`/`SymPatternNamed`/`SymRule`/
+  `SymReplaceAll`), but no backend implements the matcher yet — that's
+  `sir-runtime-symbolic`, a separate future package (see the SIR23 spec's
+  "Backend impact")
 
 ## Related crates
 

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -447,6 +447,34 @@ where
         Expr::Convert { value, .. } => {
             walk_intrinsics_in_expr(value, f, depth + 1);
         }
+
+        // ── SIR23: symbolic expression + pattern/rewrite nodes ──────
+        Expr::SymSymbol { .. } => {}
+        Expr::SymRational { .. } => {}
+        Expr::SymApply { head, args, .. } => {
+            walk_intrinsics_in_expr(head, f, depth + 1);
+            for a in args {
+                walk_intrinsics_in_expr(a, f, depth + 1);
+            }
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            if let Some(h) = head {
+                walk_intrinsics_in_expr(h, f, depth + 1);
+            }
+        }
+        Expr::SymPatternNamed { pattern, .. } => {
+            walk_intrinsics_in_expr(pattern, f, depth + 1);
+        }
+        Expr::SymRule { lhs, rhs, .. } => {
+            walk_intrinsics_in_expr(lhs, f, depth + 1);
+            walk_intrinsics_in_expr(rhs, f, depth + 1);
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            walk_intrinsics_in_expr(expr, f, depth + 1);
+            for r in rules {
+                walk_intrinsics_in_expr(r, f, depth + 1);
+            }
+        }
     }
 }
 
@@ -721,6 +749,170 @@ mod tests {
         assert!(errs
             .iter()
             .all(|e| e.kind == BackendErrorKind::UnsupportedFeature));
+    }
+
+    // ── SIR23: capability-rejection tests ────────────────────────────
+    //
+    // Per the SIR23 spec's "Backend impact" section: "Rust/Go/Python
+    // backends: not required in this first wave; they reject modules
+    // declaring SymbolicExpr/PatternMatching per the existing
+    // capability-rejection path."  Same style as the SIR22 block above:
+    // prove the claim against the *actual* mechanism
+    // (`Backend::check_module`), not just by reasoning about it.
+
+    #[test]
+    fn backend_without_symbolic_expr_rejects_module_declaring_it() {
+        let b = NoFeaturesBackend;
+        let m = module_with_feature(Feature::SymbolicExpr);
+        let errs = b.check_module(&m);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].kind, BackendErrorKind::UnsupportedFeature);
+        assert!(errs[0].message.contains("symbolic-expr"));
+    }
+
+    #[test]
+    fn backend_without_pattern_matching_rejects_module_declaring_it() {
+        let b = NoFeaturesBackend;
+        let m = module_with_feature(Feature::PatternMatching);
+        let errs = b.check_module(&m);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].kind, BackendErrorKind::UnsupportedFeature);
+        assert!(errs[0].message.contains("pattern-matching"));
+    }
+
+    #[test]
+    fn backend_accepting_all_features_allows_symbolic_expr_and_pattern_matching() {
+        let b = AllFeaturesBackend;
+        let m = module_with_feature(Feature::SymbolicExpr);
+        assert!(b.check_module(&m).is_empty());
+        let m2 = module_with_feature(Feature::PatternMatching);
+        assert!(b.check_module(&m2).is_empty());
+    }
+
+    /// The single most important correctness property in the SIR23 spec:
+    /// end-to-end capability-rejection with no bypass.  Build a real
+    /// module whose body contains an actual `Expr::SymReplaceAll` wrapping
+    /// an `Expr::SymApply` and rewriting via an `Expr::SymRule` whose
+    /// left-hand side is an `Expr::SymPatternNamed`/`Expr::SymPatternBlank`
+    /// — the full symbolic + pattern-matching vocabulary the spec
+    /// introduces, in one tree — declare the matching manifest features,
+    /// and confirm a backend that only accepts the SIR v0 baseline still
+    /// rejects it via the *actual* `Backend::check_module` path (not a
+    /// hand-set manifest flag in isolation, and not just a unit assertion
+    /// on the validator's internal state).
+    #[test]
+    fn backend_rejects_module_whose_body_uses_sym_replace_all_and_sym_apply() {
+        let b = NoFeaturesBackend;
+        let mut m = module_with_feature(Feature::SymbolicExpr);
+        m.manifest.add(Feature::PatternMatching);
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                // f(x) /. (x_ -> 0)
+                value: Expr::SymReplaceAll {
+                    expr: Box::new(Expr::SymApply {
+                        head: Box::new(Expr::SymSymbol {
+                            name: "f".into(),
+                            span: s(),
+                        }),
+                        args: vec![Expr::SymSymbol {
+                            name: "x".into(),
+                            span: s(),
+                        }],
+                        span: s(),
+                    }),
+                    rules: vec![Expr::SymRule {
+                        lhs: Box::new(Expr::SymPatternNamed {
+                            name: "x".into(),
+                            pattern: Box::new(Expr::SymPatternBlank {
+                                head: None,
+                                span: s(),
+                            }),
+                            span: s(),
+                        }),
+                        rhs: Box::new(Expr::IntLit {
+                            value: 0,
+                            span: s(),
+                        }),
+                        delayed: false,
+                        span: s(),
+                    }],
+                    repeated: false,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        let errs = b.check_module(&m);
+        // Both declared-but-unaccepted features are reported.
+        assert_eq!(errs.len(), 2);
+        assert!(errs
+            .iter()
+            .all(|e| e.kind == BackendErrorKind::UnsupportedFeature));
+    }
+
+    /// Companion to the rejection test above: the identical module tree,
+    /// compiled against a backend that accepts every feature, must pass
+    /// `check_module` cleanly — proving the rejection above is really
+    /// about capability declaration, not some incidental shape problem in
+    /// the constructed tree.
+    #[test]
+    fn backend_accepting_symbolic_features_allows_the_same_module() {
+        let b = AllFeaturesBackend;
+        let mut m = module_with_feature(Feature::SymbolicExpr);
+        m.manifest.add(Feature::PatternMatching);
+        m.functions.push(Function {
+            name: "f".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts: vec![],
+                value: Expr::SymReplaceAll {
+                    expr: Box::new(Expr::SymApply {
+                        head: Box::new(Expr::SymSymbol {
+                            name: "f".into(),
+                            span: s(),
+                        }),
+                        args: vec![Expr::SymSymbol {
+                            name: "x".into(),
+                            span: s(),
+                        }],
+                        span: s(),
+                    }),
+                    rules: vec![Expr::SymRule {
+                        lhs: Box::new(Expr::SymPatternNamed {
+                            name: "x".into(),
+                            pattern: Box::new(Expr::SymPatternBlank {
+                                head: None,
+                                span: s(),
+                            }),
+                            span: s(),
+                        }),
+                        rhs: Box::new(Expr::IntLit {
+                            value: 0,
+                            span: s(),
+                        }),
+                        delayed: false,
+                        span: s(),
+                    }],
+                    repeated: false,
+                    span: s(),
+                },
+                span: s(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: s(),
+        });
+        assert!(b.check_module(&m).is_empty());
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/lib.rs
+++ b/code/packages/rust/semantic-ir/src/lib.rs
@@ -100,7 +100,7 @@ mod smoke {
         let r = validate(&m);
         assert!(r.is_ok());
         let t = print_module(&m);
-        assert!(t.contains("(sir-module empty v2"));
+        assert!(t.contains("(sir-module empty v3"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/manifest.rs
+++ b/code/packages/rust/semantic-ir/src/manifest.rs
@@ -40,6 +40,8 @@ use std::fmt;
 /// | `Rationals`                | a `SirType::Rational`                 |
 /// | `Complex`                  | a `SirType::Complex`                  |
 /// | `ArrayColumnMajor`         | any `ArrayLit`/matrix op — column-major storage convention |
+/// | `SymbolicExpr`             | a `SymSymbol` or `SymApply` node       |
+/// | `PatternMatching`          | a `SymPatternBlank`, `SymPatternNamed`, `SymRule`, or `SymReplaceAll` node |
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Feature {
     Closures,
@@ -178,10 +180,12 @@ pub enum Feature {
     /// together.
     MatrixOps,
     /// The module uses an exact rational scalar (`SirType::Rational`).
-    /// Shared with the future SIR23 symbolic extension.
+    /// Shared with the SIR23 symbolic extension — an `Expr::SymRational`
+    /// node observes this same feature rather than a new one (see
+    /// `validator.rs`'s SIR23 `check_expr` arm).
     Rationals,
     /// The module uses a complex scalar (`SirType::Complex`).  Shared
-    /// with the future SIR23 symbolic extension.  Named `Complex` to
+    /// with the SIR23 symbolic extension.  Named `Complex` to
     /// match the `SirType::Complex` variant it gates (not to be
     /// confused with `SirType`'s own naming — this is a `Feature`).
     Complex,
@@ -202,6 +206,24 @@ pub enum Feature {
     /// type also implies `SizedIntegers`/`Unsigned` per SIR21.  See
     /// [SIR26](../../../../specs/SIR26-integer-conversions.md).
     Conversions,
+    // ── SIR23 (symbolic expression + pattern/rewrite IR extension) ───
+    /// The module uses a symbolic-expression node — `Expr::SymSymbol` (a
+    /// bare Wolfram-style symbol used as data) or `Expr::SymApply`
+    /// (`head[args…]` application as data, where `head` may itself be a
+    /// computed expression).  A backend that doesn't declare this in
+    /// `accepts_features()` cleanly rejects the module via the existing
+    /// capability-check mechanism (SIR10) — no new mechanism needed.
+    /// See [SIR23](../../../../specs/SIR23-symbolic-pattern-semantic-ir.md).
+    SymbolicExpr,
+    /// The module uses pattern-matching or rewrite-rule vocabulary —
+    /// `Expr::SymPatternBlank` (`_`/`_h`), `Expr::SymPatternNamed`
+    /// (`x_`/`x_h`), `Expr::SymRule` (`->`/`:>`), or
+    /// `Expr::SymReplaceAll` (`/.`/`//.`).  Split out from
+    /// `SymbolicExpr` because a backend could in principle carry
+    /// symbolic *values* (via `SymSymbol`/`SymApply`) without
+    /// implementing the pattern matcher these nodes require — matching
+    /// how `MatrixOps` is split from `NDArrays` in SIR22.
+    PatternMatching,
 }
 
 impl Feature {
@@ -245,6 +267,8 @@ impl Feature {
         Feature::Complex,
         Feature::ArrayColumnMajor,
         Feature::Conversions,
+        Feature::SymbolicExpr,
+        Feature::PatternMatching,
     ];
 
     /// Kebab-case name for the SIR text format.
@@ -288,6 +312,8 @@ impl Feature {
             Feature::Complex => "complex",
             Feature::ArrayColumnMajor => "array-column-major",
             Feature::Conversions => "conversions",
+            Feature::SymbolicExpr => "symbolic-expr",
+            Feature::PatternMatching => "pattern-matching",
         }
     }
 
@@ -396,6 +422,22 @@ mod tests {
             (Feature::Pointers, "pointers"),
             (Feature::Structs, "structs"),
             (Feature::Bignum, "bignum"),
+        ];
+        for (feat, name) in new {
+            assert_eq!(feat.name(), name);
+            assert_eq!(Feature::from_name(name), Some(feat));
+            assert!(Feature::ALL.contains(&feat), "{} missing from ALL", name);
+        }
+    }
+
+    #[test]
+    fn sir23_features_present_and_named() {
+        // SymbolicExpr / PatternMatching round-trip through name()/from_name()
+        // and are members of ALL, mirroring how the SIR21 T1b test above
+        // pins its own new flags.
+        let new = [
+            (Feature::SymbolicExpr, "symbolic-expr"),
+            (Feature::PatternMatching, "pattern-matching"),
         ];
         for (feat, name) in new {
             assert_eq!(feat.name(), name);

--- a/code/packages/rust/semantic-ir/src/metadata.rs
+++ b/code/packages/rust/semantic-ir/src/metadata.rs
@@ -31,7 +31,18 @@ use std::fmt;
 ///   moved `"0"` → `"1"` applies again here.  A frontend lowering
 ///   MATLAB/Octave sets `metadata.sir_version` to this value when its
 ///   module uses any SIR22 node.
-pub const CURRENT_SIR_VERSION: &str = "2";
+/// - `"3"` — SIR23: the symbolic expression + pattern/rewrite IR
+///   extension.  One new `SirType` variant (`SymExpr`), seven new
+///   `Expr` variants (`SymSymbol`/`SymRational`/`SymApply`/
+///   `SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`), no
+///   new `Stmt` variant (every SIR23 node is `Pure`), and two new
+///   `Feature` flags (`SymbolicExpr`/`PatternMatching`; `Rationals`/
+///   `Complex` are reused from SIR22) — again additive, again new SIR
+///   text tokens, so the same policy bumps `"2"` → `"3"`.  A frontend
+///   lowering a Wolfram/Macsyma/Maxima-family CAS language sets
+///   `metadata.sir_version` to this value when its module uses any
+///   SIR23 node.
+pub const CURRENT_SIR_VERSION: &str = "3";
 
 /// Advisory metadata.  All fields are optional.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -122,7 +133,7 @@ mod tests {
             .with_sir_version(CURRENT_SIR_VERSION);
         assert_eq!(m.source_language.as_deref(), Some("twig"));
         assert_eq!(m.source_version.as_deref(), Some("0.7"));
-        assert_eq!(m.sir_version.as_deref(), Some("2"));
+        assert_eq!(m.sir_version.as_deref(), Some("3"));
         assert!(!m.is_empty());
     }
 
@@ -147,11 +158,11 @@ mod tests {
     }
 
     #[test]
-    fn current_sir_version_is_two() {
-        // Bumped 1 → 2 in SIR22 (array/matrix IR extension: new
-        // SirType/Expr/Stmt/Feature text tokens), following the same
-        // "adding a feature is a v.bump" policy that moved 0 → 1 in
-        // SIR21 T1b.
-        assert_eq!(CURRENT_SIR_VERSION, "2");
+    fn current_sir_version_is_three() {
+        // Bumped 2 → 3 in SIR23 (symbolic expression + pattern/rewrite IR
+        // extension: new SirType/Expr/Feature text tokens), following the
+        // same "adding a feature is a v.bump" policy that moved 1 → 2 in
+        // SIR22.
+        assert_eq!(CURRENT_SIR_VERSION, "3");
     }
 }

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -915,6 +915,121 @@ pub enum Expr {
         to: IntSpec,
         span: Span,
     },
+
+    // ── SIR23: symbolic expression + pattern/rewrite nodes ─────────
+    //
+    // Every node kind below is mapped 1:1 onto `symbolic_ir::IRNode`'s
+    // existing five-variant shape (`Symbol`/`Integer`/`Rational`/`Float`/
+    // `Str`/`Apply`) — see the SIR23 spec's "Motivation" and "New `Expr`
+    // variants" sections.  `IntLit`/`FloatLit`/`StrLit` above already
+    // cover `IRNode::Integer`/`Float`/`Str`; the seven variants below
+    // cover `Symbol`/`Rational`/`Apply` plus the pattern-matching and
+    // rewrite-rule vocabulary a Wolfram-family CAS frontend needs.  All
+    // are `Pure` (see `effects.rs`'s SIR23 doc note) — building,
+    // matching, and substituting a symbolic term has no observable side
+    // effect distinct from the value it computes; SIR23 adds no new
+    // `Stmt` variant at all (unlike SIR22's `IndexSet`).
+    /// A bare symbolic-expression symbol — Wolfram `x`, `Plus`, `f` used
+    /// as *data* rather than evaluated as a variable reference.
+    /// Distinct from [`Expr::VarRef`] (a host-language variable lookup)
+    /// and [`Expr::SymLit`] (a Ruby-style interned `:symbol` literal) —
+    /// `SymSymbol` is a leaf of a *symbolic-expression tree*, mirroring
+    /// `symbolic_ir::IRNode::Symbol`.
+    SymSymbol {
+        name: String,
+        span: Span,
+    },
+
+    /// An exact rational scalar in **reduced form** (numerator and
+    /// denominator share no common factor; denominator positive) —
+    /// Wolfram `1/3`, `Rational[1, 3]`.  The frontend normalizes exactly
+    /// as `symbolic_ir::IRNode::rational` does; the IR itself does not
+    /// reduce or validate the fraction (SIR10 "types carry, don't
+    /// verify").  Mirrors `symbolic_ir::IRNode::Rational`.
+    SymRational {
+        numer: i64,
+        denom: i64,
+        span: Span,
+    },
+
+    /// `head[args…]` / `head(args…)` as **data** — the same expression
+    /// may appear as a value, a pattern target, or a rewrite-rule
+    /// left-hand side (the SIR23 spec's "fidelity decision": patterns
+    /// and rules are first-class data, not a frontend-side
+    /// evaluate-then-lower shortcut).  `head` is a full `Expr`, not a
+    /// bare name, because a *computed* head is legal Wolfram (`f[x][y]`
+    /// applies the result of `f[x]` to `y`) — usually it is a
+    /// `SymSymbol`, but the IR does not narrow the type.  Mirrors
+    /// `symbolic_ir::IRNode::Apply`.
+    SymApply {
+        head: Box<Expr>,
+        args: Vec<Expr>,
+        span: Span,
+    },
+
+    /// A pattern blank — Wolfram `_` (`head: None`) or `_h` (`head:
+    /// Some(SymSymbol("h"))`, a head-constrained blank that matches only
+    /// a subtree whose own "head" — per Wolfram's `Head[]` convention —
+    /// is structurally `h`).  Only meaningful inside a [`SymRule`]'s
+    /// `lhs` (directly, or nested inside a [`SymPatternNamed`]); the
+    /// validator does not itself enforce that placement restriction
+    /// (mirrors how [`Expr::KeywordArg`] restricts its own placement via
+    /// a runtime flag rather than a type-level rule) — a "wild" blank
+    /// appearing outside a pattern position is a frontend bug, not a
+    /// distinct IR shape.
+    ///
+    /// [`SymRule`]: Expr::SymRule
+    /// [`SymPatternNamed`]: Expr::SymPatternNamed
+    SymPatternBlank {
+        head: Option<Box<Expr>>,
+        span: Span,
+    },
+
+    /// A **named** pattern variable — Wolfram `x_` (desugars to
+    /// `SymPatternNamed { name: "x", pattern: SymPatternBlank { head:
+    /// None } }`) or `x_h` (`pattern: SymPatternBlank { head: Some(h) }`).
+    /// Binds `name` to whatever subtree `pattern` matches, for the rest
+    /// of that match attempt — the SIR23 spec's matcher contract: a
+    /// repeated occurrence of the same `name` elsewhere in a rule's
+    /// `lhs` requires structural equality with the first binding, not
+    /// just any match.
+    SymPatternNamed {
+        name: String,
+        pattern: Box<Expr>,
+        span: Span,
+    },
+
+    /// A rewrite rule — Wolfram `lhs -> rhs` (`delayed: false`, `Rule`:
+    /// the rhs is built once, at rule-construction time) or `lhs :> rhs`
+    /// (`delayed: true`, `RuleDelayed`: the rhs is re-evaluated fresh
+    /// per match).  Only the flag distinguishes the two; both share the
+    /// same `lhs`/`rhs` shape.
+    SymRule {
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+        delayed: bool,
+        span: Span,
+    },
+
+    /// Apply a set of rewrite rules to `expr` — Wolfram `expr /. rules`
+    /// (`repeated: false`, `ReplaceAll`: one top-down, left-to-right
+    /// pass) or `expr //. rules` (`repeated: true`, `ReplaceRepeated`:
+    /// reruns to a fixed point).  `rules` is typically a `Vec` of
+    /// [`SymRule`](Expr::SymRule)s, though the spec allows an element
+    /// that is itself a `SymApply` evaluating to a list of rules at
+    /// runtime (a backend concern, not an IR shape).  See the SIR23
+    /// spec's "Matcher semantics" for the full binding contract —
+    /// notably that every backend implementing `repeated: true` **must**
+    /// enforce an iteration cap: an unbounded `//.` is a guaranteed
+    /// non-terminating program for some inputs, matching the DoS-cap
+    /// convention every other unbounded SIR construct in this repo
+    /// already follows.
+    SymReplaceAll {
+        expr: Box<Expr>,
+        rules: Vec<Expr>,
+        repeated: bool,
+        span: Span,
+    },
 }
 
 /// The five elementwise (broadcast) binary arithmetic operators
@@ -1032,6 +1147,13 @@ impl Expr {
             Expr::Transpose { span, .. } => span,
             Expr::IndexGet { span, .. } => span,
             Expr::Convert { span, .. } => span,
+            Expr::SymSymbol { span, .. } => span,
+            Expr::SymRational { span, .. } => span,
+            Expr::SymApply { span, .. } => span,
+            Expr::SymPatternBlank { span, .. } => span,
+            Expr::SymPatternNamed { span, .. } => span,
+            Expr::SymRule { span, .. } => span,
+            Expr::SymReplaceAll { span, .. } => span,
         }
     }
 
@@ -1069,6 +1191,13 @@ impl Expr {
             Expr::Transpose { .. } => "transpose",
             Expr::IndexGet { .. } => "index-get",
             Expr::Convert { .. } => "convert",
+            Expr::SymSymbol { .. } => "sym-symbol",
+            Expr::SymRational { .. } => "sym-rational",
+            Expr::SymApply { .. } => "sym-apply",
+            Expr::SymPatternBlank { .. } => "sym-pattern-blank",
+            Expr::SymPatternNamed { .. } => "sym-pattern-named",
+            Expr::SymRule { .. } => "sym-rule",
+            Expr::SymReplaceAll { .. } => "sym-replace-all",
         }
     }
 }
@@ -1770,6 +1899,255 @@ mod tests {
             assert_eq!(indices.len(), 3);
         } else {
             panic!("expected IndexGet");
+        }
+    }
+
+    // ── SIR23: symbolic expression + pattern/rewrite nodes ───────────
+
+    #[test]
+    fn sir23_expr_kind_names_and_spans() {
+        let span = s();
+        let cases: Vec<(Expr, &'static str)> = vec![
+            (
+                Expr::SymSymbol {
+                    name: "x".into(),
+                    span: span.clone(),
+                },
+                "sym-symbol",
+            ),
+            (
+                Expr::SymRational {
+                    numer: 1,
+                    denom: 3,
+                    span: span.clone(),
+                },
+                "sym-rational",
+            ),
+            (
+                Expr::SymApply {
+                    head: Box::new(Expr::SymSymbol {
+                        name: "Plus".into(),
+                        span: span.clone(),
+                    }),
+                    args: vec![
+                        Expr::IntLit {
+                            value: 1,
+                            span: span.clone(),
+                        },
+                        Expr::IntLit {
+                            value: 2,
+                            span: span.clone(),
+                        },
+                    ],
+                    span: span.clone(),
+                },
+                "sym-apply",
+            ),
+            (
+                Expr::SymPatternBlank {
+                    head: None,
+                    span: span.clone(),
+                },
+                "sym-pattern-blank",
+            ),
+            (
+                Expr::SymPatternNamed {
+                    name: "x".into(),
+                    pattern: Box::new(Expr::SymPatternBlank {
+                        head: None,
+                        span: span.clone(),
+                    }),
+                    span: span.clone(),
+                },
+                "sym-pattern-named",
+            ),
+            (
+                Expr::SymRule {
+                    lhs: Box::new(Expr::SymSymbol {
+                        name: "x".into(),
+                        span: span.clone(),
+                    }),
+                    rhs: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: span.clone(),
+                    }),
+                    delayed: false,
+                    span: span.clone(),
+                },
+                "sym-rule",
+            ),
+            (
+                Expr::SymReplaceAll {
+                    expr: Box::new(Expr::SymSymbol {
+                        name: "x".into(),
+                        span: span.clone(),
+                    }),
+                    rules: vec![],
+                    repeated: false,
+                    span: span.clone(),
+                },
+                "sym-replace-all",
+            ),
+        ];
+        for (e, expected) in &cases {
+            assert_eq!(e.kind_name(), *expected);
+            assert_eq!(e.span(), &span);
+        }
+    }
+
+    #[test]
+    fn sym_apply_head_is_an_expr_not_a_bare_string() {
+        // The SIR23 spec's explicit callout: `head` is a full `Expr` (not
+        // a bare `String`) because a *computed* head is legal Wolfram
+        // (`f[x][y]` applies the result of `f[x]` to `y`).  Pin that a
+        // SymApply's own head may itself be a SymApply.
+        let inner = Expr::SymApply {
+            head: Box::new(Expr::SymSymbol {
+                name: "f".into(),
+                span: s(),
+            }),
+            args: vec![Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }],
+            span: s(),
+        };
+        let outer = Expr::SymApply {
+            head: Box::new(inner),
+            args: vec![Expr::SymSymbol {
+                name: "y".into(),
+                span: s(),
+            }],
+            span: s(),
+        };
+        match outer {
+            Expr::SymApply { head, .. } => {
+                assert!(matches!(*head, Expr::SymApply { .. }));
+            }
+            _ => panic!("expected SymApply"),
+        }
+    }
+
+    #[test]
+    fn sym_pattern_blank_head_constrained_vs_bare() {
+        // Wolfram `_` (head: None) vs `_h` (head: Some(SymSymbol("h"))).
+        let bare = Expr::SymPatternBlank {
+            head: None,
+            span: s(),
+        };
+        let constrained = Expr::SymPatternBlank {
+            head: Some(Box::new(Expr::SymSymbol {
+                name: "Integer".into(),
+                span: s(),
+            })),
+            span: s(),
+        };
+        assert_ne!(bare, constrained);
+        match constrained {
+            Expr::SymPatternBlank { head: Some(h), .. } => {
+                assert_eq!(
+                    *h,
+                    Expr::SymSymbol {
+                        name: "Integer".into(),
+                        span: s()
+                    }
+                );
+            }
+            _ => panic!("expected head-constrained SymPatternBlank"),
+        }
+    }
+
+    #[test]
+    fn sym_pattern_named_desugars_x_underscore() {
+        // Wolfram `x_` desugars to SymPatternNamed { name: "x", pattern:
+        // SymPatternBlank { head: None } } per the SIR23 spec.
+        let e = Expr::SymPatternNamed {
+            name: "x".into(),
+            pattern: Box::new(Expr::SymPatternBlank {
+                head: None,
+                span: s(),
+            }),
+            span: s(),
+        };
+        match e {
+            Expr::SymPatternNamed { name, pattern, .. } => {
+                assert_eq!(name, "x");
+                assert!(matches!(*pattern, Expr::SymPatternBlank { head: None, .. }));
+            }
+            _ => panic!("expected SymPatternNamed"),
+        }
+    }
+
+    #[test]
+    fn sym_rule_delayed_flag_distinguishes_rule_from_rule_delayed() {
+        // `->` (Rule, delayed: false) vs `:>` (RuleDelayed, delayed: true).
+        let rule = Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        let rule_delayed = Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            delayed: true,
+            span: s(),
+        };
+        assert_ne!(rule, rule_delayed);
+    }
+
+    #[test]
+    fn sym_replace_all_repeated_flag_distinguishes_replace_all_from_repeated() {
+        // `/.` (ReplaceAll, repeated: false) vs `//.` (ReplaceRepeated,
+        // repeated: true).
+        let once = Expr::SymReplaceAll {
+            expr: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rules: vec![],
+            repeated: false,
+            span: s(),
+        };
+        let fixed_point = Expr::SymReplaceAll {
+            expr: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rules: vec![],
+            repeated: true,
+            span: s(),
+        };
+        assert_ne!(once, fixed_point);
+    }
+
+    #[test]
+    fn sym_rational_carries_numer_denom_without_reducing() {
+        // The IR is a carrier, not a verifier (SIR10): it does not itself
+        // reduce 2/4 to 1/2 — that's the frontend's job, mirroring
+        // `symbolic_ir::IRNode::rational`'s own contract.
+        let unreduced = Expr::SymRational {
+            numer: 2,
+            denom: 4,
+            span: s(),
+        };
+        match unreduced {
+            Expr::SymRational { numer, denom, .. } => {
+                assert_eq!((numer, denom), (2, 4));
+            }
+            _ => panic!("expected SymRational"),
         }
     }
 

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -652,6 +652,72 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             print_expr_inline_depth(out, value, depth + 1);
             out.push(')');
         }
+
+        // ── SIR23: symbolic expression + pattern/rewrite nodes ─────────
+        // Every head keyword below is prefixed `sym-` so it can never
+        // collide with an existing form — notably `(sym name)` above is
+        // `Expr::SymLit` (a Ruby-style interned `:symbol` literal), a
+        // wholly different concept from `SymSymbol`'s symbolic-expression-
+        // tree leaf.
+        Expr::SymSymbol { name, .. } => {
+            let _ = write!(out, "(sym-symbol {})", name);
+        }
+        // `(sym-rational <numer> <denom>)` — printed as the two integer
+        // fields rather than a single `n/d` token so the shape matches
+        // every other multi-field node in this file (e.g. `Transpose`,
+        // `IndexArg::Scalar`); the IR does not reduce the fraction (see
+        // `SymRational`'s doc comment), and neither does the printer.
+        Expr::SymRational { numer, denom, .. } => {
+            let _ = write!(out, "(sym-rational {} {})", numer, denom);
+        }
+        Expr::SymApply { head, args, .. } => {
+            let _ = write!(out, "(sym-apply ");
+            print_expr_inline_depth(out, head, depth + 1);
+            print_args(out, args, depth);
+            out.push(')');
+        }
+        // `(sym-pattern-blank)` for Wolfram `_`; `(sym-pattern-blank
+        // <head>)` for `_h`.
+        Expr::SymPatternBlank { head, .. } => {
+            let _ = write!(out, "(sym-pattern-blank");
+            if let Some(h) = head {
+                out.push(' ');
+                print_expr_inline_depth(out, h, depth + 1);
+            }
+            out.push(')');
+        }
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            let _ = write!(out, "(sym-pattern-named {} ", name);
+            print_expr_inline_depth(out, pattern, depth + 1);
+            out.push(')');
+        }
+        // `(sym-rule <lhs> <rhs> eager)` for `->`; `... delayed)` for
+        // `:>` — mirroring how `Transpose` renders its boolean flag as a
+        // trailing keyword (`conjugate`/`plain`) rather than `true`/`false`.
+        Expr::SymRule {
+            lhs, rhs, delayed, ..
+        } => {
+            let _ = write!(out, "(sym-rule ");
+            print_expr_inline_depth(out, lhs, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, rhs, depth + 1);
+            let _ = write!(out, " {})", if *delayed { "delayed" } else { "eager" });
+        }
+        // `(sym-replace-all <expr> (rules <rule>...) once)` for `/.`;
+        // `... repeated)` for `//.`.
+        Expr::SymReplaceAll {
+            expr,
+            rules,
+            repeated,
+            ..
+        } => {
+            let _ = write!(out, "(sym-replace-all ");
+            print_expr_inline_depth(out, expr, depth + 1);
+            let _ = write!(out, " (rules");
+            print_args(out, rules, depth);
+            out.push(')');
+            let _ = write!(out, " {})", if *repeated { "repeated" } else { "once" });
+        }
     }
 }
 
@@ -764,7 +830,7 @@ mod tests {
     fn print_empty_module() {
         let m = module_with(vec![], FeatureManifest::new());
         let t = print_module(&m);
-        assert!(t.starts_with("(sir-module demo v2"));
+        assert!(t.starts_with("(sir-module demo v3"));
         assert!(t.contains("(metadata"));
         assert!(t.ends_with(")\n"));
     }
@@ -1734,5 +1800,199 @@ mod tests {
             "got:\n{}",
             out
         );
+    }
+
+    // ── SIR23: symbolic expression + pattern/rewrite printer tests ──
+
+    #[test]
+    fn print_sym_symbol() {
+        let e = Expr::SymSymbol {
+            name: "Plus".into(),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(sym-symbol Plus)");
+    }
+
+    #[test]
+    fn print_sym_rational_unreduced() {
+        // The printer does not reduce the fraction — 2/4 prints verbatim.
+        let e = Expr::SymRational {
+            numer: 2,
+            denom: 4,
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(sym-rational 2 4)");
+    }
+
+    #[test]
+    fn print_sym_apply_with_computed_head() {
+        // f[x][y] — head is itself a SymApply, not a bare name.
+        let e = Expr::SymApply {
+            head: Box::new(Expr::SymApply {
+                head: Box::new(Expr::SymSymbol {
+                    name: "f".into(),
+                    span: s(),
+                }),
+                args: vec![Expr::SymSymbol {
+                    name: "x".into(),
+                    span: s(),
+                }],
+                span: s(),
+            }),
+            args: vec![Expr::SymSymbol {
+                name: "y".into(),
+                span: s(),
+            }],
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(sym-apply (sym-apply (sym-symbol f) (sym-symbol x)) (sym-symbol y))"
+        );
+    }
+
+    #[test]
+    fn print_sym_apply_no_args() {
+        let e = Expr::SymApply {
+            head: Box::new(Expr::SymSymbol {
+                name: "f".into(),
+                span: s(),
+            }),
+            args: vec![],
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(sym-apply (sym-symbol f))");
+    }
+
+    #[test]
+    fn print_sym_pattern_blank_bare_and_head_constrained() {
+        // Wolfram `_` vs `_h`.
+        let bare = Expr::SymPatternBlank {
+            head: None,
+            span: s(),
+        };
+        assert_eq!(print_expr(&bare), "(sym-pattern-blank)");
+        let constrained = Expr::SymPatternBlank {
+            head: Some(Box::new(Expr::SymSymbol {
+                name: "Integer".into(),
+                span: s(),
+            })),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&constrained),
+            "(sym-pattern-blank (sym-symbol Integer))"
+        );
+    }
+
+    #[test]
+    fn print_sym_pattern_named() {
+        // Wolfram `x_`.
+        let e = Expr::SymPatternNamed {
+            name: "x".into(),
+            pattern: Box::new(Expr::SymPatternBlank {
+                head: None,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(sym-pattern-named x (sym-pattern-blank))"
+        );
+    }
+
+    #[test]
+    fn print_sym_rule_eager_vs_delayed() {
+        // `->` (Rule) vs `:>` (RuleDelayed).
+        let eager = Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&eager),
+            "(sym-rule (sym-symbol x) (int 1) eager)"
+        );
+        let delayed = Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            delayed: true,
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&delayed),
+            "(sym-rule (sym-symbol x) (int 1) delayed)"
+        );
+    }
+
+    #[test]
+    fn print_sym_replace_all_once_vs_repeated() {
+        // `/.` (ReplaceAll) vs `//.` (ReplaceRepeated).
+        let rule = Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        let once = Expr::SymReplaceAll {
+            expr: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rules: vec![rule.clone()],
+            repeated: false,
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&once),
+            "(sym-replace-all (sym-symbol x) (rules (sym-rule (sym-symbol x) (int 0) eager)) once)"
+        );
+        let repeated = Expr::SymReplaceAll {
+            expr: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rules: vec![rule],
+            repeated: true,
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&repeated),
+            "(sym-replace-all (sym-symbol x) (rules (sym-rule (sym-symbol x) (int 0) eager)) repeated)"
+        );
+    }
+
+    #[test]
+    fn print_sym_replace_all_no_rules() {
+        let e = Expr::SymReplaceAll {
+            expr: Box::new(Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            }),
+            rules: vec![],
+            repeated: false,
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(sym-replace-all (sym-symbol x) (rules) once)");
     }
 }

--- a/code/packages/rust/semantic-ir/src/types.rs
+++ b/code/packages/rust/semantic-ir/src/types.rs
@@ -280,6 +280,7 @@ impl fmt::Display for IntSpec {
 /// | `NDArray { elem, rank }`    | dense N-D numeric array     (SIR22)    |
 /// | `Rational`                  | exact rational scalar       (SIR22/SIR23) |
 /// | `Complex`                   | complex scalar `{re, im}`   (SIR22/SIR23) |
+/// | `SymExpr`                   | opaque symbolic-expression handle (SIR23) |
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SirType {
     /// Top type — unknown/any.  The default; renamed from `Any` in SIR21.
@@ -347,15 +348,25 @@ pub enum SirType {
     /// denominator).  This is a type-level carrier only — SIR22 adds no
     /// numerator/denominator *storage* at the type level (that's a
     /// runtime concern for the backend); the pair representation itself
-    /// is shared with the future symbolic-math extension
+    /// is shared with the symbolic-math extension
     /// [SIR23](../../../../specs/SIR23-symbolic-pattern-semantic-ir.md),
     /// landed once here rather than twice.
     Rational,
     /// A complex scalar (`{ re: f64, im: f64 }`).  Like `Rational`, this
     /// is a type-level carrier with no additional fields — the value
     /// representation is a backend/runtime concern — shared with the
-    /// future SIR23 symbolic extension.
+    /// SIR23 symbolic extension.
     Complex,
+    // ── SIR23 (symbolic expression + pattern/rewrite IR extension) ───
+    /// An opaque symbolic-expression handle — mirrors
+    /// `symbolic_ir::IRNode`'s own dynamically-shaped tree.  Carries no
+    /// static shape: a value of this type may be a bare symbol, a
+    /// number, or an arbitrarily nested `head[args…]` application, none
+    /// of which the type itself distinguishes (the shape lives in the
+    /// `Expr` tree — `SymSymbol`/`SymRational`/`SymApply`/etc. — not in
+    /// the type carrier). See
+    /// [SIR23](../../../../specs/SIR23-symbolic-pattern-semantic-ir.md).
+    SymExpr,
 }
 
 impl SirType {
@@ -469,6 +480,9 @@ impl fmt::Display for SirType {
             },
             SirType::Rational => write!(f, "rational"),
             SirType::Complex => write!(f, "complex"),
+            // SIR23 token — a bare keyword, no fields, same shape as
+            // `Rational`/`Complex` above.
+            SirType::SymExpr => write!(f, "sym-expr"),
         }
     }
 }
@@ -737,5 +751,24 @@ mod tests {
         let inner = SirType::ndarray(SirType::Float, Some(1));
         let outer = SirType::ndarray(inner, None);
         assert_eq!(format!("{}", outer), "(ndarray (ndarray float 1))");
+    }
+
+    // ── SIR23 symbolic-expression type tests ──────────────────────────
+
+    #[test]
+    fn display_sym_expr() {
+        assert_eq!(format!("{}", SirType::SymExpr), "sym-expr");
+    }
+
+    #[test]
+    fn sym_expr_is_not_dynamic() {
+        assert!(!SirType::SymExpr.is_dynamic());
+    }
+
+    #[test]
+    fn sym_expr_equality() {
+        assert_eq!(SirType::SymExpr, SirType::SymExpr);
+        assert_ne!(SirType::SymExpr, SirType::Rational);
+        assert_ne!(SirType::SymExpr, SirType::Complex);
     }
 }

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -1042,6 +1042,45 @@ impl<'m> ValidatorState<'m> {
                 }
                 self.check_expr(value, env, depth + 1);
             }
+
+            // ── SIR23: symbolic expression + pattern/rewrite nodes ──
+            Expr::SymSymbol { .. } => {
+                self.observed.add(Feature::SymbolicExpr);
+            }
+            Expr::SymRational { .. } => {
+                // Shares the SIR22 `Rationals` feature rather than a new
+                // one — see the SIR23 spec's "New `Feature` flags".
+                self.observed.add(Feature::Rationals);
+            }
+            Expr::SymApply { head, args, .. } => {
+                self.observed.add(Feature::SymbolicExpr);
+                self.check_expr(head, env, depth + 1);
+                for a in args {
+                    self.check_expr(a, env, depth + 1);
+                }
+            }
+            Expr::SymPatternBlank { head, .. } => {
+                self.observed.add(Feature::PatternMatching);
+                if let Some(h) = head {
+                    self.check_expr(h, env, depth + 1);
+                }
+            }
+            Expr::SymPatternNamed { pattern, .. } => {
+                self.observed.add(Feature::PatternMatching);
+                self.check_expr(pattern, env, depth + 1);
+            }
+            Expr::SymRule { lhs, rhs, .. } => {
+                self.observed.add(Feature::PatternMatching);
+                self.check_expr(lhs, env, depth + 1);
+                self.check_expr(rhs, env, depth + 1);
+            }
+            Expr::SymReplaceAll { expr, rules, .. } => {
+                self.observed.add(Feature::PatternMatching);
+                self.check_expr(expr, env, depth + 1);
+                for r in rules {
+                    self.check_expr(r, env, depth + 1);
+                }
+            }
         }
     }
 
@@ -4314,6 +4353,467 @@ mod tests {
             metadata: Metadata::new(),
             span: s(),
         });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    // ── SIR23: symbolic expression + pattern/rewrite validator tests ──
+    //
+    // Same shape as the SIR22 block above: for every new node kind, one
+    // test proves the module is REJECTED when the matching `Feature` is
+    // not declared (the "manifest does not declare feature `X` but
+    // module uses it" error from `compare_manifests`), and a companion
+    // test proves it is ACCEPTED once declared. This is the validator-
+    // level half of the SIR23 spec's most important correctness
+    // property; `backend.rs` has the end-to-end `Backend::check_module`
+    // half.
+
+    #[test]
+    fn sym_symbol_observes_symbolic_expr_feature() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("symbolic-expr")));
+    }
+
+    #[test]
+    fn sym_symbol_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::SymbolicExpr]),
+            Expr::SymSymbol {
+                name: "x".into(),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn sym_rational_observes_rationals_feature() {
+        // SymRational reuses the SIR22 `Rationals` feature, not a new one.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymRational {
+                numer: 1,
+                denom: 3,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("rationals")));
+    }
+
+    #[test]
+    fn sym_rational_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::Rationals]),
+            Expr::SymRational {
+                numer: 1,
+                denom: 3,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn sym_apply_observes_symbolic_expr_feature_and_validates_head_and_args() {
+        // f(ghost) — the unresolvable local `ghost` inside args must
+        // still be scope-checked, alongside the missing-feature error.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymApply {
+                head: Box::new(Expr::SymSymbol {
+                    name: "f".into(),
+                    span: s(),
+                }),
+                args: vec![Expr::VarRef {
+                    name: "ghost".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                }],
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("symbolic-expr")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    #[test]
+    fn sym_apply_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::SymbolicExpr]),
+            Expr::SymApply {
+                head: Box::new(Expr::SymSymbol {
+                    name: "f".into(),
+                    span: s(),
+                }),
+                args: vec![Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }],
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn sym_apply_computed_head_is_validated() {
+        // f[x][y] — the outer SymApply's own head is a SymApply, which
+        // must itself observe SymbolicExpr and be recursively validated.
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::SymbolicExpr]),
+            Expr::SymApply {
+                head: Box::new(Expr::SymApply {
+                    head: Box::new(Expr::SymSymbol {
+                        name: "f".into(),
+                        span: s(),
+                    }),
+                    args: vec![Expr::VarRef {
+                        name: "ghost".into(),
+                        scope: Scope::Local,
+                        span: s(),
+                    }],
+                    span: s(),
+                }),
+                args: vec![],
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    #[test]
+    fn sym_pattern_blank_observes_pattern_matching_feature() {
+        // Bare `_` (head: None).
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymPatternBlank {
+                head: None,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("pattern-matching")));
+    }
+
+    #[test]
+    fn sym_pattern_blank_head_constrained_validates_head() {
+        // `_h` where `h` is an unresolvable local — the head must be
+        // scope-checked too.
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::PatternMatching]),
+            Expr::SymPatternBlank {
+                head: Some(Box::new(Expr::VarRef {
+                    name: "ghost".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                })),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    #[test]
+    fn sym_pattern_blank_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::PatternMatching]),
+            Expr::SymPatternBlank {
+                head: None,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn sym_pattern_named_observes_pattern_matching_feature() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymPatternNamed {
+                name: "x".into(),
+                pattern: Box::new(Expr::SymPatternBlank {
+                    head: None,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("pattern-matching")));
+    }
+
+    #[test]
+    fn sym_pattern_named_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::PatternMatching]),
+            Expr::SymPatternNamed {
+                name: "x".into(),
+                pattern: Box::new(Expr::SymPatternBlank {
+                    head: None,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn sym_rule_observes_pattern_matching_feature_and_validates_lhs_rhs() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymRule {
+                lhs: Box::new(Expr::SymSymbol {
+                    name: "x".into(),
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::VarRef {
+                    name: "ghost".into(),
+                    scope: Scope::Local,
+                    span: s(),
+                }),
+                delayed: false,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("pattern-matching")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    #[test]
+    fn sym_rule_with_declared_feature_is_valid() {
+        // Both `->` (delayed: false) and `:>` (delayed: true) observe the
+        // same feature.  `lhs`/`rhs` are plain `IntLit`s here (rather than
+        // a `SymSymbol`) so this test stays focused on `SymRule`'s own
+        // `PatternMatching` observation, without also pulling in
+        // `SymbolicExpr` (a `SymSymbol`'s own feature).
+        for delayed in [false, true] {
+            let m = module_with_fn_body_value(
+                FeatureManifest::from_features(&[Feature::PatternMatching]),
+                Expr::SymRule {
+                    lhs: Box::new(Expr::IntLit {
+                        value: 1,
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }),
+                    delayed,
+                    span: s(),
+                },
+            );
+            let r = validate(&m);
+            assert!(r.is_ok(), "expected ok for delayed={}, got {:?}", delayed, r.issues);
+        }
+    }
+
+    #[test]
+    fn sym_replace_all_observes_pattern_matching_feature_and_validates_rules() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymReplaceAll {
+                expr: Box::new(Expr::SymSymbol {
+                    name: "x".into(),
+                    span: s(),
+                }),
+                rules: vec![Expr::SymRule {
+                    lhs: Box::new(Expr::SymSymbol {
+                        name: "x".into(),
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::VarRef {
+                        name: "ghost".into(),
+                        scope: Scope::Local,
+                        span: s(),
+                    }),
+                    delayed: false,
+                    span: s(),
+                }],
+                repeated: false,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("pattern-matching")));
+        assert!(r
+            .errors()
+            .any(|i| i.message.contains("unknown name `ghost`")));
+    }
+
+    #[test]
+    fn sym_replace_all_with_declared_feature_is_valid() {
+        // Both `/.` (repeated: false) and `//.` (repeated: true) observe
+        // the same feature.  `expr`/`lhs`/`rhs` are plain `IntLit`s here
+        // (rather than `SymSymbol`s) for the same reason as
+        // `sym_rule_with_declared_feature_is_valid` above: stay focused on
+        // `SymReplaceAll`'s own `PatternMatching` observation without also
+        // requiring `SymbolicExpr`.
+        for repeated in [false, true] {
+            let m = module_with_fn_body_value(
+                FeatureManifest::from_features(&[Feature::PatternMatching]),
+                Expr::SymReplaceAll {
+                    expr: Box::new(Expr::IntLit {
+                        value: 5,
+                        span: s(),
+                    }),
+                    rules: vec![Expr::SymRule {
+                        lhs: Box::new(Expr::IntLit {
+                            value: 1,
+                            span: s(),
+                        }),
+                        rhs: Box::new(Expr::IntLit {
+                            value: 0,
+                            span: s(),
+                        }),
+                        delayed: false,
+                        span: s(),
+                    }],
+                    repeated,
+                    span: s(),
+                },
+            );
+            let r = validate(&m);
+            assert!(
+                r.is_ok(),
+                "expected ok for repeated={}, got {:?}",
+                repeated,
+                r.issues
+            );
+        }
+    }
+
+    /// End-to-end version of the rejection tests above, in the same spirit
+    /// as `backend.rs`'s `backend_rejects_module_whose_body_uses_array_lit_and_matmul`:
+    /// a real module whose body nests `SymReplaceAll` around a `SymApply`
+    /// and a `SymRule` with a `SymPatternNamed`/`SymPatternBlank` pattern —
+    /// the full symbolic + pattern-matching vocabulary in one tree — with
+    /// NO features declared, confirming every one of `SymbolicExpr` and
+    /// `PatternMatching` is independently required.
+    #[test]
+    fn sym_replace_all_over_sym_apply_with_pattern_rule_requires_both_features() {
+        // f(x) /. (x_ -> 0) — replace any argument matching the pattern
+        // `x_` with 0 inside the symbolic application `f(x)`.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::SymReplaceAll {
+                expr: Box::new(Expr::SymApply {
+                    head: Box::new(Expr::SymSymbol {
+                        name: "f".into(),
+                        span: s(),
+                    }),
+                    args: vec![Expr::SymSymbol {
+                        name: "x".into(),
+                        span: s(),
+                    }],
+                    span: s(),
+                }),
+                rules: vec![Expr::SymRule {
+                    lhs: Box::new(Expr::SymPatternNamed {
+                        name: "x".into(),
+                        pattern: Box::new(Expr::SymPatternBlank {
+                            head: None,
+                            span: s(),
+                        }),
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }),
+                    delayed: false,
+                    span: s(),
+                }],
+                repeated: false,
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(
+            r.errors().any(|i| i.message.contains("symbolic-expr")),
+            "expected a symbolic-expr rejection, got {:?}",
+            r.issues
+        );
+        assert!(
+            r.errors().any(|i| i.message.contains("pattern-matching")),
+            "expected a pattern-matching rejection, got {:?}",
+            r.issues
+        );
+    }
+
+    #[test]
+    fn sym_replace_all_over_sym_apply_with_pattern_rule_valid_when_declared() {
+        // The same tree as above, but with both required features
+        // declared — must validate cleanly end to end.
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::SymbolicExpr, Feature::PatternMatching]),
+            Expr::SymReplaceAll {
+                expr: Box::new(Expr::SymApply {
+                    head: Box::new(Expr::SymSymbol {
+                        name: "f".into(),
+                        span: s(),
+                    }),
+                    args: vec![Expr::SymSymbol {
+                        name: "x".into(),
+                        span: s(),
+                    }],
+                    span: s(),
+                }),
+                rules: vec![Expr::SymRule {
+                    lhs: Box::new(Expr::SymPatternNamed {
+                        name: "x".into(),
+                        pattern: Box::new(Expr::SymPatternBlank {
+                            head: None,
+                            span: s(),
+                        }),
+                        span: s(),
+                    }),
+                    rhs: Box::new(Expr::IntLit {
+                        value: 0,
+                        span: s(),
+                    }),
+                    delayed: false,
+                    span: s(),
+                }],
+                repeated: false,
+                span: s(),
+            },
+        );
         let r = validate(&m);
         assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
     }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -356,6 +356,34 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
         Expr::Convert { value, .. } => {
             v.visit_expr(value);
         }
+
+        // ── SIR23: symbolic expression + pattern/rewrite nodes ──────
+        Expr::SymSymbol { .. } => {}
+        Expr::SymRational { .. } => {}
+        Expr::SymApply { head, args, .. } => {
+            v.visit_expr(head);
+            for a in args {
+                v.visit_expr(a);
+            }
+        }
+        Expr::SymPatternBlank { head, .. } => {
+            if let Some(h) = head {
+                v.visit_expr(h);
+            }
+        }
+        Expr::SymPatternNamed { pattern, .. } => {
+            v.visit_expr(pattern);
+        }
+        Expr::SymRule { lhs, rhs, .. } => {
+            v.visit_expr(lhs);
+            v.visit_expr(rhs);
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            v.visit_expr(expr);
+            for r in rules {
+                v.visit_expr(r);
+            }
+        }
     }
 }
 
@@ -905,5 +933,213 @@ mod tests {
         c.visit_module(&m);
         // The index-arg IntLit(0) and the value IntLit(9) — 2 total.
         assert_eq!(c.ints, 2);
+    }
+
+    // ── SIR23: symbolic expression + pattern/rewrite walker tests ────
+
+    #[test]
+    fn visitor_walks_sym_apply_head_and_args() {
+        // f(1, 2) as symbolic data: head `f` (not an IntLit) plus two
+        // IntLit args.
+        let m = module_with_body_value(Expr::SymApply {
+            head: Box::new(Expr::SymSymbol {
+                name: "f".into(),
+                span: s(),
+            }),
+            args: vec![
+                Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                },
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+            ],
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_sym_apply_computed_head() {
+        // f[x][y] — the outer SymApply's head is itself a SymApply whose
+        // own args contain an IntLit; the walker must recurse into it.
+        let m = module_with_body_value(Expr::SymApply {
+            head: Box::new(Expr::SymApply {
+                head: Box::new(Expr::SymSymbol {
+                    name: "f".into(),
+                    span: s(),
+                }),
+                args: vec![Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }],
+                span: s(),
+            }),
+            args: vec![Expr::IntLit {
+                value: 2,
+                span: s(),
+            }],
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_sym_pattern_blank_head() {
+        // `_h` — the head-constrained blank's `head` must be visited.
+        // Use an IntLit stand-in (not a realistic head, but sufficient to
+        // prove the walker recurses).
+        let m = module_with_body_value(Expr::SymPatternBlank {
+            head: Some(Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            })),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+
+        // Bare `_` (head: None) has no children to visit.
+        let m2 = module_with_body_value(Expr::SymPatternBlank {
+            head: None,
+            span: s(),
+        });
+        let mut c2 = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c2.visit_module(&m2);
+        assert_eq!(c2.ints, 0);
+    }
+
+    #[test]
+    fn visitor_walks_sym_pattern_named_pattern() {
+        let m = module_with_body_value(Expr::SymPatternNamed {
+            name: "x".into(),
+            pattern: Box::new(Expr::SymPatternBlank {
+                head: Some(Box::new(Expr::IntLit {
+                    value: 7,
+                    span: s(),
+                })),
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_sym_rule_lhs_and_rhs() {
+        let m = module_with_body_value(Expr::SymRule {
+            lhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            delayed: true,
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_sym_replace_all_expr_and_rules() {
+        // expr /. {rule1, rule2} — the target expr plus every rule in the
+        // rules vec must be visited.
+        let rule1 = Expr::SymRule {
+            lhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        let rule2 = Expr::SymRule {
+            lhs: Box::new(Expr::IntLit {
+                value: 3,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 4,
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        let m = module_with_body_value(Expr::SymReplaceAll {
+            expr: Box::new(Expr::IntLit {
+                value: 0,
+                span: s(),
+            }),
+            rules: vec![rule1, rule2],
+            repeated: true,
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        // expr(0) + rule1(1,2) + rule2(3,4) = 5 IntLits total.
+        assert_eq!(c.ints, 5);
+    }
+
+    #[test]
+    fn visitor_sym_symbol_and_sym_rational_have_no_children() {
+        let m = module_with_body_value(Expr::SymSymbol {
+            name: "x".into(),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 0);
+
+        let m2 = module_with_body_value(Expr::SymRational {
+            numer: 1,
+            denom: 2,
+            span: s(),
+        });
+        let mut c2 = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c2.visit_module(&m2);
+        assert_eq!(c2.ints, 0);
     }
 }


### PR DESCRIPTION
## Summary
- Implements [SIR23](code/specs/SIR23-symbolic-pattern-semantic-ir.md) -- the narrow-waist vocabulary for symbolic-CAS math languages (Stream B of HML01), the substrate for `wolfram-to-semantic-ir` / `macsyma-to-semantic-ir` / `maxima-to-semantic-ir`. Additive only, same discipline SIR22 used -- every existing module/backend match arm stays valid.
- New `SirType::SymExpr` (opaque symbolic-expression handle). New `Expr` variants mapped 1:1 onto `symbolic_ir::IRNode`'s five-variant shape: `SymSymbol`, `SymRational`, `SymApply` (`head: Box<Expr>`, not a bare `String`, since a computed head like `f[x][y]` is legal Wolfram), `SymPatternBlank`, `SymPatternNamed`, `SymRule`, `SymReplaceAll`. `IntLit`/`FloatLit`/`StrLit` (already in SIR10/SIR16) are reused directly -- no new literal nodes.
- No new `Stmt` variant (unlike SIR22's `IndexSet`) -- every new node is `Expr`-shaped and `Pure`, so `effects.rs` needed zero changes.
- New `Feature::SymbolicExpr` / `Feature::PatternMatching` flags. `SymRational` reuses SIR22's existing `Feature::Rationals` rather than duplicating it, per the spec's explicit share-don't-duplicate instruction.
- `CURRENT_SIR_VERSION` bumped `"2"` -> `"3"`.

## Verification
Capability-rejection verified end-to-end, not just asserted: a real `Module` with an `Expr::SymReplaceAll` wrapping `Expr::SymApply` and rewriting via `Expr::SymRule`/`SymPatternNamed`/`SymPatternBlank` (the full symbolic + pattern-matching vocabulary in one tree, `f(x) /. (x_ -> 0)`) is rejected by a backend that doesn't declare `SymbolicExpr`/`PatternMatching` through the actual `Backend::check_module` path, and the identical tree passes cleanly against a backend that does declare both.

Downstream compile-compat (matches SIR22's pattern): `javascript`/`python`/`ruby-to-semantic-ir` frontends and `semantic-ir-to-{go,javascript,python,rust,typescript}` backends gain new match arms -- no real codegen for the new nodes in this first wave, per the spec's own scope (Rust/Go/Python backends reject via the existing capability-rejection path; JS/TS real codegen depends on a not-yet-built `sir-runtime-symbolic` package, out of scope here exactly as `sir-runtime-array` was out of scope for SIR22 core).

## Test plan
- [x] `cargo build`/`cargo test` clean across `semantic-ir` and all 8 downstream crates (full `--workspace` build has 3 pre-existing, unrelated UEFI/panic_impl platform failures on macOS -- verified unrelated to this change)
- [x] End-to-end capability-rejection + acceptance tests (see above)
- [x] `/security-review`: passed with 2 non-blocking findings (LOW + INFO, neither introduced by this PR) -- see note below

## Security review notes (LOW/INFO, non-blocking per the security-review skill's own policy)
- **LOW**: `walker.rs`'s public `Visitor` trait has no `MAX_IR_DEPTH` recursion-depth guard, unlike the other three recursive `Expr`-tree passes in this crate (`validator.rs`, `backend.rs`, `text/printer.rs`), which all correctly cap at 1024. This predates SIR23 (affects every pre-existing recursive `Expr` variant too, not just the new ones) and is not currently exploitable -- no production consumer implements `Visitor` yet, and the frontends that parse untrusted source already cap depth during lowering before a tree could reach a `Visitor`. Filed as a tracked follow-up (not fixed here, to keep this PR's diff scoped to SIR23).
- **INFO**: `SymRational { numer: i64, denom: i64 }` has no arithmetic implemented in this PR (pure data carrier), so no overflow risk yet -- noted for whenever a future PR adds actual rational arithmetic (should use `checked_add`/`i128` widening then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)