### PR TITLE
feat(sha1): pure-Dart port (FIPS 180-4 + streaming Sha1Digest)

### DIFF
--- a/code/packages/dart/sha1/BUILD
+++ b/code/packages/dart/sha1/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/sha1/CHANGELOG.md
+++ b/code/packages/dart/sha1/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — coding_adventures_sha1
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Dart port of the `sha1` reference package.
+- `sum1(List<int>)` → `Uint8List` — 20-byte FIPS 180-4 digest.
+- `hexString(List<int>)` → `String` — 40-char lowercase hex digest.
+- `Sha1Digest` — streaming hasher with `update`, non-destructive `sum1` /
+  `hexDigest`, and `cloneDigest` for independent snapshots.
+- 32-bit wrap-around arithmetic on Dart's 64-bit `int` via `& 0xFFFFFFFF`
+  masking and logical (`>>>`) shifts; big-endian block parsing, length, output.
+- 23 unit tests: the FIPS 180-4 / RFC 3174 vectors (empty, "abc", 56-byte,
+  one-million-'a'), output-format/determinism/avalanche properties, padding
+  block-boundary edge cases (0/55/56/63/64/127/128), and streaming parity with
+  the one-shot API (byte-at-a-time, block-split, clone independence).
+- Documented security note: SHA-1 collision resistance is broken; checksum use
+  only.

--- a/code/packages/dart/sha1/README.md
+++ b/code/packages/dart/sha1/README.md
@@ -1,0 +1,51 @@
+# coding_adventures_sha1
+
+SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch in pure
+Dart — no `crypto` package, no native code.
+
+Dart port of the `sha1` package that already exists in Rust, Python, and other
+languages in the monorepo; produces byte-identical digests to those ports and to
+any conforming SHA-1.
+
+> **Security:** SHA-1 is **broken** for collision resistance (SHAttered, 2017).
+> Never use it for signatures or certificates. Legacy-protocol and
+> non-adversarial checksum use only (e.g. git object names).
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `sum1(List<int> data)` → `Uint8List` | 20-byte digest. |
+| `hexString(List<int> data)` → `String` | 40-char lowercase hex digest. |
+| `Sha1Digest` | Incremental: `update` / `sum1` / `hexDigest` / `cloneDigest`. |
+
+## Usage
+
+```dart
+import 'dart:convert';
+import 'package:coding_adventures_sha1/coding_adventures_sha1.dart';
+
+void main() {
+  print(hexString(utf8.encode('abc')));
+  // a9993e364706816aba3e25717850c26c9cd0d89d
+
+  final h = Sha1Digest();
+  h.update(utf8.encode('ab'));
+  h.update(utf8.encode('c'));
+  print(h.hexDigest()); // same digest, computed incrementally
+}
+```
+
+## How it works
+
+SHA-1 pads the message (append `0x80`, zero-fill to 56 mod 64, then the 64-bit
+**big-endian** bit length) and folds each 64-byte block into a five-word state
+through 80 rounds. It is big-endian like SHA-256 (the opposite of MD5). Because
+Dart's `int` is 64-bit, every add and rotate is masked with `& 0xFFFFFFFF`.
+
+## Running the tests
+
+```
+dart pub get
+dart test
+```

--- a/code/packages/dart/sha1/lib/coding_adventures_sha1.dart
+++ b/code/packages/dart/sha1/lib/coding_adventures_sha1.dart
@@ -1,0 +1,27 @@
+/// SHA-1 cryptographic hash (FIPS 180-4), implemented from scratch in pure Dart.
+///
+/// Provides a one-shot API ([sum1] / [hexString]) and an incremental
+/// [Sha1Digest] for streaming data.
+///
+/// **Security note:** SHA-1 is broken for collision resistance (SHAttered,
+/// 2017) — do not use it for signatures. Legacy/checksum use only.
+///
+/// ## Usage
+///
+/// ```dart
+/// import 'dart:convert';
+/// import 'package:coding_adventures_sha1/coding_adventures_sha1.dart';
+///
+/// void main() {
+///   print(hexString(utf8.encode('abc')));
+///   // a9993e364706816aba3e25717850c26c9cd0d89d
+///
+///   final h = Sha1Digest()
+///     ..update(utf8.encode('ab'))
+///     ..update(utf8.encode('c'));
+///   print(h.hexDigest()); // same digest, computed incrementally
+/// }
+/// ```
+library coding_adventures_sha1;
+
+export 'src/sha1.dart';

--- a/code/packages/dart/sha1/lib/src/sha1.dart
+++ b/code/packages/dart/sha1/lib/src/sha1.dart
@@ -1,0 +1,183 @@
+/// SHA-1 cryptographic hash function (FIPS 180-4), implemented from scratch in
+/// pure Dart.
+///
+/// SHA-1 maps any byte sequence to a fixed 20-byte (160-bit) digest. Like MD5
+/// and SHA-256 it uses the Merkle–Damgård construction over 64-byte blocks, but
+/// with five state words and 80 rounds.
+///
+/// **Security note:** SHA-1 is **broken** for collision resistance (the
+/// SHAttered attack, 2017) — do not use it for signatures or certificates. It
+/// remains in legacy protocols and as a non-adversarial checksum (e.g. git
+/// object names), and implementing it illuminates the family shared with
+/// SHA-256.
+///
+/// ## 32-bit arithmetic on a 64-bit VM
+///
+/// SHA-1 is defined over unsigned 32-bit words with wrap-around (mod 2³²)
+/// arithmetic and rotations. Dart's `int` is 64-bit, so every add and rotate is
+/// masked with [_mask32], and shifts use the logical (`>>>`) right shift.
+library sha1;
+
+import 'dart:typed_data';
+
+const int _mask32 = 0xFFFFFFFF;
+
+/// Initial state H₀..H₄ ("nothing up my sleeve" counting-sequence constants).
+const List<int> _init = [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0];
+
+/// Per-stage round constants: floor(sqrt(2,3,5,10) × 2³⁰).
+const List<int> _k = [0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6];
+
+/// Rotate the 32-bit word [x] left by [n] bits.
+int _rotl(int x, int n) => ((x << n) | (x >>> (32 - n))) & _mask32;
+
+/// Fold one 64-byte block into the five-word [state] over 80 rounds.
+Uint32List _compress(Uint32List state, Uint8List block, int offset) {
+  // Message schedule: 16 big-endian words expanded to 80.
+  final w = Uint32List(80);
+  for (var i = 0; i < 16; i++) {
+    final j = offset + i * 4;
+    w[i] = (block[j] << 24) |
+        (block[j + 1] << 16) |
+        (block[j + 2] << 8) |
+        block[j + 3];
+  }
+  for (var i = 16; i < 80; i++) {
+    w[i] = _rotl(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+  }
+
+  var a = state[0], b = state[1], c = state[2], d = state[3], e = state[4];
+
+  for (var t = 0; t < 80; t++) {
+    int f, k;
+    if (t < 20) {
+      f = (b & c) | (~b & d);
+      k = _k[0];
+    } else if (t < 40) {
+      f = b ^ c ^ d;
+      k = _k[1];
+    } else if (t < 60) {
+      f = (b & c) | (b & d) | (c & d);
+      k = _k[2];
+    } else {
+      f = b ^ c ^ d;
+      k = _k[3];
+    }
+    f &= _mask32; // clear high bits Dart's 64-bit ~ sets above bit 31
+    final temp = (_rotl(a, 5) + f + e + k + w[t]) & _mask32;
+    e = d;
+    d = c;
+    c = _rotl(b, 30);
+    b = a;
+    a = temp;
+  }
+
+  final out = Uint32List(5);
+  out[0] = (state[0] + a) & _mask32;
+  out[1] = (state[1] + b) & _mask32;
+  out[2] = (state[2] + c) & _mask32;
+  out[3] = (state[3] + d) & _mask32;
+  out[4] = (state[4] + e) & _mask32;
+  return out;
+}
+
+/// Serialise the five state words into a 20-byte big-endian digest.
+Uint8List _finalize(Uint32List state) {
+  final digest = Uint8List(20);
+  for (var i = 0; i < 5; i++) {
+    final w = state[i];
+    digest[i * 4] = (w >>> 24) & 0xFF;
+    digest[i * 4 + 1] = (w >>> 16) & 0xFF;
+    digest[i * 4 + 2] = (w >>> 8) & 0xFF;
+    digest[i * 4 + 3] = w & 0xFF;
+  }
+  return digest;
+}
+
+/// Build the padded tail: append 0x80, zeros until length ≡ 56 (mod 64), then
+/// the original bit length as a 64-bit **big-endian** integer (FIPS 180-4).
+Uint8List _padTail(List<int> buf, int totalBytes) {
+  final bitLen = totalBytes * 8;
+  final tail = <int>[...buf, 0x80];
+  while (tail.length % 64 != 56) {
+    tail.add(0x00);
+  }
+  for (var i = 7; i >= 0; i--) {
+    tail.add((bitLen >>> (i * 8)) & 0xFF); // big-endian length
+  }
+  return Uint8List.fromList(tail);
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Compute the SHA-1 digest of [data] and return it as a 20-byte [Uint8List].
+///
+/// Named `sum1` to mirror the reference crate (avoiding a clash with any `sum`).
+Uint8List sum1(List<int> data) {
+  final padded = _padTail(data, data.length);
+  var state = Uint32List.fromList(_init);
+  for (var off = 0; off < padded.length; off += 64) {
+    state = _compress(state, padded, off);
+  }
+  return _finalize(state);
+}
+
+/// Compute SHA-1 and return the 40-character lowercase hex string.
+///
+/// ```dart
+/// hexString(utf8.encode('abc')); // 'a9993e364706816aba3e25717850c26c9cd0d89d'
+/// ```
+String hexString(List<int> data) => _toHex(sum1(data));
+
+String _toHex(Uint8List bytes) {
+  final sb = StringBuffer();
+  for (final b in bytes) {
+    sb.write(b.toRadixString(16).padLeft(2, '0'));
+  }
+  return sb.toString();
+}
+
+/// A streaming SHA-1 hasher that accepts data in multiple [update] chunks and
+/// produces the same digest as the one-shot [sum1] over the concatenation.
+class Sha1Digest {
+  Uint32List _state;
+  final List<int> _buf;
+  int _byteCount;
+
+  /// Create a new streaming hasher initialised with the SHA-1 constants.
+  Sha1Digest()
+      : _state = Uint32List.fromList(_init),
+        _buf = <int>[],
+        _byteCount = 0;
+
+  Sha1Digest._(this._state, this._buf, this._byteCount);
+
+  /// Feed more bytes into the hash. Complete 64-byte blocks are compressed
+  /// immediately; a partial block is retained until [sum1] is called.
+  void update(List<int> data) {
+    _byteCount += data.length;
+    _buf.addAll(data);
+    while (_buf.length >= 64) {
+      final block = Uint8List.fromList(_buf.sublist(0, 64));
+      _state = _compress(_state, block, 0);
+      _buf.removeRange(0, 64);
+    }
+  }
+
+  /// Return the 20-byte digest of all data fed so far. Non-destructive.
+  Uint8List sum1() {
+    final tail = _padTail(_buf, _byteCount);
+    var state = Uint32List.fromList(_state);
+    for (var off = 0; off < tail.length; off += 64) {
+      state = _compress(state, tail, off);
+    }
+    return _finalize(state);
+  }
+
+  /// Return the 40-character lowercase hex digest string.
+  String hexDigest() => _toHex(sum1());
+
+  /// Return an independent copy of the current hasher.
+  Sha1Digest cloneDigest() =>
+      Sha1Digest._(Uint32List.fromList(_state), List<int>.of(_buf), _byteCount);
+}

--- a/code/packages/dart/sha1/pubspec.yaml
+++ b/code/packages/dart/sha1/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_sha1
+version: 0.1.0
+description: >
+  SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch in
+  pure Dart. One-shot sum1/hexString plus a streaming Sha1Digest. Pure-Dart
+  port of the sha1 reference package.
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/sha1/test/sha1_test.dart
+++ b/code/packages/dart/sha1/test/sha1_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coding_adventures_sha1/coding_adventures_sha1.dart';
+import 'package:test/test.dart';
+
+List<int> a(String s) => utf8.encode(s);
+
+void main() {
+  // ==========================================================================
+  // FIPS 180-4 / RFC 3174 known-answer vectors
+  // ==========================================================================
+  group('known-answer vectors', () {
+    test('empty string', () {
+      expect(hexString(a('')),
+          equals('da39a3ee5e6b4b0d3255bfef95601890afd80709'));
+    });
+    test('"abc"', () {
+      expect(hexString(a('abc')),
+          equals('a9993e364706816aba3e25717850c26c9cd0d89d'));
+    });
+    test('448-bit message (56 bytes)', () {
+      const msg = 'abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq';
+      expect(msg.length, equals(56));
+      expect(hexString(a(msg)),
+          equals('84983e441c3bd26ebaae4aa1f95129e5e54670f1'));
+    });
+    test('one million "a"', () {
+      final data = List<int>.filled(1000000, 0x61);
+      expect(hexString(data),
+          equals('34aa973cd4c4daa4f61eeb2bdbad27316534016f'));
+    });
+  });
+
+  // ==========================================================================
+  // Output format
+  // ==========================================================================
+  group('output format', () {
+    test('digest is always 20 bytes', () {
+      expect(sum1(a('')).length, equals(20));
+      expect(sum1(a('hello world')).length, equals(20));
+      expect(sum1(List<int>.filled(1000, 0)).length, equals(20));
+    });
+    test('digest is a Uint8List', () {
+      expect(sum1(a('abc')), isA<Uint8List>());
+    });
+    test('hex string is 40 lowercase hex chars', () {
+      final h = hexString(a('abc'));
+      expect(h.length, equals(40));
+      expect(RegExp(r'^[0-9a-f]{40}$').hasMatch(h), isTrue);
+    });
+  });
+
+  // ==========================================================================
+  // Core properties
+  // ==========================================================================
+  group('properties', () {
+    test('deterministic', () {
+      expect(sum1(a('hello')), equals(sum1(a('hello'))));
+    });
+    test('avalanche: one-char change flips many bits', () {
+      final h1 = sum1(a('hello'));
+      final h2 = sum1(a('helo'));
+      expect(h1, isNot(equals(h2)));
+      var bits = 0;
+      for (var i = 0; i < 20; i++) {
+        var x = h1[i] ^ h2[i];
+        while (x != 0) {
+          bits += x & 1;
+          x >>= 1;
+        }
+      }
+      expect(bits, greaterThan(30), reason: 'only $bits bits differed');
+    });
+    test('a null byte differs from the empty message', () {
+      expect(sum1([0x00]), isNot(equals(sum1(a('')))));
+    });
+    test('every single byte value hashes distinctly', () {
+      final seen = <String>{};
+      for (var i = 0; i <= 255; i++) {
+        seen.add(hexString([i]));
+      }
+      expect(seen.length, equals(256));
+    });
+  });
+
+  // ==========================================================================
+  // Padding / block boundaries
+  // ==========================================================================
+  group('block boundaries', () {
+    test('lengths 0,55,56,63,64,127,128 all give 20-byte digests', () {
+      for (final n in [0, 55, 56, 63, 64, 127, 128]) {
+        expect(sum1(List<int>.filled(n, 0)).length, equals(20));
+      }
+    });
+    test('55 and 56 bytes differ (padding crosses a block)', () {
+      expect(sum1(List<int>.filled(55, 0)),
+          isNot(equals(sum1(List<int>.filled(56, 0)))));
+    });
+    test('all seven boundary sizes are distinct', () {
+      final seen = <String>{};
+      for (final n in [0, 55, 56, 63, 64, 127, 128]) {
+        seen.add(hexString(List<int>.filled(n, 0)));
+      }
+      expect(seen.length, equals(7));
+    });
+  });
+
+  // ==========================================================================
+  // Streaming hasher
+  // ==========================================================================
+  group('Sha1Digest', () {
+    test('single write matches one-shot', () {
+      final h = Sha1Digest()..update(a('abc'));
+      expect(h.sum1(), equals(sum1(a('abc'))));
+    });
+    test('split mid-message matches one-shot', () {
+      final h = Sha1Digest()
+        ..update(a('ab'))
+        ..update(a('c'));
+      expect(h.sum1(), equals(sum1(a('abc'))));
+    });
+    test('split on a block boundary matches one-shot', () {
+      final data = List<int>.filled(128, 0);
+      final h = Sha1Digest()
+        ..update(data.sublist(0, 64))
+        ..update(data.sublist(64));
+      expect(h.sum1(), equals(sum1(data)));
+    });
+    test('byte-at-a-time matches one-shot', () {
+      final data = List<int>.generate(100, (i) => i);
+      final h = Sha1Digest();
+      for (final b in data) {
+        h.update([b]);
+      }
+      expect(h.sum1(), equals(sum1(data)));
+    });
+    test('empty stream matches empty one-shot', () {
+      expect(Sha1Digest().sum1(), equals(sum1(a(''))));
+    });
+    test('sum1() is non-destructive and can continue', () {
+      final h = Sha1Digest()..update(a('hello'));
+      final d1 = h.sum1();
+      expect(d1, equals(h.sum1()));
+      h.update(a(' world'));
+      expect(h.sum1(), equals(sum1(a('hello world'))));
+      expect(d1, equals(sum1(a('hello'))));
+    });
+    test('hexDigest matches hexString', () {
+      final h = Sha1Digest()..update(a('abc'));
+      expect(h.hexDigest(), equals(hexString(a('abc'))));
+    });
+    test('cloneDigest produces an independent copy', () {
+      final h = Sha1Digest()..update(a('ab'));
+      final h2 = h.cloneDigest();
+      h2.update(a('c'));
+      h.update(a('x'));
+      expect(h2.sum1(), equals(sum1(a('abc'))));
+      expect(h.sum1(), equals(sum1(a('abx'))));
+    });
+    test('one million "a" streamed in two halves', () {
+      final data = List<int>.filled(1000000, 0x61);
+      final h = Sha1Digest()
+        ..update(data.sublist(0, 500000))
+        ..update(data.sublist(500000));
+      expect(h.hexDigest(),
+          equals('34aa973cd4c4daa4f61eeb2bdbad27316534016f'));
+    });
+  });
+}


### PR DESCRIPTION
## What

Pure-Dart port of the `sha1` package — SHA-1 (FIPS 180-4) implemented from scratch, no `crypto` package. Pure-port half of the sha1 pair (native binding to follow). Completes the common hash family in Dart alongside `md5` and `sha256`.

**Why:** `sha1` is a self-contained canon package with a zero-dep Rust crate, missing from Dart, Java, and Kotlin.

## API (matches the Rust reference)

- `sum1(List<int>)` → `Uint8List` — 20-byte digest.
- `hexString(List<int>)` → `String` — 40-char lowercase hex.
- `Sha1Digest` — streaming `update` / non-destructive `sum1` / `hexDigest` / `cloneDigest`.

## Implementation note

SHA-1 is **big-endian** like SHA-256 (opposite of MD5); five state words, 80 rounds. 32-bit wrap-around arithmetic on Dart's 64-bit `int` uses `& 0xFFFFFFFF` masking, including masking `~b` in the stage-1 aux function.

## Verification

- **FIPS 180-4 / RFC 3174 vectors** pass (empty, `"abc"`, 56-byte, one-million-'a').
- Determinism + avalanche, padding/block-boundary edge cases (0/55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, clone independence, one-million-'a').
- 23 tests green, `dart analyze` clean.
- Security review passed: 32-bit arithmetic + both rotates correctly masked; big-endian block/length/output verified; streaming `sum1()` non-destructive, `cloneDigest()` deep-copies.

> **Security note** (docs + README): SHA-1 collision resistance is broken (SHAttered, 2017) — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)