### PR TITLE
test(closure-emitter): CodePrinter class-field conformance port (CLOC12.175 PR3)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.39.1] - 2026-07-11
+
+### Added — CLOC12.175 PR3: CodePrinter class-field conformance port
+
+New `tests/upstream/code_printer_class_field_test.rs` (registered as the
+`upstream_code_printer_class_field` `[[test]]`), the third class port — mirroring
+upstream Closure `CodePrinterTest`'s class-**field** printing cases. 14 active
+`#[test]`s, 0 `#[ignore]`, driving `emit_class_field` + the shared
+`emit_class_tail` `Field` arm from HAND-BUILT AST (so it also covers computed /
+numeric / string keys and a sequence initializer the grammar/bridge cannot yet
+parse): initialized field (`x=1;`), bare field (`y;`, no stray `=`), `static`
+prefix (`static z=2;` / `static z;`), computed / literal keys (`[k]=v;` /
+`static [k]=v;` / `0=1;` / quoted `"a-b"=1;`), the `PREC_ASSIGNMENT` sequence wrap
+(`x=(a,b);`), and field/method interleave (`x=1;m(){}` / `m(){}x=1;` /
+`x=1;y;static z=2;`). PATCH — test-only, no emitter change.
+
 ## [0.39.0] - 2026-07-11
 
 ### Added — CLOC12.175 PR1: emit class fields

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.39.0"
+version = "0.39.1"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 
@@ -128,3 +128,7 @@ path = "tests/upstream/code_printer_class_test.rs"
 [[test]]
 name = "upstream_code_printer_class_declaration"
 path = "tests/upstream/code_printer_class_declaration_test.rs"
+
+[[test]]
+name = "upstream_code_printer_class_field"
+path = "tests/upstream/code_printer_class_field_test.rs"

--- a/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
+++ b/code/packages/rust/closure-emitter/tests/upstream/ATTRIBUTION.md
@@ -236,6 +236,27 @@ under the Apache License, Version 2.0:
       building the AST directly lets the port cover the generator / async /
       computed-key / multi-member shapes the grammar cannot yet parse.
 
+- `code_printer_class_field_test.rs`
+    - upstream: `test/com/google/javascript/jscomp/CodePrinterTest.java`
+      (the class-**field** `[static ]key[=value];` printing cases — a
+      `PropertyDefinition` member, the non-method class member)
+    - tracked commit: see `UPSTREAM_SHA`
+    - Companion to `code_printer_class_test.rs` /
+      `code_printer_class_declaration_test.rs`; isolates `emit_class_field` + the
+      shared `emit_class_tail` member loop's `Field` arm that landed with
+      `ClassMember::Field` (CLOC12.175 PR1). 14 active `#[test]`s and **0
+      `#[ignore]`** — the emitter conforms to every covered shape: an initialized
+      field (`x=1;`, `x=y;`); a **bare** field (`y;`, with no stray `=`); the
+      `static` prefix (`static z=2;`, `static z;`); computed / literal keys
+      (`[k]=v;`, `static [k]=v;`, `0=1;`, a non-identifier string key stays quoted
+      `"a-b"=1;`); the initializer emitted at `PREC_ASSIGNMENT` so a bare comma
+      *sequence* wraps (`x=(a,b);`); and fields interleaving with methods and each
+      other (`x=1;m(){}`, `m(){}x=1;`, `x=1;y;static z=2;`). Inputs are
+      hand-constructed AST; the bridge conversion of a field (CLOC12.175 PR2) is
+      exercised separately in `javascript-parser`, and building the AST directly
+      lets the port cover computed / numeric / string-key and sequence-initializer
+      shapes the grammar/bridge cannot yet parse.
+
 ## Translation notes
 
 Fourth port under CLOC12 (after `closure-pass-constant-fold` in

--- a/code/packages/rust/closure-emitter/tests/upstream/code_printer_class_field_test.rs
+++ b/code/packages/rust/closure-emitter/tests/upstream/code_printer_class_field_test.rs
@@ -1,0 +1,299 @@
+//! Ported from `CodePrinterTest.java` in `google/closure-compiler`,
+//! Apache-2.0. Upstream SHA: see `tests/upstream/UPSTREAM_SHA`.
+//!
+//! Translation policy: see
+//! `code/specs/CLOC12-upstream-test-suite-port.md`.
+//!
+//! # What this file covers
+//!
+//! Upstream `CodePrinterTest`'s **class-field** printing cases — a
+//! `PropertyDefinition` member (`ClassMember::Field`), the non-method class
+//! member. This is the twenty-second CodePrinter port into `closure-emitter`
+//! (companion to the class-*expression* port `code_printer_class_test.rs` and
+//! the class-*declaration* port `code_printer_class_declaration_test.rs`) and
+//! isolates `emit_class_field` + the shared `emit_class_tail` member loop that
+//! grew a `Field` arm with `ClassMember::Field` (CLOC12.175 PR1).
+//!
+//! # How the emitter prints a class field (recap)
+//!
+//! Inside a class body a field prints `[static ]key[=value];`:
+//!
+//! ```text
+//!   x = 1        → x=1;
+//!   y            → y;
+//!   static z = 2 → static z=2;
+//!   [k] = v      → [k]=v;
+//! ```
+//!
+//! Two differences from a *method* member: a field **ends with `;`** (a method's
+//! `}` is self-terminating; a field has no brace so the `;` separates it from the
+//! next member), and it has **no** parameter-list/body tail. The `static` prefix
+//! and computed-key bracketing reuse the same helpers as a method; the
+//! initializer, when present, is emitted at `PREC_ASSIGNMENT` (the RHS of `=`),
+//! so a looser bare `a,b` sequence wraps while an ordinary expression prints bare.
+//! A **bare** field (`y;`) has no initializer and emits just `key;`.
+//!
+//! # Note on hand-constructed inputs
+//!
+//! These assertions build typed-AST inputs directly (the emitter is the unit
+//! under test). The bridge conversion of a field lands in CLOC12.175 PR2 and is
+//! exercised separately in `javascript-parser`; here the emitter is driven from
+//! hand-constructed AST so this port does not depend on the bridge. Building the
+//! AST directly also lets the port exercise field shapes the grammar/bridge
+//! cannot yet parse (computed / numeric / string keys, a static computed key, a
+//! sequence initializer that must wrap — see `CLOC12-gaps.md`).
+
+use coding_adventures_closure_emitter::{emit, EmitOptions};
+use coding_adventures_correlation_vector::CVLog;
+use coding_adventures_javascript_ast::{
+    ClassDeclaration, ClassMember, Declaration, Expression, Identifier, MethodDefinition, MethodKind,
+    NumericLiteral, Program, ProgramItem, PropertyDefinition, PropertyKey, SequenceExpression,
+    SourceType, StringLiteral,
+};
+use coding_adventures_javascript_ast::{BlockStatement, FunctionExpression};
+use coding_adventures_javascript_tokens::EsVersion;
+use coding_adventures_type_sidecar::Sidecar;
+
+// =====================================================================
+// Test-support helpers
+// =====================================================================
+
+fn ident(name: &str) -> Expression {
+    Expression::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+fn num(value: f64, raw: &str) -> Expression {
+    Expression::NumericLiteral(NumericLiteral { cv: None, value, raw: raw.to_string() })
+}
+
+/// A `PropertyKey::Identifier` key.
+fn ident_key(name: &str) -> PropertyKey {
+    PropertyKey::Identifier(Identifier { cv: None, name: name.to_string() })
+}
+
+/// Build one class **field** member.
+fn field(key: PropertyKey, value: Option<Expression>, computed: bool, is_static: bool) -> ClassMember {
+    ClassMember::Field(PropertyDefinition { cv: None, key, value, computed, is_static })
+}
+
+/// A no-op method value `(){}` (no params, empty body).
+fn plain_method_value() -> FunctionExpression {
+    FunctionExpression {
+        cv: None,
+        id: None,
+        params: vec![],
+        body: BlockStatement { cv: None, body: vec![] },
+        generator: false,
+        is_async: false,
+    }
+}
+
+/// Build one plain method member (used only to prove field/method interleave).
+fn method(name: &str) -> ClassMember {
+    ClassMember::Method(MethodDefinition {
+        cv: None,
+        key: ident_key(name),
+        kind: MethodKind::Method,
+        value: plain_method_value(),
+        computed: false,
+        is_static: false,
+    })
+}
+
+/// Emit `class C{<members>}` as a top-level declaration, returning the code.
+fn emit_body(body: Vec<ClassMember>) -> String {
+    let decl = Declaration::ClassDeclaration(ClassDeclaration {
+        cv: None,
+        id: Identifier { cv: None, name: "C".to_string() },
+        super_class: None,
+        body,
+    });
+    let prog = Program::new_untraced(EsVersion::Es2025, SourceType::Module)
+        .with_body(vec![ProgramItem::Declaration(decl)]);
+    let sidecar = Sidecar::new();
+    let mut cv = CVLog::new(false);
+    emit(&prog, &sidecar, &mut cv, &EmitOptions::default())
+        .expect("emit failed")
+        .code
+}
+
+/// Upstream `assertPrint(input, expected)` reshaped: emit a single-field (or
+/// multi-member) class `C` and assert the emitted code equals `expected`.
+fn assert_emits(body: Vec<ClassMember>, expected: &str) {
+    let code = emit_body(body);
+    assert_eq!(
+        code, expected,
+        "class-field emit output did not match\n  actual:   {:?}\n  expected: {:?}",
+        code, expected
+    );
+}
+
+// =====================================================================
+// Active — an initialized field prints `key=value;`
+// =====================================================================
+
+/// `class C{x=1;}` — an identifier key with a numeric initializer. The `=` has
+/// no surrounding spaces and the member terminates with `;`.
+#[test]
+fn field_with_initializer() {
+    assert_emits(vec![field(ident_key("x"), Some(num(1.0, "1")), false, false)], "class C{x=1;}");
+}
+
+/// The initializer is an identifier reference — `class C{x=y;}`.
+#[test]
+fn field_with_identifier_initializer() {
+    assert_emits(vec![field(ident_key("x"), Some(ident("y")), false, false)], "class C{x=y;}");
+}
+
+// =====================================================================
+// Active — a bare field prints `key;` (no `=`, no value)
+// =====================================================================
+
+/// `class C{y;}` — a bare field (no initializer) prints just the key and the
+/// terminating `;`.
+#[test]
+fn bare_field_has_no_equals() {
+    assert_emits(vec![field(ident_key("y"), None, false, false)], "class C{y;}");
+}
+
+/// The bare shape is exactly the emitted string — a regression guard that a
+/// value-less field emits no stray `=`.
+#[test]
+fn bare_field_emits_no_equals_char() {
+    let code = emit_body(vec![field(ident_key("y"), None, false, false)]);
+    assert_eq!(code, "class C{y;}");
+    assert!(!code.contains('='), "a bare field must not emit `=`, got {code:?}");
+}
+
+// =====================================================================
+// Active — `static` prefix
+// =====================================================================
+
+/// `class C{static z=2;}` — a static field prints the `static` keyword (with a
+/// space) before the key.
+#[test]
+fn static_field() {
+    assert_emits(vec![field(ident_key("z"), Some(num(2.0, "2")), false, true)], "class C{static z=2;}");
+}
+
+/// `class C{static z;}` — a static *bare* field.
+#[test]
+fn static_bare_field() {
+    assert_emits(vec![field(ident_key("z"), None, false, true)], "class C{static z;}");
+}
+
+// =====================================================================
+// Active — computed / literal keys
+// =====================================================================
+
+/// `class C{[k]=v;}` — a computed key is bracketed.
+#[test]
+fn computed_key_field() {
+    assert_emits(
+        vec![field(PropertyKey::Expression(Box::new(ident("k"))), Some(ident("v")), true, false)],
+        "class C{[k]=v;}",
+    );
+}
+
+/// `class C{static [k]=v;}` — `static` stacks before a computed key.
+#[test]
+fn static_computed_key_field() {
+    assert_emits(
+        vec![field(PropertyKey::Expression(Box::new(ident("k"))), Some(ident("v")), true, true)],
+        "class C{static [k]=v;}",
+    );
+}
+
+/// `class C{0=1;}` — a numeric-literal key prints the number bare.
+#[test]
+fn numeric_key_field() {
+    assert_emits(
+        vec![field(
+            PropertyKey::NumericLiteral(NumericLiteral { cv: None, value: 0.0, raw: "0".to_string() }),
+            Some(num(1.0, "1")),
+            false,
+            false,
+        )],
+        "class C{0=1;}",
+    );
+}
+
+/// `class C{"a-b"=1;}` — a string key that is NOT a valid identifier stays
+/// quoted (the emitter's quote-vs-bare choice, shared with object keys).
+#[test]
+fn string_key_field_stays_quoted() {
+    assert_emits(
+        vec![field(
+            PropertyKey::StringLiteral(StringLiteral {
+                cv: None,
+                value: "a-b".to_string(),
+                raw: "\"a-b\"".to_string(),
+            }),
+            Some(num(1.0, "1")),
+            false,
+            false,
+        )],
+        "class C{\"a-b\"=1;}",
+    );
+}
+
+// =====================================================================
+// Active — the initializer is emitted at PREC_ASSIGNMENT
+// =====================================================================
+
+/// `class C{x=(a,b);}` — a bare comma *sequence* initializer binds looser than
+/// `PREC_ASSIGNMENT`, so it is wrapped to preserve the field-boundary (an
+/// unwrapped `x=a,b` would parse the `,b` as a second field / syntax error).
+#[test]
+fn sequence_initializer_is_wrapped() {
+    assert_emits(
+        vec![field(
+            ident_key("x"),
+            Some(Expression::SequenceExpression(SequenceExpression {
+                cv: None,
+                expressions: vec![ident("a"), ident("b")],
+            })),
+            false,
+            false,
+        )],
+        "class C{x=(a,b);}",
+    );
+}
+
+// =====================================================================
+// Active — fields interleave with methods and each other
+// =====================================================================
+
+/// `class C{x=1;m(){}}` — a field then a method, in source order, each printing
+/// its own terminator (the field's `;`, the method's `}`).
+#[test]
+fn field_then_method() {
+    assert_emits(
+        vec![field(ident_key("x"), Some(num(1.0, "1")), false, false), method("m")],
+        "class C{x=1;m(){}}",
+    );
+}
+
+/// `class C{m(){}x=1;}` — a method then a field: the method's `}` abuts the
+/// field key with no separator.
+#[test]
+fn method_then_field() {
+    assert_emits(
+        vec![method("m"), field(ident_key("x"), Some(num(1.0, "1")), false, false)],
+        "class C{m(){}x=1;}",
+    );
+}
+
+/// `class C{x=1;y;static z=2;}` — three fields back-to-back, each terminated by
+/// its own `;`; the `static` prefix survives on the third.
+#[test]
+fn three_fields_back_to_back() {
+    assert_emits(
+        vec![
+            field(ident_key("x"), Some(num(1.0, "1")), false, false),
+            field(ident_key("y"), None, false, false),
+            field(ident_key("z"), Some(num(2.0, "2")), false, true),
+        ],
+        "class C{x=1;y;static z=2;}",
+    );
+}

--- a/code/specs/CLOC12-gaps.md
+++ b/code/specs/CLOC12-gaps.md
@@ -2306,6 +2306,25 @@ class-declaration bodies (shared body conversion).
 
 Emit conformance port (PR3) remains.
 
+### PR3 (DONE)
+
+CodePrinter conformance port. New
+`tests/upstream/code_printer_class_field_test.rs` (registered as the
+`upstream_code_printer_class_field` `[[test]]`), the third class port, mirroring
+upstream Closure `CodePrinterTest`'s class-field printing cases. 14 active
+`#[test]`s, 0 `#[ignore]`, driving `emit_class_field` + the shared
+`emit_class_tail` `Field` arm from **hand-built AST** — so it covers shapes the
+grammar/bridge cannot yet parse (computed / numeric / string keys, a
+sequence initializer): `x=1;` / `y;` (bare) / `static z=2;` / `[k]=v;` /
+`static [k]=v;` / `0=1;` / quoted `"a-b"=1;` / the `PREC_ASSIGNMENT` wrap
+`x=(a,b);` / interleave `x=1;m(){}`, `m(){}x=1;`, `x=1;y;static z=2;`.
+`closure-emitter` 0.39.1 (PATCH — test-only, no emitter change).
+
+**CLOC12.175 arc COMPLETE** — the class-field surface is node (PR1) + bridge
+(PR2) + conformance (PR3) end-to-end. Remaining class members (private `#x`,
+`static { … }` static-init blocks, decorators) stay deferred to their own
+additive slices.
+
 ## CLOC12.174 — `ClassDeclaration` (`class C [extends S] { … }`): the class *statement* arc (design)
 
 CLOC12.173 shipped the class **expression** (a value: `x = class {}`, `f(class C {})`).


### PR DESCRIPTION
## CLOC12.175 PR3 — CodePrinter class-field conformance port

The **third and final** PR of the class-fields arc. PR1 (#7933) shipped the node + emit + pass arms; PR2 (#7949) bridged the grammar. This PR is the upstream-conformance port that pins the emitter's class-field printing against Closure's `CodePrinterTest`.

### What's in it
New `tests/upstream/code_printer_class_field_test.rs` (registered as the `upstream_code_printer_class_field` `[[test]]`) — the companion to the class expression / declaration ports. **14 active `#[test]`s, 0 `#[ignore]`**, driving `emit_class_field` + the shared `emit_class_tail` `Field` arm from **hand-built AST** (so the port also covers shapes the grammar/bridge cannot yet parse):

| shape | emits |
|---|---|
| initialized field | `x=1;`, `x=y;` |
| bare field (asserts no stray `=`) | `y;` |
| `static` prefix | `static z=2;`, `static z;` |
| computed / literal keys | `[k]=v;`, `static [k]=v;`, `0=1;`, quoted `"a-b"=1;` |
| initializer at `PREC_ASSIGNMENT` (sequence wraps) | `x=(a,b);` |
| field/method interleave | `x=1;m(){}`, `m(){}x=1;`, `x=1;y;static z=2;` |

### Notes
- **Test-only** — no emitter change (the emitter code shipped in PR1). `closure-emitter` 0.39.1 (PATCH). The earlier PR1/PR2 security reviews cover the emitter/bridge production code; this PR adds zero production surface.
- Full `closure-emitter` suite green (30 test binaries).
- ATTRIBUTION.md + spec `CLOC12.175` PR3-DONE note updated.

**CLOC12.175 arc COMPLETE** — class fields are node (PR1) + bridge (PR2) + conformance (PR3) end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)