### PR TITLE
feat(sir-runtime-oop): Numeric divmod/fdiv/round(n)/clamp/between? (TS, v0.1.17)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.17] - 2026-07-11
+
+### Added — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
+
+Completes the numeric-breadth sweep across all five backends (Python
+`sir-runtime-oop` v0.1.17 is the reference; Go/Rust/JS backends already landed).
+Extends the `Integer`/`Float` catalog (`numericMethod` + the `NUMERIC_METHODS`
+`respond_to?` set) with five more Ruby numeric methods:
+
+- `round(ndigits)` — `round` gains an optional digits argument: a positive
+  `ndigits` rounds to that many decimals (half **away from zero**, via
+  `rubyRound`, not `Math.round`); `ndigits <= 0` rounds to a power of ten. TS
+  numbers are f64, so a hostile-magnitude `ndigits` degrades naturally (the
+  `factor` saturates to `Infinity` and `recv / Infinity` is `0`) — no bignum, no
+  allocation. A non-finite receiver returns unchanged.
+- `divmod(n)` — `[quotient, remainder]` with a floored quotient and the
+  divisor-signed remainder (a JS array, so it prints `[3, 1]`); a zero divisor
+  raises a typed `ZeroDivisionError`.
+- `fdiv(n)` — floating-point division that never throws: a zero divisor yields
+  `Infinity`/`-Infinity`/`NaN`.
+- `clamp(min, max)` / `between?(min, max)` — compared numerically.
+
+Dispatch stays an explicit `switch` on the literal method name (never
+reflection). Numeric breadth is now complete across all five backends.
+
 ## [0.1.16] - 2026-07-10
 
 ### Added — String char-set methods: `tr` / `count` / `delete` / `squeeze`

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -82,7 +82,8 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 char sets*, `each_char`);
 and (item **M1c**) the **`Integer`/`Float`** catalog (`abs`, `to_i`/`to_f`,
 `even?`/`odd?`/`zero?`/`positive?`/`negative?`, `succ`/`pred`,
-`floor`/`ceil`/`round`, `gcd`, `pow`/`**`, `digits`, and block
+`floor`/`ceil`/`round` (with optional `ndigits`), `divmod`, `fdiv`, `clamp`,
+`between?`, `gcd`, `pow`/`**`, `digits`, and block
 `times`/`upto`/`downto`/`step`), the **`Symbol`** catalog
 (`to_s`/`to_sym`/`length`/`upcase`/`downcase`/`inspect`), and universal
 **`to_s`/`inspect`** Ruby display forms (so `null`/`true`/`false` need no catalog)

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -687,6 +687,10 @@ const NUMERIC_METHODS = new Set<string>([
   "floor",
   "ceil",
   "round",
+  "divmod",
+  "fdiv",
+  "clamp",
+  "between?",
   "gcd",
   "pow",
   "**",
@@ -1611,8 +1615,52 @@ function numericMethod(recv: number, name: string, args: Val[]): Val | typeof MI
       return Math.floor(recv);
     case "ceil":
       return Math.ceil(recv);
-    case "round":
-      return Number.isInteger(recv) ? recv : rubyRound(recv);
+    case "round": {
+      // Ruby `round` / `round(ndigits)` — half AWAY from zero (via `rubyRound`,
+      // NOT `Math.round` which is half-toward-+∞).  With no argument (or an
+      // integer receiver and `ndigits >= 0`) the result is an integer; a
+      // positive `ndigits` rounds to that many decimals; `ndigits <= 0` rounds
+      // to a power of ten.  TS numbers are f64 — a hostile-magnitude `ndigits`
+      // degrades naturally (the `factor` saturates to `Infinity` and
+      // `recv / Infinity` is `0`), with no bignum and no allocation.  A
+      // non-finite receiver returns unchanged.
+      const nd = typeof args[0] === "number" ? Math.trunc(args[0]) : 0;
+      if (!Number.isFinite(recv)) return recv;
+      if (Number.isInteger(recv) && nd >= 0) return recv;
+      const factor = Math.pow(10, nd);
+      return rubyRound(recv * factor) / factor;
+    }
+    case "divmod": {
+      // Ruby `divmod(n)` → `[quotient, remainder]` with a FLOORED quotient and
+      // the divisor-signed remainder.  Division by zero raises a typed
+      // `ZeroDivisionError` (so a translated `rescue` catches it).
+      const d = typeof args[0] === "number" ? args[0] : 0;
+      if (d === 0) raiseError("ZeroDivisionError", "divided by 0");
+      const q = Math.floor(recv / d);
+      const r = recv - q * d;
+      return [q, r];
+    }
+    case "fdiv": {
+      // Ruby `fdiv(n)` — floating-point division that NEVER raises: dividing by
+      // zero yields `Infinity`/`-Infinity`/`NaN` (JS `/` already produces these),
+      // honouring the never-raise floor.
+      return recv / (typeof args[0] === "number" ? args[0] : 0);
+    }
+    case "clamp": {
+      // Ruby `Comparable#clamp(min, max)`: `min` if recv < min, `max` if
+      // recv > max, else recv.  (The Range form is a follow-up.)
+      const lo = typeof args[0] === "number" ? args[0] : 0;
+      const hi = typeof args[1] === "number" ? args[1] : 0;
+      if (recv < lo) return lo;
+      if (recv > hi) return hi;
+      return recv;
+    }
+    case "between?": {
+      // Ruby `Comparable#between?(min, max)`: `min <= recv <= max`.
+      const lo = typeof args[0] === "number" ? args[0] : 0;
+      const hi = typeof args[1] === "number" ? args[1] : 0;
+      return recv >= lo && recv <= hi;
+    }
     case "gcd":
       return gcdInt(recv, args[0]);
     case "pow":

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -693,6 +693,31 @@ describe("built-in method catalog: Numeric (Integer/Float) (M1c)", () => {
     expect(callMethod(5, "round")).toBe(5);
   });
 
+  it("numeric breadth (N1): round(ndigits) / divmod / fdiv / clamp / between?", () => {
+    // round(ndigits): positive → decimals half-away; ndigits <= 0 → power of ten.
+    expect(callMethod(3.14159, "round", 2)).toBe(3.14);
+    expect(callMethod(1250, "round", -2)).toBe(1300); // half away from zero
+    expect(callMethod(2.675, "round", 2)).toBe(2.68);
+    // divmod: floored quotient, divisor-signed remainder.
+    expect(callMethod(13, "divmod", 4)).toEqual([3, 1]);
+    expect(callMethod(13, "divmod", -4)).toEqual([-4, -3]);
+    // divmod by zero raises a typed ZeroDivisionError; a non-numeric divisor
+    // degrades to 0 → the same typed error (never an untyped throw).
+    expect(() => callMethod(1, "divmod", 0)).toThrow();
+    expect(() => callMethod(1, "divmod", "x")).toThrow();
+    // fdiv: float division that never throws (zero divisor → ±Infinity).
+    expect(callMethod(7, "fdiv", 2)).toBe(3.5);
+    expect(callMethod(1, "fdiv", 0)).toBe(Infinity);
+    expect(callMethod(-1, "fdiv", 0)).toBe(-Infinity);
+    // clamp / between?.
+    expect(callMethod(5, "clamp", 1, 10)).toBe(5);
+    expect(callMethod(-3, "clamp", 1, 10)).toBe(1);
+    expect(callMethod(99, "clamp", 1, 10)).toBe(10);
+    expect(callMethod(5, "between?", 1, 10)).toBe(true);
+    expect(callMethod(0, "between?", 1, 10)).toBe(false);
+    expect(callMethod(10, "between?", 1, 10)).toBe(true);
+  });
+
   it("gcd / pow / digits", () => {
     expect(callMethod(12, "gcd", 18)).toBe(6);
     expect(callMethod(2, "**", 10)).toBe(1024);


### PR DESCRIPTION
## Summary

**Completes the numeric-breadth sweep across all five backends** (Python reference #7883, Go #7885, Rust #7888, JS #7895 — this is the final one, the TypeScript library). Extends the `Integer`/`Float` catalog (`numericMethod` + `NUMERIC_METHODS`) with five Ruby numeric methods:

- **`round(ndigits)`** — optional digits arg: positive `ndigits` rounds to N decimals half-away-from-zero (via `rubyRound`, not `Math.round`); `ndigits <= 0` rounds to a power of ten.
- **`divmod(n)`** — `[floored quotient, divisor-signed remainder]` as a JS array (prints `[3, 1]`); zero divisor → typed `ZeroDivisionError`.
- **`fdiv(n)`** — float division; never throws (zero divisor → `Infinity`/`-Infinity`/`NaN`).
- **`clamp(min, max)`** / **`between?(min, max)`**.

## No bignum/overflow hazard

TS numbers are **IEEE754 f64** — the `i64::MIN`/bignum-`OverflowError` pitfalls that took multiple review rounds on the Python and Rust backends don't exist here: a hostile-magnitude `round` `ndigits` degrades naturally (`Math.pow(10, huge)` → `Infinity`, `recv / Infinity` → `0`). The only throw site is `divmod`'s explicit typed `ZeroDivisionError`.

## Testing

- **vitest: 113 tests pass** (new `numeric breadth (N1)` case covers `round(2)`/`round(-2)`, `divmod` incl. divisor-signed remainder + zero/non-numeric-divisor errors, `fdiv` incl. `±Infinity`, `clamp`/`between?`).
- Chain-installed `file:` deps leaf-to-root; lockfile churn restored (clean 5-file diff).
- Security review: **PASSED** (no untyped throw, no DoS, no prototype pollution, no reflection).

Bumps `0.1.16` → `0.1.17`; CHANGELOG + README updated.

**Numeric breadth (`divmod`/`fdiv`/`round(n)`/`clamp`/`between?`) is now complete across Python, JS, TS, Go, and Rust.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)