### PR TITLE
feat(javascript-parser): bridge class_declaration → ClassDeclaration (CLOC12.174 PR2)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.38.0] - 2026-07-11
+
+### Added — CLOC12.174 PR2: bridge `class_declaration` → `Declaration::ClassDeclaration`
+
+`javascript-ast` 0.33.0 added the `Declaration::ClassDeclaration` node (PR1). The
+bridge's `convert_source_element` now converts a top-level class **declaration**
+(`class C { … }`) into `Declaration::ClassDeclaration` via the new
+`convert_class_declaration`, instead of declining (`UnsupportedSyntax`, which
+dropped the whole file to WHITESPACE_ONLY).
+
+The grammar wraps a class declaration in `decorated_class_declaration` →
+`class_declaration` at the source-element level (both the decorated wrapper and a
+bare `class_declaration` are handled; a *decorated* form carrying actual
+`@decorator`s declines — a later slice). The `class_declaration` node's flat
+child shape is **identical to `class_expression`** (`class` / NAME / optional
+`class_heritage` / `class_body`) except the name is **required** — so
+`convert_class_declaration` reuses `convert_class_heritage` and
+`convert_class_element` unchanged, and DECLINES a nameless class rather than
+fabricate an empty id. Generator / async / computed / multi-member methods decline
+to WHITESPACE_ONLY exactly as for the expression form (never a miscompile).
+
+10 bridge unit tests (`class_decl_*`) cover the accepted forms (empty, `extends`
+identifier / member, method, static, constructor, get/set, full shape) and the
+generator / async declines.
+
 ## [0.37.0] - 2026-07-08
 
 ### Added — CLOC12.173 PR2: bridge class expressions `class { … }` → `ClassExpression` (closes gap-167)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -49,7 +49,7 @@ use lexer::token::{Token, TokenType};
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 use coding_adventures_javascript_ast::{
     declaration::{
-        BindingTarget, Declaration, FunctionDeclaration, FunctionParam, VarKind,
+        BindingTarget, ClassDeclaration, Declaration, FunctionDeclaration, FunctionParam, VarKind,
         VariableDeclaration, VariableDeclarator,
     },
     expression::{
@@ -241,6 +241,23 @@ fn convert_source_element(node: &GrammarASTNode) -> Result<ProgramItem, BridgeEr
         "function_declaration" | "generator_declaration" => {
             let decl = convert_function_declaration(child)?;
             Ok(ProgramItem::Declaration(Declaration::FunctionDeclaration(decl)))
+        }
+        // A class *declaration* (`class C { … }`) — CLOC12.174 PR2. The grammar
+        // wraps it in `decorated_class_declaration` (the outer rule that would
+        // also carry `@decorator`s); the bare `class_declaration` alternative is
+        // handled too for robustness. A decorated form with actual decorators
+        // carries extra child nodes this slice does not model, so it DECLINES
+        // (safe WHITESPACE_ONLY fallback).
+        "decorated_class_declaration" => match node_children(child).as_slice() {
+            [cd] if cd.rule_name == "class_declaration" => {
+                let decl = convert_class_declaration(cd)?;
+                Ok(ProgramItem::Declaration(Declaration::ClassDeclaration(decl)))
+            }
+            _ => Err(unsupported(child)),
+        },
+        "class_declaration" => {
+            let decl = convert_class_declaration(child)?;
+            Ok(ProgramItem::Declaration(Declaration::ClassDeclaration(decl)))
         }
         "statement" => {
             let stmt = convert_statement(child)?;
@@ -1097,6 +1114,72 @@ fn convert_class_expression(node: &GrammarASTNode) -> Result<ClassExpression, Br
     }
 
     Ok(ClassExpression { cv: None, id, super_class, body })
+}
+
+/// Convert a `class_declaration` grammar node into a [`ClassDeclaration`] — the
+/// **statement** form (`class C { … }`), CLOC12.174 PR2.
+///
+/// The parse-tree shape (confirmed by dumping the grammar parser's output — see
+/// the throwaway probe removed with this PR) is the *same flat child list* as
+/// `class_expression`, with **one difference: the name is required**:
+///
+/// ```text
+///   class_declaration = [ Token("class"),
+///                         Token(NAME),          // REQUIRED — a declaration binds a name
+///                         Node(class_heritage)?,
+///                         Node(class_body) ]
+/// ```
+///
+/// (At the `source_element` level this node is wrapped in
+/// `decorated_class_declaration`, unwrapped by [`convert_source_element`].)
+/// Heritage and body are byte-identical to the expression form, so this reuses
+/// [`convert_class_heritage`] and [`convert_class_element`] unchanged — only the
+/// name handling differs: a missing name is not a valid declaration, so it
+/// DECLINES (safe WHITESPACE_ONLY fallback) rather than fabricating an empty id.
+fn convert_class_declaration(node: &GrammarASTNode) -> Result<ClassDeclaration, BridgeError> {
+    // Name: the required class name — the single direct-child token that is not
+    // the `class` keyword. Unlike `class_expression` (optional id), a *missing*
+    // name here DECLINES: a class declaration with no name is not valid syntax
+    // this slice represents.
+    let id = node
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.value != "class" => Some(t.value.clone()),
+            _ => None,
+        })
+        .map(|name| Identifier { cv: None, name })
+        .ok_or_else(|| unsupported(node))?;
+
+    // Heritage (`extends <operand>`), if present — same converter as the
+    // expression form.
+    let mut super_class: Option<Box<Expression>> = None;
+    if let Some(heritage) = node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) if n.rule_name == "class_heritage" => Some(n),
+        _ => None,
+    }) {
+        super_class = Some(Box::new(convert_class_heritage(heritage)?));
+    }
+
+    // Body: iterate `class_element` children of the `class_body` node — same
+    // converter as the expression form.
+    let body_node = node
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ASTNodeOrToken::Node(n) if n.rule_name == "class_body" => Some(n),
+            _ => None,
+        })
+        .ok_or_else(|| internal(node, "class_declaration: missing class_body"))?;
+
+    let mut body = Vec::new();
+    for el in node_children(body_node) {
+        if el.rule_name == "class_element" {
+            body.push(convert_class_element(el)?);
+        }
+    }
+
+    Ok(ClassDeclaration { cv: None, id, super_class, body })
 }
 
 /// Convert a `class_heritage` (`extends <operand>`) node into the super-class
@@ -3549,6 +3632,111 @@ mod tests {
     fn class_async_method_declines() {
         assert!(matches!(
             bridge("x = class { async am(){} };"),
+            Err(BridgeError::UnsupportedSyntax { .. })
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // ClassDeclaration bridging (CLOC12.174 PR2)
+    // -----------------------------------------------------------------
+
+    /// Pull the `ClassDeclaration` out of a top-level `class … { … }` statement.
+    fn class_decl_of(src: &str) -> ClassDeclaration {
+        let p = bridge_ok(src);
+        match &p.body[0] {
+            ProgramItem::Declaration(Declaration::ClassDeclaration(c)) => c.clone(),
+            other => panic!("expected a ClassDeclaration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn class_decl_empty() {
+        let c = class_decl_of("class C {}");
+        assert_eq!(c.id.name, "C");
+        assert!(c.super_class.is_none());
+        assert!(c.body.is_empty());
+    }
+
+    #[test]
+    fn class_decl_extends_identifier() {
+        let c = class_decl_of("class C extends B {}");
+        assert_eq!(c.id.name, "C");
+        match c.super_class.as_deref() {
+            Some(Expression::Identifier(id)) => assert_eq!(id.name, "B"),
+            other => panic!("expected Identifier super-class, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn class_decl_extends_member() {
+        // `extends ns.B` — heritage is a member expression (a node operand).
+        let c = class_decl_of("class C extends ns.B {}");
+        assert!(matches!(
+            c.super_class.as_deref(),
+            Some(Expression::MemberExpression(_))
+        ));
+    }
+
+    #[test]
+    fn class_decl_single_method() {
+        let c = class_decl_of("class C { m(){} }");
+        assert_eq!(c.body.len(), 1);
+        let ClassMember::Method(m) = &c.body[0];
+        assert!(matches!(m.kind, MethodKind::Method));
+        assert!(!m.is_static);
+        match &m.key {
+            PropertyKey::Identifier(id) => assert_eq!(id.name, "m"),
+            other => panic!("expected identifier key, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn class_decl_static_method() {
+        let c = class_decl_of("class C { static m(){} }");
+        let ClassMember::Method(m) = &c.body[0];
+        assert!(m.is_static);
+    }
+
+    #[test]
+    fn class_decl_constructor() {
+        let c = class_decl_of("class C { constructor(){} }");
+        let ClassMember::Method(m) = &c.body[0];
+        assert!(matches!(m.kind, MethodKind::Constructor));
+    }
+
+    #[test]
+    fn class_decl_getter_setter() {
+        let g = class_decl_of("class C { get x(){} }");
+        let ClassMember::Method(gm) = &g.body[0];
+        assert!(matches!(gm.kind, MethodKind::Get));
+        let s = class_decl_of("class C { set x(v){} }");
+        let ClassMember::Method(sm) = &s.body[0];
+        assert!(matches!(sm.kind, MethodKind::Set));
+    }
+
+    #[test]
+    fn class_decl_full_shape() {
+        // `class C extends B { m(){} }` — name + heritage + one member together.
+        let c = class_decl_of("class C extends B { m(){} }");
+        assert_eq!(c.id.name, "C");
+        assert!(c.super_class.is_some());
+        assert_eq!(c.body.len(), 1);
+    }
+
+    #[test]
+    fn class_decl_generator_method_declines() {
+        // `*m(){}` is a generator method — a form this slice does not model, so
+        // the whole file DECLINES to WHITESPACE_ONLY (never a miscompile).
+        assert!(matches!(
+            bridge("class C { *m(){} }"),
+            Err(BridgeError::UnsupportedSyntax { .. })
+        ));
+    }
+
+    #[test]
+    fn class_decl_async_method_declines() {
+        assert!(matches!(
+            bridge("class C { async am(){} }"),
             Err(BridgeError::UnsupportedSyntax { .. })
         ));
     }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.13] - 2026-07-11
+
+### Added — CLOC12.174 PR2: class-declaration end-to-end (`tests/diff/simple-class-decl/`)
+
+With `javascript-parser` 0.38.0's bridge, a top-level class **declaration**
+(`class C { … }`) now flows through the full SIMPLE pipeline
+(parser → typed-AST bridge → passes → emitter) instead of dropping the whole file
+to WHITESPACE_ONLY. New e2e diff fixture `tests/diff/simple-class-decl/`: input
+`class C { m() { return 1 + 2 } }` minifies to `class C{m(){return 3}}` —
+asserting the class declaration round-trips, the method body folds (`1 + 2` → `3`,
+proving the pass descended into the method), and it emits **bare** (no trailing
+`;`, no wrapping paren — unlike the class *expression* form's `(class …);`).
+
 ## [0.234.12] - 2026-07-08
 
 ### Added — CLOC12.173 PR2: class expressions flow through the SIMPLE/ADVANCED pipelines (gap-167)

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.12"
+version = "0.234.13"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.12",
+  "version": "0.234.13",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.12
+Version: 0.234.13
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-class-decl/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-class-decl/expected.stdout
@@ -1,0 +1,1 @@
+class C{m(){return 3}}

--- a/code/programs/rust/closurec/tests/diff/simple-class-decl/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-class-decl/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-class-decl/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-class-decl/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-class-decl/input/a.js
@@ -1,0 +1,1 @@
+class C { m() { return 1 + 2 } }

--- a/code/programs/rust/closurec/tests/diff_simple_class_decl.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_class_decl.rs
@@ -1,0 +1,89 @@
+//! Integration test for the `tests/diff/simple-class-decl/` fixture.
+//!
+//! Exercises CLOC12.174 PR2 — a **class declaration** (`class C { … }` in
+//! statement position, a `Declaration::ClassDeclaration` with a
+//! `MethodDefinition` body) now flows through the full SIMPLE pipeline
+//! (parser → typed-AST bridge → passes → emitter) instead of being declined at
+//! the bridge (`class_declaration` → `UnsupportedSyntax`, which dropped the
+//! whole file to WHITESPACE_ONLY).
+//!
+//! The fixture is `class C { m() { return 1 + 2 } }` — a top-level class
+//! declaration carrying one method `m`. Three facts prove the pipeline ran
+//! end-to-end rather than falling back:
+//!   1. the class round-trips as `class C{m(){…}}` (minified, no inner spaces),
+//!      proving the bridge built a real `ClassDeclaration` the emitter prints;
+//!   2. the method body folds — `return 1 + 2` → `return 3` — proving the
+//!      constant-fold pass descended into the method's `FunctionExpression`
+//!      body (PR1 wired `fold_class_declaration`); and
+//!   3. there is **no trailing `;`** and **no wrapping paren** — a class
+//!      *declaration* is emitted bare (unlike the *expression* form's
+//!      `(class C{…});`), the point of the PR1 emit contract.
+//! A WHITESPACE_ONLY fallback — which a bridge decline forces for the *whole*
+//! file — would instead re-emit the source verbatim, leaving `1 + 2` unfolded
+//! and the source spacing intact.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-class-decl/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_class_decl_fixture_matches_expected_stdout() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-class-decl/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture. Strip spaces so the checks are
+    // insensitive to inter-token whitespace.
+    let a = actual.replace(' ', "");
+    // (1) the class declaration round-tripped — proving the bridge built a real
+    //     `ClassDeclaration` the emitter can print, not a WHITESPACE_ONLY pass.
+    assert!(
+        a.contains("class C{m()") || a.contains("classC{m()"),
+        "class declaration did not round-trip: {actual}"
+    );
+    // (2) the method body folded — proving the pass descended into the method's
+    //     function body (`1 + 2` → `3`), so the bridge produced a real AST.
+    assert!(
+        a.contains("return 3") || a.contains("return3}"),
+        "method body `1 + 2` did not fold to `3`: {actual}"
+    );
+    // (3) a class *declaration* is emitted bare — NO trailing `;` after the
+    //     closing `}` (unlike a function declaration's gap-030 `;`) and NO
+    //     wrapping paren (unlike the class *expression* form's `(class …);`).
+    let t = actual.trim_end_matches('\n');
+    assert!(
+        t.ends_with('}') && !t.ends_with("};") && !t.starts_with('('),
+        "class declaration must emit bare (no trailing `;`, no wrap): {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2284,6 +2284,27 @@ shared helper (`fold_class_body`, `classify_class_members` /
 `rewrite_class_members`). Reachable end-to-end once the PR2 bridge produces the
 node.
 
+**PR2 (DONE) — `javascript-parser` 0.38.0 + `closurec` 0.234.13.** The bridge's
+`convert_source_element` converts a top-level `class_declaration` →
+`Declaration::ClassDeclaration` via new `convert_class_declaration`, so a class
+declaration flows through the full pipeline instead of declining to
+WHITESPACE_ONLY. **The design held with one grammar-shape refinement found by
+dumping the parse tree:** at the `source_element` level the node is wrapped in
+`decorated_class_declaration` → `class_declaration` (the outer rule that would
+also carry `@decorator`s), so the source-element arm unwraps it (and declines a
+genuinely *decorated* form — a later slice). The inner `class_declaration` node's
+flat child shape is **identical to `class_expression`** (`class` / NAME / optional
+`class_heritage` / `class_body`) save the required name, so
+`convert_class_declaration` reuses `convert_class_heritage` /
+`convert_class_element` unchanged and DECLINES a nameless class rather than
+fabricate an empty id. Generator / async / computed / multi-member methods decline
+to WHITESPACE_ONLY exactly as for the expression form. 10 bridge unit tests
+(`class_decl_*`); `closurec` e2e fixture `tests/diff/simple-class-decl/`
+(`class C { m() { return 1 + 2 } }` → `class C{m(){return 3}}`) proves the class
+round-trips, the method body folds, and the declaration emits **bare** (no
+trailing `;`, no wrapping paren). PR3 (upstream CodePrinter class-declaration
+conformance port) remains.
+
 ## CLOC12.173 — `ClassExpression` (`class [id] [extends S] { … }`): the class arc (design)
 
 `ClassExpression` is the next `Expression` node, and unlike every arc since


### PR DESCRIPTION
## CLOC12.174 PR2 — class-declaration bridge

Wires PR1's `Declaration::ClassDeclaration` node through the parser bridge, so a top-level class **declaration** (`class C { … }`) now flows through the full pipeline (parser → typed-AST bridge → passes → emitter) instead of declining at the bridge (`class_declaration` → `UnsupportedSyntax`, which dropped the whole file to WHITESPACE_ONLY).

### What's here
- **javascript-parser 0.38.0** — `convert_source_element` converts a class declaration via new `convert_class_declaration`. The grammar wraps it as `decorated_class_declaration` → `class_declaration` at the source-element level (both the decorated wrapper and a bare `class_declaration` are handled; a *decorated* form with real `@decorator`s declines — a later slice). The `class_declaration` node's flat child shape is **identical to `class_expression`** (`class` / NAME / optional `class_heritage` / `class_body`) except the name is **required** — so the converter reuses `convert_class_heritage` / `convert_class_element` unchanged and **DECLINES a nameless class** rather than fabricate an empty id. Generator / async / computed / multi-member methods decline to WHITESPACE_ONLY exactly as for the expression form (never a miscompile). **10 bridge unit tests** (`class_decl_*`).
- **closurec 0.234.13** — e2e diff fixture `tests/diff/simple-class-decl/`: `class C { m() { return 1 + 2 } }` → `class C{m(){return 3}}`, proving the class round-trips, the method body folds (`1+2`→`3`), and the declaration emits **bare** (no trailing `;`, no wrapping paren — unlike the class *expression* form). Version synced (`cli.spec.json` + help-markdown fixture) per the version-sync rule.

### Notes
- Parse-tree shape dumped first (throwaway probe, removed) — that revealed the `decorated_class_declaration` wrapper and the trailing member `;` (harmlessly ignored by the reused `convert_class_element`).
- Spec (`code/specs/CLOC12-gaps.md`) updated with a PR2-DONE note.
- Full `javascript-parser` (191) + `closurec` (685) suites green.
- Security review: PASSED (faithful mirror of `convert_class_expression`; declines rather than panics/fabricates; recursion bounded by the parser depth limit; no `unsafe`).
- **PR3** (upstream CodePrinter class-declaration conformance port) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)