### PR TITLE
feat(cobol): lexer + tokens grammar with column-strip hook (PL07, PR2)

### DIFF
--- a/code/grammars/cobol/cobol.tokens
+++ b/code/grammars/cobol/cobol.tokens
@@ -1,0 +1,252 @@
+# COBOL-60 Token Grammar
+# ============================================================
+#
+# COBOL — COmmon Business-Oriented Language — was designed by CODASYL in 1959
+# under U.S. Department of Defense sponsorship and first specified in the 1960
+# report.  It is the direct descendant of FLOW-MATIC (Grace Hopper's B-0, our
+# PL06): English-keyword verbs, hyphenated data names, and the separation of
+# data description from procedure all came from FLOW-MATIC.  See PL07-cobol-60.md.
+#
+# This is the LEXER half of the frontend.  Like every language frontend in this
+# repo it is fed to the shared `GrammarLexer`; nothing is hand-tokenised.  The
+# ONE piece of COBOL-specific imperative code is the `strip_cobol_columns`
+# pre-tokenize hook (in the crate's lib.rs), which turns 80-column card images
+# into the free-form text this grammar tokenizes — see PL07 and
+# lexer-parser-hooks.md.
+#
+# ------------------------------------------------------------
+# Two features FLOW-MATIC let us skip, now handled here
+# ------------------------------------------------------------
+#
+# 1. FIXED-COLUMN CARDS — handled *before* this grammar runs, by the
+#    `strip_cobol_columns` pre-tokenize hook.  By the time these patterns see the
+#    text, sequence numbers (cols 1-6), the indicator (col 7), and the
+#    identification area (cols 73-80) are already gone; comment lines are
+#    dropped and continuations spliced.  So this grammar is free-form.
+#
+# 2. PICTURE STRINGS — context-sensitive.  A picture like `X(20)` begins with
+#    `X`, which is otherwise a NAME, so it can only be read correctly *after* a
+#    PIC/PICTURE keyword.  We use the lexer's declarative mode-transition feature
+#    (F10): the PIC/PICTURE keyword switches into the `picture` group, one
+#    PIC_STRING is matched, then we switch back.  The core picture pattern
+#    `[9XAVSP()0-9]+` deliberately excludes the period, so a picture terminates
+#    cleanly at a space OR at the entry-ending period (`PIC X(20).`).
+
+# @version 1
+# @case_insensitive true
+case_sensitive: false
+start_mode: default
+
+# ============================================================
+# Historical case handling
+# ============================================================
+#
+# COBOL of 1960 was written on uppercase-only keypunches, exactly like
+# FLOW-MATIC's UNIVAC and BASIC's teletypes.  Following those sister grammars we
+# treat case as insignificant:
+#   case_sensitive: false    — token PATTERNS match regardless of case.
+#   @case_insensitive true   — reserved words are normalized to uppercase on
+#                              lookup, so grammar literals like "DIVISION" match
+#                              DIVISION / division / Division alike.
+# Net effect: KEYWORDs surface uppercase; a NAME's value keeps its source case.
+
+# ============================================================
+# SECTION 1: Literals and names (default group)
+# ============================================================
+#
+# Numeric literal: optional sign, digits, optional fractional part.  This also
+# covers the two-digit LEVEL numbers (01, 02, 77, 88) — the lexer emits them as
+# NUMBER and the parser recognises a level by its value and position (an entry
+# begins `NUMBER NAME …`).  A distinct LEVEL token would need context the lexer
+# does not have, so we keep the lexer dumb here, as with FLOW-MATIC operation
+# numbers.
+#
+# The optional fractional part `(\.[0-9]+)?` requires a digit after the point,
+# so `100.` matches just `100` and leaves the `.` to be lexed as a DOT (the
+# sentence terminator).  This is what disambiguates a decimal point from the
+# period that ends a sentence.
+NUMBER = /-?[0-9]+(\.[0-9]+)?/
+
+# Data / paragraph / section names: the COBOL-family hyphenated identifier,
+# inherited from FLOW-MATIC.  Must start with a letter; may contain internal
+# hyphens (EMP-NAME, GROSS-PAY, MAIN-PARAGRAPH).  The hyphenated RESERVED words
+# (PROGRAM-ID, WORKING-STORAGE, FILE-CONTROL, HIGH-VALUE, …) match this pattern
+# too and are then promoted to KEYWORD via the keywords list below.
+NAME = /[A-Za-z][A-Za-z0-9]*(-[A-Za-z0-9]+)*/
+
+# Nonnumeric literals: COBOL allows either double or single quotes.  Both emit a
+# STRING token (the alias unifies them).  No escape sequences in the 1960
+# language; a quote cannot appear inside its own kind of literal.
+STRING_DQ = /"[^"]*"/ -> STRING
+STRING_SQ = /'[^']*'/ -> STRING
+
+# ============================================================
+# SECTION 2: Punctuation (default group)
+# ============================================================
+#
+# DOT is the sentence / entry terminator — the period that ends nearly every
+# COBOL construct.  LPAREN/RPAREN wrap subscripts (and picture repetition, but
+# those are matched inside the picture group).  COBOL treats the period as a
+# separator that must be followed by a space; we lex it as a bare token and let
+# the parser enforce structure.
+DOT    = "."
+LPAREN = "("
+RPAREN = ")"
+
+# ============================================================
+# SECTION 3: The `picture` group (context-sensitive)
+# ============================================================
+#
+# Active only after a PIC/PICTURE keyword (see the transitions section).  A core
+# picture string is a run of the data-description symbols:
+#   9  digit position      X  any character     A  alphabetic
+#   V  implied decimal      S  operational sign  P  assumed scaling
+# plus repetition `(n)`.  Editing symbols (Z * $ , . + - CR DB …) are the full
+# language's job and are out of scope for this first cut (see PL07 futures).
+#
+# Excluding the period from this class is deliberate: it makes a picture end at
+# the entry-terminating period, so `PIC X(20).` lexes as PIC_STRING("X(20)")
+# then DOT.
+group picture:
+  PIC_STRING = /[9XAVSPxavsp()0-9]+/
+
+# ============================================================
+# SECTION 4: Reserved words (global)
+# ============================================================
+#
+# A focused subset of COBOL-60's ~300 reserved words — enough to lex a complete
+# four-division program.  The full list is future work (see PL07).  A NAME whose
+# uppercased value appears here becomes a KEYWORD; everything else stays a NAME.
+# Keyword-prefix safety is automatic: `DATE-CODE` is not in the set, so it stays
+# a NAME even though `DATE-WRITTEN` is a keyword.
+keywords:
+  # -- Divisions & the DIVISION/SECTION words --
+  IDENTIFICATION
+  ENVIRONMENT
+  DATA
+  PROCEDURE
+  DIVISION
+  SECTION
+  # -- IDENTIFICATION paragraphs --
+  PROGRAM-ID
+  AUTHOR
+  INSTALLATION
+  DATE-WRITTEN
+  DATE-COMPILED
+  SECURITY
+  REMARKS
+  # -- ENVIRONMENT --
+  CONFIGURATION
+  SOURCE-COMPUTER
+  OBJECT-COMPUTER
+  INPUT-OUTPUT
+  FILE-CONTROL
+  SELECT
+  ASSIGN
+  # -- DATA --
+  FILE
+  WORKING-STORAGE
+  FD
+  SD
+  PICTURE
+  PIC
+  VALUE
+  FILLER
+  OCCURS
+  REDEFINES
+  USAGE
+  COMPUTATIONAL
+  COMP
+  # -- Verbs --
+  MOVE
+  ADD
+  SUBTRACT
+  MULTIPLY
+  DIVIDE
+  COMPUTE
+  PERFORM
+  DISPLAY
+  ACCEPT
+  OPEN
+  CLOSE
+  READ
+  WRITE
+  GO
+  STOP
+  RUN
+  ALTER
+  EXAMINE
+  IF
+  ELSE
+  # -- Prepositions / connectives / operators-in-words --
+  TO
+  FROM
+  BY
+  INTO
+  GIVING
+  IS
+  ARE
+  OF
+  IN
+  AND
+  OR
+  NOT
+  GREATER
+  LESS
+  EQUAL
+  THAN
+  THROUGH
+  THRU
+  UNTIL
+  VARYING
+  TIMES
+  DEPENDING
+  ON
+  WHEN
+  NEXT
+  SENTENCE
+  # -- Figurative constants --
+  ZERO
+  ZEROS
+  ZEROES
+  SPACE
+  SPACES
+  HIGH-VALUE
+  HIGH-VALUES
+  LOW-VALUE
+  LOW-VALUES
+  QUOTE
+  QUOTES
+  ALL
+
+# ============================================================
+# SECTION 5: Mode transitions (F10 declarative)
+# ============================================================
+#
+# Enter `picture` mode on a PIC/PICTURE keyword; leave it as soon as the single
+# PIC_STRING has been emitted.  Because `skip:` is global, the space between
+# PICTURE and the picture is consumed in `picture` mode before PIC_STRING is
+# matched.  A flat set-mode toggle (not push/pop) is all we need — pictures do
+# not nest.
+transitions:
+  on KEYWORD="PICTURE" -> set-mode picture
+  on KEYWORD="PIC"     -> set-mode picture
+  on PIC_STRING        -> set-mode default
+
+# ============================================================
+# SECTION 6: Skipped separators (global)
+# ============================================================
+#
+# Whitespace is insignificant (the card layout is already handled by the
+# pre-tokenize hook).  COBOL also allows the comma and semicolon as OPTIONAL
+# separators — pure punctuation noise, equivalent to a space — so we skip them
+# too.  (They never appear inside a core picture, which lives in its own group.)
+skip:
+  WHITESPACE = /[ \t\r\n]+/
+  SEPARATOR  = /[,;]/
+
+# ============================================================
+# SECTION 7: Error recovery (global)
+# ============================================================
+errors:
+  UNKNOWN = /./

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -223,6 +223,7 @@ members = [
     "c-lexer",
     "c-parser",
     "c-to-semantic-ir",
+    "cobol-lexer",
     "matlab-runtime",
     "matlab-repl",
     "octave-runtime",

--- a/code/packages/rust/cobol-lexer/BUILD
+++ b/code/packages/rust/cobol-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-cobol-lexer -- --nocapture

--- a/code/packages/rust/cobol-lexer/BUILD_windows
+++ b/code/packages/rust/cobol-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-cobol-lexer -- --nocapture

--- a/code/packages/rust/cobol-lexer/CHANGELOG.md
+++ b/code/packages/rust/cobol-lexer/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 0.1.0 — COBOL-60 lexer (PL07)
+
+- Grammar-driven tokenizer over `code/grammars/cobol/cobol.tokens`, wrapping
+  `lexer::GrammarLexer`. Public API: `tokenize_cobol` / `try_tokenize_cobol` /
+  `create_cobol_lexer`, plus the exported `strip_cobol_columns` hook.
+- **`strip_cobol_columns` pre-tokenize hook**: turns 80-column card images into
+  free-form text — drops the sequence (1–6) and identification (73–80) areas,
+  removes `*`/`/` comment lines, splices `-` continuations, keeps the code area
+  (8–72). Registered via `GrammarLexer::add_pre_tokenize`; unit-tested on its
+  own.
+- **PICTURE strings** via declarative mode transitions (F10): `PIC`/`PICTURE`
+  switches into a `picture` group matching one `PIC_STRING` (core symbols
+  `9 X A V S P` + repetition), then switches back. `PIC X(20).` → `PIC_STRING`
+  then `DOT`.
+- Reuses FLOW-MATIC machinery: hyphenated `NAME`s, English reserved words as
+  case-insensitive `KEYWORD`s (including hyphenated ones like `PROGRAM-ID`,
+  `WORKING-STORAGE`, `HIGH-VALUE`), numeric/quoted literals, `. ( )` punctuation,
+  and `,`/`;` skipped as optional separators. Level numbers lex as `NUMBER`.
+- Scope: a focused reserved-word subset and core PICTUREs — enough to lex a
+  complete four-division program. Editing PICTUREs, the full reserved list, and
+  Area A/B enforcement are future work.

--- a/code/packages/rust/cobol-lexer/Cargo.toml
+++ b/code/packages/rust/cobol-lexer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "coding-adventures-cobol-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Lexer for COBOL-60 — strips the 80-column card format via a pre-tokenize hook and tokenizes with the grammar-driven lexer and the cobol.tokens grammar file."
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/cobol-lexer/README.md
+++ b/code/packages/rust/cobol-lexer/README.md
@@ -1,0 +1,55 @@
+# cobol-lexer (coding-adventures-cobol-lexer)
+
+Lexer for **COBOL-60** (CODASYL, the 1960 report) — the lexical layer of the
+COBOL frontend and the descendant of the FLOW-MATIC lexer. It loads the compiled
+`cobol.tokens` grammar (`code/grammars/cobol/cobol.tokens`) and feeds it to
+the generic `lexer::GrammarLexer`; no tokenization is hand-written.
+
+Implements the lexical layer of [PL07](../../../specs/PL07-cobol-60.md).
+
+## API
+
+```rust
+use coding_adventures_cobol_lexer::{tokenize_cobol, strip_cobol_columns};
+
+// Carded (80-column) source is handled automatically by the pre-tokenize hook:
+let tokens = tokenize_cobol("000100 PROCEDURE DIVISION.\n000200     STOP RUN.");
+```
+
+## What's COBOL-specific here
+
+Two things FLOW-MATIC didn't need:
+
+1. **The fixed-column card format** — handled by the `strip_cobol_columns`
+   **pre-tokenize hook** (a pure `String -> String` function registered via
+   `GrammarLexer::add_pre_tokenize`). It drops the sequence area (cols 1–6) and
+   identification area (cols 73–80), removes `*`/`/` comment lines, splices `-`
+   continuation lines, and keeps the code area (cols 8–72). It is exported and
+   unit-tested independently of the grammar.
+2. **PICTURE strings** — context-sensitive. `X(20)` looks like a name, so it is
+   lexed only after a `PIC`/`PICTURE` keyword, using the grammar's declarative
+   **mode transition** (F10): the keyword switches into a `picture` group that
+   matches one `PIC_STRING`, then switches back. The core picture pattern
+   excludes the period, so `PIC X(20).` lexes as `PIC_STRING("X(20)")` then
+   `DOT`.
+
+Everything else reuses the FLOW-MATIC machinery: hyphenated `NAME`s, English
+reserved words as case-insensitive `KEYWORD`s, numeric/quoted literals, and the
+`. ( )` punctuation. Level numbers (`01`/`77`/…) lex as `NUMBER`; the parser
+recognises a level by value and position.
+
+## Scope
+
+A historically faithful first cut: the column-strip hook, a focused reserved-word
+subset, core PICTURE symbols (`9 X A V S P` + repetition), and literals — enough
+to lex a complete four-division program. Editing PICTUREs, the full ~300-word
+reserved list, and Area A/B enforcement are future work (see PL07).
+
+## Regenerating the grammar
+
+`src/_grammar.rs` is generated from `code/grammars/cobol/cobol.tokens`:
+
+```
+cargo run --release --manifest-path code/programs/rust/grammar-tools/Cargo.toml \
+  -- generate-rust-compiled-grammars cobol
+```

--- a/code/packages/rust/cobol-lexer/src/_grammar.rs
+++ b/code/packages/rust/cobol-lexer/src/_grammar.rs
@@ -1,0 +1,140 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: cobol.tokens
+// Regenerate with: grammar-tools compile-tokens cobol.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"-?[0-9]+(\.[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 68,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[A-Za-z][A-Za-z0-9]*(-[A-Za-z0-9]+)*"#.to_string(),
+                is_regex: true,
+                line_number: 75,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STRING_DQ"#.to_string(),
+                pattern: r#""[^"]*""#.to_string(),
+                is_regex: true,
+                line_number: 80,
+                alias: Some(r#"STRING"#.to_string()),
+            },
+            TokenDefinition {
+                name: r#"STRING_SQ"#.to_string(),
+                pattern: r#"'[^']*'"#.to_string(),
+                is_regex: true,
+                line_number: 81,
+                alias: Some(r#"STRING"#.to_string()),
+            },
+            TokenDefinition {
+                name: r#"DOT"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: false,
+                line_number: 92,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 93,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 94,
+                alias: None,
+            },
+        ],
+        keywords: vec![r#"IDENTIFICATION"#.to_string(), r#"ENVIRONMENT"#.to_string(), r#"DATA"#.to_string(), r#"PROCEDURE"#.to_string(), r#"DIVISION"#.to_string(), r#"SECTION"#.to_string(), r#"PROGRAM-ID"#.to_string(), r#"AUTHOR"#.to_string(), r#"INSTALLATION"#.to_string(), r#"DATE-WRITTEN"#.to_string(), r#"DATE-COMPILED"#.to_string(), r#"SECURITY"#.to_string(), r#"REMARKS"#.to_string(), r#"CONFIGURATION"#.to_string(), r#"SOURCE-COMPUTER"#.to_string(), r#"OBJECT-COMPUTER"#.to_string(), r#"INPUT-OUTPUT"#.to_string(), r#"FILE-CONTROL"#.to_string(), r#"SELECT"#.to_string(), r#"ASSIGN"#.to_string(), r#"FILE"#.to_string(), r#"WORKING-STORAGE"#.to_string(), r#"FD"#.to_string(), r#"SD"#.to_string(), r#"PICTURE"#.to_string(), r#"PIC"#.to_string(), r#"VALUE"#.to_string(), r#"FILLER"#.to_string(), r#"OCCURS"#.to_string(), r#"REDEFINES"#.to_string(), r#"USAGE"#.to_string(), r#"COMPUTATIONAL"#.to_string(), r#"COMP"#.to_string(), r#"MOVE"#.to_string(), r#"ADD"#.to_string(), r#"SUBTRACT"#.to_string(), r#"MULTIPLY"#.to_string(), r#"DIVIDE"#.to_string(), r#"COMPUTE"#.to_string(), r#"PERFORM"#.to_string(), r#"DISPLAY"#.to_string(), r#"ACCEPT"#.to_string(), r#"OPEN"#.to_string(), r#"CLOSE"#.to_string(), r#"READ"#.to_string(), r#"WRITE"#.to_string(), r#"GO"#.to_string(), r#"STOP"#.to_string(), r#"RUN"#.to_string(), r#"ALTER"#.to_string(), r#"EXAMINE"#.to_string(), r#"IF"#.to_string(), r#"ELSE"#.to_string(), r#"TO"#.to_string(), r#"FROM"#.to_string(), r#"BY"#.to_string(), r#"INTO"#.to_string(), r#"GIVING"#.to_string(), r#"IS"#.to_string(), r#"ARE"#.to_string(), r#"OF"#.to_string(), r#"IN"#.to_string(), r#"AND"#.to_string(), r#"OR"#.to_string(), r#"NOT"#.to_string(), r#"GREATER"#.to_string(), r#"LESS"#.to_string(), r#"EQUAL"#.to_string(), r#"THAN"#.to_string(), r#"THROUGH"#.to_string(), r#"THRU"#.to_string(), r#"UNTIL"#.to_string(), r#"VARYING"#.to_string(), r#"TIMES"#.to_string(), r#"DEPENDING"#.to_string(), r#"ON"#.to_string(), r#"WHEN"#.to_string(), r#"NEXT"#.to_string(), r#"SENTENCE"#.to_string(), r#"ZERO"#.to_string(), r#"ZEROS"#.to_string(), r#"ZEROES"#.to_string(), r#"SPACE"#.to_string(), r#"SPACES"#.to_string(), r#"HIGH-VALUE"#.to_string(), r#"HIGH-VALUES"#.to_string(), r#"LOW-VALUE"#.to_string(), r#"LOW-VALUES"#.to_string(), r#"QUOTE"#.to_string(), r#"QUOTES"#.to_string(), r#"ALL"#.to_string()],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t\r\n]+"#.to_string(),
+                is_regex: true,
+                line_number: 245,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SEPARATOR"#.to_string(),
+                pattern: r#"[,;]"#.to_string(),
+                is_regex: true,
+                line_number: 246,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: None,
+        error_definitions: vec![
+            TokenDefinition {
+                name: r#"UNKNOWN"#.to_string(),
+                pattern: r#"."#.to_string(),
+                is_regex: true,
+                line_number: 252,
+                alias: None,
+            },
+        ],
+        groups: {
+            let mut __map: HashMap<String, PatternGroup> = HashMap::new();
+            let mut __g_picture = PatternGroup { name: r#"picture"#.to_string(), definitions: vec![
+                    TokenDefinition {
+                        name: r#"PIC_STRING"#.to_string(),
+                        pattern: r#"[9XAVSPxavsp()0-9]+"#.to_string(),
+                        is_regex: true,
+                        line_number: 111,
+                        alias: None,
+                    },
+                ] };
+            __map.insert(r#"picture"#.to_string(), __g_picture);
+            __map
+        },
+        case_sensitive: false,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: Some(r#"default"#.to_string()),
+        transitions: vec![
+            ModeTransition {
+                on_tokens: vec![r#"KEYWORD"#.to_string()],
+                on_value: Some(r#"PICTURE"#.to_string()),
+                in_mode: None,
+                actions: vec![TransitionAction::SetMode(r#"picture"#.to_string())],
+                line_number: 232,
+            },
+            ModeTransition {
+                on_tokens: vec![r#"KEYWORD"#.to_string()],
+                on_value: Some(r#"PIC"#.to_string()),
+                in_mode: None,
+                actions: vec![TransitionAction::SetMode(r#"picture"#.to_string())],
+                line_number: 233,
+            },
+            ModeTransition {
+                on_tokens: vec![r#"PIC_STRING"#.to_string()],
+                on_value: None,
+                in_mode: None,
+                actions: vec![TransitionAction::SetMode(r#"default"#.to_string())],
+                line_number: 234,
+            },
+        ],
+    }
+}

--- a/code/packages/rust/cobol-lexer/src/lib.rs
+++ b/code/packages/rust/cobol-lexer/src/lib.rs
@@ -1,0 +1,411 @@
+//! # COBOL-60 lexer — tokenizing the language that FLOW-MATIC became.
+//!
+//! [COBOL](https://en.wikipedia.org/wiki/COBOL) — COmmon Business-Oriented
+//! Language — was designed by CODASYL in 1959 under U.S. Department of Defense
+//! sponsorship and first specified in the 1960 report. It is the direct
+//! descendant of FLOW-MATIC (Grace Hopper's B-0, our `flow-matic-lexer`):
+//! English-verb keywords, hyphenated data names, and the separation of data
+//! description from procedure all came from FLOW-MATIC. See
+//! [PL07](../../../specs/PL07-cobol-60.md).
+//!
+//! # Architecture
+//!
+//! Like every language frontend in this repo, this crate is a **thin wrapper**
+//! around the generic [`GrammarLexer`]; nothing is hand-tokenised. Two features
+//! FLOW-MATIC deliberately let us skip get handled here:
+//!
+//! ```text
+//! COBOL-60 source (80-column card images)
+//!        │  pre_tokenize hook: strip_cobol_columns   ← COBOL-specific, this crate
+//!        ▼
+//! free-form COBOL text (cols 8–72)
+//!        │  lexer::GrammarLexer (cobol.tokens, with a `picture` mode group)
+//!        ▼
+//! Vec<Token>   (KEYWORD, NAME, NUMBER, STRING, PIC_STRING, DOT, ( ))
+//! ```
+//!
+//! 1. **The fixed-column card format** is handled by [`strip_cobol_columns`], a
+//!    pure `String -> String` pre-tokenize hook (registered via
+//!    [`GrammarLexer::add_pre_tokenize`]). It is the only COBOL-specific
+//!    imperative code, and it is unit-tested on its own.
+//! 2. **PICTURE strings** are context-sensitive (`X(20)` looks like a name), so
+//!    the grammar uses a declarative mode transition: a `PIC`/`PICTURE` keyword
+//!    switches the lexer into a `picture` group that matches one `PIC_STRING`,
+//!    then switches back. No hook needed for that — it lives in the grammar.
+//!
+//! # Public API
+//!
+//! - [`strip_cobol_columns`] — the column-strip hook, exported for direct use/testing.
+//! - [`create_cobol_lexer`] — a configured [`GrammarLexer`] with the hook registered.
+//! - [`tokenize_cobol`] — convenience `&str` → `Vec<Token>` (panics on error).
+//! - [`try_tokenize_cobol`] — the fallible form.
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+// ===========================================================================
+// The COBOL-specific pre-tokenize hook: fixed-column card stripping
+// ===========================================================================
+
+/// Strip COBOL-60 fixed-format columns, turning 80-column card images into the
+/// free-form text the grammar tokenizes.
+///
+/// COBOL source is laid out in fixed columns (1-based):
+///
+/// | Columns | Meaning                                            |
+/// |---------|----------------------------------------------------|
+/// | 1–6     | Sequence number — **dropped**                      |
+/// | 7       | Indicator (`*`/`/` comment, `-` continuation, …)   |
+/// | 8–11    | Area A                                              |
+/// | 12–72   | Area B                                              |
+/// | 73–80   | Identification — **dropped**                        |
+///
+/// This function keeps only the code area (columns 8–72, i.e. char indices
+/// `7..72`), drops the sequence and identification areas, removes `*`/`/`
+/// comment lines entirely, and splices `-` continuation lines onto their
+/// predecessor. The result is ordinary free-form COBOL.
+///
+/// It is a pure function of the source text — no state, no I/O — exactly the
+/// contract a `pre_tokenize` hook requires.
+///
+/// # Examples
+///
+/// ```
+/// use coding_adventures_cobol_lexer::strip_cobol_columns;
+///
+/// // "000100" is the sequence area (cols 1–6), the space is the col-7 indicator,
+/// // and the code begins at column 8.
+/// let carded = "000100 IDENTIFICATION DIVISION.".to_string();
+/// assert_eq!(strip_cobol_columns(carded), "IDENTIFICATION DIVISION.");
+/// ```
+pub fn strip_cobol_columns(source: String) -> String {
+    let mut out: Vec<String> = Vec::new();
+
+    for raw in source.split('\n') {
+        // Normalise a trailing CR from CRLF-terminated cards so it never lands
+        // inside the code area of a short line.
+        let raw = raw.strip_suffix('\r').unwrap_or(raw);
+        let chars: Vec<char> = raw.chars().collect();
+
+        // A line with no indicator column (fewer than 7 chars) carries no code.
+        if chars.len() < 7 {
+            out.push(String::new());
+            continue;
+        }
+
+        // Column 7 (index 6) is the indicator.
+        let indicator = chars[6];
+        if indicator == '*' || indicator == '/' {
+            // Whole-line comment (`/` also means page-eject) — drop it.
+            continue;
+        }
+
+        // Code area: columns 8–72 → char indices 7..72, clipped to the line.
+        let start = 7.min(chars.len());
+        let end = 72.min(chars.len());
+        let code: String = chars[start..end].iter().collect();
+
+        if indicator == '-' {
+            // Continuation: append this line's code onto the previous one. A
+            // simple splice (drop the joint's surrounding spaces) suffices for
+            // the demonstrated subset; literal-aware continuation is future work.
+            if let Some(last) = out.last_mut() {
+                let joined = format!("{}{}", last.trim_end(), code.trim_start());
+                *last = joined;
+                continue;
+            }
+            // No predecessor to continue — fall through and keep the code as-is.
+        }
+
+        out.push(code);
+    }
+
+    out.join("\n")
+}
+
+// ===========================================================================
+// Public lexer API
+// ===========================================================================
+
+/// Create a [`GrammarLexer`] configured for COBOL-60 source, with the
+/// [`strip_cobol_columns`] pre-tokenize hook registered so callers can pass raw
+/// carded source directly.
+pub fn create_cobol_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    let mut lexer = GrammarLexer::new(source, &grammar);
+    lexer.add_pre_tokenize(Box::new(strip_cobol_columns));
+    lexer
+}
+
+/// Tokenize COBOL-60 `source` (carded or already free-form) into a `Vec<Token>`
+/// ending in EOF. Panics on a lexical error; use [`try_tokenize_cobol`] for the
+/// fallible form.
+pub fn tokenize_cobol(source: &str) -> Vec<Token> {
+    try_tokenize_cobol(source).unwrap_or_else(|e| panic!("COBOL tokenization failed: {e}"))
+}
+
+/// Tokenize COBOL-60 `source`, returning a human-readable error string on
+/// failure instead of panicking.
+pub fn try_tokenize_cobol(source: &str) -> Result<Vec<Token>, String> {
+    create_cobol_lexer(source).tokenize().map_err(|e| format!("{e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lexer::token::TokenType;
+
+    // ----------------------------------------------------------------------
+    // The column-strip hook, tested on its own
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn strip_drops_sequence_and_keeps_code() {
+        // cols 1–6 = "000100", col 7 = ' ', code begins at col 8.
+        assert_eq!(
+            strip_cobol_columns("000100 PROGRAM-ID. PAYROLL.".into()),
+            "PROGRAM-ID. PAYROLL."
+        );
+    }
+
+    #[test]
+    fn strip_drops_identification_area() {
+        // Build an 80-col card: 6 seq + 1 indicator + code padded to col 72 +
+        // an 8-char identification tail (cols 73–80) that must be dropped.
+        let code = "DISPLAY X."; // 10 chars of code starting col 8
+        let pad = " ".repeat(72 - 7 - code.len()); // fill up to col 72
+        let card = format!("000100 {code}{pad}IDENTTAG");
+        assert_eq!(card.chars().count(), 80, "test card must be 80 columns");
+        assert_eq!(strip_cobol_columns(card).trim_end(), "DISPLAY X.");
+    }
+
+    #[test]
+    fn strip_removes_comment_lines() {
+        // col 7 = '*' → whole line dropped; '/' likewise.
+        let src = "000100 DATA DIVISION.\n000200*THIS IS A COMMENT\n000300/PAGE EJECT\n000400 PROCEDURE DIVISION.";
+        assert_eq!(
+            strip_cobol_columns(src.into()),
+            "DATA DIVISION.\nPROCEDURE DIVISION."
+        );
+    }
+
+    #[test]
+    fn strip_splices_continuation_lines() {
+        // col 7 = '-' → this line's code appends to the previous line.
+        let src = "000100 MOVE FIRST-\n000200-PART TO X.";
+        assert_eq!(strip_cobol_columns(src.into()), "MOVE FIRST-PART TO X.");
+    }
+
+    // ----------------------------------------------------------------------
+    // Lexer test helpers (operate on already-stripped output too, since the
+    // hook is a no-op when there are no columns... but note: the hook DROPS the
+    // first 7 chars of every line, so test inputs are written as card images).
+    // ----------------------------------------------------------------------
+
+    /// (effective_type_name, value) for every non-EOF token.
+    fn pairs(src: &str) -> Vec<(String, String)> {
+        tokenize_cobol(src)
+            .into_iter()
+            .filter(|t| t.type_ != TokenType::Eof)
+            .map(|t| (t.effective_type_name().to_string(), t.value.clone()))
+            .collect()
+    }
+
+    fn kinds(src: &str) -> Vec<String> {
+        pairs(src).into_iter().map(|(k, _)| k).collect()
+    }
+
+    /// A one-line card: 7 leading columns (6 sequence + 1 space indicator) then
+    /// the code. Keeps the lexer tests readable without hand-counting columns.
+    fn card(code: &str) -> String {
+        format!("000000 {code}")
+    }
+
+    // ----------------------------------------------------------------------
+    // Core tokens
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn division_headers_are_keywords() {
+        assert_eq!(
+            pairs(&card("IDENTIFICATION DIVISION.")),
+            vec![
+                ("KEYWORD".into(), "IDENTIFICATION".into()),
+                ("KEYWORD".into(), "DIVISION".into()),
+                ("DOT".into(), ".".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn hyphenated_names_and_reserved_words() {
+        // GROSS-PAY is a NAME; WORKING-STORAGE and PROGRAM-ID are reserved.
+        assert_eq!(pairs(&card("GROSS-PAY")), vec![("NAME".into(), "GROSS-PAY".into())]);
+        assert_eq!(pairs(&card("WORKING-STORAGE")), vec![("KEYWORD".into(), "WORKING-STORAGE".into())]);
+        assert_eq!(pairs(&card("PROGRAM-ID")), vec![("KEYWORD".into(), "PROGRAM-ID".into())]);
+    }
+
+    #[test]
+    fn level_numbers_lex_as_number() {
+        // 01, 77, 88 are just NUMBERs here; the parser recognises the level.
+        assert_eq!(
+            pairs(&card("01  EMP-NAME")),
+            vec![("NUMBER".into(), "01".into()), ("NAME".into(), "EMP-NAME".into())]
+        );
+        assert_eq!(pairs(&card("77"))[0], ("NUMBER".into(), "77".into()));
+    }
+
+    #[test]
+    fn numeric_literal_vs_terminating_dot() {
+        // `3.14` is one NUMBER; the trailing `.` (VALUE 100.) is a separate DOT.
+        assert_eq!(
+            pairs(&card("VALUE 3.14.")),
+            vec![
+                ("KEYWORD".into(), "VALUE".into()),
+                ("NUMBER".into(), "3.14".into()),
+                ("DOT".into(), ".".into()),
+            ]
+        );
+        assert_eq!(
+            pairs(&card("VALUE 100.")),
+            vec![
+                ("KEYWORD".into(), "VALUE".into()),
+                ("NUMBER".into(), "100".into()),
+                ("DOT".into(), ".".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn string_literals_both_quote_styles() {
+        assert_eq!(kinds(&card("DISPLAY \"HELLO\" 'X'")), vec!["KEYWORD", "STRING", "STRING"]);
+    }
+
+    #[test]
+    fn optional_separators_are_skipped() {
+        // COBOL commas/semicolons are optional separators — pure noise.
+        assert_eq!(
+            kinds(&card("DISPLAY A, B; C")),
+            vec!["KEYWORD", "NAME", "NAME", "NAME"]
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // PICTURE strings via the `picture` mode transition
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn picture_clause_yields_one_pic_string() {
+        assert_eq!(
+            pairs(&card("PICTURE X(20)")),
+            vec![("KEYWORD".into(), "PICTURE".into()), ("PIC_STRING".into(), "X(20)".into())]
+        );
+        assert_eq!(
+            pairs(&card("PIC 9(3)V99")),
+            vec![("KEYWORD".into(), "PIC".into()), ("PIC_STRING".into(), "9(3)V99".into())]
+        );
+    }
+
+    #[test]
+    fn picture_terminates_at_entry_period() {
+        // The core picture pattern excludes `.`, so `PIC X(20).` splits the
+        // picture from the entry-terminating DOT.
+        assert_eq!(
+            pairs(&card("PIC X(20).")),
+            vec![
+                ("KEYWORD".into(), "PIC".into()),
+                ("PIC_STRING".into(), "X(20)".into()),
+                ("DOT".into(), ".".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mode_returns_to_default_after_picture() {
+        // After the picture, `VALUE ZERO` must lex as ordinary keywords — proof
+        // the lexer left `picture` mode.
+        assert_eq!(
+            pairs(&card("PIC S9(4)V99 VALUE ZERO.")),
+            vec![
+                ("KEYWORD".into(), "PIC".into()),
+                ("PIC_STRING".into(), "S9(4)V99".into()),
+                ("KEYWORD".into(), "VALUE".into()),
+                ("KEYWORD".into(), "ZERO".into()),
+                ("DOT".into(), ".".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_bare_x_outside_picture_is_a_name() {
+        // Critically: `X` is only a picture symbol *after* PIC. In a MOVE it is
+        // an ordinary data name.
+        assert_eq!(
+            pairs(&card("MOVE ZERO TO X.")),
+            vec![
+                ("KEYWORD".into(), "MOVE".into()),
+                ("KEYWORD".into(), "ZERO".into()),
+                ("KEYWORD".into(), "TO".into()),
+                ("NAME".into(), "X".into()),
+                ("DOT".into(), ".".into()),
+            ]
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // Whole carded program (column strip + mode transitions together)
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn full_carded_program_tokenizes() {
+        // A complete four-division program as 80-column card images, including a
+        // comment line, level entries with PICTUREs, and a PROCEDURE paragraph.
+        let src = "\
+000100 IDENTIFICATION DIVISION.
+000200 PROGRAM-ID. PAYROLL.
+000300*COMPUTE ONE EMPLOYEE'S PAY
+000400 DATA DIVISION.
+000500 WORKING-STORAGE SECTION.
+000600 01  EMP-NAME     PICTURE X(20).
+000700 77  GROSS-PAY    PIC 9(6)V99 VALUE ZERO.
+000800 PROCEDURE DIVISION.
+000900 MAIN-PARAGRAPH.
+001000     MOVE ZERO TO GROSS-PAY.
+001100     DISPLAY EMP-NAME GROSS-PAY.
+001200     STOP RUN.";
+        let toks = tokenize_cobol(src);
+
+        // Ends in exactly one EOF.
+        assert_eq!(toks.last().unwrap().type_, TokenType::Eof);
+        assert_eq!(toks.iter().filter(|t| t.type_ == TokenType::Eof).count(), 1);
+
+        // The comment line was dropped: no token has value "COMPUTE".
+        assert!(!toks.iter().any(|t| t.value == "COMPUTE"), "comment line leaked");
+
+        // Two PICTURE clauses → two PIC_STRING tokens, with the expected values.
+        let pics: Vec<&str> = toks
+            .iter()
+            .filter(|t| t.effective_type_name() == "PIC_STRING")
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(pics, vec!["X(20)", "9(6)V99"]);
+
+        // All four division headers are present as keywords.
+        for div in ["IDENTIFICATION", "DATA", "PROCEDURE"] {
+            assert!(
+                toks.iter().any(|t| t.effective_type_name() == "KEYWORD" && t.value == div),
+                "missing division keyword {div}"
+            );
+        }
+        // ENVIRONMENT is optional and omitted here — confirm we didn't invent it.
+        assert!(!toks.iter().any(|t| t.value == "ENVIRONMENT"));
+    }
+
+    #[test]
+    fn unknown_character_is_an_error() {
+        // `@` is not a COBOL character (in the code area).
+        assert!(try_tokenize_cobol(&card("MOVE @ TO X.")).is_err());
+    }
+}


### PR DESCRIPTION
## COBOL-60 frontend — PR2 (lexer)

The COBOL-60 lexer: the FLOW-MATIC lexer pattern (#7958) **plus** the two things FLOW-MATIC deliberately let us skip — the **fixed-column card format** and **PICTURE** strings. Implements the lexer half of the PL07 spec (#7967).

### What's in this PR
- **`code/grammars/cobol/cobol.tokens`** — token grammar: hyphenated `NAME`s, a focused subset of COBOL-60 reserved words as case-insensitive `KEYWORD`s, numeric/quoted literals, `. ( )` punctuation, `,`/`;` skipped as optional separators, and a `picture` mode group.
- **`code/packages/rust/cobol-lexer/`** — a thin `GrammarLexer` wrapper. The **one** piece of COBOL-specific imperative code is **`strip_cobol_columns`**, a pure `String -> String` pre-tokenize hook (registered via `GrammarLexer::add_pre_tokenize`) that drops the sequence (1–6) and identification (73–80) areas, removes `*`/`/` comment lines, splices `-` continuations, and keeps the code area (8–72). **16 tests + a doctest**, including the strip hook in isolation and a complete carded four-division program.
- One-line workspace member registration.

### Design decisions
- **PICTURE strings are context-sensitive** (`X(20)` looks like a `NAME`), so they use the lexer's declarative **mode-transition** feature (F10): `PIC`/`PICTURE` switches into a `picture` group matching one `PIC_STRING` (core symbols `9 X A V S P` + repetition), then switches back. The core pattern excludes `.`, so `PIC X(20).` cleanly splits the picture from the entry-terminating `DOT`. No hook needed.
- **Level numbers** (`01`/`77`/`88`) lex as `NUMBER`; the parser recognises a level by value and position — keeping the lexer dumb, as with FLOW-MATIC operation numbers.
- Grammar named `cobol.tokens` (matching the crate-derived stem, like `dartmouth_basic`) so the generator's auto-discovery finds it without a versioned family.

### Verification
- `validate-tokens` → OK (7 tokens). `cargo test -p coding-adventures-cobol-lexer` → **16 + doctest pass**.
- Branched fresh off current `origin/main`.
- Security review passed: `strip_cobol_columns` is panic-safe on all adversarial input (char-based indexing, guarded bounds); NAME's nested quantifier is ReDoS-safe (hyphen is a hard delimiter); the `picture` mode transition provably cannot loop (inheriting set-mode + guaranteed loop progress).

Implements the lexer half of #7967. Parser (PR3) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)