### PR TITLE
feat(sir-rust): Hash catalog catch-up (empty?/to_a/merge/dig/invert/store/delete/clear/reject/each_key/each_value)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.28.0 — Hash catalog catch-up: `empty?` / `to_a` / `merge` / `dig` / `invert` / `store` / `delete` / `clear` / `reject` / `each_key` / `each_value`
+
+Brings the Rust backend's `map_method` Hash catalog to parity with the
+Go/JS/TS/Python `sir-runtime-oop` reference, which already shipped these.  All
+dispatch through the same EXPLICIT method-name `match` (never reflection) and
+route key comparison through `value_eq`:
+
+- **`empty?`** — `true` iff the hash has no pairs.
+- **`to_a`** — an Array of two-element `[key, value]` Arrays, in insertion order.
+- **`merge(other)`** — a NEW hash with `other` overlaid on a copy of the receiver;
+  on a collision `other` wins while the key holds its first-seen position. A
+  non-`Map` argument is ignored.
+- **`dig(k, …)`** — a NESTED lookup walking one key per argument, returning `nil`
+  the moment a level is missing (never raising). Recurses into a nested `Map`
+  (by key) or `Seq` (by integer index, negative-from-end), matching the Go/JS
+  backends' nested `dig` (a superset of the single-level Python/TS `dig`).
+- **`invert`** — a NEW hash mapping each value back to its key; equal values
+  collapse onto one key with the last pair's key at the first-seen position.
+- **`store(k, v)` / `[]=`** — MUTATES the receiver (overwrite-in-place or append)
+  and returns the value.
+- **`delete(k)`** — MUTATES: removes the first entry with a matching key and
+  returns its value; a missing key yields `nil`.
+- **`clear`** — MUTATES, emptying the receiver, and returns it.
+- **`reject { |k, v| … }`** — a NEW hash of the pairs for which the block is
+  falsy (the complement of `select`).
+- **`each_key { |k| … }` / `each_value { |v| … }`** — yield ONE argument per
+  entry and return the receiver.
+
+`responds_to?` now advertises all of the above.
+
+Exec-proof: new `tests/compile_and_run_hash_catalog.rs` compiles and runs (under
+real `rustc`) a module exercising every new arm — including a nested `dig`
+hit/miss, a `merge` collision, an `invert`, a mutating `delete`/`store`/`clear`,
+and `reject`/`each_key`/`each_value` — diffing stdout against the Python
+reference semantics.
+
 ## 0.27.0 — Hash transforming block methods: `transform_values` / `transform_keys`
 
 Mirrors the Python `sir-runtime-oop` v0.1.18 reference (PR #7909) into the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -142,8 +142,10 @@ rather than panicking:
   - **Array** (`Seq`): `length`/`size`, `first`, `last`, `push`/`append`,
     `pop`, `include?`, `reverse`, `sort`, `join`, `map`, `select`/`filter`,
     `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`.
-  - **Hash** (`Map`): `keys`, `values`, `size`, `has_key?`, `each`, `map`,
-    `select`, `transform_values`, `transform_keys`.
+  - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,
+    `fetch`, `to_a`, `merge`, `dig` (nested), `invert`, `store`/`[]=`, `delete`,
+    `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,
+    `reject`, `transform_values`, `transform_keys`.
   - **String** (`Str`): `length`, `upcase`, `downcase`, `reverse`, `strip`,
     `include?`, `split`, char-set `tr`/`count`/`delete`/`squeeze` (literal
     sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1473,9 +1473,11 @@ pub const RUNTIME: &str = r##"mod __sir {
             ),
             Value::Map(_) => matches!(
                 name,
-                "keys" | "values" | "[]" | "size" | "length" | "has_key?" | "key?" | "include?"
-                    | "member?" | "fetch" | "each" | "each_pair" | "map" | "collect" | "select"
-                    | "filter" | "transform_values" | "transform_keys"
+                "keys" | "values" | "[]" | "size" | "length" | "empty?" | "has_key?" | "key?"
+                    | "include?" | "member?" | "fetch" | "to_a" | "merge" | "dig" | "invert"
+                    | "store" | "[]=" | "delete" | "clear" | "each" | "each_pair" | "each_key"
+                    | "each_value" | "map" | "collect" | "select" | "filter" | "reject"
+                    | "transform_values" | "transform_keys"
             ),
             Value::Str(_) => matches!(
                 name,
@@ -2273,6 +2275,144 @@ pub const RUNTIME: &str = r##"mod __sir {
                 }
                 None => unknown_method(&recv, name),
             },
+            "empty?" => Value::Bool(entries_rc.borrow().is_empty()),
+            // `Hash#to_a` — an Array of two-element `[key, value]` Arrays, in
+            // insertion order.
+            "to_a" => seq_lit(
+                entries_rc
+                    .borrow()
+                    .iter()
+                    .map(|(k, v)| seq_lit(vec![k.clone(), v.clone()]))
+                    .collect(),
+            ),
+            // `Hash#merge(other)` — a NEW hash with `other`'s entries overlaid on
+            // a copy of the receiver; on a key collision `other` WINS while the
+            // key holds its FIRST-seen position (Ruby / Python `{**a, **b}`
+            // semantics).  Non-`Map` args are ignored (no faithful merge source).
+            "merge" => {
+                let mut out: Vec<(Value, Value)> = entries_rc.borrow().clone();
+                if let Some(Value::Map(other)) = pos.first() {
+                    for (k, v) in other.borrow().iter() {
+                        match out.iter_mut().find(|(ek, _)| value_eq(ek, k)) {
+                            Some(slot) => slot.1 = v.clone(),
+                            None => out.push((k.clone(), v.clone())),
+                        }
+                    }
+                }
+                Value::Map(Rc::new(RefCell::new(out)))
+            }
+            // `Hash#dig(k, …)` — a NESTED lookup that walks one key per argument,
+            // returning `nil` the moment a level is missing (never raising).  A
+            // single argument degrades to a plain lookup; extra arguments recurse
+            // into a nested `Map` (by key) or `Seq` (by integer index, folding a
+            // negative index from the end once) — matching Go/JS.  A level that
+            // is neither stops the walk with `nil`.
+            "dig" => {
+                let mut cur = recv.clone();
+                for k in &pos {
+                    cur = match &cur {
+                        Value::Map(entries) => entries
+                            .borrow()
+                            .iter()
+                            .find(|(ek, _)| value_eq(ek, k))
+                            .map(|(_, v)| v.clone())
+                            .unwrap_or(Value::Nil),
+                        Value::Seq(items) => {
+                            let items = items.borrow();
+                            let len = items.len() as i64;
+                            let raw = as_i64(k);
+                            let idx = if raw < 0 { raw + len } else { raw };
+                            if idx >= 0 && idx < len {
+                                items[idx as usize].clone()
+                            } else {
+                                Value::Nil
+                            }
+                        }
+                        _ => Value::Nil,
+                    };
+                    if matches!(cur, Value::Nil) {
+                        return Value::Nil;
+                    }
+                }
+                cur
+            }
+            // `Hash#invert` — a NEW hash mapping each value back to its key.  Two
+            // equal values collapse onto one key; Ruby keeps the LAST pair's key
+            // at the value's FIRST-seen position (Python dict-comprehension rule).
+            "invert" => {
+                let mut out: Vec<(Value, Value)> = Vec::new();
+                for (k, v) in entries_rc.borrow().iter() {
+                    match out.iter_mut().find(|(ek, _)| value_eq(ek, v)) {
+                        Some(slot) => slot.1 = k.clone(),
+                        None => out.push((v.clone(), k.clone())),
+                    }
+                }
+                Value::Map(Rc::new(RefCell::new(out)))
+            }
+            // `Hash#store(k, v)` / `Hash#[]=` — MUTATES the receiver (overwrites
+            // an existing key in place, else appends) and returns the value.
+            "store" | "[]=" => {
+                let key = pos.first().cloned().unwrap_or(Value::Nil);
+                let val = pos.get(1).cloned().unwrap_or(Value::Nil);
+                {
+                    let mut entries = entries_rc.borrow_mut();
+                    match entries.iter_mut().find(|(ek, _)| value_eq(ek, &key)) {
+                        Some(slot) => slot.1 = val.clone(),
+                        None => entries.push((key, val.clone())),
+                    }
+                }
+                val
+            }
+            // `Hash#delete(k)` — MUTATES: removes the first entry whose key equals
+            // `k` and returns its value; a missing key yields `nil` (never raises).
+            "delete" => {
+                let needle = pos.first().cloned().unwrap_or(Value::Nil);
+                let mut entries = entries_rc.borrow_mut();
+                match entries.iter().position(|(ek, _)| value_eq(ek, &needle)) {
+                    Some(i) => entries.remove(i).1,
+                    None => Value::Nil,
+                }
+            }
+            // `Hash#clear` — MUTATES, removing every pair, and returns the (now
+            // empty) receiver.
+            "clear" => {
+                entries_rc.borrow_mut().clear();
+                recv
+            }
+            // `Hash#reject { |k, v| … }` — a NEW hash of the pairs for which the
+            // block is FALSY (the complement of `select`).  Non-mutating.
+            "reject" => match &block {
+                Some(b) => {
+                    let kept: Vec<(Value, Value)> = entries_rc
+                        .borrow()
+                        .clone()
+                        .into_iter()
+                        .filter(|(k, v)| !truthy(&apply_closure(b, vec![k.clone(), v.clone()])))
+                        .collect();
+                    Value::Map(Rc::new(RefCell::new(kept)))
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `Hash#each_key { |k| … }` — yields ONE argument (the key) per entry
+            // and returns the receiver.
+            "each_key" => {
+                if let Some(b) = &block {
+                    for (k, _) in entries_rc.borrow().clone() {
+                        apply_closure(b, vec![k]);
+                    }
+                }
+                recv
+            }
+            // `Hash#each_value { |v| … }` — yields ONE argument (the value) per
+            // entry and returns the receiver.
+            "each_value" => {
+                if let Some(b) = &block {
+                    for (_, v) in entries_rc.borrow().clone() {
+                        apply_closure(b, vec![v]);
+                    }
+                }
+                recv
+            }
             _ => no_method_error(&recv, name),
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -2317,17 +2317,23 @@ pub const RUNTIME: &str = r##"mod __sir {
                             .find(|(ek, _)| value_eq(ek, k))
                             .map(|(_, v)| v.clone())
                             .unwrap_or(Value::Nil),
-                        Value::Seq(items) => {
-                            let items = items.borrow();
-                            let len = items.len() as i64;
-                            let raw = as_i64(k);
-                            let idx = if raw < 0 { raw + len } else { raw };
-                            if idx >= 0 && idx < len {
-                                items[idx as usize].clone()
-                            } else {
-                                Value::Nil
+                        // `Array#dig` indexes by an Integer; a non-integer key
+                        // is a MISS (nil), never a panic — honouring the
+                        // never-panic floor and matching the JS backend (which
+                        // digs an Array only when the key is a number).
+                        Value::Seq(items) => match k {
+                            Value::Int(raw) => {
+                                let items = items.borrow();
+                                let len = items.len() as i64;
+                                let idx = if *raw < 0 { raw + len } else { *raw };
+                                if idx >= 0 && idx < len {
+                                    items[idx as usize].clone()
+                                } else {
+                                    Value::Nil
+                                }
                             }
-                        }
+                            _ => Value::Nil,
+                        },
                         _ => Value::Nil,
                     };
                     if matches!(cur, Value::Nil) {
@@ -2381,11 +2387,17 @@ pub const RUNTIME: &str = r##"mod __sir {
             }
             // `Hash#reject { |k, v| … }` — a NEW hash of the pairs for which the
             // block is FALSY (the complement of `select`).  Non-mutating.
+            // Each block arm SNAPSHOTS the entries into an owned `Vec` in a
+            // `let` binding *before* iterating, so the `RefCell` borrow is
+            // released prior to any `apply_closure` call.  A block that
+            // reentrantly mutates the SAME hash (`h.each_key { h.store(...) }`)
+            // therefore cannot trip a `BorrowMutError` panic — the never-panic
+            // floor holds even now that mutating Hash arms (`store`/`delete`/
+            // `clear`) exist.
             "reject" => match &block {
                 Some(b) => {
-                    let kept: Vec<(Value, Value)> = entries_rc
-                        .borrow()
-                        .clone()
+                    let snapshot = entries_rc.borrow().clone();
+                    let kept: Vec<(Value, Value)> = snapshot
                         .into_iter()
                         .filter(|(k, v)| !truthy(&apply_closure(b, vec![k.clone(), v.clone()])))
                         .collect();
@@ -2397,7 +2409,8 @@ pub const RUNTIME: &str = r##"mod __sir {
             // and returns the receiver.
             "each_key" => {
                 if let Some(b) = &block {
-                    for (k, _) in entries_rc.borrow().clone() {
+                    let snapshot = entries_rc.borrow().clone();
+                    for (k, _) in snapshot {
                         apply_closure(b, vec![k]);
                     }
                 }
@@ -2407,7 +2420,8 @@ pub const RUNTIME: &str = r##"mod __sir {
             // entry and returns the receiver.
             "each_value" => {
                 if let Some(b) = &block {
-                    for (_, v) in entries_rc.borrow().clone() {
+                    let snapshot = entries_rc.borrow().clone();
+                    for (_, v) in snapshot {
                         apply_closure(b, vec![v]);
                     }
                 }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -189,6 +189,19 @@ fn catalog_demo() -> Module {
         print_stmt(method(nested(), "dig", vec![symlit("a"), symlit("b")])),
         // {a:{b:1}}.dig(:a,:z) → nil  (nested miss)
         print_stmt(method(nested(), "dig", vec![symlit("a"), symlit("z")])),
+        // {a:[10,20]}.dig(:a, :b) → nil  (non-integer index into an Array is a
+        // MISS, never a panic — never-panic floor)
+        print_stmt(method(
+            map_lit(vec![(symlit("a"), Expr::SeqLit { items: vec![ilit(10), ilit(20)], span: s() })]),
+            "dig",
+            vec![symlit("a"), symlit("b")],
+        )),
+        // {a:[10,20]}.dig(:a, 1) → 20  (integer index into the nested Array)
+        print_stmt(method(
+            map_lit(vec![(symlit("a"), Expr::SeqLit { items: vec![ilit(10), ilit(20)], span: s() })]),
+            "dig",
+            vec![symlit("a"), ilit(1)],
+        )),
         // {a:1,b:2}.invert → {1: a, 2: b}
         print_stmt(method(ab_map(), "invert", vec![])),
         // {a:1,b:2}.store(:c, 3) → 3  (returns stored value)
@@ -273,6 +286,8 @@ fn hash_catalog_compile_and_run() {
             "{a: 1, b: 9}",     // merge (collision → other wins)
             "1",                // dig nested hit
             "nil",              // dig nested miss
+            "nil",              // dig non-integer Array index → nil (no panic)
+            "20",               // dig integer Array index
             "{1: a, 2: b}",     // invert
             "3",                // store → stored value
             "1",                // delete → removed value

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -1,0 +1,294 @@
+//! End-to-end proof for the Rust backend's **`Hash` catalog catch-up** — the
+//! non-block methods `empty?`, `to_a`, `merge`, `dig` (nested), `invert`,
+//! `store`/`[]=`, `delete`, `clear`, and the block methods `reject`,
+//! `each_key`, `each_value`, bringing the Rust `map_method` catalog to parity
+//! with the Go/JS/TS/Python `sir-runtime-oop` reference.
+//!
+//! The test hand-builds SIR modules that exercise each arm, emits Rust,
+//! compiles it with `rustc`, runs the binary, and diffs stdout against the
+//! values the Python reference produces for the SAME operations.  Symbol keys
+//! (`{a: 1}`) are used so the printed form (`a`) matches Ruby's surface.
+//!
+//! A missing `rustc`/linker logs a skip rather than reddening the build; the
+//! host may point at a working linker via `SIR_TEST_RUSTC_LINKER`.
+
+use std::process::Command;
+
+use semantic_ir::nodes::MapEntry;
+use semantic_ir::{
+    Block, CaptureValue, Effect, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Scope, Span, Stmt,
+};
+use semantic_ir_to_rust::compile;
+
+fn s() -> Span {
+    Span::synthetic()
+}
+
+fn ilit(v: i64) -> Expr {
+    Expr::IntLit { value: v, span: s() }
+}
+
+fn slit(v: &str) -> Expr {
+    Expr::StrLit { value: v.into(), span: s() }
+}
+
+fn symlit(v: &str) -> Expr {
+    Expr::SymLit { name: v.into(), span: s() }
+}
+
+fn param(name: &str) -> Expr {
+    Expr::VarRef { name: name.into(), scope: Scope::Param, span: s() }
+}
+
+/// `recv.meth(args…)` — the `__method__` dispatch envelope.
+fn method(recv: Expr, name: &str, mut args: Vec<Expr>) -> Expr {
+    let mut all = vec![recv, slit(name)];
+    all.append(&mut args);
+    Expr::BuiltinCall { name: "__method__".into(), args: all, effects: EffectSet::PURE, span: s() }
+}
+
+/// A no-capture block closure over a top-level block function.
+fn block(fn_name: &str) -> Expr {
+    Expr::MakeClosure { fn_name: fn_name.into(), captures: Vec::<CaptureValue>::new(), span: s() }
+}
+
+/// `{k: v, …}` from `(key, value)` expression pairs.
+fn map_lit(entries: Vec<(Expr, Expr)>) -> Expr {
+    Expr::MapLit {
+        entries: entries.into_iter().map(|(key, value)| MapEntry { key, value }).collect(),
+        span: s(),
+    }
+}
+
+fn print_stmt(expr: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: Expr::BuiltinCall {
+            name: "print".into(),
+            args: vec![expr],
+            effects: EffectSet::PURE.with(Effect::MayPrint),
+            span: s(),
+        },
+        span: s(),
+    }
+}
+
+/// A one-statement block that `print`s its parameter and returns nil — used by
+/// the `each_key` / `each_value` demos so the yielded values are observable.
+fn block_fn_print(name: &str, pname: &str) -> Function {
+    Function {
+        name: name.into(),
+        params: vec![semantic_ir::Param {
+            name: pname.into(),
+            kind: semantic_ir::ParamKind::Required,
+            sir_type: None,
+            default: None,
+            span: s(),
+        }],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print_stmt(param(pname))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+/// A pure expression-bodied block over the given params.
+fn block_fn(name: &str, params: &[&str], value: Expr) -> Function {
+    Function {
+        name: name.into(),
+        params: params
+            .iter()
+            .map(|p| semantic_ir::Param {
+                name: (*p).into(),
+                kind: semantic_ir::ParamKind::Required,
+                sir_type: None,
+                default: None,
+                span: s(),
+            })
+            .collect(),
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value, span: s() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn demo_module(main_stmts: Vec<Stmt>, block_fns: Vec<Function>) -> Module {
+    let mut functions = vec![Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: main_stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }];
+    functions.extend(block_fns);
+
+    Module {
+        name: "hash_catalog_demo".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Symbols,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("test")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: s(),
+    }
+}
+
+/// `{a: 1, b: 2}` with symbol keys.
+fn ab_map() -> Expr {
+    map_lit(vec![(symlit("a"), ilit(1)), (symlit("b"), ilit(2))])
+}
+
+fn catalog_demo() -> Module {
+    // `reject { |k, v| v.even? }` drops the even-valued pairs.
+    let reject_even = block_fn("__blk_v_even", &["k", "v"], method(param("v"), "even?", vec![]));
+    let block_fns = vec![
+        reject_even,
+        block_fn_print("__blk_print", "x"),
+    ];
+
+    // `{a: {b: 1}}` — a nested hash for the `dig` walk.
+    let nested = || map_lit(vec![(symlit("a"), map_lit(vec![(symlit("b"), ilit(1))]))]);
+
+    let main_stmts = vec![
+        // empty? — non-empty ⇒ #f, empty ⇒ #t
+        print_stmt(method(ab_map(), "empty?", vec![])),
+        print_stmt(method(map_lit(vec![]), "empty?", vec![])),
+        // to_a → [[a, 1], [b, 2]]
+        print_stmt(method(ab_map(), "to_a", vec![])),
+        // {a:1}.merge({b:2}) → {a: 1, b: 2}
+        print_stmt(method(
+            map_lit(vec![(symlit("a"), ilit(1))]),
+            "merge",
+            vec![map_lit(vec![(symlit("b"), ilit(2))])],
+        )),
+        // {a:1,b:2}.merge({b:9}) → {a: 1, b: 9}  (other wins on collision)
+        print_stmt(method(ab_map(), "merge", vec![map_lit(vec![(symlit("b"), ilit(9))])])),
+        // {a:{b:1}}.dig(:a,:b) → 1  (nested hit)
+        print_stmt(method(nested(), "dig", vec![symlit("a"), symlit("b")])),
+        // {a:{b:1}}.dig(:a,:z) → nil  (nested miss)
+        print_stmt(method(nested(), "dig", vec![symlit("a"), symlit("z")])),
+        // {a:1,b:2}.invert → {1: a, 2: b}
+        print_stmt(method(ab_map(), "invert", vec![])),
+        // {a:1,b:2}.store(:c, 3) → 3  (returns stored value)
+        print_stmt(method(ab_map(), "store", vec![symlit("c"), ilit(3)])),
+        // {a:1,b:2}.delete(:a) → 1  (returns removed value)
+        print_stmt(method(ab_map(), "delete", vec![symlit("a")])),
+        // {a:1}.delete(:z) → nil  (absent key)
+        print_stmt(method(map_lit(vec![(symlit("a"), ilit(1))]), "delete", vec![symlit("z")])),
+        // {a:1,b:2}.clear → {}
+        print_stmt(method(ab_map(), "clear", vec![])),
+        // {a:1,b:2}.reject { |k, v| v.even? } → {a: 1}
+        print_stmt(method(ab_map(), "reject", vec![block("__blk_v_even")])),
+        // {a:1,b:2}.each_key { |k| print k } → prints a, b, returns {a: 1, b: 2}
+        print_stmt(method(ab_map(), "each_key", vec![block("__blk_print")])),
+        // {a:1,b:2}.each_value { |v| print v } → prints 1, 2, returns {a: 1, b: 2}
+        print_stmt(method(ab_map(), "each_value", vec![block("__blk_print")])),
+    ];
+
+    demo_module(main_stmts, block_fns)
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc").arg("--version").output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+#[test]
+fn hash_catalog_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&catalog_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_hash_catalog_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_hash_catalog_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out =
+        cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "#f",               // empty? on non-empty
+            "#t",               // empty? on {}
+            "[[a, 1], [b, 2]]", // to_a
+            "{a: 1, b: 2}",     // merge (append)
+            "{a: 1, b: 9}",     // merge (collision → other wins)
+            "1",                // dig nested hit
+            "nil",              // dig nested miss
+            "{1: a, 2: b}",     // invert
+            "3",                // store → stored value
+            "1",                // delete → removed value
+            "nil",              // delete absent → nil
+            "{}",               // clear
+            "{a: 1}",           // reject { even? } drops b:2
+            "a",                // each_key yields a
+            "b",                // each_key yields b
+            "{a: 1, b: 2}",     // each_key returns self
+            "1",                // each_value yields 1
+            "2",                // each_value yields 2
+            "{a: 1, b: 2}",     // each_value returns self
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## Summary

Brings the **Rust backend** (`semantic-ir-to-rust`) `map_method` Hash catalog to **parity with the Go/JS/TS/Python** `sir-runtime-oop` reference, which already shipped these. This closes a discovered gap where Rust's Hash was notably thinner than its sibling backends. All arms dispatch through the same explicit method-name `match` (never reflection) and route key comparison through `value_eq`.

**Non-block:** `empty?`, `to_a`, `merge` (other-wins, first-seen position), `dig` (nested — walks `Map` by key / `Seq` by integer index, nil on miss), `invert` (last-key-wins dedup), `store`/`[]=`, `delete`, `clear` (the mutating trio).
**Block:** `reject` (complement of `select`), `each_key`, `each_value`.

`respond_to?` now advertises all of the above. `dig` is **nested** to match the Go/JS backends (a superset of the single-level Python/TS `dig`).

## Security hardening (from review)

The review flagged two LOW never-panic-floor violations, both fixed in a follow-up commit:
- `dig` into a nested Array with a **non-integer key** previously reached `as_i64` (which panics); now a non-`Int` index is a **miss (nil)**, matching JS. Regression-tested.
- `reject`/`each_key`/`each_value` now **snapshot** entries into a `let` before iterating, releasing the `RefCell` borrow before any `apply_closure` — so a block that reentrantly mutates the same hash (via the newly-added `store`/`delete`/`clear`) can't trip a `BorrowMutError`.

## Exec-proof

New `tests/compile_and_run_hash_catalog.rs` compiles + runs (real `rustc`) every new arm — nested `dig` hit/miss, non-integer Array dig → nil, integer Array dig, `merge` collision, `invert`, mutating `delete`/`store`/`clear`, `reject`/`each_key`/`each_value` — diffing stdout against the Python reference. **Full crate suite green (no regressions); clippy clean.**

## Checklist
- [x] CHANGELOG.md (0.27.0 → **0.28.0**), README Hash catalog updated
- [x] Exec-proof green under `rustc`; full `cargo test -p semantic-ir-to-rust` passes
- [x] Security review passed; two LOW panic-path findings fixed

Part of the SIR Ruby→{…} full-parity effort — a Rust-backend catch-up to its peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)