### PR TITLE
fix(sql-vm,sql-codegen): scalar functions match SQLite — retire string_functions ledger entry (Stream B / L3)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.1 — Scalar functions match SQLite (ledger 7 → 6)
+
+Stream B / L3 of the full-SQLite-replacement roadmap: retire the differential
+oracle's `string_functions` divergence, the last *wrong-value* entry in the
+ledger.
+
+- `SELECT UPPER(name), LENGTH(name)` previously came back as `LENGTH(name),
+  LENGTH(name)` with both columns named `?`. Two independent bugs, one symptom:
+  - **sql-vm** (0.2.1): Phase-4 materialization collapsed each row's positional
+    `(name, value)` pairs through a `HashMap` keyed by column name, so two
+    same-named output columns kept only the *last* value. Now projects by
+    position (the row buffer is already parallel to the locked column list).
+  - **sql-codegen** (0.4.0): un-aliased function columns were labelled `?`. Now
+    labelled with the reconstructed call text (`UPPER(name)`), matching SQLite.
+- `tests/differential_oracle.rs`: removed `string_functions` from the `LEDGER`
+  (now **6** entries — `full_join` plus five aggregate computed-column *naming*
+  divergences); the case is now asserted to match real SQLite exactly.
+- No mini-sqlite `src/` changes — the fixes land in the shared pipeline crates;
+  this crate's bump documents the conformance gain the oracle now enforces.
+
 ## 0.4.0 — Open a real `.sqlite` file
 
 Stream C / L4 of the full-SQLite-replacement roadmap: `connect()` can now open a

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -404,9 +404,14 @@ const CASES: &[Case] = &[
 ///   `having`): the result *rows* match SQLite exactly, but mini-sqlite names an
 ///   aggregate output column `agg_N` where SQLite uses the expression text
 ///   (`SUM(n)`). A naming-only divergence.
-/// - **Scalar functions** (`string_functions`): function-call output columns are
-///   unnamed (`?`), and `UPPER(name)` returns the wrong value (an integer, not
-///   the uppercased text) — a real codegen/builtin bug.
+///
+/// Scalar functions (`string_functions`) used to be ledgered here: `UPPER(name)`
+/// came back as an integer and the columns were unnamed (`?`). Both are now
+/// fixed and the case matches SQLite — see the commit that retired it. The root
+/// cause was a positional→named→positional round-trip in `sql-vm`'s Phase-4
+/// materialize that collapsed same-named output columns through a `HashMap`
+/// (dropping every value but the last), plus `sql-codegen` labelling function
+/// columns `?` instead of the SQLite-style expression text.
 const LEDGER: &[(&str, &str)] = &[
     (
         "full_join",
@@ -431,10 +436,6 @@ const LEDGER: &[(&str, &str)] = &[
     (
         "having",
         "rows match; computed-column naming differs — agg_0 vs SUM(amt).",
-    ),
-    (
-        "string_functions",
-        "function-call output columns unnamed (?), and UPPER(name) returns the wrong value (int, not uppercased text). Real codegen/builtin bug.",
     ),
 ];
 

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.4.0] - Unreleased
+
+### Added
+
+- **SQLite-style column names for un-aliased function calls.** `output_column_name`
+  now labels an un-aliased function-call output column with the reconstructed
+  call text — `SELECT UPPER(name), LENGTH(name)` yields columns `UPPER(name)` and
+  `LENGTH(name)` instead of two `?`s, matching what real SQLite returns (an
+  un-aliased expression column is named after its source text). A new
+  `render_expr_label` helper best-effort-renders columns, simple literals, and
+  nested calls, returning `None` (→ `?`) for shapes it can't faithfully print, so
+  we never emit a misleading name. Aliases still win, and non-function complex
+  expressions keep the `?` default. Together with the sql-vm positional-projection
+  fix this retires the differential-oracle `string_functions` divergence.
+
+### Removed
+
+- Dropped the unused top-level `SortKey` import (it is re-imported inside the test
+  module where it is actually used), clearing a compiler warning.
+
 ## [0.3.0] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -73,7 +73,7 @@ use coding_adventures_sql_backend::{ColumnDef, SqlValue};
 use coding_adventures_sql_optimizer::OptimizedPlan;
 use coding_adventures_sql_planner::{
     AggFunc, AggregateItem, Assignment, BinaryOp as PlanBinaryOp, InsertSource, JoinKind,
-    OutputColumn, SortKey, SqlExpr, UnaryOp as PlanUnaryOp,
+    OutputColumn, SqlExpr, UnaryOp as PlanUnaryOp,
 };
 
 // ---------------------------------------------------------------------------
@@ -2090,14 +2090,64 @@ fn peel_post_ops(plan: &OptimizedPlan) -> (&OptimizedPlan, Vec<Instruction>) {
 /// 2. If the expression is a bare column reference (`SELECT col`), use the
 ///    column name as the implicit label.  This matches SQL's convention that
 ///    `SELECT id FROM t` exposes a column named `id`.
-/// 3. Fall back to `"?"` for complex expressions without an alias.
+/// 3. For a function call (`SELECT UPPER(name)`), reconstruct the call text —
+///    `UPPER(name)` — as the label.  SQLite names an un-aliased expression
+///    column after the *source text* of the expression, so `SELECT UPPER(name),
+///    LENGTH(name)` returns columns `UPPER(name)` and `LENGTH(name)`.  Giving
+///    the two columns distinct names is not just cosmetic: the VM keys nothing
+///    by name (it projects positionally), but the differential oracle compares
+///    column names against real SQLite, and two `?`-named columns previously
+///    diverged.  We reconstruct rather than thread source spans through the
+///    parser, which matches SQLite exactly for the whitespace-free calls we
+///    emit and degrades to `?` for arguments we cannot render.
+/// 4. Fall back to `"?"` for other complex expressions without an alias.
 fn output_column_name(col: &OutputColumn) -> String {
     if let Some(alias) = &col.alias {
         return alias.clone();
     }
     match &col.expr {
         SqlExpr::Column { name, .. } => name.clone(),
+        SqlExpr::FunctionCall { .. } => render_expr_label(&col.expr).unwrap_or_else(|| "?".to_string()),
         _ => "?".to_string(),
+    }
+}
+
+/// Best-effort reconstruction of an expression's *source text*, used as the
+/// implicit column label for un-aliased expressions (mirroring SQLite).
+///
+/// Returns `None` for any node we do not know how to render, so the caller can
+/// fall back to `"?"` rather than emitting a misleading label.  We only render
+/// the shapes that actually appear as function arguments today — columns,
+/// simple literals, and nested calls — because the goal is faithful column
+/// *names*, not a general SQL pretty-printer.
+///
+/// | expression            | rendered label   |
+/// |-----------------------|------------------|
+/// | `UPPER(name)`         | `UPPER(name)`    |
+/// | `SUBSTR(name,1,2)`    | `SUBSTR(name,1,2)` |
+/// | `LENGTH(u.name)`      | `LENGTH(u.name)` |
+/// | `COALESCE(x,'-')`     | `COALESCE(x,'-')`|
+fn render_expr_label(expr: &SqlExpr) -> Option<String> {
+    match expr {
+        SqlExpr::Column { table: Some(t), name } => Some(format!("{t}.{name}")),
+        SqlExpr::Column { table: None, name } => Some(name.clone()),
+        SqlExpr::Literal(v) => Some(match v {
+            SqlValue::Null => "NULL".to_string(),
+            SqlValue::Bool(b) => if *b { "TRUE".to_string() } else { "FALSE".to_string() },
+            SqlValue::Int(n) => n.to_string(),
+            // Render floats via SQLite's own default text form is out of scope;
+            // the plain Rust form matches for the integral/simple cases we emit.
+            SqlValue::Float(f) => f.to_string(),
+            // Single-quote string literals, doubling embedded quotes as SQL does.
+            SqlValue::Text(s) => format!("'{}'", s.replace('\'', "''")),
+            // Blobs have no simple textual column-name form; decline to render.
+            SqlValue::Blob(_) => return None,
+        }),
+        SqlExpr::FunctionCall { name, args, .. } => {
+            let rendered: Option<Vec<String>> = args.iter().map(render_expr_label).collect();
+            Some(format!("{}({})", name, rendered?.join(",")))
+        }
+        _ => None,
     }
 }
 

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,7 +3,21 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.2.0] - Unreleased
+## [0.2.1] - Unreleased
+
+### Fixed
+
+- **Same-named output columns no longer collide.** Phase-4 materialization used
+  to collapse each row's positional `(name, value)` pairs into a
+  `HashMap<String, SqlValue>` and then re-read one value per output-column name.
+  Two output columns that share a name — e.g. `SELECT UPPER(x), LENGTH(x)` (both
+  default to `?`) or `SELECT id, id` — collided in the map, so every such column
+  returned the *last* value (`SELECT UPPER(x), LENGTH(x)` came back as
+  `LENGTH(x), LENGTH(x)`). The row buffer is already positional and parallel to
+  the locked `output_columns` (both are produced by the same `EmitColumn`
+  sequence, and hidden sort-key columns are truncated off both together), so we
+  now project by **position** and drop the name-keyed map entirely. Fixes the
+  differential-oracle `string_functions` divergence.
 
 ### Added
 

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -962,21 +962,35 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
     // ── Phase 4: materialize ──────────────────────────────────────────────────
     //
     // Each row in `output_rows` is a `Vec<(String, SqlValue)>` in emission
-    // order.  Project it onto `output_columns` to produce `Vec<SqlValue>`.
+    // order.  Strip the names and keep the values — the row is already POSITIONAL
+    // and parallel to `output_columns`, because both are produced by the same
+    // `EmitColumn` sequence (the codegen emits one `EmitColumn` per output column,
+    // in order; `output_columns` was locked from the first row's buffer; and any
+    // hidden sort-key columns are truncated off BOTH the rows and `output_columns`
+    // together in Phase 3).  So position `i` of every row is column `i`.
+    //
+    // We deliberately do NOT rebuild a `name → value` map here.  Two output
+    // columns can legitimately share a name — e.g. `SELECT UPPER(x), LENGTH(x)`
+    // yields two columns both defaulting to the name `?`, and `SELECT id, id`
+    // yields two `id` columns.  Collapsing `(name, value)` pairs into a `HashMap`
+    // would drop all but the last value for each repeated name, so both `UPPER(x)`
+    // and `LENGTH(x)` would come back as `LENGTH(x)`'s value.  Positional
+    // projection is both correct and cheaper.
+    let ncols = output_columns.len();
     let rows: Vec<Vec<SqlValue>> = output_rows
         .into_iter()
         .map(|row| {
-            if output_columns.is_empty() {
-                // No named columns (e.g. SELECT without EmitColumn) — return raw values.
-                row.into_iter().map(|(_, v)| v).collect()
-            } else {
-                // Build a name→value map and project onto the locked column order.
-                let map: HashMap<String, SqlValue> = row.into_iter().collect();
-                output_columns
-                    .iter()
-                    .map(|col| map.get(col).cloned().unwrap_or(SqlValue::Null))
-                    .collect()
+            let mut vals: Vec<SqlValue> = row.into_iter().map(|(_, v)| v).collect();
+            // When column names were locked (the normal SELECT path), keep exactly
+            // one value per column so `columns.len() == row.len()`.  `is_empty()`
+            // means no `EmitColumn` ran (raw-value path) — return the values as-is.
+            if ncols != 0 {
+                vals.truncate(ncols);
+                while vals.len() < ncols {
+                    vals.push(SqlValue::Null);
+                }
             }
+            vals
         })
         .collect();
 


### PR DESCRIPTION
## Stream B / L3 — shrink the conformance ledger (7 → 6)

The differential oracle's **`string_functions`** case — the last *wrong-value* entry in the ledger — diverged from real SQLite:

```sql
SELECT UPPER(name), LENGTH(name) FROM users
-- mini-sqlite (before): rows [[3,3],[5,5]], columns ["?","?"]
-- real SQLite:          rows [["ADA",3],["GRACE",5]], columns ["UPPER(name)","LENGTH(name)"]
```

One symptom, **two independent bugs** in the shared pipeline crates:

### 1. `sql-vm` (0.2.1) — result materialization collapsed same-named columns
Phase-4 materialize collapsed each row's positional `Vec<(String, SqlValue)>` into a `HashMap<String, SqlValue>` keyed by column name, then re-read one value *per output-column name*. Two output columns sharing a name collide in the map (last write wins) — so `UPPER(name)` and `LENGTH(name)` (both defaulting to `?`), **and even `SELECT id, id`**, returned the last column's value twice.

The row buffer is already **positional and parallel** to the locked `output_columns` (same `EmitColumn` sequence; hidden sort-key columns are truncated off both together), so we now project **by position** and drop the name-keyed map entirely — cheaper *and* correct for duplicate names.

### 2. `sql-codegen` (0.4.0) — un-aliased function columns were named `?`
Real SQLite names an un-aliased expression column after its **source text**. `output_column_name` now reconstructs the call text (`UPPER(name)`, `SUBSTR(name,1,2)`) via a new `render_expr_label` helper that renders columns / simple literals / nested calls and returns `None` (→ `?`) for shapes it can't faithfully print — never a misleading label. Aliases still win; other complex expressions keep `?`. Also drops an unused top-level `SortKey` import (re-imported in the test module), clearing a warning.

## Ledger
Removed `string_functions` from `differential_oracle.rs`'s `LEDGER` → **6 entries** (`full_join` + five aggregate computed-column *naming* divergences). The case is now asserted to match real SQLite exactly.

## Verification
- Full **mini-sqlite** suite green (45 lib + oracle + 2 file-backed + 11 integration + doctest); **sql-vm** (81), **sql-codegen** (75) unit tests green.
- Own `cargo fmt` + `clippy` clean; only downstream consumer of the two crates (mini-sqlite) tested per the shared-crate rule.
- Security review **passed** (positional loop is bounded by schema width; `render_expr_label` recursion is bounded by the already-parsed AST depth, output is a column *label* never re-parsed as SQL — no injection/DoS; no `unsafe`, no trust-boundary change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)