### PR TITLE
feat(build-tool): recognize c/cpp languages + cpp toolchain (CCPP01 PR1)

### DIFF
--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Go build tool will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **C and C++ as first-class languages.** `inferLanguage` now recognizes `c`
+  and `cpp` path components (exact-match, so `c` never fires inside `csharp` or
+  `cpp`). Existing C++ packages (`cpp/conduit`, `cpp/conduit-hello`,
+  `cpp/mosaic-flux-qt`) are now inferred as language `cpp` instead of `unknown`.
+- **`cpp` CI toolchain.** Added to `allToolchains`; both the `c` and `cpp`
+  package languages map to the single `cpp` toolchain in
+  `toolchainForPackageLanguage` (they share compilers: gcc/g++, clang/clang++,
+  cl.exe), mirroring the `csharp`/`fsharp` → `dotnet` collapse. See spec
+  `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`. CI wiring for the new
+  toolchain lands in a follow-up change.
+
 ## [0.3.1] - 2026-03-30
 
 ### Fixed

--- a/code/programs/go/build-tool/detect_languages_test.go
+++ b/code/programs/go/build-tool/detect_languages_test.go
@@ -19,6 +19,9 @@ func TestAllToolchainsConstant(t *testing.T) {
 		"python": true, "ruby": true, "go": true,
 		"typescript": true, "rust": true, "elixir": true, "lua": true, "perl": true,
 		"swift": true, "dart": true, "java": true, "kotlin": true, "haskell": true, "dotnet": true,
+		// "cpp" installs the C/C++ compilers (gcc/g++, clang/clang++, cl.exe)
+		// and serves both the "c" and "cpp" package languages.
+		"cpp": true,
 	}
 	if len(allToolchains) != len(expected) {
 		t.Errorf("allToolchains has %d entries, want %d", len(allToolchains), len(expected))
@@ -203,6 +206,8 @@ func TestToolchainForPackageLanguage(t *testing.T) {
 		"kotlin":  "kotlin",
 		"python":  "python",
 		"swift":   "swift",
+		"c":       "cpp",
+		"cpp":     "cpp",
 		"unknown": "unknown",
 	}
 

--- a/code/programs/go/build-tool/internal/discovery/discovery.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery.go
@@ -60,7 +60,7 @@ type Package struct {
 	Name          string   // Qualified name, e.g. "python/logic-gates"
 	Path          string   // Absolute path to the package directory
 	BuildCommands []string // Lines from the BUILD file (commands to execute)
-	Language      string   // Inferred language: "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "csharp", "fsharp", "dotnet", "starlark", or "unknown"
+	Language      string   // Inferred language: "python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "c", "cpp", "csharp", "fsharp", "dotnet", "starlark", or "unknown"
 	BuildContent  string   // Raw BUILD file content (used for Starlark detection)
 	IsStarlark    bool     // Whether this BUILD file is Starlark (vs shell)
 	DeclaredSrcs  []string // Explicit source files from Starlark srcs field
@@ -119,13 +119,17 @@ func readLines(filepath string) []string {
 // inferLanguage inspects the directory path to determine the programming
 // language. We look for known language names ("python", "ruby", "go", "rust",
 // "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell",
-// "starlark", "csharp", "fsharp", "dotnet") as path components.
+// "starlark", "c", "cpp", "csharp", "fsharp", "dotnet") as path components.
 // For example, "/repo/code/packages/python/logic-gates" yields "python" and
 // "/repo/code/programs/dotnet/hello-world-csharp" yields "dotnet".
+//
+// The match is by *exact* path component, so "c" matches only a literal `c/`
+// directory (e.g. code/packages/c/ringbuf) — it never matches inside "csharp"
+// or "cpp". Likewise "cpp" matches only a `cpp/` directory.
 func inferLanguage(path string) string {
 	// Split the path into its components and search for a known language.
 	parts := strings.Split(filepath.ToSlash(path), "/")
-	for _, lang := range []string{"python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell", "starlark", "java", "kotlin", "csharp", "fsharp", "dotnet"} {
+	for _, lang := range []string{"python", "ruby", "go", "rust", "typescript", "elixir", "lua", "perl", "swift", "dart", "wasm", "haskell", "starlark", "java", "kotlin", "cpp", "c", "csharp", "fsharp", "dotnet"} {
 		for _, part := range parts {
 			if part == lang {
 				return lang

--- a/code/programs/go/build-tool/internal/discovery/discovery_test.go
+++ b/code/programs/go/build-tool/internal/discovery/discovery_test.go
@@ -126,6 +126,37 @@ func TestInferLanguageFSharp(t *testing.T) {
 	}
 }
 
+func TestInferLanguageC(t *testing.T) {
+	lang := inferLanguage("/repo/code/packages/c/ringbuf")
+	if lang != "c" {
+		t.Fatalf("expected c, got %s", lang)
+	}
+}
+
+func TestInferLanguageCpp(t *testing.T) {
+	lang := inferLanguage("/repo/code/packages/cpp/conduit")
+	if lang != "cpp" {
+		t.Fatalf("expected cpp, got %s", lang)
+	}
+}
+
+// The single-letter "c" language must match only a literal `c/` directory. It
+// must never fire inside "csharp" or "cpp" path components, and "cpp" must never
+// fire inside "csharp". These guard against the exact-match regressing to a
+// substring match.
+func TestInferLanguageCDoesNotCollide(t *testing.T) {
+	cases := map[string]string{
+		"/repo/code/packages/csharp/graph": "csharp",
+		"/repo/code/packages/cpp/conduit":  "cpp",
+		"/repo/code/programs/c/hello":      "c",
+	}
+	for path, want := range cases {
+		if got := inferLanguage(path); got != want {
+			t.Fatalf("inferLanguage(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
 func TestInferLanguageUnknown(t *testing.T) {
 	lang := inferLanguage("/repo/code/packages/zig/something")
 	if lang != "unknown" {

--- a/code/programs/go/build-tool/main.go
+++ b/code/programs/go/build-tool/main.go
@@ -141,7 +141,7 @@ func run() int {
 	force := flag.Bool("force", false, "Rebuild everything regardless of cache")
 	dryRun := flag.Bool("dry-run", false, "Show what would build without executing")
 	jobs := flag.Int("jobs", runtime.NumCPU(), "Max parallel jobs")
-	language := flag.String("language", "all", "Filter to package language: python, ruby, go, rust, typescript, elixir, lua, perl, swift, dart, wasm, csharp, fsharp, dotnet, all")
+	language := flag.String("language", "all", "Filter to package language: python, ruby, go, rust, typescript, elixir, lua, perl, swift, dart, wasm, c, cpp, csharp, fsharp, dotnet, all")
 	diffBase := flag.String("diff-base", "origin/main", "Git ref to diff against for change detection (default: origin/main)")
 	cacheFile := flag.String("cache-file", ".build-cache.json", "Path to cache file (fallback when git diff unavailable)")
 	detectLanguages := flag.Bool("detect-languages", false, "Output which language toolchains are needed based on git diff, then exit")
@@ -537,7 +537,7 @@ func run() int {
 
 // allToolchains is the canonical list of build toolchains we may need in CI.
 // The order is stable and matches the order used in CI setup.
-var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "dart", "java", "kotlin", "haskell", "dotnet"}
+var allToolchains = []string{"python", "ruby", "go", "typescript", "rust", "elixir", "lua", "perl", "swift", "dart", "java", "kotlin", "haskell", "dotnet", "cpp"}
 
 func toolchainForPackageLanguage(language string) string {
 	switch language {
@@ -545,6 +545,11 @@ func toolchainForPackageLanguage(language string) string {
 		return "rust"
 	case "csharp", "fsharp", "dotnet":
 		return "dotnet"
+	case "c", "cpp":
+		// C and C++ share compilers (gcc/g++, clang/clang++, cl.exe), so a
+		// single "cpp" toolchain installs the compilers for both languages —
+		// mirroring the csharp/fsharp → dotnet collapse above.
+		return "cpp"
 	default:
 		return language
 	}

--- a/code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md
+++ b/code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md
@@ -1,0 +1,95 @@
+# CCPP01 — C & C++ multi-compiler (GCC · Clang/LLVM · MSVC) ISO lane
+
+Status: in progress (PR1 of ~5)
+
+## Motivation
+
+The monorepo builds ~15 languages through the Go build tool
+(`code/programs/go/build-tool/`). C and C++ are **not** first-class:
+
+- `inferLanguage` (`internal/discovery/discovery.go`) does not recognize `c` or
+  `cpp` as path components, so the existing C++ packages (`cpp/conduit`,
+  `cpp/conduit-hello`, `cpp/mosaic-flux-qt`) are inferred as language
+  `"unknown"`.
+- There is no C/C++ toolchain in `allToolchains` (`main.go`), so CI never
+  deliberately installs a C/C++ compiler — those packages merely happen to build
+  on the runner's preinstalled `cc`.
+- Existing C/C++ build scripts pick **one** compiler (`clang++` else `g++`) and
+  **skip Windows/MSVC** entirely. Nothing forces the code to be portable ISO
+  C/C++.
+
+**Goal:** make C and C++ first-class in the build tool and CI, and guarantee that
+every *pure-ISO* C/C++ package compiles under **GCC, Clang (LLVM), and MSVC** with
+strict standards-conformance flags, so non-portable / extension-dependent code
+fails the build.
+
+## Design
+
+### Language inference & toolchain
+
+- `inferLanguage` recognizes two new path components: `c` and `cpp`. The match is
+  by *exact* path component, so `c` matches only a literal `code/**/c/**`
+  directory — `csharp` and `cpp` directories are unaffected.
+- A single CI toolchain named `cpp` covers **both** the `c` and `cpp` languages,
+  because they share compilers (`gcc`/`g++`, `clang`/`clang++`, `cl.exe`). This
+  mirrors the existing `csharp`/`fsharp` → `dotnet` collapse in
+  `toolchainForPackageLanguage`.
+- Dependencies of C/C++ packages are declared via the `# build-tool: deps=…`
+  BUILD comment (already supported and used by `conduit`), **not** a package
+  manifest. Therefore `c`/`cpp` are deliberately kept **out** of the validator's
+  `requiresExplicitPrereqs` set so promotion from `"unknown"` to a real language
+  does not start demanding `../`-style refs in the BUILD line.
+
+### Compiler coverage = across the CI matrix
+
+No single machine has all three compilers: MSVC exists only on Windows, and a
+real GCC only on Linux (macOS's `gcc` is a Clang shim). Coverage is therefore
+achieved **across** the 3-OS pull-request matrix:
+
+| Runner         | Compilers exercised            |
+| -------------- | ------------------------------ |
+| ubuntu-latest  | GCC (`g++`/`gcc`) **and** Clang |
+| windows-latest | MSVC (`cl.exe`) (+ optional clang-cl) |
+| macos-latest   | Apple Clang                    |
+
+Every pure-ISO C/C++ package is compiled by GCC, Clang, and MSVC across a single
+PR CI run.
+
+### Standards & strict flags
+
+- **C17** and **C++17**.
+- GCC / Clang: `-std=c17` / `-std=c++17 -pedantic-errors -Wall -Wextra -Werror`.
+- MSVC: `/std:c17` / `/std:c++17 /permissive- /W4 /WX` (`/EHsc` for C++).
+
+`-pedantic-errors` (GCC/Clang) and `/permissive-` (MSVC) are the switches that
+actually reject non-ISO extensions; `-Werror` / `/WX` make every diagnostic fatal.
+
+### Reusable ISO harness (later PR)
+
+A shared, self-verifying harness at `code/packages/c/iso-harness/` compiles each
+translation unit with **every** compiler present on the runner under the strict
+flags, fails if zero suitable compilers are found, and supports an optional
+`ISO_REQUIRE="gcc clang"` guard so CI can assert that both GCC and Clang actually
+ran (making the guarantee firm, not best-effort). It also ships a header-only,
+ISO-only test harness (`iso_test.h`) so sample packages need no external test
+dependency.
+
+### Existing packages
+
+`cpp/conduit`, `cpp/conduit-hello`, and `cpp/mosaic-flux-qt` use POSIX sockets,
+Qt, and Rust FFI; they cannot be pure ISO and keep their current
+single-compiler builds. Promotion to language `cpp` does not change how they build
+(the build tool runs every affected package regardless of language; language only
+drives toolchain installation). Their BUILD lines contain no `../` refs, so the
+validator's ref checks skip them exactly as before.
+
+## Rollout (PRs)
+
+1. **PR1 (this):** spec + `inferLanguage` recognizes `c`/`cpp`; `cpp` added to
+   `allToolchains`; `c`/`cpp` → `cpp` in `toolchainForPackageLanguage`; tests.
+2. **PR2:** ci.yml `needs_cpp` output + normalize + install (clang on ubuntu,
+   MSVC on windows); `cpp` added to the validator's `ciManagedToolchainLanguages`.
+3. **PR3:** shared `code/packages/c/iso-harness/` (self-testing).
+4. **PR4:** scaffold-generator `c`/`cpp` templates.
+5. **PR5:** sample pure-ISO C (`c/ringbuf`) and C++ (`cpp/static-vector`)
+   packages that exercise the harness end-to-end across the matrix.


### PR DESCRIPTION
## Summary

PR1 of ~5 for the **C/C++ multi-compiler ISO lane** (spec: `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`).

Makes **C and C++ first-class in the build tool** so CI can install a C/C++ toolchain and (in later PRs) compile every pure-ISO C/C++ package under GCC, Clang (LLVM), and MSVC across the 3-OS matrix.

### Changes
- `inferLanguage` recognizes `c` and `cpp` path components (exact-match, so `c` never fires inside `csharp`/`cpp`). Existing `cpp/conduit`, `cpp/conduit-hello`, `cpp/mosaic-flux-qt` are now inferred as `cpp` instead of `unknown`.
- Added a single `cpp` toolchain to `allToolchains`; both `c` and `cpp` map to it in `toolchainForPackageLanguage` (they share gcc/g++, clang/clang++, cl.exe) — mirroring `csharp`/`fsharp` → `dotnet`.
- Committed the CCPP01 spec first (spec-first rule).

### Why this is safe for existing packages
`c`/`cpp` are deliberately **not** added to the validator's `requiresExplicitPrereqs`. C/C++ declare deps via the `# build-tool: deps=` comment and their BUILD lines carry no `../` refs, so validating the newly-promoted packages is a no-op. Verified: a full `-validate-build-files -dry-run -force` over the repo exits 0 with `cpp/conduit`, `cpp/mosaic-flux-qt`, `cpp/programs/conduit-hello` correctly recognized.

CI `needs_cpp` wiring + the validator's `ciManagedToolchainLanguages` entry land together in **PR2**.

### Tests
- Expected `allToolchains` set (+`cpp`); `c`/`cpp` → `cpp` mapping.
- Inference tests incl. collision guards (`c` vs `csharp`/`cpp`).
- `go test ./...` green.

### Security review
Passed (1 round, Go reviewer): static string additions, exact-match inference, no new input surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
