### PR TITLE
feat(ci): C/C++ toolchain lane — GCC+Clang/MSVC (CCPP01 PR2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       needs_java: ${{ steps.toolchains.outputs.needs_java }}
       needs_kotlin: ${{ steps.toolchains.outputs.needs_kotlin }}
       needs_swift: ${{ steps.toolchains.outputs.needs_swift }}
+      needs_cpp: ${{ steps.toolchains.outputs.needs_cpp }}
       diff_base: ${{ steps.diff-base.outputs.base }}
       is_main: ${{ steps.detect-main.outputs.is_main }}
       build_shards: ${{ steps.detect.outputs.build_shards }}
@@ -167,6 +168,8 @@ jobs:
               'needs_kotlin=true' >> "$GITHUB_OUTPUT"
             printf '%s\n' \
               'needs_swift=true' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
+              'needs_cpp=true' >> "$GITHUB_OUTPUT"
           else
             printf '%s\n' \
               'needs_python=${{ steps.detect.outputs.needs_python }}' \
@@ -185,6 +188,8 @@ jobs:
               'needs_kotlin=${{ steps.detect.outputs.needs_kotlin }}' >> "$GITHUB_OUTPUT"
             printf '%s\n' \
               'needs_swift=${{ steps.detect.outputs.needs_swift }}' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
+              'needs_cpp=${{ steps.detect.outputs.needs_cpp }}' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Plan build matrix
@@ -291,8 +296,12 @@ jobs:
       # linker that Lua needs to compile. By installing MSVC + Lua
       # first, the MSVC `link.exe` is in PATH before Ruby's MSYS2.
 
-      - name: Set up MSVC (required for Lua on Windows)
-        if: needs.detect.outputs.needs_lua == 'true' && runner.os == 'Windows'
+      # MSVC on Windows serves two consumers: Lua (needs the MSVC linker) and
+      # the C/C++ lane (needs `cl.exe` for the MSVC arm of the pure-ISO check).
+      # A single msvc-dev-cmd invocation covers both — invoking the action twice
+      # would double-prepend the MSVC environment.
+      - name: Set up MSVC (Lua linker + C/C++ cl.exe)
+        if: (needs.detect.outputs.needs_lua == 'true' || needs.detect.outputs.needs_cpp == 'true') && runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Set up Lua
@@ -355,6 +364,25 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      # ── C/C++ compilers (pure-ISO multi-compiler lane) ──────────
+      #
+      # The goal is that every pure-ISO C/C++ package compiles under GCC, Clang
+      # (LLVM), and MSVC across the 3-OS matrix. Each runner contributes the
+      # compilers only it can host:
+      #   • ubuntu  → GCC (g++/gcc, preinstalled) + Clang (installed below)
+      #   • windows → MSVC (cl.exe, via the msvc-dev-cmd step above)
+      #   • macOS   → Apple Clang (preinstalled)
+      # A real GCC exists only on Linux and real MSVC only on Windows, so no
+      # single machine can host all three — coverage is achieved across the
+      # matrix, and the ISO harness compiles with every compiler it finds.
+      - name: Install Clang alongside GCC (Linux C/C++)
+        if: needs.detect.outputs.needs_cpp == 'true' && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+          gcc --version | head -1
+          clang --version | head -1
 
       - name: Set up Rust
         if: needs.detect.outputs.needs_rust == 'true'

--- a/code/programs/go/build-tool/CHANGELOG.md
+++ b/code/programs/go/build-tool/CHANGELOG.md
@@ -14,8 +14,12 @@ All notable changes to the Go build tool will be documented in this file.
   package languages map to the single `cpp` toolchain in
   `toolchainForPackageLanguage` (they share compilers: gcc/g++, clang/clang++,
   cl.exe), mirroring the `csharp`/`fsharp` → `dotnet` collapse. See spec
-  `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`. CI wiring for the new
-  toolchain lands in a follow-up change.
+  `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`.
+- **`cpp` is now a CI-managed toolchain** (`validateCIFullBuildToolchains`): the
+  validator requires `.github/workflows/ci.yml` to bind `needs_cpp` and force it
+  on the main full-build path. ci.yml installs Clang alongside GCC on Linux and
+  MSVC on Windows so the pure-ISO multi-compiler check sees all three across the
+  matrix.
 
 ## [0.3.1] - 2026-03-30
 

--- a/code/programs/go/build-tool/internal/validator/validator.go
+++ b/code/programs/go/build-tool/internal/validator/validator.go
@@ -50,6 +50,11 @@ var ciManagedToolchainLanguages = map[string]bool{
 	"dart":       true,
 	"swift":      true,
 	"haskell":    true,
+	// C/C++: CI installs Clang alongside GCC on Linux and MSVC on Windows so the
+	// pure-ISO multi-compiler check has all three across the matrix. Adding this
+	// makes validateCIFullBuildToolchains require ci.yml to bind needs_cpp and
+	// force it on the main full-build path.
+	"cpp": true,
 }
 
 // ValidateBuildFiles returns an error describing every package whose BUILD file

--- a/code/programs/go/build-tool/internal/validator/validator_test.go
+++ b/code/programs/go/build-tool/internal/validator/validator_test.go
@@ -336,6 +336,80 @@ jobs:
 	}
 }
 
+// A cpp package must force the CI workflow to bind and normalize needs_cpp on
+// the forced main full-build path. This locks in the ciManagedToolchainLanguages
+// entry added for the C/C++ multi-compiler lane (CCPP01 PR2).
+func TestValidateBuildFilesRequiresNeedsCppForCppPackages(t *testing.T) {
+	pkgs := makePackages(t, []struct {
+		name     string
+		relPath  string
+		lang     string
+		commands []string
+	}{
+		{name: "cpp/static-vector", relPath: "code/packages/cpp/static-vector", lang: "cpp"},
+	})
+
+	repoRoot := inferRepoRoot(pkgs)
+	if repoRoot == "" {
+		t.Fatal("expected repo root inference to succeed")
+	}
+	ciDir := filepath.Join(repoRoot, ".github", "workflows")
+	if err := os.MkdirAll(ciDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := directedgraph.New()
+	graph.AddNode("cpp/static-vector")
+
+	// Workflow missing the needs_cpp binding entirely → must fail and name cpp.
+	if err := os.WriteFile(filepath.Join(ciDir, "ci.yml"), []byte(`
+jobs:
+  detect:
+    outputs:
+      needs_swift: ${{ steps.toolchains.outputs.needs_swift }}
+    steps:
+      - name: Normalize toolchain requirements
+        id: toolchains
+        run: |
+          printf '%s\n' 'needs_swift=true' >> "$GITHUB_OUTPUT"
+  build:
+    steps:
+      - name: Full build on main merge
+        run: ./build-tool -root . -force -validate-build-files -language all
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateBuildFiles(pkgs, graph)
+	if err == nil {
+		t.Fatal("expected CI validation failure for missing needs_cpp")
+	}
+	if !strings.Contains(err.Error(), "cpp") {
+		t.Fatalf("expected cpp to be named in the error, got %v", err)
+	}
+
+	// Workflow with the binding + forced main value → must pass.
+	if err := os.WriteFile(filepath.Join(ciDir, "ci.yml"), []byte(`
+jobs:
+  detect:
+    outputs:
+      needs_cpp: ${{ steps.toolchains.outputs.needs_cpp }}
+    steps:
+      - name: Normalize toolchain requirements
+        id: toolchains
+        run: |
+          printf '%s\n' 'needs_cpp=true' >> "$GITHUB_OUTPUT"
+  build:
+    steps:
+      - name: Full build on main merge
+        run: ./build-tool -root . -force -validate-build-files -language all
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateBuildFiles(pkgs, graph); err != nil {
+		t.Fatalf("expected CI validation to pass with needs_cpp bound, got %v", err)
+	}
+}
+
 func TestValidateBuildFilesFailsLuaBuildWithForeignRemoveAndBadOrder(t *testing.T) {
 	pkgs := makePackages(t, []struct {
 		name     string


### PR DESCRIPTION
## Summary

PR2 of ~5 for the **C/C++ multi-compiler ISO lane** (spec: `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`).

Wires the `cpp` toolchain into CI so the pure-ISO multi-compiler check gets **GCC, Clang (LLVM), and MSVC** across the 3-OS matrix.

### Changes
- **ci.yml**
  - Bind `needs_cpp` in the detect job outputs.
  - Normalize it: force `needs_cpp=true` on the main full-build path; pass through the detect output on PRs (identical pattern to every other toolchain).
  - Install: `apt-get install -y clang` on Linux (g++ is preinstalled) so **both GCC and Clang** run; broaden the existing `msvc-dev-cmd` step to also fire on `needs_cpp` so `cl.exe` is on PATH (one shared invocation with Lua). macOS uses preinstalled Apple Clang.
- **validator**: add `cpp` to `ciManagedToolchainLanguages` so `validateCIFullBuildToolchains` enforces the `needs_cpp` binding + main force. New test: missing binding fails and names `cpp`; present binding passes.

### Coverage model
No single runner can host all three compilers (real GCC only on Linux, real MSVC only on Windows). Coverage is achieved **across** the matrix — ubuntu: GCC+Clang, windows: MSVC, macOS: Apple Clang.

### Verification
- `-validate-build-files -dry-run -force` over the real repo exits 0 with the updated ci.yml.
- Full build-tool test suite green; ci.yml is valid YAML.

### Security review
Passed (1 round, CI/CD reviewer): `needs_cpp` is a `%t`-formatted `true`/`false` (no injection surface); workflow runs on `pull_request` (read-only token); no untrusted `${{ }}` in run blocks.

PR1 (#7904) is already merged; this applies on top of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
