### PR TITLE
feat(sir-oop-py): Hash Enumerable aggregates (find/detect/any?/all?/none?/count/sort_by/min_by/max_by)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.19] - 2026-07-11
+
+### Added
+
+- **`Hash` Enumerable aggregates** (`_hash_block_method` + `_HASH_BLOCK_METHODS`):
+  `find`/`detect`, `any?`, `all?`, `none?`, `count` (block form), `sort_by`,
+  `min_by`, `max_by`.  Ruby's `Hash` mixes in `Enumerable`, so these iterate the
+  hash as a sequence of `[key, value]` pairs — the block is yielded
+  `[key, value]` (two arguments, matching `each`), and the "element" an
+  aggregate returns is the two-element `[key, value]` list.  For example
+  `{a: 1, b: 2}.min_by { |k, v| v }` is `[:a, 1]`, and
+  `{a: 1, b: 2, c: 3}.sort_by { |k, v| -v }` is `[[:c, 3], [:b, 2], [:a, 1]]`.
+  `min_by`/`max_by` on an empty hash return `nil`.  This is the reference
+  implementation for a cross-backend cascade (Go/Rust/JS/TS mirrors follow).
+
 ## [0.1.18] - 2026-07-11
 
 ### Added — Hash block methods: `transform_values` / `transform_keys`

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -75,7 +75,7 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 `flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
-(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/…);
+(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/…);
 and (item
 **M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
 `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.18"
+version = "0.1.19"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -651,6 +651,15 @@ _HASH_BLOCK_METHODS = frozenset(
         "each_value",
         "transform_values",
         "transform_keys",
+        "find",
+        "detect",
+        "any?",
+        "all?",
+        "none?",
+        "count",
+        "sort_by",
+        "min_by",
+        "max_by",
     }
 )
 
@@ -1213,6 +1222,45 @@ def _hash_block_method(recv: dict[Val, Val], name: str, block: Closure) -> Val:
         # block's result; values are untouched.  On a collision the LAST pair
         # wins (Ruby's rule, matching dict-comprehension insertion order).
         return {apply(block, [key]): value for key, value in recv.items()}
+    # ── Enumerable aggregates (Hash includes Enumerable) ───────────────────
+    #
+    # Ruby's ``Hash`` mixes in ``Enumerable``, so these iterate the hash as a
+    # sequence of ``[key, value]`` pairs: the block is yielded ``[key, value]``
+    # (two arguments, matching ``each``), and the "element" an aggregate returns
+    # is the two-element ``[key, value]`` list — e.g.
+    # ``{a: 1, b: 2}.min_by { |k, v| v }`` is ``[:a, 1]``.
+    if name in ("find", "detect"):
+        # First ``[k, v]`` pair whose block result is truthy; ``nil`` if none.
+        for key, value in recv.items():
+            if truthy(apply(block, [key, value])):
+                return [key, value]
+        return None
+    if name == "any?":
+        return any(truthy(apply(block, [k, v])) for k, v in recv.items())
+    if name == "all?":
+        return all(truthy(apply(block, [k, v])) for k, v in recv.items())
+    if name == "none?":
+        return not any(truthy(apply(block, [k, v])) for k, v in recv.items())
+    if name == "count":
+        # ``count { |k, v| pred }`` — number of pairs with a truthy block result.
+        return sum(1 for k, v in recv.items() if truthy(apply(block, [k, v])))
+    if name == "sort_by":
+        # A NEW Array of ``[k, v]`` pairs sorted by the block key.  Python's sort
+        # is stable, matching Ruby; a non-comparable key raises ``TypeError``.
+        return sorted(
+            ([k, v] for k, v in recv.items()),
+            key=lambda pair: apply(block, [pair[0], pair[1]]),
+        )
+    if name in ("min_by", "max_by"):
+        # The ``[k, v]`` pair minimising / maximising the block key; ``nil`` on an
+        # empty hash.
+        if not recv:
+            return None
+        chooser = min if name == "min_by" else max
+        return chooser(
+            ([k, v] for k, v in recv.items()),
+            key=lambda pair: apply(block, [pair[0], pair[1]]),
+        )
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -516,6 +516,35 @@ def test_hash_transform_values_and_keys() -> None:
     assert oop.call_method({"a": 1, "b": 2}, "transform_keys", Closure(lambda _k: "x")) == {"x": 2}
 
 
+def test_hash_enumerable_aggregates() -> None:
+    # Hash mixes in Enumerable: the block is yielded [key, value] and the
+    # "element" an aggregate returns is the two-element [key, value] pair.
+    h = {"a": 1, "b": 2, "c": 3}
+    # find/detect → first matching [k, v] pair (or nil).
+    assert oop.call_method(h, "find", Closure(lambda k, v: v > 1)) == ["b", 2]
+    assert oop.call_method(h, "detect", Closure(lambda k, v: v > 9)) is None
+    # any?/all?/none? over block([k, v]).
+    assert oop.call_method(h, "any?", Closure(lambda k, v: v == 2)) is True
+    assert oop.call_method(h, "all?", Closure(lambda k, v: v > 0)) is True
+    assert oop.call_method(h, "none?", Closure(lambda k, v: v > 9)) is True
+    # count { |k, v| pred } → number of truthy pairs.
+    assert oop.call_method(h, "count", Closure(lambda k, v: v % 2 == 1)) == 2
+    # sort_by → NEW array of [k, v] pairs ordered by the block key.
+    assert oop.call_method(h, "sort_by", Closure(lambda k, v: -v)) == [
+        ["c", 3],
+        ["b", 2],
+        ["a", 1],
+    ]
+    # min_by / max_by → the extremal [k, v] pair.
+    assert oop.call_method(h, "min_by", Closure(lambda k, v: v)) == ["a", 1]
+    assert oop.call_method(h, "max_by", Closure(lambda k, v: v)) == ["c", 3]
+    # min_by / max_by on an empty hash → nil.
+    assert oop.call_method({}, "min_by", Closure(lambda k, v: v)) is None
+    # respond_to? advertises the new aggregates.
+    assert oop.call_method(h, "respond_to?", "min_by") is True
+    assert oop.call_method(h, "respond_to?", "sort_by") is True
+
+
 def test_hash_respond_to_and_no_method_error_floor() -> None:
     assert oop.call_method({"a": 1}, "respond_to?", "keys") is True
     assert oop.call_method({"a": 1}, "respond_to?", "each") is True


### PR DESCRIPTION
## Summary

**Reference PR** kicking off a cross-backend cascade. Ruby's `Hash` mixes in `Enumerable`, so it iterates as a sequence of `[key, value]` pairs. This adds the core Enumerable aggregates to the Python `sir-runtime-oop` reference (`_hash_block_method` + `_HASH_BLOCK_METHODS`) — they were present for `Array` but missing for `Hash` in every backend.

The block is yielded `[key, value]` (two args, matching `each`), and the "element" an aggregate returns is the two-element `[key, value]` list:

| method | result |
|---|---|
| `find`/`detect` | first matching `[k, v]` pair, else `nil` |
| `any?`/`all?`/`none?` | boolean over `block([k, v])` |
| `count { \|k, v\| pred }` | number of truthy pairs |
| `sort_by` | new Array of `[k, v]` pairs ordered by the block key (stable) |
| `min_by`/`max_by` | the extremal `[k, v]` pair (`nil` on empty) |

Examples: `{a:1,b:2}.min_by { |k,v| v }` → `[:a, 1]`; `{a:1,b:2,c:3}.sort_by { |k,v| -v }` → `[[:c,3],[:b,2],[:a,1]]`.

## Tests
`test_hash_enumerable_aggregates` covers all arms incl. the empty-hash `min_by` → nil and `respond_to?`. **pytest 125 passing, 97% coverage; ruff clean.**

## Checklist
- [x] CHANGELOG.md (0.1.18 → **0.1.19**), README Hash catalog updated
- [x] pytest green (97% cov), ruff clean
- [x] Security review passed (explicit-switch dispatch, read-only dict iteration, no injection surface)

Follows the reference-first delivery model: Go/Rust/JS/TS mirrors land one-per-PR after this. Same pattern as the just-completed `transform_values`/`transform_keys` cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)