### PR TITLE
feat(md5): pure-Java port (RFC 1321 + streaming Digest)

### DIFF
--- a/code/packages/java/md5/.gitignore
+++ b/code/packages/java/md5/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/md5/BUILD
+++ b/code/packages/java/md5/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/md5/BUILD_windows
+++ b/code/packages/java/md5/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/md5/CHANGELOG.md
+++ b/code/packages/java/md5/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — md5 (Java)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Java port of the `md5` reference package.
+- `Md5.sumMd5(byte[])` → 16-byte RFC 1321 digest.
+- `Md5.hexString(byte[])` → 32-char lowercase hex digest.
+- `Md5.Digest` — streaming hasher with `update`, non-destructive `digest` /
+  `hexDigest`, and `copy` for independent snapshots.
+- Correct little-endian block parsing, length field, and digest output; Java's
+  native 32-bit `int` arithmetic (`Integer.rotateLeft`, `& 0xff` byte masking).
+- 21 JUnit tests: all seven RFC 1321 Appendix A.5 vectors, little-endian byte
+  order + the 0x00..0xFF known digest, output-format/determinism/avalanche
+  properties, padding block boundaries (0/55/56/63/64/127/128), and streaming
+  parity with the one-shot API.
+- Documented security note: MD5 is cryptographically broken; checksum use only.

--- a/code/packages/java/md5/README.md
+++ b/code/packages/java/md5/README.md
@@ -1,0 +1,48 @@
+# md5 (Java)
+
+MD5 message-digest algorithm (RFC 1321) implemented from scratch in pure Java —
+no `java.security.MessageDigest`.
+
+Java port of the `md5` package that already exists in Rust, Python, Dart, and
+other languages in the monorepo; produces byte-identical digests.
+
+> **Security:** MD5 is cryptographically **broken** — practical collisions
+> exist. Never use it for signatures or passwords. Checksum use only.
+
+## API
+
+`com.codingadventures.md5.Md5`:
+
+| Member | Purpose |
+|---|---|
+| `static byte[] sumMd5(byte[] data)` | 16-byte digest. |
+| `static String hexString(byte[] data)` | 32-char lowercase hex digest. |
+| `Md5.Digest` | Streaming: `update`, non-destructive `digest` / `hexDigest`, `copy`. |
+
+## Usage
+
+```java
+import com.codingadventures.md5.Md5;
+import java.nio.charset.StandardCharsets;
+
+byte[] data = "abc".getBytes(StandardCharsets.UTF_8);
+System.out.println(Md5.hexString(data)); // 900150983cd24fb0d6963f7d28e17f72
+
+Md5.Digest h = new Md5.Digest();
+h.update("ab".getBytes(StandardCharsets.UTF_8));
+h.update("c".getBytes(StandardCharsets.UTF_8));
+System.out.println(h.hexDigest()); // same digest, computed incrementally
+```
+
+## Implementation note
+
+MD5 is **little-endian** throughout (block parsing, length field, digest output),
+the opposite of SHA-1/SHA-256. Java's `int` is native 32-bit two's-complement, so
+unsigned 32-bit arithmetic needs no masking; `Integer.rotateLeft` performs the
+rotations and block bytes are masked with `& 0xff` before shifting.
+
+## Running the tests
+
+```
+gradle test
+```

--- a/code/packages/java/md5/build.gradle.kts
+++ b/code/packages/java/md5/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/md5/settings.gradle.kts
+++ b/code/packages/java/md5/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "md5"

--- a/code/packages/java/md5/src/main/java/com/codingadventures/md5/Md5.java
+++ b/code/packages/java/md5/src/main/java/com/codingadventures/md5/Md5.java
@@ -1,0 +1,213 @@
+// ============================================================================
+// Md5.java — MD5 message-digest algorithm (RFC 1321), from scratch
+// ============================================================================
+//
+// MD5 maps any sequence of bytes to a fixed 16-byte (128-bit) digest. This is a
+// from-scratch implementation (no java.security.MessageDigest), the Java port of
+// the `md5` package in the coding-adventures monorepo; it produces
+// byte-identical digests to the Rust/Python/Dart ports.
+//
+// SECURITY: MD5 is cryptographically BROKEN — practical collision attacks exist.
+// Never use it for signatures, certificates, or password storage. It remains a
+// fast, non-adversarial integrity checksum.
+//
+// Little-endian:
+// -------------
+// Unlike SHA-1/SHA-256, MD5 is little-endian: block words are read with the
+// first byte as the least-significant, the length is appended little-endian, and
+// the digest words are emitted least-significant byte first.
+//
+// 32-bit arithmetic:
+// ------------------
+// MD5 is defined over unsigned 32-bit words. Java's `int` is a 32-bit
+// two's-complement value whose `+` and bitwise operators wrap and mix exactly as
+// unsigned 32-bit arithmetic requires, so no masking is needed;
+// `Integer.rotateLeft` performs the circular rotations.
+
+package com.codingadventures.md5;
+
+public final class Md5 {
+
+    // Per-round left-rotation amounts (four repeating groups of four).
+    private static final int[] S = {
+        7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+        5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+        4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+        6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21
+    };
+
+    // The 64 sine-derived constants: T[i] = floor(abs(sin(i+1)) * 2^32).
+    private static final int[] T = {
+        0xD76AA478, 0xE8C7B756, 0x242070DB, 0xC1BDCEEE, 0xF57C0FAF, 0x4787C62A,
+        0xA8304613, 0xFD469501, 0x698098D8, 0x8B44F7AF, 0xFFFF5BB1, 0x895CD7BE,
+        0x6B901122, 0xFD987193, 0xA679438E, 0x49B40821, 0xF61E2562, 0xC040B340,
+        0x265E5A51, 0xE9B6C7AA, 0xD62F105D, 0x02441453, 0xD8A1E681, 0xE7D3FBC8,
+        0x21E1CDE6, 0xC33707D6, 0xF4D50D87, 0x455A14ED, 0xA9E3E905, 0xFCEFA3F8,
+        0x676F02D9, 0x8D2A4C8A, 0xFFFA3942, 0x8771F681, 0x6D9D6122, 0xFDE5380C,
+        0xA4BEEA44, 0x4BDECFA9, 0xF6BB4B60, 0xBEBFBC70, 0x289B7EC6, 0xEAA127FA,
+        0xD4EF3085, 0x04881D05, 0xD9D4D039, 0xE6DB99E5, 0x1FA27CF8, 0xC4AC5665,
+        0xF4292244, 0x432AFF97, 0xAB9423A7, 0xFC93A039, 0x655B59C3, 0x8F0CCC92,
+        0xFFEFF47D, 0x85845DD1, 0x6FA87E4F, 0xFE2CE6E0, 0xA3014314, 0x4E0811A1,
+        0xF7537E82, 0xBD3AF235, 0x2AD7D2BB, 0xEB86D391
+    };
+
+    // Initial state (A, B, C, D). Little-endian bytes spell 01 23 45 67 …
+    private static final int[] INIT = {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476};
+
+    private Md5() {}
+
+    // ── Compression ─────────────────────────────────────────────────────────
+    //
+    // Fold one 64-byte block (at `offset`) into the four-word state over 64
+    // rounds. Four stages use different auxiliary functions and message-word
+    // schedules; each round rotates the register set (a,b,c,d) ← (d,temp,b,c).
+    private static void compress(int[] state, byte[] data, int offset) {
+        int[] m = new int[16];
+        for (int i = 0; i < 16; i++) {
+            int j = offset + i * 4;
+            // Little-endian: byte j is the least-significant byte of word i.
+            m[i] = (data[j] & 0xff)
+                 | ((data[j + 1] & 0xff) << 8)
+                 | ((data[j + 2] & 0xff) << 16)
+                 | ((data[j + 3] & 0xff) << 24);
+        }
+
+        int a = state[0], b = state[1], c = state[2], d = state[3];
+
+        for (int i = 0; i < 64; i++) {
+            int f, g;
+            if (i < 16) {
+                f = (b & c) | (~b & d);
+                g = i;
+            } else if (i < 32) {
+                f = (d & b) | (~d & c);
+                g = (5 * i + 1) & 15;
+            } else if (i < 48) {
+                f = b ^ c ^ d;
+                g = (3 * i + 5) & 15;
+            } else {
+                f = c ^ (b | ~d);
+                g = (7 * i) & 15;
+            }
+            int sum = a + f + m[g] + T[i];
+            int temp = b + Integer.rotateLeft(sum, S[i]);
+            a = d;
+            d = c;
+            c = b;
+            b = temp;
+        }
+
+        state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+    }
+
+    // Serialise the four state words into a 16-byte little-endian digest.
+    private static byte[] stateToDigest(int[] state) {
+        byte[] out = new byte[16];
+        for (int i = 0; i < 4; i++) {
+            out[i * 4]     = (byte) (state[i]);
+            out[i * 4 + 1] = (byte) (state[i] >>> 8);
+            out[i * 4 + 2] = (byte) (state[i] >>> 16);
+            out[i * 4 + 3] = (byte) (state[i] >>> 24);
+        }
+        return out;
+    }
+
+    // Pad: append 0x80, zero-fill to 56 (mod 64), then the bit length as a
+    // 64-bit LITTLE-endian integer (RFC 1321 §3).
+    private static byte[] pad(byte[] tail, long totalBytes) {
+        long bitLen = totalBytes * 8L;
+        int padLen = 1;
+        while ((tail.length + padLen) % 64 != 56) padLen++;
+        byte[] padded = new byte[tail.length + padLen + 8];
+        System.arraycopy(tail, 0, padded, 0, tail.length);
+        padded[tail.length] = (byte) 0x80;
+        for (int i = 0; i < 8; i++) {
+            padded[tail.length + padLen + i] = (byte) (bitLen >>> (i * 8)); // little-endian
+        }
+        return padded;
+    }
+
+    // ── Public one-shot API ─────────────────────────────────────────────────
+
+    /** Compute the MD5 digest of {@code data} as a 16-byte array. */
+    public static byte[] sumMd5(byte[] data) {
+        byte[] padded = pad(data, data.length);
+        int[] state = INIT.clone();
+        for (int off = 0; off < padded.length; off += 64) {
+            compress(state, padded, off);
+        }
+        return stateToDigest(state);
+    }
+
+    /** Compute MD5 and return the 32-character lowercase hex string. */
+    public static String hexString(byte[] data) {
+        return toHex(sumMd5(data));
+    }
+
+    static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >>> 4) & 0xf, 16));
+            sb.append(Character.forDigit(b & 0xf, 16));
+        }
+        return sb.toString();
+    }
+
+    // ── Streaming digest ────────────────────────────────────────────────────
+
+    /**
+     * Incremental MD5. Feed data with {@link #update}; {@link #digest} is
+     * non-destructive so the hasher can keep receiving updates afterwards.
+     */
+    public static final class Digest {
+        private final int[] state;
+        private byte[] buf;
+        private long byteCount;
+
+        public Digest() {
+            this.state = INIT.clone();
+            this.buf = new byte[0];
+            this.byteCount = 0;
+        }
+
+        private Digest(int[] state, byte[] buf, long byteCount) {
+            this.state = state.clone();
+            this.buf = buf.clone();
+            this.byteCount = byteCount;
+        }
+
+        /** Feed more bytes into the hash. */
+        public void update(byte[] data) {
+            byteCount += data.length;
+            byte[] combined = new byte[buf.length + data.length];
+            System.arraycopy(buf, 0, combined, 0, buf.length);
+            System.arraycopy(data, 0, combined, buf.length, data.length);
+            int full = combined.length - (combined.length % 64);
+            for (int off = 0; off < full; off += 64) {
+                compress(state, combined, off);
+            }
+            buf = new byte[combined.length - full];
+            System.arraycopy(combined, full, buf, 0, buf.length);
+        }
+
+        /** Return the 16-byte digest of all data fed so far (non-destructive). */
+        public byte[] digest() {
+            byte[] tail = pad(buf, byteCount);
+            int[] s = state.clone();
+            for (int off = 0; off < tail.length; off += 64) {
+                compress(s, tail, off);
+            }
+            return stateToDigest(s);
+        }
+
+        /** Return the 32-character lowercase hex digest string. */
+        public String hexDigest() {
+            return toHex(digest());
+        }
+
+        /** Return an independent copy of this hasher's current state. */
+        public Digest copy() {
+            return new Digest(state, buf, byteCount);
+        }
+    }
+}

--- a/code/packages/java/md5/src/test/java/com/codingadventures/md5/Md5Test.java
+++ b/code/packages/java/md5/src/test/java/com/codingadventures/md5/Md5Test.java
@@ -1,0 +1,196 @@
+// ============================================================================
+// Md5Test.java — Unit tests for Md5 (RFC 1321 vectors + properties)
+// ============================================================================
+
+package com.codingadventures.md5;
+
+import org.junit.jupiter.api.Test;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.*;
+
+class Md5Test {
+
+    private static byte[] a(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    // ── RFC 1321 Appendix A.5 known-answer vectors ───────────────────────────
+
+    @Test
+    void rfc1321Vectors() {
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", Md5.hexString(a("")));
+        assertEquals("0cc175b9c0f1b6a831c399e269772661", Md5.hexString(a("a")));
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", Md5.hexString(a("abc")));
+        assertEquals("f96b697d7cb7938d525a2f31aaf161d0", Md5.hexString(a("message digest")));
+        assertEquals("c3fcd3d76192e4007dfb496cca67e13b",
+            Md5.hexString(a("abcdefghijklmnopqrstuvwxyz")));
+        assertEquals("d174ab98d277d9f5a5611c2c9f419d9f",
+            Md5.hexString(a("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")));
+        assertEquals("57edf4a22be3c955ac49da2e2107b67a", Md5.hexString(a(
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890")));
+    }
+
+    // ── Little-endian byte order ──────────────────────────────────────────────
+
+    @Test
+    void littleEndianByteOrderOfA() {
+        byte[] d = Md5.sumMd5(a("a"));
+        assertEquals(0x0c, d[0] & 0xff);
+        assertEquals(0xc1, d[1] & 0xff);
+        assertEquals(0x75, d[2] & 0xff);
+        assertEquals(0xb9, d[3] & 0xff);
+    }
+
+    @Test
+    void bytes0To255KnownDigest() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        assertEquals("e2c865db4162bed963bfaa9ef6ac18f0", Md5.hexString(data));
+    }
+
+    // ── Output format ────────────────────────────────────────────────────────
+
+    @Test
+    void digestIs16Bytes() {
+        assertEquals(16, Md5.sumMd5(a("")).length);
+        assertEquals(16, Md5.sumMd5(a("hello world")).length);
+        assertEquals(16, Md5.sumMd5(new byte[1000]).length);
+    }
+
+    @Test
+    void hexIs32LowercaseChars() {
+        String h = Md5.hexString(a("abc"));
+        assertEquals(32, h.length());
+        assertTrue(h.matches("[0-9a-f]{32}"));
+    }
+
+    // ── Properties ───────────────────────────────────────────────────────────
+
+    @Test
+    void deterministic() {
+        assertArrayEquals(Md5.sumMd5(a("hello")), Md5.sumMd5(a("hello")));
+    }
+
+    @Test
+    void avalanche() {
+        byte[] h1 = Md5.sumMd5(a("hello"));
+        byte[] h2 = Md5.sumMd5(a("helo"));
+        assertFalse(Arrays.equals(h1, h2));
+        int bits = 0;
+        for (int i = 0; i < 16; i++) bits += Integer.bitCount((h1[i] ^ h2[i]) & 0xff);
+        assertTrue(bits > 20, "only " + bits + " bits differed");
+    }
+
+    @Test
+    void nullByteDiffersFromEmpty() {
+        assertFalse(Arrays.equals(Md5.sumMd5(new byte[]{0}), Md5.sumMd5(a(""))));
+    }
+
+    @Test
+    void everyByteValueHashesDistinctly() {
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i <= 255; i++) seen.add(Md5.hexString(new byte[]{(byte) i}));
+        assertEquals(256, seen.size());
+    }
+
+    // ── Padding / block boundaries ───────────────────────────────────────────
+
+    @Test
+    void blockBoundariesProduce16ByteDigests() {
+        for (int n : new int[]{0, 55, 56, 63, 64, 127, 128}) {
+            assertEquals(16, Md5.sumMd5(new byte[n]).length);
+        }
+    }
+
+    @Test
+    void boundary55And56Differ() {
+        assertFalse(Arrays.equals(Md5.sumMd5(new byte[55]), Md5.sumMd5(new byte[56])));
+    }
+
+    @Test
+    void allBoundarySizesDistinct() {
+        Set<String> seen = new HashSet<>();
+        for (int n : new int[]{0, 55, 56, 63, 64, 127, 128}) seen.add(Md5.hexString(new byte[n]));
+        assertEquals(7, seen.size());
+    }
+
+    // ── Streaming digest ─────────────────────────────────────────────────────
+
+    @Test
+    void streamingSingleWriteMatchesOneShot() {
+        Md5.Digest h = new Md5.Digest();
+        h.update(a("abc"));
+        assertArrayEquals(Md5.sumMd5(a("abc")), h.digest());
+    }
+
+    @Test
+    void streamingSplitMatchesOneShot() {
+        Md5.Digest h = new Md5.Digest();
+        h.update(a("ab"));
+        h.update(a("c"));
+        assertArrayEquals(Md5.sumMd5(a("abc")), h.digest());
+    }
+
+    @Test
+    void streamingBlockSplitMatchesOneShot() {
+        byte[] data = new byte[128];
+        Md5.Digest h = new Md5.Digest();
+        h.update(Arrays.copyOfRange(data, 0, 64));
+        h.update(Arrays.copyOfRange(data, 64, 128));
+        assertArrayEquals(Md5.sumMd5(data), h.digest());
+    }
+
+    @Test
+    void streamingByteAtATimeMatchesOneShot() {
+        byte[] data = new byte[100];
+        for (int i = 0; i < 100; i++) data[i] = (byte) i;
+        Md5.Digest h = new Md5.Digest();
+        for (byte b : data) h.update(new byte[]{b});
+        assertArrayEquals(Md5.sumMd5(data), h.digest());
+    }
+
+    @Test
+    void streamingEmptyMatchesEmptyOneShot() {
+        assertArrayEquals(Md5.sumMd5(a("")), new Md5.Digest().digest());
+    }
+
+    @Test
+    void streamingDigestIsNonDestructive() {
+        Md5.Digest h = new Md5.Digest();
+        h.update(a("hello"));
+        assertArrayEquals(h.digest(), h.digest());
+        h.update(a(" world"));
+        assertArrayEquals(Md5.sumMd5(a("hello world")), h.digest());
+    }
+
+    @Test
+    void streamingHexDigestMatches() {
+        Md5.Digest h = new Md5.Digest();
+        h.update(a("abc"));
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", h.hexDigest());
+    }
+
+    @Test
+    void streamingCopyIsIndependent() {
+        Md5.Digest h = new Md5.Digest();
+        h.update(a("ab"));
+        Md5.Digest h2 = h.copy();
+        h2.update(a("c"));
+        h.update(a("x"));
+        assertArrayEquals(Md5.sumMd5(a("abc")), h2.digest());
+        assertArrayEquals(Md5.sumMd5(a("abx")), h.digest());
+    }
+
+    @Test
+    void streamingMillionAInTwoHalves() {
+        byte[] data = new byte[1_000_000];
+        Arrays.fill(data, (byte) 'a');
+        Md5.Digest h = new Md5.Digest();
+        h.update(Arrays.copyOfRange(data, 0, 500_000));
+        h.update(Arrays.copyOfRange(data, 500_000, 1_000_000));
+        assertArrayEquals(Md5.sumMd5(data), h.digest());
+    }
+}


### PR DESCRIPTION
## What

Pure-Java port of the `md5` package — MD5 (RFC 1321) from scratch, no `java.security.MessageDigest`. Second Java pure port (after `sha256`), continuing the campaign's cross-language spread.

**Why:** `md5` is a canon package missing from Java.

## API (`com.codingadventures.md5.Md5`)

- `static byte[] sumMd5(byte[])` — 16-byte digest.
- `static String hexString(byte[])` — 32-char lowercase hex.
- `Md5.Digest` — streaming `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Implementation note

MD5 is **little-endian** throughout (block parsing, length field, digest output) — the opposite of SHA-256. Java's native 32-bit `int` needs no masking; uses `Integer.rotateLeft` and `& 0xff` byte masking before shifts.

## Verification

- All **seven RFC 1321 Appendix A.5 vectors** pass, plus little-endian byte-order checks (incl. the `0x00..0xFF` known digest).
- Determinism + avalanche, padding/block-boundary edge cases (0/55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, copy independence, one-million-'a').
- **21 JUnit tests**, `gradle test` green.
- Security review passed: `>>>` vs `>>`, `& 0xff` masking, consistent little-endian parse/length/output, padding sizing, and streaming non-destructiveness/copy-independence all verified.

> **Security note** (docs + README): MD5 is cryptographically broken — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)