### PR TITLE
feat(trie): pure-Swift port (prefix tree with prefix operations)

### DIFF
--- a/code/packages/swift/trie/BUILD
+++ b/code/packages/swift/trie/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test; else swift test; fi

--- a/code/packages/swift/trie/BUILD_windows
+++ b/code/packages/swift/trie/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >/dev/null 2>/dev/null && swift test || echo Swift not available on this runner — skipping

--- a/code/packages/swift/trie/CHANGELOG.md
+++ b/code/packages/swift/trie/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — Trie (Swift)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Swift port of the `trie` reference package.
+- `Trie<Value>` with `insert`, `search`, `containsKey`, `delete`, `startsWith`,
+  `wordsWithPrefix`, `allWords`, `keys`, `longestPrefixMatch`, plus `count`,
+  `isEmpty`, `isValid()`, and a `CustomStringConvertible` description.
+- Keys on `Unicode.Scalar` (matching the reference's `char`), so combining and
+  precomposed forms stay distinct; enumerations are scalar-sorted.
+- Value-type semantics (assigning a trie makes an independent copy).
+- 11 XCTest cases: exact search vs prefix, size-stable overwrite, lexicographic
+  prefix enumeration, leaf/shared-prefix deletion, delete-nonexistent, longest-
+  prefix-match, Unicode-scalar + empty-string keys, sorted keys/allWords,
+  description, and a value-semantics copy check.

--- a/code/packages/swift/trie/Package.swift
+++ b/code/packages/swift/trie/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift — Trie
+// ============================================================================
+//
+// Swift Package Manager manifest for the Trie library: a prefix tree for string
+// keys with insert/search/delete and prefix operations (words-with-prefix,
+// longest-prefix-match). Part of the coding-adventures stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "Trie",
+    products: [
+        .library(name: "Trie", targets: ["Trie"]),
+    ],
+    targets: [
+        .target(name: "Trie"),
+        .testTarget(name: "TrieTests", dependencies: ["Trie"]),
+    ]
+)

--- a/code/packages/swift/trie/README.md
+++ b/code/packages/swift/trie/README.md
@@ -1,0 +1,50 @@
+# Trie (Swift)
+
+A prefix tree (trie) for `String` keys with prefix operations, in pure Swift.
+
+Swift port of the `trie` package that already exists in Rust, Python, and other
+languages in the coding-adventures monorepo.
+
+## What it does
+
+| Member | Purpose |
+|---|---|
+| `insert(_:value:)` | store a key with a value (overwrites) |
+| `search(_:)` | value for an exact key, or `nil` |
+| `containsKey(_:)` | is this an exact stored key? |
+| `delete(_:)` | remove a key, pruning empty nodes |
+| `startsWith(_:)` | does any key begin with this prefix? |
+| `wordsWithPrefix(_:)` | all keys under a prefix, sorted, with values |
+| `allWords()` / `keys()` | every key (with/without values), sorted |
+| `longestPrefixMatch(_:)` | most specific stored key that prefixes a string |
+| `count` / `isEmpty` / `isValid()` | introspection |
+
+## Unicode
+
+Like the Rust reference (which keys on `char`), this trie keys on
+**`Unicode.Scalar`**, not `Character` (grapheme clusters). So a combining
+sequence (`"e"` + U+0301) and the precomposed `"é"` (U+00E9) are **distinct**
+keys. Children are visited in scalar order, so enumerations come back
+lexicographically sorted.
+
+`Trie` is a value type: assigning it makes an independent copy.
+
+## Usage
+
+```swift
+import Trie
+
+var trie = Trie<Int>()
+trie.insert("apple", value: 1)
+trie.insert("app", value: 2)
+trie.search("app")                 // 2
+trie.startsWith("ap")              // true
+trie.wordsWithPrefix("app").map { $0.0 } // ["app", "apple"]
+trie.longestPrefixMatch("applet")  // ("apple", 1)
+```
+
+## Running the tests
+
+```
+swift test
+```

--- a/code/packages/swift/trie/Sources/Trie/Trie.swift
+++ b/code/packages/swift/trie/Sources/Trie/Trie.swift
@@ -1,0 +1,194 @@
+// ============================================================================
+// Trie.swift — Prefix tree (trie) for string keys with prefix operations
+// ============================================================================
+//
+// A trie stores string keys as paths through a tree: each edge is labelled with
+// one character, and a node flagged `isEnd` marks where a stored key finishes.
+// This makes prefix questions cheap — "does any key start with `app`?" is just
+// a walk to the `app` node — which is why tries back autocomplete, routers, and
+// dictionaries.
+//
+// This is the Swift port of the `trie` package in the coding-adventures
+// monorepo. Like the Rust reference (which keys on `char`, i.e. Unicode
+// scalars), this trie keys on `Unicode.Scalar` rather than `Character`
+// (grapheme clusters) — so a combining sequence like "e" + U+0301 and the
+// precomposed "é" (U+00E9) remain distinct keys, exactly as in the reference.
+// Children are visited in scalar order, so `keys()`, `allWords()`, and
+// `wordsWithPrefix(_:)` come back lexicographically sorted.
+
+/// A prefix tree mapping `String` keys to values of type `Value`.
+public struct Trie<Value> {
+
+    // A node is a value type; a Dictionary of the same struct type is allowed in
+    // Swift because Dictionary provides the heap indirection.
+    private struct Node {
+        var children: [Unicode.Scalar: Node] = [:]
+        var isEnd = false
+        var value: Value?
+    }
+
+    private var root = Node()
+    private var size = 0
+
+    /// Create an empty trie.
+    public init() {}
+
+    // ── Mutation ─────────────────────────────────────────────────────────────
+
+    /// Insert `key` with `value`, overwriting any existing value for `key`.
+    public mutating func insert(_ key: String, value: Value) {
+        let scalars = Array(key.unicodeScalars)
+        if Self.insert(&root, scalars, 0, value) { size += 1 }
+    }
+
+    private static func insert(_ node: inout Node, _ scalars: [Unicode.Scalar],
+                               _ depth: Int, _ value: Value) -> Bool {
+        if depth == scalars.count {
+            let wasNew = !node.isEnd
+            node.isEnd = true
+            node.value = value
+            return wasNew
+        }
+        let ch = scalars[depth]
+        var child = node.children[ch] ?? Node()
+        let wasNew = insert(&child, scalars, depth + 1, value)
+        node.children[ch] = child
+        return wasNew
+    }
+
+    /// Remove `key`. Returns `true` if it was present, pruning now-empty nodes.
+    @discardableResult
+    public mutating func delete(_ key: String) -> Bool {
+        guard keyExists(key) else { return false }
+        let scalars = Array(key.unicodeScalars)
+        _ = Self.delete(&root, scalars, 0)
+        size -= 1
+        return true
+    }
+
+    private static func delete(_ node: inout Node, _ scalars: [Unicode.Scalar],
+                               _ depth: Int) -> Bool {
+        if depth == scalars.count {
+            node.isEnd = false
+            node.value = nil
+            return node.children.isEmpty
+        }
+        let ch = scalars[depth]
+        if var child = node.children[ch] {
+            if delete(&child, scalars, depth + 1) {
+                node.children[ch] = nil
+            } else {
+                node.children[ch] = child
+            }
+        }
+        return node.children.isEmpty && !node.isEnd
+    }
+
+    // ── Lookup ───────────────────────────────────────────────────────────────
+
+    /// The value stored for exactly `key`, or `nil` if `key` is not a stored key.
+    public func search(_ key: String) -> Value? {
+        guard let node = findNode(key), node.isEnd else { return nil }
+        return node.value
+    }
+
+    /// Whether `key` is a stored key (an exact match, not merely a prefix).
+    public func containsKey(_ key: String) -> Bool { keyExists(key) }
+
+    /// Whether any stored key begins with `prefix`. The empty prefix matches
+    /// whenever the trie is non-empty.
+    public func startsWith(_ prefix: String) -> Bool {
+        if prefix.isEmpty { return size > 0 }
+        return findNode(prefix) != nil
+    }
+
+    /// The most specific stored key that is a prefix of `string`, with its value
+    /// (or `nil` if no stored key is a prefix of `string`).
+    public func longestPrefixMatch(_ string: String) -> (String, Value)? {
+        var node = root
+        var best: (String, Value)? = node.isEnd ? node.value.map { ("", $0) } : nil
+        var current = String.UnicodeScalarView()
+        for ch in string.unicodeScalars {
+            guard let next = node.children[ch] else { break }
+            current.append(ch)
+            node = next
+            if node.isEnd, let value = node.value {
+                best = (String(current), value)
+            }
+        }
+        return best
+    }
+
+    // ── Enumeration (lexicographically sorted) ───────────────────────────────
+
+    /// Every stored key beginning with `prefix`, paired with its value, sorted.
+    public func wordsWithPrefix(_ prefix: String) -> [(String, Value)] {
+        guard let node = findNode(prefix) else { return [] }
+        var results: [(String, Value)] = []
+        Self.collect(node, Array(prefix.unicodeScalars), &results)
+        return results
+    }
+
+    /// Every stored key paired with its value, sorted.
+    public func allWords() -> [(String, Value)] {
+        var results: [(String, Value)] = []
+        Self.collect(root, [], &results)
+        return results
+    }
+
+    /// Every stored key, sorted.
+    public func keys() -> [String] { allWords().map { $0.0 } }
+
+    private static func collect(_ node: Node, _ current: [Unicode.Scalar],
+                                _ results: inout [(String, Value)]) {
+        if node.isEnd, let value = node.value {
+            results.append((scalarsToString(current), value))
+        }
+        for ch in node.children.keys.sorted(by: { $0.value < $1.value }) {
+            collect(node.children[ch]!, current + [ch], &results)
+        }
+    }
+
+    // ── Introspection ────────────────────────────────────────────────────────
+
+    /// The number of stored keys.
+    public var count: Int { size }
+
+    /// Whether the trie stores no keys.
+    public var isEmpty: Bool { size == 0 }
+
+    /// Consistency check: the number of `isEnd` nodes equals the tracked size.
+    public func isValid() -> Bool { Self.countEndpoints(root) == size }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    private func findNode(_ key: String) -> Node? {
+        var node = root
+        for ch in key.unicodeScalars {
+            guard let next = node.children[ch] else { return nil }
+            node = next
+        }
+        return node
+    }
+
+    private func keyExists(_ key: String) -> Bool { findNode(key)?.isEnd ?? false }
+
+    private static func countEndpoints(_ node: Node) -> Int {
+        var count = node.isEnd ? 1 : 0
+        for child in node.children.values { count += countEndpoints(child) }
+        return count
+    }
+
+    private static func scalarsToString(_ scalars: [Unicode.Scalar]) -> String {
+        var view = String.UnicodeScalarView()
+        view.append(contentsOf: scalars)
+        return String(view)
+    }
+}
+
+extension Trie: CustomStringConvertible {
+    public var description: String {
+        let preview = allWords().prefix(5).map { $0.0 }
+        return "Trie(\(size) keys: \(preview))"
+    }
+}

--- a/code/packages/swift/trie/Tests/TrieTests/TrieTests.swift
+++ b/code/packages/swift/trie/Tests/TrieTests/TrieTests.swift
@@ -1,0 +1,119 @@
+// ============================================================================
+// TrieTests.swift — Unit tests for Trie
+// ============================================================================
+
+import XCTest
+@testable import Trie
+
+final class TrieTests: XCTestCase {
+
+    private func makeTrie(_ words: [String]) -> Trie<Bool> {
+        var trie = Trie<Bool>()
+        for w in words { trie.insert(w, value: true) }
+        return trie
+    }
+
+    func testEmptyTrieHasNoKeys() {
+        let trie = Trie<Int>()
+        XCTAssertEqual(trie.count, 0)
+        XCTAssertTrue(trie.isEmpty)
+        XCTAssertNil(trie.search("anything"))
+        XCTAssertFalse(trie.startsWith("a"))
+        XCTAssertTrue(trie.isValid())
+    }
+
+    func testInsertAndSearchExactKeys() {
+        var trie = Trie<Int>()
+        trie.insert("hello", value: 42)
+        XCTAssertEqual(trie.search("hello"), 42)
+        XCTAssertNil(trie.search("hell"))    // prefix, not a key
+        XCTAssertNil(trie.search("hellos"))  // extends past a key
+        XCTAssertTrue(trie.containsKey("hello"))
+        XCTAssertFalse(trie.containsKey("hell"))
+        XCTAssertTrue(trie.startsWith("hell"))
+    }
+
+    func testInsertUpdatesExistingKeyWithoutGrowingSize() {
+        var trie = Trie<Int>()
+        trie.insert("hello", value: 1)
+        trie.insert("hello", value: 99)
+        XCTAssertEqual(trie.search("hello"), 99)
+        XCTAssertEqual(trie.count, 1)
+    }
+
+    func testWordsWithPrefixAreLexicographic() {
+        let trie = makeTrie(["app", "apple", "apply", "apt"])
+        XCTAssertEqual(trie.wordsWithPrefix("app").map { $0.0 }, ["app", "apple", "apply"])
+        XCTAssertEqual(trie.wordsWithPrefix("z").map { $0.0 }, [])
+    }
+
+    func testDeleteLeafAndSharedPrefixCases() {
+        var trie = makeTrie(["app", "apple"])
+        XCTAssertTrue(trie.delete("app"))
+        XCTAssertFalse(trie.containsKey("app"))
+        XCTAssertTrue(trie.containsKey("apple"))
+        XCTAssertEqual(trie.count, 1)
+
+        XCTAssertTrue(trie.delete("apple"))
+        XCTAssertEqual(trie.count, 0)
+        XCTAssertTrue(trie.isEmpty)
+        XCTAssertTrue(trie.isValid())
+    }
+
+    func testDeleteNonexistentKeyReturnsFalse() {
+        var trie = makeTrie(["apple"])
+        XCTAssertFalse(trie.delete("xyz"))
+        XCTAssertFalse(trie.delete("app")) // prefix, not a stored key
+        XCTAssertEqual(trie.count, 1)
+    }
+
+    func testLongestPrefixMatchTracksMostSpecificKey() {
+        var trie = Trie<Int>()
+        trie.insert("a", value: 1)
+        trie.insert("ab", value: 2)
+        trie.insert("abc", value: 3)
+        trie.insert("abcd", value: 4)
+        let m = trie.longestPrefixMatch("abcde")
+        XCTAssertEqual(m?.0, "abcd"); XCTAssertEqual(m?.1, 4)
+        XCTAssertNil(trie.longestPrefixMatch("xyz"))
+        let a = trie.longestPrefixMatch("a")
+        XCTAssertEqual(a?.0, "a"); XCTAssertEqual(a?.1, 1)
+    }
+
+    func testUnicodeScalarAndEmptyStringKeys() {
+        var trie = Trie<String>()
+        trie.insert("", value: "root")
+        trie.insert("cafe", value: "plain")
+        trie.insert("cafe\u{301}", value: "accent-combining") // e + combining accent
+        trie.insert("caf\u{e9}", value: "accent-single")       // precomposed é
+        XCTAssertEqual(trie.search(""), "root")
+        XCTAssertTrue(trie.startsWith("caf"))
+        XCTAssertEqual(trie.search("caf\u{e9}"), "accent-single")
+        // The combining form and the precomposed form are distinct scalar keys.
+        XCTAssertEqual(trie.search("cafe\u{301}"), "accent-combining")
+        XCTAssertEqual(trie.count, 4)
+    }
+
+    func testKeysAndAllWordsAreSorted() {
+        let trie = makeTrie(["banana", "app", "apple", "apt"])
+        XCTAssertEqual(trie.keys(), ["app", "apple", "apt", "banana"])
+        XCTAssertEqual(trie.allWords().count, 4)
+    }
+
+    func testDescriptionMentionsSize() {
+        let trie = makeTrie(["app", "apple"])
+        XCTAssertTrue(trie.description.contains("2 keys"))
+    }
+
+    func testValueSemanticsCopyOnAssign() {
+        var a = makeTrie(["x"])
+        var b = a
+        b.insert("y", value: true)
+        // Mutating the copy must not affect the original (value type).
+        XCTAssertEqual(a.count, 1)
+        XCTAssertEqual(b.count, 2)
+        a.delete("x")
+        XCTAssertEqual(a.count, 0)
+        XCTAssertEqual(b.count, 2)
+    }
+}

--- a/code/packages/swift/trie/required_capabilities.json
+++ b/code/packages/swift/trie/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/trie",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}


### PR DESCRIPTION
## What

Pure-Swift port of the `trie` package — a prefix tree for `String` keys. Second Swift pure port (after `fenwick-tree`), continuing the Swift front.

**Why:** `trie` is a canon package missing from Swift.

## API (`Trie<Value>`)

`insert` / `search` / `containsKey` / `delete` / `startsWith` / `wordsWithPrefix` / `allWords` / `keys` / `longestPrefixMatch`, plus `count` / `isEmpty` / `isValid()` / `description`.

## Implementation notes

- **Keys on `Unicode.Scalar`** (matching the Rust reference's `char`), so a combining sequence (`"e"` + U+0301) and the precomposed `"é"` (U+00E9) stay **distinct** keys — Swift's default `Character` (grapheme) would collide them. Children are visited in scalar order, so enumerations are lexicographically sorted.
- **Value-type semantics**: assigning a trie makes an independent copy. Rust's recursive insert/delete are adapted to `inout` struct-node mutation with write-back.

## Verification

- **11 XCTest cases** — exact search vs prefix, size-stable overwrite, lexicographic prefix enumeration, leaf/shared-prefix deletion (verifying shared paths survive), delete-nonexistent, longest-prefix-match, Unicode-scalar + empty-string keys, sorted enumeration, description, and a value-semantics copy check.
- `swift test` green (Swift 6.3).
- Security review passed: insert/delete write-back correctness, pruning of empty non-end nodes while preserving shared prefixes, `size`/`isValid` consistency, scalar-keying consistency across all ops, value semantics (no aliasing), and the single `!` proven safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)