### PR TITLE
feat(binary-search-tree): pure-Swift port (immutable BST with order statistics)

### DIFF
--- a/code/packages/swift/binary-search-tree/BUILD
+++ b/code/packages/swift/binary-search-tree/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test; else swift test; fi

--- a/code/packages/swift/binary-search-tree/BUILD_windows
+++ b/code/packages/swift/binary-search-tree/BUILD_windows
@@ -1,0 +1,1 @@
+where swift >/dev/null 2>/dev/null && swift test || echo Swift not available on this runner — skipping

--- a/code/packages/swift/binary-search-tree/CHANGELOG.md
+++ b/code/packages/swift/binary-search-tree/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — BinarySearchTree (Swift)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: pure-Swift port of the `binary-search-tree` reference package.
+- Immutable `BST<Element>` — `insert` / `delete` return a new tree; `search`,
+  `contains`, `minValue` / `maxValue`, `predecessor` / `successor`,
+  `kthSmallest`, `rank`, `toSortedArray`, `isValid`, `height`, `count`,
+  `isEmpty`, a `fromSorted` balanced builder, and a description.
+- Backed by an `indirect enum` (value type) with cached subtree sizes for O(h)
+  order-statistic queries; unchanged subtrees are shared structurally between
+  versions.
+- 11 XCTest cases: reference insert/search/delete/rank/kthSmallest example with
+  immutability check, balanced `fromSorted`, empty-tree behaviour, duplicate
+  no-op, in-order output, all delete node-shapes + absent-value no-op, repeated-
+  delete validity/sortedness, predecessor/successor (present/absent/edge),
+  full-range kthSmallest/rank, String elements, and description.

--- a/code/packages/swift/binary-search-tree/Package.swift
+++ b/code/packages/swift/binary-search-tree/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// ============================================================================
+// Package.swift — BinarySearchTree
+// ============================================================================
+//
+// Swift Package Manager manifest for the BinarySearchTree library: an immutable
+// binary search tree with order-statistic queries (kthSmallest, rank) backed by
+// cached subtree sizes. Part of the coding-adventures stack.
+// ============================================================================
+
+import PackageDescription
+
+let package = Package(
+    name: "BinarySearchTree",
+    products: [
+        .library(name: "BinarySearchTree", targets: ["BinarySearchTree"]),
+    ],
+    targets: [
+        .target(name: "BinarySearchTree"),
+        .testTarget(name: "BinarySearchTreeTests", dependencies: ["BinarySearchTree"]),
+    ]
+)

--- a/code/packages/swift/binary-search-tree/README.md
+++ b/code/packages/swift/binary-search-tree/README.md
@@ -1,0 +1,52 @@
+# BinarySearchTree (Swift)
+
+An **immutable** binary search tree of `Comparable` elements, in pure Swift.
+
+Swift port of the `binary-search-tree` package that already exists in Rust and
+other languages in the coding-adventures monorepo.
+
+## What it does
+
+Every node keeps left-subtree values smaller and right-subtree values larger, so
+search / insert / delete are O(h) and an in-order walk yields sorted output.
+Each node caches its subtree size, which powers the O(h) order-statistic
+queries.
+
+| Member | Purpose |
+|---|---|
+| `insert(_:)` / `delete(_:)` | return a **new** tree; the original is untouched |
+| `search(_:)` / `contains(_:)` | exact lookup |
+| `minValue()` / `maxValue()` | smallest / largest element |
+| `predecessor(_:)` / `successor(_:)` | nearest strictly-smaller / -larger element |
+| `kthSmallest(_:)` | the k-th smallest element (1-based) |
+| `rank(_:)` | number of elements strictly less than a value |
+| `toSortedArray()` | elements in ascending order |
+| `isValid()` / `height` / `count` / `isEmpty` | introspection |
+| `BST.fromSorted(_:)` | O(n) balanced build from a sorted array |
+
+## Immutability
+
+`insert` and `delete` return a new tree; the receiver is unchanged. Internally
+the tree is an `indirect enum` (a value type), so unchanged subtrees are shared
+structurally between versions — the same behaviour as the reference's
+clone-on-write, done cheaply.
+
+## Usage
+
+```swift
+import BinarySearchTree
+
+let tree = BST<Int>().insert(8).insert(3).insert(10).insert(1).insert(6)
+tree.contains(6)          // true
+tree.minValue()           // 1
+tree.kthSmallest(3)       // 6
+tree.rank(6)              // 2
+tree.toSortedArray()      // [1, 3, 6, 8, 10]
+let smaller = tree.delete(3)  // a new tree; `tree` still has 3
+```
+
+## Running the tests
+
+```
+swift test
+```

--- a/code/packages/swift/binary-search-tree/Sources/BinarySearchTree/BinarySearchTree.swift
+++ b/code/packages/swift/binary-search-tree/Sources/BinarySearchTree/BinarySearchTree.swift
@@ -1,0 +1,241 @@
+// ============================================================================
+// BinarySearchTree.swift — an immutable (persistent) binary search tree
+// ============================================================================
+//
+// A binary search tree keeps its elements ordered: every value in a node's left
+// subtree is smaller, every value on the right is larger. That invariant makes
+// search, insert, and delete O(h) — O(log n) when the tree is balanced — and
+// an in-order walk yields the elements sorted.
+//
+// This `BST` is **immutable**: `insert` and `delete` return a *new* tree and
+// leave the original untouched, matching the reference `binary-search-tree`
+// package. Under the hood the tree is an `indirect enum` (a value type), so
+// unchanged subtrees are shared structurally between old and new versions — the
+// same observable behaviour as the reference's clone-on-write, done cheaply.
+//
+// Each node caches its subtree `size`, which powers the order-statistic queries
+// `kthSmallest(_:)` and `rank(_:)` in O(h).
+
+/// An immutable binary search tree of `Comparable` elements.
+public struct BST<Element: Comparable> {
+
+    // A node is either empty or an interior node caching its subtree size.
+    private indirect enum Node {
+        case empty
+        case node(value: Element, left: Node, right: Node, size: Int)
+
+        var size: Int {
+            if case let .node(_, _, _, s) = self { return s }
+            return 0
+        }
+    }
+
+    private let root: Node
+
+    private init(_ root: Node) { self.root = root }
+
+    /// Create an empty tree.
+    public init() { self.root = .empty }
+
+    /// Build a balanced tree from an already-sorted array (the middle element
+    /// becomes each subtree's root).
+    public static func fromSorted(_ array: [Element]) -> BST {
+        BST(buildBalanced(ArraySlice(array)))
+    }
+
+    // ── Immutable mutation ───────────────────────────────────────────────────
+
+    /// Return a new tree with `value` inserted (a no-op if already present).
+    public func insert(_ value: Element) -> BST { BST(Self.insert(root, value)) }
+
+    /// Return a new tree with `value` removed (a no-op if absent).
+    public func delete(_ value: Element) -> BST { BST(Self.delete(root, value)) }
+
+    // ── Lookup ───────────────────────────────────────────────────────────────
+
+    /// The stored element equal to `value`, or `nil`.
+    public func search(_ value: Element) -> Element? {
+        var current = root
+        while case let .node(v, l, r, _) = current {
+            if value < v { current = l }
+            else if value > v { current = r }
+            else { return v }
+        }
+        return nil
+    }
+
+    /// Whether `value` is present.
+    public func contains(_ value: Element) -> Bool { search(value) != nil }
+
+    /// The smallest element, or `nil` when empty.
+    public func minValue() -> Element? {
+        var current = root
+        var result: Element?
+        while case let .node(v, l, _, _) = current {
+            result = v
+            current = l
+        }
+        return result
+    }
+
+    /// The largest element, or `nil` when empty.
+    public func maxValue() -> Element? {
+        var current = root
+        var result: Element?
+        while case let .node(v, _, r, _) = current {
+            result = v
+            current = r
+        }
+        return result
+    }
+
+    /// The largest stored element strictly less than `value`, or `nil`.
+    public func predecessor(_ value: Element) -> Element? {
+        var current = root
+        var best: Element?
+        while case let .node(v, l, r, _) = current {
+            if v < value {
+                best = v
+                current = r
+            } else {
+                current = l
+            }
+        }
+        return best
+    }
+
+    /// The smallest stored element strictly greater than `value`, or `nil`.
+    public func successor(_ value: Element) -> Element? {
+        var current = root
+        var best: Element?
+        while case let .node(v, l, r, _) = current {
+            if v > value {
+                best = v
+                current = l
+            } else {
+                current = r
+            }
+        }
+        return best
+    }
+
+    /// The `k`-th smallest element (1-based), or `nil` if out of range.
+    public func kthSmallest(_ k: Int) -> Element? {
+        guard k >= 1 else { return nil }
+        var current = root
+        var target = k
+        while case let .node(v, l, r, _) = current {
+            let leftSize = l.size
+            if target == leftSize + 1 { return v }
+            if target <= leftSize { current = l }
+            else { current = r; target -= leftSize + 1 }
+        }
+        return nil
+    }
+
+    /// The number of stored elements strictly less than `value`.
+    public func rank(_ value: Element) -> Int {
+        var current = root
+        var acc = 0
+        while case let .node(v, l, r, _) = current {
+            if value < v { current = l }
+            else if value > v { acc += l.size + 1; current = r }
+            else { return acc + l.size }
+        }
+        return acc
+    }
+
+    // ── Whole-tree views ─────────────────────────────────────────────────────
+
+    /// The elements in ascending order.
+    public func toSortedArray() -> [Element] {
+        var out: [Element] = []
+        Self.inorder(root, &out)
+        return out
+    }
+
+    /// Whether the tree satisfies the BST ordering invariant.
+    public func isValid() -> Bool { Self.validate(root, min: nil, max: nil) }
+
+    /// The height of the tree: `-1` for an empty tree, `0` for a single node.
+    public var height: Int { Self.height(root) }
+
+    /// The number of stored elements.
+    public var count: Int { root.size }
+
+    /// Whether the tree stores no elements.
+    public var isEmpty: Bool { count == 0 }
+
+    // ── Internal recursive machinery ─────────────────────────────────────────
+
+    private static func make(_ value: Element, _ left: Node, _ right: Node) -> Node {
+        .node(value: value, left: left, right: right, size: 1 + left.size + right.size)
+    }
+
+    private static func insert(_ node: Node, _ value: Element) -> Node {
+        switch node {
+        case .empty:
+            return .node(value: value, left: .empty, right: .empty, size: 1)
+        case let .node(v, l, r, _):
+            if value < v { return make(v, insert(l, value), r) }
+            if value > v { return make(v, l, insert(r, value)) }
+            return node // equal: unchanged
+        }
+    }
+
+    private static func delete(_ node: Node, _ value: Element) -> Node {
+        guard case let .node(v, l, r, _) = node else { return .empty }
+        if value < v { return make(v, delete(l, value), r) }
+        if value > v { return make(v, l, delete(r, value)) }
+        // Found `v`. Replace by successor (min of right subtree) when needed.
+        switch (l, r) {
+        case (.empty, .empty): return .empty
+        case (_, .empty): return l
+        case (.empty, _): return r
+        default:
+            let (newRight, successor) = extractMin(r)
+            return make(successor, l, newRight)
+        }
+    }
+
+    /// Remove and return the smallest value of a non-empty subtree.
+    private static func extractMin(_ node: Node) -> (Node, Element) {
+        guard case let .node(v, l, r, _) = node else {
+            preconditionFailure("extractMin on empty node")
+        }
+        if case .empty = l { return (r, v) }
+        let (newLeft, minValue) = extractMin(l)
+        return (make(v, newLeft, r), minValue)
+    }
+
+    private static func inorder(_ node: Node, _ out: inout [Element]) {
+        guard case let .node(v, l, r, _) = node else { return }
+        inorder(l, &out)
+        out.append(v)
+        inorder(r, &out)
+    }
+
+    private static func height(_ node: Node) -> Int {
+        guard case let .node(_, l, r, _) = node else { return -1 }
+        return 1 + Swift.max(height(l), height(r))
+    }
+
+    private static func validate(_ node: Node, min: Element?, max: Element?) -> Bool {
+        guard case let .node(v, l, r, _) = node else { return true }
+        if let lo = min, v <= lo { return false }
+        if let hi = max, v >= hi { return false }
+        return validate(l, min: min, max: v) && validate(r, min: v, max: max)
+    }
+
+    private static func buildBalanced(_ values: ArraySlice<Element>) -> Node {
+        guard !values.isEmpty else { return .empty }
+        let mid = values.startIndex + values.count / 2
+        let left = buildBalanced(values[values.startIndex..<mid])
+        let right = buildBalanced(values[(mid + 1)..<values.endIndex])
+        return make(values[mid], left, right)
+    }
+}
+
+extension BST: CustomStringConvertible {
+    public var description: String { "BST(count=\(count), sorted=\(toSortedArray()))" }
+}

--- a/code/packages/swift/binary-search-tree/Tests/BinarySearchTreeTests/BinarySearchTreeTests.swift
+++ b/code/packages/swift/binary-search-tree/Tests/BinarySearchTreeTests/BinarySearchTreeTests.swift
@@ -1,0 +1,141 @@
+// ============================================================================
+// BinarySearchTreeTests.swift — Unit tests for BST
+// ============================================================================
+
+import XCTest
+@testable import BinarySearchTree
+
+final class BinarySearchTreeTests: XCTestCase {
+
+    private func sample() -> BST<Int> {
+        // Mirrors the reference test tree.
+        BST<Int>()
+            .insert(8).insert(3).insert(10).insert(1)
+            .insert(6).insert(14).insert(4).insert(7)
+    }
+
+    func testInsertSearchAndDelete() {
+        let tree = sample()
+        XCTAssertTrue(tree.contains(4))
+        XCTAssertEqual(tree.search(4), 4)
+        XCTAssertNil(tree.search(99))
+        XCTAssertEqual(tree.minValue(), 1)
+        XCTAssertEqual(tree.maxValue(), 14)
+        XCTAssertEqual(tree.rank(6), 3)
+        XCTAssertEqual(tree.kthSmallest(4), 6)
+        XCTAssertEqual(tree.count, 8)
+
+        let deleted = tree.delete(3)
+        XCTAssertFalse(deleted.contains(3))
+        XCTAssertTrue(deleted.isValid())
+        XCTAssertEqual(deleted.count, 7)
+        // Original is untouched (immutability).
+        XCTAssertTrue(tree.contains(3))
+        XCTAssertEqual(tree.count, 8)
+    }
+
+    func testFromSortedBuildsBalancedTree() {
+        let tree = BST.fromSorted([1, 2, 3, 4, 5, 6, 7])
+        XCTAssertEqual(tree.toSortedArray(), [1, 2, 3, 4, 5, 6, 7])
+        XCTAssertLessThanOrEqual(tree.height, 2)
+        XCTAssertTrue(tree.isValid())
+    }
+
+    func testEmptyTree() {
+        let tree = BST<Int>()
+        XCTAssertTrue(tree.isEmpty)
+        XCTAssertEqual(tree.count, 0)
+        XCTAssertEqual(tree.height, -1)
+        XCTAssertNil(tree.minValue())
+        XCTAssertNil(tree.maxValue())
+        XCTAssertNil(tree.search(1))
+        XCTAssertNil(tree.kthSmallest(1))
+        XCTAssertEqual(tree.rank(5), 0)
+        XCTAssertTrue(tree.isValid())
+        XCTAssertEqual(tree.toSortedArray(), [])
+    }
+
+    func testInsertDuplicateIsNoOp() {
+        let tree = BST<Int>().insert(5).insert(5).insert(5)
+        XCTAssertEqual(tree.count, 1)
+        XCTAssertEqual(tree.toSortedArray(), [5])
+    }
+
+    func testToSortedArrayIsInOrder() {
+        let tree = BST<Int>().insert(5).insert(2).insert(8).insert(1).insert(9).insert(3)
+        XCTAssertEqual(tree.toSortedArray(), [1, 2, 3, 5, 8, 9])
+    }
+
+    func testDeleteAllNodeShapes() {
+        // Delete a leaf, a one-child node, and a two-child node.
+        var tree = BST.fromSorted([1, 2, 3, 4, 5, 6, 7])
+        tree = tree.delete(1)          // leaf
+        XCTAssertFalse(tree.contains(1))
+        tree = tree.delete(2)          // node with one child (after leaf removal)
+        XCTAssertFalse(tree.contains(2))
+        tree = tree.delete(4)          // (likely) two-child node
+        XCTAssertFalse(tree.contains(4))
+        XCTAssertTrue(tree.isValid())
+        XCTAssertEqual(tree.toSortedArray(), [3, 5, 6, 7])
+
+        // Deleting an absent value is a no-op.
+        let same = tree.delete(999)
+        XCTAssertEqual(same.toSortedArray(), tree.toSortedArray())
+    }
+
+    func testDeleteRepeatedlyStaysValidAndSorted() {
+        var tree = BST<Int>()
+        for v in [50, 30, 70, 20, 40, 60, 80, 10, 25, 35, 45] { tree = tree.insert(v) }
+        var expected = tree.toSortedArray()
+        while !tree.isEmpty {
+            // Repeatedly delete the median element — exercises many node shapes.
+            let mid = tree.toSortedArray()[tree.count / 2]
+            tree = tree.delete(mid)
+            expected.removeAll { $0 == mid }
+            XCTAssertTrue(tree.isValid())
+            XCTAssertEqual(tree.toSortedArray(), expected)
+        }
+        XCTAssertTrue(tree.isEmpty)
+    }
+
+    func testPredecessorAndSuccessor() {
+        let tree = BST<Int>().insert(20).insert(10).insert(30).insert(5).insert(15).insert(25).insert(35)
+        XCTAssertEqual(tree.predecessor(20), 15)
+        XCTAssertEqual(tree.successor(20), 25)
+        XCTAssertEqual(tree.predecessor(15), 10)   // present value → strictly less
+        XCTAssertEqual(tree.successor(15), 20)
+        XCTAssertNil(tree.predecessor(5))          // nothing smaller than the min
+        XCTAssertNil(tree.successor(35))           // nothing larger than the max
+        XCTAssertEqual(tree.predecessor(12), 10)   // absent value between elements
+        XCTAssertEqual(tree.successor(12), 15)
+    }
+
+    func testKthSmallestAndRankAcrossFullRange() {
+        let values = [15, 3, 27, 9, 21, 1, 33, 6, 12, 18, 24, 30]
+        var tree = BST<Int>()
+        for v in values { tree = tree.insert(v) }
+        let sorted = values.sorted()
+        for i in 1...values.count {
+            XCTAssertEqual(tree.kthSmallest(i), sorted[i - 1], "kthSmallest(\(i))")
+        }
+        XCTAssertNil(tree.kthSmallest(0))
+        XCTAssertNil(tree.kthSmallest(values.count + 1))
+        for v in sorted {
+            XCTAssertEqual(tree.rank(v), sorted.firstIndex(of: v)!, "rank(\(v))")
+        }
+        // rank of an absent value == count of elements strictly less than it.
+        XCTAssertEqual(tree.rank(10), sorted.filter { $0 < 10 }.count)
+    }
+
+    func testWorksWithStrings() {
+        let tree = BST<String>().insert("pear").insert("apple").insert("fig").insert("date")
+        XCTAssertEqual(tree.toSortedArray(), ["apple", "date", "fig", "pear"])
+        XCTAssertEqual(tree.minValue(), "apple")
+        XCTAssertEqual(tree.kthSmallest(2), "date")
+        XCTAssertTrue(tree.isValid())
+    }
+
+    func testDescriptionMentionsCount() {
+        XCTAssertTrue(sample().description.contains("count=8"))
+    }
+}

--- a/code/packages/swift/binary-search-tree/required_capabilities.json
+++ b/code/packages/swift/binary-search-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/binary-search-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}


### PR DESCRIPTION
## What

Pure-Swift port of the `binary-search-tree` package — an **immutable** BST of `Comparable` elements. Third Swift pure port, continuing the Swift front.

**Why:** `binary-search-tree` is a canon package missing from Swift.

## API (`BST<Element: Comparable>`)

- `insert(_:)` / `delete(_:)` — return a **new** tree; the receiver is untouched.
- `search` / `contains` / `minValue` / `maxValue`.
- `predecessor` / `successor` — nearest strictly-smaller / -larger.
- `kthSmallest` / `rank` — O(h) order statistics via cached subtree sizes.
- `toSortedArray` / `isValid` / `height` / `count` / `isEmpty`, and `BST.fromSorted` (O(n) balanced build).

## Implementation note

Modelled as an `indirect enum` (a value type) with a cached subtree size per node, so unchanged subtrees are shared structurally between versions — the same observable immutability as the reference's clone-on-write, done cheaply. `delete` uses successor (min-of-right) replacement for two-child nodes.

## Verification

- **11 XCTest cases** — reference insert/search/delete/rank/kthSmallest with an immutability check, balanced `fromSorted`, empty-tree behaviour, duplicate no-op, in-order output, all delete node-shapes + absent-value no-op, repeated-delete validity/sortedness, predecessor/successor (present/absent/edge), a **full-range kthSmallest/rank cross-check** against a linear scan, String elements, and description.
- `swift test` green (Swift 6.3).
- Security review passed: delete child-combination completeness, `size`-cache consistency across every rebuild (kthSmallest/rank/count depend on it), `extractMin` precondition unreachable on valid use, `buildBalanced` ArraySlice index arithmetic, value-semantics immutability, and no traps/force-unwraps in library code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)