### PR TITLE
feat(md5): pure-Kotlin port (RFC 1321 + streaming Digest)

### DIFF
--- a/code/packages/kotlin/md5/.gitignore
+++ b/code/packages/kotlin/md5/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/md5/BUILD
+++ b/code/packages/kotlin/md5/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/md5/BUILD_windows
+++ b/code/packages/kotlin/md5/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/md5/CHANGELOG.md
+++ b/code/packages/kotlin/md5/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — md5 (Kotlin)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Kotlin port of the `md5` reference package.
+- `Md5.sumMd5(ByteArray)` → 16-byte RFC 1321 digest.
+- `Md5.hexString(ByteArray)` → 32-char lowercase hex digest.
+- `Md5.Digest` — streaming hasher with `update`, non-destructive `digest` /
+  `hexDigest`, and `copy` for independent snapshots.
+- Correct little-endian block parsing, length field, and digest output; Kotlin's
+  native 32-bit `Int` arithmetic (`Int.rotateLeft`, `and 0xff` byte masking,
+  `.toInt()` for constants > 0x7FFFFFFF).
+- 21 tests (kotlin.test): all seven RFC 1321 Appendix A.5 vectors, little-endian
+  byte order + the 0x00..0xFF known digest, output-format/determinism/avalanche
+  properties, padding block boundaries (0/55/56/63/64/127/128), and streaming
+  parity with the one-shot API.
+- Documented security note: MD5 is cryptographically broken; checksum use only.

--- a/code/packages/kotlin/md5/README.md
+++ b/code/packages/kotlin/md5/README.md
@@ -1,0 +1,47 @@
+# md5 (Kotlin)
+
+MD5 message-digest algorithm (RFC 1321) implemented from scratch in pure Kotlin
+— no `java.security.MessageDigest`.
+
+Kotlin port of the `md5` package that already exists in Rust, Java, Dart, and
+other languages in the monorepo; produces byte-identical digests.
+
+> **Security:** MD5 is cryptographically **broken** — practical collisions
+> exist. Never use it for signatures or passwords. Checksum use only.
+
+## API
+
+`com.codingadventures.md5.Md5`:
+
+| Member | Purpose |
+|---|---|
+| `fun sumMd5(data: ByteArray): ByteArray` | 16-byte digest. |
+| `fun hexString(data: ByteArray): String` | 32-char lowercase hex digest. |
+| `Md5.Digest` | Streaming: `update`, non-destructive `digest` / `hexDigest`, `copy`. |
+
+## Usage
+
+```kotlin
+import com.codingadventures.md5.Md5
+
+println(Md5.hexString("abc".toByteArray())) // 900150983cd24fb0d6963f7d28e17f72
+
+val h = Md5.Digest()
+h.update("ab".toByteArray())
+h.update("c".toByteArray())
+println(h.hexDigest()) // same digest, computed incrementally
+```
+
+## Implementation note
+
+MD5 is **little-endian** throughout (block parsing, length field, digest output),
+the opposite of SHA-1/SHA-256. Kotlin's `Int` is native 32-bit two's-complement,
+so unsigned 32-bit arithmetic needs no masking; `Int.rotateLeft` performs the
+rotations and block bytes are masked with `and 0xff` before shifting. Constants
+above `0x7FFFFFFF` are Long literals, truncated via `.toInt()`.
+
+## Running the tests
+
+```
+gradle test
+```

--- a/code/packages/kotlin/md5/build.gradle.kts
+++ b/code/packages/kotlin/md5/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/md5/settings.gradle.kts
+++ b/code/packages/kotlin/md5/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "md5"

--- a/code/packages/kotlin/md5/src/main/kotlin/com/codingadventures/md5/Md5.kt
+++ b/code/packages/kotlin/md5/src/main/kotlin/com/codingadventures/md5/Md5.kt
@@ -1,0 +1,186 @@
+// ============================================================================
+// Md5.kt — MD5 message-digest algorithm (RFC 1321), from scratch
+// ============================================================================
+//
+// MD5 maps any sequence of bytes to a fixed 16-byte (128-bit) digest. This is a
+// from-scratch implementation (no java.security.MessageDigest), the Kotlin port
+// of the `md5` package; it produces byte-identical digests to the
+// Rust/Java/Dart ports.
+//
+// SECURITY: MD5 is cryptographically BROKEN — practical collision attacks exist.
+// Never use it for signatures, certificates, or password storage. It remains a
+// fast, non-adversarial integrity checksum.
+//
+// Little-endian & 32-bit arithmetic:
+// ----------------------------------
+// Unlike SHA-1/SHA-256, MD5 is little-endian: block words are read least-
+// significant byte first, the length is appended little-endian, and the digest
+// words are emitted least-significant byte first. Kotlin's `Int` is a 32-bit
+// two's-complement value whose `+` and bitwise operators match unsigned 32-bit
+// semantics, so no masking is needed; `Int.rotateLeft` performs the rotations.
+
+package com.codingadventures.md5
+
+object Md5 {
+
+    // Per-round left-rotation amounts (four repeating groups of four).
+    private val S = intArrayOf(
+        7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+        5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+        4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+        6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+    )
+
+    // The 64 sine-derived constants: T[i] = floor(abs(sin(i+1)) * 2^32).
+    // Constants above 0x7FFFFFFF are Long literals in Kotlin, so `.toInt()`
+    // truncates each to its exact 32-bit pattern.
+    private val T = intArrayOf(
+        0xD76AA478.toInt(), 0xE8C7B756.toInt(), 0x242070DB.toInt(), 0xC1BDCEEE.toInt(),
+        0xF57C0FAF.toInt(), 0x4787C62A.toInt(), 0xA8304613.toInt(), 0xFD469501.toInt(),
+        0x698098D8.toInt(), 0x8B44F7AF.toInt(), 0xFFFF5BB1.toInt(), 0x895CD7BE.toInt(),
+        0x6B901122.toInt(), 0xFD987193.toInt(), 0xA679438E.toInt(), 0x49B40821.toInt(),
+        0xF61E2562.toInt(), 0xC040B340.toInt(), 0x265E5A51.toInt(), 0xE9B6C7AA.toInt(),
+        0xD62F105D.toInt(), 0x02441453.toInt(), 0xD8A1E681.toInt(), 0xE7D3FBC8.toInt(),
+        0x21E1CDE6.toInt(), 0xC33707D6.toInt(), 0xF4D50D87.toInt(), 0x455A14ED.toInt(),
+        0xA9E3E905.toInt(), 0xFCEFA3F8.toInt(), 0x676F02D9.toInt(), 0x8D2A4C8A.toInt(),
+        0xFFFA3942.toInt(), 0x8771F681.toInt(), 0x6D9D6122.toInt(), 0xFDE5380C.toInt(),
+        0xA4BEEA44.toInt(), 0x4BDECFA9.toInt(), 0xF6BB4B60.toInt(), 0xBEBFBC70.toInt(),
+        0x289B7EC6.toInt(), 0xEAA127FA.toInt(), 0xD4EF3085.toInt(), 0x04881D05.toInt(),
+        0xD9D4D039.toInt(), 0xE6DB99E5.toInt(), 0x1FA27CF8.toInt(), 0xC4AC5665.toInt(),
+        0xF4292244.toInt(), 0x432AFF97.toInt(), 0xAB9423A7.toInt(), 0xFC93A039.toInt(),
+        0x655B59C3.toInt(), 0x8F0CCC92.toInt(), 0xFFEFF47D.toInt(), 0x85845DD1.toInt(),
+        0x6FA87E4F.toInt(), 0xFE2CE6E0.toInt(), 0xA3014314.toInt(), 0x4E0811A1.toInt(),
+        0xF7537E82.toInt(), 0xBD3AF235.toInt(), 0x2AD7D2BB.toInt(), 0xEB86D391.toInt(),
+    )
+
+    // Initial state (A, B, C, D).
+    private val INIT = intArrayOf(0x67452301, 0xEFCDAB89.toInt(), 0x98BADCFE.toInt(), 0x10325476)
+
+    // Fold one 64-byte block (at `offset`) into the four-word state over 64 rounds.
+    private fun compress(state: IntArray, data: ByteArray, offset: Int) {
+        val m = IntArray(16)
+        for (i in 0 until 16) {
+            val j = offset + i * 4
+            // Little-endian: byte j is the least-significant byte of word i.
+            m[i] = (data[j].toInt() and 0xff) or
+                ((data[j + 1].toInt() and 0xff) shl 8) or
+                ((data[j + 2].toInt() and 0xff) shl 16) or
+                ((data[j + 3].toInt() and 0xff) shl 24)
+        }
+
+        var a = state[0]; var b = state[1]; var c = state[2]; var d = state[3]
+
+        for (i in 0 until 64) {
+            val f: Int
+            val g: Int
+            when {
+                i < 16 -> { f = (b and c) or (b.inv() and d); g = i }
+                i < 32 -> { f = (d and b) or (d.inv() and c); g = (5 * i + 1) and 15 }
+                i < 48 -> { f = b xor c xor d; g = (3 * i + 5) and 15 }
+                else -> { f = c xor (b or d.inv()); g = (7 * i) and 15 }
+            }
+            val sum = a + f + m[g] + T[i]
+            val temp = b + sum.rotateLeft(S[i])
+            a = d; d = c; c = b; b = temp
+        }
+
+        state[0] += a; state[1] += b; state[2] += c; state[3] += d
+    }
+
+    // Serialise the four state words into a 16-byte little-endian digest.
+    private fun stateToDigest(state: IntArray): ByteArray {
+        val out = ByteArray(16)
+        for (i in 0 until 4) {
+            out[i * 4] = state[i].toByte()
+            out[i * 4 + 1] = (state[i] ushr 8).toByte()
+            out[i * 4 + 2] = (state[i] ushr 16).toByte()
+            out[i * 4 + 3] = (state[i] ushr 24).toByte()
+        }
+        return out
+    }
+
+    // Pad: append 0x80, zero-fill to 56 (mod 64), then the bit length as a
+    // 64-bit LITTLE-endian integer (RFC 1321 §3).
+    private fun pad(tail: ByteArray, totalBytes: Long): ByteArray {
+        val bitLen = totalBytes * 8L
+        var padLen = 1
+        while ((tail.size + padLen) % 64 != 56) padLen++
+        val padded = ByteArray(tail.size + padLen + 8)
+        tail.copyInto(padded, 0)
+        padded[tail.size] = 0x80.toByte()
+        for (i in 0 until 8) {
+            padded[tail.size + padLen + i] = (bitLen ushr (i * 8)).toByte() // little-endian
+        }
+        return padded
+    }
+
+    // ── Public one-shot API ─────────────────────────────────────────────────
+
+    /** Compute the MD5 digest of [data] as a 16-byte array. */
+    fun sumMd5(data: ByteArray): ByteArray {
+        val padded = pad(data, data.size.toLong())
+        val state = INIT.copyOf()
+        var off = 0
+        while (off < padded.size) {
+            compress(state, padded, off)
+            off += 64
+        }
+        return stateToDigest(state)
+    }
+
+    /** Compute MD5 and return the 32-character lowercase hex string. */
+    fun hexString(data: ByteArray): String = toHex(sumMd5(data))
+
+    internal fun toHex(bytes: ByteArray): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            sb.append("0123456789abcdef"[v ushr 4])
+            sb.append("0123456789abcdef"[v and 0xf])
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Incremental MD5. Feed data with [update]; [digest] is non-destructive so
+     * the hasher can keep receiving updates afterwards.
+     */
+    class Digest private constructor(
+        private val state: IntArray,
+        private var buf: ByteArray,
+        private var byteCount: Long,
+    ) {
+        constructor() : this(INIT.copyOf(), ByteArray(0), 0L)
+
+        /** Feed more bytes into the hash. */
+        fun update(data: ByteArray) {
+            byteCount += data.size
+            val combined = buf + data
+            val full = combined.size - (combined.size % 64)
+            var off = 0
+            while (off < full) {
+                compress(state, combined, off)
+                off += 64
+            }
+            buf = combined.copyOfRange(full, combined.size)
+        }
+
+        /** Return the 16-byte digest of all data fed so far (non-destructive). */
+        fun digest(): ByteArray {
+            val tail = pad(buf, byteCount)
+            val s = state.copyOf()
+            var off = 0
+            while (off < tail.size) {
+                compress(s, tail, off)
+                off += 64
+            }
+            return stateToDigest(s)
+        }
+
+        /** Return the 32-character lowercase hex digest string. */
+        fun hexDigest(): String = toHex(digest())
+
+        /** Return an independent copy of this hasher's current state. */
+        fun copy(): Digest = Digest(state.copyOf(), buf.copyOf(), byteCount)
+    }
+}

--- a/code/packages/kotlin/md5/src/test/kotlin/com/codingadventures/md5/Md5Test.kt
+++ b/code/packages/kotlin/md5/src/test/kotlin/com/codingadventures/md5/Md5Test.kt
@@ -1,0 +1,169 @@
+// ============================================================================
+// Md5Test.kt — Unit tests for Md5 (RFC 1321 vectors + properties)
+// ============================================================================
+
+package com.codingadventures.md5
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class Md5Test {
+
+    private fun a(s: String): ByteArray = s.toByteArray(Charsets.UTF_8)
+
+    @Test
+    fun rfc1321Vectors() {
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", Md5.hexString(a("")))
+        assertEquals("0cc175b9c0f1b6a831c399e269772661", Md5.hexString(a("a")))
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", Md5.hexString(a("abc")))
+        assertEquals("f96b697d7cb7938d525a2f31aaf161d0", Md5.hexString(a("message digest")))
+        assertEquals("c3fcd3d76192e4007dfb496cca67e13b",
+            Md5.hexString(a("abcdefghijklmnopqrstuvwxyz")))
+        assertEquals("d174ab98d277d9f5a5611c2c9f419d9f",
+            Md5.hexString(a("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")))
+        assertEquals("57edf4a22be3c955ac49da2e2107b67a", Md5.hexString(a(
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890")))
+    }
+
+    @Test
+    fun littleEndianByteOrderOfA() {
+        val d = Md5.sumMd5(a("a"))
+        assertEquals(0x0c, d[0].toInt() and 0xff)
+        assertEquals(0xc1, d[1].toInt() and 0xff)
+        assertEquals(0x75, d[2].toInt() and 0xff)
+        assertEquals(0xb9, d[3].toInt() and 0xff)
+    }
+
+    @Test
+    fun bytes0To255KnownDigest() {
+        val data = ByteArray(256) { it.toByte() }
+        assertEquals("e2c865db4162bed963bfaa9ef6ac18f0", Md5.hexString(data))
+    }
+
+    @Test
+    fun digestIs16Bytes() {
+        assertEquals(16, Md5.sumMd5(a("")).size)
+        assertEquals(16, Md5.sumMd5(a("hello world")).size)
+        assertEquals(16, Md5.sumMd5(ByteArray(1000)).size)
+    }
+
+    @Test
+    fun hexIs32LowercaseChars() {
+        val h = Md5.hexString(a("abc"))
+        assertEquals(32, h.length)
+        assertTrue(Regex("[0-9a-f]{32}").matches(h))
+    }
+
+    @Test
+    fun deterministic() {
+        assertContentEquals(Md5.sumMd5(a("hello")), Md5.sumMd5(a("hello")))
+    }
+
+    @Test
+    fun avalanche() {
+        val h1 = Md5.sumMd5(a("hello"))
+        val h2 = Md5.sumMd5(a("helo"))
+        assertFalse(h1.contentEquals(h2))
+        var bits = 0
+        for (i in 0 until 16) bits += Integer.bitCount((h1[i].toInt() xor h2[i].toInt()) and 0xff)
+        assertTrue(bits > 20, "only $bits bits differed")
+    }
+
+    @Test
+    fun nullByteDiffersFromEmpty() {
+        assertFalse(Md5.sumMd5(byteArrayOf(0)).contentEquals(Md5.sumMd5(a(""))))
+    }
+
+    @Test
+    fun everyByteValueHashesDistinctly() {
+        val seen = HashSet<String>()
+        for (i in 0..255) seen.add(Md5.hexString(byteArrayOf(i.toByte())))
+        assertEquals(256, seen.size)
+    }
+
+    @Test
+    fun blockBoundariesProduce16ByteDigests() {
+        for (n in intArrayOf(0, 55, 56, 63, 64, 127, 128)) {
+            assertEquals(16, Md5.sumMd5(ByteArray(n)).size)
+        }
+    }
+
+    @Test
+    fun boundary55And56Differ() {
+        assertFalse(Md5.sumMd5(ByteArray(55)).contentEquals(Md5.sumMd5(ByteArray(56))))
+    }
+
+    @Test
+    fun allBoundarySizesDistinct() {
+        val seen = HashSet<String>()
+        for (n in intArrayOf(0, 55, 56, 63, 64, 127, 128)) seen.add(Md5.hexString(ByteArray(n)))
+        assertEquals(7, seen.size)
+    }
+
+    @Test
+    fun streamingSingleWriteMatchesOneShot() {
+        val h = Md5.Digest(); h.update(a("abc"))
+        assertContentEquals(Md5.sumMd5(a("abc")), h.digest())
+    }
+
+    @Test
+    fun streamingSplitMatchesOneShot() {
+        val h = Md5.Digest(); h.update(a("ab")); h.update(a("c"))
+        assertContentEquals(Md5.sumMd5(a("abc")), h.digest())
+    }
+
+    @Test
+    fun streamingBlockSplitMatchesOneShot() {
+        val data = ByteArray(128)
+        val h = Md5.Digest()
+        h.update(data.copyOfRange(0, 64)); h.update(data.copyOfRange(64, 128))
+        assertContentEquals(Md5.sumMd5(data), h.digest())
+    }
+
+    @Test
+    fun streamingByteAtATimeMatchesOneShot() {
+        val data = ByteArray(100) { it.toByte() }
+        val h = Md5.Digest()
+        for (b in data) h.update(byteArrayOf(b))
+        assertContentEquals(Md5.sumMd5(data), h.digest())
+    }
+
+    @Test
+    fun streamingEmptyMatchesEmptyOneShot() {
+        assertContentEquals(Md5.sumMd5(a("")), Md5.Digest().digest())
+    }
+
+    @Test
+    fun streamingDigestIsNonDestructive() {
+        val h = Md5.Digest(); h.update(a("hello"))
+        assertContentEquals(h.digest(), h.digest())
+        h.update(a(" world"))
+        assertContentEquals(Md5.sumMd5(a("hello world")), h.digest())
+    }
+
+    @Test
+    fun streamingHexDigestMatches() {
+        val h = Md5.Digest(); h.update(a("abc"))
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", h.hexDigest())
+    }
+
+    @Test
+    fun streamingCopyIsIndependent() {
+        val h = Md5.Digest(); h.update(a("ab"))
+        val h2 = h.copy()
+        h2.update(a("c")); h.update(a("x"))
+        assertContentEquals(Md5.sumMd5(a("abc")), h2.digest())
+        assertContentEquals(Md5.sumMd5(a("abx")), h.digest())
+    }
+
+    @Test
+    fun streamingMillionAInTwoHalves() {
+        val data = ByteArray(1_000_000) { 'a'.code.toByte() }
+        val h = Md5.Digest()
+        h.update(data.copyOfRange(0, 500_000)); h.update(data.copyOfRange(500_000, 1_000_000))
+        assertContentEquals(Md5.sumMd5(data), h.digest())
+    }
+}


### PR DESCRIPTION
## What

Pure-Kotlin port of the `md5` package — MD5 (RFC 1321) from scratch, no `java.security.MessageDigest`. Second Kotlin pure port (after `sha256`), continuing the Kotlin hash family.

**Why:** `md5` is a canon package missing from Kotlin.

## API (`com.codingadventures.md5.Md5`, an `object`)

- `fun sumMd5(data: ByteArray): ByteArray` — 16-byte digest.
- `fun hexString(data: ByteArray): String` — 32-char lowercase hex.
- `Md5.Digest` — streaming `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Implementation note

MD5 is **little-endian** throughout (block parsing, length field, digest output) — the opposite of SHA-256. Kotlin's native 32-bit `Int` needs no masking; uses `Int.rotateLeft`, `and 0xff` byte masking, and `.toInt()` for constants above `0x7FFFFFFF`.

## Verification

- All **seven RFC 1321 Appendix A.5 vectors** pass, plus little-endian byte-order checks (incl. the `0x00..0xFF` known digest).
- Determinism + avalanche, padding/block-boundary edge cases (0/55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, copy independence, one-million-'a').
- **21 tests** (`kotlin.test`), `gradle test` green.
- Security review passed: constant bit-patterns, `Int.rotateLeft` (rotate-left for MD5), `ushr` vs `shr`, `and 0xff` masking, consistent little-endian parse/length/output, padding sizing, streaming non-destructiveness/copy, and shared-`INIT`-never-mutated all verified.

> **Security note** (docs + README): MD5 is cryptographically broken — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)