### PR TITLE
feat(storage-sqlite): queryable sqlite_master / sqlite_schema catalog (Stream C)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.3 — Query `sqlite_master` over a real file
+
+Stream C / L4: the schema catalog `sqlite_master` (and its alias `sqlite_schema`)
+is now queryable over a real `.sqlite` file — `SELECT name FROM sqlite_master
+WHERE type = 'table'`, `SELECT COUNT(*) FROM sqlite_master`, the full
+five-column shape, and so on. Applications (Anki included) introspect the
+database this way. The `storage-sqlite` backend (0.2.0) exposes the catalog it
+already parses; no mini-sqlite `src/` change. New differential test
+`tests/file_backed.rs::sqlite_master_is_queryable_and_matches_real_sqlite` diffs
+the results against real bundled SQLite over the same file.
+
 ## 0.4.2 — FULL OUTER JOIN matches SQLite (ledger 6 → 5)
 
 Stream A / L2 of the full-SQLite-replacement roadmap: retire the differential

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/file_backed.rs
+++ b/code/packages/rust/mini-sqlite/tests/file_backed.rs
@@ -89,3 +89,81 @@ fn writes_to_a_file_backed_connection_are_rejected_for_now() {
 
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
+
+/// Normalize a mini-sqlite `SqlValue` to a comparable string so results from the
+/// two engines can be diffed regardless of representation nuance.
+fn norm_mini(v: &SqlValue) -> String {
+    match v {
+        SqlValue::Null => "NULL".to_string(),
+        SqlValue::Bool(b) => (*b as i64).to_string(),
+        SqlValue::Int(i) => i.to_string(),
+        SqlValue::Float(f) => format!("{f:?}"),
+        SqlValue::Text(s) => format!("T:{s}"),
+        SqlValue::Blob(b) => format!("B:{b:?}"),
+    }
+}
+
+/// The same normalization for a real-SQLite (`rusqlite`) value.
+fn norm_real(v: &rusqlite::types::Value) -> String {
+    use rusqlite::types::Value;
+    match v {
+        Value::Null => "NULL".to_string(),
+        Value::Integer(i) => i.to_string(),
+        Value::Real(f) => format!("{f:?}"),
+        Value::Text(s) => format!("T:{s}"),
+        Value::Blob(b) => format!("B:{b:?}"),
+    }
+}
+
+/// Run `query` through real SQLite over the same file and return normalized rows.
+fn real_rows(path: &std::path::Path, query: &str, ncols: usize) -> Vec<Vec<String>> {
+    let conn = rusqlite::Connection::open(path).expect("open real sqlite");
+    let mut stmt = conn.prepare(query).expect("prepare");
+    let rows = stmt
+        .query_map([], |row| {
+            let mut out = Vec::with_capacity(ncols);
+            for i in 0..ncols {
+                out.push(norm_real(&row.get::<_, rusqlite::types::Value>(i).unwrap()));
+            }
+            Ok(out)
+        })
+        .expect("query_map")
+        .map(|r| r.unwrap())
+        .collect();
+    rows
+}
+
+/// The schema catalog (`sqlite_master` / `sqlite_schema`) is queryable and its
+/// contents match real SQLite — applications introspect the database this way.
+#[test]
+fn sqlite_master_is_queryable_and_matches_real_sqlite() {
+    let path = build_sqlite_file(&[
+        "CREATE TABLE cards (id INTEGER PRIMARY KEY, due INTEGER, note TEXT)",
+        "CREATE TABLE notes (id INTEGER PRIMARY KEY, flds TEXT)",
+        "CREATE INDEX ix_due ON cards(due)",
+        "INSERT INTO cards VALUES (1, 100, 'a'), (2, 50, 'b')",
+    ]);
+    let conn = connect(path.to_str().unwrap()).expect("open file-backed connection");
+
+    // A representative spread: filtered projection, the `sqlite_schema` alias,
+    // an aggregate, and the full five-column row shape including `rootpage`/`sql`.
+    let checks: &[(&str, usize)] = &[
+        ("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name", 1),
+        ("SELECT name FROM sqlite_schema WHERE type = 'index' ORDER BY name", 1),
+        ("SELECT COUNT(*) FROM sqlite_master", 1),
+        ("SELECT type, name, tbl_name FROM sqlite_master ORDER BY name, type", 3),
+        ("SELECT type, name, tbl_name, rootpage, sql FROM sqlite_master ORDER BY name, type", 5),
+    ];
+    for (q, ncols) in checks {
+        let mut cur = conn.execute(q, &[]).unwrap_or_else(|e| panic!("mini failed on {q}: {e:?}"));
+        let mine: Vec<Vec<String>> = cur
+            .fetchall()
+            .iter()
+            .map(|row| row.iter().map(norm_mini).collect())
+            .collect();
+        let theirs = real_rows(&path, q, *ncols);
+        assert_eq!(mine, theirs, "sqlite_master divergence on: {q}");
+    }
+
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}

--- a/code/packages/rust/storage-sqlite/CHANGELOG.md
+++ b/code/packages/rust/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog — storage-sqlite
 
+## 0.2.0 — Queryable `sqlite_master` / `sqlite_schema` catalog
+
+`SELECT … FROM sqlite_master` (and its modern alias `sqlite_schema`) now works
+over a real `.sqlite` file — applications introspect the database this way, so
+the file backend must expose the schema catalog it already parses internally.
+
+- `columns("sqlite_master")` returns the fixed five-column shape SQLite uses:
+  `type text, name text, tbl_name text, rootpage integer, sql text`.
+- `scan("sqlite_master")` yields one row per catalog object (tables, indexes,
+  views, triggers) in on-disk (rowid) order — the same order SQLite returns.
+  `rootpage` is `0` for objects with no b-tree (views/triggers), and `sql` is
+  `NULL` only where SQLite stored none (e.g. auto-created indexes).
+- Both names are matched case-insensitively. The catalog is **not** listed by
+  `tables()` (nor by SQLite's `.tables`), but it is fully queryable — filters,
+  projections, aggregates, and `ORDER BY` all run through the normal pipeline.
+- Verified by a new differential test (`mini-sqlite/tests/file_backed.rs`,
+  `sqlite_master_is_queryable_and_matches_real_sqlite`) that diffs mini-sqlite's
+  answers against real bundled SQLite (`rusqlite`, dev-dep) over the same file,
+  plus unit tests for the name matching and column shape.
+
 ## 0.1.0 — SqliteFileBackend (read-only)
 
 First increment of Stream C / L4 in the mini-sqlite → full-SQLite-replacement

--- a/code/packages/rust/storage-sqlite/Cargo.toml
+++ b/code/packages/rust/storage-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-storage-sqlite"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A file-backed storage engine for the mini-sqlite pipeline: exposes a real .sqlite database as a sql-backend Backend, so the SQL engine can query it unmodified. The Rust sibling of python/storage-sqlite; read-only for now (built on the zero-dep sqlite-file reader)."
 license = "MIT"

--- a/code/packages/rust/storage-sqlite/src/lib.rs
+++ b/code/packages/rust/storage-sqlite/src/lib.rs
@@ -73,6 +73,54 @@ impl SqliteFileBackend {
             .iter()
             .find(|e| e.object_type == "table" && e.name.eq_ignore_ascii_case(table))
     }
+
+    /// Is `name` the schema catalog table? SQLite exposes the catalog under two
+    /// interchangeable names, `sqlite_master` (historical) and `sqlite_schema`
+    /// (modern), both case-insensitive. It is not returned by [`Backend::tables`]
+    /// (nor by SQLite's `.tables`), but `SELECT … FROM sqlite_master` must work —
+    /// applications, Anki included, introspect the database this way.
+    fn is_schema_table(name: &str) -> bool {
+        name.eq_ignore_ascii_case("sqlite_master") || name.eq_ignore_ascii_case("sqlite_schema")
+    }
+
+    /// The fixed five-column shape of `sqlite_master`, matching real SQLite:
+    /// `CREATE TABLE sqlite_master(type text, name text, tbl_name text, rootpage
+    /// integer, sql text)`.
+    fn schema_column_defs() -> Vec<ColumnDef> {
+        vec![
+            ColumnDef::new("type", "text"),
+            ColumnDef::new("name", "text"),
+            ColumnDef::new("tbl_name", "text"),
+            ColumnDef::new("rootpage", "integer"),
+            ColumnDef::new("sql", "text"),
+        ]
+    }
+
+    /// Project the parsed schema catalog into `sqlite_master` rows — one per
+    /// catalog object (tables, indexes, views, triggers), in the b-tree/rowid
+    /// order SQLite itself stores them. `rootpage` is `0` for objects with no
+    /// b-tree (views and triggers), exactly as SQLite reports it; `sql` is NULL
+    /// only when SQLite stored no text (e.g. auto-created indexes).
+    fn schema_rows(&self) -> Vec<Row> {
+        self.schema
+            .iter()
+            .map(|e| {
+                let mut row: Row = BTreeMap::new();
+                row.insert("type".to_string(), SqlValue::Text(e.object_type.clone()));
+                row.insert("name".to_string(), SqlValue::Text(e.name.clone()));
+                row.insert("tbl_name".to_string(), SqlValue::Text(e.table_name.clone()));
+                row.insert(
+                    "rootpage".to_string(),
+                    SqlValue::Int(e.root_page.unwrap_or(0) as i64),
+                );
+                row.insert(
+                    "sql".to_string(),
+                    e.sql.clone().map_or(SqlValue::Null, SqlValue::Text),
+                );
+                row
+            })
+            .collect()
+    }
 }
 
 /// Map a value decoded by the on-disk reader onto the query engine's value type.
@@ -328,6 +376,9 @@ impl Backend for SqliteFileBackend {
     }
 
     fn columns(&self, table: &str) -> Result<Vec<ColumnDef>, BackendError> {
+        if Self::is_schema_table(table) {
+            return Ok(Self::schema_column_defs());
+        }
         let entry = self
             .table_entry(table)
             .ok_or_else(|| BackendError::TableNotFound {
@@ -342,6 +393,9 @@ impl Backend for SqliteFileBackend {
     }
 
     fn scan(&self, table: &str) -> Result<Box<dyn RowIterator>, BackendError> {
+        if Self::is_schema_table(table) {
+            return Ok(Box::new(ListRowIterator::new(self.schema_rows())));
+        }
         let entry = self
             .table_entry(table)
             .ok_or_else(|| BackendError::TableNotFound {
@@ -537,5 +591,22 @@ mod tests {
             file_value_to_backend(FileValue::Blob(vec![1, 2])),
             SqlValue::Blob(vec![1, 2])
         );
+    }
+
+    #[test]
+    fn recognizes_both_schema_table_names_case_insensitively() {
+        assert!(SqliteFileBackend::is_schema_table("sqlite_master"));
+        assert!(SqliteFileBackend::is_schema_table("SQLite_Master"));
+        assert!(SqliteFileBackend::is_schema_table("sqlite_schema"));
+        assert!(SqliteFileBackend::is_schema_table("SQLITE_SCHEMA"));
+        assert!(!SqliteFileBackend::is_schema_table("cards"));
+        assert!(!SqliteFileBackend::is_schema_table("sqlite_sequence"));
+    }
+
+    #[test]
+    fn schema_catalog_has_the_five_sqlite_master_columns() {
+        let cols = SqliteFileBackend::schema_column_defs();
+        let names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["type", "name", "tbl_name", "rootpage", "sql"]);
     }
 }


### PR DESCRIPTION
## Stream C — the schema catalog is now queryable over a real file

Applications introspect a database by querying its schema catalog:

```sql
SELECT name FROM sqlite_master WHERE type = 'table';
SELECT COUNT(*) FROM sqlite_master;
```

Anki does exactly this. mini-sqlite's file backend already **parses** the catalog (`self.schema`) to resolve tables and columns — it just didn't expose it as a queryable table, so every `sqlite_master` query failed with `unknown table`. (Verified with a probe before the fix.)

### What changed (`storage-sqlite` 0.2.0)
- **`is_schema_table(name)`** — case-insensitive match on the two interchangeable catalog names: `sqlite_master` (historical) and `sqlite_schema` (modern).
- **`columns("sqlite_master")`** → SQLite's fixed five-column shape: `type text, name text, tbl_name text, rootpage integer, sql text`.
- **`scan("sqlite_master")`** → one row per already-parsed `SchemaEntry`, in on-disk (rowid) order — the order SQLite returns. `rootpage` is `0` for objects with no b-tree (views/triggers); `sql` is `NULL` only where SQLite stored none (auto-created indexes). **No new byte parsing, no new file I/O** — reads the in-memory catalog.
- Intercepted in `columns()`/`scan()` but deliberately **not** listed by `tables()` — matching SQLite, where `sqlite_master` is queryable yet absent from `.tables`. The planner resolves via `columns()` and the VM scans via `scan()`, so a full `SELECT` (filter / projection / aggregate / `ORDER BY`) resolves.

### Verification
- New **differential** test `file_backed.rs::sqlite_master_is_queryable_and_matches_real_sqlite` diffs mini-sqlite's answers against real bundled SQLite (`rusqlite`, **dev-dep**) over the *same file* for five representative queries — filtered projection, the `sqlite_schema` alias, `COUNT(*)`, and the full five-column row shape including `rootpage`/`sql`.
- +2 `storage-sqlite` unit tests (name matching, column shape).
- Full **storage-sqlite** (8) + **mini-sqlite** (45 lib + oracle + 3 file-backed + 11 integration + doctest) suites green; fmt + clippy clean; only downstream consumer (mini-sqlite) tested.
- Security review **passed** (exposes only schema metadata from the caller's own file, identical to SQLite; no new parsing/I/O, no injection, `#![forbid(unsafe_code)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)