### PR TITLE
feat(sir-oop-ts): Hash transform_values/transform_keys (final backend)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.18] - 2026-07-11
+
+### Added
+
+- **`Hash#transform_values` / `Hash#transform_keys`** block methods
+  (`hashBlockMethod` + `HASH_BLOCK_METHODS`), completing the cross-backend
+  mirror of this pair (Python reference, then Go/Rust/JS backends):
+  - `transform_values { |v| … }` — a NEW hash whose keys are copied verbatim
+    (unique ⇒ no collision) and whose values are the block results. Yields ONE
+    argument (the value); insertion order preserved; receiver unmodified.
+  - `transform_keys { |k| … }` — a NEW hash whose values are untouched and whose
+    keys are the block results (yields ONE argument, the key). Two source keys
+    can collapse onto one new key; Ruby keeps the **last** value at the
+    **first-seen** position — matching how the `Map` constructor folds a list of
+    pairs.
+- Vitest coverage for both, including a `transform_keys` **collision** case
+  (`{a:1,b:2}` with a constant `"z"` key ⇒ `{z: 2}`) and a receiver-unchanged
+  assertion.
+
 ## [0.1.17] - 2026-07-11
 
 ### Added — Numeric breadth: `divmod` / `fdiv` / `round(ndigits)` / `clamp` / `between?`

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -74,7 +74,8 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
 (proc-lenient), predicates routed through SIR `truthy`; (item **M1c**) the
 **`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/
-`select`/…); and (item **M1c**) the **`String`** catalog (`length`,
+`select`/`transform_values`/`transform_keys`/…); and (item **M1c**) the
+**`String`** catalog (`length`,
 `upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
 `chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,
 `sub`/`gsub` *literal*, `to_i`/`to_f`/`to_sym`, `empty?`, `*`/`+`,

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -621,6 +621,8 @@ const HASH_BLOCK_METHODS = new Set<string>([
   "reject",
   "each_key",
   "each_value",
+  "transform_values",
+  "transform_keys",
 ]);
 
 // Non-block `String` methods (M1c).  A Ruby `String` is a JS `string`, which is
@@ -1238,6 +1240,20 @@ function hashBlockMethod(recv: Map<Val, Val>, name: string, block: Closure): Val
       return new Map<Val, Val>([...recv].filter(([k, v]: [Val, Val]) => truthy(apply(block, [k, v]))));
     case "reject":
       return new Map<Val, Val>([...recv].filter(([k, v]: [Val, Val]) => !truthy(apply(block, [k, v]))));
+    case "transform_values":
+      // Ruby `Hash#transform_values { |v| … }`: a NEW hash whose keys are copied
+      // verbatim and whose values are the block results.  The block yields ONE
+      // argument (the value); keys stay untouched (and unique, so no collision)
+      // and insertion order is preserved.  Non-mutating.
+      return new Map<Val, Val>([...recv].map(([k, v]: [Val, Val]) => [k, apply(block, [v])]));
+    case "transform_keys":
+      // Ruby `Hash#transform_keys { |k| … }`: a NEW hash whose values are
+      // untouched and whose keys are the block results (yields ONE argument, the
+      // key).  Two source keys can map to the SAME new key; Ruby keeps the LAST
+      // such entry's value at the FIRST-seen position — which is exactly how the
+      // `Map` constructor folds a list of pairs (later duplicate keys overwrite
+      // the value while the slot stays put).
+      return new Map<Val, Val>([...recv].map(([k, v]: [Val, Val]) => [apply(block, [k]), v]));
     default:
       return MISS;
   }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -536,13 +536,41 @@ describe("built-in method catalog: Hash (M1c)", () => {
     expect(vs).toEqual([1, 2]);
   });
 
+  it("block transform_values / transform_keys", () => {
+    // transform_values: keys untouched, values are block results, non-mutating.
+    const h = new Map<Val, Val>([["a", 1], ["b", 2]]);
+    const tv = callMethod(h, "transform_values", new Closure((v: Val) => (v as number) * 10)) as Map<Val, Val>;
+    expect([...tv.entries()]).toEqual([
+      ["a", 10],
+      ["b", 20],
+    ]);
+    expect([...h.entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+    ]); // receiver unchanged
+
+    // transform_keys: values untouched, keys are block results.
+    const tk = callMethod(h, "transform_keys", new Closure((k: Val) => `${k}!`)) as Map<Val, Val>;
+    expect([...tk.entries()]).toEqual([
+      ["a!", 1],
+      ["b!", 2],
+    ]);
+
+    // transform_keys collision: both keys collapse onto "z" — Ruby keeps the
+    // LAST value at the FIRST-seen position, matching the Map pair-fold.
+    const collide = callMethod(h, "transform_keys", new Closure((_k: Val) => "z")) as Map<Val, Val>;
+    expect([...collide.entries()]).toEqual([["z", 2]]);
+  });
+
   it("respond_to? honesty + nil floor", () => {
     const h = new Map<Val, Val>([["a", 1]]);
     expect(callMethod(h, "respond_to?", "keys")).toBe(true);
     expect(callMethod(h, "respond_to?", "each")).toBe(true);
-    expect(callMethod(h, "respond_to?", "transform_keys")).toBe(false);
+    expect(callMethod(h, "respond_to?", "transform_values")).toBe(true);
+    // `transform_keys!` (in-place bang variant) is still uncatalogued.
+    expect(callMethod(h, "respond_to?", "transform_keys!")).toBe(false);
     // T2: an unknown Hash method now raises NoMethodError (was nil).
-    expect(() => callMethod(h, "transform_keys")).toThrow(SirError);
+    expect(() => callMethod(h, "transform_keys!")).toThrow(SirError);
     expect(callMethod(h, "nil?")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

**Completes** the cross-backend mirror of Ruby `Hash#transform_values` / `Hash#transform_keys` — the last of five backends. Adds both non-mutating block methods to the `sir-runtime-oop` TypeScript library (`hashBlockMethod` + `HASH_BLOCK_METHODS`):

- **`transform_values { |v| … }`** — new `Map`; keys copied verbatim (unique ⇒ no collision), values are block results, insertion order preserved. Yields ONE block arg (the value).
- **`transform_keys { |k| … }`** — new `Map`; values untouched, keys are block results (yields ONE arg, the key). Two source keys can collapse onto one new key; Ruby keeps the **last** value at the **first-seen** position — exactly how `new Map([...pairs])` folds a duplicate-key pair list.

Both leave the receiver unmodified.

## Tests

Vitest (`tests/oop.test.ts`) — all **114 pass**:
- `transform_values` → `{a:1,b:2}` × 10 ⇒ `{a:10, b:20}`, receiver unchanged
- `transform_keys` → `{a:1,b:2}` append `!` ⇒ `{a!:1, b!:2}`
- **collision** `transform_keys` (constant `"z"`) ⇒ `{z: 2}` (last value wins)
- the `respond_to?` honesty test's "uncatalogued" example moved to the still-unimplemented `transform_keys!` bang variant.

## Checklist
- [x] CHANGELOG.md (0.1.17 → **0.1.18**)
- [x] README.md Hash catalog updated
- [x] `npx vitest run` green (114/114); `tsc` shows only pre-existing errors (@types/node `process` gap #62 + unrelated `min_by`/`max_by` narrowing — untouched by this diff)
- [x] Security review passed (native `Map` keys → no prototype-pollution; identical to sibling arms)
- [x] Restored unrelated package-lock churn; only the 5 intended oop files committed

Reference = Python #7909. Backends: Go #7917, Rust #7927, JS #7934, **TS = this PR**. With this, `transform_values`/`transform_keys` are at full parity across Python/Go/Rust/JS/TS. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)