### PR TITLE
feat(sql-codegen): SQLite-style aggregate column names — differential ledger → 0 (Stream B)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.0 — Differential conformance ledger driven to ZERO
+
+Stream B / L3: aggregate output columns are now named the SQLite way —
+`SELECT COUNT(*)` returns a column named `COUNT(*)` (likewise `SUM(n)`,
+`MIN(n)`, `MAX(n)`, `AVG(n)`), not the engine-internal `agg_N`. The fix is in
+`sql-codegen` (0.6.0); no mini-sqlite `src/` change.
+
+This retires the **last five** entries of the differential-conformance
+`LEDGER` in `tests/differential_oracle.rs` (`count_star`, `sum_min_max`, `avg`,
+`group_by`, `having`) — **the ledger is now empty**. Every one of the harness's
+seed cases now matches real bundled SQLite exactly: `INNER`/`LEFT`/`RIGHT`/`FULL`
+joins, scalar functions and their result columns, and aggregate naming. The
+oracle opened at ten reproduced gaps and has been closed out one PR at a time;
+it now enforces full agreement on the seed corpus and stands ready to catch the
+next divergence a new case surfaces.
+
 ## 0.4.3 — Query `sqlite_master` over a real file
 
 Stream C / L4: the schema catalog `sqlite_master` (and its alias `sqlite_schema`)

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -34,15 +34,16 @@
 //! quietly leave stale ledger entries behind.
 //!
 //! On introduction this harness measured 12 of 22 seed cases already matching
-//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). Five have
-//! since been retired: `INNER JOIN` qualified-column resolution; correct
-//! `LEFT`/`RIGHT OUTER JOIN` (NULL-padded via a per-outer-row match flag);
-//! `FULL OUTER JOIN` (a LEFT pass unioned with a RIGHT anti-join pass); and
+//! real SQLite, and reproduced ten genuine gaps (see [`LEDGER`]). **All ten have
+//! since been retired** — the ledger is now empty and every seed case matches
+//! real SQLite. The gaps closed, in order: `INNER JOIN` qualified-column
+//! resolution; `LEFT`/`RIGHT OUTER JOIN` NULL-padding (a per-outer-row match
+//! flag); `FULL OUTER JOIN` (a LEFT pass unioned with a RIGHT anti-join pass);
 //! scalar functions (`UPPER()` returned the right value once same-named output
-//! columns stopped colliding, and columns got SQLite-style names). The
-//! remaining ledger entries are all *aggregate computed-column naming*
-//! divergences (`agg_N` vs `COUNT(*)`/`SUM(n)`); the rows already match. The
-//! harness is what makes fixing each one verifiable.
+//! columns stopped colliding, and columns got SQLite-style names); and finally
+//! aggregate computed-column names (`agg_N` → `COUNT(*)`/`SUM(n)`/`AVG(n)`). The
+//! harness is what made fixing each one verifiable — and what will catch the
+//! next divergence a new case surfaces.
 
 use coding_adventures_mini_sqlite::{connect, SqlValue};
 
@@ -402,50 +403,34 @@ const CASES: &[Case] = &[
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but
 /// exempt from the equality gate. **Shrinking this list is the conformance
-/// metric.** This is the honest baseline the harness measured on introduction —
-/// every entry is a real, reproduced gap between mini-sqlite and SQLite, each
-/// slated for a later increment.
+/// metric**, and it is now **empty** — every seed case matches real SQLite.
 ///
-/// Every remaining entry is now a **computed-column naming** divergence — the
-/// result *rows* already match SQLite. The join and scalar-function *result*
-/// gaps have all been retired: `inner_join` qualified-column resolution,
-/// `LEFT`/`RIGHT OUTER JOIN` NULL-padding, `FULL OUTER JOIN` (a LEFT pass unioned
-/// with a RIGHT anti-join pass), and `string_functions` (positional projection
-/// plus SQLite-style function column names).
+/// It opened at ten reproduced gaps and was driven to zero one oracle-gated
+/// increment at a time, in order:
 ///
-/// - **Computed-column naming** (`count_star`/`sum_min_max`/`avg`/`group_by`/
-///   `having`): the result *rows* match SQLite exactly, but mini-sqlite names an
-///   aggregate output column `agg_N` where SQLite uses the expression text
-///   (`SUM(n)`). A naming-only divergence.
+/// - **`inner_join`** — a qualified reference like `a.name` across a join
+///   resolved to `NULL` (cursor keyed under `None` while `LoadColumn` looked it
+///   up under `Some("a")`); fixed by keying cursors on the effective alias.
+/// - **`left_join`/`right_join`** — outer joins now NULL-pad the unmatched side
+///   via a per-outer-row match flag (`RIGHT a b` = `LEFT b a`).
+/// - **`full_join`** — a LEFT pass unioned with a RIGHT anti-join pass.
+/// - **`string_functions`** — `UPPER(name)` returned an integer because a
+///   positional→named→positional round-trip in `sql-vm`'s Phase-4 materialize
+///   collapsed same-named output columns through a `HashMap` (last value wins);
+///   fixed with positional projection, plus SQLite-style function column names.
+/// - **`count_star`/`sum_min_max`/`avg`/`group_by`/`having`** — the aggregate
+///   *rows* always matched; the output columns are now named the SQLite way
+///   (`COUNT(*)`, `SUM(n)`, `AVG(n)`) instead of the engine-internal `agg_N`.
 ///
-/// Scalar functions (`string_functions`) used to be ledgered here: `UPPER(name)`
-/// came back as an integer and the columns were unnamed (`?`). Both are now
-/// fixed and the case matches SQLite — see the commit that retired it. The root
-/// cause was a positional→named→positional round-trip in `sql-vm`'s Phase-4
-/// materialize that collapsed same-named output columns through a `HashMap`
-/// (dropping every value but the last), plus `sql-codegen` labelling function
-/// columns `?` instead of the SQLite-style expression text.
+/// A newly discovered divergence is added back here with a reason rather than
+/// silently skipped, so the list stays an honest measure.
 const LEDGER: &[(&str, &str)] = &[
-    (
-        "count_star",
-        "rows match; computed-column naming differs — mini names it agg_0, SQLite names it COUNT(*).",
-    ),
-    (
-        "sum_min_max",
-        "rows match; computed-column naming differs — agg_N vs SUM(n)/MIN(n)/MAX(n).",
-    ),
-    (
-        "avg",
-        "rows match; computed-column naming differs — agg_0 vs AVG(n).",
-    ),
-    (
-        "group_by",
-        "rows match; computed-column naming differs — agg_0 vs SUM(amt).",
-    ),
-    (
-        "having",
-        "rows match; computed-column naming differs — agg_0 vs SUM(amt).",
-    ),
+    // Empty — every seed case now matches real SQLite. The ledger opened at ten
+    // reproduced gaps and has been driven to zero, one oracle-gated increment at
+    // a time: INNER/LEFT/RIGHT/FULL JOIN semantics, scalar-function results and
+    // names, and finally aggregate computed-column names (`agg_N` → `COUNT(*)`/
+    // `SUM(n)`). New divergences, when found, are added back here with a reason
+    // rather than silently skipped — shrinking this list remains the metric.
 ];
 
 #[test]

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.6.0] - Unreleased
+
+### Added
+
+- **SQLite-style names for un-aliased aggregate output columns.** A bare
+  `SELECT COUNT(*)` now returns a column literally named `COUNT(*)` (and
+  `SUM(n)`, `MIN(n)`, `MAX(n)`, `AVG(n)`, `COUNT(DISTINCT x)`) instead of the
+  engine-internal `agg_0`/`agg_N`, matching what real SQLite reports. A new
+  `aggregate_column_name(&AggregateItem)` helper builds the call text from the
+  aggregate's function, argument (rendered via `render_expr_label`, `*` for
+  `COUNT(*)`, `DISTINCT`-prefixed when distinct), and honours an explicit `AS`
+  alias first. Applied at all three emit sites (plain aggregate, and both the
+  predicate-finalize and row-emit paths of `HAVING`); the now-redundant
+  `agg_aliases` bindings were removed. This retires the last five entries of the
+  mini-sqlite differential-conformance ledger (`count_star`, `sum_min_max`,
+  `avg`, `group_by`, `having`) — driving it to **zero**.
+
 ## [0.5.0] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -1240,8 +1240,6 @@ impl Compiler {
             .collect();
         let agg_args: Vec<Option<SqlExpr>> =
             aggregates.iter().map(|a| a.arg.clone()).collect();
-        let agg_aliases: Vec<Option<String>> =
-            aggregates.iter().map(|a| a.alias.clone()).collect();
 
         // Phase 1: scan loop body — save group key + update each aggregate.
         let loop_lbl = self.fresh_label("agg_loop");
@@ -1326,11 +1324,11 @@ impl Compiler {
             };
             self.emit(Instruction::EmitColumn(name));
         }
-        // Emit finalized aggregate values.
-        for (i, (fn_tag, alias)) in agg_fns.iter().zip(agg_aliases.iter()).enumerate() {
+        // Emit finalized aggregate values, each named the SQLite way
+        // (`SUM(n)`, `COUNT(*)`, …) unless an explicit alias overrides it.
+        for (i, (fn_tag, item)) in agg_fns.iter().zip(aggregates.iter()).enumerate() {
             self.emit(Instruction::FinalizeAgg(i, fn_tag.clone()));
-            let col_name = alias.clone().unwrap_or_else(|| format!("agg_{}", i));
-            self.emit(Instruction::EmitColumn(col_name));
+            self.emit(Instruction::EmitColumn(aggregate_column_name(item)));
         }
         self.emit(Instruction::EmitRow);
     }
@@ -1370,8 +1368,6 @@ impl Compiler {
                     .collect();
                 let agg_args: Vec<Option<SqlExpr>> =
                     aggregates.iter().map(|a| a.arg.clone()).collect();
-                let agg_aliases: Vec<Option<String>> =
-                    aggregates.iter().map(|a| a.alias.clone()).collect();
 
                 let loop_lbl = self.fresh_label("having_loop");
                 let end_lbl = self.fresh_label("having_end");
@@ -1423,10 +1419,7 @@ impl Compiler {
                 // then check predicate, then emit row.
                 for (i, fn_tag) in agg_fns.iter().enumerate() {
                     self.emit(Instruction::FinalizeAgg(i, fn_tag.clone()));
-                    let col_name = agg_aliases[i]
-                        .clone()
-                        .unwrap_or_else(|| format!("agg_{}", i));
-                    self.emit(Instruction::EmitColumn(col_name));
+                    self.emit(Instruction::EmitColumn(aggregate_column_name(&aggregates[i])));
                 }
 
                 // HAVING predicate check — skip the row if false.
@@ -1453,10 +1446,9 @@ impl Compiler {
                     };
                     self.emit(Instruction::EmitColumn(name));
                 }
-                for (i, (fn_tag, alias)) in agg_fns.iter().zip(agg_aliases.iter()).enumerate() {
+                for (i, (fn_tag, item)) in agg_fns.iter().zip(aggregates.iter()).enumerate() {
                     self.emit(Instruction::FinalizeAgg(i, fn_tag.clone()));
-                    let col_name = alias.clone().unwrap_or_else(|| format!("agg_{}", i));
-                    self.emit(Instruction::EmitColumn(col_name));
+                    self.emit(Instruction::EmitColumn(aggregate_column_name(item)));
                 }
                 self.emit(Instruction::EmitRow);
                 self.emit(Instruction::Label(skip_lbl));
@@ -2214,6 +2206,40 @@ fn render_expr_label(expr: &SqlExpr) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// SQLite-style implicit column name for an un-aliased aggregate: the function
+/// call text — `COUNT(*)`, `SUM(n)`, `MIN(x)`, `AVG(n)`, `COUNT(DISTINCT id)`.
+///
+/// An explicit `AS` alias always wins. Otherwise this mirrors SQLite, which
+/// names an un-aliased result column after the expression's source text — so a
+/// bare `SELECT COUNT(*)` returns a column literally named `COUNT(*)`, not the
+/// engine-internal `agg_0`. `COUNT(*)` alone has no argument (rendered `*`);
+/// every other aggregate renders its argument via [`render_expr_label`],
+/// prefixed with `DISTINCT ` when the aggregate is distinct.
+fn aggregate_column_name(item: &AggregateItem) -> String {
+    if let Some(alias) = &item.alias {
+        return alias.clone();
+    }
+    let func = match item.func {
+        AggFunc::Count => "COUNT",
+        AggFunc::Sum => "SUM",
+        AggFunc::Avg => "AVG",
+        AggFunc::Min => "MIN",
+        AggFunc::Max => "MAX",
+    };
+    let inner = match &item.arg {
+        None => "*".to_string(),
+        Some(expr) => {
+            let base = render_expr_label(expr).unwrap_or_else(|| "?".to_string());
+            if item.distinct {
+                format!("DISTINCT {base}")
+            } else {
+                base
+            }
+        }
+    };
+    format!("{func}({inner})")
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Stream B — the differential-conformance ledger reaches ZERO 🎯

An un-aliased aggregate output column was named `agg_0`/`agg_N`; real SQLite names it after the expression text. `SELECT COUNT(*)` now returns a column literally named `COUNT(*)` — likewise `SUM(n)`, `MIN(n)`, `MAX(n)`, `AVG(n)`, `COUNT(DISTINCT x)`. An explicit `AS` alias still wins.

### The fix
New `aggregate_column_name(&AggregateItem)` helper builds `FUNC(inner)` from the aggregate's function and argument — rendered via the existing `render_expr_label` helper (`*` for `COUNT(*)`, `DISTINCT`-prefixed when distinct). Applied at all three emit sites: the plain aggregate, and both the predicate-finalize and row-emit paths of `HAVING`. The now-redundant `agg_aliases` bindings are removed.

### Ledger → 0
This retires the **last five** entries of the differential-conformance `LEDGER` (`count_star`, `sum_min_max`, `avg`, `group_by`, `having`). **The ledger is now empty.**

The oracle opened at **ten** reproduced gaps and has been closed out one PR at a time this session — every one of its seed cases now matches real bundled SQLite exactly:

| retired | how |
|---|---|
| `inner_join` | cursor keyed on effective alias |
| `left_join` / `right_join` | per-outer-row match flag |
| `full_join` | LEFT pass ∪ RIGHT anti-join pass |
| `string_functions` | positional projection + SQLite fn column names |
| `count_star` / `sum_min_max` / `avg` / `group_by` / `having` | **this PR** — aggregate expression-text names |

### Verification
- Oracle passes with an **empty ledger** (every seed case gated for equality against real SQLite); full **mini-sqlite** (45 lib + oracle + 3 file-backed + 11 integration + doctest), **sql-vm** (81), **sql-codegen** (75) suites green.
- Bonus `COUNT(DISTINCT n)` and `AS`-alias-wins confirmed.
- My changed region is fmt + clippy clean (pre-existing file-wide warnings untouched — no scope creep).
- Security review **passed** (only changes an output column *label* — no injection, no format-string vuln, in-bounds indexing, no `unsafe`/I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)