### PR TITLE
feat(sir-js): Hash transform_values/transform_keys

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.26.0 — Hash transforming block methods: `transform_values` / `transform_keys`
+
+Mirrors the Python `sir-runtime-oop` v0.1.18 reference (PR #7909) into the
+JavaScript backend's emitted runtime (`hashMethod` + the `HASH_METHODS`
+`respond_to?` set), adding two non-mutating Ruby `Hash` block methods:
+
+- `transform_values { |v| … }` — builds a **new** `Map` whose keys are copied
+  verbatim (unique ⇒ no collision) and whose values are the block results.
+  Yields ONE block argument (the value); insertion order is preserved.
+- `transform_keys { |k| … }` — builds a **new** `Map` whose values are untouched
+  and whose keys are the block results (yields ONE argument, the key).  Two
+  source keys can collapse onto one new key; Ruby keeps the **last** colliding
+  entry's value at the **first-seen** position — which is exactly how native
+  `Map.set` behaves on an existing key (updates the value, keeps the slot).
+
+Both leave the receiver unmodified (a non-function block returns a shallow copy
+of the receiver, matching the sibling `select`/`reject` arms).
+
+Exec-proof: `tests/run_with_node.rs` gains `hash_transform_values_and_keys`,
+running under real `node` a `transform_values` case
+(`{a:1,b:2}.transform_values { 99 }.to_a` → `[[a, 99], [b, 99]]`), an identity
+`transform_keys` (→ `[[a, 1], [b, 2]]`), and a **collision** `transform_keys`
+(constant `"z"` key ⇒ `[[z, 2]]`), diffed against the Python/TS reference.
+
 ## 0.25.0 — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`
 
 Mirrors the Python `sir-runtime-oop` v0.1.17 reference (and the Go v0.25.0 /

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -924,7 +924,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "keys", "values", "size", "length", "empty?", "has_key?", "key?",
     "include?", "member?", "has_value?", "value?", "to_a", "merge", "dig",
     "invert", "delete", "store", "[]=", "fetch", "clear", "each", "each_pair",
-    "map", "select", "filter", "reject",
+    "map", "select", "filter", "reject", "transform_values", "transform_keys",
   ]);
   function hashMethod(recv, name, args) {
     switch (name) {
@@ -1017,6 +1017,29 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           const t = truthy(blk(k, v));
           if (keepWhenTruthy ? t : !t) { out.set(k, v); }
         }
+        return out;
+      }
+      case "transform_values": {
+        // Ruby `Hash#transform_values { |v| … }`: a NEW hash whose keys are
+        // copied verbatim and whose values are the block results.  The block
+        // yields ONE argument (the value); keys stay untouched (and unique, so
+        // no collision) and insertion order is preserved.  Non-mutating.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return new Map(recv); }
+        const out = new Map();
+        for (const [k, v] of recv) { out.set(k, blk(v)); }
+        return out;
+      }
+      case "transform_keys": {
+        // Ruby `Hash#transform_keys { |k| … }`: a NEW hash whose values are
+        // untouched and whose keys are the block results (yields ONE argument,
+        // the key).  Two source keys can map to the SAME new key; Ruby keeps the
+        // LAST such entry's value at the FIRST-seen position — which is exactly
+        // how `Map.set` behaves on an existing key (updates value, keeps slot).
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return new Map(recv); }
+        const out = new Map();
+        for (const [k, v] of recv) { out.set(blk(k), v); }
         return out;
       }
     }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2479,6 +2479,89 @@ fn hash_catalog_methods() {
     }
 }
 
+// ── Ruby Hash transforming block methods: transform_values/transform_keys ──
+//
+// Both are non-mutating and yield exactly ONE block argument per entry:
+//   * `transform_values { |v| … }` → new hash, keys copied verbatim (unique ⇒
+//     no collision), values replaced by the block result.
+//   * `transform_keys { |k| … }` → new hash, values untouched, keys replaced by
+//     the block result; two source keys colliding onto one new key keep the
+//     LAST value at the FIRST-seen position (native `Map.set` semantics).
+// Results are read back via `to_a` (a Map has no faithful `format`, but
+// `to_a` yields observable `[key, value]` Arrays), mirroring the Python
+// reference (#7909).
+#[test]
+fn hash_transform_values_and_keys() {
+    let mk = |pairs: Vec<(&str, Expr)>| Expr::MapLit {
+        entries: pairs
+            .into_iter()
+            .map(|(k, v)| MapEntry { key: str_(k), value: v })
+            .collect(),
+        span: sp(),
+    };
+    let ab = || mk(vec![("a", int(1)), ("b", int(2))]);
+    let block_fns = vec![
+        // transform_values { |v| 99 } — constant body ⇒ predictable values.
+        func("__ht_v99", vec![param("v")], vec![], int(99)),
+        // transform_keys { |k| k } — identity ⇒ faithful, non-colliding copy.
+        func("__ht_kid", vec![param("k")], vec![], param_ref("k")),
+        // transform_keys { |k| "z" } — constant key ⇒ every entry collides.
+        func("__ht_kz", vec![param("k")], vec![], str_("z")),
+    ];
+    let stmts = vec![
+        // {a:1,b:2}.transform_values { 99 }.to_a → [[a, 99], [b, 99]]  (keys kept)
+        print(method(
+            method(ab(), "transform_values", vec![method_closure("__ht_v99")]),
+            "to_a",
+            vec![],
+        )),
+        // {a:1,b:2}.transform_keys { |k| k }.to_a → [[a, 1], [b, 2]]  (values kept)
+        print(method(
+            method(ab(), "transform_keys", vec![method_closure("__ht_kid")]),
+            "to_a",
+            vec![],
+        )),
+        // {a:1,b:2}.transform_keys { "z" }.to_a → [[z, 2]]  (collision → last wins)
+        print(method(
+            method(ab(), "transform_keys", vec![method_closure("__ht_kz")]),
+            "to_a",
+            vec![],
+        )),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let mut functions = vec![main];
+    functions.extend(block_fns);
+    let module = Module {
+        name: "hashtransform".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "hashtransform") {
+        assert_eq!(stdout, "[[a, 99], [b, 99]]\n[[a, 1], [b, 2]]\n[[z, 2]]");
+    }
+}
+
 // ── source-language display convention: Ruby booleans (SIR spec) ──
 //
 // A Ruby-sourced module renders booleans as `true`/`false`; every other


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.18 reference (#7909) into the **JavaScript backend** (`semantic-ir-to-javascript`) emitted runtime, adding two non-mutating Ruby `Hash` block methods to `hashMethod` (+ the `HASH_METHODS` `respond_to?` set):

- **`transform_values { |v| … }`** — new `Map`; keys copied verbatim (unique ⇒ no collision), values are block results, insertion order preserved. Yields ONE block arg (the value).
- **`transform_keys { |k| … }`** — new `Map`; values untouched, keys are block results (yields ONE arg, the key). Two source keys can collapse onto one new key; Ruby keeps the **last** value at the **first-seen** position — exactly how native `Map.set` behaves on an existing key.

Both leave the receiver unmodified (a non-function block returns a shallow copy, matching the sibling `select`/`reject` arms).

## Exec-proof

`tests/run_with_node.rs` gains `hash_transform_values_and_keys`, run under real `node`:
- `{a:1,b:2}.transform_values { 99 }.to_a` → `[[a, 99], [b, 99]]` (keys kept)
- identity `transform_keys` → `[[a, 1], [b, 2]]` (values kept)
- **collision** `transform_keys` (constant `"z"`) → `[[z, 2]]` (last value wins)

Read back via `to_a` (a native `Map` has no faithful `format`). Diffed against the Python/TS reference. `cargo test -p semantic-ir-to-javascript --test run_with_node hash_transform_values_and_keys` passes.

## Checklist
- [x] CHANGELOG.md (0.25.0 → **0.26.0**)
- [x] Exec-proof green under `node`
- [x] Security review passed (no findings — native `Map` keys, no prototype-pollution surface; identical to sibling arms)

Part of the SIR Ruby→{…} full-parity effort. One-PR-per-crate mirror; reference = #7909. Go=#7917, Rust=#7927. **TS-lib is the final backend.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)