### PR TITLE
feat(sir-go): Hash Enumerable aggregates (find/detect/any?/all?/none?/count/sort_by/min_by/max_by)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.27.0 — Hash Enumerable aggregates: `find` / `any?` / `all?` / `none?` / `count` / `sort_by` / `min_by` / `max_by`
+
+Mirrors the Python `sir-runtime-oop` v0.1.19 reference (PR #7957) into the Go
+backend's emitted runtime (`_sir_hash_block_method` + `_sir_hash_responds`).
+Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as a sequence of
+`[key, value]` pairs: the block is yielded `(key, value)` (two arguments,
+matching `each`), and the "element" an aggregate returns is the two-element
+`[key, value]` Array (`&Seq{key, value}`).
+
+- `find`/`detect` — first `[k, v]` pair with a truthy block result; `nil` if none.
+- `any?`/`all?`/`none?` — booleans over `block(k, v)`.
+- `count { |k, v| … }` — number of pairs with a truthy block result.
+- `sort_by` — a NEW Array of `[k, v]` pairs sorted by the block key (stable on
+  ties, Schwartzian; the never-panic `_sir_value_lt` comparator).
+- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty).
+
+`_sir_hash_responds` now advertises all of the above.
+
+Exec-proof: `tests/compile_and_run_hash_methods.rs` gains
+`hash_enumerable_aggregates_compile_and_run`, running `sort_by`/`min_by`/
+`max_by` (by value), `find`/`count`/`any?`/`all?`/`none?` (even-value
+predicate) under real `go run`, diffed against the Python reference semantics.
+
 ## 0.26.0 — Hash transforming block methods: `transform_values` / `transform_keys`
 
 Mirrors the Python `sir-runtime-oop` v0.1.18 reference into the Go backend's

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -185,7 +185,9 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`; **Hash** `keys`,
 `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `size`/
 `length`, `empty?`, `each`/`each_pair`, `each_key`, `each_value`, `map`,
-`select`/`filter`, `reject`, `transform_values`, `transform_keys`;
+`select`/`filter`, `reject`, `transform_values`, `transform_keys`, and the
+Enumerable aggregates `find`/`detect`, `any?`/`all?`/`none?`, `count`,
+`sort_by`, `min_by`/`max_by`;
 **String** `length`/`size`, `upcase`, `downcase`, `reverse`, `strip`/`lstrip`/
 `rstrip`, `empty?`, `include?`, `start_with?`, `end_with?`, `split`, `chars`,
 `to_i`, `to_f`, `to_sym`; **Numeric** `abs`, `to_i`, `to_f`, `even?`, `odd?`,

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1717,7 +1717,9 @@ func _sir_hash_responds(name string) bool {
 		return true
 	// Block-taking Hash methods.
 	case "each", "each_pair", "each_key", "each_value", "map",
-		"select", "filter", "reject", "transform_values", "transform_keys":
+		"select", "filter", "reject", "transform_values", "transform_keys",
+		"find", "detect", "any?", "all?", "none?", "count",
+		"sort_by", "min_by", "max_by":
 		return true
 	}
 	return false
@@ -2566,6 +2568,92 @@ func _sir_hash_block_method(recv *Map, name string, args []Value, block *Closure
 			_sir_map_put(m, _sir_apply(block, []Value{e.Key}), e.Val)
 		}
 		return m, true
+	// ── Enumerable aggregates (Hash includes Enumerable) ───────────
+	//
+	// Ruby's Hash mixes in Enumerable, so these iterate the hash as a
+	// sequence of [key, value] pairs: the block is yielded (key, value)
+	// (two arguments, matching `each`), and the "element" an aggregate
+	// returns is the two-element [key, value] Array (`&Seq{key, value}`).
+	case "find", "detect":
+		// First [k, v] pair whose block result is truthy; nil if none.
+		for _, e := range recv.Entries {
+			if _sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
+				return &Seq{Items: []Value{e.Key, e.Val}}, true
+			}
+		}
+		return nil, true
+	case "any?":
+		for _, e := range recv.Entries {
+			if _sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
+				return true, true
+			}
+		}
+		return false, true
+	case "all?":
+		for _, e := range recv.Entries {
+			if !_sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
+				return false, true
+			}
+		}
+		return true, true
+	case "none?":
+		for _, e := range recv.Entries {
+			if _sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
+				return false, true
+			}
+		}
+		return true, true
+	case "count":
+		// count { |k, v| pred } — number of pairs with a truthy block result.
+		n := int64(0)
+		for _, e := range recv.Entries {
+			if _sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
+				n++
+			}
+		}
+		return n, true
+	case "sort_by":
+		// A NEW Array of [k, v] pairs sorted by the block key, stable on ties.
+		// Keys are computed once (Schwartzian); `_sir_value_lt` never panics.
+		type sbKV struct {
+			key  Value
+			pair Value
+		}
+		keyed := make([]sbKV, len(recv.Entries))
+		for i, e := range recv.Entries {
+			keyed[i] = sbKV{_sir_apply(block, []Value{e.Key, e.Val}), &Seq{Items: []Value{e.Key, e.Val}}}
+		}
+		sort.SliceStable(keyed, func(i, j int) bool {
+			return _sir_value_lt(keyed[i].key, keyed[j].key)
+		})
+		out := make([]Value, len(keyed))
+		for i := range keyed {
+			out[i] = keyed[i].pair
+		}
+		return &Seq{Items: out}, true
+	case "min_by", "max_by":
+		// The [k, v] pair with the extremal block key (first-on-tie; nil on
+		// an empty hash).
+		if len(recv.Entries) == 0 {
+			return nil, true
+		}
+		wantMin := name == "min_by"
+		best := recv.Entries[0]
+		bestKey := _sir_apply(block, []Value{best.Key, best.Val})
+		for _, e := range recv.Entries[1:] {
+			k := _sir_apply(block, []Value{e.Key, e.Val})
+			take := false
+			if wantMin {
+				take = _sir_value_lt(k, bestKey)
+			} else {
+				take = _sir_value_lt(bestKey, k)
+			}
+			if take {
+				best = e
+				bestKey = k
+			}
+		}
+		return &Seq{Items: []Value{best.Key, best.Val}}, true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
@@ -286,3 +286,133 @@ fn hash_methods_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+/// Two-parameter lambda `fn_name(a, b) -> body`, for Hash Enumerable blocks
+/// which are yielded `(key, value)`.
+fn lambda_fn2(fn_name: &str, p1: &str, p2: &str, body: Expr) -> Function {
+    let mk = |name: &str| semantic_ir::Param {
+        name: name.into(),
+        kind: semantic_ir::ParamKind::Required,
+        sir_type: None,
+        default: None,
+        span: s(),
+    };
+    Function {
+        name: fn_name.into(),
+        params: vec![mk(p1), mk(p2)],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts: vec![], value: body, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+/// Demo for the Hash Enumerable aggregates (`find`/`any?`/`all?`/`none?`/
+/// `count`/`sort_by`/`min_by`/`max_by`).  Each block is yielded `(key, value)`;
+/// aggregates that return an "element" return the two-element `[key, value]`
+/// Array.  Expected values match the Python reference for the same ops.
+fn enum_module() -> Module {
+    // { |k, v| v } — the value, used as the sort/min/max key.
+    let by_val = lambda_fn2("__lam_val", "k", "v", var_p("v"));
+    // { |k, v| v.even? } — an even-value predicate.
+    let is_even = lambda_fn2("__lam_even", "k", "v", method(var_p("v"), "even?", vec![]));
+
+    let stmts = vec![
+        // {c:3,a:1,b:2}.sort_by { |k,v| v } → [[a, 1], [b, 2], [c, 3]]
+        print_stmt(method(
+            map_of(vec![("c", 3), ("a", 1), ("b", 2)]),
+            "sort_by",
+            vec![closure("__lam_val")],
+        )),
+        // {c:3,a:1,b:2}.min_by { |k,v| v } → [a, 1]
+        print_stmt(method(
+            map_of(vec![("c", 3), ("a", 1), ("b", 2)]),
+            "min_by",
+            vec![closure("__lam_val")],
+        )),
+        // {c:3,a:1,b:2}.max_by { |k,v| v } → [c, 3]
+        print_stmt(method(
+            map_of(vec![("c", 3), ("a", 1), ("b", 2)]),
+            "max_by",
+            vec![closure("__lam_val")],
+        )),
+        // {a:1,b:2,c:3,d:4}.find { |k,v| v.even? } → [b, 2]
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "find",
+            vec![closure("__lam_even")],
+        )),
+        // {a:1,b:2,c:3,d:4}.count { |k,v| v.even? } → 2
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "count",
+            vec![closure("__lam_even")],
+        )),
+        // {a:1,b:2,c:3,d:4}.any? { v.even? } → #t
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "any?",
+            vec![closure("__lam_even")],
+        )),
+        // {a:1,b:2,c:3,d:4}.all? { v.even? } → #f
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "all?",
+            vec![closure("__lam_even")],
+        )),
+        // {a:1,c:3}.none? { v.even? } → #t  (no even values)
+        print_stmt(method(
+            map_of(vec![("a", 1), ("c", 3)]),
+            "none?",
+            vec![closure("__lam_even")],
+        )),
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![by_val, is_even, main])
+}
+
+#[test]
+fn hash_enumerable_aggregates_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&enum_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "enum");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "[[a, 1], [b, 2], [c, 3]]", // sort_by { v }
+            "[a, 1]",                   // min_by { v }
+            "[c, 3]",                   // max_by { v }
+            "[b, 2]",                   // find { even? } → first even-valued pair
+            "2",                        // count { even? }
+            "#t",                       // any? { even? }
+            "#f",                       // all? { even? }
+            "#t",                       // none? { even? } on all-odd values
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.19 reference (#7957) into the **Go backend** (`semantic-ir-to-go`) — first backend of the Hash Enumerable aggregates cascade. Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as `[key, value]` pairs: the block is yielded `(key, value)` (two args, matching `each`), and the "element" an aggregate returns is the two-element `[key, value]` Array (`&Seq{key, value}`).

- `find`/`detect` — first `[k, v]` pair with a truthy block result; `nil` if none.
- `any?`/`all?`/`none?` — booleans over `block(k, v)`.
- `count { |k, v| … }` — number of truthy pairs.
- `sort_by` — new Array of `[k, v]` pairs sorted by the block key (stable, Schwartzian; the never-panic `_sir_value_lt` comparator).
- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty).

`_sir_hash_responds` advertises all of the above. Byte-for-byte the same shape as the existing `_sir_array_block_method` arms, differing only in iterating `recv.Entries` and yielding/returning `[k, v]` pairs.

## Exec-proof

`tests/compile_and_run_hash_methods.rs` gains `hash_enumerable_aggregates_compile_and_run`, run under real `go run`:
- `{c:3,a:1,b:2}.sort_by { |k,v| v }` → `[[a, 1], [b, 2], [c, 3]]`; `min_by` → `[a, 1]`; `max_by` → `[c, 3]`
- `.find { v.even? }` → `[b, 2]`; `.count { v.even? }` → `2`; `.any?` → `#t`; `.all?` → `#f`; all-odd `.none?` → `#t`

Diffed against the Python reference. `cargo test -p semantic-ir-to-go --test compile_and_run_hash_methods` passes (2/2).

## Checklist
- [x] CHANGELOG.md (0.26.0 → **0.27.0**), README Hash catalog updated
- [x] Exec-proof green under `go run`
- [x] Security review passed (no new panic/injection/DoS; identical to sibling array arms)

Cascade: reference = #7957. Go = this PR; Rust/JS/TS follow one-per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)