### PR TITLE
feat(sql-vm): IFNULL/NULLIF/TYPEOF/INSTR/HEX scalar functions (Stream A — grow the oracle corpus)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.1 — Scalar functions: IFNULL / NULLIF / TYPEOF / INSTR / HEX
+
+Stream A, corpus-growth phase (the differential ledger is at zero, so the
+metric is now the *size* of the seed corpus that matches real SQLite). Five
+common scalar functions used by real-world queries now work: `IFNULL`,
+`NULLIF`, `TYPEOF`, `INSTR`, `HEX`. They already parsed as function calls but
+hit the engine's `unknown built-in function` fallthrough; implemented in
+`sql-vm` (0.3.0). Five new differential-oracle cases (`ifnull`, `nullif`,
+`typeof`, `instr`, `hex`) diff mini-sqlite's results against real bundled
+SQLite. No mini-sqlite `src/` change.
+
 ## 0.5.0 — Differential conformance ledger driven to ZERO
 
 Stream B / L3: aggregate output columns are now named the SQLite way —

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -399,6 +399,49 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a.name, b.tag FROM a FULL JOIN b ON a.id = b.aid ORDER BY a.name, b.tag",
     },
+    // --- Scalar functions: IFNULL / NULLIF / TYPEOF / INSTR / HEX. Aliased so
+    //     the case exercises the function *values* (column naming is covered
+    //     elsewhere); each is diffed against real SQLite. ---
+    Case {
+        id: "ifnull",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, v INTEGER)",
+            "INSERT INTO t VALUES (1, 10), (2, NULL), (3, 30)",
+        ],
+        query: "SELECT IFNULL(v, -1) AS r FROM t ORDER BY id",
+    },
+    Case {
+        id: "nullif",
+        setup: &[
+            "CREATE TABLE t (id INTEGER)",
+            "INSERT INTO t VALUES (1), (2), (3)",
+        ],
+        query: "SELECT NULLIF(id, 2) AS r FROM t ORDER BY id",
+    },
+    Case {
+        id: "typeof",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, v INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1, 10, 'a'), (2, NULL, NULL)",
+        ],
+        query: "SELECT TYPEOF(v) AS tv, TYPEOF(name) AS tn, TYPEOF(id) AS ti FROM t ORDER BY id",
+    },
+    Case {
+        id: "instr",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1, 'abc'), (2, 'bbc'), (3, NULL)",
+        ],
+        query: "SELECT INSTR(name, 'b') AS r FROM t ORDER BY id",
+    },
+    Case {
+        id: "hex",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (255, 'abc'), (16, 'z')",
+        ],
+        query: "SELECT HEX(id) AS hi, HEX(name) AS hn FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.3.0] - Unreleased
+
+### Added
+
+- **Five scalar built-in functions** in `call_builtin`, matching SQLite:
+  - `IFNULL(a, b)` — the two-argument `COALESCE`.
+  - `NULLIF(a, b)` — NULL when the arguments are equal, else `a`.
+  - `TYPEOF(x)` — the storage-class name (`null`/`integer`/`real`/`text`/`blob`).
+  - `INSTR(haystack, needle)` — 1-based **character** index of the first match
+    (0 if absent, NULL on a NULL argument, 1 for an empty needle).
+  - `HEX(x)` — uppercase hex of the argument's bytes (text → UTF-8, blob → raw,
+    integer → decimal-text bytes; NULL → NULL; floats are declined).
+  These parsed as function calls already but hit the `unknown built-in function`
+  fallthrough; each is now implemented and unit-tested, and validated end-to-end
+  against real SQLite by the mini-sqlite differential oracle.
+
 ## [0.2.1] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1224,6 +1224,104 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             Ok(SqlValue::Float(rounded))
         }
 
+        "IFNULL" => {
+            // IFNULL(a, b): the two-argument COALESCE — `a` unless it is NULL,
+            // in which case `b`.
+            if args.len() != 2 {
+                return Err(VmError::TypeMismatch(format!("IFNULL expects 2 args, got {}", args.len())));
+            }
+            let mut it = args.into_iter();
+            let a = it.next().unwrap();
+            let b = it.next().unwrap();
+            Ok(if matches!(a, SqlValue::Null) { b } else { a })
+        }
+
+        "NULLIF" => {
+            // NULLIF(a, b): NULL when the two arguments are equal, else `a`.
+            // Equivalent to `CASE WHEN a = b THEN NULL ELSE a END`, so a NULL
+            // first argument still yields NULL.
+            if args.len() != 2 {
+                return Err(VmError::TypeMismatch(format!("NULLIF expects 2 args, got {}", args.len())));
+            }
+            if sql_eq(&args[0], &args[1]) {
+                Ok(SqlValue::Null)
+            } else {
+                Ok(args.into_iter().next().unwrap())
+            }
+        }
+
+        "TYPEOF" => {
+            // TYPEOF(x): SQLite's storage-class name for the value.
+            if args.len() != 1 {
+                return Err(VmError::TypeMismatch(format!("TYPEOF expects 1 arg, got {}", args.len())));
+            }
+            let t = match &args[0] {
+                SqlValue::Null => "null",
+                // SQLite has no boolean storage class — booleans are integers.
+                SqlValue::Bool(_) | SqlValue::Int(_) => "integer",
+                SqlValue::Float(_) => "real",
+                SqlValue::Text(_) => "text",
+                SqlValue::Blob(_) => "blob",
+            };
+            Ok(SqlValue::Text(t.to_string()))
+        }
+
+        "INSTR" => {
+            // INSTR(haystack, needle): 1-based character index of the first
+            // occurrence of `needle` in `haystack`, 0 if absent, NULL if either
+            // argument is NULL. `instr(x, '')` is 1, matching SQLite. (SQLite
+            // also accepts blobs; text covers every current caller, and the
+            // engine's other string builtins are likewise text-only.)
+            if args.len() != 2 {
+                return Err(VmError::TypeMismatch(format!("INSTR expects 2 args, got {}", args.len())));
+            }
+            if matches!(args[0], SqlValue::Null) || matches!(args[1], SqlValue::Null) {
+                return Ok(SqlValue::Null);
+            }
+            let hay = match &args[0] {
+                SqlValue::Text(s) => s,
+                other => return Err(VmError::TypeMismatch(format!("INSTR arg1 expects TEXT, got {:?}", other))),
+            };
+            let needle = match &args[1] {
+                SqlValue::Text(s) => s,
+                other => return Err(VmError::TypeMismatch(format!("INSTR arg2 expects TEXT, got {:?}", other))),
+            };
+            let pos = if needle.is_empty() {
+                1
+            } else {
+                match hay.find(needle.as_str()) {
+                    // Byte offset → 1-based character offset.
+                    Some(byte_idx) => hay[..byte_idx].chars().count() as i64 + 1,
+                    None => 0,
+                }
+            };
+            Ok(SqlValue::Int(pos))
+        }
+
+        "HEX" => {
+            // HEX(x): uppercase hexadecimal of the argument's bytes. SQLite reads
+            // the argument as a blob — text uses its UTF-8 bytes, a blob its raw
+            // bytes, and an integer its decimal-text bytes (`hex(255)` → "323535").
+            // NULL maps to NULL. Floats are declined: their SQLite text form
+            // (`2.0`, not Rust's `2`) is subtle enough that we don't guess here.
+            if args.len() != 1 {
+                return Err(VmError::TypeMismatch(format!("HEX expects 1 arg, got {}", args.len())));
+            }
+            let bytes: Vec<u8> = match &args[0] {
+                SqlValue::Null => return Ok(SqlValue::Null),
+                SqlValue::Text(s) => s.as_bytes().to_vec(),
+                SqlValue::Blob(b) => b.clone(),
+                SqlValue::Int(i) => i.to_string().into_bytes(),
+                SqlValue::Bool(b) => (*b as i64).to_string().into_bytes(),
+                other => return Err(VmError::TypeMismatch(format!("HEX expects TEXT/BLOB/INTEGER, got {:?}", other))),
+            };
+            let mut out = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                out.push_str(&format!("{byte:02X}"));
+            }
+            Ok(SqlValue::Text(out))
+        }
+
         other => {
             // Unknown function — return NULL rather than crashing.
             // This matches SQLite's behaviour for unrecognised scalar functions.
@@ -3333,5 +3431,69 @@ mod tests {
             Instruction::DistinctResult,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
+    }
+
+    #[test]
+    fn builtin_ifnull_and_nullif() {
+        // IFNULL passes through a non-NULL, substitutes on NULL.
+        assert_eq!(
+            call_builtin("IFNULL", vec![SqlValue::Int(5), SqlValue::Int(-1)]).unwrap(),
+            SqlValue::Int(5)
+        );
+        assert_eq!(
+            call_builtin("IFNULL", vec![SqlValue::Null, SqlValue::Int(-1)]).unwrap(),
+            SqlValue::Int(-1)
+        );
+        // NULLIF collapses equal args to NULL, else returns the first.
+        assert_eq!(
+            call_builtin("NULLIF", vec![SqlValue::Int(2), SqlValue::Int(2)]).unwrap(),
+            SqlValue::Null
+        );
+        assert_eq!(
+            call_builtin("NULLIF", vec![SqlValue::Int(1), SqlValue::Int(2)]).unwrap(),
+            SqlValue::Int(1)
+        );
+    }
+
+    #[test]
+    fn builtin_typeof_names_each_storage_class() {
+        let t = |v: SqlValue| match call_builtin("TYPEOF", vec![v]).unwrap() {
+            SqlValue::Text(s) => s,
+            other => panic!("expected text, got {other:?}"),
+        };
+        assert_eq!(t(SqlValue::Null), "null");
+        assert_eq!(t(SqlValue::Int(3)), "integer");
+        assert_eq!(t(SqlValue::Float(1.5)), "real");
+        assert_eq!(t(SqlValue::Text("x".into())), "text");
+        assert_eq!(t(SqlValue::Blob(vec![1])), "blob");
+    }
+
+    #[test]
+    fn builtin_instr_char_positions_and_nulls() {
+        let i = |h: &str, n: &str| {
+            call_builtin("INSTR", vec![SqlValue::Text(h.into()), SqlValue::Text(n.into())]).unwrap()
+        };
+        assert_eq!(i("abc", "b"), SqlValue::Int(2));
+        assert_eq!(i("abc", "x"), SqlValue::Int(0));
+        assert_eq!(i("abc", ""), SqlValue::Int(1)); // instr(x, '') == 1
+        // Multi-byte prefix: 'é' is one character, so the match is at char 2.
+        assert_eq!(i("éb", "b"), SqlValue::Int(2));
+        // NULL in either argument propagates.
+        assert_eq!(
+            call_builtin("INSTR", vec![SqlValue::Null, SqlValue::Text("b".into())]).unwrap(),
+            SqlValue::Null
+        );
+    }
+
+    #[test]
+    fn builtin_hex_encodes_bytes_uppercase() {
+        let h = |v: SqlValue| match call_builtin("HEX", vec![v]).unwrap() {
+            SqlValue::Text(s) => s,
+            other => panic!("expected text, got {other:?}"),
+        };
+        assert_eq!(h(SqlValue::Text("abc".into())), "616263");
+        assert_eq!(h(SqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])), "DEADBEEF");
+        assert_eq!(h(SqlValue::Int(255)), "323535"); // hex of the text "255"
+        assert_eq!(call_builtin("HEX", vec![SqlValue::Null]).unwrap(), SqlValue::Null);
     }
 }


### PR DESCRIPTION
## Stream A — first corpus-growth increment (post-ledger-zero)

With the differential-conformance ledger driven to **zero**, the metric flips: it's now the *size* of the oracle's seed corpus that matches real SQLite. This PR grows it with **five common scalar functions** that real-world queries (Anki) use. They already parsed as function calls but hit `call_builtin`'s `unknown built-in function` fallthrough:

| function | semantics |
|---|---|
| `IFNULL(a, b)` | two-argument `COALESCE` — `a` unless NULL, else `b` |
| `NULLIF(a, b)` | NULL when args are equal (via `sql_eq`), else `a` |
| `TYPEOF(x)` | storage-class name: `null`/`integer`/`real`/`text`/`blob` |
| `INSTR(hay, needle)` | 1-based **character** index of first match; 0 if absent, NULL on NULL arg, `1` for empty needle (byte offset from `str::find` → char count, multi-byte safe) |
| `HEX(x)` | uppercase hex of the argument's bytes: text→UTF-8, blob→raw, integer→decimal-text bytes (`hex(255)`=`323535`); NULL→NULL; floats declined |

Each validates arity/type and returns `TypeMismatch` otherwise — no panic on bad input.

## Verification
- **4 new `sql-vm` unit tests** (incl. blob `HEX` and multi-byte `INSTR`) + **5 new differential-oracle cases** (`ifnull`/`nullif`/`typeof`/`instr`/`hex`, `AS`-aliased to focus on values) that diff mini-sqlite against real bundled SQLite (`rusqlite`, **dev-dep**) — all match.
- Full **sql-vm** (85) + **mini-sqlite** (45 lib + oracle + 3 file-backed + 11 integration + doctest) suites green.
- My new builtins match the exact style of the adjacent existing builtins; clippy-clean (the file's pre-existing rustfmt nits are untouched — no scope creep).
- Security review **passed** (arity-guarded `unwrap`s, `find`-derived slice is always a valid char boundary, allocation bounded by input, no injection/I/O/`unsafe`, O(input) — no ReDoS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)