### PR TITLE
feat(sha1): pure-Kotlin port (FIPS 180-4 + streaming Digest)

### DIFF
--- a/code/packages/kotlin/sha1/.gitignore
+++ b/code/packages/kotlin/sha1/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/sha1/BUILD
+++ b/code/packages/kotlin/sha1/BUILD
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sha1/BUILD_windows
+++ b/code/packages/kotlin/sha1/BUILD_windows
@@ -1,0 +1,1 @@
+gradle test

--- a/code/packages/kotlin/sha1/CHANGELOG.md
+++ b/code/packages/kotlin/sha1/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — sha1 (Kotlin)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Kotlin port of the `sha1` reference package, completing
+  the common hash family in Kotlin (alongside sha256 and md5).
+- `Sha1.sum1(ByteArray)` → 20-byte FIPS 180-4 digest.
+- `Sha1.hexString(ByteArray)` → 40-char lowercase hex digest.
+- `Sha1.Digest` — streaming hasher with `update`, non-destructive `digest` /
+  `hexDigest`, and `copy` for independent snapshots.
+- Big-endian block parsing/length/output; Kotlin's native 32-bit `Int`
+  arithmetic (`Int.rotateLeft`, `ushr`, `and 0xff` byte masking, `.toInt()` for
+  constants > 0x7FFFFFFF).
+- 20 tests (kotlin.test): FIPS 180-4 / RFC 3174 vectors (empty, "abc", 56-byte,
+  one-million-'a'), output-format/determinism/avalanche, padding block
+  boundaries (0/55/56/63/64/127/128), and streaming parity with the one-shot API.
+- Documented security note: SHA-1 collision resistance is broken; checksum use only.

--- a/code/packages/kotlin/sha1/README.md
+++ b/code/packages/kotlin/sha1/README.md
@@ -1,0 +1,42 @@
+# sha1 (Kotlin)
+
+SHA-1 cryptographic hash function (FIPS 180-4) implemented from scratch in pure
+Kotlin — no `java.security.MessageDigest`.
+
+Kotlin port of the `sha1` package that already exists in Rust, Java, Dart, and
+other languages in the monorepo; produces byte-identical digests.
+
+> **Security:** SHA-1 is **broken** for collision resistance (SHAttered, 2017).
+> Never use it for signatures or certificates. Legacy/checksum use only.
+
+## API
+
+`com.codingadventures.sha1.Sha1`:
+
+| Member | Purpose |
+|---|---|
+| `fun sum1(data: ByteArray): ByteArray` | 20-byte digest. |
+| `fun hexString(data: ByteArray): String` | 40-char lowercase hex digest. |
+| `Sha1.Digest` | Streaming: `update`, non-destructive `digest` / `hexDigest`, `copy`. |
+
+## Usage
+
+```kotlin
+import com.codingadventures.sha1.Sha1
+
+println(Sha1.hexString("abc".toByteArray()))
+// a9993e364706816aba3e25717850c26c9cd0d89d
+```
+
+## Implementation note
+
+SHA-1 is **big-endian** like SHA-256 (opposite of MD5); five state words, 80
+rounds. Kotlin's native 32-bit `Int` needs no masking; uses `Int.rotateLeft`,
+`ushr`, and `and 0xff` byte masking. Constants above `0x7FFFFFFF` are Long
+literals, truncated via `.toInt()`.
+
+## Running the tests
+
+```
+gradle test
+```

--- a/code/packages/kotlin/sha1/build.gradle.kts
+++ b/code/packages/kotlin/sha1/build.gradle.kts
@@ -1,0 +1,35 @@
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/code/packages/kotlin/sha1/settings.gradle.kts
+++ b/code/packages/kotlin/sha1/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sha1"

--- a/code/packages/kotlin/sha1/src/main/kotlin/com/codingadventures/sha1/Sha1.kt
+++ b/code/packages/kotlin/sha1/src/main/kotlin/com/codingadventures/sha1/Sha1.kt
@@ -1,0 +1,162 @@
+// ============================================================================
+// Sha1.kt — SHA-1 cryptographic hash (FIPS 180-4), from scratch
+// ============================================================================
+//
+// SHA-1 maps any sequence of bytes to a fixed 20-byte (160-bit) digest. Like
+// MD5 and SHA-256 it uses the Merkle–Damgård construction over 64-byte blocks,
+// but with five state words and 80 rounds. This is a from-scratch
+// implementation (no java.security.MessageDigest), the Kotlin port of the `sha1`
+// package; it produces byte-identical digests to the Rust/Java/Dart ports.
+//
+// SECURITY: SHA-1 is BROKEN for collision resistance (the SHAttered attack,
+// 2017). Never use it for signatures or certificates. Legacy protocols and
+// non-adversarial checksums (e.g. git object names) only.
+//
+// 32-bit arithmetic:
+// ------------------
+// SHA-1 is big-endian (like SHA-256, the opposite of MD5). Kotlin's `Int` is a
+// 32-bit two's-complement value whose arithmetic and bitwise operators match
+// unsigned 32-bit semantics, so no masking is needed; `Int.rotateLeft` performs
+// the rotations and block bytes are masked with `and 0xff` before shifting.
+
+package com.codingadventures.sha1
+
+object Sha1 {
+
+    // Initial state H0..H4.
+    private val INIT = intArrayOf(
+        0x67452301, 0xEFCDAB89.toInt(), 0x98BADCFE.toInt(), 0x10325476, 0xC3D2E1F0.toInt(),
+    )
+
+    // Per-stage round constants: floor(sqrt(2,3,5,10) * 2^30).
+    private val K = intArrayOf(0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC.toInt(), 0xCA62C1D6.toInt())
+
+    // Fold one 64-byte block (at `offset`) into the five-word state over 80 rounds.
+    private fun compress(state: IntArray, data: ByteArray, offset: Int) {
+        val w = IntArray(80)
+        for (i in 0 until 16) {
+            val j = offset + i * 4
+            w[i] = ((data[j].toInt() and 0xff) shl 24) or
+                ((data[j + 1].toInt() and 0xff) shl 16) or
+                ((data[j + 2].toInt() and 0xff) shl 8) or
+                (data[j + 3].toInt() and 0xff)
+        }
+        for (i in 16 until 80) {
+            w[i] = (w[i - 3] xor w[i - 8] xor w[i - 14] xor w[i - 16]).rotateLeft(1)
+        }
+
+        var a = state[0]; var b = state[1]; var c = state[2]; var d = state[3]; var e = state[4]
+
+        for (t in 0 until 80) {
+            val f: Int
+            val k: Int
+            when {
+                t < 20 -> { f = (b and c) or (b.inv() and d); k = K[0] }
+                t < 40 -> { f = b xor c xor d; k = K[1] }
+                t < 60 -> { f = (b and c) or (b and d) or (c and d); k = K[2] }
+                else -> { f = b xor c xor d; k = K[3] }
+            }
+            val temp = a.rotateLeft(5) + f + e + k + w[t]
+            e = d; d = c; c = b.rotateLeft(30); b = a; a = temp
+        }
+
+        state[0] += a; state[1] += b; state[2] += c; state[3] += d; state[4] += e
+    }
+
+    // Serialise the five state words into a 20-byte big-endian digest.
+    private fun stateToDigest(state: IntArray): ByteArray {
+        val out = ByteArray(20)
+        for (i in 0 until 5) {
+            out[i * 4] = (state[i] ushr 24).toByte()
+            out[i * 4 + 1] = (state[i] ushr 16).toByte()
+            out[i * 4 + 2] = (state[i] ushr 8).toByte()
+            out[i * 4 + 3] = state[i].toByte()
+        }
+        return out
+    }
+
+    // Pad: append 0x80, zero-fill to 56 (mod 64), then the bit length as a
+    // 64-bit big-endian integer (FIPS 180-4).
+    private fun pad(tail: ByteArray, totalBytes: Long): ByteArray {
+        val bitLen = totalBytes * 8L
+        var padLen = 1
+        while ((tail.size + padLen) % 64 != 56) padLen++
+        val padded = ByteArray(tail.size + padLen + 8)
+        tail.copyInto(padded, 0)
+        padded[tail.size] = 0x80.toByte()
+        for (i in 0 until 8) {
+            padded[padded.size - 1 - i] = (bitLen ushr (i * 8)).toByte() // big-endian
+        }
+        return padded
+    }
+
+    // ── Public one-shot API ─────────────────────────────────────────────────
+
+    /** Compute the SHA-1 digest of [data] as a 20-byte array. */
+    fun sum1(data: ByteArray): ByteArray {
+        val padded = pad(data, data.size.toLong())
+        val state = INIT.copyOf()
+        var off = 0
+        while (off < padded.size) {
+            compress(state, padded, off)
+            off += 64
+        }
+        return stateToDigest(state)
+    }
+
+    /** Compute SHA-1 and return the 40-character lowercase hex string. */
+    fun hexString(data: ByteArray): String = toHex(sum1(data))
+
+    internal fun toHex(bytes: ByteArray): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            sb.append("0123456789abcdef"[v ushr 4])
+            sb.append("0123456789abcdef"[v and 0xf])
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Incremental SHA-1. Feed data with [update]; [digest] is non-destructive so
+     * the hasher can keep receiving updates afterwards.
+     */
+    class Digest private constructor(
+        private val state: IntArray,
+        private var buf: ByteArray,
+        private var byteCount: Long,
+    ) {
+        constructor() : this(INIT.copyOf(), ByteArray(0), 0L)
+
+        /** Feed more bytes into the hash. */
+        fun update(data: ByteArray) {
+            byteCount += data.size
+            val combined = buf + data
+            val full = combined.size - (combined.size % 64)
+            var off = 0
+            while (off < full) {
+                compress(state, combined, off)
+                off += 64
+            }
+            buf = combined.copyOfRange(full, combined.size)
+        }
+
+        /** Return the 20-byte digest of all data fed so far (non-destructive). */
+        fun digest(): ByteArray {
+            val tail = pad(buf, byteCount)
+            val s = state.copyOf()
+            var off = 0
+            while (off < tail.size) {
+                compress(s, tail, off)
+                off += 64
+            }
+            return stateToDigest(s)
+        }
+
+        /** Return the 40-character lowercase hex digest string. */
+        fun hexDigest(): String = toHex(digest())
+
+        /** Return an independent copy of this hasher's current state. */
+        fun copy(): Digest = Digest(state.copyOf(), buf.copyOf(), byteCount)
+    }
+}

--- a/code/packages/kotlin/sha1/src/test/kotlin/com/codingadventures/sha1/Sha1Test.kt
+++ b/code/packages/kotlin/sha1/src/test/kotlin/com/codingadventures/sha1/Sha1Test.kt
@@ -1,0 +1,155 @@
+// ============================================================================
+// Sha1Test.kt — Unit tests for Sha1 (FIPS 180-4 / RFC 3174 vectors)
+// ============================================================================
+
+package com.codingadventures.sha1
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class Sha1Test {
+
+    private fun a(s: String): ByteArray = s.toByteArray(Charsets.UTF_8)
+
+    @Test
+    fun vectors() {
+        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", Sha1.hexString(a("")))
+        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", Sha1.hexString(a("abc")))
+        val msg = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+        assertEquals(56, msg.length)
+        assertEquals("84983e441c3bd26ebaae4aa1f95129e5e54670f1", Sha1.hexString(a(msg)))
+    }
+
+    @Test
+    fun millionA() {
+        val data = ByteArray(1_000_000) { 'a'.code.toByte() }
+        assertEquals("34aa973cd4c4daa4f61eeb2bdbad27316534016f", Sha1.hexString(data))
+    }
+
+    @Test
+    fun digestIs20Bytes() {
+        assertEquals(20, Sha1.sum1(a("")).size)
+        assertEquals(20, Sha1.sum1(a("hello world")).size)
+        assertEquals(20, Sha1.sum1(ByteArray(1000)).size)
+    }
+
+    @Test
+    fun hexIs40LowercaseChars() {
+        val h = Sha1.hexString(a("abc"))
+        assertEquals(40, h.length)
+        assertTrue(Regex("[0-9a-f]{40}").matches(h))
+    }
+
+    @Test
+    fun deterministic() {
+        assertContentEquals(Sha1.sum1(a("hello")), Sha1.sum1(a("hello")))
+    }
+
+    @Test
+    fun avalanche() {
+        val h1 = Sha1.sum1(a("hello"))
+        val h2 = Sha1.sum1(a("helo"))
+        assertFalse(h1.contentEquals(h2))
+        var bits = 0
+        for (i in 0 until 20) bits += Integer.bitCount((h1[i].toInt() xor h2[i].toInt()) and 0xff)
+        assertTrue(bits > 30, "only $bits bits differed")
+    }
+
+    @Test
+    fun nullByteDiffersFromEmpty() {
+        assertFalse(Sha1.sum1(byteArrayOf(0)).contentEquals(Sha1.sum1(a(""))))
+    }
+
+    @Test
+    fun everyByteValueHashesDistinctly() {
+        val seen = HashSet<String>()
+        for (i in 0..255) seen.add(Sha1.hexString(byteArrayOf(i.toByte())))
+        assertEquals(256, seen.size)
+    }
+
+    @Test
+    fun blockBoundariesProduce20ByteDigests() {
+        for (n in intArrayOf(0, 55, 56, 63, 64, 127, 128)) {
+            assertEquals(20, Sha1.sum1(ByteArray(n)).size)
+        }
+    }
+
+    @Test
+    fun boundary55And56Differ() {
+        assertFalse(Sha1.sum1(ByteArray(55)).contentEquals(Sha1.sum1(ByteArray(56))))
+    }
+
+    @Test
+    fun allBoundarySizesDistinct() {
+        val seen = HashSet<String>()
+        for (n in intArrayOf(0, 55, 56, 63, 64, 127, 128)) seen.add(Sha1.hexString(ByteArray(n)))
+        assertEquals(7, seen.size)
+    }
+
+    @Test
+    fun streamingSingleWriteMatchesOneShot() {
+        val h = Sha1.Digest(); h.update(a("abc"))
+        assertContentEquals(Sha1.sum1(a("abc")), h.digest())
+    }
+
+    @Test
+    fun streamingSplitMatchesOneShot() {
+        val h = Sha1.Digest(); h.update(a("ab")); h.update(a("c"))
+        assertContentEquals(Sha1.sum1(a("abc")), h.digest())
+    }
+
+    @Test
+    fun streamingBlockSplitMatchesOneShot() {
+        val data = ByteArray(128)
+        val h = Sha1.Digest()
+        h.update(data.copyOfRange(0, 64)); h.update(data.copyOfRange(64, 128))
+        assertContentEquals(Sha1.sum1(data), h.digest())
+    }
+
+    @Test
+    fun streamingByteAtATimeMatchesOneShot() {
+        val data = ByteArray(100) { it.toByte() }
+        val h = Sha1.Digest()
+        for (b in data) h.update(byteArrayOf(b))
+        assertContentEquals(Sha1.sum1(data), h.digest())
+    }
+
+    @Test
+    fun streamingEmptyMatchesEmptyOneShot() {
+        assertContentEquals(Sha1.sum1(a("")), Sha1.Digest().digest())
+    }
+
+    @Test
+    fun streamingDigestIsNonDestructive() {
+        val h = Sha1.Digest(); h.update(a("hello"))
+        assertContentEquals(h.digest(), h.digest())
+        h.update(a(" world"))
+        assertContentEquals(Sha1.sum1(a("hello world")), h.digest())
+    }
+
+    @Test
+    fun streamingHexDigestMatches() {
+        val h = Sha1.Digest(); h.update(a("abc"))
+        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", h.hexDigest())
+    }
+
+    @Test
+    fun streamingCopyIsIndependent() {
+        val h = Sha1.Digest(); h.update(a("ab"))
+        val h2 = h.copy()
+        h2.update(a("c")); h.update(a("x"))
+        assertContentEquals(Sha1.sum1(a("abc")), h2.digest())
+        assertContentEquals(Sha1.sum1(a("abx")), h.digest())
+    }
+
+    @Test
+    fun streamingMillionAInTwoHalves() {
+        val data = ByteArray(1_000_000) { 'a'.code.toByte() }
+        val h = Sha1.Digest()
+        h.update(data.copyOfRange(0, 500_000)); h.update(data.copyOfRange(500_000, 1_000_000))
+        assertEquals("34aa973cd4c4daa4f61eeb2bdbad27316534016f", h.hexDigest())
+    }
+}


### PR DESCRIPTION
## What

Pure-Kotlin port of the `sha1` package — SHA-1 (FIPS 180-4) from scratch, no `java.security.MessageDigest`. Third Kotlin pure port, **completing the common hash family in Kotlin** (sha256, md5, sha1).

**Why:** `sha1` is a canon package missing from Kotlin.

## API (`com.codingadventures.sha1.Sha1`, an `object`)

- `fun sum1(data: ByteArray): ByteArray` — 20-byte digest.
- `fun hexString(data: ByteArray): String` — 40-char lowercase hex.
- `Sha1.Digest` — streaming `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Implementation note

SHA-1 is **big-endian** like SHA-256 (opposite of MD5); five state words, 80 rounds. Kotlin's native 32-bit `Int` needs no masking; uses `Int.rotateLeft`, `ushr`, `and 0xff` byte masking, and `.toInt()` for constants above `0x7FFFFFFF`.

## Verification

- **FIPS 180-4 / RFC 3174 vectors** pass (empty, `"abc"`, 56-byte, one-million-'a').
- Determinism + avalanche, padding/block-boundary edge cases (0/55/56/63/64/127/128), streaming parity with one-shot (byte-at-a-time, block-split, copy independence, one-million-'a').
- **20 tests** (`kotlin.test`), `gradle test` green.
- Security review passed: constant bit-patterns and `.toInt()` placement, `Int.rotateLeft`, `ushr` vs `shr`, `and 0xff` masking, big-endian consistency, round function/schedule, padding sizing, streaming non-destructiveness/copy, and shared-`INIT`-never-mutated all verified.

> **Security note** (docs + README): SHA-1 collision resistance is broken (SHAttered, 2017) — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)