### PR TITLE
feat(sir-go): Hash transform_values/transform_keys

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.26.0 — Hash transforming block methods: `transform_values` / `transform_keys`
+
+Mirrors the Python `sir-runtime-oop` v0.1.18 reference into the Go backend's
+emitted runtime (`_sir_hash_block_method` + `_sir_hash_responds`), adding two
+non-mutating Ruby `Hash` block methods:
+
+- `transform_values { |v| … }` — builds a **new** hash whose keys are copied
+  verbatim (so no collision is possible) and whose values are the block results.
+  Original insertion order is preserved via a straight append.
+- `transform_keys { |k| … }` — builds a **new** hash whose values are untouched
+  and whose keys are the block results.  Two source keys can map to the SAME new
+  key; Ruby keeps the **last** colliding entry's value, so every write is routed
+  through `_sir_map_put`, which overwrites an existing key in place.
+
+Both yield exactly ONE block argument (the value / the key) and leave the
+receiver unmodified.  `_sir_hash_responds` now also advertises the pre-existing
+`each_key` / `each_value` block methods (previously reachable but not reported by
+`respond_to?`).
+
+Exec-proof: `tests/compile_and_run_hash_methods.rs` gains a `transform_values`
+case ({a:1,b:2} → {a: 99, b: 99}) and a `transform_keys` **collision** case
+({a:1,b:2} with a constant `:z` key → {z: 2}), compiled and run under real
+`go run` with stdout diffed against the Python/TS reference semantics.
+
 ## 0.25.0 — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
 
 Mirrors the Python `sir-runtime-oop` v0.1.17 reference into the Go backend's

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -184,7 +184,8 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `sort`, `join`, `to_a`, `each`, `map`/`collect`, `select`/`filter`, `reject`,
 `reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`; **Hash** `keys`,
 `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `size`/
-`length`, `empty?`, `each`/`each_pair`, `map`, `select`/`filter`, `reject`;
+`length`, `empty?`, `each`/`each_pair`, `each_key`, `each_value`, `map`,
+`select`/`filter`, `reject`, `transform_values`, `transform_keys`;
 **String** `length`/`size`, `upcase`, `downcase`, `reverse`, `strip`/`lstrip`/
 `rstrip`, `empty?`, `include?`, `start_with?`, `end_with?`, `split`, `chars`,
 `to_i`, `to_f`, `to_sym`; **Numeric** `abs`, `to_i`, `to_f`, `even?`, `odd?`,

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1716,7 +1716,8 @@ func _sir_hash_responds(name string) bool {
 		"has_value?", "value?", "size", "length", "empty?", "fetch":
 		return true
 	// Block-taking Hash methods.
-	case "each", "each_pair", "map", "select", "filter", "reject":
+	case "each", "each_pair", "each_key", "each_value", "map",
+		"select", "filter", "reject", "transform_values", "transform_keys":
 		return true
 	}
 	return false
@@ -2541,6 +2542,28 @@ func _sir_hash_block_method(recv *Map, name string, args []Value, block *Closure
 			if !_sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
 				m.Entries = append(m.Entries, MapEntry{Key: e.Key, Val: e.Val})
 			}
+		}
+		return m, true
+	case "transform_values":
+		// Ruby `Hash#transform_values` yields ONE argument (the value) per
+		// entry and builds a NEW hash whose keys are untouched and whose
+		// values are the block results. Because the keys are copied verbatim
+		// and stay distinct, no collision can occur — a straight append keeps
+		// the original insertion order.
+		m := &Map{Entries: make([]MapEntry, 0, len(recv.Entries))}
+		for _, e := range recv.Entries {
+			m.Entries = append(m.Entries, MapEntry{Key: e.Key, Val: _sir_apply(block, []Value{e.Val})})
+		}
+		return m, true
+	case "transform_keys":
+		// Ruby `Hash#transform_keys` yields ONE argument (the key) per entry
+		// and builds a NEW hash whose values are untouched and whose keys are
+		// the block results. Two source keys can map to the SAME new key; Ruby
+		// keeps the LAST such entry's value, so we route every write through
+		// `_sir_map_put`, which overwrites an existing key in place.
+		m := &Map{Entries: make([]MapEntry, 0, len(recv.Entries))}
+		for _, e := range recv.Entries {
+			_sir_map_put(m, _sir_apply(block, []Value{e.Key}), e.Val)
 		}
 		return m, true
 	}

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
@@ -1,7 +1,8 @@
 //! End-to-end proof for the **Ruby `Hash` method catalog** in the Go
 //! backend — the newly-added `merge`, `to_a`, `dig`, `invert`, `delete`,
 //! `store`/`[]=`, `clear`, and the block methods `each_key` / `each_value`
-//! (plus the pre-existing `each_pair`), bringing the Go runtime to parity
+//! (plus the pre-existing `each_pair`) and the transforming block methods
+//! `transform_values` / `transform_keys`, bringing the Go runtime to parity
 //! with the Python/TS `sir-runtime-oop` catalogs.
 //!
 //! Like `compile_and_run_coll_methods.rs`, this hand-builds SIR modules that
@@ -133,6 +134,12 @@ fn catalog_module() -> Module {
         "x",
         builtin("print", vec![var_p("x")]),
     );
+    // `transform_values` replaces every value with the block result; a constant
+    // body makes the expected hash trivially predictable ({a: 99, b: 99}).
+    let const99 = lambda_fn("__lam_const99", "v", ilit(99));
+    // `transform_keys` collapses BOTH keys onto the single symbol `:z`; Ruby
+    // keeps the LAST colliding entry's value, so {a:1,b:2} → {z: 2}.
+    let const_z = lambda_fn("__lam_const_z", "k", sym("z"));
 
     let stmts = vec![
         // {a:1}.merge({b:2}) → {a: 1, b: 2}   (fresh hash, other appended)
@@ -187,6 +194,18 @@ fn catalog_module() -> Module {
             "each_key",
             vec![closure("__lam_print_x")],
         )),
+        // {a:1,b:2}.transform_values { 99 } → {a: 99, b: 99}   (keys untouched)
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2)]),
+            "transform_values",
+            vec![closure("__lam_const99")],
+        )),
+        // {a:1,b:2}.transform_keys { :z } → {z: 2}   (collision → last value wins)
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2)]),
+            "transform_keys",
+            vec![closure("__lam_const_z")],
+        )),
     ];
 
     let main = Function {
@@ -200,7 +219,7 @@ fn catalog_module() -> Module {
         span: s(),
     };
 
-    program(vec![print_x, main])
+    program(vec![print_x, const99, const_z, main])
 }
 
 fn go_available() -> bool {
@@ -261,6 +280,8 @@ fn hash_methods_compile_and_run() {
             "a",                // each_key yields a
             "b",                // each_key yields b
             "{a: 1, b: 2}",     // each_key returns self
+            "{a: 99, b: 99}",   // transform_values (keys untouched)
+            "{z: 2}",           // transform_keys (collision → last value wins)
         ],
         "unexpected stdout:\n{stdout}"
     );


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.18 reference (#7909) into the **Go backend** (`semantic-ir-to-go`) emitted runtime, adding two non-mutating Ruby `Hash` block methods to `_sir_hash_block_method`:

- **`transform_values { |v| … }`** — builds a new hash; keys copied verbatim (already unique ⇒ no collision possible), values are block results, insertion order preserved via straight append.
- **`transform_keys { |k| … }`** — builds a new hash; values untouched, keys are block results. Two source keys can collapse onto one new key; Ruby keeps the **last** colliding entry's value, so every write routes through `_sir_map_put` (last-wins, order-preserving).

`_sir_hash_responds` now also advertises the pre-existing `each_key`/`each_value` block methods (previously reachable but not reported by `respond_to?`).

## Exec-proof

`tests/compile_and_run_hash_methods.rs` gains:
- `transform_values` → `{a:1,b:2}` with a constant `99` block ⇒ `{a: 99, b: 99}` (keys untouched)
- `transform_keys` **collision** → `{a:1,b:2}` with a constant `:z` block ⇒ `{z: 2}` (last value wins)

Compiled and run under real `go run`, stdout diffed against the Python/TS reference semantics. `cargo test -p semantic-ir-to-go --test compile_and_run_hash_methods` passes.

## Checklist
- [x] CHANGELOG.md (0.25.0 → **0.26.0**)
- [x] README.md Hash catalog updated
- [x] Exec-proof green under `go run`
- [x] Security review passed (no findings)

Part of the SIR Ruby→{…} full-parity effort. One-PR-per-crate mirror; reference = #7909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)