### PR TITLE
feat(sql-codegen): FULL OUTER JOIN — two-pass (LEFT ∪ RIGHT anti-join); retire full_join ledger entry (Stream A / L2)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.4.2 — FULL OUTER JOIN matches SQLite (ledger 6 → 5)
+
+Stream A / L2 of the full-SQLite-replacement roadmap: retire the differential
+oracle's `full_join` divergence — the last *wrong-result* entry in the ledger.
+
+- `SELECT ... FROM a FULL JOIN b ON ...` previously degraded to a cross product
+  (a single forward pass can't emit the right rows that matched no left row).
+  `sql-codegen` (0.5.0) now compiles FULL JOIN as **two passes**: a LEFT JOIN
+  (matched pairs + left-only rows) unioned with a RIGHT anti-join (right rows
+  that matched no left row, NULL-padded on the left). No new VM instructions —
+  it reuses the outer-join match flag. See that crate's changelog.
+- `tests/differential_oracle.rs`: removed `full_join` from the `LEDGER` (now
+  **5** entries, all aggregate computed-column *naming* divergences whose rows
+  already match). Added a second FULL JOIN case, `full_join_multi`, with
+  duplicate join keys on both sides (many-to-many) plus rows unmatched on each
+  side — asserted against real SQLite to guard the two-pass implementation
+  against double-emitting matched pairs or dropping an anti-join row.
+- No mini-sqlite `src/` changes — the fix lands in the shared pipeline; this
+  crate's bump documents the conformance gain the oracle now enforces.
+
 ## 0.4.1 — Scalar functions match SQLite (ledger 7 → 6)
 
 Stream B / L3 of the full-SQLite-replacement roadmap: retire the differential

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -34,12 +34,15 @@
 //! quietly leave stale ledger entries behind.
 //!
 //! On introduction this harness measured 12 of 22 seed cases already matching
-//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). Three have
-//! since been retired: `INNER JOIN` qualified-column resolution, and correct
-//! `LEFT`/`RIGHT OUTER JOIN` (NULL-padded via a per-outer-row match flag). The
-//! remaining ledger entries — `FULL JOIN`, misnamed aggregate columns, and a
-//! wrong `UPPER()` — are each a tracked increment; the harness is what makes
-//! fixing them verifiable.
+//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). Five have
+//! since been retired: `INNER JOIN` qualified-column resolution; correct
+//! `LEFT`/`RIGHT OUTER JOIN` (NULL-padded via a per-outer-row match flag);
+//! `FULL OUTER JOIN` (a LEFT pass unioned with a RIGHT anti-join pass); and
+//! scalar functions (`UPPER()` returned the right value once same-named output
+//! columns stopped colliding, and columns got SQLite-style names). The
+//! remaining ledger entries are all *aggregate computed-column naming*
+//! divergences (`agg_N` vs `COUNT(*)`/`SUM(n)`); the rows already match. The
+//! harness is what makes fixing each one verifiable.
 
 use coding_adventures_mini_sqlite::{connect, SqlValue};
 
@@ -382,6 +385,19 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a.name, b.tag FROM a FULL JOIN b ON a.id = b.aid ORDER BY a.name, b.tag",
     },
+    // A trickier FULL JOIN: duplicate join keys on both sides (many-to-many)
+    // plus rows unmatched on each side. Guards the two-pass implementation
+    // against emitting a matched pair twice or missing an anti-join row.
+    Case {
+        id: "full_join_multi",
+        setup: &[
+            "CREATE TABLE a (id INTEGER, name TEXT)",
+            "CREATE TABLE b (aid INTEGER, tag TEXT)",
+            "INSERT INTO a VALUES (1, 'x'), (1, 'x2'), (2, 'y'), (4, 'w')",
+            "INSERT INTO b VALUES (1, 'p'), (1, 'q'), (3, 'r')",
+        ],
+        query: "SELECT a.name, b.tag FROM a FULL JOIN b ON a.id = b.aid ORDER BY a.name, b.tag",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but
@@ -390,16 +406,13 @@ const CASES: &[Case] = &[
 /// every entry is a real, reproduced gap between mini-sqlite and SQLite, each
 /// slated for a later increment.
 ///
-/// The gaps fall into a few families:
+/// Every remaining entry is now a **computed-column naming** divergence — the
+/// result *rows* already match SQLite. The join and scalar-function *result*
+/// gaps have all been retired: `inner_join` qualified-column resolution,
+/// `LEFT`/`RIGHT OUTER JOIN` NULL-padding, `FULL OUTER JOIN` (a LEFT pass unioned
+/// with a RIGHT anti-join pass), and `string_functions` (positional projection
+/// plus SQLite-style function column names).
 ///
-/// - **Join column resolution** (`inner_join`): a qualified reference like
-///   `a.name` across a join resolves to `NULL`, because a `FROM a` with no
-///   explicit alias opens its cursor keyed under `None` while `LoadColumn` looks
-///   it up under `Some("a")` (`sql-vm` `LoadColumn`). This breaks *even* inner
-///   joins and is the highest-priority fix — it underlies the outer joins too.
-/// - **`FULL JOIN`**: needs the unmatched right rows too, which a single forward
-///   pass can't produce; still degrades to a cross product. (`LEFT`/`RIGHT` are
-///   now implemented via a per-outer-row match flag and no longer diverge.)
 /// - **Computed-column naming** (`count_star`/`sum_min_max`/`avg`/`group_by`/
 ///   `having`): the result *rows* match SQLite exactly, but mini-sqlite names an
 ///   aggregate output column `agg_N` where SQLite uses the expression text
@@ -413,10 +426,6 @@ const CASES: &[Case] = &[
 /// (dropping every value but the last), plus `sql-codegen` labelling function
 /// columns `?` instead of the SQLite-style expression text.
 const LEDGER: &[(&str, &str)] = &[
-    (
-        "full_join",
-        "FULL JOIN needs the unmatched right rows too, which a single forward pass can't produce; still degrades to a cross product. (LEFT/RIGHT are now implemented and no longer ledgered.)",
-    ),
     (
         "count_star",
         "rows match; computed-column naming differs — mini names it agg_0, SQLite names it COUNT(*).",

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.5.0] - Unreleased
+
+### Added
+
+- **`FULL OUTER JOIN`** now executes correctly instead of degrading to a cross
+  product. A single nested loop can't tell whether a given right row matched
+  *any* left row (the inner side is re-scanned per outer row), so
+  `compile_join_projected` now emits **two passes** for `JoinKind::Full`: pass 1
+  is an ordinary LEFT JOIN (matched pairs + left-only rows), and pass 2 is a
+  RIGHT *anti*-join that evaluates `ON` but suppresses the matched-pair emit —
+  it emits only the right rows that matched no left row, NULL-padded on the
+  left. The union is a FULL JOIN with no duplicated matched pairs. Ordering
+  across the two passes is handled by the surrounding `ORDER BY` sort.
+- Refactored the join loop body out of `compile_join_projected` into a reusable
+  `emit_join_pass(outer, inner, condition, eval_condition, emit_matched,
+  emit_unmatched, columns)` helper. INNER/LEFT/RIGHT/CROSS are now single calls
+  with the appropriate flags; FULL is two calls. **No new VM instructions** —
+  both passes reuse the existing `ClearMatch`/`SetMatch`/`JumpIfMatched`
+  match-flag machinery.
+
 ## [0.4.0] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -1598,9 +1598,21 @@ impl Compiler {
     ///   by name, so the output is unchanged). The NULL padding falls out for
     ///   free: `CloseScan` drops the inner cursor's `current_row`, so its columns
     ///   read NULL while the still-open outer cursor keeps its real values.
-    /// - **FULL OUTER** — needs the unmatched *right* rows too, which a single
-    ///   forward pass can't produce; still degrades to a cross product and stays
-    ///   in the conformance ledger (a later increment).
+    /// - **FULL OUTER** — every row from *both* sides, matched pairs joined and
+    ///   unmatched rows NULL-padded on the missing side. A single nested loop
+    ///   can't produce the unmatched *right* rows (the inner side is re-scanned
+    ///   per outer row, so "did this right row ever match *any* left row?" isn't
+    ///   known during the forward pass), so we run two passes and union them.
+    ///   Pass 1 is a LEFT JOIN (outer = left): all matched pairs, plus each left
+    ///   row that matched nothing, NULL-padded on the right. Pass 2 is a RIGHT
+    ///   *anti*-join (outer = right): for each right row we evaluate `ON` against
+    ///   every left row but **suppress the matched-pair emit** (pass 1 already
+    ///   produced those) and emit only the right rows that matched no left row,
+    ///   NULL-padded on the left. The union is exactly a FULL JOIN with no
+    ///   duplicated matched pairs; both passes reuse the same match-flag
+    ///   machinery, so no new VM instructions are needed. Ordering across the two
+    ///   passes is handled by the surrounding `ORDER BY` sort, which runs after
+    ///   every row is emitted.
     fn compile_join_projected(
         &mut self,
         left: &OptimizedPlan,
@@ -1609,17 +1621,67 @@ impl Compiler {
         condition: &Option<SqlExpr>,
         columns: &[OutputColumn],
     ) {
-        // RIGHT JOIN is LEFT JOIN with the operands swapped.
-        let (outer_plan, inner_plan) = if *kind == JoinKind::Right {
-            (right, left)
-        } else {
-            (left, right)
-        };
-        let is_outer = matches!(kind, JoinKind::Left | JoinKind::Right);
-        // INNER/LEFT/RIGHT evaluate the ON condition; CROSS has none, and FULL is
-        // (for now) degraded to a cross product — so neither evaluates it.
-        let eval_condition = condition.is_some()
-            && matches!(kind, JoinKind::Inner | JoinKind::Left | JoinKind::Right);
+        match kind {
+            // FULL OUTER = LEFT JOIN  ∪  RIGHT anti-join (see the doc above).
+            JoinKind::Full => {
+                let eval = condition.is_some();
+                // Pass 1: the LEFT half — matched pairs + left-only rows.
+                self.emit_join_pass(left, right, condition, eval, true, true, columns);
+                // Pass 2: the right rows that matched no left row. `emit_matched`
+                // is false so matched pairs are NOT emitted a second time.
+                self.emit_join_pass(right, left, condition, eval, false, true, columns);
+            }
+            _ => {
+                // RIGHT JOIN is LEFT JOIN with the operands swapped.
+                let (outer_plan, inner_plan) = if *kind == JoinKind::Right {
+                    (right, left)
+                } else {
+                    (left, right)
+                };
+                let is_outer = matches!(kind, JoinKind::Left | JoinKind::Right);
+                // INNER/LEFT/RIGHT evaluate the ON condition; CROSS has none.
+                let eval_condition = condition.is_some()
+                    && matches!(kind, JoinKind::Inner | JoinKind::Left | JoinKind::Right);
+                self.emit_join_pass(
+                    outer_plan,
+                    inner_plan,
+                    condition,
+                    eval_condition,
+                    /* emit_matched   */ true,
+                    /* emit_unmatched */ is_outer,
+                    columns,
+                );
+            }
+        }
+    }
+
+    /// Emit one nested-loop join pass over `outer_plan` × `inner_plan`.
+    ///
+    /// - `eval_condition` — evaluate the `ON` predicate to gate matches (false ⇒
+    ///   every pair "matches", i.e. a cross product).
+    /// - `emit_matched` — project + emit a row for each matched pair. FULL JOIN's
+    ///   second (anti-join) pass sets this false: it needs the match *flag* to
+    ///   know which right rows were unmatched, but must not re-emit pairs.
+    /// - `emit_unmatched` — after the inner loop, if this outer row matched no
+    ///   inner row, emit one row with the inner side NULL-padded (its cursor is
+    ///   closed, so its columns read NULL while the outer cursor holds its row).
+    ///
+    /// The match flag (`ClearMatch`/`SetMatch`/`JumpIfMatched`) is used whenever
+    /// `emit_unmatched` is set — that is the only case that must distinguish a
+    /// matched outer row from an unmatched one.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_join_pass(
+        &mut self,
+        outer_plan: &OptimizedPlan,
+        inner_plan: &OptimizedPlan,
+        condition: &Option<SqlExpr>,
+        eval_condition: bool,
+        emit_matched: bool,
+        emit_unmatched: bool,
+        columns: &[OutputColumn],
+    ) {
+        // The flag is needed only to decide the post-loop NULL-padded emit.
+        let use_match_flag = emit_unmatched;
 
         let outer_loop = self.fresh_label("joinp_outer_loop");
         let outer_end = self.fresh_label("joinp_outer_end");
@@ -1630,7 +1692,7 @@ impl Compiler {
         } else {
             String::new()
         };
-        let after_null = if is_outer {
+        let after_null = if emit_unmatched {
             self.fresh_label("joinp_after_null")
         } else {
             String::new()
@@ -1652,8 +1714,8 @@ impl Compiler {
             outer_end.clone(),
         ));
 
-        // Outer joins start each outer row with the match flag cleared.
-        if is_outer {
+        // Start each outer row with the match flag cleared.
+        if use_match_flag {
             self.emit(Instruction::ClearMatch);
         }
 
@@ -1674,11 +1736,14 @@ impl Compiler {
             }
         }
 
-        // A matched pair: record the match (for outer joins) and project the row.
-        if is_outer {
+        // A matched pair: record the match, and project the row unless this pass
+        // only wants the unmatched (anti-join) rows.
+        if use_match_flag {
             self.emit(Instruction::SetMatch);
         }
-        self.emit_row_projection(columns);
+        if emit_matched {
+            self.emit_row_projection(columns);
+        }
 
         if eval_condition {
             self.emit(Instruction::Label(cond_skip));
@@ -1688,10 +1753,10 @@ impl Compiler {
         self.emit(Instruction::Label(inner_end));
         self.emit(Instruction::CloseScan(inner_alias));
 
-        // Outer join: if no inner row matched this outer row, emit one row with
-        // the inner side NULL (its cursor is now closed, so its columns read
-        // NULL; the outer cursor still holds this outer row).
-        if is_outer {
+        // If no inner row matched this outer row, emit one row with the inner
+        // side NULL (its cursor is now closed, so its columns read NULL; the
+        // outer cursor still holds this outer row).
+        if emit_unmatched {
             self.emit(Instruction::JumpIfMatched(after_null.clone()));
             self.emit_row_projection(columns);
             self.emit(Instruction::Label(after_null));


### PR DESCRIPTION
## Stream A / L2 — the last *wrong-result* ledger entry (6 → 5)

The differential oracle's **`full_join`** case diverged: `FULL JOIN` degraded to a cross product. A single nested loop can't tell whether a given right row matched *any* left row — the inner side is re-scanned per outer row, so the answer isn't known during the forward pass.

### The two-pass algorithm
`compile_join_projected` now compiles `JoinKind::Full` as **two sequential passes** whose union is a correct FULL JOIN:

1. **LEFT JOIN** (outer = left) — all matched pairs, plus each left row that matched nothing, NULL-padded on the right.
2. **RIGHT anti-join** (outer = right) — evaluate `ON` against every left row but **suppress the matched-pair emit** (pass 1 already produced those); emit only the right rows that matched no left row, NULL-padded on the left.

No duplicated matched pairs; ordering across the two passes falls to the surrounding `ORDER BY` sort. The join loop body is extracted into a reusable `emit_join_pass(outer, inner, condition, eval_condition, emit_matched, emit_unmatched, columns)` helper — INNER/LEFT/RIGHT/CROSS are single calls, FULL is two. **No new VM instructions** — both passes reuse the existing `ClearMatch`/`SetMatch`/`JumpIfMatched` match flag, so `sql-vm` is untouched.

### Ledger
Removed `full_join` from `differential_oracle.rs`'s `LEDGER` → **5 entries**, now *all* aggregate computed-column **naming** divergences (`agg_N` vs `COUNT(*)`/`SUM(n)`) whose rows already match. Every join and scalar-function *result* gap is now retired.

Added a second differential case **`full_join_multi`** — duplicate join keys on both sides (many-to-many) plus rows unmatched on each side — asserted against real SQLite, guarding the two-pass impl against double-emitting a matched pair or dropping an anti-join row.

## Verification
- Oracle + full **mini-sqlite** suite green (45 lib + oracle + 2 file-backed + 11 integration + doctest); **sql-vm** (81), **sql-codegen** (75) unit tests green.
- My changed region is `cargo fmt` + `clippy` clean (pre-existing warnings elsewhere left untouched — no scope creep).
- Security review **passed** (two passes are *sequential* not nested → O(2·n·m), same complexity class; fresh per-pass labels, symmetric OpenScan/CloseScan, no unterminated loop; no `unsafe`, no I/O, no trust-boundary change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)