### PR TITLE
feat(adj-ladder): rung-125 EMG recruitment index (lone term over subtract-then-add three-term denom)

### DIFF
--- a/code/specs/data/adj-ladder/rung125_electromyography_recruitment/gen_items.py
+++ b/code/specs/data/adj-ladder/rung125_electromyography_recruitment/gen_items.py
@@ -1,0 +1,269 @@
+"""Generate rung-125 (EMG recruitment index / lone term over a subtract-THEN-add three-term denominator) items.json.
+
+Rung 125 opens the **electromyography / motor-unit recruitment** panel on the ADJ-LADDER's quantitative band — the arithmetic of a
+recruitment index. A single observed `motor_response` is DIVIDED by a net amplitude formed from a `baseline_amplitude` with a
+`decrement_drop` SUBTRACTED and then a `facilitation_gain` ADDED back, to give the recruitment index. A **lone term over a
+subtract-THEN-add three-term denominator**, `a/(b - c + d)`, i.e. `(a / ((b - c) + d))` (the subtraction and addition bind
+left-to-right inside the denominator parentheses, whole net amplitude under the division), introduces a genuinely NEW arithmetic
+family on the ladder — the **subtract-then-add sibling of rung-124's all-MINUS `a/(b - c - d)`**.
+
+This is genuinely new. The three-term denominators shipped so far are b+c+d (116), b+c-d (117), b*c+d (118), b*c-d (119), b*c*d (121),
+b+c*d (122), b-c*d (123), and rung-124's all-minus b-c-d — **but a/(b-c+d) has NEVER been a headline**: it appears on the ladder only
+as rung-124's SWAPPED distractor, never as a queried gold. rung-125 promotes that grouping to a headline. It is the mirror of rung-124:
+rung-124 SUBTRACTS both later terms (b-c-d), rung-125 subtracts the first and ADDS the second (b-c+d). Their swapped distractors are
+each other's headlines — rung-125's swapped slip is `a/(b-c-d)` (rung-124's real shape), the classic "was the last term added or
+subtracted?" confusion. Also distinct from rung-117 `a/(b+c-d)` (which ADDS the first two and subtracts the third): rung-125 subtracts
+the FIRST later term and adds the second.
+
+The setup: a `motor_response`, a `baseline_amplitude`, a `decrement_drop`, and a `facilitation_gain`. The figures are:
+
+  RECRUITMENT INDEX   motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)  [ lone term / subtract-then-add denom ]
+  NET AMPLITUDE       baseline_amplitude - decrement_drop + facilitation_gain                     [ the subtract-then-add denominator ]
+  RESIDUAL            baseline_amplitude - decrement_drop                                          [ baseline minus the decrement ]
+
+The **recruitment index** is what makes this rung distinctive — it is the ladder's first **lone quantity over a subtract-THEN-add
+three-term denominator (as a headline)**. It is a rate (motor response per unit of net amplitude), framed as an *index* to keep it
+dimensionless-clean — the same discipline rungs 100/.../123/124 used for their ratios. (The net amplitude `b-c+d` and the residual
+`b-c` ride alongside as component readouts, so the panel teaches the whole calculation — exactly as rungs 47-124 shipped their
+component sums/products/differences/ratios beside the headline figure. The residual `b-c` is the baseline after the decrement, before
+the facilitation is added back, anchoring the "subtract first, then add" grouping against the swapped distractor.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries the
+arithmetic — the subtraction of the decrement drop from the baseline amplitude, then the addition of the facilitation gain to form the
+whole net amplitude, then the division of the motor response by that whole net amplitude (so a/(b-c+d) evaluates as (a/((b-c)+d))) —
+and the harness reads the scalar via the existing `compute_dimensioned` extractor. No harness/engine change, exactly as rungs
+8/16/.../123/124. This rung exercises the engine across a **lone-term-over-(subtract-then-add-three-term) ratio** — the fact that
+`a/(b-c+d)` is `(a/((b-c)+d))` and NOT `a/b-c+d` and NOT `a/(b-c-d)` made computable. The ratio golds are non-integer f64s; the
+engine's IEEE-double division matches Python's the same way rungs 100/.../123/124 relied on (well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `-`, `+`, and `/` — **no
+structural constants** — so no numeric literal appears in any program, and neither the net amplitude, the residual, nor the
+recruitment index is ever a literal (each is computed from the observed quantities). The observed quantities carry **digit-free
+identifiers** (`motor_response`, `baseline_amplitude`, `decrement_drop`, `facilitation_gain`) so no numeral hides inside a variable
+name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  CROSSED    motor_response / baseline_amplitude - decrement_drop + facilitation_gain  drop the denominator parentheses so only the
+                                                                    baseline amplitude divides the motor response, then the decrement
+                                                                    is subtracted and the facilitation added (the classic `a/(b-c+d)`
+                                                                    vs `a/b-c+d` grouping error, evaluating (a/b)-c+d), and
+  SWAPPED    motor_response / (baseline_amplitude - decrement_drop - facilitation_gain)  subtract the decrement AND subtract the
+                                                                    facilitation (`a/(b-c-d)`, rung-124's grouping, instead of
+                                                                    `a/(b-c+d)` — the "was the last term added or subtracted?" slip),
+
+which are exactly the mistakes a student makes (failing to keep the whole subtract-then-add denominator under the bar, or flipping the
+sign of the last term). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as options.
+
+Distinctness and positivity: this rung SUBTRACTS a term inside the denominator (and both distractors subtract), so positivity is NOT
+automatic — it is guarded explicitly per table. Every observed quantity is `>= 2`, and each table guarantees **baseline_amplitude >
+decrement_drop + facilitation_gain** with `b-c-d >= 2` — which makes the swapped denominator `b-c-d` positive (and away from zero), the
+residual `b-c` comfortably positive, and the net amplitude `b-c+d` (which only adds `d` back) positive as well — and
+**motor_response/baseline_amplitude - decrement_drop + facilitation_gain > 0** so the crossed slip `(a/b)-c+d` stays positive. Every
+family member is asserted `> 0` at build time. And — so all three queried readouts vary across the panel — the seven tables give
+distinct recruitment indices, distinct net amplitudes, and distinct residuals, all asserted at build time; the five family values are
+pairwise distinct with a comfortable margin.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (MOTOR_RESPONSE, BASELINE_AMPLITUDE, DECREMENT_DROP, FACILITATION_GAIN) — a lone motor response divided by a net amplitude (a
+# baseline amplitude with a decrement drop subtracted and a facilitation gain added back) for the recruitment index. This rung
+# SUBTRACTS a term inside the denominator (and both distractors subtract), so positivity is NOT automatic; each table guarantees
+# baseline_amplitude > decrement_drop + facilitation_gain (b-c-d >= 2), which keeps the swapped denom b-c-d positive, the residual b-c
+# comfortably positive, and the net amplitude b-c+d positive, and motor_response/baseline_amplitude - decrement_drop +
+# facilitation_gain > 0 (crossed (a/b)-c+d positive). The five family values are asserted pairwise-distinct below. The seven tables
+# give distinct recruitment indices, distinct net amplitudes, and distinct residuals so all three queried readouts vary across the
+# panel.
+TABLES = [
+    (18, 7, 3, 2),
+    (32, 7, 2, 3),
+    (45, 8, 2, 3),
+    (60, 9, 2, 3),
+    (77, 10, 2, 3),
+    (96, 11, 2, 3),
+    (117, 12, 2, 3),
+]
+
+# The option family (5 members), all built from the four observed quantities via -, + and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the
+# options.
+FAMILY = [
+    (
+        "recruitment_index",
+        "recruitment index (the motor response divided by the net amplitude)",
+        "motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)",
+    ),
+    (
+        "net_amplitude",
+        "the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)",
+        "baseline_amplitude - decrement_drop + facilitation_gain",
+    ),
+    (
+        "residual",
+        "the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)",
+        "baseline_amplitude - decrement_drop",
+    ),
+    (
+        "crossed",
+        "the motor response divided by the baseline amplitude, minus the decrement drop plus the facilitation gain, dropping the denominator parentheses so only the baseline amplitude divides (a wrong grouping)",
+        "motor_response / baseline_amplitude - decrement_drop + facilitation_gain",
+    ),
+    (
+        "swapped",
+        "the motor response divided by the baseline amplitude minus the decrement drop minus the facilitation gain, flipping the sign of the last term (a wrong grouping)",
+        "motor_response / (baseline_amplitude - decrement_drop - facilitation_gain)",
+    ),
+]
+QUERIED = ["recruitment_index", "net_amplitude", "residual"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(motor_response, baseline_amplitude, decrement_drop, facilitation_gain):
+    # Operation order mirrors the ADJ programs exactly (the decrement drop is subtracted from the baseline amplitude, then the
+    # facilitation gain is added to form the whole net amplitude, then the motor response is divided by that whole net amplitude, so
+    # a/(b-c+d) evaluates as (a/((b-c)+d))), so the Python option value and the engine result are the same IEEE-double (well within
+    # the 1e-9 tolerance).
+    return {
+        "recruitment_index": motor_response / (baseline_amplitude - decrement_drop + facilitation_gain),
+        "net_amplitude": baseline_amplitude - decrement_drop + facilitation_gain,
+        "residual": baseline_amplitude - decrement_drop,
+        "crossed": motor_response / baseline_amplitude - decrement_drop + facilitation_gain,
+        "swapped": motor_response / (baseline_amplitude - decrement_drop - facilitation_gain),
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for motor_response, baseline_amplitude, decrement_drop, facilitation_gain in TABLES:
+        # Every observed quantity is a plain positive number >= 2. This rung SUBTRACTS a term inside the denominator (and both
+        # distractors subtract), so positivity is NOT automatic; it is guarded explicitly per table.
+        assert (
+            motor_response >= 2
+            and baseline_amplitude >= 2
+            and decrement_drop >= 2
+            and facilitation_gain >= 2
+        ), (motor_response, baseline_amplitude, decrement_drop, facilitation_gain)
+        assert baseline_amplitude - decrement_drop - facilitation_gain >= 2, (
+            "baseline_amplitude - decrement_drop - facilitation_gain must be >= 2 (swapped denom positive; residual & net positive)",
+            motor_response,
+            baseline_amplitude,
+            decrement_drop,
+            facilitation_gain,
+        )
+        assert motor_response / baseline_amplitude - decrement_drop + facilitation_gain > 0, (
+            "crossed (a/b)-c+d must be positive",
+            motor_response,
+            baseline_amplitude,
+            decrement_drop,
+            facilitation_gain,
+        )
+        fv = family_values(motor_response, baseline_amplitude, decrement_drop, facilitation_gain)
+        for key, v in fv.items():
+            assert v > 0, (key, motor_response, baseline_amplitude, decrement_drop, facilitation_gain, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    motor_response,
+                    baseline_amplitude,
+                    decrement_drop,
+                    facilitation_gain,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                motor_response,
+                baseline_amplitude,
+                decrement_drop,
+                facilitation_gain,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r125emg-{idx + 1:02d}",
+                "qtype": "recruitment_index",
+                "stem": (
+                    f"An electromyography chart records a motor response of {num(motor_response)} divided by a baseline amplitude of "
+                    f"{num(baseline_amplitude)} minus a decrement drop of {num(decrement_drop)} plus a facilitation gain of "
+                    f"{num(facilitation_gain)}. What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe motor_response({num(motor_response)})\n"
+                    f"observe baseline_amplitude({num(baseline_amplitude)})\n"
+                    f"observe decrement_drop({num(decrement_drop)})\n"
+                    f"observe facilitation_gain({num(facilitation_gain)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 125 — EMG recruitment index from four stated quantities (a NEW panel: electromyography / motor-unit "
+            "recruitment). From a lone motor response divided by a net amplitude (a baseline amplitude with a decrement drop "
+            "subtracted and a facilitation gain added back), compute the recruitment index "
+            "(motor_response/(baseline_amplitude-decrement_drop+facilitation_gain)), the net amplitude "
+            "(baseline_amplitude-decrement_drop+facilitation_gain), or the residual (baseline_amplitude-decrement_drop). Each item is "
+            "a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the "
+            "arithmetic — a NEW family, a LONE TERM OVER A SUBTRACT-THEN-ADD THREE-TERM DENOMINATOR a/(b-c+d) (subtract the decrement "
+            "drop from the baseline amplitude, add the facilitation gain, then divide the motor response by that whole net amplitude, "
+            "so a/(b-c+d) = (a/((b-c)+d)); the subtract-then-add sibling of rung-124's all-minus a/(b-c-d). a/(b-c+d) has never been "
+            "a headline on the ladder — only rung-124's swapped distractor — so this promotes that grouping to a queried gold. "
+            "Distinct from rung-117 a/(b+c-d), which adds the first two and subtracts the third; rung-125 subtracts the first later "
+            "term and adds the second. The last-term sign-flip a/(b-c-d) (rung-124's real shape) rides alongside as the swapped "
+            "distractor. The harness matches the scalar to the printed options. The recruitment index is a rate (motor response per "
+            "unit of net amplitude), framed as an INDEX so the dimensionless value stays honest. Contamination-safe: every figure is "
+            "built only from the four observed quantities via -, + and / — no constant leaks, and neither the net amplitude, the "
+            "residual, nor the recruitment index ever appears as a literal (each is computed) — and the observed quantities carry "
+            "digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four "
+            "quantities, so the distractors are exactly the slips students make: dropping the denominator parentheses so only the "
+            "baseline amplitude divides (a/b-c+d, evaluating (a/b)-c+d, a wrong grouping) and flipping the sign of the last term "
+            "(a/(b-c-d), rung-124's grouping, a wrong grouping). The core confusion tested is that a/(b-c+d) is (a/((b-c)+d)), not "
+            "a/b-c+d and not a/(b-c-d). This rung SUBTRACTS a term inside the denominator so positivity is NOT automatic; each table "
+            "guards baseline_amplitude > decrement_drop + facilitation_gain (b-c-d >= 2, keeping the swapped denom, the residual, and "
+            "the net amplitude all positive) and motor_response/baseline_amplitude - decrement_drop + facilitation_gain > 0 (crossed "
+            "positive), keeping the five family values pairwise distinct and all three queried readouts varying across the panel, all "
+            "asserted strictly positive at build time."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung125_electromyography_recruitment/items.json
+++ b/code/specs/data/adj-ladder/rung125_electromyography_recruitment/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 125 \u2014 EMG recruitment index from four stated quantities (a NEW panel: electromyography / motor-unit recruitment). From a lone motor response divided by a net amplitude (a baseline amplitude with a decrement drop subtracted and a facilitation gain added back), compute the recruitment index (motor_response/(baseline_amplitude-decrement_drop+facilitation_gain)), the net amplitude (baseline_amplitude-decrement_drop+facilitation_gain), or the residual (baseline_amplitude-decrement_drop). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a NEW family, a LONE TERM OVER A SUBTRACT-THEN-ADD THREE-TERM DENOMINATOR a/(b-c+d) (subtract the decrement drop from the baseline amplitude, add the facilitation gain, then divide the motor response by that whole net amplitude, so a/(b-c+d) = (a/((b-c)+d)); the subtract-then-add sibling of rung-124's all-minus a/(b-c-d). a/(b-c+d) has never been a headline on the ladder \u2014 only rung-124's swapped distractor \u2014 so this promotes that grouping to a queried gold. Distinct from rung-117 a/(b+c-d), which adds the first two and subtracts the third; rung-125 subtracts the first later term and adds the second. The last-term sign-flip a/(b-c-d) (rung-124's real shape) rides alongside as the swapped distractor. The harness matches the scalar to the printed options. The recruitment index is a rate (motor response per unit of net amplitude), framed as an INDEX so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed quantities via -, + and / \u2014 no constant leaks, and neither the net amplitude, the residual, nor the recruitment index ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make: dropping the denominator parentheses so only the baseline amplitude divides (a/b-c+d, evaluating (a/b)-c+d, a wrong grouping) and flipping the sign of the last term (a/(b-c-d), rung-124's grouping, a wrong grouping). The core confusion tested is that a/(b-c+d) is (a/((b-c)+d)), not a/b-c+d and not a/(b-c-d). This rung SUBTRACTS a term inside the denominator so positivity is NOT automatic; each table guards baseline_amplitude > decrement_drop + facilitation_gain (b-c-d >= 2, keeping the swapped denom, the residual, and the net amplitude all positive) and motor_response/baseline_amplitude - decrement_drop + facilitation_gain > 0 (crossed positive), keeping the five family values pairwise distinct and all three queried readouts varying across the panel, all asserted strictly positive at build time.",
+  "items": [
+    {
+      "id": "r125emg-01",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 18 divided by a baseline amplitude of 7 minus a decrement drop of 3 plus a facilitation gain of 2. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(18)\nobserve baseline_amplitude(7)\nobserve decrement_drop(3)\nobserve facilitation_gain(2)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5714285714285716,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r125emg-02",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 18 divided by a baseline amplitude of 7 minus a decrement drop of 3 plus a facilitation gain of 2. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(18)\nobserve baseline_amplitude(7)\nobserve decrement_drop(3)\nobserve facilitation_gain(2)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5714285714285716,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r125emg-03",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 18 divided by a baseline amplitude of 7 minus a decrement drop of 3 plus a facilitation gain of 2. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(18)\nobserve baseline_amplitude(7)\nobserve decrement_drop(3)\nobserve facilitation_gain(2)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 3.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 4,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5714285714285716,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 9.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r125emg-04",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 32 divided by a baseline amplitude of 7 minus a decrement drop of 2 plus a facilitation gain of 3. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(32)\nobserve baseline_amplitude(7)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.571428571428571,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r125emg-05",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 32 divided by a baseline amplitude of 7 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(32)\nobserve baseline_amplitude(7)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 5.571428571428571,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r125emg-06",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 32 divided by a baseline amplitude of 7 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(32)\nobserve baseline_amplitude(7)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 4.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 5.571428571428571,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r125emg-07",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 45 divided by a baseline amplitude of 8 minus a decrement drop of 2 plus a facilitation gain of 3. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(45)\nobserve baseline_amplitude(8)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.625,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r125emg-08",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 45 divided by a baseline amplitude of 8 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(45)\nobserve baseline_amplitude(8)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6.625,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r125emg-09",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 45 divided by a baseline amplitude of 8 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(45)\nobserve baseline_amplitude(8)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 5.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 6.625,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r125emg-10",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 60 divided by a baseline amplitude of 9 minus a decrement drop of 2 plus a facilitation gain of 3. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(60)\nobserve baseline_amplitude(9)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7.666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 6.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r125emg-11",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 60 divided by a baseline amplitude of 9 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(60)\nobserve baseline_amplitude(9)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r125emg-12",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 60 divided by a baseline amplitude of 9 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(60)\nobserve baseline_amplitude(9)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 7,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 7.666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r125emg-13",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 77 divided by a baseline amplitude of 10 minus a decrement drop of 2 plus a facilitation gain of 3. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(77)\nobserve baseline_amplitude(10)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8.7,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r125emg-14",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 77 divided by a baseline amplitude of 10 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(77)\nobserve baseline_amplitude(10)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 15.4,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r125emg-15",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 77 divided by a baseline amplitude of 10 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(77)\nobserve baseline_amplitude(10)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 7.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 11,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8.7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 15.4,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r125emg-16",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 96 divided by a baseline amplitude of 11 minus a decrement drop of 2 plus a facilitation gain of 3. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(96)\nobserve baseline_amplitude(11)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.727272727272727,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r125emg-17",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 96 divided by a baseline amplitude of 11 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(96)\nobserve baseline_amplitude(11)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.727272727272727,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r125emg-18",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 96 divided by a baseline amplitude of 11 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(96)\nobserve baseline_amplitude(11)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.727272727272727,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.0,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r125emg-19",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 117 divided by a baseline amplitude of 12 minus a decrement drop of 2 plus a facilitation gain of 3. What is the recruitment index (the motor response divided by the net amplitude)?",
+      "program": "observe motor_response(117)\nobserve baseline_amplitude(12)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.714285714285715,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r125emg-20",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 117 divided by a baseline amplitude of 12 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the net amplitude (the baseline amplitude minus the decrement drop plus the facilitation gain, the divisor the motor response is divided by)?",
+      "program": "observe motor_response(117)\nobserve baseline_amplitude(12)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop + facilitation_gain\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10.75,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 16.714285714285715,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 13,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r125emg-21",
+      "qtype": "recruitment_index",
+      "stem": "An electromyography chart records a motor response of 117 divided by a baseline amplitude of 12 minus a decrement drop of 2 plus a facilitation gain of 3. What is the the residual (the baseline amplitude minus the decrement drop, before the facilitation gain is added back)?",
+      "program": "observe motor_response(117)\nobserve baseline_amplitude(12)\nobserve decrement_drop(2)\nobserve facilitation_gain(3)\nlet answer = baseline_amplitude - decrement_drop\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9.0,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 13,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 10.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16.714285714285715,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -162,6 +162,7 @@ SELF_CONTAINED_RUNGS = (
     "rung122_rehabilitation_recovery",
     "rung123_sports_concussion_clearance",
     "rung124_vestibular_response_index",
+    "rung125_electromyography_recruitment",
 )
 
 


### PR DESCRIPTION
## Rung-125 — EMG recruitment index (lone term over a subtract-THEN-add three-term denominator)

Opens the **electromyography / motor-unit recruitment** panel with a **genuinely new arithmetic family**: a **lone term over a subtract-THEN-add three-term denominator**, `a/(b - c + d)` = `(a/((b - c) + d))`. A `baseline_amplitude` has a `decrement_drop` subtracted and a `facilitation_gain` added back; the `motor_response` is then divided by that whole net amplitude.

### Why it's new (verified by grepping every three-var parenthesised denominator)
`a/(b-c+d)` has **never been a headline** on the ladder — it appears only as **rung-124's swapped distractor**, never as a queried gold. rung-125 promotes that grouping to a headline. It is the **subtract-then-add mirror** of rung-124's all-minus `a/(b-c-d)`: their swapped distractors are each other's real shapes (a clean confusable pair). Distinct from rung-117 `a/(b+c-d)`, which *adds* the first two and subtracts the third.

### The family (5 mutually-confusable scalars over the same four quantities)
| key | formula | role |
|---|---|---|
| `recruitment_index` | `motor_response / (baseline_amplitude - decrement_drop + facilitation_gain)` | headline · **queried** |
| `net_amplitude` | `baseline_amplitude - decrement_drop + facilitation_gain` | the denominator · **queried** |
| `residual` | `baseline_amplitude - decrement_drop` | baseline minus the decrement · **queried** |
| `crossed` | `motor_response / baseline_amplitude - decrement_drop + facilitation_gain` | `(a/b)-c+d`, drops denominator parens |
| `swapped` | `motor_response / (baseline_amplitude - decrement_drop - facilitation_gain)` | `a/(b-c-d)`, last-term sign flip (= rung-124's shape) |

The distractors are exactly the slips a student makes: failing to keep the whole subtract-then-add denominator under the bar, or flipping the sign of the last term. Gold rotates A–E by index; **7 tables × 3 queried readouts = 21 items**.

### Contamination-safe & guarded
- Every formula is built only from the four observed quantities via `-`, `+`, `/` — **no numeric constant** appears in any program; neither the net amplitude, the residual, nor the recruitment index is ever a literal.
- **Digit-free identifiers** (`motor_response`, `baseline_amplitude`, `decrement_drop`, `facilitation_gain`).
- Positivity is **not** automatic (the denominator subtracts a term, and both distractors subtract), so it is guarded per table: `baseline_amplitude > decrement_drop + facilitation_gain` (`b-c-d >= 2`, which keeps the swapped denom, the residual `b-c`, and the net amplitude `b-c+d` all positive) and `motor_response/baseline_amplitude - decrement_drop + facilitation_gain > 0` (crossed positive). All five family values are asserted pairwise-distinct (`>1e-6`) and strictly positive; all three queried readouts vary across the seven tables.

### No harness/engine change
Each item is a `compute_dimensioned` program (`observe` the four quantities, `let answer = formula`, `? answer`); the ADJ engine carries the arithmetic and the existing extractor reads the scalar. Registered `rung125_electromyography_recruitment` in `SELF_CONTAINED_RUNGS`.

### Verification
- `python3 gen_items.py` → `wrote items.json: 21 items`
- `python3 -m pytest test_ladder_eval.py -k rung125 -q` → **3 passed** (arm-A gold, arm-B program-eval, options-distinct)
- Scratchpad table-search checker: all 7 tables pass, all three queried golds vary, every family pairwise-distinct.
- Inline security review: **PASSED**.

Exactly 3 files changed (new `rung125_electromyography_recruitment/{gen_items.py,items.json}` + the one-line tuple registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
