### PR TITLE
feat(sir-rust): Hash transform_values/transform_keys

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.27.0 — Hash transforming block methods: `transform_values` / `transform_keys`
+
+Mirrors the Python `sir-runtime-oop` v0.1.18 reference (PR #7909) into the
+Rust backend's inline `__sir` runtime (`map_method` + the `Value::Map`
+`responds_to?` arm), adding two non-mutating Ruby `Hash` block methods:
+
+- `transform_values { |v| … }` — builds a **new** hash whose keys are copied
+  verbatim (so they stay unique and no collision is possible) and whose values
+  are the block results.  Yields ONE block argument (the value); insertion order
+  is preserved by rebuilding in place.
+- `transform_keys { |k| … }` — builds a **new** hash whose values are untouched
+  and whose keys are the block results (yields ONE argument, the key).  Two
+  source keys can collapse onto one new key; Ruby keeps the **last** colliding
+  entry's value while holding the new key at its **first-seen** position, so we
+  overwrite an existing slot in place (via `value_eq`) and otherwise append.
+
+Both leave the receiver unmodified.
+
+Exec-proof: new `tests/compile_and_run_hash_transform.rs` compiles and runs
+(under real `rustc`) a module exercising `transform_values` ({a:1,b:2} → {a: 99,
+b: 99}), an identity `transform_keys` ({a:1,b:2} → {a: 1, b: 2}), and a
+**collision** `transform_keys` (constant `:z` key ⇒ {z: 2}), diffing stdout
+against the Python/TS reference semantics.
+
 ## 0.26.0 — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
 
 Mirrors the Python `sir-runtime-oop` v0.1.17 reference (and the Go backend

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -143,7 +143,7 @@ rather than panicking:
     `pop`, `include?`, `reverse`, `sort`, `join`, `map`, `select`/`filter`,
     `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`.
   - **Hash** (`Map`): `keys`, `values`, `size`, `has_key?`, `each`, `map`,
-    `select`.
+    `select`, `transform_values`, `transform_keys`.
   - **String** (`Str`): `length`, `upcase`, `downcase`, `reverse`, `strip`,
     `include?`, `split`, char-set `tr`/`count`/`delete`/`squeeze` (literal
     sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1475,7 +1475,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                 name,
                 "keys" | "values" | "[]" | "size" | "length" | "has_key?" | "key?" | "include?"
                     | "member?" | "fetch" | "each" | "each_pair" | "map" | "collect" | "select"
-                    | "filter"
+                    | "filter" | "transform_values" | "transform_keys"
             ),
             Value::Str(_) => matches!(
                 name,
@@ -2233,6 +2233,43 @@ pub const RUNTIME: &str = r##"mod __sir {
                         .filter(|(k, v)| truthy(&apply_closure(b, vec![k.clone(), v.clone()])))
                         .collect();
                     Value::Map(Rc::new(RefCell::new(kept)))
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `Hash#transform_values { |v| … }` — a NEW hash whose keys are
+            // copied verbatim and whose values are the block results.  The
+            // block yields ONE argument (the value); the keys are untouched, so
+            // they stay unique and a straight rebuild preserves insertion order.
+            // Non-mutating — `recv` is never edited in place.
+            "transform_values" => match &block {
+                Some(b) => {
+                    let out: Vec<(Value, Value)> = entries_rc
+                        .borrow()
+                        .clone()
+                        .into_iter()
+                        .map(|(k, v)| (k, apply_closure(b, vec![v])))
+                        .collect();
+                    Value::Map(Rc::new(RefCell::new(out)))
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `Hash#transform_keys { |k| … }` — a NEW hash whose values are
+            // untouched and whose keys are the block results (yields ONE
+            // argument, the key).  Two source keys can map to the SAME new key;
+            // Ruby keeps the LAST such entry's value while holding the new key
+            // at its FIRST-seen position, so we overwrite an existing slot in
+            // place (`value_eq` match) and otherwise append.
+            "transform_keys" => match &block {
+                Some(b) => {
+                    let mut out: Vec<(Value, Value)> = Vec::new();
+                    for (k, v) in entries_rc.borrow().clone() {
+                        let nk = apply_closure(b, vec![k]);
+                        match out.iter_mut().find(|(ek, _)| value_eq(ek, &nk)) {
+                            Some(slot) => slot.1 = v,
+                            None => out.push((nk, v)),
+                        }
+                    }
+                    Value::Map(Rc::new(RefCell::new(out)))
                 }
                 None => unknown_method(&recv, name),
             },

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_transform.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_transform.rs
@@ -1,0 +1,235 @@
+//! End-to-end proof for the Rust backend's **`Hash#transform_values` /
+//! `Hash#transform_keys`** block methods, mirroring the Python
+//! `sir-runtime-oop` reference (PR #7909).
+//!
+//! Both are non-mutating: they build a FRESH hash and yield exactly ONE block
+//! argument per entry —
+//!
+//!   * `transform_values { |v| … }` replaces every value with the block result
+//!     while copying keys verbatim (keys stay unique ⇒ no collision), so
+//!     `{a:1, b:2}.transform_values { 99 }` ⇒ `{a: 99, b: 99}`.
+//!   * `transform_keys { |k| … }` replaces every key with the block result
+//!     while leaving values untouched.  Two source keys can collapse onto one
+//!     new key; Ruby keeps the LAST such entry's value at the FIRST-seen
+//!     position, so `{a:1, b:2}.transform_keys { :z }` ⇒ `{z: 2}`.
+//!
+//! The test hand-builds SIR modules that exercise these arms, emits Rust,
+//! compiles it with `rustc`, runs the binary, and diffs stdout against the
+//! values the Python/TS reference produces for the SAME operations.
+//!
+//! Like the sibling exec-proof tests, a missing `rustc`/linker logs a skip
+//! rather than reddening the build; the host may point at a working linker via
+//! `SIR_TEST_RUSTC_LINKER` (e.g. the toolchain's bundled `rust-lld`).
+
+use std::process::Command;
+
+use semantic_ir::nodes::MapEntry;
+use semantic_ir::{
+    Block, CaptureValue, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn symlit(v: &str) -> Expr {
+    Expr::SymLit { name: v.into(), span: s() }
+}
+
+fn param(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, slit(name)];
+    all.append(&mut args);
+    Expr::BuiltinCall { name: "__method__".into(), args: all, effects: EffectSet::PURE, span: s() }
+}
+
+/// A no-capture block closure over a top-level block function.
+fn block(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: Vec::<CaptureValue>::new(), span: s() }
+}
+
+/// `{k: v, …}` from `(key, value)` expression pairs.
+fn map_lit(entries: Vec<(Expr, Expr)>) -> Expr {
+    Expr::MapLit {
+        entries: entries.into_iter().map(|(key, value)| MapEntry { key, value }).collect(),
+        span: s(),
+    }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+fn block_fn(name: &str, params: &[&str], value: Expr) -> Function {
+    Function {
+        name: name.into(),
+        params: params
+            .iter()
+            .map(|p| semantic_ir::Param {
+                name: (*p).into(),
+                kind: semantic_ir::ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            })
+            .collect(),
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
+    let mut functions = vec![Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }];
+    functions.extend(block_fns);
+
+    Module {
+        name: "hash_transform_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Symbols,
+            Feature::Closures,
+            // Block-body functions have untyped params.
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// `{a: 1, b: 2}` with symbol keys (so the printed form is `a`/`b`, matching
+/// Ruby's surface — a `Symbol` renders bare).
+fn ab_map() -> Expr {
+    map_lit(vec![(symlit("a"), ilit(1)), (symlit("b"), ilit(2))])
+}
+
+fn transform_demo() -> Module {
+    let block_fns = vec![
+        // transform_values { |v| 99 } — constant body ⇒ predictable values.
+        block_fn("__blk_const99", &["v"], ilit(99)),
+        // transform_keys { |k| k } — identity ⇒ a faithful, non-colliding copy.
+        block_fn("__blk_id", &["k"], param("k")),
+        // transform_keys { |k| :z } — constant key ⇒ every entry collides.
+        block_fn("__blk_const_z", &["k"], symlit("z")),
+    ];
+
+    let main_stmts = vec![
+        // 1. {a:1,b:2}.transform_values { 99 } → {a: 99, b: 99}  (keys untouched)
+        print_stmt(method(ab_map(), "transform_values", vec![block("__blk_const99")])),
+        // 2. {a:1,b:2}.transform_keys { |k| k } → {a: 1, b: 2}  (values untouched)
+        print_stmt(method(ab_map(), "transform_keys", vec![block("__blk_id")])),
+        // 3. {a:1,b:2}.transform_keys { :z } → {z: 2}  (collision → last value wins)
+        print_stmt(method(ab_map(), "transform_keys", vec![block("__blk_const_z")])),
+    ];
+
+    demo_module(main_stmts, block_fns)
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+#[test]
+fn hash_transform_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&transform_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_hash_transform_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_hash_transform_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out =
+        cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "{a: 99, b: 99}", // transform_values (keys untouched)
+            "{a: 1, b: 2}",   // transform_keys identity (values untouched)
+            "{z: 2}",         // transform_keys collision (last value wins)
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.18 reference (#7909) into the **Rust backend** (`semantic-ir-to-rust`) inline `__sir` runtime, adding two non-mutating Ruby `Hash` block methods to `map_method` (+ the `Value::Map` `respond_to?` arm):

- **`transform_values { |v| … }`** — builds a new hash; keys copied verbatim (already unique ⇒ no collision), values are block results, insertion order preserved. Yields ONE block arg (the value).
- **`transform_keys { |k| … }`** — builds a new hash; values untouched, keys are block results (yields ONE arg, the key). Two source keys can collapse onto one new key; Ruby keeps the **last** colliding value at the **first-seen** position, so an existing slot is overwritten in place (via `value_eq`) and otherwise appended.

Both leave the receiver unmodified.

## Exec-proof

New `tests/compile_and_run_hash_transform.rs` compiles + runs (real `rustc`):
- `transform_values` → `{a:1,b:2}` with a constant `99` block ⇒ `{a: 99, b: 99}` (keys untouched)
- identity `transform_keys` → `{a:1,b:2}` ⇒ `{a: 1, b: 2}` (values untouched, non-colliding)
- **collision** `transform_keys` → `{a:1,b:2}` with a constant `:z` block ⇒ `{z: 2}` (last value wins)

stdout diffed against the Python/TS reference semantics. `cargo test -p semantic-ir-to-rust --test compile_and_run_hash_transform` passes; clippy-clean.

## Checklist
- [x] CHANGELOG.md (0.26.0 → **0.27.0**)
- [x] README.md Hash catalog updated
- [x] Exec-proof green under `rustc`
- [x] Security review passed (no new findings; the LOW re-entrant-borrow note is pre-existing and identical across all sibling Map block arms)

Part of the SIR Ruby→{…} full-parity effort. One-PR-per-crate mirror; reference = #7909. Go mirror was #7917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)