### PR TITLE
feat(adj-lang): formula-library substrate + BMI (rung-0 of ADJ-FORMULA-LIBRARIES)

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -40,6 +40,7 @@ statement   = prior_decl
             | dictionary_decl
             | define_decl
             | rulebook_decl
+            | formulabook_decl
             | use_decl
             | import_decl
             ;
@@ -278,6 +279,43 @@ surface_clause = "surface" STRING { COMMA STRING } ;
 rulebook_decl = "rulebook" IDENT LBRACE { statement } RBRACE ;
 
 use_decl      = "use" IDENT ;
+
+# ----------------------------------------------------------------
+# Formulabook + formula (ADJ-FORMULA-LIBRARIES rung-0 — the importable,
+# provenanced, PARAMETERIZED formula as a first-class library construct, a
+# SIBLING of `rulebook`). This is the substrate the ladder always named but
+# never built: a reusable, cited formula that lives in a library, is `import`ed,
+# and is APPLIED — not inlined per question.
+#
+#   formulabook body_metrics {
+#       use bmi_vocab
+#       formula bmi(body_mass, height) = body_mass / (height * height)
+#           source "BMI is body mass divided by the square of body height … kg/m²."
+#           locator "https://www.who.int/…/body-mass-index"
+#           trust authoritative
+#   }
+#
+# A `formulabook <name> { … }` groups formulas under one importable name; a
+# `use <dict>` brings a dictionary's terms into scope so the formula's parameter
+# names are typed vocabulary. A `formula <name>(<p>, …) = <expr>` is a NAMED,
+# PARAMETERIZED `let`: `<expr>` REUSES the existing `let` expression grammar
+# (`expr`) verbatim — fractions / products / sums / calls / parens over
+# identifiers + numbers — and the only new idea is that a leaf naming a `<param>`
+# is a FORMAL PARAMETER, bound at apply time (`? bmi(body_mass, height)`) instead
+# of a `Ref` to an already-`observe`d fact. Each formula carries the SAME
+# provenance envelope every grounded clause carries (`source "…" locator "…"
+# trust <tier>`, the `{ annotation }` tail); a shipped formula MUST be sourced
+# (the provenance-required lint, enforced in the lowerer). `formulabook`/`formula`
+# are IDENT-matched literals — no lexer keywords, exactly like `rulebook`/`define`.
+# ----------------------------------------------------------------
+
+formulabook_decl = "formulabook" IDENT LBRACE { formulabook_item } RBRACE ;
+
+formulabook_item = use_decl | formula_decl ;
+
+formula_decl     = "formula" IDENT LPAREN [ formula_params ] RPAREN EQUALS expr { annotation } ;
+
+formula_params   = IDENT { COMMA IDENT } ;
 
 # ----------------------------------------------------------------
 # Import (MYCIN-2026 M3 — composition across files). `import "<path>"`

--- a/code/packages/rust/adj-lang-cli/CHANGELOG.md
+++ b/code/packages/rust/adj-lang-cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — render applied-formula provenance in the `derived` section
+
+### Added
+
+- A `derived` value produced by APPLYING a provenanced `formula`
+  (ADJ-FORMULA-LIBRARIES rung-0) now renders the formula's cited
+  `source`/`locator`/`trust`/`corroborations` alongside its `name`/`value`/`dim` —
+  the audit channel proving WHY the formula is trusted, beside the derivation tree
+  proving HOW the number was computed. A plain `let` (no library claim) omits the
+  field, so existing output is byte-for-byte unchanged.
+
 ## [0.11.0] - 2026-06-29 — surface `let`-derived dimensioned values
 
 ### Added

--- a/code/packages/rust/adj-lang-cli/src/main.rs
+++ b/code/packages/rust/adj-lang-cli/src/main.rs
@@ -110,12 +110,23 @@ fn derived_json(kb: &KnowledgeBase) -> String {
                 Some(r) => format!(",\"exact\":{{\"num\":{},\"den\":{}}}", r.num, r.den),
                 None => String::new(),
             };
+            // A value produced by APPLYING a provenanced `formula`
+            // (ADJ-FORMULA-LIBRARIES rung-0) carries the formula's cited
+            // `source`/`locator`/`trust` — the audit channel proving WHY the
+            // formula is trusted, alongside the derivation tree proving HOW the
+            // number was computed. A plain `let` has no such library claim, so
+            // the field is omitted (output byte-for-byte unchanged there).
+            let provenance = match &d.provenance {
+                Some(p) => format!(",{}", prov(p)),
+                None => String::new(),
+            };
             format!(
-                "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}}}",
+                "{{\"name\":\"{}\",\"value\":{},\"dim\":\"{}\"{}{}}}",
                 esc(&d.name),
                 jnum(d.value),
                 esc(&d.dim.tag()),
-                exact
+                exact,
+                provenance
             )
         })
         .collect();

--- a/code/packages/rust/adj-lang-cli/tests/formula_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_e2e.rs
@@ -1,0 +1,65 @@
+//! End-to-end test for the ADJ-FORMULA-LIBRARIES rung-0 substrate through the
+//! built CLI binary: a consumer `import`s the SHIPPED `bmi.adj` formula library,
+//! binds the variables from its own `observe`d facts, and applies the cited
+//! formula. The CLI must compute the value on the CPU and render the applied
+//! formula's citation in the `derived` section — the auditable answer.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped BMI library, resolved from this crate's manifest
+/// dir so the test is location-independent.
+fn shipped_bmi_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/clinical/bmi.adj")
+        .canonicalize()
+        .expect("shipped bmi.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_formula_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn imports_bmi_library_binds_and_computes_with_its_citation() {
+    // Copy the shipped library next to a consumer that imports it, so the CLI's
+    // sandbox-checked relative import resolves. The consumer states NO arithmetic
+    // — it binds the numbers and applies the recalled formula.
+    let dir = scratch("bmi");
+    let lib = std::fs::read_to_string(shipped_bmi_lib()).unwrap();
+    std::fs::write(dir.join("bmi.adj"), lib).unwrap();
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"bmi.adj\"\n\
+         observe body_mass(70)\n\
+         observe height(1.75)\n\
+         ? bmi(body_mass, height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result …
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"bmi\"") && s.contains("\"value\":22.857142857142858"),
+        "computed BMI ≈ 22.857 kg/m²: {s}"
+    );
+    // … AND the WHO citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("who.int"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [Unreleased] — `formulabook` / `formula` — importable, provenanced, parameterized formulas (ADJ-FORMULA-LIBRARIES rung-0)
+
+### Added
+
+- **`formulabook <name> { use <dict>… formula… }`** and **`formula <name>(<params>) = <expr>`** — the
+  rung-0 substrate of the *compute* standard library (a sibling of `rulebook`). A `formula` is a named,
+  importable, reusable `let`: `<expr>` reuses the existing `let` expression grammar verbatim, and a leaf
+  naming a declared `<param>` is a **formal parameter**, bound at apply time. Each formula carries the
+  same `source "…" locator "…" trust <tier>` provenance envelope every grounded clause carries.
+- **Formula application** — a consumer's `? name(args)` whose functor names a registered formula (with
+  matching arity) is APPLIED, not treated as a hypothesis query: each parameter binds to its argument
+  (a like-named `observe`d slot or a number literal), the body is substituted, and the result is
+  evaluated through the **existing** `logic_engine::compute` (`ComputeExpr`) path and bound as a derived
+  value named after the formula — carrying the formula's cited provenance for the audit trail.
+- **Two validations**: parameter-scoping (`LowerError::FormulaFreeVariable` — a body identifier that is
+  not a declared parameter) and a provenance-required lint (`LowerError::FormulaMissingProvenance` — a
+  shipped formula must carry a non-empty `source`). Vocabulary enforcement now accepts a formula-application
+  query so the closed-vocabulary gate does not reject the new construct.
+- AST: `Statement::Formulabook { name, uses, formulas }` + `FormulaDef { name, params, body, annotations }`.
+
 ## [0.49.0] - 2026-07-03 — `constrain asciimath "…"` — a second frontend reaches the constraint surface
 
 ### Added

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -42,6 +42,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"dictionary_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"define_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"rulebook_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"formulabook_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
                 GrammarElement::RuleReference { name: r#"import_decl"#.to_string() },
             ] },
@@ -56,7 +57,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 52,
+            line_number: 53,
         },
         GrammarRule {
             name: r#"contributes_decl"#.to_string(),
@@ -69,7 +70,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 54,
+            line_number: 55,
         },
         GrammarRule {
             name: r#"evidence"#.to_string(),
@@ -77,7 +78,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"predicate"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 65,
+            line_number: 66,
         },
         GrammarRule {
             name: r#"predicate"#.to_string(),
@@ -92,7 +93,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 67,
+            line_number: 68,
         },
         GrammarRule {
             name: r#"interacts_decl"#.to_string(),
@@ -111,7 +112,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 69,
+            line_number: 70,
         },
         GrammarRule {
             name: r#"uncertain_decl"#.to_string(),
@@ -128,7 +129,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 71,
+            line_number: 72,
         },
         GrammarRule {
             name: r#"observe_decl"#.to_string(),
@@ -136,7 +137,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"observe"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 73,
+            line_number: 74,
         },
         GrammarRule {
             name: r#"relate_decl"#.to_string(),
@@ -145,7 +146,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
-            line_number: 86,
+            line_number: 87,
         },
         GrammarRule {
             name: r#"rule_decl"#.to_string(),
@@ -175,7 +176,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 108,
+            line_number: 109,
         },
         GrammarRule {
             name: r#"body_literal"#.to_string(),
@@ -183,7 +184,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"not"#.to_string() }) },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 110,
+            line_number: 111,
         },
         GrammarRule {
             name: r#"context_order_decl"#.to_string(),
@@ -201,7 +202,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 121,
+            line_number: 122,
         },
         GrammarRule {
             name: r#"functional_decl"#.to_string(),
@@ -209,7 +210,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"functional"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 132,
+            line_number: 133,
         },
         GrammarRule {
             name: r#"query_decl"#.to_string(),
@@ -217,7 +218,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"QUESTION"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 134,
+            line_number: 135,
         },
         GrammarRule {
             name: r#"let_decl"#.to_string(),
@@ -227,7 +228,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 148,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"expr"#.to_string(),
@@ -241,7 +242,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"term_expr"#.to_string() },
                     ] }) },
             ] },
-            line_number: 150,
+            line_number: 151,
         },
         GrammarRule {
             name: r#"term_expr"#.to_string(),
@@ -255,7 +256,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 152,
+            line_number: 153,
         },
         GrammarRule {
             name: r#"factor"#.to_string(),
@@ -273,7 +274,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 154,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"agg"#.to_string(),
@@ -289,7 +290,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
             ] },
-            line_number: 156,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"latex_expr"#.to_string(),
@@ -297,7 +298,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 163,
+            line_number: 164,
         },
         GrammarRule {
             name: r#"asciimath_expr"#.to_string(),
@@ -305,7 +306,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 174,
+            line_number: 175,
         },
         GrammarRule {
             name: r#"mathml_expr"#.to_string(),
@@ -313,7 +314,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"mathml"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 186,
+            line_number: 187,
         },
         GrammarRule {
             name: r#"unicodemath_expr"#.to_string(),
@@ -321,7 +322,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"unicodemath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 198,
+            line_number: 199,
         },
         GrammarRule {
             name: r#"symbol_decl"#.to_string(),
@@ -331,7 +332,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"COLON"#.to_string() },
                 GrammarElement::RuleReference { name: r#"term"#.to_string() },
             ] },
-            line_number: 208,
+            line_number: 209,
         },
         GrammarRule {
             name: r#"constrain_latex_decl"#.to_string(),
@@ -339,7 +340,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"latex_relation"#.to_string() },
             ] },
-            line_number: 210,
+            line_number: 211,
         },
         GrammarRule {
             name: r#"constrain_asciimath_decl"#.to_string(),
@@ -347,7 +348,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"constrain"#.to_string() },
                 GrammarElement::RuleReference { name: r#"asciimath_relation"#.to_string() },
             ] },
-            line_number: 220,
+            line_number: 221,
         },
         GrammarRule {
             name: r#"constrain_decl"#.to_string(),
@@ -357,7 +358,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 222,
+            line_number: 223,
         },
         GrammarRule {
             name: r#"latex_relation"#.to_string(),
@@ -365,7 +366,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"latex"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 224,
+            line_number: 225,
         },
         GrammarRule {
             name: r#"asciimath_relation"#.to_string(),
@@ -373,7 +374,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"asciimath"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 226,
+            line_number: 227,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -386,7 +387,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
                 GrammarElement::TokenReference { name: r#"NE"#.to_string() },
             ] },
-            line_number: 228,
+            line_number: 229,
         },
         GrammarRule {
             name: r#"solve_decl"#.to_string(),
@@ -401,12 +402,12 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 230,
+            line_number: 231,
         },
         GrammarRule {
             name: r#"check_decl"#.to_string(),
             body: GrammarElement::Literal { value: r#"check"#.to_string() },
-            line_number: 232,
+            line_number: 233,
         },
         GrammarRule {
             name: r#"optimize_decl"#.to_string(),
@@ -417,7 +418,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
             ] },
-            line_number: 239,
+            line_number: 240,
         },
         GrammarRule {
             name: r#"dictionary_decl"#.to_string(),
@@ -428,7 +429,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"define_decl"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 251,
+            line_number: 252,
         },
         GrammarRule {
             name: r#"define_decl"#.to_string(),
@@ -439,7 +440,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"define_kind"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"surface_clause"#.to_string() }) },
             ] },
-            line_number: 253,
+            line_number: 254,
         },
         GrammarRule {
             name: r#"define_kind"#.to_string(),
@@ -467,7 +468,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
                 ] },
             ] },
-            line_number: 255,
+            line_number: 256,
         },
         GrammarRule {
             name: r#"surface_clause"#.to_string(),
@@ -479,7 +480,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 261,
+            line_number: 262,
         },
         GrammarRule {
             name: r#"rulebook_decl"#.to_string(),
@@ -490,7 +491,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
             ] },
-            line_number: 278,
+            line_number: 279,
         },
         GrammarRule {
             name: r#"use_decl"#.to_string(),
@@ -498,7 +499,51 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"use"#.to_string() },
                 GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
             ] },
-            line_number: 280,
+            line_number: 281,
+        },
+        GrammarRule {
+            name: r#"formulabook_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"formulabook"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"formulabook_item"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+            ] },
+            line_number: 312,
+        },
+        GrammarRule {
+            name: r#"formulabook_item"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"use_decl"#.to_string() },
+                GrammarElement::RuleReference { name: r#"formula_decl"#.to_string() },
+            ] },
+            line_number: 314,
+        },
+        GrammarRule {
+            name: r#"formula_decl"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"formula"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"formula_params"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
+            ] },
+            line_number: 316,
+        },
+        GrammarRule {
+            name: r#"formula_params"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 318,
         },
         GrammarRule {
             name: r#"import_decl"#.to_string(),
@@ -506,7 +551,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 296,
+            line_number: 334,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -516,7 +561,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
             ] },
-            line_number: 308,
+            line_number: 346,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -524,7 +569,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 314,
+            line_number: 352,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -532,7 +577,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 315,
+            line_number: 353,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -540,7 +585,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 316,
+            line_number: 354,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -550,7 +595,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 317,
+            line_number: 355,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -561,7 +606,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 319,
+            line_number: 357,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -585,7 +630,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 341,
+            line_number: 379,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -32,8 +32,8 @@ use math_frontend::{BigOp, BinOp, Func, MathExpr, Number, RelOp as MathRelOp, Un
 use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
 
 use crate::ast::{
-    AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, NamedFn,
-    OptDir, Program, RelOp, RuleLiteral, Statement, Term, TrustTierName,
+    AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, FormulaDef,
+    NamedFn, OptDir, Program, RelOp, RuleLiteral, Statement, Term, TrustTierName,
 };
 
 /// Errors raised while adapting a generic AST to the typed AST.
@@ -155,6 +155,7 @@ fn adapt_statement(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         "dictionary_decl" => adapt_dictionary(child),
         "define_decl" => adapt_define(child).map(Statement::Define),
         "rulebook_decl" => adapt_rulebook(child),
+        "formulabook_decl" => adapt_formulabook(child),
         "use_decl" => adapt_use(child),
         "import_decl" => adapt_import(child),
         other => Err(AdapterError::UnexpectedRule {
@@ -784,6 +785,89 @@ fn adapt_rulebook(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
         })
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Statement::Rulebook { name, statements })
+}
+
+fn adapt_formulabook(node: &GrammarASTNode) -> Result<Statement, AdapterError> {
+    // formulabook_decl = "formulabook" IDENT LBRACE { formulabook_item } RBRACE
+    // The name is the first Name token that isn't the `formulabook` keyword; each
+    // `formulabook_item` wraps either a `use_decl` (a vocabulary binding) or a
+    // `formula_decl` (a definition).
+    let name = first_name_not(node, "formulabook")
+        .ok_or(AdapterError::MissingChild {
+            rule: "formulabook_decl".into(),
+            position: "formulabook name",
+        })?
+        .to_string();
+    let mut uses = Vec::new();
+    let mut formulas = Vec::new();
+    for c in &node.children {
+        if let ASTNodeOrToken::Node(item) = c {
+            if item.rule_name == "formulabook_item" {
+                let inner = first_child_node(item, "formulabook_item", "use_decl or formula_decl")?;
+                match inner.rule_name.as_str() {
+                    "use_decl" => {
+                        if let Statement::Use(u) = adapt_use(inner)? {
+                            uses.push(u);
+                        }
+                    }
+                    "formula_decl" => formulas.push(adapt_formula(inner)?),
+                    other => {
+                        return Err(AdapterError::UnexpectedRule {
+                            expected: "use_decl or formula_decl",
+                            actual: other.to_string(),
+                        })
+                    }
+                }
+            }
+        }
+    }
+    Ok(Statement::Formulabook {
+        name,
+        uses,
+        formulas,
+    })
+}
+
+fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
+    // formula_decl = "formula" IDENT LPAREN [ formula_params ] RPAREN EQUALS expr { annotation }
+    //
+    // The name is the first Name token that isn't the `formula` keyword (the
+    // parameter Name tokens live INSIDE the nested `formula_params` node, so they
+    // are not direct children and cannot be mistaken for the name).
+    let name = first_name_not(node, "formula")
+        .ok_or(AdapterError::MissingChild {
+            rule: "formula_decl".into(),
+            position: "formula name",
+        })?
+        .to_string();
+    // formula_params = IDENT { COMMA IDENT } — the parameter names are the Name
+    // tokens of the `formula_params` child (COMMA is a punctuation token). Absent
+    // (a zero-parameter formula) yields an empty vector.
+    let params = first_named_child(node, "formula_params")
+        .map(|p| {
+            p.children
+                .iter()
+                .filter_map(|c| match c {
+                    ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    // The body reuses the EXISTING `let` expression grammar/adapter verbatim.
+    let expr_node = first_named_child(node, "expr").ok_or(AdapterError::MissingChild {
+        rule: "formula_decl".into(),
+        position: "body expr",
+    })?;
+    let body = adapt_expr(expr_node)?;
+    // Same provenance envelope as every grounded clause (`{ annotation }`).
+    let annotations = collect_annotations(node)?;
+    Ok(FormulaDef {
+        name,
+        params,
+        body,
+        annotations,
+    })
 }
 
 fn adapt_use(node: &GrammarASTNode) -> Result<Statement, AdapterError> {

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -338,6 +338,20 @@ pub enum Statement {
         name: String,
         statements: Vec<Statement>,
     },
+    /// `formulabook <name> { use <dict>… formula… }` — a named, importable
+    /// collection of reusable, provenanced, PARAMETERIZED formulas
+    /// (ADJ-FORMULA-LIBRARIES rung-0). A sibling of [`Statement::Rulebook`]: where
+    /// a rulebook groups belief clauses, a formulabook groups `formula`
+    /// definitions. `uses` records the dictionaries a `use <dict>` brought into
+    /// scope (documentation of the vocabulary the formulas are typed against);
+    /// `formulas` are the definitions themselves. The formulabook adds nothing to
+    /// the KB directly — its formulas are registered so a later `? name(args)`
+    /// can APPLY them (see [`FormulaDef`]).
+    Formulabook {
+        name: String,
+        uses: Vec<String>,
+        formulas: Vec<FormulaDef>,
+    },
     /// `use <dictionary>` — bind a `dictionary` (by name) as the controlled
     /// vocabulary the enclosing scope's clauses are checked against (MYCIN-2026
     /// M2). Legal at top level or inside a `rulebook`.
@@ -358,6 +372,41 @@ pub enum Statement {
 pub struct RuleLiteral {
     pub negated: bool,
     pub term: Term,
+}
+
+/// A reusable, provenanced, PARAMETERIZED formula — the rung-0 substrate of
+/// ADJ-FORMULA-LIBRARIES. A `formula bmi(body_mass, height) = body_mass /
+/// (height * height)` is, semantically, a **named, importable `let`**: `body` is
+/// the same [`ExprAst`] a `let` binds, and the leaves that name a declared
+/// parameter are FORMAL PARAMETERS, bound at apply time rather than resolved to
+/// an already-`observe`d fact.
+///
+/// ## Provenance is not a decoration — it is the claim
+///
+/// A formula asserts a fact about the world ("BMI is mass ÷ height²"). Like a
+/// `relate` edge, it carries the SAME provenance envelope — `source` / `locator`
+/// / `trust` — captured here as the shared [`Annotation`] vector (so there is
+/// ONE provenance surface and ONE lowering path, `annotations_to_provenance`).
+/// The lowerer enforces a non-empty `source` on a shipped formula (the
+/// provenance-required lint), and stamps the resolved provenance onto the
+/// applied value so the computed answer is auditable back to WHY its formula is
+/// trusted.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormulaDef {
+    /// The formula's name — also the functor a consumer applies (`? bmi(...)`)
+    /// and the name of the derived value the application binds.
+    pub name: String,
+    /// The formal parameters, in declaration order. A body [`ExprAst::Ref`]
+    /// (or [`ExprAst::Agg`] slot) naming one of these is a parameter reference;
+    /// any other free identifier is a compile error (parameter-scoping).
+    pub params: Vec<String>,
+    /// The formula body — the EXISTING `let` expression AST, reused verbatim.
+    pub body: ExprAst,
+    /// The provenance envelope (`source` / `locator` / `trust`, plus any
+    /// corroborating `cites`), reusing the shared [`Annotation`] set every
+    /// grounded clause carries. Lowered via `annotations_to_provenance`; a
+    /// shipped formula must carry a non-empty `source`.
+    pub annotations: Vec<Annotation>,
 }
 
 /// A single dictionary entry (MYCIN-2026).

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -32,8 +32,8 @@ use logic_engine::{
 use std::collections::HashMap;
 
 use crate::ast::{
-    AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, NamedFn,
-    OptDir, Program, RelOp, Statement, Term as AstTerm, TrustTierName,
+    AggOp, Annotation, ArithOp, BinFn, CmpOp, Define, DefineKind, Evidence, ExprAst, FormulaDef,
+    NamedFn, OptDir, Program, RelOp, Statement, Term as AstTerm, TrustTierName,
 };
 
 /// One lowered constraint: `lhs <op> rhs`, with both sides kept as
@@ -143,6 +143,30 @@ pub enum LowerError {
         outer: String,
         inner: String,
     },
+    /// A `formula`'s body referenced a free identifier that is not one of its
+    /// declared parameters (ADJ-FORMULA-LIBRARIES rung-0 parameter-scoping). A
+    /// formula is a *closed* parameterized expression — every leaf must name a
+    /// parameter — so a stray identifier is a clean compile error, never a silent
+    /// mis-binding to some observed slot at apply time. Carries the offending
+    /// formula and variable.
+    FormulaFreeVariable {
+        formula: String,
+        variable: String,
+    },
+    /// A shipped `formula` carried no `source` (the provenance-required lint,
+    /// mirroring the recall-library adversarial write gate). A formula is a *claim
+    /// about the world* ("BMI is mass ÷ height²") and may not enter a library
+    /// unsourced — humans correct provenance, they do not author formulas by fiat.
+    FormulaMissingProvenance {
+        formula: String,
+    },
+    /// A `? name(args)` applied a `formula` whose argument was neither a plain
+    /// identifier (bind a parameter to a like-named slot) nor a number literal.
+    /// A compound / variable argument has no meaning as a formula binding at
+    /// rung-0, so it is rejected rather than silently mis-applied.
+    FormulaBadArgument {
+        formula: String,
+    },
     /// An `import "<path>"` survived to lowering (MYCIN-2026 M3). Imports must be
     /// resolved by [`crate::resolve`] *before* `lower` runs — reaching here means
     /// the caller used `compile` directly on a program that still has imports,
@@ -181,6 +205,26 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
     // structure is used afterward to scope vocabulary enforcement per `use`.
     let mut flat: Vec<&Statement> = Vec::new();
     flatten_clauses(&program.statements, &mut flat)?;
+
+    // ADJ-FORMULA-LIBRARIES rung-0: register every `formula` from every
+    // `formulabook` into a name→definition map, up front (formulas are
+    // order-independent declarations). Each is validated as it is registered:
+    // parameter-scoping (no free identifier in the body) and the
+    // provenance-required lint (a shipped formula must be sourced). A later
+    // `? name(args)` looks the name up here and APPLIES it — a named, importable,
+    // reusable `let` (see the `Statement::Query` arm below).
+    let mut formulas: HashMap<&str, &FormulaDef> = HashMap::new();
+    for stmt in flat.iter().copied() {
+        if let Statement::Formulabook {
+            formulas: defs, ..
+        } = stmt
+        {
+            for fd in defs {
+                validate_formula(fd)?;
+                formulas.insert(fd.name.as_str(), fd);
+            }
+        }
+    }
 
     for stmt in flat.iter().copied() {
         match stmt {
@@ -323,11 +367,36 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 kb.add_rule(rule);
             }
             Statement::Query { conclusion } => {
-                // Lower with a per-query variable scope so repeated `$Var`s in one
-                // goal share identity (Prolog clause-scope semantics). A ground
-                // hypothesis query lowers identically to before (no variables).
-                let mut vars = HashMap::new();
-                queries.push(lower_term_scoped(conclusion, &mut vars));
+                // ADJ-FORMULA-LIBRARIES rung-0: is this a FORMULA APPLICATION? If the
+                // goal's functor names a declared `formula` with matching arity
+                // (`? bmi(body_mass, height)`), APPLY it: bind each parameter to its
+                // argument, substitute into the formula body, and evaluate through the
+                // SAME `ComputeExpr` evaluator a `let` uses — a formula is a named,
+                // importable, reusable `let`. The result is bound as a derived value
+                // named after the formula, carrying the formula's cited provenance so
+                // the computed answer is auditable back to WHY its formula is trusted.
+                if let Some(fd) = formula_for_query(conclusion, &formulas) {
+                    let substituted = apply_formula(fd, conclusion)?;
+                    let cexpr = lower_expr(&substituted);
+                    let derived =
+                        compute(fd.name.clone(), &cexpr, &kb).map_err(|e| {
+                            LowerError::ComputationFailed {
+                                name: fd.name.clone(),
+                                detail: format!("{e:?}"),
+                            }
+                        })?;
+                    // The provenance-required lint already guaranteed a non-empty
+                    // source at registration; stamp the resolved envelope onto the
+                    // value so the derivation carries the formula's cites + trust.
+                    let prov = annotations_to_provenance(&fd.annotations)?;
+                    kb.add_derived(derived.with_provenance(prov));
+                } else {
+                    // An ordinary query. Lower with a per-query variable scope so
+                    // repeated `$Var`s in one goal share identity (Prolog clause-scope
+                    // semantics). A ground hypothesis query lowers as before.
+                    let mut vars = HashMap::new();
+                    queries.push(lower_term_scoped(conclusion, &mut vars));
+                }
             }
             Statement::Let { name, expr } => {
                 // Evaluate the formula against the facts (and any earlier
@@ -390,6 +459,12 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
             // — `flatten_clauses` expanded it into its inner clauses already.
             Statement::Use(_) => {}
             Statement::Rulebook { .. } => {}
+            // A `formulabook` adds nothing to the KB itself — its formulas were
+            // registered (and validated) in the pre-pass above, ready to be
+            // APPLIED by a matching `? name(args)`. The inner `use <dict>`
+            // bindings are documentation of the vocabulary the formulas are typed
+            // against (rung-0 does not enforce dictionary typing of parameters).
+            Statement::Formulabook { .. } => {}
             // ---- import (MYCIN-2026 M3) ----
             // Imports are resolved away by `crate::resolve` before lowering; one
             // reaching here means `compile` was called on an unresolved program.
@@ -439,7 +514,7 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                 .statements
                 .iter()
                 .filter(|s| !matches!(s, Statement::Rulebook { .. }));
-            enforce_vocabulary(top_clauses, defs)?;
+            enforce_vocabulary(top_clauses, defs, &formulas)?;
         }
         // Each rulebook is its own scope (its `use`, else the top-level `use`).
         for s in &program.statements {
@@ -448,12 +523,12 @@ pub fn lower(program: &Program) -> Result<LoweredProgram, LowerError> {
                     let defs = resolve(d)?;
                     let mut clauses: Vec<&Statement> = Vec::new();
                     flatten_clauses(statements, &mut clauses)?;
-                    enforce_vocabulary(clauses.into_iter(), defs)?;
+                    enforce_vocabulary(clauses.into_iter(), defs, &formulas)?;
                 }
             }
         }
     } else if !dictionary.is_empty() {
-        enforce_vocabulary(flat.iter().copied(), &dictionary)?;
+        enforce_vocabulary(flat.iter().copied(), &dictionary, &formulas)?;
     }
 
     Ok(LoweredProgram {
@@ -532,6 +607,7 @@ fn first_use(statements: &[Statement]) -> Option<&str> {
 fn enforce_vocabulary<'a>(
     statements: impl IntoIterator<Item = &'a Statement>,
     dictionary: &[Define],
+    formulas: &HashMap<&str, &FormulaDef>,
 ) -> Result<(), LowerError> {
     use std::collections::HashMap;
     let dict: HashMap<&str, &DefineKind> = dictionary
@@ -578,6 +654,14 @@ fn enforce_vocabulary<'a>(
     // hypothesis.
     let check_query = |t: &AstTerm| -> Result<(), LowerError> {
         let (functor, _) = term_functor_value(t);
+        // A FORMULA APPLICATION query (`? bmi(body_mass, height)`) names a
+        // registered formula, not a hypothesis or relation — accept it here so
+        // the closed-vocabulary gate does not reject the very construct this
+        // feature introduces. The formula's own parameter-scoping was checked at
+        // registration.
+        if formulas.contains_key(functor) {
+            return Ok(());
+        }
         match dict.get(functor) {
             Some(DefineKind::Relation { .. }) => Ok(()),
             _ => check_hypothesis(t),
@@ -841,6 +925,141 @@ fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, L
 }
 
 // ---------------------------------------------------------------------------
+// Formula libraries (ADJ-FORMULA-LIBRARIES rung-0)
+// ---------------------------------------------------------------------------
+
+/// Validate a `formula` at registration time: (1) **parameter-scoping** — every
+/// identifier leaf in the body must name a declared parameter, so a stray
+/// identifier is a clean compile error rather than a silent mis-binding at apply
+/// time; and (2) the **provenance-required lint** — a shipped formula must carry
+/// a non-empty `source`, mirroring the recall-library adversarial write gate.
+fn validate_formula(fd: &FormulaDef) -> Result<(), LowerError> {
+    let params: std::collections::HashSet<&str> =
+        fd.params.iter().map(String::as_str).collect();
+    let mut refs = Vec::new();
+    collect_refs(&fd.body, &mut refs);
+    for r in refs {
+        if !params.contains(r.as_str()) {
+            return Err(LowerError::FormulaFreeVariable {
+                formula: fd.name.clone(),
+                variable: r,
+            });
+        }
+    }
+    // Reuse the shared provenance path (the same relate/rule/prior use), then
+    // enforce that the primary `source` span is non-empty.
+    let prov = annotations_to_provenance(&fd.annotations)?;
+    if prov.source.trim().is_empty() {
+        return Err(LowerError::FormulaMissingProvenance {
+            formula: fd.name.clone(),
+        });
+    }
+    Ok(())
+}
+
+/// Collect every identifier leaf of an [`ExprAst`] — a [`ExprAst::Ref`] name or
+/// an [`ExprAst::Agg`] slot — into `out`. Used by [`validate_formula`] to check
+/// parameter-scoping. Numbers and operators contribute no identifiers.
+fn collect_refs(expr: &ExprAst, out: &mut Vec<String>) {
+    match expr {
+        ExprAst::Ref(name) => out.push(name.clone()),
+        ExprAst::Agg(_, slot) => out.push(slot.clone()),
+        ExprAst::Lit(_) => {}
+        ExprAst::Bin(_, a, b) | ExprAst::Call2(_, a, b) => {
+            collect_refs(a, out);
+            collect_refs(b, out);
+        }
+        ExprAst::Abs(a)
+        | ExprAst::Floor(a)
+        | ExprAst::Ceil(a)
+        | ExprAst::Round(a)
+        | ExprAst::Trunc(a)
+        | ExprAst::Sign(a)
+        | ExprAst::Call(_, a) => collect_refs(a, out),
+    }
+}
+
+/// If the query `goal` is a FORMULA APPLICATION — its functor names a registered
+/// formula and its argument count matches that formula's parameter count —
+/// return the matching definition. A ground atom, a `$variable` goal, or an
+/// arity mismatch returns `None` (it is an ordinary query, not an application).
+fn formula_for_query<'a>(
+    goal: &AstTerm,
+    formulas: &HashMap<&str, &'a FormulaDef>,
+) -> Option<&'a FormulaDef> {
+    if let AstTerm::Compound { functor, args } = goal {
+        if let Some(fd) = formulas.get(functor.as_str()) {
+            if fd.params.len() == args.len() {
+                return Some(fd);
+            }
+        }
+    }
+    None
+}
+
+/// APPLY a formula: bind each parameter to the correspondingly-positioned
+/// argument and substitute into the formula body, yielding a parameter-free
+/// [`ExprAst`] ready for the existing [`lower_expr`]/`compute` path. An argument
+/// that is a plain identifier binds the parameter to a like-named slot
+/// (`ExprAst::Ref`); a number literal binds it to that constant (`ExprAst::Lit`).
+/// Any other argument shape is a [`LowerError::FormulaBadArgument`].
+fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError> {
+    let args: &[AstTerm] = match goal {
+        AstTerm::Compound { args, .. } => args,
+        _ => &[],
+    };
+    let mut subst: HashMap<String, ExprAst> = HashMap::new();
+    for (param, arg) in fd.params.iter().zip(args.iter()) {
+        let bound = match arg {
+            AstTerm::Atom(name) => ExprAst::Ref(name.clone()),
+            AstTerm::Num(x) => ExprAst::Lit(*x),
+            _ => {
+                return Err(LowerError::FormulaBadArgument {
+                    formula: fd.name.clone(),
+                })
+            }
+        };
+        subst.insert(param.clone(), bound);
+    }
+    Ok(substitute_expr(&fd.body, &subst))
+}
+
+/// Substitute parameter references in a formula body with their bound argument
+/// expressions. A [`ExprAst::Ref`] naming a parameter becomes the bound
+/// expression; a non-parameter identifier is left as-is (validation already
+/// proved every identifier is a parameter, so this branch is defensive). An
+/// [`ExprAst::Agg`] slot naming a parameter is rewritten to the bound slot name
+/// when the binding is itself a slot reference (an aggregation folds a named
+/// slot, so only a `Ref` binding is meaningful there).
+fn substitute_expr(expr: &ExprAst, subst: &HashMap<String, ExprAst>) -> ExprAst {
+    match expr {
+        ExprAst::Ref(name) => subst.get(name).cloned().unwrap_or_else(|| expr.clone()),
+        ExprAst::Lit(_) => expr.clone(),
+        ExprAst::Agg(op, slot) => match subst.get(slot) {
+            Some(ExprAst::Ref(bound)) => ExprAst::Agg(*op, bound.clone()),
+            _ => expr.clone(),
+        },
+        ExprAst::Bin(op, a, b) => ExprAst::Bin(
+            *op,
+            Box::new(substitute_expr(a, subst)),
+            Box::new(substitute_expr(b, subst)),
+        ),
+        ExprAst::Call2(f, a, b) => ExprAst::Call2(
+            *f,
+            Box::new(substitute_expr(a, subst)),
+            Box::new(substitute_expr(b, subst)),
+        ),
+        ExprAst::Abs(a) => ExprAst::Abs(Box::new(substitute_expr(a, subst))),
+        ExprAst::Floor(a) => ExprAst::Floor(Box::new(substitute_expr(a, subst))),
+        ExprAst::Ceil(a) => ExprAst::Ceil(Box::new(substitute_expr(a, subst))),
+        ExprAst::Round(a) => ExprAst::Round(Box::new(substitute_expr(a, subst))),
+        ExprAst::Trunc(a) => ExprAst::Trunc(Box::new(substitute_expr(a, subst))),
+        ExprAst::Sign(a) => ExprAst::Sign(Box::new(substitute_expr(a, subst))),
+        ExprAst::Call(f, a) => ExprAst::Call(*f, Box::new(substitute_expr(a, subst))),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -849,6 +1068,242 @@ mod tests {
     use super::*;
     use crate::compile;
     use logic_engine::{enumerate_all, search, SearchMode, SearchResult};
+
+    // ---- ADJ-FORMULA-LIBRARIES rung-0: formulabook / formula ----
+
+    #[test]
+    fn formula_applies_and_carries_its_cited_provenance() {
+        // A single-file program that DEFINES a provenanced formula, binds its
+        // variables from `observe`d facts, and APPLIES it — the whole rung-0 loop.
+        // The engine computes 70 / 1.75² = 22.857 on the CPU, and the derived value
+        // carries the formula's WHO citation (source non-empty, trust authoritative).
+        let src = r#"
+            dictionary bmi_vocab {
+                define body_mass : finding
+                define height    : finding
+                define bmi       : finding
+            }
+            formulabook body_metrics {
+                use bmi_vocab
+                formula bmi(body_mass, height) = body_mass / (height * height)
+                    source "BMI is weight in kilograms divided by the square of height in metres."
+                    locator "https://www.who.int/health-topics/obesity"
+                    trust authoritative
+            }
+            observe body_mass(70)
+            observe height(1.75)
+            ? bmi(body_mass, height)
+        "#;
+        let lowered = compile(src).unwrap();
+        // A formula application is a derived value, not a differential query.
+        assert!(lowered.queries.is_empty(), "formula query is not a hypothesis");
+        let d = lowered
+            .kb
+            .derived_for("bmi")
+            .expect("the formula bound a derived `bmi`");
+        assert!(
+            (d.value - 22.857).abs() < 0.01,
+            "expected ≈22.857, got {}",
+            d.value
+        );
+        let prov = d.provenance.as_ref().expect("derivation carries provenance");
+        assert!(!prov.source.is_empty(), "the WHO source span is attached");
+        assert_eq!(prov.trust_tier, TrustTier::Authoritative);
+        assert_eq!(
+            prov.locator.as_deref(),
+            Some("https://www.who.int/health-topics/obesity")
+        );
+    }
+
+    #[test]
+    fn formula_rebinds_to_differently_named_arguments() {
+        // The parameters are FORMAL: applying `bmi(weight, stature)` substitutes
+        // param→argument, so the engine reads the `weight`/`stature` slots even
+        // though the formula was written over `body_mass`/`height`.
+        let src = r#"
+            formulabook m {
+                formula bmi(body_mass, height) = body_mass / (height * height)
+                    source "WHO BMI definition." trust authoritative
+            }
+            observe weight(80)
+            observe stature(2)
+            ? bmi(weight, stature)
+        "#;
+        let lowered = compile(src).unwrap();
+        let d = lowered.kb.derived_for("bmi").unwrap();
+        assert!((d.value - 20.0).abs() < 1e-9, "80 / 2² = 20, got {}", d.value);
+    }
+
+    #[test]
+    fn formula_free_variable_is_a_clean_scoping_error() {
+        // `b` is not a declared parameter — a stray identifier must be rejected,
+        // never silently mis-bound to some observed slot at apply time.
+        let src = r#"
+            formulabook m {
+                formula f(a) = a + b
+                    source "x" trust authoritative
+            }
+        "#;
+        let err = compile(src).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::CompileError::Lower(LowerError::FormulaFreeVariable { ref variable, .. })
+                    if variable == "b"
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn shipped_formula_without_provenance_is_rejected() {
+        // The provenance-required lint: a formula is a claim about the world and
+        // may not enter a library unsourced.
+        let src = r#"
+            formulabook m {
+                formula f(a) = a + a
+            }
+        "#;
+        let err = compile(src).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::CompileError::Lower(LowerError::FormulaMissingProvenance { ref formula })
+                    if formula == "f"
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn three_parameter_formula_applies() {
+        // Arity > 2: a mean-arterial-pressure-shaped 3-parameter formula. Confirms
+        // parameters bind positionally and the body substitutes all three.
+        let src = r#"
+            formulabook hemo {
+                formula weighted3(a, b, c) = (a + b + c) / 3
+                    source "arithmetic mean of three readings" trust authoritative
+            }
+            observe a(3)
+            observe b(6)
+            observe c(9)
+            ? weighted3(a, b, c)
+        "#;
+        let lowered = compile(src).unwrap();
+        let d = lowered.kb.derived_for("weighted3").unwrap();
+        assert!((d.value - 6.0).abs() < 1e-9, "(3+6+9)/3 = 6, got {}", d.value);
+    }
+
+    #[test]
+    fn formulabook_round_trips_through_the_parser() {
+        // Round-trip render: the surface `formulabook` parses to exactly the
+        // expected typed AST — name, parameters, body shape, and the provenance
+        // annotations — so a downstream consumer (formatter, doc-gen) can rebuild it.
+        let program = crate::parse(
+            "formulabook m {\n\
+               use v\n\
+               formula bmi(body_mass, height) = body_mass / (height * height)\n\
+                 source \"WHO\" locator \"loc\" trust authoritative\n\
+             }\n",
+        )
+        .unwrap();
+        let fb = program
+            .statements
+            .iter()
+            .find(|s| matches!(s, Statement::Formulabook { .. }))
+            .expect("a formulabook statement");
+        let Statement::Formulabook {
+            name,
+            uses,
+            formulas,
+        } = fb
+        else {
+            unreachable!()
+        };
+        assert_eq!(name, "m");
+        assert_eq!(uses, &vec!["v".to_string()]);
+        assert_eq!(formulas.len(), 1);
+        let f = &formulas[0];
+        assert_eq!(f.name, "bmi");
+        assert_eq!(f.params, vec!["body_mass".to_string(), "height".to_string()]);
+        // body = body_mass / (height * height)
+        assert_eq!(
+            f.body,
+            ExprAst::Bin(
+                ArithOp::Div,
+                Box::new(ExprAst::Ref("body_mass".into())),
+                Box::new(ExprAst::Bin(
+                    ArithOp::Mul,
+                    Box::new(ExprAst::Ref("height".into())),
+                    Box::new(ExprAst::Ref("height".into())),
+                )),
+            )
+        );
+        assert_eq!(
+            f.annotations,
+            vec![
+                Annotation::Source("WHO".into()),
+                Annotation::Locator("loc".into()),
+                Annotation::Trust(TrustTierName::Authoritative),
+            ]
+        );
+    }
+
+    #[test]
+    fn formula_end_to_end_via_import_of_the_shipped_library() {
+        // The real consumer surface: `import "bmi.adj"` + bind + apply. Uses the
+        // SHIPPED library file (loaded from disk) through an in-memory provider, so
+        // this test also proves `code/specs/data/adj-formula-stdlib/clinical/bmi.adj`
+        // parses, lints (provenance-required), and computes.
+        use crate::{compile_with_imports, ImportLimits, ImportProvider};
+        use std::collections::HashMap;
+
+        struct Mem {
+            files: HashMap<String, String>,
+        }
+        impl ImportProvider for Mem {
+            fn resolve(&self, _importer: &str, literal: &str) -> Result<String, String> {
+                self.files
+                    .contains_key(literal)
+                    .then(|| literal.to_string())
+                    .ok_or_else(|| format!("no such file: {literal}"))
+            }
+            fn load(&self, canonical: &str) -> Result<String, String> {
+                self.files
+                    .get(canonical)
+                    .cloned()
+                    .ok_or_else(|| format!("no such file: {canonical}"))
+            }
+        }
+
+        let bmi_lib = include_str!(
+            "../../../../specs/data/adj-formula-stdlib/clinical/bmi.adj"
+        );
+        let consumer = "import \"bmi.adj\"\n\
+                        observe body_mass(70)\n\
+                        observe height(1.75)\n\
+                        ? bmi(body_mass, height)\n";
+        let mut files = HashMap::new();
+        files.insert("bmi.adj".to_string(), bmi_lib.to_string());
+        files.insert("consumer.adj".to_string(), consumer.to_string());
+        let provider = Mem { files };
+
+        let lowered =
+            compile_with_imports("consumer.adj", &provider, ImportLimits::default()).unwrap();
+        let d = lowered.kb.derived_for("bmi").expect("applied imported formula");
+        assert!(
+            (d.value - 22.857).abs() < 0.01,
+            "expected ≈22.857, got {}",
+            d.value
+        );
+        let prov = d.provenance.as_ref().expect("carries the library citation");
+        assert!(
+            prov.source.contains("weight") || prov.source.contains("BMI"),
+            "WHO source span attached: {}",
+            prov.source
+        );
+        assert_eq!(prov.trust_tier, TrustTier::Authoritative);
+    }
 
     // ---- REL-2: relational recall (relate edges + binding queries) ----
 

--- a/code/packages/rust/logic-engine/CHANGELOG.md
+++ b/code/packages/rust/logic-engine/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] — optional provenance on `Derived`
+
+### Added
+
+- `Derived::provenance: Option<Provenance>` + `Derived::with_provenance(..)` — a
+  computed value may now carry the cited `source`/`locator`/`trust` of the
+  **formula** that produced it (ADJ-FORMULA-LIBRARIES rung-0 formula application).
+  `compute` sets it to `None`; a plain `let` leaves it `None` (its audit trail is
+  the derivation tree over observed facts). This is the channel by which a computed
+  answer carries *why* its formula is trustworthy, so an independent checker can
+  re-verify the citation without the model.
+
 ## [0.37.0] - 2026-07-02 — sign function (`Sign`)
 
 ### Added

--- a/code/packages/rust/logic-engine/src/compute.rs
+++ b/code/packages/rust/logic-engine/src/compute.rs
@@ -432,6 +432,24 @@ pub struct Derived {
     pub exact: Option<ExactRational>,
     pub dim: Dimension,
     pub tree: DerivationNode,
+    /// Provenance for the *formula* that produced this value, when it came from
+    /// APPLYING a provenanced `formula` (ADJ-FORMULA-LIBRARIES rung-0): the
+    /// formula's cited `source` / `locator` / `trust`. A plain `let` leaves this
+    /// `None` — its audit trail is the derivation `tree` over observed facts, and
+    /// there is no library claim to cite. This is the channel by which a computed
+    /// answer carries **why** its formula is trustworthy, so an independent
+    /// checker can re-verify the citation without the model.
+    pub provenance: Option<crate::Provenance>,
+}
+
+impl Derived {
+    /// Attach the applied formula's provenance (its cited `source`/`locator`/
+    /// `trust`). Consumes and returns `self` so it composes with [`compute`]:
+    /// `compute(name, expr, kb)?.with_provenance(prov)`.
+    pub fn with_provenance(mut self, provenance: crate::Provenance) -> Self {
+        self.provenance = Some(provenance);
+        self
+    }
 }
 
 /// Why a computation could not be carried out. These are clean errors — the
@@ -496,6 +514,9 @@ pub fn compute(
         exact,
         dim,
         tree,
+        // A plain `let` carries no library-formula provenance; a formula
+        // application attaches it afterward via [`Derived::with_provenance`].
+        provenance: None,
     })
 }
 

--- a/code/specs/data/adj-formula-stdlib/clinical/bmi.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/bmi.adj
@@ -1,0 +1,55 @@
+% ============================================================================
+% bmi.adj — the body-mass-index formula library (ADJ-FORMULA-LIBRARIES rung-0).
+% ============================================================================
+% The FIRST worked entry of the *compute* standard library: an importable,
+% byte-provenanced, PARAMETERIZED formula. Where the recall libraries ship
+% grounded `relate` edges (facts a model recalls), this ships a grounded
+% `formula` (arithmetic a model recalls) — the same contract, the other half of
+% the stdlib.
+%
+% A consumer states NO arithmetic. It `import`s this file, binds the variables
+% from its own byte-provenance decomposition, and asks the engine to apply the
+% cited formula on the CPU:
+%
+%     import "bmi.adj"
+%     observe body_mass(70)     % "…weighs 70 kg…"     (span cited by the model)
+%     observe height(1.75)      % "…height of 1.75 m…" (span cited by the model)
+%     ? bmi(body_mass, height)  % engine → 22.857 kg/m², carrying WHO's definition
+%
+% The formula (and its source) live HERE; the numbers (and their spans) come
+% from the input. Zero math is performed by the model.
+%
+% Run a worked consumer (from a directory it can resolve this import from):
+%     adj-lang-cli <consumer>.adj
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each term is an observable quantity the formula ranges over. The
+% spec's dimensional sketch is `body_mass : quantity(mass)`, `height :
+% quantity(length)`, `bmi : quantity`; rung-0's grammar types an observable slot
+% as `finding`, so we register them as findings and record the intended
+% dimension in the surface synonyms + comments. (Dimensional typing of formula
+% parameters is a later rung; the engine already infers + checks dimensions when
+% the formula is APPLIED — 70 kg / (1.75 m)² reports kg/m² — so the audit is
+% dimensional regardless.)
+% ----------------------------------------------------------------------------
+dictionary bmi_vocab {
+    define body_mass : finding  surface "weight", "body weight", "mass"      % mass, e.g. kg
+    define height    : finding  surface "height", "stature", "body height"   % length, e.g. m
+    define bmi       : finding  surface "body mass index", "BMI"             % mass / length²
+}
+
+% ----------------------------------------------------------------------------
+% The formula. A named, importable, reusable `let`: `body_mass / (height *
+% height)` is the SAME expression a `let` binds, and `body_mass` / `height` are
+% FORMAL PARAMETERS bound at apply time. The provenance clause is the same
+% envelope every grounded clause carries — required on a shipped formula.
+% ----------------------------------------------------------------------------
+formulabook body_metrics {
+    use bmi_vocab
+
+    formula bmi(body_mass, height) = body_mass / (height * height)
+        source "BMI is a person's weight in kilograms divided by the square of height in metres. A high BMI can indicate high body fatness."
+        locator "https://www.who.int/health-topics/obesity"
+        trust authoritative
+}


### PR DESCRIPTION
## FL-2 — rung-0: the formula-library substrate + BMI (end-to-end)

The language unblocker for ADJ-FORMULA-LIBRARIES. adj-lang can now define a **reusable, importable, byte-provenanced, parameterized formula** — the compute-side twin of the recall libraries' grounded `relate` facts. A consumer states **no arithmetic**: it imports a library, binds variables from its own byte-provenance decomposition, and asks the engine to apply the *cited* formula on the CPU.

### The money demo (verified end-to-end)
```adj
% bmi.adj (the shipped library)
formulabook body_metrics {
    use bmi_vocab
    formula bmi(body_mass, height) = body_mass / (height * height)
        source "BMI is a person's weight in kilograms divided by the square of height in metres…"
        locator "https://www.who.int/health-topics/obesity"
        trust authoritative
}
```
```adj
% a consumer
import "bmi.adj"
observe body_mass(70)     % "…weighs 70 kg…"     (span cited by the model)
observe height(1.75)      % "…height of 1.75 m…" (span cited by the model)
? bmi(body_mass, height)
```
→ engine yields `22.857142857142858` **carrying WHO's cited definition** (`source` + `locator` + `trust=authoritative`). Zero math performed by the model.

### Design (spec §3/§5)
- A `formula` body **is** the existing `let` expression grammar (`ExprAst`). The only new idea: a leaf identifier naming a declared parameter is a **formal parameter** bound at apply time. **No new evaluator** — `? name(args)` binds params to positional args (atom→slot `Ref`, number→`Lit`), substitutes into the body, and evaluates through the **same** `lower_expr`/`compute` CPU path `let` uses. Dimensions are inferred+checked at apply time.
- **Provenance required**: every shipped formula carries the same `source`/`locator`/`trust` envelope as a `relate` edge. `validate_formula` rejects an unsourced formula (`FormulaMissingProvenance`) and any body identifier that isn't a parameter (`FormulaFreeVariable`) — a clean compile error, never a silent mis-binding. The computed `Derived` carries the formula's provenance (logic-engine gains `Derived.provenance` + `with_provenance`); the CLI renders it, so the answer is auditable end-to-end.
- Importable across files via the existing `import`/`use` resolver (cycle-detected, depth-bounded).

### Deviations (flagged, all rung-0-appropriate)
- Provenance stored as the shared `Vec<Annotation>` envelope (one lowering path, max reuse) + the required-source lint.
- Dictionary terms typed `finding` (the grammar's observable-slot kind); dimensional `quantity(dim)` parameter typing is a later rung — the engine still checks dimensions at apply time.
- Params are bare names (`Vec<String>`), sufficient for rung-0 binding.

### Verification
- `cargo test -p adj-lang -p adj-lang-cli` — **green** (147 adj-lang incl. 7 new formula tests + `formula_e2e` + 38 cli-golden; logic-engine green).
- New code **clippy-clean** — every clippy warning is pre-existing, outside the diff hunks (verified by line cross-reference); clippy is not a CI gate here regardless.
- `regen_grammars` idempotent (only `_parser_grammar.rs` changed; no new lexer tokens).
- **Security review: PASSED** — no panics/unsafe/DoS; substitution is a bounded AST walk with no amplification (args restricted to atom/number leaves, arity pre-checked), errors flow through the existing `compute` contract.

Next (FL-3): K/elementary primitive formula libraries (add/subtract/multiply/divide) as provenanced formulabooks with decompose-bind queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
