### PR TITLE
feat(sir-rust): Hash Enumerable aggregates (find/detect/any?/all?/none?/count/sort_by/min_by/max_by)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.29.0 — Hash Enumerable aggregates: `find` / `any?` / `all?` / `none?` / `count` / `sort_by` / `min_by` / `max_by`
+
+Mirrors the Python `sir-runtime-oop` v0.1.19 reference (PR #7957) into the Rust
+backend's inline `__sir` runtime (`map_method` block arms + the `Value::Map`
+`respond_to?` arm).  Ruby's `Hash` mixes in `Enumerable`, so these iterate the
+hash as a sequence of `[key, value]` pairs: the block is yielded `(key, value)`
+(two arguments, matching `each`), and the "element" an aggregate returns is the
+two-element `[key, value]` Array (`seq_lit(vec![k, v])`).
+
+- `find`/`detect` — first `[k, v]` pair with a truthy block result; `nil` if none.
+- `any?`/`all?`/`none?` — booleans over `block(k, v)` (block form; the block-less
+  forms degrade to the emptiness checks Ruby uses).
+- `count { |k, v| … }` — number of pairs with a truthy block result.
+- `sort_by` — a NEW Array of `[k, v]` pairs sorted by the block key using the
+  runtime's numeric ordering (`num_lt`), stable on ties (Schwartzian).
+- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty).
+
+Every arm SNAPSHOTS the entries into an owned `Vec` before iterating, so no
+`RefCell` borrow is held across `apply_closure` — the never-panic floor holds
+even against a block that reentrantly mutates the same hash.
+
+Exec-proof: `tests/compile_and_run_hash_catalog.rs` gains
+`hash_enumerable_aggregates_compile_and_run`, running `sort_by`/`min_by`/
+`max_by` (by value), `find`/`count`/`any?`/`all?`/`none?` (even-value predicate)
+under real `rustc`, diffed against the Python reference semantics.
+
 ## 0.28.0 — Hash catalog catch-up: `empty?` / `to_a` / `merge` / `dig` / `invert` / `store` / `delete` / `clear` / `reject` / `each_key` / `each_value`
 
 Brings the Rust backend's `map_method` Hash catalog to parity with the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -145,7 +145,9 @@ rather than panicking:
   - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,
     `fetch`, `to_a`, `merge`, `dig` (nested), `invert`, `store`/`[]=`, `delete`,
     `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,
-    `reject`, `transform_values`, `transform_keys`.
+    `reject`, `transform_values`, `transform_keys`, and the Enumerable
+    aggregates `find`/`detect`, `any?`/`all?`/`none?`, `count`, `sort_by`,
+    `min_by`/`max_by`.
   - **String** (`Str`): `length`, `upcase`, `downcase`, `reverse`, `strip`,
     `include?`, `split`, char-set `tr`/`count`/`delete`/`squeeze` (literal
     sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1478,6 +1478,9 @@ pub const RUNTIME: &str = r##"mod __sir {
                     | "store" | "[]=" | "delete" | "clear" | "each" | "each_pair" | "each_key"
                     | "each_value" | "map" | "collect" | "select" | "filter" | "reject"
                     | "transform_values" | "transform_keys"
+                    // Enumerable aggregates (Hash includes Enumerable)
+                    | "find" | "detect" | "any?" | "all?" | "none?" | "count"
+                    | "sort_by" | "min_by" | "max_by"
             ),
             Value::Str(_) => matches!(
                 name,
@@ -2427,6 +2430,117 @@ pub const RUNTIME: &str = r##"mod __sir {
                 }
                 recv
             }
+            // ── Enumerable aggregates (Hash includes Enumerable) ───────
+            //
+            // Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as
+            // a sequence of `[key, value]` pairs: the block is yielded
+            // `(key, value)` (two arguments, matching `each`), and the "element"
+            // an aggregate returns is the two-element `[key, value]` Array
+            // (`seq_lit(vec![k, v])`).  Every arm SNAPSHOTS the entries into an
+            // owned `Vec` before iterating so no `RefCell` borrow is held across
+            // `apply_closure` — a block that reentrantly mutates the same hash
+            // cannot trip a `BorrowMutError` panic.
+            "find" | "detect" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    snapshot
+                        .into_iter()
+                        .find(|(k, v)| truthy(&apply_closure(b, vec![k.clone(), v.clone()])))
+                        .map(|(k, v)| seq_lit(vec![k, v]))
+                        .unwrap_or(Value::Nil)
+                }
+                None => unknown_method(&recv, name),
+            },
+            "any?" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    Value::Bool(
+                        snapshot.into_iter().any(|(k, v)| truthy(&apply_closure(b, vec![k, v]))),
+                    )
+                }
+                None => Value::Bool(!entries_rc.borrow().is_empty()),
+            },
+            "all?" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    Value::Bool(
+                        snapshot.into_iter().all(|(k, v)| truthy(&apply_closure(b, vec![k, v]))),
+                    )
+                }
+                None => Value::Bool(true),
+            },
+            "none?" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    Value::Bool(
+                        !snapshot.into_iter().any(|(k, v)| truthy(&apply_closure(b, vec![k, v]))),
+                    )
+                }
+                None => Value::Bool(entries_rc.borrow().is_empty()),
+            },
+            "count" if block.is_some() => {
+                // `count { |k, v| pred }` — number of pairs with a truthy result.
+                let b = block.as_ref().unwrap();
+                let snapshot = entries_rc.borrow().clone();
+                let n = snapshot
+                    .into_iter()
+                    .filter(|(k, v)| truthy(&apply_closure(b, vec![k.clone(), v.clone()])))
+                    .count();
+                Value::Int(n as i64)
+            }
+            // `sort_by { |k, v| key }` — a NEW Array of `[k, v]` pairs sorted by
+            // the block key using the runtime's numeric ordering (`num_lt`),
+            // stable on ties.  Keys are computed once (Schwartzian).
+            "sort_by" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    let mut keyed: Vec<(Value, Value)> = snapshot
+                        .into_iter()
+                        .map(|(k, v)| {
+                            (apply_closure(b, vec![k.clone(), v.clone()]), seq_lit(vec![k, v]))
+                        })
+                        .collect();
+                    keyed.sort_by(|(ka, _), (kb, _)| {
+                        if num_lt(ka, kb) {
+                            std::cmp::Ordering::Less
+                        } else if num_lt(kb, ka) {
+                            std::cmp::Ordering::Greater
+                        } else {
+                            std::cmp::Ordering::Equal
+                        }
+                    });
+                    seq_lit(keyed.into_iter().map(|(_, pair)| pair).collect())
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `min_by`/`max_by { |k, v| key }` — the `[k, v]` pair with the
+            // smallest / largest block key.  First pair wins a tie (strict `<`);
+            // an empty hash yields `nil`.
+            "min_by" | "max_by" => match &block {
+                Some(b) => {
+                    let want_min = name == "min_by";
+                    let snapshot = entries_rc.borrow().clone();
+                    let mut best: Option<(Value, (Value, Value))> = None;
+                    for (k, v) in snapshot {
+                        let key = apply_closure(b, vec![k.clone(), v.clone()]);
+                        let take = match &best {
+                            None => true,
+                            Some((bk, _)) => {
+                                if want_min {
+                                    num_lt(&key, bk)
+                                } else {
+                                    num_lt(bk, &key)
+                                }
+                            }
+                        };
+                        if take {
+                            best = Some((key, (k, v)));
+                        }
+                    }
+                    best.map(|(_, (k, v))| seq_lit(vec![k, v])).unwrap_or(Value::Nil)
+                }
+                None => unknown_method(&recv, name),
+            },
             _ => no_method_error(&recv, name),
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -307,3 +307,119 @@ fn hash_catalog_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+/// `{c:3, a:1, b:2}` — symbol keys in a non-sorted order (so `sort_by` is a
+/// real reordering).
+fn cab_map() -> Expr {
+    map_lit(vec![(symlit("c"), ilit(3)), (symlit("a"), ilit(1)), (symlit("b"), ilit(2))])
+}
+
+/// `{a:1, b:2, c:3, d:4}`.
+fn abcd_map() -> Expr {
+    map_lit(vec![
+        (symlit("a"), ilit(1)),
+        (symlit("b"), ilit(2)),
+        (symlit("c"), ilit(3)),
+        (symlit("d"), ilit(4)),
+    ])
+}
+
+fn enum_demo() -> Module {
+    let block_fns = vec![
+        // { |k, v| v } — the value, used as the sort/min/max key.
+        block_fn("__blk_val", &["k", "v"], param("v")),
+        // { |k, v| v.even? } — an even-value predicate.
+        block_fn("__blk_even", &["k", "v"], method(param("v"), "even?", vec![])),
+    ];
+    let main_stmts = vec![
+        // {c:3,a:1,b:2}.sort_by { |k,v| v } → [[a, 1], [b, 2], [c, 3]]
+        print_stmt(method(cab_map(), "sort_by", vec![block("__blk_val")])),
+        // {c:3,a:1,b:2}.min_by { |k,v| v } → [a, 1]
+        print_stmt(method(cab_map(), "min_by", vec![block("__blk_val")])),
+        // {c:3,a:1,b:2}.max_by { |k,v| v } → [c, 3]
+        print_stmt(method(cab_map(), "max_by", vec![block("__blk_val")])),
+        // {a:1,b:2,c:3,d:4}.find { |k,v| v.even? } → [b, 2]
+        print_stmt(method(abcd_map(), "find", vec![block("__blk_even")])),
+        // {a:1,b:2,c:3,d:4}.count { |k,v| v.even? } → 2
+        print_stmt(method(abcd_map(), "count", vec![block("__blk_even")])),
+        // {a:1,b:2,c:3,d:4}.any? { v.even? } → #t
+        print_stmt(method(abcd_map(), "any?", vec![block("__blk_even")])),
+        // {a:1,b:2,c:3,d:4}.all? { v.even? } → #f
+        print_stmt(method(abcd_map(), "all?", vec![block("__blk_even")])),
+        // {a:1,c:3}.none? { v.even? } → #t  (no even values)
+        print_stmt(method(
+            map_lit(vec![(symlit("a"), ilit(1)), (symlit("c"), ilit(3))]),
+            "none?",
+            vec![block("__blk_even")],
+        )),
+    ];
+    demo_module(main_stmts, block_fns)
+}
+
+#[test]
+fn hash_enumerable_aggregates_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&enum_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_hash_enum_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_hash_enum_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out =
+        cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "[[a, 1], [b, 2], [c, 3]]", // sort_by { v }
+            "[a, 1]",                   // min_by { v }
+            "[c, 3]",                   // max_by { v }
+            "[b, 2]",                   // find { even? }
+            "2",                        // count { even? }
+            "#t",                       // any? { even? }
+            "#f",                       // all? { even? }
+            "#t",                       // none? { even? } on all-odd values
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.19 reference (#7957) into the **Rust backend** (`semantic-ir-to-rust`) inline `__sir` runtime (`map_method` block arms + the `Value::Map` `respond_to?` arm). Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as `[key, value]` pairs: the block is yielded `(key, value)` (two args, matching `each`), and the "element" an aggregate returns is the two-element `[key, value]` Array (`seq_lit(vec![k, v])`).

- `find`/`detect` — first `[k, v]` pair with a truthy block result; `nil` if none.
- `any?`/`all?`/`none?` — booleans over `block(k, v)`.
- `count { |k, v| … }` — number of truthy pairs.
- `sort_by` — new Array of `[k, v]` pairs sorted by the block key (`num_lt`, stable/Schwartzian).
- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty).

Every arm **snapshots** entries into an owned `Vec` before iterating, so no `RefCell` borrow is held across `apply_closure` — the never-panic floor holds against a block that reentrantly mutates the same hash. `respond_to?` advertises all of the above.

## Exec-proof

`tests/compile_and_run_hash_catalog.rs` gains `hash_enumerable_aggregates_compile_and_run`, run under real `rustc`:
- `{c:3,a:1,b:2}.sort_by { |k,v| v }` → `[[a, 1], [b, 2], [c, 3]]`; `min_by` → `[a, 1]`; `max_by` → `[c, 3]`
- `.find { v.even? }` → `[b, 2]`; `.count { v.even? }` → `2`; `.any?` → `#t`; `.all?` → `#f`; all-odd `.none?` → `#t`

Diffed against the Python reference. `cargo test -p semantic-ir-to-rust --test compile_and_run_hash_catalog` passes (2/2); clippy clean.

## Checklist
- [x] CHANGELOG.md (0.28.0 → **0.29.0**), README Hash catalog updated
- [x] Exec-proof green under `rustc`; clippy clean
- [x] Security review passed (snapshot-first on all arms; no new panic/injection/DoS)

Cascade: reference = #7957. Python ✓, Go #7962 ✓, **Rust = this PR**; JS/TS follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)