### PR TITLE
feat(sir-js): Hash Enumerable aggregates (find/detect/any?/all?/none?/count/sort_by/min_by/max_by)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.27.0 — Hash Enumerable aggregates: `find` / `any?` / `all?` / `none?` / `count` / `sort_by` / `min_by` / `max_by`
+
+Mirrors the Python `sir-runtime-oop` v0.1.19 reference (PR #7957) into the
+JavaScript backend's emitted runtime (`hashMethod` + the `HASH_METHODS`
+`respond_to?` set).  Ruby's `Hash` mixes in `Enumerable`, so these iterate the
+hash as a sequence of `[key, value]` pairs: the block is yielded `(key, value)`
+(two arguments, matching `each`), and the "element" an aggregate returns is the
+two-element `[key, value]` Array.
+
+- `find`/`detect` — first `[k, v]` pair with a truthy block result; `nil` if none.
+- `any?`/`all?`/`none?` — booleans over `block(k, v)` (the block-less forms
+  degrade to the emptiness checks Ruby uses).
+- `count { |k, v| … }` — number of pairs with a truthy block result (block-less
+  `count` returns the size).
+- `sort_by` — a NEW Array of `[k, v]` pairs sorted by the block key (`arrCmp`,
+  the never-throw comparator used by `Array#sort_by`).
+- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty).
+
+Because these return plain JS Arrays (not a `Map`), they format directly.
+
+Exec-proof: `tests/run_with_node.rs` gains `hash_enumerable_aggregates`, running
+`sort_by`/`min_by`/`max_by` (by value) and `find`/`count`/`any?`/`all?`/`none?`
+(even-value predicate) under real `node`, diffed against the Python reference.
+
 ## 0.26.0 — Hash transforming block methods: `transform_values` / `transform_keys`
 
 Mirrors the Python `sir-runtime-oop` v0.1.18 reference (PR #7909) into the

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -925,6 +925,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "include?", "member?", "has_value?", "value?", "to_a", "merge", "dig",
     "invert", "delete", "store", "[]=", "fetch", "clear", "each", "each_pair",
     "map", "select", "filter", "reject", "transform_values", "transform_keys",
+    "find", "detect", "any?", "all?", "none?", "count",
+    "sort_by", "min_by", "max_by",
   ]);
   function hashMethod(recv, name, args) {
     switch (name) {
@@ -1041,6 +1043,71 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         const out = new Map();
         for (const [k, v] of recv) { out.set(blk(k), v); }
         return out;
+      }
+      // ── Enumerable aggregates (Hash includes Enumerable) ─────────
+      //
+      // Ruby's Hash mixes in Enumerable, so these iterate the hash as a
+      // sequence of [key, value] pairs: the block is yielded (key, value)
+      // (two arguments, matching `each`), and the "element" an aggregate
+      // returns is the two-element [key, value] Array.
+      case "find": case "detect": {
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        for (const [k, v] of recv) { if (truthy(blk(k, v))) { return [k, v]; } }
+        return null;
+      }
+      case "any?": {
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return recv.size > 0; }
+        for (const [k, v] of recv) { if (truthy(blk(k, v))) { return true; } }
+        return false;
+      }
+      case "all?": {
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return true; }
+        for (const [k, v] of recv) { if (!truthy(blk(k, v))) { return false; } }
+        return true;
+      }
+      case "none?": {
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return recv.size === 0; }
+        for (const [k, v] of recv) { if (truthy(blk(k, v))) { return false; } }
+        return true;
+      }
+      case "count": {
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return recv.size; }
+        let n = 0;
+        for (const [k, v] of recv) { if (truthy(blk(k, v))) { n++; } }
+        return n;
+      }
+      case "sort_by": {
+        // A NEW Array of [k, v] pairs sorted by the block key (`arrCmp` is the
+        // never-throw numeric-aware comparator used by Array#sort_by).
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        const keyed = [];
+        for (const [k, v] of recv) { keyed.push([blk(k, v), [k, v]]); }
+        keyed.sort((a, b) => arrCmp(a[0], b[0]));
+        return keyed.map((p) => p[1]);
+      }
+      case "min_by": case "max_by": {
+        // The [k, v] pair with the extremal block key (first-on-tie; nil on
+        // an empty hash).
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        if (recv.size === 0) { return null; }
+        const wantMin = name === "min_by";
+        let bestPair = null;
+        let bestKey;
+        for (const [k, v] of recv) {
+          const key = blk(k, v);
+          if (bestPair === null || (wantMin ? key < bestKey : key > bestKey)) {
+            bestPair = [k, v];
+            bestKey = key;
+          }
+        }
+        return bestPair;
       }
     }
     return HASH_MISS;

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2736,3 +2736,83 @@ fn array_catalog_methods() {
         );
     }
 }
+
+// ── Ruby Hash Enumerable aggregates (find/any?/all?/none?/count/sort_by/…) ──
+//
+// Ruby's Hash mixes in Enumerable, so these iterate the hash as [key, value]
+// pairs: the block is yielded (key, value) and the "element" an aggregate
+// returns is the two-element [key, value] Array.  Because these return plain JS
+// arrays (not a Map), they format directly — no `to_a` round-trip needed.
+#[test]
+fn hash_enumerable_aggregates() {
+    let mk = |pairs: Vec<(&str, Expr)>| Expr::MapLit {
+        entries: pairs.into_iter().map(|(k, v)| MapEntry { key: str_(k), value: v }).collect(),
+        span: sp(),
+    };
+    let cab = || mk(vec![("c", int(3)), ("a", int(1)), ("b", int(2))]);
+    let abcd = || mk(vec![("a", int(1)), ("b", int(2)), ("c", int(3)), ("d", int(4))]);
+    let block_fns = vec![
+        // { |k, v| v } — the value, used as the sort/min/max key.
+        func("__he_val", vec![param("k"), param("v")], vec![], param_ref("v")),
+        // { |k, v| v.even? } — an even-value predicate.
+        func("__he_even", vec![param("k"), param("v")], vec![], method(param_ref("v"), "even?", vec![])),
+    ];
+    let stmts = vec![
+        // {c:3,a:1,b:2}.sort_by { |k,v| v } → [[a, 1], [b, 2], [c, 3]]
+        print(method(cab(), "sort_by", vec![method_closure("__he_val")])),
+        // {c:3,a:1,b:2}.min_by { |k,v| v } → [a, 1]
+        print(method(cab(), "min_by", vec![method_closure("__he_val")])),
+        // {c:3,a:1,b:2}.max_by { |k,v| v } → [c, 3]
+        print(method(cab(), "max_by", vec![method_closure("__he_val")])),
+        // {a:1,b:2,c:3,d:4}.find { |k,v| v.even? } → [b, 2]
+        print(method(abcd(), "find", vec![method_closure("__he_even")])),
+        // {a:1,b:2,c:3,d:4}.count { |k,v| v.even? } → 2
+        print(method(abcd(), "count", vec![method_closure("__he_even")])),
+        // {a:1,b:2,c:3,d:4}.any? { v.even? } → #t
+        print(method(abcd(), "any?", vec![method_closure("__he_even")])),
+        // {a:1,b:2,c:3,d:4}.all? { v.even? } → #f
+        print(method(abcd(), "all?", vec![method_closure("__he_even")])),
+        // {a:1,c:3}.none? { v.even? } → #t  (no even values)
+        print(method(
+            mk(vec![("a", int(1)), ("c", int(3))]),
+            "none?",
+            vec![method_closure("__he_even")],
+        )),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let mut functions = vec![main];
+    functions.extend(block_fns);
+    let module = Module {
+        name: "hashenum".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "hashenum") {
+        assert_eq!(
+            stdout,
+            "[[a, 1], [b, 2], [c, 3]]\n[a, 1]\n[c, 3]\n[b, 2]\n2\n#t\n#f\n#t"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.19 reference (#7957) into the **JavaScript backend** (`semantic-ir-to-javascript`) emitted runtime (`hashMethod` + `HASH_METHODS`). Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as `[key, value]` pairs: the block is yielded `(key, value)` (two args, matching `each`), and the "element" an aggregate returns is the two-element `[key, value]` Array.

- `find`/`detect` — first `[k, v]` pair with a truthy block result; `nil` if none.
- `any?`/`all?`/`none?` — booleans over `block(k, v)` (block-less → emptiness checks).
- `count { |k, v| … }` — number of truthy pairs (block-less → size).
- `sort_by` — new Array of `[k, v]` pairs sorted by the block key (`arrCmp`, the never-throw comparator).
- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty).

Because these return plain JS Arrays (not a `Map`), they format directly. `HASH_METHODS` advertises all of the above.

## Exec-proof

`tests/run_with_node.rs` gains `hash_enumerable_aggregates`, run under real `node`:
- `{c:3,a:1,b:2}.sort_by { |k,v| v }` → `[[a, 1], [b, 2], [c, 3]]`; `min_by` → `[a, 1]`; `max_by` → `[c, 3]`
- `.find { v.even? }` → `[b, 2]`; `.count { v.even? }` → `2`; `.any?` → `#t`; `.all?` → `#f`; all-odd `.none?` → `#t`

Diffed against the Python reference.

## Checklist
- [x] CHANGELOG.md (0.26.0 → **0.27.0**)
- [x] Exec-proof green under `node`
- [x] Security review passed (native `Map` iteration, fresh array returns → no prototype pollution; identical to sibling array arms)

Cascade: reference = #7957. Python ✓, Go #7962 ✓, Rust #7966 ✓, **JS = this PR**; TS is the final backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)