### PR TITLE
feat(storage-sqlite): list_indexes reports a real file's indexes (Stream C)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.2 — Introspect a file's indexes (`list_indexes`)
+
+Stream C: the file backend's `list_indexes` now reports a real `.sqlite` file's
+indexes (name, unique, columns, auto) from the parsed catalog — see
+`storage-sqlite` 0.3.0. New differential test
+`tests/file_backed.rs::list_indexes_matches_real_sqlite` diffs the result
+against real SQLite's `PRAGMA index_list` / `PRAGMA index_info`. No mini-sqlite
+`src/` change.
+
 ## 0.5.1 — Scalar functions: IFNULL / NULLIF / TYPEOF / INSTR / HEX
 
 Stream A, corpus-growth phase (the differential ledger is at zero, so the

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/file_backed.rs
+++ b/code/packages/rust/mini-sqlite/tests/file_backed.rs
@@ -167,3 +167,62 @@ fn sqlite_master_is_queryable_and_matches_real_sqlite() {
 
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
+
+/// The file backend's `list_indexes` matches what real SQLite reports through
+/// `PRAGMA index_list` / `PRAGMA index_info` — tools can introspect a real
+/// database's indexes even though the planner still scans.
+#[test]
+fn list_indexes_matches_real_sqlite() {
+    use coding_adventures_sql_backend::Backend;
+    use coding_adventures_storage_sqlite::SqliteFileBackend;
+
+    let path = build_sqlite_file(&[
+        "CREATE TABLE cards (id INTEGER PRIMARY KEY, due INTEGER, ord INTEGER, note TEXT)",
+        "CREATE INDEX ix_due ON cards(due)",
+        "CREATE UNIQUE INDEX ix_ord ON cards(ord, due)",
+        "CREATE TABLE other (x INTEGER)",
+        "CREATE INDEX ix_x ON other(x)",
+    ]);
+
+    // Normalized (name, unique, columns) from real SQLite for one table.
+    let real = |table: &str| -> Vec<(String, bool, Vec<String>)> {
+        let conn = rusqlite::Connection::open(&path).unwrap();
+        let mut list = conn.prepare(&format!("PRAGMA index_list('{table}')")).unwrap();
+        let idxs: Vec<(String, bool)> = list
+            .query_map([], |r| Ok((r.get::<_, String>(1)?, r.get::<_, i64>(2)? != 0)))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        let mut out = Vec::new();
+        for (name, uniq) in idxs {
+            let mut info = conn.prepare(&format!("PRAGMA index_info('{name}')")).unwrap();
+            let cols: Vec<String> = info
+                .query_map([], |r| r.get::<_, Option<String>>(2))
+                .unwrap()
+                .map(|c| c.unwrap().unwrap_or_default())
+                .collect();
+            out.push((name, uniq, cols));
+        }
+        out.sort();
+        out
+    };
+
+    let backend = SqliteFileBackend::open(std::fs::read(&path).unwrap()).unwrap();
+    let mine = |table: &str| -> Vec<(String, bool, Vec<String>)> {
+        let mut v: Vec<(String, bool, Vec<String>)> = backend
+            .list_indexes(Some(table))
+            .into_iter()
+            .map(|i| (i.name, i.unique, i.columns))
+            .collect();
+        v.sort();
+        v
+    };
+
+    // cards has ix_due (non-unique, [due]) and ix_ord (unique, [ord, due]).
+    assert_eq!(mine("cards"), real("cards"), "cards indexes");
+    // Filtering to one table excludes the other table's index.
+    assert_eq!(mine("other"), real("other"), "other indexes");
+    assert_eq!(mine("cards").len(), 2);
+
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}

--- a/code/packages/rust/storage-sqlite/CHANGELOG.md
+++ b/code/packages/rust/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog — storage-sqlite
 
+## 0.3.0 — `list_indexes` reports the file's real indexes
+
+`Backend::list_indexes` was a stub returning `Vec::new()`; it now reports the
+index objects in the parsed `sqlite_schema` catalog (optionally filtered to one
+table), so tools can introspect a real database's indexes the way `PRAGMA
+index_list` does. The planner still full-scans (no `scan_index` yet).
+
+- Explicit `CREATE INDEX` objects yield their `unique` flag and column list,
+  recovered from the stored SQL: `parse_index_columns` takes the parenthesised
+  column list (each column reduced to its bare identifier, so `col DESC` /
+  `col COLLATE NOCASE` → `col`), and `index_is_unique` scans only the tokens
+  before the column-list `(` and stops at `INDEX` (so a name containing
+  "unique" is not misread).
+- Auto-indexes (the ones SQLite creates to back `UNIQUE`/`PRIMARY KEY`) carry no
+  catalog SQL; they are reported with `auto = true`, `unique = true`, and an
+  empty column list (not recoverable from the catalog SQL).
+- Verified by a new differential test (`mini-sqlite/tests/file_backed.rs::
+  list_indexes_matches_real_sqlite`) that diffs the result — index names, unique
+  flags, and column lists — against real SQLite's `PRAGMA index_list` /
+  `PRAGMA index_info` over the same file, plus unit tests for the two parsers.
+
 ## 0.2.0 — Queryable `sqlite_master` / `sqlite_schema` catalog
 
 `SELECT … FROM sqlite_master` (and its modern alias `sqlite_schema`) now works

--- a/code/packages/rust/storage-sqlite/Cargo.toml
+++ b/code/packages/rust/storage-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-storage-sqlite"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A file-backed storage engine for the mini-sqlite pipeline: exposes a real .sqlite database as a sql-backend Backend, so the SQL engine can query it unmodified. The Rust sibling of python/storage-sqlite; read-only for now (built on the zero-dep sqlite-file reader)."
 license = "MIT"

--- a/code/packages/rust/storage-sqlite/src/lib.rs
+++ b/code/packages/rust/storage-sqlite/src/lib.rs
@@ -178,6 +178,39 @@ fn affinity_is_real(type_name: &str) -> bool {
 /// This covers the ordinary schemas mini-sqlite and the Anki tables use. Exotic
 /// corners (deeply nested constraint expressions, unusual quoting) are refined in
 /// later increments; the cross-check tests measure it against real SQLite.
+/// Recover the indexed column names from a `CREATE INDEX … ON t (a, b, …)`
+/// statement — the parenthesised list, split at top level and reduced to each
+/// leading identifier (so `col DESC` or `col COLLATE NOCASE` yields `col`).
+/// Expression indexes (`ON t (a + b)`) degrade to their first identifier, which
+/// is the best a name-only view can offer.
+fn parse_index_columns(create_index_sql: &str) -> Vec<String> {
+    let Some(inner) = outermost_parens(create_index_sql) else {
+        return Vec::new();
+    };
+    split_top_level_commas(inner)
+        .into_iter()
+        .filter_map(|piece| {
+            let (name, _) = read_identifier(piece);
+            (!name.is_empty()).then_some(name)
+        })
+        .collect()
+}
+
+/// Whether a `CREATE INDEX` statement declares a UNIQUE index. We scan only the
+/// tokens *before* the column-list `(`, and stop at `INDEX`, so an index or
+/// table whose name merely contains "unique" is not misread as unique.
+fn index_is_unique(create_index_sql: &str) -> bool {
+    let head = create_index_sql.split('(').next().unwrap_or("");
+    for tok in head.split_whitespace() {
+        match tok.to_ascii_uppercase().as_str() {
+            "UNIQUE" => return true,
+            "INDEX" => return false,
+            _ => {}
+        }
+    }
+    false
+}
+
 fn parse_create_columns(create_sql: &str) -> Vec<ParsedColumn> {
     let Some(inner) = outermost_parens(create_sql) else {
         return Vec::new();
@@ -481,10 +514,35 @@ impl Backend for SqliteFileBackend {
         Err(unsupported("drop an index in a read-only .sqlite file"))
     }
 
-    fn list_indexes(&self, _table: Option<&str>) -> Vec<IndexDef> {
-        // No index access is offered yet; reporting none keeps the planner on the
-        // full-scan path (which `scan` serves) and never asks for `scan_index`.
-        Vec::new()
+    fn list_indexes(&self, table: Option<&str>) -> Vec<IndexDef> {
+        // Report the catalog's index objects (optionally filtered to one table),
+        // recovered from the same parsed `sqlite_schema` we serve everything from.
+        // We still don't offer `scan_index`, so the planner stays on the full
+        // scan — but tools that introspect indexes (PRAGMA-style) can now see
+        // them. Explicit `CREATE INDEX` objects carry their SQL, from which we
+        // recover the unique flag and column list. Auto-indexes (the ones SQLite
+        // creates to back `UNIQUE`/`PRIMARY KEY` constraints) store no SQL text
+        // in the catalog; they are always unique, and their columns aren't
+        // recoverable from the catalog SQL, so we report them with an empty list.
+        self.schema
+            .iter()
+            .filter(|e| e.object_type == "index")
+            .filter(|e| table.is_none_or(|t| e.table_name.eq_ignore_ascii_case(t)))
+            .map(|e| {
+                let auto = e.sql.is_none();
+                let (unique, columns) = match &e.sql {
+                    Some(sql) => (index_is_unique(sql), parse_index_columns(sql)),
+                    None => (true, Vec::new()),
+                };
+                IndexDef {
+                    name: e.name.clone(),
+                    table: e.table_name.clone(),
+                    columns,
+                    unique,
+                    auto,
+                }
+            })
+            .collect()
     }
 
     fn scan_index(
@@ -608,5 +666,31 @@ mod tests {
         let cols = SqliteFileBackend::schema_column_defs();
         let names: Vec<&str> = cols.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, ["type", "name", "tbl_name", "rootpage", "sql"]);
+    }
+
+    #[test]
+    fn parses_indexed_columns_from_create_index() {
+        assert_eq!(parse_index_columns("CREATE INDEX ix ON t (a)"), ["a"]);
+        assert_eq!(
+            parse_index_columns("CREATE UNIQUE INDEX ix ON t (ord, due)"),
+            ["ord", "due"]
+        );
+        // Sort order / collation suffixes reduce to the bare column name.
+        assert_eq!(
+            parse_index_columns("CREATE INDEX ix ON t (a DESC, b COLLATE NOCASE)"),
+            ["a", "b"]
+        );
+        assert_eq!(
+            parse_index_columns(r#"CREATE INDEX ix ON t ("odd name")"#),
+            ["odd name"]
+        );
+    }
+
+    #[test]
+    fn detects_unique_index_without_false_positives() {
+        assert!(index_is_unique("CREATE UNIQUE INDEX ix ON t (a)"));
+        assert!(!index_is_unique("CREATE INDEX ix ON t (a)"));
+        // "unique" appearing only in a name (after INDEX) is not a UNIQUE index.
+        assert!(!index_is_unique("CREATE INDEX my_unique_idx ON t (a)"));
     }
 }


### PR DESCRIPTION
## Stream C — introspect a real file's indexes

`Backend::list_indexes` was a stub returning `Vec::new()`. It now reports the index objects in the parsed `sqlite_schema` catalog (optionally filtered to one table), so tools can introspect a real database's indexes the way `PRAGMA index_list` does. The planner still full-scans (no `scan_index` yet) — this is the read/introspection surface, not an index-driven query path.

### What changed (`storage-sqlite` 0.3.0)
- Explicit `CREATE INDEX` objects yield their `unique` flag and column list, recovered from the stored SQL via two small pure helpers (reusing the existing paren/comma/identifier parsers):
  - `parse_index_columns` — the parenthesised column list, each column reduced to its bare identifier (`col DESC` / `col COLLATE NOCASE` → `col`).
  - `index_is_unique` — scans only the tokens **before** the column-list `(` and stops at `INDEX`, so an index whose *name* contains "unique" isn't misread.
- Auto-indexes (backing `UNIQUE`/`PRIMARY KEY`) carry no catalog SQL; reported with `auto = true`, `unique = true`, empty columns.
- **No new byte parsing or file I/O** — reads the in-memory catalog + its SQL text.

### Verification
- New **differential** test `file_backed.rs::list_indexes_matches_real_sqlite` diffs the result — index names, unique flags, and column lists — against real SQLite's `PRAGMA index_list` / `PRAGMA index_info` over the same file, for two tables (including table-filtering).
- +2 `storage-sqlite` unit tests for the parsers (incl. the "unique in a name" false-positive guard).
- Full **storage-sqlite** (10) + **mini-sqlite** (45 lib + oracle + 4 file-backed + 11 integration + doctest) suites green; fmt + clippy clean; only downstream consumer (mini-sqlite) tested.
- Security review **passed** (reads pre-parsed catalog + SQL text only; no panic/OOB on malformed SQL, output bounded by the caller's file, no injection, `#![forbid(unsafe_code)]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
