### PR TITLE
feat(sha1): pure-Java port (FIPS 180-4 + streaming Digest)

### DIFF
--- a/code/packages/java/sha1/.gitignore
+++ b/code/packages/java/sha1/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/sha1/BUILD
+++ b/code/packages/java/sha1/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/sha1/BUILD_windows
+++ b/code/packages/java/sha1/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/java/sha1/CHANGELOG.md
+++ b/code/packages/java/sha1/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — sha1 (Java)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Java port of the `sha1` reference package, completing
+  the common hash family in Java (alongside sha256 and md5).
+- `Sha1.sum1(byte[])` → 20-byte FIPS 180-4 digest.
+- `Sha1.hexString(byte[])` → 40-char lowercase hex digest.
+- `Sha1.Digest` — streaming hasher with `update`, non-destructive `digest` /
+  `hexDigest`, and `copy` for independent snapshots.
+- Big-endian block parsing/length/output; Java's native 32-bit `int` arithmetic
+  (`Integer.rotateLeft`, `& 0xff` byte masking).
+- 20 JUnit tests: FIPS 180-4 / RFC 3174 vectors (empty, "abc", 56-byte,
+  one-million-'a'), output-format/determinism/avalanche, padding block
+  boundaries (0/55/56/63/64/127/128), and streaming parity with the one-shot API.
+- Documented security note: SHA-1 collision resistance is broken; checksum use only.

--- a/code/packages/java/sha1/README.md
+++ b/code/packages/java/sha1/README.md
@@ -1,0 +1,43 @@
+# sha1 (Java)
+
+SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch in pure
+Java — no `java.security.MessageDigest`.
+
+Java port of the `sha1` package that already exists in Rust, Dart, and other
+languages in the monorepo; produces byte-identical digests.
+
+> **Security:** SHA-1 is **broken** for collision resistance (SHAttered, 2017).
+> Never use it for signatures or certificates. Legacy/checksum use only.
+
+## API
+
+`com.codingadventures.sha1.Sha1`:
+
+| Member | Purpose |
+|---|---|
+| `static byte[] sum1(byte[] data)` | 20-byte digest. |
+| `static String hexString(byte[] data)` | 40-char lowercase hex digest. |
+| `Sha1.Digest` | Streaming: `update`, non-destructive `digest` / `hexDigest`, `copy`. |
+
+## Usage
+
+```java
+import com.codingadventures.sha1.Sha1;
+import java.nio.charset.StandardCharsets;
+
+byte[] data = "abc".getBytes(StandardCharsets.UTF_8);
+System.out.println(Sha1.hexString(data));
+// a9993e364706816aba3e25717850c26c9cd0d89d
+```
+
+## Implementation note
+
+SHA-1 is **big-endian** like SHA-256 (opposite of MD5); five state words, 80
+rounds. Java's native 32-bit `int` needs no masking; uses `Integer.rotateLeft`
+and `& 0xff` byte masking before shifts.
+
+## Running the tests
+
+```
+gradle test
+```

--- a/code/packages/java/sha1/build.gradle.kts
+++ b/code/packages/java/sha1/build.gradle.kts
@@ -1,0 +1,28 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/java/sha1/settings.gradle.kts
+++ b/code/packages/java/sha1/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sha1"

--- a/code/packages/java/sha1/src/main/java/com/codingadventures/sha1/Sha1.java
+++ b/code/packages/java/sha1/src/main/java/com/codingadventures/sha1/Sha1.java
@@ -1,0 +1,190 @@
+// ============================================================================
+// Sha1.java — SHA-1 cryptographic hash (FIPS 180-4), from scratch
+// ============================================================================
+//
+// SHA-1 maps any sequence of bytes to a fixed 20-byte (160-bit) digest. Like
+// MD5 and SHA-256 it uses the Merkle–Damgård construction over 64-byte blocks,
+// but with five state words and 80 rounds. This is a from-scratch
+// implementation (no java.security.MessageDigest), the Java port of the `sha1`
+// package; it produces byte-identical digests to the Rust/Dart ports.
+//
+// SECURITY: SHA-1 is BROKEN for collision resistance (the SHAttered attack,
+// 2017). Never use it for signatures or certificates. Legacy protocols and
+// non-adversarial checksums (e.g. git object names) only.
+//
+// 32-bit arithmetic:
+// ------------------
+// SHA-1 is big-endian (like SHA-256, the opposite of MD5). Java's `int` is a
+// 32-bit two's-complement value whose arithmetic and bitwise operators match
+// unsigned 32-bit semantics, so no masking is needed; `Integer.rotateLeft`
+// performs the rotations and block bytes are masked with `& 0xff` before shifting.
+
+package com.codingadventures.sha1;
+
+public final class Sha1 {
+
+    // Initial state H0..H4 ("nothing up my sleeve" counting-sequence constants).
+    private static final int[] INIT = {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
+
+    // Per-stage round constants: floor(sqrt(2,3,5,10) * 2^30).
+    private static final int[] K = {0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6};
+
+    private Sha1() {}
+
+    // ── Compression ─────────────────────────────────────────────────────────
+    //
+    // Fold one 64-byte block (at `offset`) into the five-word state over 80
+    // rounds. The 16 big-endian words of the block are expanded to an 80-word
+    // schedule, then four stages of 20 rounds each mix them in.
+    private static void compress(int[] state, byte[] data, int offset) {
+        int[] w = new int[80];
+        for (int i = 0; i < 16; i++) {
+            int j = offset + i * 4;
+            w[i] = ((data[j] & 0xff) << 24)
+                 | ((data[j + 1] & 0xff) << 16)
+                 | ((data[j + 2] & 0xff) << 8)
+                 |  (data[j + 3] & 0xff);
+        }
+        for (int i = 16; i < 80; i++) {
+            w[i] = Integer.rotateLeft(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+        }
+
+        int a = state[0], b = state[1], c = state[2], d = state[3], e = state[4];
+
+        for (int t = 0; t < 80; t++) {
+            int f, k;
+            if (t < 20) {
+                f = (b & c) | (~b & d);
+                k = K[0];
+            } else if (t < 40) {
+                f = b ^ c ^ d;
+                k = K[1];
+            } else if (t < 60) {
+                f = (b & c) | (b & d) | (c & d);
+                k = K[2];
+            } else {
+                f = b ^ c ^ d;
+                k = K[3];
+            }
+            int temp = Integer.rotateLeft(a, 5) + f + e + k + w[t];
+            e = d;
+            d = c;
+            c = Integer.rotateLeft(b, 30);
+            b = a;
+            a = temp;
+        }
+
+        state[0] += a; state[1] += b; state[2] += c; state[3] += d; state[4] += e;
+    }
+
+    // Serialise the five state words into a 20-byte big-endian digest.
+    private static byte[] stateToDigest(int[] state) {
+        byte[] out = new byte[20];
+        for (int i = 0; i < 5; i++) {
+            out[i * 4]     = (byte) (state[i] >>> 24);
+            out[i * 4 + 1] = (byte) (state[i] >>> 16);
+            out[i * 4 + 2] = (byte) (state[i] >>> 8);
+            out[i * 4 + 3] = (byte) (state[i]);
+        }
+        return out;
+    }
+
+    // Pad: append 0x80, zero-fill to 56 (mod 64), then the bit length as a
+    // 64-bit big-endian integer (FIPS 180-4).
+    private static byte[] pad(byte[] tail, long totalBytes) {
+        long bitLen = totalBytes * 8L;
+        int padLen = 1;
+        while ((tail.length + padLen) % 64 != 56) padLen++;
+        byte[] padded = new byte[tail.length + padLen + 8];
+        System.arraycopy(tail, 0, padded, 0, tail.length);
+        padded[tail.length] = (byte) 0x80;
+        for (int i = 0; i < 8; i++) {
+            padded[padded.length - 1 - i] = (byte) (bitLen >>> (i * 8)); // big-endian
+        }
+        return padded;
+    }
+
+    // ── Public one-shot API ─────────────────────────────────────────────────
+
+    /** Compute the SHA-1 digest of {@code data} as a 20-byte array. */
+    public static byte[] sum1(byte[] data) {
+        byte[] padded = pad(data, data.length);
+        int[] state = INIT.clone();
+        for (int off = 0; off < padded.length; off += 64) {
+            compress(state, padded, off);
+        }
+        return stateToDigest(state);
+    }
+
+    /** Compute SHA-1 and return the 40-character lowercase hex string. */
+    public static String hexString(byte[] data) {
+        return toHex(sum1(data));
+    }
+
+    static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >>> 4) & 0xf, 16));
+            sb.append(Character.forDigit(b & 0xf, 16));
+        }
+        return sb.toString();
+    }
+
+    // ── Streaming digest ────────────────────────────────────────────────────
+
+    /**
+     * Incremental SHA-1. Feed data with {@link #update}; {@link #digest} is
+     * non-destructive so the hasher can keep receiving updates afterwards.
+     */
+    public static final class Digest {
+        private final int[] state;
+        private byte[] buf;
+        private long byteCount;
+
+        public Digest() {
+            this.state = INIT.clone();
+            this.buf = new byte[0];
+            this.byteCount = 0;
+        }
+
+        private Digest(int[] state, byte[] buf, long byteCount) {
+            this.state = state.clone();
+            this.buf = buf.clone();
+            this.byteCount = byteCount;
+        }
+
+        /** Feed more bytes into the hash. */
+        public void update(byte[] data) {
+            byteCount += data.length;
+            byte[] combined = new byte[buf.length + data.length];
+            System.arraycopy(buf, 0, combined, 0, buf.length);
+            System.arraycopy(data, 0, combined, buf.length, data.length);
+            int full = combined.length - (combined.length % 64);
+            for (int off = 0; off < full; off += 64) {
+                compress(state, combined, off);
+            }
+            buf = new byte[combined.length - full];
+            System.arraycopy(combined, full, buf, 0, buf.length);
+        }
+
+        /** Return the 20-byte digest of all data fed so far (non-destructive). */
+        public byte[] digest() {
+            byte[] tail = pad(buf, byteCount);
+            int[] s = state.clone();
+            for (int off = 0; off < tail.length; off += 64) {
+                compress(s, tail, off);
+            }
+            return stateToDigest(s);
+        }
+
+        /** Return the 40-character lowercase hex digest string. */
+        public String hexDigest() {
+            return toHex(digest());
+        }
+
+        /** Return an independent copy of this hasher's current state. */
+        public Digest copy() {
+            return new Digest(state, buf, byteCount);
+        }
+    }
+}

--- a/code/packages/java/sha1/src/test/java/com/codingadventures/sha1/Sha1Test.java
+++ b/code/packages/java/sha1/src/test/java/com/codingadventures/sha1/Sha1Test.java
@@ -1,0 +1,180 @@
+// ============================================================================
+// Sha1Test.java — Unit tests for Sha1 (FIPS 180-4 / RFC 3174 vectors)
+// ============================================================================
+
+package com.codingadventures.sha1;
+
+import org.junit.jupiter.api.Test;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.*;
+
+class Sha1Test {
+
+    private static byte[] a(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    // ── Known-answer vectors ─────────────────────────────────────────────────
+
+    @Test
+    void vectors() {
+        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", Sha1.hexString(a("")));
+        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", Sha1.hexString(a("abc")));
+        String msg = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+        assertEquals(56, msg.length());
+        assertEquals("84983e441c3bd26ebaae4aa1f95129e5e54670f1", Sha1.hexString(a(msg)));
+    }
+
+    @Test
+    void millionA() {
+        byte[] data = new byte[1_000_000];
+        Arrays.fill(data, (byte) 'a');
+        assertEquals("34aa973cd4c4daa4f61eeb2bdbad27316534016f", Sha1.hexString(data));
+    }
+
+    // ── Output format ────────────────────────────────────────────────────────
+
+    @Test
+    void digestIs20Bytes() {
+        assertEquals(20, Sha1.sum1(a("")).length);
+        assertEquals(20, Sha1.sum1(a("hello world")).length);
+        assertEquals(20, Sha1.sum1(new byte[1000]).length);
+    }
+
+    @Test
+    void hexIs40LowercaseChars() {
+        String h = Sha1.hexString(a("abc"));
+        assertEquals(40, h.length());
+        assertTrue(h.matches("[0-9a-f]{40}"));
+    }
+
+    // ── Properties ───────────────────────────────────────────────────────────
+
+    @Test
+    void deterministic() {
+        assertArrayEquals(Sha1.sum1(a("hello")), Sha1.sum1(a("hello")));
+    }
+
+    @Test
+    void avalanche() {
+        byte[] h1 = Sha1.sum1(a("hello"));
+        byte[] h2 = Sha1.sum1(a("helo"));
+        assertFalse(Arrays.equals(h1, h2));
+        int bits = 0;
+        for (int i = 0; i < 20; i++) bits += Integer.bitCount((h1[i] ^ h2[i]) & 0xff);
+        assertTrue(bits > 30, "only " + bits + " bits differed");
+    }
+
+    @Test
+    void nullByteDiffersFromEmpty() {
+        assertFalse(Arrays.equals(Sha1.sum1(new byte[]{0}), Sha1.sum1(a(""))));
+    }
+
+    @Test
+    void everyByteValueHashesDistinctly() {
+        Set<String> seen = new HashSet<>();
+        for (int i = 0; i <= 255; i++) seen.add(Sha1.hexString(new byte[]{(byte) i}));
+        assertEquals(256, seen.size());
+    }
+
+    // ── Padding / block boundaries ───────────────────────────────────────────
+
+    @Test
+    void blockBoundariesProduce20ByteDigests() {
+        for (int n : new int[]{0, 55, 56, 63, 64, 127, 128}) {
+            assertEquals(20, Sha1.sum1(new byte[n]).length);
+        }
+    }
+
+    @Test
+    void boundary55And56Differ() {
+        assertFalse(Arrays.equals(Sha1.sum1(new byte[55]), Sha1.sum1(new byte[56])));
+    }
+
+    @Test
+    void allBoundarySizesDistinct() {
+        Set<String> seen = new HashSet<>();
+        for (int n : new int[]{0, 55, 56, 63, 64, 127, 128}) seen.add(Sha1.hexString(new byte[n]));
+        assertEquals(7, seen.size());
+    }
+
+    // ── Streaming digest ─────────────────────────────────────────────────────
+
+    @Test
+    void streamingSingleWriteMatchesOneShot() {
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(a("abc"));
+        assertArrayEquals(Sha1.sum1(a("abc")), h.digest());
+    }
+
+    @Test
+    void streamingSplitMatchesOneShot() {
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(a("ab"));
+        h.update(a("c"));
+        assertArrayEquals(Sha1.sum1(a("abc")), h.digest());
+    }
+
+    @Test
+    void streamingBlockSplitMatchesOneShot() {
+        byte[] data = new byte[128];
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(Arrays.copyOfRange(data, 0, 64));
+        h.update(Arrays.copyOfRange(data, 64, 128));
+        assertArrayEquals(Sha1.sum1(data), h.digest());
+    }
+
+    @Test
+    void streamingByteAtATimeMatchesOneShot() {
+        byte[] data = new byte[100];
+        for (int i = 0; i < 100; i++) data[i] = (byte) i;
+        Sha1.Digest h = new Sha1.Digest();
+        for (byte b : data) h.update(new byte[]{b});
+        assertArrayEquals(Sha1.sum1(data), h.digest());
+    }
+
+    @Test
+    void streamingEmptyMatchesEmptyOneShot() {
+        assertArrayEquals(Sha1.sum1(a("")), new Sha1.Digest().digest());
+    }
+
+    @Test
+    void streamingDigestIsNonDestructive() {
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(a("hello"));
+        assertArrayEquals(h.digest(), h.digest());
+        h.update(a(" world"));
+        assertArrayEquals(Sha1.sum1(a("hello world")), h.digest());
+    }
+
+    @Test
+    void streamingHexDigestMatches() {
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(a("abc"));
+        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", h.hexDigest());
+    }
+
+    @Test
+    void streamingCopyIsIndependent() {
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(a("ab"));
+        Sha1.Digest h2 = h.copy();
+        h2.update(a("c"));
+        h.update(a("x"));
+        assertArrayEquals(Sha1.sum1(a("abc")), h2.digest());
+        assertArrayEquals(Sha1.sum1(a("abx")), h.digest());
+    }
+
+    @Test
+    void streamingMillionAInTwoHalves() {
+        byte[] data = new byte[1_000_000];
+        Arrays.fill(data, (byte) 'a');
+        Sha1.Digest h = new Sha1.Digest();
+        h.update(Arrays.copyOfRange(data, 0, 500_000));
+        h.update(Arrays.copyOfRange(data, 500_000, 1_000_000));
+        assertEquals("34aa973cd4c4daa4f61eeb2bdbad27316534016f", h.hexDigest());
+    }
+}


### PR DESCRIPTION
## What

Pure-Java port of the `sha1` package — SHA-1 (FIPS 180-4) from scratch, no `java.security.MessageDigest`. Third Java pure port, **completing the common hash family in Java** (sha256, md5, sha1).

**Why:** `sha1` is a canon package missing from Java.

## API (`com.codingadventures.sha1.Sha1`)

- `static byte[] sum1(byte[])` — 20-byte digest.
- `static String hexString(byte[])` — 40-char lowercase hex.
- `Sha1.Digest` — streaming `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Implementation note

SHA-1 is **big-endian** like SHA-256 (opposite of MD5); five state words, 80 rounds. Java's native 32-bit `int` needs no masking; uses `Integer.rotateLeft` and `& 0xff` byte masking before shifts.

## Verification

- **FIPS 180-4 / RFC 3174 vectors** pass (empty, `"abc"`, 56-byte, one-million-'a').
- Determinism + avalanche, padding/block-boundary edge cases (0/55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, copy independence, one-million-'a').
- **20 JUnit tests**, `gradle test` green.
- Security review passed: `>>>` vs `>>`, `& 0xff` masking, consistent big-endian parse/length/output, round function/schedule/constants, padding sizing, and streaming non-destructiveness/copy-independence all verified.

> **Security note** (docs + README): SHA-1 collision resistance is broken (SHAttered, 2017) — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)