### PR TITLE
feat(fenwick-tree): pure-Swift port (Binary Indexed Tree)

### DIFF
--- a/code/packages/swift/fenwick-tree/BUILD
+++ b/code/packages/swift/fenwick-tree/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test; else swift test; fi

--- a/code/packages/swift/fenwick-tree/BUILD_windows
+++ b/code/packages/swift/fenwick-tree/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >/dev/null 2>/dev/null && swift test || echo Swift not available on this runner — skipping

--- a/code/packages/swift/fenwick-tree/CHANGELOG.md
+++ b/code/packages/swift/fenwick-tree/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — FenwickTree (Swift)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Swift port of the `fenwick-tree` reference package — the
+  fourth language (after Dart, Java, Kotlin) in the pure-port + native campaign.
+- `FenwickTree` over `Double` with `update`, `prefixSum`, `rangeSum`,
+  `pointQuery`, and `findKth` (order-statistic search), plus `count`, `isEmpty`,
+  `bitArray`, and a `CustomStringConvertible` description.
+- Two initialisers: `init(size:)` (all-zero) and `init(values:)` (O(n) build).
+- Fallible operations `throw FenwickError` (indexOutOfRange / invalidRange /
+  emptyTree / nonPositiveTarget / targetExceedsTotal) — the idiomatic Swift
+  equivalent of the reference's `Result`.
+- 11 XCTest cases: reference prefix/range/point examples, updates (incl.
+  negative delta), find_kth order statistics and its error cases, invalid-index
+  and invalid-range errors, introspection, and a brute-force prefix/range
+  cross-check.

--- a/code/packages/swift/fenwick-tree/Package.swift
+++ b/code/packages/swift/fenwick-tree/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift — FenwickTree
+// ============================================================================
+//
+// Swift Package Manager manifest for the FenwickTree library: a Binary Indexed
+// Tree over Double supporting O(log n) point updates, prefix/range sums, point
+// queries, and an order-statistic search. Part of the coding-adventures stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "FenwickTree",
+    products: [
+        .library(name: "FenwickTree", targets: ["FenwickTree"]),
+    ],
+    targets: [
+        .target(name: "FenwickTree"),
+        .testTarget(name: "FenwickTreeTests", dependencies: ["FenwickTree"]),
+    ]
+)

--- a/code/packages/swift/fenwick-tree/README.md
+++ b/code/packages/swift/fenwick-tree/README.md
@@ -1,0 +1,49 @@
+# FenwickTree (Swift)
+
+A Binary Indexed Tree (Fenwick tree) over `Double`, implemented in pure Swift.
+
+Swift port of the `fenwick-tree` package that already exists in Rust, Python,
+and other languages in the coding-adventures monorepo; mirrors the reference
+behaviour exactly (1-based indices, `prefixSum(0) == 0`).
+
+## What it does
+
+A Fenwick tree answers, in **O(log n)**:
+
+| Operation | Meaning |
+|---|---|
+| `update(i, delta:)` | add `delta` to the value at 1-based index `i` |
+| `prefixSum(i)` | sum of the first `i` values (`prefixSum(0) == 0`) |
+| `rangeSum(l, r)` | sum over the inclusive range `l...r` |
+| `pointQuery(i)` | the single value at index `i` |
+| `findKth(target)` | smallest index whose prefix sum ≥ `target` (order statistic) |
+
+Plus `count`, `isEmpty`, and `bitArray` for introspection. Operations that can
+fail (out-of-range index, invalid range, bad `findKth` target) **throw**
+`FenwickError` — the idiomatic Swift equivalent of the reference's `Result`.
+
+## Usage
+
+```swift
+import FenwickTree
+
+var tree = FenwickTree(values: [3, 2, 1, 7, 4])
+try tree.prefixSum(4)      // 13
+try tree.rangeSum(2, 4)    // 10
+try tree.update(3, delta: 5)
+try tree.pointQuery(3)     // 6
+try tree.findKth(10)       // 4
+```
+
+## How it works
+
+Each 1-based slot `i` stores the sum of the `lowbit(i)` values ending at `i`,
+where `lowbit(i) = i & -i` isolates the lowest set bit. Walking up
+(`i += lowbit(i)`) reaches every slot an update must touch; walking down
+(`i -= lowbit(i)`) accumulates a prefix — each in log-many steps.
+
+## Running the tests
+
+```
+swift test
+```

--- a/code/packages/swift/fenwick-tree/Sources/FenwickTree/FenwickTree.swift
+++ b/code/packages/swift/fenwick-tree/Sources/FenwickTree/FenwickTree.swift
@@ -1,0 +1,164 @@
+// ============================================================================
+// FenwickTree.swift — Binary Indexed Tree (Fenwick Tree)
+// ============================================================================
+//
+// A Fenwick tree stores a running array of `Double` values and answers two
+// operations in O(log n):
+//
+//   • update(index, delta)  — add `delta` to the value at `index`
+//   • prefixSum(index)      — sum of the first `index` values
+//
+// Range sums, point queries, and an order-statistic search (`findKth`) are all
+// built on top. The trick is that each 1-based slot `i` stores the sum of the
+// `lowbit(i)` values ending at `i`, where `lowbit(i) = i & -i` isolates the
+// lowest set bit — so walking up (`i += lowbit(i)`) covers the updates and
+// walking down (`i -= lowbit(i)`) accumulates a prefix, each in log-many steps.
+//
+// This is the Swift port of the `fenwick-tree` package in the coding-adventures
+// monorepo; it mirrors the reference behaviour exactly (1-based indices,
+// prefixSum(0) == 0). Where the Rust reference returns `Result`, this Swift
+// version throws — the idiomatic Swift equivalent.
+
+import Foundation
+
+/// Errors thrown by ``FenwickTree`` operations.
+public enum FenwickError: Error, Equatable {
+    /// An index fell outside the valid range `[min, max]`.
+    case indexOutOfRange(index: Int, min: Int, max: Int)
+    /// A range had `left > right`.
+    case invalidRange(left: Int, right: Int)
+    /// `findKth` was called on a tree of size 0.
+    case emptyTree
+    /// `findKth` received a target `<= 0`.
+    case nonPositiveTarget(target: Double)
+    /// `findKth`'s target exceeded the total sum of the tree.
+    case targetExceedsTotal(target: Double, total: Double)
+}
+
+/// A Binary Indexed Tree over `Double`, with 1-based external indices.
+public struct FenwickTree: Equatable {
+    private let n: Int
+    private var bit: [Double]
+
+    /// Isolate the lowest set bit of `i` (`i & -i`).
+    private static func lowbit(_ i: Int) -> Int { i & (-i) }
+
+    /// The largest power of two `<= n` (0 when `n == 0`).
+    private static func highestPowerOfTwoAtMost(_ n: Int) -> Int {
+        n == 0 ? 0 : 1 << (Int.bitWidth - n.leadingZeroBitCount - 1)
+    }
+
+    // ── Construction ─────────────────────────────────────────────────────────
+
+    /// Create an all-zero tree that can hold `size` values.
+    public init(size: Int) {
+        self.n = max(size, 0)
+        self.bit = Array(repeating: 0.0, count: self.n + 1)
+    }
+
+    /// Build a tree from `values` in O(n) via the in-place parent-propagation
+    /// construction.
+    public init(values: [Double]) {
+        self.init(size: values.count)
+        var i = 1
+        while i <= n {
+            bit[i] += values[i - 1]
+            let parent = i + Self.lowbit(i)
+            if parent <= n { bit[parent] += bit[i] }
+            i += 1
+        }
+    }
+
+    // ── Queries and updates ──────────────────────────────────────────────────
+
+    /// Add `delta` to the value at 1-based `index`.
+    public mutating func update(_ index: Int, delta: Double) throws {
+        try checkIndex(index)
+        var current = index
+        while current <= n {
+            bit[current] += delta
+            current += Self.lowbit(current)
+        }
+    }
+
+    /// Sum of the first `index` values. `prefixSum(0)` is `0`; `index` may range
+    /// over `0...count`.
+    public func prefixSum(_ index: Int) throws -> Double {
+        guard index >= 0 && index <= n else {
+            throw FenwickError.indexOutOfRange(index: index, min: 0, max: n)
+        }
+        var total = 0.0
+        var current = index
+        while current > 0 {
+            total += bit[current]
+            current -= Self.lowbit(current)
+        }
+        return total
+    }
+
+    /// Sum of the values in the inclusive 1-based range `left...right`.
+    public func rangeSum(_ left: Int, _ right: Int) throws -> Double {
+        guard left <= right else {
+            throw FenwickError.invalidRange(left: left, right: right)
+        }
+        try checkIndex(left)
+        try checkIndex(right)
+        if left == 1 {
+            return try prefixSum(right)
+        }
+        return try prefixSum(right) - prefixSum(left - 1)
+    }
+
+    /// The single value stored at 1-based `index`.
+    public func pointQuery(_ index: Int) throws -> Double {
+        try checkIndex(index)
+        return try rangeSum(index, index)
+    }
+
+    /// The smallest 1-based index whose prefix sum is `>= target` (an
+    /// order-statistic search). Requires strictly positive values for a
+    /// meaningful result, matching the reference.
+    public func findKth(_ target: Double) throws -> Int {
+        guard n != 0 else { throw FenwickError.emptyTree }
+        guard target > 0.0 else { throw FenwickError.nonPositiveTarget(target: target) }
+
+        let total = try prefixSum(n)
+        guard target <= total else {
+            throw FenwickError.targetExceedsTotal(target: target, total: total)
+        }
+
+        var index = 0
+        var step = Self.highestPowerOfTwoAtMost(n)
+        var remaining = target
+        while step > 0 {
+            let next = index + step
+            if next <= n && bit[next] < remaining {
+                index = next
+                remaining -= bit[index]
+            }
+            step >>= 1
+        }
+        return index + 1
+    }
+
+    // ── Introspection ────────────────────────────────────────────────────────
+
+    /// The number of values the tree holds.
+    public var count: Int { n }
+
+    /// Whether the tree holds no values.
+    public var isEmpty: Bool { n == 0 }
+
+    /// A copy of the internal 1-based BIT array (index 0 dropped).
+    public var bitArray: [Double] { Array(bit.dropFirst()) }
+
+    private func checkIndex(_ index: Int) throws {
+        guard index >= 1 && index <= n else {
+            throw FenwickError.indexOutOfRange(index: index, min: 1, max: n)
+        }
+    }
+}
+
+extension FenwickTree: CustomStringConvertible {
+    public var description: String { "FenwickTree(n=\(n), bit=\(bitArray))" }
+}

--- a/code/packages/swift/fenwick-tree/Tests/FenwickTreeTests/FenwickTreeTests.swift
+++ b/code/packages/swift/fenwick-tree/Tests/FenwickTreeTests/FenwickTreeTests.swift
@@ -1,0 +1,133 @@
+// ============================================================================
+// FenwickTreeTests.swift — Unit tests for FenwickTree
+// ============================================================================
+
+import XCTest
+@testable import FenwickTree
+
+final class FenwickTreeTests: XCTestCase {
+
+    private func assertClose(_ a: Double, _ b: Double, _ msg: String = "",
+                             file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertLessThan(abs(a - b), 1e-9, msg, file: file, line: line)
+    }
+
+    // ── Construction / prefix sums ───────────────────────────────────────────
+
+    func testFromValuesBuildsExpectedPrefixSums() throws {
+        let tree = FenwickTree(values: [3, 2, 1, 7, 4])
+        assertClose(try tree.prefixSum(1), 3)
+        assertClose(try tree.prefixSum(2), 5)
+        assertClose(try tree.prefixSum(3), 6)
+        assertClose(try tree.prefixSum(4), 13)
+        assertClose(try tree.prefixSum(5), 17)
+    }
+
+    func testPrefixSumAcceptsZero() throws {
+        let tree = FenwickTree(values: [1, 2, 3])
+        assertClose(try tree.prefixSum(0), 0)
+    }
+
+    // ── Range sum / point query ──────────────────────────────────────────────
+
+    func testRangeSumAndPointQuery() throws {
+        let tree = FenwickTree(values: [3, 2, 1, 7, 4])
+        assertClose(try tree.rangeSum(2, 4), 10)
+        assertClose(try tree.pointQuery(4), 7)
+        assertClose(try tree.rangeSum(1, 5), 17)
+        assertClose(try tree.rangeSum(3, 3), 1)
+    }
+
+    // ── Updates ──────────────────────────────────────────────────────────────
+
+    func testUpdateChangesFutureQueries() throws {
+        var tree = FenwickTree(values: [3, 2, 1, 7, 4])
+        try tree.update(3, delta: 5)
+        assertClose(try tree.prefixSum(3), 11)
+        assertClose(try tree.pointQuery(3), 6)
+        assertClose(try tree.prefixSum(5), 22)
+    }
+
+    func testNegativeDelta() throws {
+        var tree = FenwickTree(values: [10, 10, 10])
+        try tree.update(2, delta: -4)
+        assertClose(try tree.pointQuery(2), 6)
+        assertClose(try tree.rangeSum(1, 3), 26)
+    }
+
+    // ── find_kth (order statistic) ───────────────────────────────────────────
+
+    func testFindKthMatchesOrderStatistic() throws {
+        let tree = FenwickTree(values: [1, 2, 3, 4, 5])
+        XCTAssertEqual(try tree.findKth(1), 1)
+        XCTAssertEqual(try tree.findKth(2), 2)
+        XCTAssertEqual(try tree.findKth(3), 2)
+        XCTAssertEqual(try tree.findKth(4), 3)
+        XCTAssertEqual(try tree.findKth(10), 4)
+    }
+
+    func testFindKthErrors() {
+        let empty = FenwickTree(size: 0)
+        XCTAssertThrowsError(try empty.findKth(1)) { XCTAssertEqual($0 as? FenwickError, .emptyTree) }
+
+        let tree = FenwickTree(values: [1, 2, 3])
+        XCTAssertThrowsError(try tree.findKth(0)) {
+            XCTAssertEqual($0 as? FenwickError, .nonPositiveTarget(target: 0))
+        }
+        XCTAssertThrowsError(try tree.findKth(100)) {
+            guard case .targetExceedsTotal = ($0 as? FenwickError) else {
+                return XCTFail("expected targetExceedsTotal")
+            }
+        }
+    }
+
+    // ── Error cases ──────────────────────────────────────────────────────────
+
+    func testInvalidIndicesThrow() {
+        let tree = FenwickTree(values: [1, 2, 3])
+        XCTAssertThrowsError(try tree.prefixSum(4)) {
+            guard case .indexOutOfRange = ($0 as? FenwickError) else {
+                return XCTFail("expected indexOutOfRange")
+            }
+        }
+        XCTAssertThrowsError(try tree.rangeSum(0, 3)) {
+            guard case .indexOutOfRange = ($0 as? FenwickError) else {
+                return XCTFail("expected indexOutOfRange")
+            }
+        }
+        XCTAssertThrowsError(try tree.rangeSum(3, 1)) {
+            XCTAssertEqual($0 as? FenwickError, .invalidRange(left: 3, right: 1))
+        }
+    }
+
+    // ── Introspection ────────────────────────────────────────────────────────
+
+    func testBitArrayAndDescription() {
+        let tree = FenwickTree(values: [1, 2])
+        XCTAssertEqual(tree.bitArray, [1, 3])
+        XCTAssertTrue(tree.description.contains("FenwickTree"))
+    }
+
+    func testCountAndIsEmpty() {
+        XCTAssertTrue(FenwickTree(size: 0).isEmpty)
+        let tree = FenwickTree(values: [1, 2, 3])
+        XCTAssertEqual(tree.count, 3)
+        XCTAssertFalse(tree.isEmpty)
+    }
+
+    // ── Brute-force cross-check ──────────────────────────────────────────────
+
+    func testBruteForcePrefixAndRange() throws {
+        let values: [Double] = [5, -2, 7, 1.5, 4.5]
+        let tree = FenwickTree(values: values)
+        for index in 1...values.count {
+            assertClose(try tree.prefixSum(index), values.prefix(index).reduce(0, +))
+        }
+        for left in 1...values.count {
+            for right in left...values.count {
+                let expected = values[(left - 1)..<right].reduce(0, +)
+                assertClose(try tree.rangeSum(left, right), expected)
+            }
+        }
+    }
+}

--- a/code/packages/swift/fenwick-tree/required_capabilities.json
+++ b/code/packages/swift/fenwick-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/fenwick-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}


### PR DESCRIPTION
## What

Pure-Swift port of the `fenwick-tree` package — a Binary Indexed Tree over `Double`. **Fourth language** in the campaign (after Dart, Java, Kotlin). `fenwick-tree` is a canon package missing from Swift.

## API (`FenwickTree`)

- `init(size:)` / `init(values:)` — all-zero, or O(n) build.
- `update(_:delta:)` — O(log n) point update.
- `prefixSum(_:)` / `rangeSum(_:_:)` / `pointQuery(_:)` — O(log n) queries (`prefixSum(0) == 0`).
- `findKth(_:)` — order-statistic search. `count` / `isEmpty` / `bitArray` — introspection.

Fallible operations **throw** `FenwickError` — the idiomatic Swift equivalent of the Rust reference's `Result`. Mirrors reference behaviour exactly (1-based indices).

## Verification

- **11 XCTest cases** — reference examples, updates (incl. negative delta), `findKth` order statistics + error cases, invalid-index/range errors, introspection, brute-force cross-check.
- `swift test` green (Swift 6.3).
- Security review passed: all array accesses guarded (no OOB traps), no infinite loop from `lowbit(0)`, `findKth`/NaN handling, no Int overflow, value-type semantics, no force-unwraps/unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)