### PR TITLE
feat(sql-codegen,sql-vm): correct LEFT/RIGHT OUTER JOIN (Stream A / L2)

### DIFF
--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -34,13 +34,12 @@
 //! quietly leave stale ledger entries behind.
 //!
 //! On introduction this harness measured 12 of 22 seed cases already matching
-//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). The first has
-//! since been retired: qualified column references across an `INNER JOIN` now
-//! resolve correctly (the join threads its projection through the inner loop and
-//! keys each cursor by its effective alias). The remaining ledger entries — outer
-//! joins dropping their `ON` clause, misnamed aggregate columns, and a wrong
-//! `UPPER()` — are each a tracked increment; the harness is what makes fixing
-//! them verifiable.
+//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). Three have
+//! since been retired: `INNER JOIN` qualified-column resolution, and correct
+//! `LEFT`/`RIGHT OUTER JOIN` (NULL-padded via a per-outer-row match flag). The
+//! remaining ledger entries — `FULL JOIN`, misnamed aggregate columns, and a
+//! wrong `UPPER()` — are each a tracked increment; the harness is what makes
+//! fixing them verifiable.
 
 use coding_adventures_mini_sqlite::{connect, SqlValue};
 
@@ -398,9 +397,9 @@ const CASES: &[Case] = &[
 ///   explicit alias opens its cursor keyed under `None` while `LoadColumn` looks
 ///   it up under `Some("a")` (`sql-vm` `LoadColumn`). This breaks *even* inner
 ///   joins and is the highest-priority fix — it underlies the outer joins too.
-/// - **Outer joins** (`left_join`/`right_join`/`full_join`): `sql-codegen` drops
-///   the `ON` clause and degrades to a cross join for any non-inner kind (the
-///   `JoinKind::Inner` guard), with no NULL-padding.
+/// - **`FULL JOIN`**: needs the unmatched right rows too, which a single forward
+///   pass can't produce; still degrades to a cross product. (`LEFT`/`RIGHT` are
+///   now implemented via a per-outer-row match flag and no longer diverge.)
 /// - **Computed-column naming** (`count_star`/`sum_min_max`/`avg`/`group_by`/
 ///   `having`): the result *rows* match SQLite exactly, but mini-sqlite names an
 ///   aggregate output column `agg_N` where SQLite uses the expression text
@@ -410,16 +409,8 @@ const CASES: &[Case] = &[
 ///   the uppercased text) — a real codegen/builtin bug.
 const LEDGER: &[(&str, &str)] = &[
     (
-        "left_join",
-        "outer joins mis-compile: ON clause dropped, degrades to cross join (sql-codegen JoinKind::Inner guard); no NULL-padding.",
-    ),
-    (
-        "right_join",
-        "RIGHT JOIN not implemented; same outer-join codegen gap.",
-    ),
-    (
         "full_join",
-        "FULL JOIN not implemented; same outer-join codegen gap.",
+        "FULL JOIN needs the unmatched right rows too, which a single forward pass can't produce; still degrades to a cross product. (LEFT/RIGHT are now implemented and no longer ledgered.)",
     ),
     (
         "count_star",

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.3.0] - Unreleased
+
+### Added
+
+- **`LEFT` and `RIGHT OUTER JOIN`** now execute correctly. `compile_join_projected`
+  keeps a per-outer-row match flag (new `ClearMatch`/`SetMatch`/`JumpIfMatched`
+  instructions, requiring matching sql-vm support): for each outer row it clears
+  the flag, sets it whenever the `ON` condition holds, and after the inner loop
+  emits one NULL-padded row iff nothing matched — the NULL padding falls out
+  because `CloseScan` drops the inner cursor, so its columns read NULL while the
+  outer cursor keeps its values. `RIGHT a b` compiles as `LEFT b a` (roles swap;
+  the projection references each table by name, so the output is unchanged).
+  Verified against real SQLite by the mini-sqlite differential oracle: `left_join`
+  and `right_join` now match and are removed from the known-divergence ledger.
+- `FULL OUTER JOIN` still degrades to a cross product (a single forward pass
+  can't emit the unmatched right rows); it stays in the ledger for a later
+  increment.
+
 ## [0.2.0] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -408,6 +408,23 @@ pub enum Instruction {
     /// ## Stack effect: `[..., val] → [...]`
     JumpIfFalse(String),
 
+    // ── Outer-join match flag ─────────────────────────────────────────────────
+    //
+    // A single boolean the VM keeps to implement `LEFT`/`RIGHT JOIN`. For each
+    // outer row we `ClearMatch`, `SetMatch` inside the inner loop whenever the
+    // `ON` condition holds, and after the inner loop `JumpIfMatched` over the
+    // NULL-padded emit — so an outer row with no match still produces one row
+    // (with the inner side's columns NULL). None of these touch the value stack.
+
+    /// Reset the outer-join match flag to `false` (start of each outer row).
+    ClearMatch,
+
+    /// Set the outer-join match flag to `true` (an inner row satisfied `ON`).
+    SetMatch,
+
+    /// Jump to `label` if the outer-join match flag is currently `true`.
+    JumpIfMatched(String),
+
     /// Halt the main scan loop and signal to the VM to move to post-processing.
     ///
     /// This instruction terminates the main program.  Post-op instructions
@@ -1569,6 +1586,21 @@ impl Compiler {
     ///    columns after the join loop closed (the old `compile_scan_loop`
     ///    fallback) evaluated them with no live cursor, producing a single
     ///    all-NULL row. They belong in the per-pair body.
+    /// ## Join kinds
+    ///
+    /// - **INNER / CROSS** — the classic nested loop; a matched pair (or every
+    ///   pair, for CROSS) is projected and emitted.
+    /// - **LEFT / RIGHT OUTER** — every *outer* row must appear at least once.
+    ///   We keep a per-outer-row match flag ([`Instruction::ClearMatch`] /
+    ///   [`Instruction::SetMatch`]); after the inner loop, if nothing matched we
+    ///   emit one row with the inner side NULL. `RIGHT a b` is just `LEFT b a`
+    ///   (the outer/inner roles swap; the projection still references each table
+    ///   by name, so the output is unchanged). The NULL padding falls out for
+    ///   free: `CloseScan` drops the inner cursor's `current_row`, so its columns
+    ///   read NULL while the still-open outer cursor keeps its real values.
+    /// - **FULL OUTER** — needs the unmatched *right* rows too, which a single
+    ///   forward pass can't produce; still degrades to a cross product and stays
+    ///   in the conformance ledger (a later increment).
     fn compile_join_projected(
         &mut self,
         left: &OptimizedPlan,
@@ -1577,26 +1609,38 @@ impl Compiler {
         condition: &Option<SqlExpr>,
         columns: &[OutputColumn],
     ) {
-        // As in `compile_join`, only INNER joins evaluate the `ON` condition for
-        // now; outer joins still degrade to a cross product (tracked separately
-        // in the conformance ledger) — but their columns now resolve correctly.
-        let has_condition = condition.is_some() && *kind == JoinKind::Inner;
+        // RIGHT JOIN is LEFT JOIN with the operands swapped.
+        let (outer_plan, inner_plan) = if *kind == JoinKind::Right {
+            (right, left)
+        } else {
+            (left, right)
+        };
+        let is_outer = matches!(kind, JoinKind::Left | JoinKind::Right);
+        // INNER/LEFT/RIGHT evaluate the ON condition; CROSS has none, and FULL is
+        // (for now) degraded to a cross product — so neither evaluates it.
+        let eval_condition = condition.is_some()
+            && matches!(kind, JoinKind::Inner | JoinKind::Left | JoinKind::Right);
 
         let outer_loop = self.fresh_label("joinp_outer_loop");
         let outer_end = self.fresh_label("joinp_outer_end");
         let inner_loop = self.fresh_label("joinp_inner_loop");
         let inner_end = self.fresh_label("joinp_inner_end");
-        let cond_skip = if has_condition {
+        let cond_skip = if eval_condition {
             self.fresh_label("joinp_cond_skip")
+        } else {
+            String::new()
+        };
+        let after_null = if is_outer {
+            self.fresh_label("joinp_after_null")
         } else {
             String::new()
         };
 
         // Effective alias = explicit alias, else the table name. This is the key
         // both the cursor and the column qualifiers agree on.
-        let (outer_table, outer_alias_opt) = extract_scan_info(left);
+        let (outer_table, outer_alias_opt) = extract_scan_info(outer_plan);
         let outer_alias = Some(outer_alias_opt.unwrap_or_else(|| outer_table.clone()));
-        let (inner_table, inner_alias_opt) = extract_scan_info(right);
+        let (inner_table, inner_alias_opt) = extract_scan_info(inner_plan);
         let inner_alias = Some(inner_alias_opt.unwrap_or_else(|| inner_table.clone()));
 
         // Outer scan.
@@ -1608,6 +1652,11 @@ impl Compiler {
             outer_end.clone(),
         ));
 
+        // Outer joins start each outer row with the match flag cleared.
+        if is_outer {
+            self.emit(Instruction::ClearMatch);
+        }
+
         // Inner scan (re-opened per outer row).
         self.emit(Instruction::OpenScan(inner_table, inner_alias.clone()));
         self.emit(Instruction::Label(inner_loop.clone()));
@@ -1618,24 +1667,20 @@ impl Compiler {
         ));
 
         // Optional join condition (both cursors are live here, correctly keyed).
-        if let Some(cond) = condition {
-            if has_condition {
+        if eval_condition {
+            if let Some(cond) = condition {
                 self.compile_expr(cond);
                 self.emit(Instruction::JumpIfFalse(cond_skip.clone()));
             }
         }
 
-        // Project the matched pair: evaluate each output column against the two
-        // live cursors and emit the row.
-        self.emit(Instruction::BeginRow);
-        for col in columns {
-            self.compile_expr(&col.expr);
-            let name = output_column_name(col);
-            self.emit(Instruction::EmitColumn(name));
+        // A matched pair: record the match (for outer joins) and project the row.
+        if is_outer {
+            self.emit(Instruction::SetMatch);
         }
-        self.emit(Instruction::EmitRow);
+        self.emit_row_projection(columns);
 
-        if has_condition {
+        if eval_condition {
             self.emit(Instruction::Label(cond_skip));
         }
 
@@ -1643,9 +1688,30 @@ impl Compiler {
         self.emit(Instruction::Label(inner_end));
         self.emit(Instruction::CloseScan(inner_alias));
 
+        // Outer join: if no inner row matched this outer row, emit one row with
+        // the inner side NULL (its cursor is now closed, so its columns read
+        // NULL; the outer cursor still holds this outer row).
+        if is_outer {
+            self.emit(Instruction::JumpIfMatched(after_null.clone()));
+            self.emit_row_projection(columns);
+            self.emit(Instruction::Label(after_null));
+        }
+
         self.emit(Instruction::Jump(outer_loop));
         self.emit(Instruction::Label(outer_end));
         self.emit(Instruction::CloseScan(outer_alias));
+    }
+
+    /// Emit `BeginRow`, one `EmitColumn` per output column, then `EmitRow` —
+    /// projecting the current cursor state into one result row.
+    fn emit_row_projection(&mut self, columns: &[OutputColumn]) {
+        self.emit(Instruction::BeginRow);
+        for col in columns {
+            self.compile_expr(&col.expr);
+            let name = output_column_name(col);
+            self.emit(Instruction::EmitColumn(name));
+        }
+        self.emit(Instruction::EmitRow);
     }
 
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.2.0] - Unreleased
+
+### Added
+
+- **Outer-join match flag** — three instructions with no value-stack effect that
+  let `sql-codegen` implement `LEFT`/`RIGHT OUTER JOIN`: `ClearMatch` (reset at
+  the start of each outer row), `SetMatch` (an inner row satisfied `ON`), and
+  `JumpIfMatched` (skip the NULL-padded emit when the outer row matched). The VM
+  keeps a single `join_matched` boolean; a false condition still advances the
+  loop, so termination and stack balance are unchanged.
+
 ## [0.1.0] — 2026-07-01
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -295,6 +295,11 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
     let mut columns_locked = false;
     // Transaction handle (used by CommitTransaction / RollbackTransaction).
     let mut tx_handle: Option<u64> = None;
+    // Outer-join match flag: set true when an inner row satisfies the ON
+    // condition for the current outer row, so LEFT/RIGHT JOIN can decide whether
+    // to emit a NULL-padded row after the inner loop. See ClearMatch/SetMatch/
+    // JumpIfMatched.
+    let mut join_matched = false;
 
     // ── Phase 2: main execution loop ──────────────────────────────────────────
     //
@@ -677,6 +682,23 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
             Instruction::JumpIfTrue(label) => {
                 let v = pop(&mut stack)?;
                 if is_truthy(&v) {
+                    pc = *label_index
+                        .get(&label)
+                        .ok_or_else(|| VmError::LabelNotFound(label.clone()))?;
+                }
+            }
+
+            // ── Outer-join match flag (no stack effect) ────────────────────
+            Instruction::ClearMatch => {
+                join_matched = false;
+            }
+
+            Instruction::SetMatch => {
+                join_matched = true;
+            }
+
+            Instruction::JumpIfMatched(label) => {
+                if join_matched {
                     pc = *label_index
                         .get(&label)
                         .ok_or_else(|| VmError::LabelNotFound(label.clone()))?;


### PR DESCRIPTION
## Stream A / L2 — outer joins, oracle-verified

The differential oracle's `left_join`/`right_join` ledger entries are now retired. Previously `LEFT`/`RIGHT`/`FULL` degraded to a cross product with no NULL-padding.

### How
Correct outer joins need a per-outer-row "matched" decision, which the opcode set lacked. Adds three **no-stack-effect** instructions — `ClearMatch` / `SetMatch` / `JumpIfMatched` — backed by a single `join_matched: bool` in the VM. For an outer join, `compile_join_projected` now:
1. `ClearMatch` at the top of each outer row,
2. `SetMatch` + emit whenever the `ON` condition holds,
3. after the inner loop, `JumpIfMatched` over a single **NULL-padded** emit — reached only when nothing matched.

The NULL padding is free: `CloseScan` drops the inner cursor's `current_row`, so `LoadColumn` reads `NULL` for its columns while the still-open outer cursor keeps its real values. **`RIGHT a b` compiles as `LEFT b a`** (roles swap; the projection references each table by name, so the output is unchanged).

### Verified
- mini-sqlite differential oracle: `left_join` **and** `right_join` now **match real SQLite** and are removed from the known-divergence `LEDGER` (**9 → 7**).
- Full `cargo test` green: sql-codegen (81), sql-vm (75), mini-sqlite (45 + oracle + 11 integration).
- New code clippy + fmt clean; adversarial security review passed (control-flow trace confirmed termination, label/scan/stack balance, single-bool soundness for the supported single-level joins, no panics, opcode exhaustiveness).

`FULL JOIN` still degrades to a cross product (needs the unmatched *right* rows, which a single forward pass can't produce) and stays ledgered for a later increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)