### PR TITLE
feat(latex): LTXDOC03 S34 duplicate_label_count ("multiply defined" \label total)

### DIFF
--- a/code/packages/rust/latex/CHANGELOG.md
+++ b/code/packages/rust/latex/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the full-fidelity LaTeX parser crate.
 
+## [0.70.0] — 2026-07-11
+
+### Added — single-integer TOTAL of the duplicate ("multiply defined") `\label`s (LTXDOC03 S34)
+
+A **new** public method `Document::duplicate_label_count(&self) -> String` that renders the decimal
+**COUNT** of the duplicate (later, losing) `\label`s — the `\label`s of already-defined keys, which LaTeX
+flags with *"Label `key' multiply defined"* — as one integer line. It is the **label-side twin** of S33's
+`duplicate_bibliography_count`: where S33 counts the losing `\bibitem`s, S34 counts the losing `\label`s.
+It is the *count-total* companion of S20's `duplicate_label_definitions` (which renders one `\label{key}`
+warning line per losing duplicate): S20 and S34 are two *views* of the one `duplicates` list
+`resolve_references()` produces — S34 collapses the whole list to a single `.len()` tally. It is the
+**warning-side companion** of S29's `label_definition_count` (which counts the *winning* label
+definitions), completing the *label totals family* just as S33 completed the citation totals family. S29
+counts the winning `definitions` and S34 the losing `duplicates`; together they **partition** every
+`\label` in the document — `label_definition_count + duplicate_label_count` equals the total number of
+`\label`s, because `resolve_references()` routes each `\label` into exactly one of
+`definitions`/`duplicates`. It reads only `resolve_references().duplicates.len()` — the winning first
+`\label` of a key lives in `definitions` (S22/S29's domain) and is excluded by construction — never a
+`key`/`kind`/`span`, no source slicing at all, so every losing `\label` (section, figure, equation, or
+inline) folds into one total. We do **not** de-duplicate: a key defined *three* times contributes *two*
+losing duplicates, exactly the two warning lines S20 emits. Being a COUNT renderer, its empty case (no
+labels, or every key defined exactly once) is the honest number `"0"` — **not** a `(no duplicate label
+definitions)` marker (that discipline belongs to the *list* renderer S20; this mirrors
+S27/S28/S29/S30/S31/S32/S33). One line, no trailing newline. E.g. `\label{x}` twice + `\label{y}` once →
+`1`. It is a read-only view over `resolve_references()`; every S1–S33 output is left **byte-for-byte
+unchanged**; S34 is purely additive and leaves the `to_latex()` round-trip fixed point intact. Total &
+panic-free.
+
 ## [0.69.0] — 2026-07-10
 
 ### Added — single-integer TOTAL of the duplicate ("multiply defined") `\bibitem`s (LTXDOC03 S33)

--- a/code/packages/rust/latex/Cargo.toml
+++ b/code/packages/rust/latex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "latex"
-version = "0.69.0"
+version = "0.70.0"
 edition = "2021"
 description = "A full-fidelity LaTeX parser (documents and math): a catcode-driven, text-mode-primary tokenizer and (in later layers) a structural + math parser producing a faithful AST. Standalone and reusable; will also implement the math-frontend MathFrontend trait."
 license = "MIT"

--- a/code/packages/rust/latex/README.md
+++ b/code/packages/rust/latex/README.md
@@ -81,6 +81,7 @@ with a **text-mode-primary** mode stack (LaTeX starts in text mode; math is ente
 | **LTXDOC03 S31 — single-integer total of the resolved citations** | `Document::citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the RESOLVED `\cite` keys — the ones some `\bibitem` defines — as one integer line. It is the **count-total companion of S15's** `citations_by_source` (which renders the resolved keys *grouped by their source `\cite`*): S15 and S31 are two views of the one `resolved` list; S31 collapses the whole list to a single `.len()` tally. It is the exact resolved-**citation-side twin of S28's** `resolved_reference_count`, extending the *totals family* onto the resolved-citation table — S27's `unresolved_reference_count` and S28's `resolved_reference_count` count the two reference tables, S29 counts the label definitions, S30 counts the bibliography entries, and S31 counts the resolved citations. It reads only `resolve_citations().resolved.len()` (a dangling `\cite{ghost}` lives in `unresolved`, S17's domain, and is excluded by construction) — never a `cite_span`/`entry_span`, no source slicing at all, so every resolved key folds into one total. Being a COUNT renderer, its empty case (every cited key dangling, or none at all) is the honest number `"0"` — **not** a `(no resolved citations)` marker (that discipline belongs to the *list* renderer S15; this mirrors S27/S28/S29/S30). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `3`. Every S1–S30 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S32 — single-integer total of the unresolved (dangling) citations** | `Document::unresolved_citation_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the UNRESOLVED (dangling) `\cite` keys — the ones **no** `\bibitem` defines — as one integer line. It is the **count-total companion of S17's** `unresolved_citations_by_source` (which renders the dangling keys *grouped by their source `\cite`*): S17 and S32 are two views of the one `unresolved` list; S32 collapses the whole list to a single `.len()` tally. It is the exact unresolved-**citation-side twin of S27's** `unresolved_reference_count`, and the **dangling sibling of S31's** resolved `citation_count`. Together S31 and S32 **partition** every per-key `\cite` record — `citation_count + unresolved_citation_count` equals the number of cited keys, because `resolve_citations()` routes each key into exactly one of `resolved`/`unresolved`. It reads only `resolve_citations().unresolved.len()` (a resolved `\cite{a}` lives in `resolved`, S15/S31's domain, and is excluded by construction) — never a `cite_span`/dangling `key`, no source slicing at all, so every dangling key folds into one total. Being a COUNT renderer, its empty case (every cited key resolving, or none at all) is the honest number `"0"` — **not** a `(no unresolved citations)` marker (that discipline belongs to the *list* renderer S17; this mirrors S27/S28/S29/S30/S31). One line, no trailing newline. E.g. `\cite{a,b}` (both defined) + `\cite{c,ghost}` (only `c` defined) → `1`. Every S1–S31 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 | **LTXDOC03 S33 — single-integer total of the duplicate ("multiply defined") `\bibitem`s** | `Document::duplicate_bibliography_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the DUPLICATE (later, losing) `\bibitem`s — the ones of already-defined keys, which LaTeX flags *"Citation `key' multiply defined"* — as one integer line. It is the **count-total companion of S16's** `duplicate_bibliography_entries` (which renders one `\bibitem{key}` *warning line per losing duplicate*): S16 and S33 are two views of the one `duplicate_entries` list; S33 collapses the whole list to a single `.len()` tally. It is the **warning-side companion** of the resolved (S30/S31) and unresolved (S32) citation totals, completing the *totals family* over the citation tables. S30 counts the winning `entries` and S33 the losing `duplicate_entries` — together they **partition** every `\bibitem` inside a `thebibliography`: `bibliography_entry_count + duplicate_bibliography_count` equals the number of `\bibitem`s, because `resolve_citations()` routes each `\bibitem` into exactly one of `entries`/`duplicate_entries`. It reads only `resolve_citations().duplicate_entries.len()` (the winning first `\bibitem` of a key lives in `entries`, S19/S30's domain, and is excluded by construction) — never a `key`/`span`, no source slicing at all, so every losing `\bibitem` folds into one total (not de-duplicated: a key defined *three* times contributes *two* losing duplicates, exactly the two S16 warning lines). Being a COUNT renderer, its empty case (no bibliography, or every key defined exactly once) is the honest number `"0"` — **not** a `(no duplicate bibliography entries)` marker (that discipline belongs to the *list* renderer S16; this mirrors S27/S28/S29/S30/S31/S32). One line, no trailing newline. E.g. `\bibitem{smith}` twice + `\bibitem{jones}` once → `1`. Every S1–S32 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
+| **LTXDOC03 S34 — single-integer total of the duplicate ("multiply defined") `\label`s** | `Document::duplicate_label_count() -> String` — a **new**, read-only method that renders the decimal **COUNT** of the DUPLICATE (later, losing) `\label`s — the ones of already-defined keys, which LaTeX flags *"Label `key' multiply defined"* — as one integer line. It is the **label-side twin of S33's** `duplicate_bibliography_count` (S33 counts the losing `\bibitem`s; S34 counts the losing `\label`s). It is the **count-total companion of S20's** `duplicate_label_definitions` (which renders one `\label{key}` *warning line per losing duplicate*): S20 and S34 are two views of the one `duplicates` list; S34 collapses the whole list to a single `.len()` tally. It is the **warning-side companion** of S29's `label_definition_count` (which counts the *winning* label definitions), completing the *label totals family* just as S33 completed the citation totals family. S29 counts the winning `definitions` and S34 the losing `duplicates` — together they **partition** every `\label` in the document: `label_definition_count + duplicate_label_count` equals the number of `\label`s, because `resolve_references()` routes each `\label` into exactly one of `definitions`/`duplicates`. It reads only `resolve_references().duplicates.len()` (the winning first `\label` of a key lives in `definitions`, S22/S29's domain, and is excluded by construction) — never a `key`/`kind`/`span`, no source slicing at all, so every losing `\label` (section, figure, equation, or inline) folds into one total (not de-duplicated: a key defined *three* times contributes *two* losing duplicates, exactly the two S20 warning lines). Being a COUNT renderer, its empty case (no labels, or every key defined exactly once) is the honest number `"0"` — **not** a `(no duplicate label definitions)` marker (that discipline belongs to the *list* renderer S20; this mirrors S27/S28/S29/S30/S31/S32/S33). One line, no trailing newline. E.g. `\label{x}` twice + `\label{y}` once → `1`. Every S1–S33 output is byte-for-byte unchanged, `to_latex()` still a fixed point. Total & panic-free. | ✅ |
 
 The low-level ladder is **complete** (L0–L6). 🎉 The hierarchical **Document** layer (LTXDOC01) is
 now **complete too** — D1–D6 all shipped, taking LaTeX → `Document` AST **end-to-end**: source →
@@ -1303,6 +1304,45 @@ defined exactly once) renders the honest number `"0"` — **not** a `(no duplica
 marker (that discipline belongs to the *list* renderer S16, whose empty case has no lines to show; this
 mirrors S27/S28/S29/S30/S31/S32). Purely additive — reuses `resolve_citations`, mutates nothing, leaves every
 S1–S32 output and the `to_latex()` fixed point unchanged.
+
+### single-integer total of the duplicate ("multiply defined") `\label`s (LTXDOC03 S34)
+
+The decimal **COUNT** of the duplicate (later, losing) `\label`s — the ones of already-defined keys, which
+LaTeX flags *"Label `key' multiply defined"* — as one integer line. It is the **label-side twin of S33's**
+`duplicate_bibliography_count` (S33 counts the losing `\bibitem`s; S34 counts the losing `\label`s). It is the
+**count-total companion of S20's** `duplicate_label_definitions` (which renders one `\label{key}` *warning
+line per losing duplicate*): S20 and S34 are two *views* of the one `duplicates` list `resolve_references()`
+produces; S34 collapses the whole list to a single `.len()` tally. It is the **warning-side companion** of
+S29's `label_definition_count` (which counts the *winning* label definitions), completing the *label totals
+family* just as S33 completed the citation totals family. S29 counts the winning `definitions` and S34 the
+losing `duplicates` — together they **partition** every `\label` in the document:
+`label_definition_count + duplicate_label_count` is exactly the number of `\label`s, because
+`resolve_references()` routes each `\label` into exactly one of `definitions`/`duplicates`.
+`duplicate_label_count` reads only `resolve_references().duplicates.len()` — the winning first `\label` of a
+key lives in `definitions` (S22/S29's domain) and is excluded by construction — never a `key`/`kind`/`span`,
+no source slicing at all, so every losing `\label` (section, figure, equation, or inline) folds into one total
+(not de-duplicated: a key defined *three* times contributes *two* losing duplicates, exactly the two S20
+warning lines).
+
+```rust
+use latex::parse_document;
+
+let src = r"\begin{document}First \label{dup} here.
+
+Second \label{dup} there.\end{document}";
+let doc = parse_document(src).unwrap();
+assert_eq!(
+    doc.duplicate_label_count(),
+    // one `\label` loses (the second `dup`); the winning first `dup` is excluded
+    "1",
+);
+```
+
+Being a COUNT renderer, a document with no duplicate `\label`s at all (no labels, or every key defined exactly
+once) renders the honest number `"0"` — **not** a `(no duplicate label definitions)` marker (that discipline
+belongs to the *list* renderer S20, whose empty case has no lines to show; this mirrors
+S27/S28/S29/S30/S31/S32/S33). Purely additive — reuses `resolve_references`, mutates nothing, leaves every
+S1–S33 output and the `to_latex()` fixed point unchanged.
 
 ## Usage
 

--- a/code/packages/rust/latex/src/references.rs
+++ b/code/packages/rust/latex/src/references.rs
@@ -3221,6 +3221,83 @@ impl Document {
         // summary of S16's per-source duplicate list.
         self.resolve_citations().duplicate_entries.len().to_string()
     }
+
+    /// The **single-integer TOTAL of the duplicate ("multiply defined") `\label`s** (LTXDOC03 S34) —
+    /// the count of the *later, losing* `\label` definitions of already-defined keys, the
+    /// **label-side twin** of S33's
+    /// [`duplicate_bibliography_count`](Document::duplicate_bibliography_count).
+    ///
+    /// This is the warning-side member of the *label totals family*. S29's
+    /// [`label_definition_count`](Document::label_definition_count) counts the *winning* label
+    /// definitions (the first `\label` of each distinct key); S34 counts the *losing* ones — the
+    /// `\label`s LaTeX would flag with *"Label `key' multiply defined"*. It is to S20's
+    /// [`duplicate_label_definitions`](Document::duplicate_label_definitions) exactly what S33 is to
+    /// S16's `duplicate_bibliography_entries`, and what S29 is to S22's `label_definitions`: a numeric
+    /// summary over the *same* list — here the **losing** duplicate `\label`s — so a reader sees "how
+    /// many labels are multiply defined" without scanning the individual warning lines. It mirrors S33
+    /// on the label side just as S29 (`label_definition_count`) mirrors S30
+    /// (`bibliography_entry_count`).
+    ///
+    /// ## What it does
+    ///
+    /// S1's [`Document::resolve_references`] splits every `\label` into the **winning** first
+    /// definition of each key ([`ReferenceResolution::definitions`] — S22/S29's domain) and the
+    /// **losing** later re-definitions ([`ReferenceResolution::duplicates`] — S20's domain), both in
+    /// [`Document::walk`] pre-order. S20 renders the losing list as one `\label{key}` warning line per
+    /// duplicate; S34 collapses the whole list to a **single count line** — the decimal `.len()` of
+    /// `duplicates`. It reads only the length, never a `key`, `kind`, or `span`, so every losing
+    /// `\label` — section, figure, equation, or inline, regardless of key — folds into one total. Only
+    /// the **losing** definitions are counted; the winning first `\label` of a key lives in
+    /// `definitions` (S22/S29), never in `duplicates`, so it is excluded by construction. We do **not**
+    /// de-duplicate: a key defined *three* times contributes *two* losing duplicates (one per
+    /// *"multiply defined"* warning LaTeX would raise), exactly the two `\label{key}` lines S20 emits.
+    ///
+    /// ## The exact rendering contract
+    ///
+    /// Read the length of [`ReferenceResolution::duplicates`] and render it as its decimal `String`,
+    /// **always** on a single line with **no** trailing newline. This is a **count** renderer, so its
+    /// honest value when there are no duplicate `\label`s is the number `0` — the string `"0"`, **not**
+    /// a `(no duplicate label definitions)` marker (a total count of zero *is* a number; the `(no …)`
+    /// marker discipline belongs to the *list* renderer S20, whose empty case has no lines to show).
+    /// This mirrors S27/S28/S29/S30/S31/S32/S33 exactly, which emit `"0"` for their empty lists. There
+    /// is no source slicing — only `.len()` is taken.
+    ///
+    /// Concretely, for a body that defines `\label{x}` twice and `\label{y}` once:
+    ///
+    /// ```text
+    /// 1
+    /// ```
+    ///
+    /// (one losing duplicate — the second `\label{x}`; the winning first `\label{x}` and the lone
+    /// `\label{y}` are in `definitions`, the "2" S29 reports). A document with **no** duplicate
+    /// `\label`s — no labels at all, or every key defined exactly once — returns `"0"`.
+    ///
+    /// **Partition note.** S29 counts `definitions` (one per distinct key, the winners) and S34 counts
+    /// `duplicates` (the losers); together they **partition** every `\label` in the document —
+    /// `label_definition_count + duplicate_label_count` is exactly the number of `\label`s, because
+    /// [`Document::resolve_references`] routes each `\label` into exactly one of `definitions` or
+    /// `duplicates`.
+    ///
+    /// ## Additive by construction
+    ///
+    /// S34 is a brand-new, read-only method that reuses [`resolve_references`](Document::resolve_references)
+    /// and mutates nothing; it changes no S1–S33 output (they are byte-for-byte unchanged) and leaves the
+    /// `to_latex` round-trip fixed point intact. It is a *second view* of the same `duplicates` list S20
+    /// renders per-source — counting never adds, drops, or reorders the duplicate `\label`s relative to
+    /// what `resolve_references` produced.
+    ///
+    /// **Total & panic-free.** No `unwrap`/`expect`, no unchecked indexing (no source slicing at all —
+    /// only `.len()` is read); a single read of the already-bounded `duplicates` list's length. Borrows
+    /// `self` immutably and returns owned `String` data, so the result outlives any borrow of the
+    /// source.
+    pub fn duplicate_label_count(&self) -> String {
+        // S1 already routed every later `\label` of an already-defined key into `duplicates`, in body
+        // pre-order (first-definition-wins; the winning first `\label`s went to `definitions`, S22/S29).
+        // We only read that list's length. No `key`/`kind`/`span` is read — every losing `\label` folds
+        // into a single total, the "multiply defined" warning-side companion of S29 and the label-side
+        // twin of S33, the numeric summary of S20's per-source duplicate list.
+        self.resolve_references().duplicates.len().to_string()
+    }
 }
 
 /// The plain-text rendering of a float's optional `\caption{…}` (LTXDOC03 S12).
@@ -8051,5 +8128,162 @@ See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}
         let winners: usize = doc.bibliography_entry_count().parse().unwrap();
         let losers: usize = doc.duplicate_bibliography_count().parse().unwrap();
         assert_eq!(winners + losers, 4);
+    }
+
+    // LTXDOC03 S34 — single-integer TOTAL of the duplicate ("multiply defined") `\label`s
+    // (`duplicate_label_count`). The label-side twin of S33's `duplicate_bibliography_count`: one
+    // decimal line = `.len()` of the SAME losing-duplicate `\label` list S20's
+    // `duplicate_label_definitions` renders as one `\label{key}` warning line each. S29 counts the
+    // winning `definitions` and S34 the losing `duplicates` — together they PARTITION every `\label`
+    // (each `\label` routes to exactly one of `definitions`/`duplicates`). Being a COUNT renderer, its
+    // empty value is the honest number "0", NOT a `(no …)` marker. The winning first `\label` of a key
+    // is in `definitions` (S22/S29), never `duplicates`, so it is excluded.
+    // ---------------------------------------------------------------------------------------------
+
+    #[test]
+    fn s34_multiple_duplicate_labels_count_the_integer() {
+        // `\label{a}` defined three times and `\label{b}` twice → the 2nd and 3rd `a` lose (two) and
+        // the 2nd `b` loses (one) → three losing duplicates, so the count is exactly "3".
+        let src = r"\begin{document}A \label{a} one.
+
+B \label{b} two.
+
+A' \label{a} again.
+
+A'' \label{a} thrice.
+
+B' \label{b} again.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_label_count(), "3");
+    }
+
+    #[test]
+    fn s34_no_duplicates_all_distinct_counts_zero() {
+        // Every `\label` key is distinct → no duplicate loses → "0" (the count of an empty `duplicates`
+        // list). A COUNT renderer's honest value for an empty list is "0".
+        let src = r"\begin{document}One \label{a} here, two \label{b} there, three \label{c} yonder.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_label_count(), "0");
+        // And S20 (the list view) shows its fixed marker for the same doc — the divergence is intended.
+        assert_eq!(
+            doc.duplicate_label_definitions(),
+            "(no duplicate label definitions)"
+        );
+    }
+
+    #[test]
+    fn s34_no_labels_at_all_counts_zero() {
+        // A document with NO `\label` at all → "0", the same honest-zero as the "all distinct" case.
+        let src = r"\begin{document}Just some text with no labels.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_label_count(), "0");
+    }
+
+    #[test]
+    fn s34_one_duplicate_counts_one() {
+        // A single key `\label{dup}` defined twice → only the SECOND loses → "1".
+        let src = r"\begin{document}First \label{dup} here.
+
+Second \label{dup} there.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_label_count(), "1");
+        // The count MUST equal the number of warning lines S20 lists (two views of the SAME list).
+        assert_eq!(
+            doc.duplicate_label_count(),
+            doc.duplicate_label_definitions().lines().count().to_string()
+        );
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+    }
+
+    #[test]
+    fn s34_partitions_with_s29_over_the_labels() {
+        // `a` twice, `b` once, `c` twice → winners are the three distinct keys (S29 = "3"); losers are
+        // the 2nd `a` and 2nd `c` (S34 = "2"). Together they partition all FIVE `\label`s — proving each
+        // `\label` routes to exactly one of `definitions`/`duplicates`. Also cross-checked against the
+        // number of warning lines S20 emits.
+        let src = r"\begin{document}A \label{a} one.
+
+B \label{b} two.
+
+A' \label{a} again.
+
+C \label{c} three.
+
+C' \label{c} again.\end{document}";
+        let doc = parse_document(src).expect("parse");
+        assert_eq!(doc.duplicate_label_count(), "2");
+        // S29 winners — unchanged by S34.
+        assert_eq!(doc.label_definition_count(), "3");
+        // S34 == number of S20 warning lines (two views of the SAME `duplicates` list).
+        assert_eq!(
+            doc.duplicate_label_count(),
+            doc.duplicate_label_definitions().lines().count().to_string()
+        );
+        // Winners + losers partition all five `\label`s.
+        let winners: usize = doc.label_definition_count().parse().unwrap();
+        let losers: usize = doc.duplicate_label_count().parse().unwrap();
+        assert_eq!(winners + losers, 5);
+    }
+
+    #[test]
+    fn s34_is_additive_leaves_s1_s33_outputs_unchanged() {
+        // Same representative doc as the S33 additive test. S34 changes NONE of the S1-S33 outputs — it
+        // only reads `resolve_references`. Its count is a second view of the SAME `duplicates` list S20
+        // renders per-source; pinned here alongside S16/S19/S20/S22/S29/S30/S31/S32/S33 to show S34
+        // neither adds, drops, nor reorders. The body defines `dup` twice (one losing duplicate) and the
+        // bibliography defines `a` twice (one losing `\bibitem`).
+        let src = r"\begin{document}\section{Introduction}\label{sec:intro}
+\begin{figure}\includegraphics{p.png}\caption{A plot}\label{fig:p}\end{figure}
+
+\begin{equation}\label{eq:e}E=mc^2\end{equation}
+
+First \label{dup} here.
+
+Second \label{dup} there.
+
+See Section~\ref{sec:intro}, \eqref{eq:e}, \eqref{eq:ghost}, \nameref{sec:intro}, \nameref{fig:p}, and \cite{a,b} plus \cite{c,ghost}.
+\begin{thebibliography}{9}
+\bibitem{a} Author A.
+\bibitem{b} Author B.
+\bibitem{c} Author C.
+\bibitem{a} Author A again.
+\end{thebibliography}
+\end{document}";
+        let doc = parse_document(src).expect("parse");
+
+        // A couple of representative earlier *list* renderers — byte-for-byte unchanged.
+        // S20 duplicate `\label` warnings (the later `\label{dup}` is the sole losing duplicate).
+        assert_eq!(doc.duplicate_label_definitions(), "\\label{dup}");
+        // S22 flat winning label definitions (four distinct keys, first-definition-wins on `dup`).
+        assert_eq!(
+            doc.label_definitions(),
+            "\\label{sec:intro}\n\\label{fig:p}\n\\label{eq:e}\n\\label{dup}"
+        );
+        // S19 flat winning bibliography entries (three distinct keys; the later `\bibitem{a}` loses).
+        assert_eq!(doc.bibliography_entries(), "[1] a\n[2] b\n[3] c");
+
+        // Prior totals-family renderers — byte-for-byte unchanged.
+        // S27 dangling-reference count — exactly one (`\eqref{eq:ghost}`).
+        assert_eq!(doc.unresolved_reference_count(), "1");
+        // S28 resolved-reference count — exactly two (`\ref{sec:intro}`, `\eqref{eq:e}`).
+        assert_eq!(doc.resolved_reference_count(), "2");
+        // S29 label-definition count — exactly four distinct label keys.
+        assert_eq!(doc.label_definition_count(), "4");
+        // S30 bibliography-entry count — exactly three distinct `\bibitem` keys (`a`, `b`, `c`).
+        assert_eq!(doc.bibliography_entry_count(), "3");
+        // S31 resolved-citation count — exactly three keys resolve (`a`, `b`, `c`).
+        assert_eq!(doc.citation_count(), "3");
+        // S32 unresolved-citation count — exactly one key dangles (`ghost`).
+        assert_eq!(doc.unresolved_citation_count(), "1");
+        // S33 duplicate-bibliography count — exactly one losing `\bibitem` (the later `\bibitem{a}`).
+        assert_eq!(doc.duplicate_bibliography_count(), "1");
+
+        // And S34 itself: exactly ONE `\label` is a losing duplicate (the later `\label{dup}`); the
+        // four winning first `\label`s are in `definitions` (S22/S29), not counted here.
+        assert_eq!(doc.duplicate_label_count(), "1");
+        // S29 winners + S34 losers partition all five `\label`s in the document.
+        let winners: usize = doc.label_definition_count().parse().unwrap();
+        let losers: usize = doc.duplicate_label_count().parse().unwrap();
+        assert_eq!(winners + losers, 5);
     }
 }

--- a/code/specs/LTXDOC03-cross-reference-resolution.md
+++ b/code/specs/LTXDOC03-cross-reference-resolution.md
@@ -2706,3 +2706,81 @@ S22's `label_definitions`, and the totals-family renderers S27's `unresolved_ref
 `citation_count`, and S32's `unresolved_citation_count` all still produce their exact prior strings, with S33
 returning `"1"` for a bibliography defining `a`, `b`, `c` once each and `a` a second time). All prior S1–S32
 tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.
+
+## 40. S34 — single-integer total of the duplicate ("multiply defined") `\label`s (`duplicate_label_count`)
+
+### 40.1 Motivation
+
+S20 (`duplicate_label_definitions`) enumerates the **duplicate** (later, losing) `\label`s — the `\label`s of
+already-defined keys, which LaTeX flags with *"Label `key' multiply defined"* — rendering one `\label{key}`
+warning line each. But a reader often wants not the enumeration but the **total** — "how many labels are
+multiply defined in this document?" — a single number answered at a glance, without scanning the individual
+warning lines. S29 (`label_definition_count`) gave that single-total discipline to the *winning* label
+definitions; S34 is the **warning-side companion** of that total, and the **label-side twin** of S33's
+`duplicate_bibliography_count` — where S33 counts the losing `\bibitem`s, S34 counts the losing `\label`s,
+collapsing the whole `duplicates` list to its decimal `.len()`. Together S29 and S34 **partition** every
+`\label` in the document — the winner count plus the duplicate count equals the total number of `\label`s,
+because S1's `resolve_references` routes each `\label` into exactly one of `definitions`/`duplicates`.
+
+### 40.2 Why a new method — additive by construction
+
+S34 adds a **new public method** `Document::duplicate_label_count(&self) -> String`. It is a pure, read-only
+render of `resolve_references().duplicates.len()` — a *second view* of the exact list S20 renders per-source.
+It reuses that list verbatim (never re-walking the body or re-collecting labels), so the report can never
+drift from the S1 resolution it summarises, and counting never adds, drops, or reorders duplicates relative to
+what `resolve_references` produced. It mutates nothing and changes no S1–S33 output — including `to_latex()`'s
+round-trip fixed point — byte-for-byte. Like S11–S33 it is a method the caller invokes directly.
+
+### 40.3 The rendering rule
+
+The output is the decimal `.len()` of the `duplicates` list, rendered as its `String`, **always** on a single
+line with **no** trailing newline. There is no ordering question (a single integer has no order) — only
+`.len()` is read, with **no** source slicing at all, and never a `key`/`kind`/`span`. We do **not**
+de-duplicate: a key defined *three* times contributes *two* losing duplicates, exactly the two warning lines
+S20 emits. Being a **count** renderer, its empty case is the honest number `"0"` — **not** a `(no duplicate
+label definitions)` marker, mirroring S27/S28/S29/S30/S31/S32/S33 exactly. The `(no …)` marker discipline
+belongs to the *list* renderer S20, whose empty case has no lines to show; a total count of zero *is* a
+number, so `"0"` is its truthful value.
+
+### 40.4 The exact rendering contract — `Document::duplicate_label_count(&self) -> String`
+
+- Read `resolve_references().duplicates.len()` and render it with `.to_string()` → the decimal count, one
+  line, no trailing newline. There is **no** source slicing at all, so the render needs no source borrow and
+  can never index out of bounds.
+- Only the **losing** duplicates are counted. The winning first `\label` of a key lives in
+  `resolve_references().definitions` (S22/S29's domain), never in `duplicates`, so it is excluded by
+  construction. Every later `\label` of an already-defined key contributes one record — section, figure,
+  equation, or inline, regardless of `LabelKind` — and the `key`/`kind`/`span` are never read.
+- The empty case (no labels, or every key defined exactly once) returns the honest number `"0"` — **not** a
+  `(no duplicate label definitions)` marker, because S34 is a count renderer (mirroring
+  S27/S28/S29/S30/S31/S32/S33).
+
+Example (a body defining `\label{x}` twice and `\label{y}` once):
+
+```text
+1
+```
+
+Only the *second* `\label{x}` loses (`1`); the winning first `\label{x}` and the lone `\label{y}` are in
+`definitions` (the `2` S29 reports). This is the count-total companion of S20's per-source warning list — a
+second view of the one `duplicates` list — and the label-side twin of S33.
+
+### 40.5 Public API (added in S34)
+
+One new method: `Document::duplicate_label_count(&self) -> String`. No existing type, field, counter, or
+signature changes; `resolve_references` and every S1–S33 method are unchanged; no AST or grammar change; no
+new dependency, no `unsafe`, no I/O.
+
+### 40.6 Verification (S34)
+
+`cargo test -p latex` green (6 new S34 tests: a multiple-duplicate case (`a` thrice + `b` twice) returning
+`"3"`; a no-duplicates all-distinct case returning `"0"` (cross-checked against S20's `(no duplicate label
+definitions)` marker); a no-`\label` case returning `"0"`; a single-duplicate case returning `"1"`
+(cross-checked against the number of S20 warning lines and the literal `\label{dup}` line); a partition check
+that S29 winners + S34 losers sum to the total `\label`s (also cross-checked against S20's line count); and an
+additivity check that S20's `duplicate_label_definitions`, S22's `label_definitions`, S19's
+`bibliography_entries`, and the totals-family renderers S27's `unresolved_reference_count`, S28's
+`resolved_reference_count`, S29's `label_definition_count`, S30's `bibliography_entry_count`, S31's
+`citation_count`, S32's `unresolved_citation_count`, and S33's `duplicate_bibliography_count` all still
+produce their exact prior strings, with S34 returning `"1"` for a body defining `dup` twice). All prior
+S1–S33 tests pass unchanged. No `cargo fmt`, no grammar regen, no new dependencies.


### PR DESCRIPTION
## LTXDOC03 S34 — `duplicate_label_count` ("multiply defined" `\label` total)

Adds one small read-only String renderer to the `latex` crate: **`Document::duplicate_label_count`**, the **label-side twin** of S33's `duplicate_bibliography_count`. It reports the integer total of the "multiply defined" `\label` warnings — the later/losing definitions of an already-defined label key.

```rust
pub fn duplicate_label_count(&self) -> String {
    self.resolve_references().duplicates.len().to_string()
}
```

### Where it sits in the totals family
S1 already partitions every `\label` into the **winning** `definitions` (first-definition-wins — the label table that S22/S29 count) and the **losing** `duplicates` (pre-order). S34 simply totals that second list. It is:
- the **numeric summary** of what **S20** LISTS per source,
- the **label-side companion** of **S33** (which totals the duplicate `\bibitem` list via `resolve_citations().duplicate_entries.len()`),
- the warning-side twin of the **S29** `label_definition_count` (winners).

The totals family now covers both resolution axes (S27/S28), both citation totals (S31/S32), the label-def and bibliography totals (S29/S30), and **both** duplicate/"warning" totals — bibliography (S33) and now label (S34).

### Conventions & safety
- **Zero renders as `"0"`** — a count renderer, NOT a `(no ...)` marker (mirrors S27–S33).
- **Total & panic-free**: delegates to the existing immutable, recursion-bounded `resolve_references()` pass; no `unwrap`/`expect`/indexing, no `unsafe`, no new input surface, no I/O. Just `Vec::len()` → `usize::to_string()`.

### Tests (6 new)
- zero duplicates → `"0"`
- one duplicate `\label` → `"1"`
- multiple duplicates → correct integer
- definitions but no duplicates → `"0"`
- an **S29 + S34 partition** test over all `\label`s (winners + losers)
- an **additivity** test pinning **S19/S20/S22/S27/S28/S29/S30/S31/S32/S33 byte-for-byte** alongside the new S34 on one representative doc.

### Gates (run from the worktree `code/packages/rust`)
- `cargo test -p latex` → **491 passed**, 0 failed
- `cargo clippy -p latex --all-targets -- -D warnings` → **clean**
- `cargo test -p adj-lang -p adj-lang-cli` → **green**
- `cargo build -p latex --no-default-features` → **compiles**

`latex` **0.69.0 → 0.70.0**; CHANGELOG, README (renderer list), and the LTXDOC03 spec (new S34 section appended; prior sections byte-for-byte unchanged) updated. Exactly 5 files changed. Inline security review: **PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
