### PR TITLE
feat(heap): pure-Dart port (MinHeap/MaxHeap + heap algorithms)

### DIFF
--- a/code/packages/dart/heap/BUILD
+++ b/code/packages/dart/heap/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/heap/CHANGELOG.md
+++ b/code/packages/dart/heap/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — coding_adventures_heap
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Dart port of the `heap` reference package.
+- `MinHeap<T>` / `MaxHeap<T>` — array-backed binary heaps with `push`, `pop`,
+  `peek`, `isEmpty`, `length`, `toList`, and an O(n) `fromIterable` constructor.
+- Companion algorithms: `heapify`, `heapSort`, `nLargest`, `nSmallest`
+  (the last two use a bounded heap of size n, O(m log n)).
+- Ordering defaults to natural `Comparable` order; an optional `Comparator<T>`
+  orders by any key.
+- 22 unit tests: ascending/descending pop order, peek/empty behaviour,
+  duplicates, heap-property validation of `fromIterable`, string and
+  custom-comparator ordering, and companion-algorithm correctness against manual
+  sorts.

--- a/code/packages/dart/heap/README.md
+++ b/code/packages/dart/heap/README.md
@@ -1,0 +1,53 @@
+# coding_adventures_heap
+
+Array-backed binary heaps and companion algorithms, in pure Dart.
+
+Dart port of the `heap` package that already exists in Rust, Java, Kotlin, and
+other languages in the monorepo.
+
+## What it provides
+
+| Type / function | Purpose |
+|---|---|
+| `MinHeap<T>` | Binary heap with the smallest element at the root. |
+| `MaxHeap<T>` | Binary heap with the largest element at the root. |
+| `heapify(items)` | Heap-ordered array (as a `MinHeap` stores it). |
+| `heapSort(items)` | Ascending sort via repeated min-heap pops. |
+| `nLargest(items, n)` | The `n` largest, descending — bounded-heap, O(m log n). |
+| `nSmallest(items, n)` | The `n` smallest, ascending. |
+
+Heaps support `push`, `pop`, `peek`, `isEmpty`, `length`, `toList`, and a
+`fromIterable` constructor that heapifies in O(n).
+
+## Ordering
+
+Ordering defaults to the natural order of the elements (`int`, `double`,
+`String`, …). Pass a `Comparator<T>` to order by any key:
+
+```dart
+// Min-heap keyed by string length:
+final h = MinHeap<String>((a, b) => a.length.compareTo(b.length));
+```
+
+## Usage
+
+```dart
+import 'package:coding_adventures_heap/coding_adventures_heap.dart';
+
+void main() {
+  final h = MinHeap<int>()..push(5)..push(1)..push(3);
+  print(h.pop()); // 1
+  print(h.pop()); // 3
+
+  print(heapSort([3, 1, 2]));           // [1, 2, 3]
+  print(nLargest([5, 1, 4, 2, 3], 2));  // [5, 4]
+  print(nSmallest([5, 1, 4, 2, 3], 2)); // [1, 2]
+}
+```
+
+## Running the tests
+
+```
+dart pub get
+dart test
+```

--- a/code/packages/dart/heap/lib/coding_adventures_heap.dart
+++ b/code/packages/dart/heap/lib/coding_adventures_heap.dart
@@ -1,0 +1,21 @@
+/// Array-backed binary heaps ([MinHeap], [MaxHeap]) and companion algorithms
+/// ([heapify], [heapSort], [nLargest], [nSmallest]), in pure Dart.
+///
+/// Ordering defaults to natural order (`int`, `double`, `String`, …); pass a
+/// [Comparator] to order by any key.
+///
+/// ```dart
+/// import 'package:coding_adventures_heap/coding_adventures_heap.dart';
+///
+/// void main() {
+///   final h = MinHeap<int>()..push(5)..push(1)..push(3);
+///   print(h.pop()); // 1
+///   print(h.pop()); // 3
+///
+///   print(heapSort([3, 1, 2]));        // [1, 2, 3]
+///   print(nLargest([5, 1, 4, 2, 3], 2)); // [5, 4]
+/// }
+/// ```
+library coding_adventures_heap;
+
+export 'src/heap.dart';

--- a/code/packages/dart/heap/lib/src/heap.dart
+++ b/code/packages/dart/heap/lib/src/heap.dart
@@ -1,0 +1,216 @@
+/// Array-backed binary heaps and companion algorithms, in pure Dart.
+///
+/// A binary heap is a complete binary tree stored in a flat list: the children
+/// of index `i` live at `2i+1` and `2i+2`. A [MinHeap] keeps the smallest
+/// element at the root; a [MaxHeap] keeps the largest. Both give O(log n) push
+/// and pop and O(1) peek.
+///
+/// Ordering defaults to the natural order of the elements (via
+/// [Comparable.compare]), so `int`, `double`, and `String` work out of the box.
+/// Pass a custom [Comparator] to order by any key.
+library heap;
+
+/// A comparator that orders elements by their natural [Comparable] order.
+Comparator<T> _naturalOrder<T>() =>
+    (a, b) => Comparable.compare(a as Comparable, b as Comparable);
+
+// ─── Internal sift/build helpers ─────────────────────────────────────────────
+//
+// All three take a `higherPriority(a, b)` predicate — "should a sit above b?".
+// For a min-heap that is `a < b`; for a max-heap `a > b`. Everything else about
+// the heap machinery is identical, so the two heap types share this code.
+
+void _siftUp<T>(List<T> data, int index, bool Function(T, T) higherPriority) {
+  while (index > 0) {
+    final parent = (index - 1) ~/ 2;
+    if (higherPriority(data[index], data[parent])) {
+      final tmp = data[index];
+      data[index] = data[parent];
+      data[parent] = tmp;
+      index = parent;
+    } else {
+      break;
+    }
+  }
+}
+
+void _siftDown<T>(List<T> data, int index, bool Function(T, T) higherPriority) {
+  final len = data.length;
+  while (true) {
+    final left = 2 * index + 1;
+    final right = 2 * index + 2;
+    var best = index;
+    if (left < len && higherPriority(data[left], data[best])) best = left;
+    if (right < len && higherPriority(data[right], data[best])) best = right;
+    if (best == index) break;
+    final tmp = data[index];
+    data[index] = data[best];
+    data[best] = tmp;
+    index = best;
+  }
+}
+
+void _buildHeap<T>(List<T> data, bool Function(T, T) higherPriority) {
+  if (data.length < 2) return;
+  for (var index = (data.length - 2) ~/ 2; index >= 0; index--) {
+    _siftDown(data, index, higherPriority);
+  }
+}
+
+/// Shared implementation of both heaps, parameterised by a priority predicate.
+abstract class _Heap<T> {
+  final List<T> _data = <T>[];
+  final Comparator<T> _compare;
+
+  _Heap(Comparator<T>? compare) : _compare = compare ?? _naturalOrder<T>();
+
+  /// True when [a] should sit above [b] in this heap. Subclasses pick the sign.
+  bool _higherPriority(T a, T b);
+
+  void _fill(Iterable<T> items) {
+    _data.addAll(items);
+    _buildHeap(_data, _higherPriority);
+  }
+
+  /// Insert [value], restoring the heap property in O(log n).
+  void push(T value) {
+    _data.add(value);
+    _siftUp(_data, _data.length - 1, _higherPriority);
+  }
+
+  /// Remove and return the root (smallest for [MinHeap], largest for [MaxHeap]),
+  /// or `null` when the heap is empty.
+  T? pop() {
+    if (_data.isEmpty) return null;
+    final last = _data.removeLast();
+    if (_data.isEmpty) return last;
+    final root = _data[0];
+    _data[0] = last;
+    _siftDown(_data, 0, _higherPriority);
+    return root;
+  }
+
+  /// The root element without removing it, or `null` when empty.
+  T? peek() => _data.isEmpty ? null : _data[0];
+
+  /// True when the heap has no elements.
+  bool get isEmpty => _data.isEmpty;
+
+  /// The number of elements in the heap.
+  int get length => _data.length;
+
+  /// A copy of the underlying array (heap order, not sorted).
+  List<T> toList() => List<T>.of(_data);
+}
+
+/// A binary heap whose root is always the **smallest** element.
+class MinHeap<T> extends _Heap<T> {
+  /// Create an empty min-heap ordered by [compare] (natural order if omitted).
+  MinHeap([Comparator<T>? compare]) : super(compare);
+
+  /// Build a min-heap from [items] in O(n) via bottom-up heapification.
+  factory MinHeap.fromIterable(Iterable<T> items, [Comparator<T>? compare]) {
+    final h = MinHeap<T>(compare);
+    h._fill(items);
+    return h;
+  }
+
+  @override
+  bool _higherPriority(T a, T b) => _compare(a, b) < 0;
+
+  @override
+  String toString() => isEmpty
+      ? 'MinHeap(size=0, root=empty)'
+      : 'MinHeap(size=$length, root=${peek()})';
+}
+
+/// A binary heap whose root is always the **largest** element.
+class MaxHeap<T> extends _Heap<T> {
+  /// Create an empty max-heap ordered by [compare] (natural order if omitted).
+  MaxHeap([Comparator<T>? compare]) : super(compare);
+
+  /// Build a max-heap from [items] in O(n) via bottom-up heapification.
+  factory MaxHeap.fromIterable(Iterable<T> items, [Comparator<T>? compare]) {
+    final h = MaxHeap<T>(compare);
+    h._fill(items);
+    return h;
+  }
+
+  @override
+  bool _higherPriority(T a, T b) => _compare(a, b) > 0;
+
+  @override
+  String toString() => isEmpty
+      ? 'MaxHeap(size=0, root=empty)'
+      : 'MaxHeap(size=$length, root=${peek()})';
+}
+
+// ─── Companion algorithms ────────────────────────────────────────────────────
+
+/// Return the heap-ordered array of [items] (as a [MinHeap] would store them).
+List<T> heapify<T>(Iterable<T> items, [Comparator<T>? compare]) =>
+    MinHeap<T>.fromIterable(items, compare).toList();
+
+/// Return [items] sorted ascending, by repeatedly popping a min-heap
+/// (heapsort, O(n log n)).
+List<T> heapSort<T>(Iterable<T> items, [Comparator<T>? compare]) {
+  final heap = MinHeap<T>.fromIterable(items, compare);
+  final result = <T>[];
+  while (!heap.isEmpty) {
+    result.add(heap.pop() as T);
+  }
+  return result;
+}
+
+/// Return the [n] largest elements of [iterable], in descending order.
+///
+/// Uses a bounded min-heap of size `n`, so it is O(m log n) for `m` items —
+/// much cheaper than a full sort when `n ≪ m`.
+List<T> nLargest<T>(Iterable<T> iterable, int n, [Comparator<T>? compare]) {
+  final cmp = compare ?? _naturalOrder<T>();
+  if (n <= 0) return <T>[];
+  final items = List<T>.of(iterable);
+  if (n >= items.length) {
+    items.sort((a, b) => cmp(b, a)); // descending
+    return items;
+  }
+  final heap = MinHeap<T>.fromIterable(items.sublist(0, n), cmp);
+  for (final value in items.sublist(n)) {
+    final top = heap.peek();
+    if (top == null || cmp(value, top) > 0) {
+      heap.pop();
+      heap.push(value);
+    }
+  }
+  final result = <T>[];
+  while (!heap.isEmpty) {
+    result.add(heap.pop() as T);
+  }
+  return result.reversed.toList();
+}
+
+/// Return the [n] smallest elements of [iterable], in ascending order.
+///
+/// Uses a bounded max-heap of size `n` (the mirror of [nLargest]).
+List<T> nSmallest<T>(Iterable<T> iterable, int n, [Comparator<T>? compare]) {
+  final cmp = compare ?? _naturalOrder<T>();
+  if (n <= 0) return <T>[];
+  final items = List<T>.of(iterable);
+  if (n >= items.length) {
+    items.sort(cmp); // ascending
+    return items;
+  }
+  final heap = MaxHeap<T>.fromIterable(items.sublist(0, n), cmp);
+  for (final value in items.sublist(n)) {
+    final top = heap.peek();
+    if (top == null || cmp(value, top) < 0) {
+      heap.pop();
+      heap.push(value);
+    }
+  }
+  final result = <T>[];
+  while (!heap.isEmpty) {
+    result.add(heap.pop() as T);
+  }
+  return result.reversed.toList();
+}

--- a/code/packages/dart/heap/pubspec.yaml
+++ b/code/packages/dart/heap/pubspec.yaml
@@ -1,0 +1,14 @@
+name: coding_adventures_heap
+version: 0.1.0
+description: >
+  Array-backed binary heaps (MinHeap, MaxHeap) and companion algorithms
+  (heapify, heapSort, nLargest, nSmallest) in pure Dart. Pure-Dart port of the
+  heap reference package.
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/heap/test/heap_test.dart
+++ b/code/packages/dart/heap/test/heap_test.dart
@@ -1,0 +1,176 @@
+import 'package:coding_adventures_heap/coding_adventures_heap.dart';
+import 'package:test/test.dart';
+
+/// Validate that [values] satisfies the min-heap property.
+bool isValidMinHeap(List<int> values) {
+  for (var i = 0; i < values.length; i++) {
+    final l = 2 * i + 1, r = 2 * i + 2;
+    if (l < values.length && values[i] > values[l]) return false;
+    if (r < values.length && values[i] > values[r]) return false;
+  }
+  return true;
+}
+
+void main() {
+  // ==========================================================================
+  // MinHeap
+  // ==========================================================================
+  group('MinHeap', () {
+    test('pops in ascending order', () {
+      final h = MinHeap<int>();
+      for (final v in [5, 3, 8, 1, 9, 2, 7]) {
+        h.push(v);
+      }
+      final out = <int>[];
+      while (!h.isEmpty) {
+        out.add(h.pop()!);
+      }
+      expect(out, equals([1, 2, 3, 5, 7, 8, 9]));
+    });
+
+    test('peek returns the smallest without removing it', () {
+      final h = MinHeap<int>()..push(4)..push(2)..push(6);
+      expect(h.peek(), equals(2));
+      expect(h.length, equals(3));
+    });
+
+    test('pop and peek on empty return null', () {
+      final h = MinHeap<int>();
+      expect(h.isEmpty, isTrue);
+      expect(h.pop(), isNull);
+      expect(h.peek(), isNull);
+    });
+
+    test('single element', () {
+      final h = MinHeap<int>()..push(42);
+      expect(h.pop(), equals(42));
+      expect(h.isEmpty, isTrue);
+    });
+
+    test('fromIterable builds a valid heap with the min at the root', () {
+      final h = MinHeap<int>.fromIterable([9, 4, 7, 1, 8, 2, 6, 3, 5]);
+      expect(h.peek(), equals(1));
+      expect(isValidMinHeap(h.toList()), isTrue);
+      expect(h.length, equals(9));
+    });
+
+    test('handles duplicates', () {
+      final h = MinHeap<int>.fromIterable([3, 1, 3, 1, 2, 2]);
+      final out = <int>[];
+      while (!h.isEmpty) {
+        out.add(h.pop()!);
+      }
+      expect(out, equals([1, 1, 2, 2, 3, 3]));
+    });
+
+    test('toString reports size and root', () {
+      expect(MinHeap<int>().toString(), equals('MinHeap(size=0, root=empty)'));
+      expect((MinHeap<int>()..push(7)).toString(),
+          equals('MinHeap(size=1, root=7)'));
+    });
+  });
+
+  // ==========================================================================
+  // MaxHeap
+  // ==========================================================================
+  group('MaxHeap', () {
+    test('pops in descending order', () {
+      final h = MaxHeap<int>();
+      for (final v in [5, 3, 8, 1, 9, 2, 7]) {
+        h.push(v);
+      }
+      final out = <int>[];
+      while (!h.isEmpty) {
+        out.add(h.pop()!);
+      }
+      expect(out, equals([9, 8, 7, 5, 3, 2, 1]));
+    });
+
+    test('fromIterable puts the max at the root', () {
+      final h = MaxHeap<int>.fromIterable([9, 4, 7, 1, 8]);
+      expect(h.peek(), equals(9));
+    });
+  });
+
+  // ==========================================================================
+  // Custom comparator & other element types
+  // ==========================================================================
+  group('ordering', () {
+    test('works with strings (natural order)', () {
+      final h = MinHeap<String>.fromIterable(['pear', 'apple', 'fig']);
+      expect(h.pop(), equals('apple'));
+      expect(h.pop(), equals('fig'));
+    });
+
+    test('custom comparator: min-heap by string length', () {
+      final h = MinHeap<String>((a, b) => a.length.compareTo(b.length))
+        ..push('ccc')
+        ..push('a')
+        ..push('bb');
+      expect(h.pop(), equals('a'));
+      expect(h.pop(), equals('bb'));
+      expect(h.pop(), equals('ccc'));
+    });
+  });
+
+  // ==========================================================================
+  // Companion algorithms
+  // ==========================================================================
+  group('heapify', () {
+    test('produces a valid min-heap array', () {
+      final arr = heapify([9, 4, 7, 1, 8, 2]);
+      expect(isValidMinHeap(arr), isTrue);
+      expect(arr.length, equals(6));
+      expect(arr.first, equals(1));
+    });
+    test('empty input', () {
+      expect(heapify(<int>[]), isEmpty);
+    });
+  });
+
+  group('heapSort', () {
+    test('sorts ascending', () {
+      expect(heapSort([3, 1, 4, 1, 5, 9, 2, 6]), equals([1, 1, 2, 3, 4, 5, 6, 9]));
+    });
+    test('empty and single', () {
+      expect(heapSort(<int>[]), isEmpty);
+      expect(heapSort([7]), equals([7]));
+    });
+    test('already sorted and reversed', () {
+      expect(heapSort([1, 2, 3, 4]), equals([1, 2, 3, 4]));
+      expect(heapSort([4, 3, 2, 1]), equals([1, 2, 3, 4]));
+    });
+  });
+
+  group('nLargest', () {
+    test('returns the n largest in descending order', () {
+      expect(nLargest([5, 1, 4, 2, 3], 2), equals([5, 4]));
+      expect(nLargest([5, 1, 4, 2, 3], 3), equals([5, 4, 3]));
+    });
+    test('n == 0 gives empty, n >= length gives full descending sort', () {
+      expect(nLargest([3, 1, 2], 0), isEmpty);
+      expect(nLargest([3, 1, 2], 5), equals([3, 2, 1]));
+    });
+    test('matches a manual sort for random-ish data', () {
+      final data = [42, 7, 19, 88, 3, 61, 25, 88, 7];
+      final sortedDesc = [...data]..sort((a, b) => b.compareTo(a));
+      expect(nLargest(data, 4), equals(sortedDesc.take(4).toList()));
+    });
+  });
+
+  group('nSmallest', () {
+    test('returns the n smallest in ascending order', () {
+      expect(nSmallest([5, 1, 4, 2, 3], 2), equals([1, 2]));
+      expect(nSmallest([5, 1, 4, 2, 3], 3), equals([1, 2, 3]));
+    });
+    test('n == 0 gives empty, n >= length gives full ascending sort', () {
+      expect(nSmallest([3, 1, 2], 0), isEmpty);
+      expect(nSmallest([3, 1, 2], 5), equals([1, 2, 3]));
+    });
+    test('matches a manual sort for random-ish data', () {
+      final data = [42, 7, 19, 88, 3, 61, 25, 88, 7];
+      final sortedAsc = [...data]..sort();
+      expect(nSmallest(data, 4), equals(sortedAsc.take(4).toList()));
+    });
+  });
+}


### PR DESCRIPTION
## What

Pure-Dart port of the `heap` package — array-backed binary heaps and companion algorithms. Pure-port half of the heap pair (native binding to follow).

**Why this one:** it adds **data-structure breadth** to the campaign (previously cipher, hashes, ML activations). `heap` is a self-contained canon package missing from Dart (present in Java/Kotlin/Rust).

## API (matches the Rust reference)

- `MinHeap<T>` / `MaxHeap<T>` — `push`, `pop`, `peek`, `isEmpty`, `length`, `toList`, and an O(n) `fromIterable` constructor.
- `heapify`, `heapSort`, `nLargest`, `nSmallest` (the last two use a bounded heap of size `n`, O(m log n)).

Rust's `T: Ord` becomes an optional `Comparator<T>` defaulting to natural `Comparable` order, so `int`/`double`/`String` work out of the box and custom keys are supported. The sift-up/sift-down/build-heap machinery is shared between both heaps, parameterised by a higher-priority predicate (min: `a<b`, max: `a>b`).

## Verification

- 22 tests — ascending/descending pop order, peek/empty behaviour, duplicates, heap-property validation of `fromIterable`, string + custom-comparator ordering, and companion-algorithm correctness vs manual sorts.
- `dart analyze` clean.
- Security review passed: no index-OOB in the sift/build math, correct pop on single/empty heaps, correct `nLargest`/`nSmallest` bounds and ordering, all loops bounded (no DoS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)