### PR TITLE
feat(sha256): pure-Kotlin port (FIPS 180-4 + streaming Hasher)

### DIFF
--- a/code/packages/kotlin/sha256/.gitignore
+++ b/code/packages/kotlin/sha256/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/sha256/BUILD
+++ b/code/packages/kotlin/sha256/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sha256/BUILD_windows
+++ b/code/packages/kotlin/sha256/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sha256/CHANGELOG.md
+++ b/code/packages/kotlin/sha256/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — sha256 (Kotlin)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Kotlin port of the `sha256` reference package — the
+  third language (after Dart and Java) in the pure-port + native campaign.
+- `Sha256.sha256(ByteArray)` → 32-byte FIPS 180-4 digest.
+- `Sha256.sha256Hex(ByteArray)` → 64-char lowercase hex digest.
+- `Sha256.Hasher` — streaming hasher with `update`, non-destructive `digest` /
+  `hexDigest`, and `copy` for independent snapshots.
+- Uses Kotlin's native 32-bit `Int` arithmetic (`ushr`, `Int.rotateRight`,
+  `and`/`or`/`xor`/`inv`) — no masking; constants > 0x7FFFFFFF via `.toInt()`.
+- 20 tests (kotlin.test): the four FIPS 180-4 vectors (incl. one-million-'a'),
+  output-format/determinism/avalanche properties, padding/block-boundary edge
+  cases (55/56/63/64/127/128), and streaming parity with the one-shot API.

--- a/code/packages/kotlin/sha256/README.md
+++ b/code/packages/kotlin/sha256/README.md
@@ -1,0 +1,52 @@
+# sha256 (Kotlin)
+
+SHA-256 cryptographic hash function (FIPS 180-4) implemented from scratch in
+pure Kotlin — no `java.security.MessageDigest`.
+
+Kotlin port of the `sha256` package that already exists in Rust, Java, Dart, and
+other languages in the monorepo; produces byte-identical digests.
+
+## API
+
+`com.codingadventures.sha256.Sha256`:
+
+| Member | Purpose |
+|---|---|
+| `fun sha256(data: ByteArray): ByteArray` | 32-byte digest. |
+| `fun sha256Hex(data: ByteArray): String` | 64-char lowercase hex digest. |
+| `Sha256.Hasher` | Streaming: `update`, non-destructive `digest` / `hexDigest`, `copy`. |
+
+## Usage
+
+```kotlin
+import com.codingadventures.sha256.Sha256
+
+val data = "abc".toByteArray()
+println(Sha256.sha256Hex(data))
+// ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+val h = Sha256.Hasher()
+h.update("ab".toByteArray())
+h.update("c".toByteArray())
+println(h.hexDigest()) // same digest, computed incrementally
+```
+
+## Implementation note
+
+SHA-256 is defined over unsigned 32-bit words. Kotlin's `Int` is a 32-bit
+two's-complement value whose `+` and bitwise operators (`and`, `or`, `xor`,
+`inv`) match unsigned 32-bit semantics, so no masking is needed — SHR uses
+`ushr` (logical shift) and rotations use `Int.rotateRight`. Constants above
+`0x7FFFFFFF` are Long literals, truncated to their exact 32-bit pattern with
+`.toInt()`.
+
+## Security note
+
+SHA-256 remains cryptographically secure, but a bare hash is **not** a password
+scheme — use a purpose-built KDF (scrypt, argon2, PBKDF2) for passwords.
+
+## Running the tests
+
+```
+gradle test
+```

--- a/code/packages/kotlin/sha256/build.gradle.kts
+++ b/code/packages/kotlin/sha256/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/sha256/settings.gradle.kts
+++ b/code/packages/kotlin/sha256/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sha256"

--- a/code/packages/kotlin/sha256/src/main/kotlin/com/codingadventures/sha256/Sha256.kt
+++ b/code/packages/kotlin/sha256/src/main/kotlin/com/codingadventures/sha256/Sha256.kt
@@ -1,0 +1,186 @@
+// ============================================================================
+// Sha256.kt — SHA-256 cryptographic hash (FIPS 180-4), from scratch
+// ============================================================================
+//
+// SHA-256 maps any sequence of bytes to a fixed 32-byte (256-bit) digest. The
+// same input always yields the same digest; flipping one input bit changes the
+// digest completely (the "avalanche effect"); and the digest cannot be reversed
+// to the input. It is the workhorse of TLS, git, Bitcoin, and code signing.
+//
+// This is a from-scratch implementation (no java.security.MessageDigest), the
+// Kotlin port of the `sha256` package; it produces byte-identical digests to
+// the Rust/Java/Dart ports.
+//
+// 32-bit arithmetic:
+// ------------------
+// SHA-256 is defined over unsigned 32-bit words. Kotlin's `Int` is a 32-bit
+// two's-complement value whose `+` and bitwise operators (`and`, `or`, `xor`,
+// `inv`) wrap and mix exactly as unsigned 32-bit arithmetic requires. We use
+// `ushr` (the logical, zero-filling right shift) for SHR and `rotateRight` for
+// rotations. No explicit masking is needed.
+
+package com.codingadventures.sha256
+
+object Sha256 {
+
+    // Initial hash values: first 32 bits of the fractional parts of the square
+    // roots of the first 8 primes. Constants above 0x7FFFFFFF are Long literals
+    // in Kotlin, so `.toInt()` truncates each to its exact 32-bit pattern.
+    private val INIT = intArrayOf(
+        0x6A09E667.toInt(), 0xBB67AE85.toInt(), 0x3C6EF372.toInt(), 0xA54FF53A.toInt(),
+        0x510E527F.toInt(), 0x9B05688C.toInt(), 0x1F83D9AB.toInt(), 0x5BE0CD19.toInt(),
+    )
+
+    // Round constants: first 32 bits of the fractional parts of the cube roots
+    // of the first 64 primes.
+    private val K = intArrayOf(
+        0x428A2F98.toInt(), 0x71374491.toInt(), 0xB5C0FBCF.toInt(), 0xE9B5DBA5.toInt(),
+        0x3956C25B.toInt(), 0x59F111F1.toInt(), 0x923F82A4.toInt(), 0xAB1C5ED5.toInt(),
+        0xD807AA98.toInt(), 0x12835B01.toInt(), 0x243185BE.toInt(), 0x550C7DC3.toInt(),
+        0x72BE5D74.toInt(), 0x80DEB1FE.toInt(), 0x9BDC06A7.toInt(), 0xC19BF174.toInt(),
+        0xE49B69C1.toInt(), 0xEFBE4786.toInt(), 0x0FC19DC6.toInt(), 0x240CA1CC.toInt(),
+        0x2DE92C6F.toInt(), 0x4A7484AA.toInt(), 0x5CB0A9DC.toInt(), 0x76F988DA.toInt(),
+        0x983E5152.toInt(), 0xA831C66D.toInt(), 0xB00327C8.toInt(), 0xBF597FC7.toInt(),
+        0xC6E00BF3.toInt(), 0xD5A79147.toInt(), 0x06CA6351.toInt(), 0x14292967.toInt(),
+        0x27B70A85.toInt(), 0x2E1B2138.toInt(), 0x4D2C6DFC.toInt(), 0x53380D13.toInt(),
+        0x650A7354.toInt(), 0x766A0ABB.toInt(), 0x81C2C92E.toInt(), 0x92722C85.toInt(),
+        0xA2BFE8A1.toInt(), 0xA81A664B.toInt(), 0xC24B8B70.toInt(), 0xC76C51A3.toInt(),
+        0xD192E819.toInt(), 0xD6990624.toInt(), 0xF40E3585.toInt(), 0x106AA070.toInt(),
+        0x19A4C116.toInt(), 0x1E376C08.toInt(), 0x2748774C.toInt(), 0x34B0BCB5.toInt(),
+        0x391C0CB3.toInt(), 0x4ED8AA4A.toInt(), 0x5B9CCA4F.toInt(), 0x682E6FF3.toInt(),
+        0x748F82EE.toInt(), 0x78A5636F.toInt(), 0x84C87814.toInt(), 0x8CC70208.toInt(),
+        0x90BEFFFA.toInt(), 0xA4506CEB.toInt(), 0xBEF9A3F7.toInt(), 0xC67178F2.toInt(),
+    )
+
+    private fun ch(x: Int, y: Int, z: Int) = (x and y) xor (x.inv() and z)
+    private fun maj(x: Int, y: Int, z: Int) = (x and y) xor (x and z) xor (y and z)
+    private fun bigSigma0(x: Int) = x.rotateRight(2) xor x.rotateRight(13) xor x.rotateRight(22)
+    private fun bigSigma1(x: Int) = x.rotateRight(6) xor x.rotateRight(11) xor x.rotateRight(25)
+    private fun smallSigma0(x: Int) = x.rotateRight(7) xor x.rotateRight(18) xor (x ushr 3)
+    private fun smallSigma1(x: Int) = x.rotateRight(17) xor x.rotateRight(19) xor (x ushr 10)
+
+    // Fold one 64-byte block (at `offset`) into the eight-word state.
+    private fun compress(state: IntArray, data: ByteArray, offset: Int) {
+        val w = IntArray(64)
+        for (i in 0 until 16) {
+            val j = offset + i * 4
+            w[i] = ((data[j].toInt() and 0xff) shl 24) or
+                ((data[j + 1].toInt() and 0xff) shl 16) or
+                ((data[j + 2].toInt() and 0xff) shl 8) or
+                (data[j + 3].toInt() and 0xff)
+        }
+        for (t in 16 until 64) {
+            w[t] = smallSigma1(w[t - 2]) + w[t - 7] + smallSigma0(w[t - 15]) + w[t - 16]
+        }
+
+        var a = state[0]; var b = state[1]; var c = state[2]; var d = state[3]
+        var e = state[4]; var f = state[5]; var g = state[6]; var h = state[7]
+
+        for (t in 0 until 64) {
+            val t1 = h + bigSigma1(e) + ch(e, f, g) + K[t] + w[t]
+            val t2 = bigSigma0(a) + maj(a, b, c)
+            h = g; g = f; f = e; e = d + t1
+            d = c; c = b; b = a; a = t1 + t2
+        }
+
+        state[0] += a; state[1] += b; state[2] += c; state[3] += d
+        state[4] += e; state[5] += f; state[6] += g; state[7] += h
+    }
+
+    // Serialise eight 32-bit state words into a big-endian 32-byte digest.
+    private fun stateToDigest(state: IntArray): ByteArray {
+        val out = ByteArray(32)
+        for (i in 0 until 8) {
+            out[i * 4] = (state[i] ushr 24).toByte()
+            out[i * 4 + 1] = (state[i] ushr 16).toByte()
+            out[i * 4 + 2] = (state[i] ushr 8).toByte()
+            out[i * 4 + 3] = state[i].toByte()
+        }
+        return out
+    }
+
+    // Pad: append 0x80, zero-fill to 56 (mod 64), then the bit length as a
+    // 64-bit big-endian integer (FIPS 180-4 §5.1.1).
+    private fun pad(tail: ByteArray, totalBytes: Long): ByteArray {
+        val bitLen = totalBytes * 8L
+        var padLen = 1
+        while ((tail.size + padLen) % 64 != 56) padLen++
+        val padded = ByteArray(tail.size + padLen + 8)
+        tail.copyInto(padded, 0)
+        padded[tail.size] = 0x80.toByte()
+        for (i in 0 until 8) {
+            padded[padded.size - 1 - i] = (bitLen ushr (i * 8)).toByte()
+        }
+        return padded
+    }
+
+    // ── Public one-shot API ─────────────────────────────────────────────────
+
+    /** Compute the SHA-256 digest of [data] as a 32-byte array. */
+    fun sha256(data: ByteArray): ByteArray {
+        val padded = pad(data, data.size.toLong())
+        val state = INIT.copyOf()
+        var off = 0
+        while (off < padded.size) {
+            compress(state, padded, off)
+            off += 64
+        }
+        return stateToDigest(state)
+    }
+
+    /** Compute SHA-256 and return the 64-character lowercase hex string. */
+    fun sha256Hex(data: ByteArray): String = toHex(sha256(data))
+
+    internal fun toHex(bytes: ByteArray): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            sb.append("0123456789abcdef"[v ushr 4])
+            sb.append("0123456789abcdef"[v and 0xf])
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Incremental SHA-256. Feed data with [update]; [digest] is non-destructive
+     * so the hasher can keep receiving updates afterwards.
+     */
+    class Hasher private constructor(
+        private val state: IntArray,
+        private var buf: ByteArray,
+        private var byteCount: Long,
+    ) {
+        constructor() : this(INIT.copyOf(), ByteArray(0), 0L)
+
+        /** Feed more bytes into the hash. */
+        fun update(data: ByteArray) {
+            byteCount += data.size
+            val combined = buf + data
+            val full = combined.size - (combined.size % 64)
+            var off = 0
+            while (off < full) {
+                compress(state, combined, off)
+                off += 64
+            }
+            buf = combined.copyOfRange(full, combined.size)
+        }
+
+        /** Return the 32-byte digest of all data fed so far (non-destructive). */
+        fun digest(): ByteArray {
+            val tail = pad(buf, byteCount)
+            val s = state.copyOf()
+            var off = 0
+            while (off < tail.size) {
+                compress(s, tail, off)
+                off += 64
+            }
+            return stateToDigest(s)
+        }
+
+        /** Return the 64-character lowercase hex digest string. */
+        fun hexDigest(): String = toHex(digest())
+
+        /** Return an independent copy of this hasher's current state. */
+        fun copy(): Hasher = Hasher(state.copyOf(), buf.copyOf(), byteCount)
+    }
+}

--- a/code/packages/kotlin/sha256/src/test/kotlin/com/codingadventures/sha256/Sha256Test.kt
+++ b/code/packages/kotlin/sha256/src/test/kotlin/com/codingadventures/sha256/Sha256Test.kt
@@ -1,0 +1,175 @@
+// ============================================================================
+// Sha256Test.kt — Unit tests for Sha256 (FIPS 180-4 vectors + properties)
+// ============================================================================
+
+package com.codingadventures.sha256
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class Sha256Test {
+
+    private fun a(s: String): ByteArray = s.toByteArray(Charsets.UTF_8)
+
+    // ── FIPS 180-4 known-answer vectors ──────────────────────────────────────
+
+    @Test
+    fun fipsVectors() {
+        assertEquals(
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            Sha256.sha256Hex(a("")))
+        assertEquals(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            Sha256.sha256Hex(a("abc")))
+        val msg = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+        assertEquals(56, msg.length)
+        assertEquals(
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+            Sha256.sha256Hex(a(msg)))
+    }
+
+    @Test
+    fun fipsMillionA() {
+        val data = ByteArray(1_000_000) { 'a'.code.toByte() }
+        assertEquals(
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+            Sha256.sha256Hex(data))
+    }
+
+    // ── Output format ────────────────────────────────────────────────────────
+
+    @Test
+    fun digestIs32Bytes() {
+        assertEquals(32, Sha256.sha256(a("")).size)
+        assertEquals(32, Sha256.sha256(a("hello world")).size)
+        assertEquals(32, Sha256.sha256(ByteArray(1000)).size)
+    }
+
+    @Test
+    fun hexIs64LowercaseChars() {
+        val h = Sha256.sha256Hex(a("abc"))
+        assertEquals(64, h.length)
+        assertTrue(Regex("[0-9a-f]{64}").matches(h))
+    }
+
+    // ── Properties ───────────────────────────────────────────────────────────
+
+    @Test
+    fun deterministic() {
+        assertContentEquals(Sha256.sha256(a("hello")), Sha256.sha256(a("hello")))
+    }
+
+    @Test
+    fun avalanche() {
+        val h1 = Sha256.sha256(a("hello"))
+        val h2 = Sha256.sha256(a("helo"))
+        assertFalse(h1.contentEquals(h2))
+        var bits = 0
+        for (i in 0 until 32) bits += Integer.bitCount((h1[i].toInt() xor h2[i].toInt()) and 0xff)
+        assertTrue(bits > 40, "only $bits bits differed")
+    }
+
+    @Test
+    fun nullByteDiffersFromEmpty() {
+        assertFalse(Sha256.sha256(byteArrayOf(0)).contentEquals(Sha256.sha256(a(""))))
+    }
+
+    @Test
+    fun everyByteValueHashesDistinctly() {
+        val seen = HashSet<String>()
+        for (i in 0..255) seen.add(Sha256.sha256Hex(byteArrayOf(i.toByte())))
+        assertEquals(256, seen.size)
+    }
+
+    // ── Padding / block boundaries ───────────────────────────────────────────
+
+    @Test
+    fun blockBoundariesProduce32ByteDigests() {
+        for (n in intArrayOf(55, 56, 63, 64, 127, 128)) {
+            assertEquals(32, Sha256.sha256(ByteArray(n)).size)
+        }
+    }
+
+    @Test
+    fun boundary55And56Differ() {
+        assertFalse(Sha256.sha256(ByteArray(55)).contentEquals(Sha256.sha256(ByteArray(56))))
+    }
+
+    @Test
+    fun allBoundarySizesDistinct() {
+        val seen = HashSet<String>()
+        for (n in intArrayOf(55, 56, 63, 64, 127, 128)) seen.add(Sha256.sha256Hex(ByteArray(n)))
+        assertEquals(6, seen.size)
+    }
+
+    // ── Streaming hasher ─────────────────────────────────────────────────────
+
+    @Test
+    fun streamingSingleWriteMatchesOneShot() {
+        val h = Sha256.Hasher(); h.update(a("abc"))
+        assertContentEquals(Sha256.sha256(a("abc")), h.digest())
+    }
+
+    @Test
+    fun streamingSplitMatchesOneShot() {
+        val h = Sha256.Hasher(); h.update(a("ab")); h.update(a("c"))
+        assertContentEquals(Sha256.sha256(a("abc")), h.digest())
+    }
+
+    @Test
+    fun streamingBlockSplitMatchesOneShot() {
+        val data = ByteArray(128)
+        val h = Sha256.Hasher()
+        h.update(data.copyOfRange(0, 64)); h.update(data.copyOfRange(64, 128))
+        assertContentEquals(Sha256.sha256(data), h.digest())
+    }
+
+    @Test
+    fun streamingByteAtATimeMatchesOneShot() {
+        val data = ByteArray(100) { it.toByte() }
+        val h = Sha256.Hasher()
+        for (b in data) h.update(byteArrayOf(b))
+        assertContentEquals(Sha256.sha256(data), h.digest())
+    }
+
+    @Test
+    fun streamingEmptyMatchesEmptyOneShot() {
+        assertContentEquals(Sha256.sha256(a("")), Sha256.Hasher().digest())
+    }
+
+    @Test
+    fun streamingDigestIsNonDestructive() {
+        val h = Sha256.Hasher(); h.update(a("abc"))
+        assertContentEquals(h.digest(), h.digest())
+        h.update(a("d"))
+        assertContentEquals(Sha256.sha256(a("abcd")), h.digest())
+    }
+
+    @Test
+    fun streamingHexDigestMatches() {
+        val h = Sha256.Hasher(); h.update(a("abc"))
+        assertEquals(Sha256.sha256Hex(a("abc")), h.hexDigest())
+    }
+
+    @Test
+    fun streamingCopyIsIndependent() {
+        val h = Sha256.Hasher(); h.update(a("ab"))
+        val h2 = h.copy()
+        h2.update(a("c")); h.update(a("x"))
+        assertContentEquals(Sha256.sha256(a("abc")), h2.digest())
+        assertContentEquals(Sha256.sha256(a("abx")), h.digest())
+    }
+
+    @Test
+    fun streamingMillionAInTwoHalves() {
+        val data = ByteArray(1_000_000) { 'a'.code.toByte() }
+        val h = Sha256.Hasher()
+        h.update(data.copyOfRange(0, 500_000)); h.update(data.copyOfRange(500_000, 1_000_000))
+        assertEquals(
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+            h.hexDigest())
+    }
+}


### PR DESCRIPTION
## What

Pure-Kotlin port of the `sha256` package — SHA-256 (FIPS 180-4) from scratch, no `java.security.MessageDigest`. This is the **third language** in the campaign (after Dart and Java).

**Why:** `sha256` is a canon package missing from Kotlin (as are md5/sha1).

## API (`com.codingadventures.sha256.Sha256`, an `object`)

- `fun sha256(data: ByteArray): ByteArray` — 32-byte digest.
- `fun sha256Hex(data: ByteArray): String` — 64-char lowercase hex.
- `Sha256.Hasher` — streaming `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Implementation note

Kotlin's `Int` is native 32-bit two's-complement, so unsigned 32-bit hash math needs no masking: `ushr` for SHR, `Int.rotateRight` for rotations, `and`/`or`/`xor`/`inv` for bitwise. Constants above `0x7FFFFFFF` are Long literals, truncated to their exact 32-bit pattern with `.toInt()`. Byte reads mask with `and 0xff` (Kotlin `Byte` is signed).

## Verification

- All four **FIPS 180-4 vectors** pass (empty, `"abc"`, 56-byte, one-million-'a').
- Determinism + avalanche, padding/block-boundary edge cases (55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, copy independence, one-million-'a').
- **20 tests** (`kotlin.test`), `gradle test` green.
- Security review passed: `.toInt()` constant bit-patterns, `ushr` vs `shr`, `and 0xff` sign-extension masking, big-endian consistency, padding sizing, streaming non-destructiveness/copy-independence, and shared-`INIT`-never-mutated all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)