### PR TITLE
feat(adj-formula-stdlib): K/elementary primitive formula libraries (FL-3)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_primitives_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_primitives_e2e.rs
@@ -1,0 +1,112 @@
+//! End-to-end test for the FL-3 elementary-arithmetic primitive library through
+//! the built CLI binary: a consumer `import`s the SHIPPED `arithmetic.adj`
+//! formula library, binds two operands from its own `observe`d facts, and applies
+//! one of the four cited primitive formulas (sum/difference/product/quotient). For
+//! each, the CLI must compute the value on the CPU and render the applied formula's
+//! citation in the `derived` section — the auditable answer, zero math by the model.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped elementary-arithmetic library, resolved from this
+/// crate's manifest dir so the test is location-independent.
+fn shipped_arithmetic_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/arithmetic/arithmetic.adj")
+        .canonicalize()
+        .expect("shipped arithmetic.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_prim_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Run one primitive: copy the shipped library next to a consumer that binds the
+/// two operands and applies `call`, then assert the derived value AND that the
+/// applied formula carries its cited provenance (mathworld locator + trust tier).
+fn check_primitive(tag: &str, obs_one: &str, obs_two: &str, call: &str, name: &str, value: &str) {
+    let dir = scratch(tag);
+    let lib = std::fs::read_to_string(shipped_arithmetic_lib()).unwrap();
+    std::fs::write(dir.join("arithmetic.adj"), lib).unwrap();
+    let consumer = format!(
+        "import \"arithmetic.adj\"\n\
+         observe {obs_one}\n\
+         observe {obs_two}\n\
+         ? {call}\n"
+    );
+    std::fs::write(dir.join("case.adj"), consumer).unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains(&format!("\"name\":\"{name}\"")) && s.contains(&format!("\"value\":{value}")),
+        "{name} computed to {value}: {s}"
+    );
+    // The applied primitive carries its cited definition + trust tier — auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("mathworld.wolfram.com"),
+        "{name} carries its cited provenance: {s}"
+    );
+}
+
+#[test]
+fn sum_primitive_binds_and_computes_with_citation() {
+    // "…3 apples… 4 apples…" → the model binds the two addends; the engine adds them.
+    check_primitive(
+        "sum",
+        "addend_one(3)",
+        "addend_two(4)",
+        "sum(addend_one, addend_two)",
+        "sum",
+        "7",
+    );
+}
+
+#[test]
+fn difference_primitive_binds_and_computes_with_citation() {
+    check_primitive(
+        "difference",
+        "minuend(10)",
+        "subtrahend(3)",
+        "difference(minuend, subtrahend)",
+        "difference",
+        "7",
+    );
+}
+
+#[test]
+fn product_primitive_binds_and_computes_with_citation() {
+    check_primitive(
+        "product",
+        "factor_one(6)",
+        "factor_two(7)",
+        "product(factor_one, factor_two)",
+        "product",
+        "42",
+    );
+}
+
+#[test]
+fn quotient_primitive_binds_and_computes_with_citation() {
+    check_primitive(
+        "quotient",
+        "dividend(20)",
+        "divisor(4)",
+        "quotient(dividend, divisor)",
+        "quotient",
+        "5",
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/arithmetic.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/arithmetic.adj
@@ -1,0 +1,83 @@
+% ============================================================================
+% arithmetic.adj — the elementary-arithmetic formula library (ADJ-FORMULA-LIBRARIES FL-3).
+% ============================================================================
+% The BOTTOM of the compute standard library's MATH track: the four primitive
+% operations a kindergartner→elementary student learns, each an importable,
+% byte-provenanced, PARAMETERIZED formula. Every higher formula library (ratio,
+% percent, average → BMI, FENa, Cockcroft-Gault) composes THESE — write-once,
+% use-many. Like `clinical/bmi.adj`, a consumer states NO arithmetic: it imports
+% this file, binds the operands from its own byte-provenance decomposition, and
+% asks the engine to apply the cited primitive on the CPU.
+%
+%     import "arithmetic.adj"
+%     observe addend_one(3)     % "…3 apples…"   (span cited by the model)
+%     observe addend_two(4)     % "…4 apples…"   (span cited by the model)
+%     ? sum(addend_one, addend_two)   % engine → 7, carrying the cited definition
+%
+% The formulas (and their sources) live HERE; the numbers (and their spans) come
+% from the input. Zero math is performed by the model.
+%
+% Each operation names its operands with the conventional arithmetic vocabulary
+% (addend/minuend/subtrahend/factor/dividend/divisor) so the audit trail reads in
+% plain arithmetic terms, and the dictionary's surface synonyms let a decomposer
+% map everyday words ("total", "times", "shared among") onto them.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The operands and results of the four primitive operations. Each is
+% an observable quantity the formulas range over; rung-0's grammar types an
+% observable slot as `finding` (dimensional typing is a later rung — the engine
+% still infers + checks dimensions when a formula is APPLIED). The `surface`
+% lists are the everyday names a decomposer maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary arithmetic_vocab {
+    define addend_one  : finding  surface "first addend", "first number", "one addend"
+    define addend_two  : finding  surface "second addend", "second number", "other addend"
+    define sum         : finding  surface "sum", "total", "combined amount"
+
+    define minuend     : finding  surface "minuend", "starting amount", "amount before"
+    define subtrahend  : finding  surface "subtrahend", "amount taken away", "amount removed"
+    define difference  : finding  surface "difference", "remainder", "amount left"
+
+    define factor_one  : finding  surface "first factor", "multiplicand", "one factor"
+    define factor_two  : finding  surface "second factor", "multiplier", "other factor"
+    define product     : finding  surface "product", "result of multiplying"
+
+    define dividend    : finding  surface "dividend", "amount to divide", "amount shared"
+    define divisor     : finding  surface "divisor", "number of parts", "number of shares"
+    define quotient    : finding  surface "quotient", "result of dividing", "share each"
+}
+
+% ----------------------------------------------------------------------------
+% The four primitives. Each is a named, importable, reusable `let` over its two
+% formal parameters, and each carries the same provenance envelope every grounded
+% clause carries — a definitional quote from an authoritative mathematics
+% reference (required on a shipped formula; the linter rejects an unsourced one).
+% ----------------------------------------------------------------------------
+formulabook elementary_arithmetic {
+    use arithmetic_vocab
+
+    % Addition — combine two quantities into their total.
+    formula sum(addend_one, addend_two) = addend_one + addend_two
+        source "A sum is a quantity obtained by the addition of two or more quantities, the summands or addends."
+        locator "https://mathworld.wolfram.com/Sum.html"
+        trust authoritative
+
+    % Subtraction — the amount left after taking the subtrahend from the minuend.
+    formula difference(minuend, subtrahend) = minuend - subtrahend
+        source "The difference of two numbers is the result of subtracting the second (the subtrahend) from the first (the minuend)."
+        locator "https://mathworld.wolfram.com/Difference.html"
+        trust authoritative
+
+    % Multiplication — the result of multiplying the two factors.
+    formula product(factor_one, factor_two) = factor_one * factor_two
+        source "A product is the result of multiplying together two or more quantities, called the factors, or multiplicand and multiplier."
+        locator "https://mathworld.wolfram.com/Product.html"
+        trust authoritative
+
+    % Division — the result of dividing the dividend by the divisor.
+    formula quotient(dividend, divisor) = dividend / divisor
+        source "The quotient is the result of dividing one number (the dividend) by another (the divisor)."
+        locator "https://mathworld.wolfram.com/Quotient.html"
+        trust authoritative
+}


### PR DESCRIPTION
## FL-3 — K/elementary primitive formula libraries

The bottom of the compute standard library's MATH track, built **on the shipped `formulabook`/`formula` substrate** (FL-2) — no language change, pure grounded data + an end-to-end test. Every higher formula library (ratio/percent/average → BMI/FENa/Cockcroft-Gault) composes these, write-once-use-many.

### `arithmetic/arithmetic.adj`
One dictionary (the conventional operand/result vocabulary — addend/sum, minuend/subtrahend/difference, factor/product, dividend/divisor/quotient — each with `surface` synonyms for the decomposer) + one `elementary_arithmetic` formulabook with the four primitives, **each byte-provenanced to an authoritative MathWorld definition** (`trust authoritative`):

| formula | body |
|---|---|
| `sum(addend_one, addend_two)` | `addend_one + addend_two` |
| `difference(minuend, subtrahend)` | `minuend - subtrahend` |
| `product(factor_one, factor_two)` | `factor_one * factor_two` |
| `quotient(dividend, divisor)` | `dividend / divisor` |

A consumer states no arithmetic — it imports the library, binds the operands from its own byte-provenance decomposition, and applies the cited primitive:
```adj
import "arithmetic.adj"
observe addend_one(3)     % "…3 apples…"
observe addend_two(4)     % "…4 apples…"
? sum(addend_one, addend_two)   % → 7, carrying MathWorld's cited definition
```

### Verified live through the CLI
`sum(3,4)=7`, `difference(10,3)=7`, `product(6,7)=42`, `quotient(20,4)=5` — each carrying its `source` + `trust=authoritative` (and exact rationals `{num,den}`).

### Tests & gates
- `adj-lang-cli/tests/formula_primitives_e2e.rs` — **4 e2e tests** (mirror `formula_e2e.rs`): import → bind → apply → assert value **and** citation + trust tier. All pass.
- `cargo test -p adj-lang -p adj-lang-cli` — green (147 adj-lang + 38 cli-golden + the 4 new).
- **Security review: PASSED** (data + test only; no production code, no untrusted input, no shell).

Exactly 2 files. Next (FL-4): ratio/percent/average/fraction libraries that **import these primitives** — the first real composition, and where the multi-step audit trail (FL-7) becomes exercisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
