### PR TITLE
feat(cobol): parser + grammar (PL07, PR3)

### DIFF
--- a/code/grammars/cobol/cobol.grammar
+++ b/code/grammars/cobol/cobol.grammar
@@ -1,0 +1,138 @@
+# COBOL-60 Parser Grammar
+# ============================================================
+#
+# The syntactic layer of the COBOL-60 frontend (see PL07-cobol-60.md).  It
+# consumes the token stream produced by cobol.tokens (after the lexer's
+# column-strip pre-tokenize hook) and builds a generic concrete syntax tree via
+# the shared `GrammarParser` (recursive-descent PEG with packrat memoization).
+# Nothing is hand-written.
+#
+# A COBOL program is exactly four divisions, always in order — IDENTIFICATION,
+# ENVIRONMENT, DATA, PROCEDURE — of which only IDENTIFICATION and PROCEDURE are
+# required.  Nearly every construct ends in a period (DOT).
+#
+# ------------------------------------------------------------
+# Grammar reminders (see grammar-format.md)
+# ------------------------------------------------------------
+#   * The FIRST rule (`program`) is the entry point; the whole token stream must
+#     be consumed.
+#   * UPPERCASE names (NAME, NUMBER, STRING, PIC_STRING, DOT, LPAREN, RPAREN)
+#     reference token TYPES.
+#   * "QUOTED" literals match a token's VALUE.  Reserved words are normalized to
+#     uppercase by the lexer, so literals here are uppercase.
+#   * `{ x }` = zero or more (greedy), `[ x ]` = optional, `( x )` = grouping,
+#     `|` = ordered choice.  No left recursion.
+#   * Level numbers arrive as NUMBER tokens (the lexer keeps no LEVEL token); a
+#     data entry is therefore `NUMBER NAME … DOT`.
+
+# @version 1
+
+# ============================================================
+# Program: the four divisions
+# ============================================================
+program = identification_division
+          [ environment_division ]
+          [ data_division ]
+          procedure_division ;
+
+# ============================================================
+# IDENTIFICATION DIVISION
+# ============================================================
+#
+# The header, the required PROGRAM-ID, then optional commentary paragraphs
+# (AUTHOR, DATE-WRITTEN, …) whose bodies are free text up to the next period.
+identification_division =
+    "IDENTIFICATION" "DIVISION" DOT
+    program_id
+    { id_paragraph } ;
+
+program_id = "PROGRAM-ID" DOT NAME DOT ;
+
+id_paragraph = id_keyword DOT { comment_word } DOT ;
+id_keyword   = "AUTHOR" | "INSTALLATION" | "DATE-WRITTEN"
+             | "DATE-COMPILED" | "SECURITY" | "REMARKS" ;
+# Commentary text is arbitrary words; we accept names, numbers, and literals.
+comment_word = NAME | NUMBER | STRING ;
+
+# ============================================================
+# ENVIRONMENT DIVISION (optional)
+# ============================================================
+#
+# A minimal but real subset: the CONFIGURATION SECTION (SOURCE/OBJECT-COMPUTER)
+# and the INPUT-OUTPUT SECTION (FILE-CONTROL / SELECT).  Richer FD descriptions
+# are future work.
+environment_division = "ENVIRONMENT" "DIVISION" DOT { env_section } ;
+env_section = configuration_section | input_output_section ;
+
+configuration_section =
+    "CONFIGURATION" "SECTION" DOT { config_paragraph } ;
+config_paragraph = ( "SOURCE-COMPUTER" | "OBJECT-COMPUTER" ) DOT NAME DOT ;
+
+input_output_section =
+    "INPUT-OUTPUT" "SECTION" DOT "FILE-CONTROL" DOT { select_sentence } ;
+select_sentence = "SELECT" NAME "ASSIGN" "TO" NAME DOT ;
+
+# ============================================================
+# DATA DIVISION (optional)
+# ============================================================
+#
+# The WORKING-STORAGE and FILE sections are lists of data entries.  A data entry
+# is a level number, a name (or FILLER), zero or more clauses, and a period.
+data_division = "DATA" "DIVISION" DOT { data_section } ;
+data_section  = working_storage_section | file_section ;
+
+working_storage_section = "WORKING-STORAGE" "SECTION" DOT { data_entry } ;
+file_section            = "FILE" "SECTION" DOT { file_or_data_entry } ;
+file_or_data_entry      = fd_entry | data_entry ;
+fd_entry                = "FD" NAME { comment_word } DOT ;
+
+data_entry  = NUMBER ( NAME | "FILLER" ) { data_clause } DOT ;
+data_clause = picture_clause | value_clause ;
+
+picture_clause = ( "PICTURE" | "PIC" ) PIC_STRING ;
+value_clause   = "VALUE" [ "IS" ] literal ;
+
+# ============================================================
+# PROCEDURE DIVISION
+# ============================================================
+#
+# Optional sections, then paragraphs (a name, then sentences).  A sentence is one
+# or more statements terminated by a period.  Statement verbs and paragraph names
+# never collide: a statement begins with a verb KEYWORD, a paragraph with a NAME.
+procedure_division = "PROCEDURE" "DIVISION" DOT { paragraph } ;
+paragraph = NAME DOT { sentence } ;
+sentence  = statement { statement } DOT ;
+
+statement = move_stmt | display_stmt | accept_stmt
+          | add_stmt | subtract_stmt | multiply_stmt | divide_stmt
+          | perform_stmt | goto_stmt | if_stmt | stop_stmt ;
+
+move_stmt     = "MOVE" operand "TO" NAME { NAME } ;
+display_stmt  = "DISPLAY" operand { operand } ;
+accept_stmt   = "ACCEPT" NAME ;
+add_stmt      = "ADD" operand { operand } "TO" NAME [ "GIVING" NAME ] ;
+subtract_stmt = "SUBTRACT" operand { operand } "FROM" NAME [ "GIVING" NAME ] ;
+multiply_stmt = "MULTIPLY" operand "BY" operand [ "GIVING" NAME ] ;
+divide_stmt   = "DIVIDE" operand "INTO" operand [ "GIVING" NAME ] ;
+perform_stmt  = "PERFORM" NAME [ "THROUGH" NAME | "THRU" NAME ]
+                        [ operand "TIMES" ] ;
+goto_stmt     = "GO" [ "TO" ] NAME ;
+stop_stmt     = "STOP" ( "RUN" | NUMBER | STRING ) ;
+
+# IF: a simple relational condition, a then-branch of statements, optional ELSE.
+# Nested sentences terminate at the enclosing sentence's period.
+if_stmt   = "IF" condition { statement } [ "ELSE" { statement } ] ;
+condition = operand relop operand ;
+relop     = [ "IS" ] [ "NOT" ]
+            ( "GREATER" [ "THAN" ] | "LESS" [ "THAN" ] | "EQUAL" [ "TO" ] ) ;
+
+# ============================================================
+# Operands and literals
+# ============================================================
+operand    = NAME | literal ;
+literal    = NUMBER | STRING | figurative ;
+figurative = "ZERO" | "ZEROS" | "ZEROES"
+           | "SPACE" | "SPACES"
+           | "HIGH-VALUE" | "HIGH-VALUES"
+           | "LOW-VALUE" | "LOW-VALUES"
+           | "QUOTE" | "QUOTES" ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -225,6 +225,7 @@ members = [
     "c-parser",
     "c-to-semantic-ir",
     "cobol-lexer",
+    "cobol-parser",
     "matlab-runtime",
     "matlab-repl",
     "octave-runtime",

--- a/code/packages/rust/cobol-parser/BUILD
+++ b/code/packages/rust/cobol-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-cobol-parser -- --nocapture

--- a/code/packages/rust/cobol-parser/BUILD_windows
+++ b/code/packages/rust/cobol-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-cobol-parser -- --nocapture

--- a/code/packages/rust/cobol-parser/CHANGELOG.md
+++ b/code/packages/rust/cobol-parser/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.0 — COBOL-60 parser (PL07)
+
+- Grammar-driven parser over `code/grammars/cobol/cobol.grammar`, wrapping
+  `parser::GrammarParser`. Public API: `parse_cobol` / `try_parse_cobol` /
+  `create_cobol_parser`. CST rooted at `"program"`.
+- Grammar covers the demonstrated language: the four divisions (IDENTIFICATION
+  and PROCEDURE required; ENVIRONMENT and DATA optional); IDENTIFICATION with
+  `PROGRAM-ID` and commentary paragraphs; a minimal ENVIRONMENT (CONFIGURATION
+  and INPUT-OUTPUT sections); DATA `WORKING-STORAGE`/`FILE` entries with level
+  numbers, `PICTURE`, and `VALUE`; and PROCEDURE paragraphs of sentences over the
+  core verbs (`MOVE`, `DISPLAY`, `ACCEPT`, `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE …
+  GIVING`, `PERFORM`, `GO TO`, `IF … ELSE`, `STOP RUN`).
+- Data entries parse as `NUMBER (NAME | FILLER) { clause } DOT` — the leading
+  NUMBER is the level (the lexer keeps no LEVEL token). Sentences and paragraph
+  names never collide (verb KEYWORD vs NAME).
+- Tests parse the full carded four-division program end to end, plus each
+  division and statement kind in isolation.

--- a/code/packages/rust/cobol-parser/Cargo.toml
+++ b/code/packages/rust/cobol-parser/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "coding-adventures-cobol-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for COBOL-60 — parses COBOL source into a generic parse tree using the grammar-driven parser and the cobol.grammar file."
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-cobol-lexer = { path = "../cobol-lexer" }

--- a/code/packages/rust/cobol-parser/README.md
+++ b/code/packages/rust/cobol-parser/README.md
@@ -1,0 +1,44 @@
+# cobol-parser (coding-adventures-cobol-parser)
+
+Parser for **COBOL-60** — the syntactic layer of the COBOL frontend. It
+tokenizes with [`coding-adventures-cobol-lexer`](../cobol-lexer) (which strips the
+80-column card format and lexes PICTURE strings) and feeds the tokens to the
+generic `parser::GrammarParser` driving the compiled `cobol.grammar`
+(`code/grammars/cobol/cobol.grammar`). Nothing is hand-written.
+
+Implements the parser layer of [PL07](../../../specs/PL07-cobol-60.md).
+
+## API
+
+```rust
+use coding_adventures_cobol_parser::{parse_cobol, try_parse_cobol};
+
+let cst = parse_cobol("000100 IDENTIFICATION DIVISION.\n000200 PROGRAM-ID. HELLO.\n\
+                       000300 PROCEDURE DIVISION.\n000400 MAIN.\n000500     STOP RUN.");
+assert_eq!(cst.rule_name, "program");
+```
+
+`parse_cobol` returns a generic `GrammarASTNode` CST rooted at `"program"`;
+consumers walk it by `rule_name`.
+
+## What it parses
+
+The **demonstrated language** of PL07: a four-division program (IDENTIFICATION
+and PROCEDURE required; ENVIRONMENT and DATA optional), `WORKING-STORAGE` data
+entries with level numbers / `PICTURE` / `VALUE`, and PROCEDURE paragraphs of
+sentences built from the core verbs (`MOVE`, `DISPLAY`, `ACCEPT`,
+`ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE … GIVING`, `PERFORM`, `GO TO`, `IF … ELSE`,
+`STOP RUN`), plus a minimal ENVIRONMENT (CONFIGURATION / INPUT-OUTPUT sections).
+
+The long tail (full FD record descriptions, `REDEFINES`/`OCCURS`, `88`
+conditions, editing PICTUREs, the complete reserved-word set) is future work; see
+PL07.
+
+## Regenerating the grammar
+
+`src/_grammar.rs` is generated from `code/grammars/cobol/cobol.grammar`:
+
+```
+cargo run --release --manifest-path code/programs/rust/grammar-tools/Cargo.toml \
+  -- generate-rust-compiled-grammars cobol
+```

--- a/code/packages/rust/cobol-parser/src/_grammar.rs
+++ b/code/packages/rust/cobol-parser/src/_grammar.rs
@@ -1,0 +1,492 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: cobol.grammar
+// Regenerate with: grammar-tools compile-grammar cobol.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"identification_division"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"environment_division"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"data_division"#.to_string() }) },
+                GrammarElement::RuleReference { name: r#"procedure_division"#.to_string() },
+            ] },
+            line_number: 33,
+        },
+        GrammarRule {
+            name: r#"identification_division"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"IDENTIFICATION"#.to_string() },
+                GrammarElement::Literal { value: r#"DIVISION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::RuleReference { name: r#"program_id"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"id_paragraph"#.to_string() }) },
+            ] },
+            line_number: 44,
+        },
+        GrammarRule {
+            name: r#"program_id"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"PROGRAM-ID"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 49,
+        },
+        GrammarRule {
+            name: r#"id_paragraph"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"id_keyword"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"comment_word"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 51,
+        },
+        GrammarRule {
+            name: r#"id_keyword"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"AUTHOR"#.to_string() },
+                GrammarElement::Literal { value: r#"INSTALLATION"#.to_string() },
+                GrammarElement::Literal { value: r#"DATE-WRITTEN"#.to_string() },
+                GrammarElement::Literal { value: r#"DATE-COMPILED"#.to_string() },
+                GrammarElement::Literal { value: r#"SECURITY"#.to_string() },
+                GrammarElement::Literal { value: r#"REMARKS"#.to_string() },
+            ] },
+            line_number: 52,
+        },
+        GrammarRule {
+            name: r#"comment_word"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+            ] },
+            line_number: 55,
+        },
+        GrammarRule {
+            name: r#"environment_division"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"ENVIRONMENT"#.to_string() },
+                GrammarElement::Literal { value: r#"DIVISION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"env_section"#.to_string() }) },
+            ] },
+            line_number: 64,
+        },
+        GrammarRule {
+            name: r#"env_section"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"configuration_section"#.to_string() },
+                GrammarElement::RuleReference { name: r#"input_output_section"#.to_string() },
+            ] },
+            line_number: 65,
+        },
+        GrammarRule {
+            name: r#"configuration_section"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"CONFIGURATION"#.to_string() },
+                GrammarElement::Literal { value: r#"SECTION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"config_paragraph"#.to_string() }) },
+            ] },
+            line_number: 67,
+        },
+        GrammarRule {
+            name: r#"config_paragraph"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"SOURCE-COMPUTER"#.to_string() },
+                        GrammarElement::Literal { value: r#"OBJECT-COMPUTER"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 69,
+        },
+        GrammarRule {
+            name: r#"input_output_section"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"INPUT-OUTPUT"#.to_string() },
+                GrammarElement::Literal { value: r#"SECTION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Literal { value: r#"FILE-CONTROL"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"select_sentence"#.to_string() }) },
+            ] },
+            line_number: 71,
+        },
+        GrammarRule {
+            name: r#"select_sentence"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"SELECT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Literal { value: r#"ASSIGN"#.to_string() },
+                GrammarElement::Literal { value: r#"TO"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 73,
+        },
+        GrammarRule {
+            name: r#"data_division"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"DATA"#.to_string() },
+                GrammarElement::Literal { value: r#"DIVISION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"data_section"#.to_string() }) },
+            ] },
+            line_number: 81,
+        },
+        GrammarRule {
+            name: r#"data_section"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"working_storage_section"#.to_string() },
+                GrammarElement::RuleReference { name: r#"file_section"#.to_string() },
+            ] },
+            line_number: 82,
+        },
+        GrammarRule {
+            name: r#"working_storage_section"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"WORKING-STORAGE"#.to_string() },
+                GrammarElement::Literal { value: r#"SECTION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"data_entry"#.to_string() }) },
+            ] },
+            line_number: 84,
+        },
+        GrammarRule {
+            name: r#"file_section"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"FILE"#.to_string() },
+                GrammarElement::Literal { value: r#"SECTION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"file_or_data_entry"#.to_string() }) },
+            ] },
+            line_number: 85,
+        },
+        GrammarRule {
+            name: r#"file_or_data_entry"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"fd_entry"#.to_string() },
+                GrammarElement::RuleReference { name: r#"data_entry"#.to_string() },
+            ] },
+            line_number: 86,
+        },
+        GrammarRule {
+            name: r#"fd_entry"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"FD"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"comment_word"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 87,
+        },
+        GrammarRule {
+            name: r#"data_entry"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        GrammarElement::Literal { value: r#"FILLER"#.to_string() },
+                    ] }) },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"data_clause"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 89,
+        },
+        GrammarRule {
+            name: r#"data_clause"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"picture_clause"#.to_string() },
+                GrammarElement::RuleReference { name: r#"value_clause"#.to_string() },
+            ] },
+            line_number: 90,
+        },
+        GrammarRule {
+            name: r#"picture_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"PICTURE"#.to_string() },
+                        GrammarElement::Literal { value: r#"PIC"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"PIC_STRING"#.to_string() },
+            ] },
+            line_number: 92,
+        },
+        GrammarRule {
+            name: r#"value_clause"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"VALUE"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"IS"#.to_string() }) },
+                GrammarElement::RuleReference { name: r#"literal"#.to_string() },
+            ] },
+            line_number: 93,
+        },
+        GrammarRule {
+            name: r#"procedure_division"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"PROCEDURE"#.to_string() },
+                GrammarElement::Literal { value: r#"DIVISION"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"paragraph"#.to_string() }) },
+            ] },
+            line_number: 102,
+        },
+        GrammarRule {
+            name: r#"paragraph"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"sentence"#.to_string() }) },
+            ] },
+            line_number: 103,
+        },
+        GrammarRule {
+            name: r#"sentence"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"DOT"#.to_string() },
+            ] },
+            line_number: 104,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"move_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"display_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"accept_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"add_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"subtract_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"multiply_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"divide_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"perform_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"goto_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"if_stmt"#.to_string() },
+                GrammarElement::RuleReference { name: r#"stop_stmt"#.to_string() },
+            ] },
+            line_number: 106,
+        },
+        GrammarRule {
+            name: r#"move_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"MOVE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Literal { value: r#"TO"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::TokenReference { name: r#"NAME"#.to_string() }) },
+            ] },
+            line_number: 110,
+        },
+        GrammarRule {
+            name: r#"display_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"DISPLAY"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"operand"#.to_string() }) },
+            ] },
+            line_number: 111,
+        },
+        GrammarRule {
+            name: r#"accept_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"ACCEPT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 112,
+        },
+        GrammarRule {
+            name: r#"add_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"ADD"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"operand"#.to_string() }) },
+                GrammarElement::Literal { value: r#"TO"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"GIVING"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 113,
+        },
+        GrammarRule {
+            name: r#"subtract_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"SUBTRACT"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"operand"#.to_string() }) },
+                GrammarElement::Literal { value: r#"FROM"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"GIVING"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 114,
+        },
+        GrammarRule {
+            name: r#"multiply_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"MULTIPLY"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Literal { value: r#"BY"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"GIVING"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 115,
+        },
+        GrammarRule {
+            name: r#"divide_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"DIVIDE"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Literal { value: r#"INTO"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"GIVING"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 116,
+        },
+        GrammarRule {
+            name: r#"perform_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"PERFORM"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"THROUGH"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"THRU"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                        ] },
+                    ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                        GrammarElement::Literal { value: r#"TIMES"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 117,
+        },
+        GrammarRule {
+            name: r#"goto_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"GO"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"TO"#.to_string() }) },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+            ] },
+            line_number: 119,
+        },
+        GrammarRule {
+            name: r#"stop_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"STOP"#.to_string() },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Literal { value: r#"RUN"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 120,
+        },
+        GrammarRule {
+            name: r#"if_stmt"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"IF"#.to_string() },
+                GrammarElement::RuleReference { name: r#"condition"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"ELSE"#.to_string() },
+                        GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
+                    ] }) },
+            ] },
+            line_number: 124,
+        },
+        GrammarRule {
+            name: r#"condition"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::RuleReference { name: r#"relop"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+            ] },
+            line_number: 125,
+        },
+        GrammarRule {
+            name: r#"relop"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"IS"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"NOT"#.to_string() }) },
+                GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"GREATER"#.to_string() },
+                            GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"THAN"#.to_string() }) },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"LESS"#.to_string() },
+                            GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"THAN"#.to_string() }) },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"EQUAL"#.to_string() },
+                            GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"TO"#.to_string() }) },
+                        ] },
+                    ] }) },
+            ] },
+            line_number: 126,
+        },
+        GrammarRule {
+            name: r#"operand"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"literal"#.to_string() },
+            ] },
+            line_number: 132,
+        },
+        GrammarRule {
+            name: r#"literal"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
+                GrammarElement::RuleReference { name: r#"figurative"#.to_string() },
+            ] },
+            line_number: 133,
+        },
+        GrammarRule {
+            name: r#"figurative"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Literal { value: r#"ZERO"#.to_string() },
+                GrammarElement::Literal { value: r#"ZEROS"#.to_string() },
+                GrammarElement::Literal { value: r#"ZEROES"#.to_string() },
+                GrammarElement::Literal { value: r#"SPACE"#.to_string() },
+                GrammarElement::Literal { value: r#"SPACES"#.to_string() },
+                GrammarElement::Literal { value: r#"HIGH-VALUE"#.to_string() },
+                GrammarElement::Literal { value: r#"HIGH-VALUES"#.to_string() },
+                GrammarElement::Literal { value: r#"LOW-VALUE"#.to_string() },
+                GrammarElement::Literal { value: r#"LOW-VALUES"#.to_string() },
+                GrammarElement::Literal { value: r#"QUOTE"#.to_string() },
+                GrammarElement::Literal { value: r#"QUOTES"#.to_string() },
+            ] },
+            line_number: 134,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/cobol-parser/src/lib.rs
+++ b/code/packages/rust/cobol-parser/src/lib.rs
@@ -1,0 +1,301 @@
+//! # COBOL-60 parser — the syntactic layer of the four-division program.
+//!
+//! COBOL-60 (CODASYL, the 1960 report) is FLOW-MATIC's direct descendant. This
+//! crate is the **parser** half of its frontend: it tokenizes with
+//! [`coding_adventures_cobol_lexer`] — which strips the 80-column card format
+//! and lexes PICTURE strings — and feeds the tokens to the generic
+//! [`GrammarParser`] driving the compiled `cobol.grammar`.
+//!
+//! ```text
+//! COBOL-60 source (carded)
+//!    │  cobol_lexer::tokenize_cobol   (column-strip hook + tokenize)
+//!    ▼
+//! Vec<Token>
+//!    │  parser::GrammarParser (cobol.grammar → CST)
+//!    ▼
+//! GrammarASTNode  { rule_name, children }   (root rule_name == "program")
+//! ```
+//!
+//! The tree is the generic, uniform [`GrammarASTNode`]; a consumer walks it by
+//! `rule_name`. Nothing is hand-written — the grammar file is the single source
+//! of truth.
+//!
+//! ## What it parses
+//!
+//! The demonstrated language of [PL07](../../../specs/PL07-cobol-60.md): a
+//! four-division program (IDENTIFICATION and PROCEDURE required; ENVIRONMENT and
+//! DATA optional), `WORKING-STORAGE` data entries (level numbers, `PICTURE`,
+//! `VALUE`), and PROCEDURE paragraphs of sentences over the core verbs.
+//!
+//! ## Public API
+//!
+//! - [`create_cobol_parser`] — a configured [`GrammarParser`], ready to `.parse()`.
+//! - [`parse_cobol`] — convenience `&str` → [`GrammarASTNode`] (panics on error).
+//! - [`try_parse_cobol`] — the fully fallible form (lexical *and* parse errors → `Err`).
+
+use coding_adventures_cobol_lexer::{tokenize_cobol, try_tokenize_cobol};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+mod _grammar;
+
+/// Create a [`GrammarParser`] wired to the COBOL grammar and tokens (with the
+/// lexer's column-strip hook), ready to call `.parse()`. Uses the panicking
+/// tokenizer; for the fully fallible path use [`try_parse_cobol`].
+pub fn create_cobol_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_cobol(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+}
+
+/// Parse COBOL-60 `source` into a [`GrammarASTNode`] CST rooted at `"program"`.
+/// Panics on a parse error; use [`try_parse_cobol`] for the fallible form.
+pub fn parse_cobol(source: &str) -> GrammarASTNode {
+    try_parse_cobol(source).unwrap_or_else(|e| panic!("COBOL parse failed: {e}"))
+}
+
+/// Parse COBOL-60 `source`, returning a human-readable error string on failure.
+/// The truly fallible path — a *lexical* error becomes an `Err` too (it routes
+/// through [`try_tokenize_cobol`], not the panicking tokenizer that
+/// [`create_cobol_parser`] uses).
+pub fn try_parse_cobol(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_cobol(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .parse()
+        .map_err(|e| format!("{e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn root(src: &str) -> GrammarASTNode {
+        parse_cobol(src)
+    }
+
+    fn has_rule(node: &GrammarASTNode, target: &str) -> bool {
+        if node.rule_name == target {
+            return true;
+        }
+        node.children.iter().any(|c| match c {
+            ASTNodeOrToken::Node(n) => has_rule(n, target),
+            ASTNodeOrToken::Token(_) => false,
+        })
+    }
+
+    fn count_rule(node: &GrammarASTNode, target: &str) -> usize {
+        let here = usize::from(node.rule_name == target);
+        here + node
+            .children
+            .iter()
+            .map(|c| match c {
+                ASTNodeOrToken::Node(n) => count_rule(n, target),
+                ASTNodeOrToken::Token(_) => 0,
+            })
+            .sum::<usize>()
+    }
+
+    /// A one-line card (6 sequence cols + 1 space indicator, then code).
+    fn card(code: &str) -> String {
+        format!("000000 {code}")
+    }
+
+    /// Assemble a program from code lines, carding each one.
+    fn program(lines: &[&str]) -> String {
+        lines.iter().map(|l| card(l)).collect::<Vec<_>>().join("\n")
+    }
+
+    // ----------------------------------------------------------------------
+    // Smallest legal program: IDENTIFICATION + PROCEDURE
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn minimal_program() {
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. HELLO.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    STOP RUN.",
+        ]));
+        assert_eq!(ast.rule_name, "program");
+        assert!(has_rule(&ast, "identification_division"));
+        assert!(has_rule(&ast, "procedure_division"));
+        assert!(has_rule(&ast, "stop_stmt"));
+        // No optional divisions were invented.
+        assert!(!has_rule(&ast, "environment_division"));
+        assert!(!has_rule(&ast, "data_division"));
+    }
+
+    // ----------------------------------------------------------------------
+    // DATA DIVISION: level numbers, PICTURE, VALUE
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn working_storage_entries() {
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. PAY.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  EMPLOYEE-RECORD.",
+            "    02  EMP-NAME  PICTURE X(20).",
+            "    02  EMP-RATE  PIC 9(3)V99.",
+            "77  GROSS-PAY  PIC 9(6)V99 VALUE ZERO.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    STOP RUN.",
+        ]));
+        assert!(has_rule(&ast, "working_storage_section"));
+        // Four data entries: the 01 record, two 02 items, and the 77 item.
+        assert_eq!(count_rule(&ast, "data_entry"), 4);
+        // Two PICTURE clauses carry PIC_STRINGs; the 01 group item has none.
+        assert_eq!(count_rule(&ast, "picture_clause"), 3);
+        assert!(has_rule(&ast, "value_clause"));
+    }
+
+    #[test]
+    fn filler_and_value_is() {
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  FILLER  PIC X VALUE IS SPACE.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    STOP RUN.",
+        ]));
+        assert_eq!(count_rule(&ast, "data_entry"), 1);
+        assert!(has_rule(&ast, "value_clause"));
+    }
+
+    // ----------------------------------------------------------------------
+    // PROCEDURE DIVISION: paragraphs, sentences, verbs
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn procedure_paragraphs_and_verbs() {
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN-PARAGRAPH.",
+            "    MOVE ZERO TO GROSS-PAY.",
+            "    MULTIPLY EMP-RATE BY EMP-HOURS GIVING GROSS-PAY.",
+            "    DISPLAY EMP-NAME GROSS-PAY.",
+            "    PERFORM SUB-ROUTINE.",
+            "    GO TO MAIN-PARAGRAPH.",
+            "SUB-ROUTINE.",
+            "    STOP RUN.",
+        ]));
+        assert_eq!(count_rule(&ast, "paragraph"), 2);
+        assert!(has_rule(&ast, "move_stmt"));
+        assert!(has_rule(&ast, "multiply_stmt"));
+        assert!(has_rule(&ast, "display_stmt"));
+        assert!(has_rule(&ast, "perform_stmt"));
+        assert!(has_rule(&ast, "goto_stmt"));
+        // DISPLAY takes multiple operands.
+        assert!(has_rule(&ast, "display_stmt"));
+    }
+
+    #[test]
+    fn if_else_statement() {
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    IF GROSS-PAY IS GREATER THAN ZERO",
+            "        DISPLAY GROSS-PAY",
+            "    ELSE",
+            "        DISPLAY ZERO.",
+            "    STOP RUN.",
+        ]));
+        assert!(has_rule(&ast, "if_stmt"));
+        assert!(has_rule(&ast, "condition"));
+        // Two DISPLAYs: one in the then-branch, one in the else-branch.
+        assert_eq!(count_rule(&ast, "display_stmt"), 2);
+    }
+
+    // ----------------------------------------------------------------------
+    // ENVIRONMENT DIVISION (optional, minimal)
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn environment_configuration_section() {
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "ENVIRONMENT DIVISION.",
+            "CONFIGURATION SECTION.",
+            "SOURCE-COMPUTER. UNIVAC-II.",
+            "OBJECT-COMPUTER. UNIVAC-II.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    STOP RUN.",
+        ]));
+        assert!(has_rule(&ast, "environment_division"));
+        assert!(has_rule(&ast, "configuration_section"));
+        assert_eq!(count_rule(&ast, "config_paragraph"), 2);
+    }
+
+    // ----------------------------------------------------------------------
+    // The whole demonstrated program, all together
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn full_four_division_program() {
+        let src = "\
+000100 IDENTIFICATION DIVISION.
+000200 PROGRAM-ID. PAYROLL.
+000300 AUTHOR. GRACE HOPPER.
+000400 ENVIRONMENT DIVISION.
+000500 CONFIGURATION SECTION.
+000600 SOURCE-COMPUTER. UNIVAC-II.
+000700 OBJECT-COMPUTER. UNIVAC-II.
+000800 DATA DIVISION.
+000900 WORKING-STORAGE SECTION.
+001000 01  EMP-NAME     PICTURE X(20).
+001100 77  GROSS-PAY    PIC 9(6)V99 VALUE ZERO.
+001200 PROCEDURE DIVISION.
+001300 MAIN-PARAGRAPH.
+001400     MOVE ZERO TO GROSS-PAY.
+001500     DISPLAY EMP-NAME GROSS-PAY.
+001600     STOP RUN.";
+        let ast = root(src);
+        assert_eq!(ast.rule_name, "program");
+        // All four divisions present.
+        for rule in [
+            "identification_division", "environment_division",
+            "data_division", "procedure_division",
+        ] {
+            assert!(has_rule(&ast, rule), "missing {rule}");
+        }
+        // The commentary AUTHOR paragraph parsed.
+        assert!(has_rule(&ast, "id_paragraph"));
+    }
+
+    // ----------------------------------------------------------------------
+    // Error paths
+    // ----------------------------------------------------------------------
+
+    /// A program with no PROCEDURE DIVISION is incomplete → parse error.
+    #[test]
+    fn missing_procedure_division_is_error() {
+        let src = program(&["IDENTIFICATION DIVISION.", "PROGRAM-ID. P."]);
+        assert!(try_parse_cobol(&src).is_err());
+    }
+
+    /// A lexical error (stray `@` in the code area) surfaces as an `Err`.
+    #[test]
+    fn lexical_error_is_reported() {
+        let src = program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    MOVE @ TO X.",
+        ]);
+        assert!(try_parse_cobol(&src).is_err());
+    }
+}


### PR DESCRIPTION
## COBOL-60 frontend — PR3 (parser)

Completes the COBOL-60 frontend: the parser that turns the lexer's token stream into a concrete syntax tree, so a full four-division program now parses end to end. Implements the parser half of PL07 (#7967).

**Stacked on #7970 (lexer)** — the parser crate depends on the lexer crate. Base is `feat/cobol-lexer`; this will retarget to `main` once the lexer merges. (Per repo history, PR merges here are squash-merges, so if the lexer merges first this branch gets rebuilt fresh off `main`.)

### What's in this PR
- **`code/grammars/cobol/cobol.grammar`** — the parser grammar for the four divisions (IDENTIFICATION + PROCEDURE required; ENVIRONMENT + DATA optional): `PROGRAM-ID` and commentary paragraphs; a minimal ENVIRONMENT (CONFIGURATION / INPUT-OUTPUT); DATA `WORKING-STORAGE`/`FILE` entries with level numbers, `PICTURE`, `VALUE`; and PROCEDURE paragraphs of sentences over the core verbs (`MOVE`, `DISPLAY`, `ACCEPT`, `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE … GIVING`, `PERFORM`, `GO TO`, `IF … ELSE`, `STOP RUN`).
- **`code/packages/rust/cobol-parser/`** — a thin `GrammarParser` wrapper. **9 tests**, including the full carded four-division program parsed end to end.
- One-line workspace member registration.

### Design notes
- **Data entries** parse as `NUMBER (NAME | FILLER) { clause } DOT` — the leading `NUMBER` is the level (the lexer keeps no `LEVEL` token).
- **Statements vs paragraph names** never collide: a statement starts with a verb `KEYWORD`, a paragraph with a `NAME`.

### Verification
- `grammar-tools validate` → 42 rules, cross-validation OK (2 benign warnings: `LPAREN`/`RPAREN` are lexer tokens reserved for pictures/future subscripts, not yet referenced by the parser grammar).
- `cargo test -p …-cobol-lexer -p …-cobol-parser` → **lexer 16 + parser 9 pass**.
- Security review passed with no blockers. One LOW/informational finding: unbounded `IF` nesting can drive recursive-descent depth (stack-overflow DoS) — but this is a **pre-existing, engine-level** property of the shared `parser::GrammarParser` affecting every recursive grammar equally; the fix is a depth guard in the shared crate (already being addressed on `fix/deep-expr-ast-overflow`), not this wrapper.

Completes the frontend begun in #7967/#7970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)