### PR TITLE
fix(sql-codegen): resolve qualified columns across a join (Stream B / L3)

### DIFF
--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -34,11 +34,13 @@
 //! quietly leave stale ledger entries behind.
 //!
 //! On introduction this harness measured 12 of 22 seed cases already matching
-//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]) — most notably
-//! that qualified column references across a join resolve to `NULL` (breaking
-//! even `INNER JOIN`), the outer joins drop their `ON` clause, aggregate columns
-//! are misnamed, and `UPPER()` returns the wrong value. Each is a tracked
-//! increment; the harness is what makes fixing them verifiable.
+//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). The first has
+//! since been retired: qualified column references across an `INNER JOIN` now
+//! resolve correctly (the join threads its projection through the inner loop and
+//! keys each cursor by its effective alias). The remaining ledger entries — outer
+//! joins dropping their `ON` clause, misnamed aggregate columns, and a wrong
+//! `UPPER()` — are each a tracked increment; the harness is what makes fixing
+//! them verifiable.
 
 use coding_adventures_mini_sqlite::{connect, SqlValue};
 
@@ -407,10 +409,6 @@ const CASES: &[Case] = &[
 ///   unnamed (`?`), and `UPPER(name)` returns the wrong value (an integer, not
 ///   the uppercased text) — a real codegen/builtin bug.
 const LEDGER: &[(&str, &str)] = &[
-    (
-        "inner_join",
-        "qualified column refs across a join resolve to NULL (cursor keyed under None vs the Some(table) qualifier in LoadColumn). Highest-priority fix.",
-    ),
     (
         "left_join",
         "outer joins mis-compile: ON clause dropped, degrades to cross join (sql-codegen JoinKind::Inner guard); no NULL-padding.",

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.2.0] - Unreleased
+
+### Fixed
+
+- **Qualified columns across a join now resolve correctly.** `SELECT a.name,
+  b.tag FROM a JOIN b ON a.id = b.aid` previously returned a single all-`NULL`
+  row: a `FROM a`/`FROM b` with no `AS` alias opened both cursors under the same
+  `None` key (so they collided and every `a.x`/`b.y` read whichever advanced
+  last), and the projection was emitted *after* the join loop with no live
+  cursor. New `compile_join_projected` keys each side by its **effective alias**
+  (explicit alias, else table name — exactly what a `LoadColumn` qualifier looks
+  up) and emits the projected columns *inside* the inner loop, so both the `ON`
+  condition and the output columns resolve against the right row. `Project(Join)`
+  now routes through this path. Verified against real SQLite by the mini-sqlite
+  differential-conformance oracle (the `inner_join` case, previously a ledger
+  divergence, now matches). Outer joins still degrade to a cross product (tracked
+  separately); their columns now resolve correctly too.
+
 ## [0.1.0] - 2026-07-01
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -1089,6 +1089,18 @@ impl Compiler {
                 self.compile_inner(input);
             }
 
+            // ── Join: thread the projection through the join's inner loop so
+            //    qualified columns resolve against the correct cursor. ─────────
+            OptimizedPlan::Join {
+                left,
+                right,
+                kind,
+                condition,
+            } => {
+                let cols = columns.to_vec();
+                self.compile_join_projected(left, right, kind, condition, &cols);
+            }
+
             // ── All other inputs (plain Scan, etc.): standard scan loop ──────
             _ => {
                 let cols = columns.to_vec();
@@ -1521,6 +1533,106 @@ impl Compiler {
 
         // Emit matched row.
         self.emit(Instruction::BeginRow);
+        self.emit(Instruction::EmitRow);
+
+        if has_condition {
+            self.emit(Instruction::Label(cond_skip));
+        }
+
+        self.emit(Instruction::Jump(inner_loop));
+        self.emit(Instruction::Label(inner_end));
+        self.emit(Instruction::CloseScan(inner_alias));
+
+        self.emit(Instruction::Jump(outer_loop));
+        self.emit(Instruction::Label(outer_end));
+        self.emit(Instruction::CloseScan(outer_alias));
+    }
+
+    /// Compile a nested-loop join of `left` and `right` **with a projection**:
+    /// the `columns` are evaluated and emitted *inside* the inner loop, once per
+    /// matched pair. This is the path a real `SELECT … FROM a JOIN b` takes
+    /// (the planner always wraps a join in a `Project`).
+    ///
+    /// ## Why this exists separately from [`compile_join`]
+    ///
+    /// Two problems had to be fixed together for qualified columns to resolve:
+    ///
+    /// 1. **Cursor keys must be distinct and match the column qualifiers.** A
+    ///    `FROM a` with no `AS` alias would otherwise open its cursor under the
+    ///    `None` key — and so would `FROM b`, so the two collided and *both*
+    ///    `a.x` and `b.y` read from whichever advanced last (resolving to NULL).
+    ///    Here each side is keyed by its **effective alias** — the explicit alias
+    ///    if given, else the table name — which is exactly what a `LoadColumn`
+    ///    qualifier (`a.x` → `LoadColumn(Some("a"), "x")`) looks up. Now the `ON`
+    ///    condition *and* the projected columns resolve against the right row.
+    /// 2. **The projection must run inside the loop.** Emitting the output
+    ///    columns after the join loop closed (the old `compile_scan_loop`
+    ///    fallback) evaluated them with no live cursor, producing a single
+    ///    all-NULL row. They belong in the per-pair body.
+    fn compile_join_projected(
+        &mut self,
+        left: &OptimizedPlan,
+        right: &OptimizedPlan,
+        kind: &JoinKind,
+        condition: &Option<SqlExpr>,
+        columns: &[OutputColumn],
+    ) {
+        // As in `compile_join`, only INNER joins evaluate the `ON` condition for
+        // now; outer joins still degrade to a cross product (tracked separately
+        // in the conformance ledger) — but their columns now resolve correctly.
+        let has_condition = condition.is_some() && *kind == JoinKind::Inner;
+
+        let outer_loop = self.fresh_label("joinp_outer_loop");
+        let outer_end = self.fresh_label("joinp_outer_end");
+        let inner_loop = self.fresh_label("joinp_inner_loop");
+        let inner_end = self.fresh_label("joinp_inner_end");
+        let cond_skip = if has_condition {
+            self.fresh_label("joinp_cond_skip")
+        } else {
+            String::new()
+        };
+
+        // Effective alias = explicit alias, else the table name. This is the key
+        // both the cursor and the column qualifiers agree on.
+        let (outer_table, outer_alias_opt) = extract_scan_info(left);
+        let outer_alias = Some(outer_alias_opt.unwrap_or_else(|| outer_table.clone()));
+        let (inner_table, inner_alias_opt) = extract_scan_info(right);
+        let inner_alias = Some(inner_alias_opt.unwrap_or_else(|| inner_table.clone()));
+
+        // Outer scan.
+        self.emit(Instruction::OpenScan(outer_table, outer_alias.clone()));
+        self.emit(Instruction::Label(outer_loop.clone()));
+        self.emit(Instruction::AdvanceCursor(outer_alias.clone()));
+        self.emit(Instruction::JumpIfExhausted(
+            outer_alias.clone(),
+            outer_end.clone(),
+        ));
+
+        // Inner scan (re-opened per outer row).
+        self.emit(Instruction::OpenScan(inner_table, inner_alias.clone()));
+        self.emit(Instruction::Label(inner_loop.clone()));
+        self.emit(Instruction::AdvanceCursor(inner_alias.clone()));
+        self.emit(Instruction::JumpIfExhausted(
+            inner_alias.clone(),
+            inner_end.clone(),
+        ));
+
+        // Optional join condition (both cursors are live here, correctly keyed).
+        if let Some(cond) = condition {
+            if has_condition {
+                self.compile_expr(cond);
+                self.emit(Instruction::JumpIfFalse(cond_skip.clone()));
+            }
+        }
+
+        // Project the matched pair: evaluate each output column against the two
+        // live cursors and emit the row.
+        self.emit(Instruction::BeginRow);
+        for col in columns {
+            self.compile_expr(&col.expr);
+            let name = output_column_name(col);
+            self.emit(Instruction::EmitColumn(name));
+        }
         self.emit(Instruction::EmitRow);
 
         if has_condition {


### PR DESCRIPTION
## Stream B / L3 — first ledger shrink, driven by the oracle

The differential-conformance oracle (merged #7894) flagged that `SELECT a.name, b.tag FROM a JOIN b ON a.id = b.aid` returned a single all-`NULL` row. Two coupled codegen bugs:

1. A `FROM a` / `FROM b` with **no `AS` alias** opened *both* cursors under the same `None` key, so they collided and every `a.x`/`b.y` read whichever cursor advanced last (→ NULL) — breaking the `ON` condition *and* the projection.
2. For `Project(Join)`, the projection was emitted **after** the join loop closed (the `compile_scan_loop` fallback ran the body once with no live cursor), so every output column evaluated to `NULL`.

### Fix
New `compile_join_projected` keys each side by its **effective alias** (explicit alias, else table name — exactly what a `LoadColumn` qualifier looks up) and emits the projected columns **inside** the inner loop. `Project(Join)` routes through it. The bare `compile_join` path and its 3 unit tests are untouched.

### Verified
- The mini-sqlite differential oracle now shows `inner_join` **matches real SQLite** — removed from the known-divergence `LEDGER` (10 → 9), so the test now *asserts* it rather than tolerating it.
- Full `cargo test` green: sql-codegen (81), sql-vm (75), mini-sqlite (45 + oracle + 11 integration).
- New code clippy + fmt clean; security-reviewed (label/scan/stack balance, no-panic, no new DoS — compile-time bytecode emission, no untrusted-input surface).

Outer joins still degrade to a cross product (a separate ledger entry, next Stream-A increment) but their columns now resolve correctly too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)