### PR TITLE
feat(sir-runtime-oop): Hash transform_values/transform_keys (Python, v0.1.18)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.18] - 2026-07-11
+
+### Added — Hash block methods: `transform_values` / `transform_keys`
+
+Extends the block-taking `Hash` catalog (`_hash_block_method` +
+`_HASH_BLOCK_METHODS`) with two more Ruby `Hash` methods — this establishes the
+**reference** semantics before the embedded backends mirror them:
+
+- `transform_values { |v| … }` — a **new** hash with each value replaced by the
+  block's result; keys are untouched (non-mutating; the `!` bang variant is a
+  follow-up).
+- `transform_keys { |k| … }` — a **new** hash with each key replaced by the
+  block's result; values are untouched. On a key collision the **last** pair
+  wins (Ruby's rule).
+
 ## [0.1.17] - 2026-07-10
 
 ### Added — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -75,7 +75,8 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 `flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
-(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/…); and (item
+(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/…);
+and (item
 **M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
 `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,
 `include?`/`start_with?`/`end_with?`/`index`, `replace`, `sub`/`gsub` *literal*,

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.17"
+version = "0.1.18"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -649,6 +649,8 @@ _HASH_BLOCK_METHODS = frozenset(
         "reject",
         "each_key",
         "each_value",
+        "transform_values",
+        "transform_keys",
     }
 )
 
@@ -1201,6 +1203,16 @@ def _hash_block_method(recv: dict[Val, Val], name: str, block: Closure) -> Val:
         return {k: v for k, v in recv.items() if truthy(apply(block, [k, v]))}
     if name == "reject":
         return {k: v for k, v in recv.items() if not truthy(apply(block, [k, v]))}
+    if name == "transform_values":
+        # ``transform_values { |v| … }`` — a NEW hash with each value replaced by
+        # the block's result; keys are untouched.  Non-mutating (Ruby's bang
+        # variant is a follow-up).
+        return {key: apply(block, [value]) for key, value in recv.items()}
+    if name == "transform_keys":
+        # ``transform_keys { |k| … }`` — a NEW hash with each key replaced by the
+        # block's result; values are untouched.  On a collision the LAST pair
+        # wins (Ruby's rule, matching dict-comprehension insertion order).
+        return {apply(block, [key]): value for key, value in recv.items()}
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -505,15 +505,27 @@ def test_hash_each_key_each_value() -> None:
     assert vs == [1, 2]
 
 
+def test_hash_transform_values_and_keys() -> None:
+    h = {"a": 1, "b": 2}
+    # transform_values: new hash, values mapped, keys unchanged, non-mutating.
+    assert oop.call_method(h, "transform_values", Closure(lambda v: v * 10)) == {"a": 10, "b": 20}
+    assert h == {"a": 1, "b": 2}
+    # transform_keys: new hash, keys mapped, values unchanged.
+    assert oop.call_method(h, "transform_keys", Closure(lambda k: k.upper())) == {"A": 1, "B": 2}
+    # transform_keys collision: the LAST pair wins.
+    assert oop.call_method({"a": 1, "b": 2}, "transform_keys", Closure(lambda _k: "x")) == {"x": 2}
+
+
 def test_hash_respond_to_and_no_method_error_floor() -> None:
     assert oop.call_method({"a": 1}, "respond_to?", "keys") is True
     assert oop.call_method({"a": 1}, "respond_to?", "each") is True
-    assert oop.call_method({"a": 1}, "respond_to?", "transform_keys") is False
+    # `transform_keys!` (the in-place bang variant) is still out of catalog.
+    assert oop.call_method({"a": 1}, "respond_to?", "transform_keys!") is False
     # An out-of-catalog Hash method is genuinely unknown → NoMethodError (T1).
     with pytest.raises(SirError) as excinfo:
-        oop.call_method({"a": 1}, "transform_keys")
+        oop.call_method({"a": 1}, "transform_keys!")
     assert excinfo.value.sir_class == "NoMethodError"
-    assert excinfo.value.args[0] == "undefined method 'transform_keys' for Hash"
+    assert excinfo.value.args[0] == "undefined method 'transform_keys!' for Hash"
     # Universal Object methods still resolve on a Hash receiver.
     assert oop.call_method({"a": 1}, "nil?") is False
 


### PR DESCRIPTION
## Summary

Establishes the **reference** semantics for the Hash-breadth follow-up (the Python `sir-runtime-oop` library is the parity reference; embedded backends mirror next). Extends the block-taking `Hash` catalog (`_hash_block_method` + `_HASH_BLOCK_METHODS`) with two Ruby `Hash` methods that were missing even from the reference:

- **`transform_values { |v| … }`** — a **new** hash with each value replaced by the block's result; keys untouched (non-mutating; the `!` bang variant is a follow-up).
- **`transform_keys { |k| … }`** — a **new** hash with each key replaced by the block's result; values untouched. On a key collision the **last** pair wins (Ruby's rule).

## Design invariants

- **Explicit dispatch** — block-method table keyed by the literal method name; no reflection.
- **No amplification** — each builds a dict of the same size (or fewer, on `transform_keys` collision).

## Testing

- **pytest: 124 pass, 97% coverage**; ruff clean. New `test_hash_transform_values_and_keys` covers value/key mapping, non-mutation, and the collision-last-wins rule.
- Updated the pre-existing `respond_to?`/`NoMethodError` floor test to use the still-uncatalogued `transform_keys!` bang variant as its unknown-method example (it previously used `transform_keys`, now catalogued).
- Security review: **PASSED** (no reflection, no DoS, no untyped-raise on well-formed input).

Bumps `0.1.17` → `0.1.18`; CHANGELOG + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)