### PR TITLE
feat(md5): pure-Dart port (RFC 1321 + streaming Md5Digest)

### DIFF
--- a/code/packages/dart/md5/BUILD
+++ b/code/packages/dart/md5/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/md5/CHANGELOG.md
+++ b/code/packages/dart/md5/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — coding_adventures_md5
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Dart port of the `md5` reference package.
+- `sumMd5(List<int>)` → `Uint8List` — 16-byte RFC 1321 digest.
+- `hexString(List<int>)` → `String` — 32-char lowercase hex digest.
+- `Md5Digest` — streaming hasher with `update`, non-destructive `sumMd5` /
+  `hexDigest`, and `cloneDigest` for independent snapshots.
+- Correct little-endian block parsing, length field, and digest output, plus
+  32-bit wrap-around arithmetic on Dart's 64-bit `int` via `& 0xFFFFFFFF`.
+- 28 unit tests: all seven RFC 1321 Appendix A.5 vectors, little-endian byte
+  order and the 0x00..0xFF known digest, output-format/determinism/avalanche
+  properties, padding/block-boundary edge cases (0/55/56/63/64/127/128), and
+  streaming parity with the one-shot API (byte-at-a-time, block-split, clone
+  independence, one-million-'a').

--- a/code/packages/dart/md5/README.md
+++ b/code/packages/dart/md5/README.md
@@ -1,0 +1,53 @@
+# coding_adventures_md5
+
+MD5 message-digest algorithm (RFC 1321) implemented from scratch in pure Dart —
+no `crypto` package, no native code.
+
+Dart port of the `md5` package that already exists in Rust, Python, Swift, and
+other languages in the coding-adventures monorepo; produces byte-identical
+digests to those ports and to any conforming MD5.
+
+> **Security:** MD5 is cryptographically **broken** — practical collision
+> attacks exist. Never use it for digital signatures, certificates, or password
+> storage. It remains fine as a fast, non-adversarial integrity checksum.
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `sumMd5(List<int> data)` → `Uint8List` | 16-byte digest. |
+| `hexString(List<int> data)` → `String` | 32-char lowercase hex digest. |
+| `Md5Digest` | Incremental hashing: `update` / `sumMd5` / `hexDigest` / `cloneDigest`. |
+
+## Usage
+
+```dart
+import 'dart:convert';
+import 'package:coding_adventures_md5/coding_adventures_md5.dart';
+
+void main() {
+  print(hexString(utf8.encode('abc')));
+  // 900150983cd24fb0d6963f7d28e17f72
+
+  final h = Md5Digest();
+  h.update(utf8.encode('ab'));
+  h.update(utf8.encode('c'));
+  print(h.hexDigest()); // same digest, computed incrementally
+}
+```
+
+## How it works
+
+MD5 pads the message (append `0x80`, zero-fill to 56 mod 64, then the 64-bit
+**little-endian** bit length) and folds each 64-byte block into a four-word
+state through 64 rounds. MD5 is **little-endian** throughout — block words and
+the output digest read least-significant byte first, the opposite of
+SHA-1/SHA-256. Because Dart's `int` is 64-bit, every add and rotate is masked
+with `& 0xFFFFFFFF`.
+
+## Running the tests
+
+```
+dart pub get
+dart test
+```

--- a/code/packages/dart/md5/lib/coding_adventures_md5.dart
+++ b/code/packages/dart/md5/lib/coding_adventures_md5.dart
@@ -1,0 +1,28 @@
+/// MD5 message-digest algorithm (RFC 1321), implemented from scratch in pure
+/// Dart.
+///
+/// Provides a one-shot API ([sumMd5] / [hexString]) and an incremental
+/// [Md5Digest] for streaming data.
+///
+/// **Security note:** MD5 is cryptographically broken (practical collisions
+/// exist) — do not use it for signatures or passwords. It remains a useful fast
+/// checksum for non-adversarial integrity checks.
+///
+/// ## Usage
+///
+/// ```dart
+/// import 'dart:convert';
+/// import 'package:coding_adventures_md5/coding_adventures_md5.dart';
+///
+/// void main() {
+///   print(hexString(utf8.encode('abc'))); // 900150983cd24fb0d6963f7d28e17f72
+///
+///   final h = Md5Digest()
+///     ..update(utf8.encode('ab'))
+///     ..update(utf8.encode('c'));
+///   print(h.hexDigest()); // same digest, computed incrementally
+/// }
+/// ```
+library coding_adventures_md5;
+
+export 'src/md5.dart';

--- a/code/packages/dart/md5/lib/src/md5.dart
+++ b/code/packages/dart/md5/lib/src/md5.dart
@@ -1,0 +1,232 @@
+/// MD5 message-digest algorithm (RFC 1321), implemented from scratch in pure
+/// Dart.
+///
+/// MD5 maps any byte sequence to a fixed 16-byte (128-bit) digest. The same
+/// input always yields the same digest; a one-bit change avalanches through the
+/// whole output; and the digest cannot be reversed to the input.
+///
+/// **Security note:** MD5 is broken for cryptographic purposes — practical
+/// collision attacks exist — so it must not be used for signatures or password
+/// storage. It remains useful as a fast, non-adversarial integrity checksum,
+/// and implementing it teaches the Merkle–Damgård construction shared by SHA-1
+/// and SHA-2.
+///
+/// ## Little-endian — the defining quirk
+///
+/// Unlike SHA-1/SHA-256, MD5 is **little-endian**: block words are read with the
+/// *first* byte as the least-significant, the length is appended as a 64-bit
+/// little-endian integer, and the digest words are emitted least-significant
+/// byte first. Getting the byte order wrong yields a completely different (and
+/// wrong) digest.
+///
+/// ## 32-bit arithmetic on a 64-bit VM
+///
+/// MD5 is defined over unsigned 32-bit words with wrap-around (mod 2³²)
+/// arithmetic and rotations. Dart's `int` is 64-bit, so every add and rotate is
+/// masked with [_mask32], and rotations use the logical (`>>>`) right shift.
+library md5;
+
+import 'dart:typed_data';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const int _mask32 = 0xFFFFFFFF;
+
+/// Initial state (A, B, C, D). In little-endian bytes these spell the counting
+/// sequence 01 23 45 67 / 89 AB CD EF / … — transparently not a backdoor.
+const List<int> _init = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476];
+
+/// The 64 sine-derived round constants: `T[i] = floor(abs(sin(i+1)) × 2³²)`.
+/// Hardcoded from RFC 1321 (Dart, like Rust `const fn`, can't call `sin` at
+/// compile time).
+const List<int> _t = [
+  0xD76AA478, 0xE8C7B756, 0x242070DB, 0xC1BDCEEE, //
+  0xF57C0FAF, 0x4787C62A, 0xA8304613, 0xFD469501,
+  0x698098D8, 0x8B44F7AF, 0xFFFF5BB1, 0x895CD7BE,
+  0x6B901122, 0xFD987193, 0xA679438E, 0x49B40821,
+  0xF61E2562, 0xC040B340, 0x265E5A51, 0xE9B6C7AA,
+  0xD62F105D, 0x02441453, 0xD8A1E681, 0xE7D3FBC8,
+  0x21E1CDE6, 0xC33707D6, 0xF4D50D87, 0x455A14ED,
+  0xA9E3E905, 0xFCEFA3F8, 0x676F02D9, 0x8D2A4C8A,
+  0xFFFA3942, 0x8771F681, 0x6D9D6122, 0xFDE5380C,
+  0xA4BEEA44, 0x4BDECFA9, 0xF6BB4B60, 0xBEBFBC70,
+  0x289B7EC6, 0xEAA127FA, 0xD4EF3085, 0x04881D05,
+  0xD9D4D039, 0xE6DB99E5, 0x1FA27CF8, 0xC4AC5665,
+  0xF4292244, 0x432AFF97, 0xAB9423A7, 0xFC93A039,
+  0x655B59C3, 0x8F0CCC92, 0xFFEFF47D, 0x85845DD1,
+  0x6FA87E4F, 0xFE2CE6E0, 0xA3014314, 0x4E0811A1,
+  0xF7537E82, 0xBD3AF235, 0x2AD7D2BB, 0xEB86D391,
+];
+
+/// Per-round left-rotation amounts, in four repeating groups of four.
+const List<int> _s = [
+  7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, //
+  5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+  4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+  6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+
+/// Rotate the 32-bit word [x] left by [s] bits.
+int _rotl(int x, int s) => ((x << s) | (x >>> (32 - s))) & _mask32;
+
+// ─── Compression ─────────────────────────────────────────────────────────────
+//
+// Fold one 64-byte block into the four-word [state] over 64 rounds. Four stages
+// use different auxiliary functions and message-word schedules:
+//   1 (FF): (b&c)|(~b&d)     g = i
+//   2 (GG): (d&b)|(~d&c)     g = (5i+1) % 16
+//   3 (HH): b^c^d            g = (3i+5) % 16
+//   4 (II): c^(b|~d)         g = (7i)   % 16
+// Each round: temp = b + ROTL(s[i], a + f + M[g] + T[i]); (a,b,c,d) ← (d,temp,b,c).
+
+Uint32List _compress(Uint32List state, Uint8List block, int offset) {
+  final m = Uint32List(16);
+  for (var i = 0; i < 16; i++) {
+    final j = offset + i * 4;
+    // Little-endian: block[j] is the least-significant byte of word i.
+    m[i] = block[j] |
+        (block[j + 1] << 8) |
+        (block[j + 2] << 16) |
+        (block[j + 3] << 24);
+  }
+
+  var a = state[0], b = state[1], c = state[2], d = state[3];
+
+  for (var i = 0; i < 64; i++) {
+    int f, g;
+    if (i < 16) {
+      f = (b & c) | (~b & d);
+      g = i;
+    } else if (i < 32) {
+      f = (d & b) | (~d & c);
+      g = (5 * i + 1) % 16;
+    } else if (i < 48) {
+      f = b ^ c ^ d;
+      g = (3 * i + 5) % 16;
+    } else {
+      f = c ^ (b | (~d & _mask32));
+      g = (7 * i) % 16;
+    }
+    f &= _mask32; // clear high bits Dart's 64-bit ~ sets above bit 31
+    final sum = (a + f + m[g] + _t[i]) & _mask32;
+    final temp = (b + _rotl(sum, _s[i])) & _mask32;
+    a = d;
+    d = c;
+    c = b;
+    b = temp;
+  }
+
+  final out = Uint32List(4);
+  out[0] = (state[0] + a) & _mask32;
+  out[1] = (state[1] + b) & _mask32;
+  out[2] = (state[2] + c) & _mask32;
+  out[3] = (state[3] + d) & _mask32;
+  return out;
+}
+
+/// Serialise the four state words into a 16-byte little-endian digest.
+Uint8List _finalize(Uint32List state) {
+  final digest = Uint8List(16);
+  for (var i = 0; i < 4; i++) {
+    final w = state[i];
+    digest[i * 4] = w & 0xFF;
+    digest[i * 4 + 1] = (w >>> 8) & 0xFF;
+    digest[i * 4 + 2] = (w >>> 16) & 0xFF;
+    digest[i * 4 + 3] = (w >>> 24) & 0xFF;
+  }
+  return digest;
+}
+
+/// Build the padded tail for a message of [totalBytes] whose unprocessed
+/// remainder is [buf]: append 0x80, zeros until length ≡ 56 (mod 64), then the
+/// original bit length as a **little-endian** 64-bit integer (RFC 1321 §3).
+Uint8List _padTail(List<int> buf, int totalBytes) {
+  final bitLen = totalBytes * 8;
+  final tail = <int>[...buf, 0x80];
+  while (tail.length % 64 != 56) {
+    tail.add(0x00);
+  }
+  for (var i = 0; i < 8; i++) {
+    tail.add((bitLen >>> (i * 8)) & 0xFF); // little-endian length
+  }
+  return Uint8List.fromList(tail);
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Compute the MD5 digest of [data] and return it as a 16-byte [Uint8List].
+Uint8List sumMd5(List<int> data) {
+  final padded = _padTail(data, data.length);
+  var state = Uint32List.fromList(_init);
+  for (var off = 0; off < padded.length; off += 64) {
+    state = _compress(state, padded, off);
+  }
+  return _finalize(state);
+}
+
+/// Compute MD5 and return the 32-character lowercase hex string.
+///
+/// ```dart
+/// hexString(utf8.encode('abc')); // '900150983cd24fb0d6963f7d28e17f72'
+/// ```
+String hexString(List<int> data) => _toHex(sumMd5(data));
+
+String _toHex(Uint8List bytes) {
+  final sb = StringBuffer();
+  for (final b in bytes) {
+    sb.write(b.toRadixString(16).padLeft(2, '0'));
+  }
+  return sb.toString();
+}
+
+/// A streaming MD5 hasher that accepts data in multiple [update] chunks and
+/// produces the same digest as the one-shot [sumMd5] over the concatenation.
+///
+/// ```dart
+/// final h = Md5Digest()..update(utf8.encode('ab'))..update(utf8.encode('c'));
+/// h.hexDigest(); // == hexString(utf8.encode('abc'))
+/// ```
+class Md5Digest {
+  Uint32List _state;
+  final List<int> _buf;
+  int _byteCount;
+
+  /// Create a new streaming hasher initialised with the MD5 constants.
+  Md5Digest()
+      : _state = Uint32List.fromList(_init),
+        _buf = <int>[],
+        _byteCount = 0;
+
+  Md5Digest._(this._state, this._buf, this._byteCount);
+
+  /// Feed more bytes into the hash. Complete 64-byte blocks are compressed
+  /// immediately; a partial block is retained until [sumMd5] is called.
+  void update(List<int> data) {
+    _byteCount += data.length;
+    _buf.addAll(data);
+    while (_buf.length >= 64) {
+      final block = Uint8List.fromList(_buf.sublist(0, 64));
+      _state = _compress(_state, block, 0);
+      _buf.removeRange(0, 64);
+    }
+  }
+
+  /// Return the 16-byte digest of all data fed so far. Non-destructive: the
+  /// hasher can keep receiving [update]s afterwards.
+  Uint8List sumMd5() {
+    final tail = _padTail(_buf, _byteCount);
+    var state = Uint32List.fromList(_state);
+    for (var off = 0; off < tail.length; off += 64) {
+      state = _compress(state, tail, off);
+    }
+    return _finalize(state);
+  }
+
+  /// Return the 32-character lowercase hex digest string.
+  String hexDigest() => _toHex(sumMd5());
+
+  /// Return an independent copy of the current hasher; hashing either the
+  /// original or the copy afterwards does not affect the other.
+  Md5Digest cloneDigest() =>
+      Md5Digest._(Uint32List.fromList(_state), List<int>.of(_buf), _byteCount);
+}

--- a/code/packages/dart/md5/pubspec.yaml
+++ b/code/packages/dart/md5/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_md5
+version: 0.1.0
+description: >
+  MD5 message-digest algorithm (RFC 1321) implemented from scratch in pure Dart.
+  One-shot sumMd5/hexString plus a streaming Md5Digest. Pure-Dart port of the
+  md5 reference package.
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/md5/test/md5_test.dart
+++ b/code/packages/dart/md5/test/md5_test.dart
@@ -1,0 +1,199 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_md5/coding_adventures_md5.dart';
+import 'package:test/test.dart';
+
+List<int> a(String s) => utf8.encode(s);
+
+void main() {
+  // ==========================================================================
+  // RFC 1321 Appendix A.5 known-answer vectors
+  // ==========================================================================
+  group('RFC 1321 vectors', () {
+    const cases = {
+      '': 'd41d8cd98f00b204e9800998ecf8427e',
+      'a': '0cc175b9c0f1b6a831c399e269772661',
+      'abc': '900150983cd24fb0d6963f7d28e17f72',
+      'message digest': 'f96b697d7cb7938d525a2f31aaf161d0',
+      'abcdefghijklmnopqrstuvwxyz': 'c3fcd3d76192e4007dfb496cca67e13b',
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789':
+          'd174ab98d277d9f5a5611c2c9f419d9f',
+      '12345678901234567890123456789012345678901234567890123456789012345678901234567890':
+          '57edf4a22be3c955ac49da2e2107b67a',
+    };
+    cases.forEach((input, expected) {
+      test('"${input.length > 20 ? '${input.substring(0, 17)}...' : input}"', () {
+        expect(hexString(a(input)), equals(expected));
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Little-endian byte order (MD5's defining quirk)
+  // ==========================================================================
+  group('little-endian', () {
+    test('digest of "a" has the expected LE byte order', () {
+      final d = sumMd5(a('a'));
+      expect(d[0], equals(0x0c));
+      expect(d[1], equals(0xc1));
+      expect(d[2], equals(0x75));
+      expect(d[3], equals(0xb9));
+    });
+
+    test('bytes 0x00..0xFF hash to the known digest', () {
+      final data = List<int>.generate(256, (i) => i);
+      expect(hexString(data), equals('e2c865db4162bed963bfaa9ef6ac18f0'));
+    });
+  });
+
+  // ==========================================================================
+  // Output format
+  // ==========================================================================
+  group('output format', () {
+    test('digest is always 16 bytes', () {
+      expect(sumMd5(a('')).length, equals(16));
+      expect(sumMd5(a('hello world')).length, equals(16));
+      expect(sumMd5(List<int>.filled(1000, 0)).length, equals(16));
+    });
+
+    test('digest is a Uint8List', () {
+      expect(sumMd5(a('abc')), isA<Uint8List>());
+    });
+
+    test('hex string is 32 lowercase hex chars', () {
+      final h = hexString(a('abc'));
+      expect(h.length, equals(32));
+      expect(RegExp(r'^[0-9a-f]{32}$').hasMatch(h), isTrue);
+    });
+  });
+
+  // ==========================================================================
+  // Core properties
+  // ==========================================================================
+  group('properties', () {
+    test('deterministic', () {
+      expect(sumMd5(a('hello')), equals(sumMd5(a('hello'))));
+    });
+
+    test('avalanche: one-char change flips many bits', () {
+      final h1 = sumMd5(a('hello'));
+      final h2 = sumMd5(a('helo'));
+      expect(h1, isNot(equals(h2)));
+      var bits = 0;
+      for (var i = 0; i < 16; i++) {
+        var x = h1[i] ^ h2[i];
+        while (x != 0) {
+          bits += x & 1;
+          x >>= 1;
+        }
+      }
+      expect(bits, greaterThan(20), reason: 'only $bits bits differed');
+    });
+
+    test('a null byte differs from the empty message', () {
+      expect(sumMd5([0x00]), isNot(equals(sumMd5(a('')))));
+    });
+
+    test('every single byte value hashes distinctly', () {
+      final seen = <String>{};
+      for (var i = 0; i <= 255; i++) {
+        seen.add(hexString([i]));
+      }
+      expect(seen.length, equals(256));
+    });
+  });
+
+  // ==========================================================================
+  // Padding / block boundaries
+  // ==========================================================================
+  group('block boundaries', () {
+    test('lengths 0,55,56,63,64,127,128 all give 16-byte digests', () {
+      for (final n in [0, 55, 56, 63, 64, 127, 128]) {
+        expect(sumMd5(List<int>.filled(n, 0)).length, equals(16));
+      }
+    });
+
+    test('55 and 56 bytes differ (padding crosses a block)', () {
+      expect(sumMd5(List<int>.filled(55, 0)),
+          isNot(equals(sumMd5(List<int>.filled(56, 0)))));
+    });
+
+    test('all seven boundary sizes are distinct', () {
+      final seen = <String>{};
+      for (final n in [0, 55, 56, 63, 64, 127, 128]) {
+        seen.add(hexString(List<int>.filled(n, 0)));
+      }
+      expect(seen.length, equals(7));
+    });
+  });
+
+  // ==========================================================================
+  // Streaming hasher
+  // ==========================================================================
+  group('Md5Digest', () {
+    test('single write matches one-shot', () {
+      final h = Md5Digest()..update(a('abc'));
+      expect(h.sumMd5(), equals(sumMd5(a('abc'))));
+    });
+
+    test('split mid-message matches one-shot', () {
+      final h = Md5Digest()
+        ..update(a('ab'))
+        ..update(a('c'));
+      expect(h.sumMd5(), equals(sumMd5(a('abc'))));
+    });
+
+    test('split on a block boundary matches one-shot', () {
+      final data = List<int>.filled(128, 0);
+      final h = Md5Digest()
+        ..update(data.sublist(0, 64))
+        ..update(data.sublist(64));
+      expect(h.sumMd5(), equals(sumMd5(data)));
+    });
+
+    test('byte-at-a-time matches one-shot', () {
+      final data = List<int>.generate(100, (i) => i);
+      final h = Md5Digest();
+      for (final b in data) {
+        h.update([b]);
+      }
+      expect(h.sumMd5(), equals(sumMd5(data)));
+    });
+
+    test('empty stream matches empty one-shot', () {
+      expect(Md5Digest().sumMd5(), equals(sumMd5(a(''))));
+    });
+
+    test('sumMd5() is non-destructive and can continue', () {
+      final h = Md5Digest()..update(a('hello'));
+      final d1 = h.sumMd5();
+      expect(d1, equals(h.sumMd5()));
+      h.update(a(' world'));
+      expect(h.sumMd5(), equals(sumMd5(a('hello world'))));
+      expect(d1, equals(sumMd5(a('hello'))));
+    });
+
+    test('hexDigest matches hexString', () {
+      final h = Md5Digest()..update(a('abc'));
+      expect(h.hexDigest(), equals(hexString(a('abc'))));
+    });
+
+    test('cloneDigest produces an independent copy', () {
+      final h = Md5Digest()..update(a('ab'));
+      final h2 = h.cloneDigest();
+      h2.update(a('c'));
+      h.update(a('x'));
+      expect(h2.sumMd5(), equals(sumMd5(a('abc'))));
+      expect(h.sumMd5(), equals(sumMd5(a('abx'))));
+    });
+
+    test('one million "a" streamed in two halves', () {
+      final data = List<int>.filled(1000000, 0x61);
+      final h = Md5Digest()
+        ..update(data.sublist(0, 500000))
+        ..update(data.sublist(500000));
+      expect(h.sumMd5(), equals(sumMd5(data)));
+    });
+  });
+}


### PR DESCRIPTION
## What

Pure-Dart port of the `md5` package — MD5 (RFC 1321) implemented from scratch, no `crypto` package, no native code. Pure-port half of the md5 pair (native binding to follow).

**Why:** `md5` is a self-contained canon package with a zero-dep Rust crate, missing from Dart, Java, and Kotlin. Dart targeted first per the weakest-language strategy.

## API (matches the Rust reference)

- `sumMd5(List<int>)` → `Uint8List` — 16-byte digest.
- `hexString(List<int>)` → `String` — 32-char lowercase hex.
- `Md5Digest` — streaming `update` / non-destructive `sumMd5` / `hexDigest` / `cloneDigest`.

## Implementation note

MD5 is **little-endian** throughout (block parsing, length field, and digest output all read least-significant byte first — the opposite of SHA-256), so the port is careful about byte order. 32-bit wrap-around arithmetic on Dart's 64-bit `int` uses `& 0xFFFFFFFF` masking, including masking `~d` in the stage-4 auxiliary function.

## Verification

- All **seven RFC 1321 Appendix A.5 vectors** pass, plus explicit little-endian byte-order checks (incl. the `0x00..0xFF` known digest).
- Determinism + avalanche, padding/block-boundary edge cases (0/55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, clone independence, one-million-'a').
- 28 tests green, `dart analyze` clean.
- Security review passed: 32-bit arithmetic correctly masked; all three little-endian paths correct and consistent; streaming `sumMd5()` non-destructive and `cloneDigest()` deep-copies — no aliasing.

> **Security note** (in docs + README): MD5 is cryptographically broken; never use it for signatures or passwords — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)