### PR TITLE
chore(clippy): clean warnings in sql-backend and mini-sqlite

### DIFF
--- a/code/packages/rust/mini-sqlite/src/lib.rs
+++ b/code/packages/rust/mini-sqlite/src/lib.rs
@@ -401,12 +401,10 @@ impl ConnectionState {
             first_kw.as_str(),
             "INSERT" | "UPDATE" | "DELETE" | "CREATE" | "DROP"
         );
-        if needs_transaction && !self.autocommit {
-            if self.backend.current_transaction().is_none() {
-                self.backend
-                    .begin_transaction()
-                    .map_err(|e| MiniSqliteError::OperationalError(e.to_string()))?;
-            }
+        if needs_transaction && !self.autocommit && self.backend.current_transaction().is_none() {
+            self.backend
+                .begin_transaction()
+                .map_err(|e| MiniSqliteError::OperationalError(e.to_string()))?;
         }
 
         // ── Pipeline ────────────────────────────────────────────────────────
@@ -1253,11 +1251,12 @@ mod tests {
                     let op = step["op"].as_str().unwrap_or("");
                     if op == "connect_expect_error" {
                         let db = step["database"].as_str().unwrap_or(":memory:");
-                        match connect(db) {
-                            Ok(_) => panic!(
+                        // A file-path connect must be rejected at Level 1; an Err
+                        // is the expected outcome, so only success is a failure.
+                        if connect(db).is_ok() {
+                            panic!(
                                 "{fixture_id}: connect({db:?}) should have returned Err but succeeded"
-                            ),
-                            Err(_) => {} // expected — continue to next step
+                            );
                         }
                     }
                 }

--- a/code/packages/rust/sql-backend/src/lib.rs
+++ b/code/packages/rust/sql-backend/src/lib.rs
@@ -867,7 +867,7 @@ impl Backend for InMemoryBackend {
     fn list_indexes(&self, table: Option<&str>) -> Vec<IndexDef> {
         self.indexes
             .values()
-            .filter(|index| table.map_or(true, |table| same_name(&index.table, table)))
+            .filter(|index| table.is_none_or(|table| same_name(&index.table, table)))
             .cloned()
             .collect()
     }


### PR DESCRIPTION
Leaves the SQL crates I'm actively working in warning-free. Mechanical, behavior-preserving clippy fixes — verified by the full mini-sqlite suite (45 unit + 11 integration + the differential-oracle test) and sql-backend (13) staying green, and by an adversarial security review confirming semantic equivalence.

### Changes
- **sql-backend**: `table.map_or(true, |t| same_name(..))` → `table.is_none_or(|t| same_name(..))` in `list_indexes` (identical: `None → true`, `Some(x) → f(x)`).
- **mini-sqlite**: clippy `--fix` auto-fixes, plus a collapsed nested `if` and a single-pattern `match connect(db) { Ok(_) => panic!, Err(_) => {} }` rewritten to `if connect(db).is_ok() { panic!(..) }` (in `#[cfg(test)]` code).

Both crates' own files are now clippy-clean (`cargo clippy --all-targets`).

### Scope
Deliberately **not** a sweep of the whole SQL pipeline. The wider crates (`sql-parser`/`planner`/`optimizer`/`codegen`/`vm` and shared `lexer`/`grammar-tools`) still carry ~270 pre-existing clippy warnings; those are left for focused, test-verified follow-ups as the Stream-B conformance work touches them, rather than one high-churn mechanical sweep of core query-engine crates. No fmt reformatting of pre-existing unrelated lines (avoids scope creep). These are warnings, not build errors — CI is green with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)