### PR TITLE
feat(scaffold): C/C++ package templates wired to iso-harness (CCPP01 PR4)

### DIFF
--- a/code/programs/go/scaffold-generator/CHANGELOG.md
+++ b/code/programs/go/scaffold-generator/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this program will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **C and C++ scaffold templates** (`--language c` / `--language cpp`). Generates
+  a pure-ISO package wired to the shared iso-harness: `BUILD`
+  (`# build-tool: deps=c/iso-harness` + `sh tools/run.sh`), `BUILD_windows`
+  (PowerShell/MSVC), `tools/run.sh` + `tools/run.ps1` that locate the harness by
+  walking up the tree and compile under every present compiler, an
+  `include/` header (C: `.h` + `src/.c`; C++: header-only `.hpp`), a
+  `tests/…_test.{c,cpp}` using the header-only `iso_test.h`, and a `.gitignore`
+  for `_build/`. C/C++ have no package manifest, so `readDeps` returns an empty
+  set (deps go in the BUILD comment). See
+  `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`.
+
 ## [1.1.0] - 2026-03-25
 
 ### Added

--- a/code/programs/go/scaffold-generator/main.go
+++ b/code/programs/go/scaffold-generator/main.go
@@ -53,7 +53,7 @@ import (
 // =========================================================================
 
 // validLanguages lists all supported target languages.
-var validLanguages = []string{"python", "go", "ruby", "typescript", "rust", "elixir", "perl", "lua", "swift", "haskell", "java", "kotlin"}
+var validLanguages = []string{"python", "go", "ruby", "typescript", "rust", "elixir", "perl", "lua", "swift", "haskell", "java", "kotlin", "c", "cpp"}
 
 // kebabCaseRe validates that a package name is kebab-case:
 // lowercase letters and digits, segments separated by single hyphens.
@@ -159,6 +159,13 @@ func readDeps(pkgDir, lang string) ([]string, error) {
 		return readJavaDeps(pkgDir)
 	case "kotlin":
 		return readKotlinDeps(pkgDir)
+	case "c", "cpp":
+		// C and C++ packages have no package manifest; their dependencies are
+		// declared inline in the BUILD file via a `# build-tool: deps=…` comment.
+		// The scaffold does not auto-discover inter-package C/C++ deps — a fresh
+		// package starts with just the iso-harness toolchain dep (baked into the
+		// generated BUILD), and any further deps are added to that comment by hand.
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown language: %s", lang)
 	}
@@ -1993,6 +2000,219 @@ class %sTest {
 // Common files (README, CHANGELOG)
 // =========================================================================
 
+// =========================================================================
+// File generation — C and C++ (pure ISO, multi-compiler via iso-harness)
+// =========================================================================
+//
+// C and C++ packages have no package manifest. They declare their toolchain
+// dependency on the shared iso-harness inline in BUILD (`# build-tool: deps=…`)
+// and build through it, so the generated sources are compiled by GCC, Clang,
+// AND MSVC under strict ISO conformance flags. See
+// code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md.
+//
+// The generated tools/run.sh and tools/run.ps1 locate the harness by walking up
+// to the repo directory that contains code/packages/c/iso-harness, so the same
+// template works whether the package lives under code/packages/ or code/programs/
+// and regardless of the C-vs-C++ subdirectory depth.
+
+// isoRunSh renders the POSIX run script shared by C and C++ packages. `lang` is
+// "c" or "cpp"; `sources` is the space-separated source list passed to the
+// harness (e.g. "tests/foo_test.c src/foo.c").
+func isoRunSh(pkgName, symbol, lang, sources string) string {
+	return fmt.Sprintf(`#!/bin/sh
+# Build and run the %s tests under EVERY available C/C++ compiler (pure ISO),
+# via the shared iso-harness (code/packages/c/iso-harness).
+set -e
+SELF=$(cd "$(dirname "$0")/.." && pwd)
+cd "$SELF"
+
+# Locate the iso-harness by walking up to the repo dir that contains it.
+d="$SELF"
+while [ "$d" != "/" ] && [ ! -d "$d/code/packages/c/iso-harness" ]; do
+    d=$(dirname "$d")
+done
+HARNESS="$d/code/packages/c/iso-harness"
+if [ ! -f "$HARNESS/lib/iso-lib.sh" ]; then
+    echo "iso-harness not found (searched upward from $SELF)" >&2
+    exit 1
+fi
+
+# Include both this package's headers and the harness's (for iso_test.h).
+ISO_INCLUDE="include $HARNESS/include"
+export ISO_INCLUDE
+
+# On Linux CI both gcc and clang are installed — require both so the pure-ISO
+# guarantee is firm rather than best-effort. Locally, use whatever is present.
+if [ "${CI:-}" = "true" ] && [ "$(uname)" = "Linux" ]; then
+    ISO_REQUIRE="gcc clang"
+    export ISO_REQUIRE
+fi
+
+. "$HARNESS/lib/iso-lib.sh"
+iso_build_and_run %s %s-tests %s
+`, pkgName, lang, symbol, sources)
+}
+
+// isoRunPs1 renders the Windows/MSVC run script shared by C and C++ packages.
+// `sources` is a comma-separated, quoted PowerShell array body (e.g.
+// `"tests\foo_test.c", "src\foo.c"`).
+func isoRunPs1(pkgName, symbol, lang, sources string) string {
+	return fmt.Sprintf(`# Build and run the %s tests under MSVC (cl.exe) — pure ISO C/C++ — via the
+# shared iso-harness (code\packages\c\iso-harness).
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$self = Split-Path -Parent $PSScriptRoot
+Set-Location $self
+
+# Locate the iso-harness by walking up to the repo dir that contains it.
+$d = $self
+while ($d -and -not (Test-Path (Join-Path $d 'code\packages\c\iso-harness'))) {
+    $d = Split-Path -Parent $d
+}
+if (-not $d) { throw 'iso-harness not found (searched upward from ' + $self + ')' }
+$harness = Join-Path $d 'code\packages\c\iso-harness'
+
+$env:ISO_INCLUDE = "include $harness\include"
+. (Join-Path $harness 'lib\iso-lib.ps1')
+Iso-BuildAndRun -Lang %s -Name %s-tests -Sources @(%s)
+`, pkgName, lang, symbol, sources)
+}
+
+// generateC scaffolds a pure-ISO C17 library: a header, a source file, and a
+// test built through the iso-harness under gcc, clang, and MSVC.
+func generateC(targetDir, pkgName, description, layerCtx string) error {
+	symbol := toSnakeCase(pkgName)
+	guard := strings.ToUpper(symbol) + "_H"
+
+	header := fmt.Sprintf(`/*
+ * %s.h — %s
+ *
+ * Part of the coding-adventures monorepo.%s
+ *
+ * This is pure ISO C17: it compiles under GCC, Clang, and MSVC with
+ * -pedantic-errors / /permissive- and warnings-as-errors. Keep it that way —
+ * no compiler extensions.
+ */
+#ifndef %s
+#define %s
+
+/* Returns a friendly, non-zero value — proof the library links and runs.
+ * Replace this with the package's real API. */
+int %s_answer(void);
+
+#endif /* %s */
+`, symbol, description, layerCtx, guard, guard, symbol, guard)
+
+	source := fmt.Sprintf(`#include "%s.h"
+
+int %s_answer(void) {
+    return 42;
+}
+`, symbol, symbol)
+
+	test := fmt.Sprintf(`/* Tests for %s, using the header-only iso_test.h harness (pure ISO). */
+#include "iso_test.h"
+
+#include "%s.h"
+
+int main(void) {
+    ISO_CHECK_EQ_INT(%s_answer(), 42);
+    return ISO_TEST_RESULT();
+}
+`, pkgName, symbol, symbol)
+
+	build := "# build-tool: deps=c/iso-harness\nsh tools/run.sh\n"
+	buildWin := "powershell -NoProfile -ExecutionPolicy Bypass -File tools\\run.ps1\n"
+	runSh := isoRunSh(pkgName, symbol, "c", fmt.Sprintf("tests/%s_test.c src/%s.c", symbol, symbol))
+	runPs1 := isoRunPs1(pkgName, symbol, "c", fmt.Sprintf("\"tests\\%s_test.c\", \"src\\%s.c\"", symbol, symbol))
+
+	return writeCFamilyFiles(targetDir, map[string]string{
+		filepath.Join("include", symbol+".h"):     header,
+		filepath.Join("src", symbol+".c"):         source,
+		filepath.Join("tests", symbol+"_test.c"):  test,
+		"BUILD":                                   build,
+		"BUILD_windows":                           buildWin,
+		filepath.Join("tools", "run.sh"):          runSh,
+		filepath.Join("tools", "run.ps1"):         runPs1,
+		".gitignore":                              "_build/\n",
+	})
+}
+
+// generateCpp scaffolds a pure-ISO C++17 header-only library plus a test built
+// through the iso-harness under g++, clang++, and MSVC.
+func generateCpp(targetDir, pkgName, description, layerCtx string) error {
+	symbol := toSnakeCase(pkgName)
+	guard := strings.ToUpper(symbol) + "_HPP"
+
+	header := fmt.Sprintf(`// %s.hpp — %s
+//
+// Part of the coding-adventures monorepo.%s
+//
+// This is pure ISO C++17: it compiles under GCC, Clang, and MSVC with
+// -pedantic-errors / /permissive- and warnings-as-errors. Keep it that way —
+// no compiler extensions.
+#ifndef %s
+#define %s
+
+namespace %s {
+
+// Returns a friendly value — proof the header compiles and links.
+// Replace this with the package's real API.
+inline int answer() {
+    return 42;
+}
+
+}  // namespace %s
+
+#endif  // %s
+`, symbol, description, layerCtx, guard, guard, symbol, symbol, guard)
+
+	test := fmt.Sprintf(`// Tests for %s, using the header-only iso_test.h harness (pure ISO).
+#include "iso_test.h"
+
+#include "%s.hpp"
+
+int main() {
+    ISO_CHECK_EQ_INT(%s::answer(), 42);
+    return ISO_TEST_RESULT();
+}
+`, pkgName, symbol, symbol)
+
+	build := "# build-tool: deps=c/iso-harness\nsh tools/run.sh\n"
+	buildWin := "powershell -NoProfile -ExecutionPolicy Bypass -File tools\\run.ps1\n"
+	runSh := isoRunSh(pkgName, symbol, "cpp", fmt.Sprintf("tests/%s_test.cpp", symbol))
+	runPs1 := isoRunPs1(pkgName, symbol, "cpp", fmt.Sprintf("\"tests\\%s_test.cpp\"", symbol))
+
+	return writeCFamilyFiles(targetDir, map[string]string{
+		filepath.Join("include", symbol+".hpp"):    header,
+		filepath.Join("tests", symbol+"_test.cpp"): test,
+		"BUILD":                                    build,
+		"BUILD_windows":                            buildWin,
+		filepath.Join("tools", "run.sh"):           runSh,
+		filepath.Join("tools", "run.ps1"):          runPs1,
+		".gitignore":                               "_build/\n",
+	})
+}
+
+// writeCFamilyFiles creates each file's parent directory and writes it. Scripts
+// under tools/ are made executable; everything else is 0644.
+func writeCFamilyFiles(targetDir string, files map[string]string) error {
+	for path, content := range files {
+		full := filepath.Join(targetDir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return err
+		}
+		mode := os.FileMode(0o644)
+		if strings.HasSuffix(path, ".sh") {
+			mode = 0o755
+		}
+		if err := os.WriteFile(full, []byte(content), mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func generateCommonFiles(targetDir, pkgName, description, lang string, layer int, directDeps []string) error {
 	today := time.Now().Format("2006-01-02")
 
@@ -2213,6 +2433,14 @@ func scaffold(cfg scaffoldConfig, lang string, stdout, stderr io.Writer) error {
 		}
 	case "kotlin":
 		if err := generateKotlin(targetDir, cfg.packageName, cfg.description, layerCtx, cfg.directDeps); err != nil {
+			return err
+		}
+	case "c":
+		if err := generateC(targetDir, cfg.packageName, cfg.description, layerCtx); err != nil {
+			return err
+		}
+	case "cpp":
+		if err := generateCpp(targetDir, cfg.packageName, cfg.description, layerCtx); err != nil {
 			return err
 		}
 	}

--- a/code/programs/go/scaffold-generator/main_test.go
+++ b/code/programs/go/scaffold-generator/main_test.go
@@ -953,3 +953,147 @@ func TestRefusesToOverwrite(t *testing.T) {
 		t.Errorf("stderr should mention directory already exists, got: %s", stderr.String())
 	}
 }
+
+// =========================================================================
+// File generation tests — C and C++ (pure ISO, iso-harness)
+// =========================================================================
+
+func TestGenerateC(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := generateC(tmpDir, "ring-buf", "A ring buffer", ""); err != nil {
+		t.Fatalf("generateC: %v", err)
+	}
+
+	// Header, source, and test use snake_case filenames/symbols derived from the
+	// kebab package name.
+	header, err := os.ReadFile(filepath.Join(tmpDir, "include", "ring_buf.h"))
+	if err != nil {
+		t.Fatalf("cannot read header: %v", err)
+	}
+	if !strings.Contains(string(header), "#ifndef RING_BUF_H") {
+		t.Error("header missing include guard")
+	}
+	if !strings.Contains(string(header), "int ring_buf_answer(void);") {
+		t.Error("header missing API declaration")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "src", "ring_buf.c")); err != nil {
+		t.Error("source file missing")
+	}
+	test, err := os.ReadFile(filepath.Join(tmpDir, "tests", "ring_buf_test.c"))
+	if err != nil {
+		t.Fatalf("cannot read test: %v", err)
+	}
+	if !strings.Contains(string(test), "#include \"iso_test.h\"") {
+		t.Error("test does not use the iso_test.h harness")
+	}
+
+	// BUILD declares the iso-harness toolchain dep and runs the POSIX script.
+	build, err := os.ReadFile(filepath.Join(tmpDir, "BUILD"))
+	if err != nil {
+		t.Fatalf("cannot read BUILD: %v", err)
+	}
+	if !strings.Contains(string(build), "# build-tool: deps=c/iso-harness") {
+		t.Error("BUILD missing iso-harness dependency comment")
+	}
+	if !strings.Contains(string(build), "sh tools/run.sh") {
+		t.Error("BUILD does not invoke tools/run.sh")
+	}
+
+	// BUILD_windows drives the MSVC path via PowerShell.
+	buildWin, err := os.ReadFile(filepath.Join(tmpDir, "BUILD_windows"))
+	if err != nil {
+		t.Fatalf("cannot read BUILD_windows: %v", err)
+	}
+	if !strings.Contains(string(buildWin), "tools\\run.ps1") {
+		t.Error("BUILD_windows does not invoke tools/run.ps1")
+	}
+
+	// run.sh locates the harness by walking up and compiles the C sources.
+	runSh, err := os.ReadFile(filepath.Join(tmpDir, "tools", "run.sh"))
+	if err != nil {
+		t.Fatalf("cannot read run.sh: %v", err)
+	}
+	if !strings.Contains(string(runSh), "code/packages/c/iso-harness") {
+		t.Error("run.sh does not reference the iso-harness location")
+	}
+	if !strings.Contains(string(runSh), "iso_build_and_run c ring_buf-tests tests/ring_buf_test.c src/ring_buf.c") {
+		t.Error("run.sh does not invoke iso_build_and_run with the expected C sources")
+	}
+
+	// _build/ is ignored so compiled artifacts never get committed.
+	gitignore, err := os.ReadFile(filepath.Join(tmpDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("cannot read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gitignore), "_build/") {
+		t.Error(".gitignore does not ignore _build/")
+	}
+}
+
+func TestGenerateCpp(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := generateCpp(tmpDir, "static-vector", "A fixed-capacity vector", ""); err != nil {
+		t.Fatalf("generateCpp: %v", err)
+	}
+
+	// Header-only: a .hpp under include/ with a namespaced inline API, and NO src/.
+	header, err := os.ReadFile(filepath.Join(tmpDir, "include", "static_vector.hpp"))
+	if err != nil {
+		t.Fatalf("cannot read header: %v", err)
+	}
+	if !strings.Contains(string(header), "#ifndef STATIC_VECTOR_HPP") {
+		t.Error("header missing include guard")
+	}
+	if !strings.Contains(string(header), "namespace static_vector") {
+		t.Error("header missing namespace")
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "src")); !os.IsNotExist(err) {
+		t.Error("C++ header-only package should not create a src/ directory")
+	}
+
+	test, err := os.ReadFile(filepath.Join(tmpDir, "tests", "static_vector_test.cpp"))
+	if err != nil {
+		t.Fatalf("cannot read test: %v", err)
+	}
+	if !strings.Contains(string(test), "static_vector::answer()") {
+		t.Error("test does not call the generated API")
+	}
+
+	runSh, err := os.ReadFile(filepath.Join(tmpDir, "tools", "run.sh"))
+	if err != nil {
+		t.Fatalf("cannot read run.sh: %v", err)
+	}
+	if !strings.Contains(string(runSh), "iso_build_and_run cpp static_vector-tests tests/static_vector_test.cpp") {
+		t.Error("run.sh does not invoke iso_build_and_run with the expected C++ source")
+	}
+}
+
+// C and C++ must be accepted by the language validator and produce packages
+// under the c/ and cpp/ buckets.
+func TestCFamilyLanguagesAreValid(t *testing.T) {
+	for _, lang := range []string{"c", "cpp"} {
+		found := false
+		for _, vl := range validLanguages {
+			if vl == lang {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%q missing from validLanguages", lang)
+		}
+	}
+}
+
+// readDeps must not error for C/C++ (they have no manifest; deps live in the
+// BUILD comment). It returns an empty dependency set.
+func TestReadDepsCFamilyIsEmpty(t *testing.T) {
+	for _, lang := range []string{"c", "cpp"} {
+		deps, err := readDeps(t.TempDir(), lang)
+		if err != nil {
+			t.Errorf("readDeps(%q) errored: %v", lang, err)
+		}
+		if len(deps) != 0 {
+			t.Errorf("readDeps(%q) = %v, want empty", lang, deps)
+		}
+	}
+}

--- a/code/programs/go/scaffold-generator/scaffold-generator.json
+++ b/code/programs/go/scaffold-generator/scaffold-generator.json
@@ -5,7 +5,10 @@
   "description": "Generate CI-ready package scaffolding for the coding-adventures monorepo",
   "version": "1.0.0",
   "parsing_mode": "gnu",
-  "builtin_flags": { "help": true, "version": true },
+  "builtin_flags": {
+    "help": true,
+    "version": true
+  },
   "flags": [
     {
       "id": "type",
@@ -13,14 +16,17 @@
       "long": "type",
       "description": "Package type: 'library' goes in code/packages/, 'program' goes in code/programs/",
       "type": "enum",
-      "enum_values": ["library", "program"],
+      "enum_values": [
+        "library",
+        "program"
+      ],
       "default": "library"
     },
     {
       "id": "language",
       "short": "l",
       "long": "language",
-      "description": "Target language(s). Comma-separated or 'all' for all 10 languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell",
+      "description": "Target language(s). Comma-separated or 'all'. Languages: python, go, ruby, typescript, rust, elixir, perl, lua, swift, haskell, java, kotlin, c, cpp",
       "type": "string",
       "default": "all"
     },


### PR DESCRIPTION
## Summary

PR4 of ~5 for the **C/C++ multi-compiler ISO lane** (spec: `code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md`). Builds on the merged PR1–PR2 and the harness in [#7913](https://github.com/adhithyan15/coding-adventures/pull/7913).

Teaches the **scaffold-generator** to emit pure-ISO C and C++ packages wired to the iso-harness, so new C/C++ packages are correct-by-construction (compiled under GCC + Clang + MSVC, strict conformance).

### Changes
- `--language c`: `include/<sym>.h` + `src/<sym>.c` + `tests/<sym>_test.c`.
- `--language cpp`: header-only `include/<sym>.hpp` + `tests/<sym>_test.cpp`.
- Both get: `BUILD` (`# build-tool: deps=c/iso-harness` + `sh tools/run.sh`), `BUILD_windows` (PowerShell/MSVC), `tools/run.sh` + `tools/run.ps1` that locate the harness by walking up the tree and set `ISO_INCLUDE` (+ `ISO_REQUIRE="gcc clang"` on Linux CI), and a `.gitignore` for `_build/`. Tests use the header-only `iso_test.h`.
- `validLanguages` += `c`, `cpp`; `readDeps` returns empty for c/cpp (deps live in the BUILD comment — no manifest); CLI spec language list refreshed.

### Verification
- **End-to-end**: generated a C and a C++ package, compiled+ran them via the harness under gcc/clang/g++/clang++ locally — all pass.
- New unit tests cover file layout, the iso-harness dep wiring, run-script contents, `readDeps`, and language validity. `go test ./...` + `go vet` green.

### Security review
Passed (1 round): package name is kebab-validated before interpolation (no shell metacharacters reach the generated scripts); `description`/`layerCtx` only appear in comments, never executed; no path traversal in written paths.

> Note: `tools/run.sh` references `c/iso-harness`, which lands in #7913 — merge that first (or together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
