### PR TITLE
feat(sir-oop-ts): Hash Enumerable aggregates (final backend)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.19] - 2026-07-11
+
+### Added
+
+- **`Hash` Enumerable aggregates** (`hashBlockMethod` + `HASH_BLOCK_METHODS`):
+  `find`/`detect`, `any?`, `all?`, `none?`, `count` (block form), `sort_by`,
+  `min_by`, `max_by` — completing the cross-backend mirror of this batch
+  (Python reference, then Go/Rust/JS backends).  Ruby's `Hash` mixes in
+  `Enumerable`, so these iterate the hash as a sequence of `[key, value]` pairs:
+  the block is yielded `[key, value]` (two arguments, matching `each`), and the
+  "element" an aggregate returns is the two-element `[key, value]` list — e.g.
+  `{a: 1, b: 2}.min_by { |k, v| v }` is `[:a, 1]`, and
+  `{a: 1, b: 2, c: 3}.sort_by { |k, v| -v }` is `[[:c, 3], [:b, 2], [:a, 1]]`.
+  `min_by`/`max_by` on an empty hash return `nil`; all are non-mutating.
+- Vitest coverage for the full batch, including the empty-hash `min_by` → nil,
+  a receiver-unchanged assertion, and `respond_to?`.
+
 ## [0.1.18] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -74,7 +74,8 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
 (proc-lenient), predicates routed through SIR `truthy`; (item **M1c**) the
 **`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/
-`select`/`transform_values`/`transform_keys`/…); and (item **M1c**) the
+`select`/`transform_values`/`transform_keys`/ Enumerable aggregates
+`find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/…); and (item **M1c**) the
 **`String`** catalog (`length`,
 `upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
 `chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -623,6 +623,15 @@ const HASH_BLOCK_METHODS = new Set<string>([
   "each_value",
   "transform_values",
   "transform_keys",
+  "find",
+  "detect",
+  "any?",
+  "all?",
+  "none?",
+  "count",
+  "sort_by",
+  "min_by",
+  "max_by",
 ]);
 
 // Non-block `String` methods (M1c).  A Ruby `String` is a JS `string`, which is
@@ -1254,6 +1263,70 @@ function hashBlockMethod(recv: Map<Val, Val>, name: string, block: Closure): Val
       // `Map` constructor folds a list of pairs (later duplicate keys overwrite
       // the value while the slot stays put).
       return new Map<Val, Val>([...recv].map(([k, v]: [Val, Val]) => [apply(block, [k]), v]));
+    // ── Enumerable aggregates (Hash includes Enumerable) ──────────────────
+    //
+    // Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as a
+    // sequence of `[key, value]` pairs: the block is yielded `[key, value]`
+    // (two arguments, matching `each`), and the "element" an aggregate returns
+    // is the two-element `[key, value]` list.
+    case "find":
+    case "detect":
+      for (const [k, v] of recv) {
+        if (truthy(apply(block, [k, v]))) return [k, v];
+      }
+      return null;
+    case "any?":
+      for (const [k, v] of recv) {
+        if (truthy(apply(block, [k, v]))) return true;
+      }
+      return false;
+    case "all?":
+      for (const [k, v] of recv) {
+        if (!truthy(apply(block, [k, v]))) return false;
+      }
+      return true;
+    case "none?":
+      for (const [k, v] of recv) {
+        if (truthy(apply(block, [k, v]))) return false;
+      }
+      return true;
+    case "count": {
+      // `count { |k, v| pred }` — number of pairs with a truthy block result.
+      let n = 0;
+      for (const [k, v] of recv) {
+        if (truthy(apply(block, [k, v]))) n++;
+      }
+      return n;
+    }
+    case "sort_by": {
+      // A NEW Array of `[k, v]` pairs sorted by the block key; `<`/`>` keeps
+      // numbers numeric (matching Array#sort_by).  Keys computed once.
+      const keyed = [...recv].map(([k, v]: [Val, Val]): [Val, Val] => [
+        apply(block, [k, v]),
+        [k, v],
+      ]);
+      keyed.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+      return keyed.map((pair) => pair[1]);
+    }
+    case "min_by":
+    case "max_by": {
+      // The `[k, v]` pair with the extremal block key (first-on-tie; nil on
+      // an empty hash).
+      const entries = [...recv];
+      if (entries.length === 0) return null;
+      const wantMin = name === "min_by";
+      let bestPair: Val = [entries[0][0], entries[0][1]];
+      let bestKey = apply(block, [entries[0][0], entries[0][1]]);
+      for (let i = 1; i < entries.length; i++) {
+        const [k, v] = entries[i];
+        const key = apply(block, [k, v]);
+        if (wantMin ? key < bestKey : key > bestKey) {
+          bestPair = [k, v];
+          bestKey = key;
+        }
+      }
+      return bestPair;
+    }
     default:
       return MISS;
   }

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -562,10 +562,42 @@ describe("built-in method catalog: Hash (M1c)", () => {
     expect([...collide.entries()]).toEqual([["z", 2]]);
   });
 
+  it("block Enumerable aggregates (find/any?/all?/none?/count/sort_by/min_by/max_by)", () => {
+    // Hash mixes in Enumerable: the block is yielded [key, value] and the
+    // "element" an aggregate returns is the two-element [key, value] pair.
+    const h = new Map<Val, Val>([["a", 1], ["b", 2], ["c", 3]]);
+    // find/detect → first matching [k, v] pair (or nil).
+    expect(callMethod(h, "find", new Closure((k: Val, v: Val) => (v as number) > 1))).toEqual(["b", 2]);
+    expect(callMethod(h, "detect", new Closure((k: Val, v: Val) => (v as number) > 9))).toBeNull();
+    // any?/all?/none? over block([k, v]).
+    expect(callMethod(h, "any?", new Closure((k: Val, v: Val) => v === 2))).toBe(true);
+    expect(callMethod(h, "all?", new Closure((k: Val, v: Val) => (v as number) > 0))).toBe(true);
+    expect(callMethod(h, "none?", new Closure((k: Val, v: Val) => (v as number) > 9))).toBe(true);
+    // count { |k, v| pred } → number of truthy pairs.
+    expect(callMethod(h, "count", new Closure((k: Val, v: Val) => (v as number) % 2 === 1))).toBe(2);
+    // sort_by → NEW array of [k, v] pairs ordered by the block key.
+    expect(callMethod(h, "sort_by", new Closure((k: Val, v: Val) => -(v as number)))).toEqual([
+      ["c", 3],
+      ["b", 2],
+      ["a", 1],
+    ]);
+    // min_by / max_by → the extremal [k, v] pair.
+    expect(callMethod(h, "min_by", new Closure((k: Val, v: Val) => v))).toEqual(["a", 1]);
+    expect(callMethod(h, "max_by", new Closure((k: Val, v: Val) => v))).toEqual(["c", 3]);
+    // min_by / max_by on an empty hash → nil; receiver unchanged throughout.
+    expect(callMethod(new Map<Val, Val>(), "min_by", new Closure((k: Val, v: Val) => v))).toBeNull();
+    expect([...h.entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+  });
+
   it("respond_to? honesty + nil floor", () => {
     const h = new Map<Val, Val>([["a", 1]]);
     expect(callMethod(h, "respond_to?", "keys")).toBe(true);
     expect(callMethod(h, "respond_to?", "each")).toBe(true);
+    expect(callMethod(h, "respond_to?", "min_by")).toBe(true);
     expect(callMethod(h, "respond_to?", "transform_values")).toBe(true);
     // `transform_keys!` (in-place bang variant) is still uncatalogued.
     expect(callMethod(h, "respond_to?", "transform_keys!")).toBe(false);


### PR DESCRIPTION
## Summary

**Completes** the cross-backend mirror of Ruby `Hash` Enumerable aggregates — the last of five backends. Adds `find`/`detect`, `any?`/`all?`/`none?`, `count`, `sort_by`, `min_by`/`max_by` to the `sir-runtime-oop` TypeScript library (`hashBlockMethod` + `HASH_BLOCK_METHODS`).

Ruby's `Hash` mixes in `Enumerable`, so these iterate the hash as `[key, value]` pairs: the block is yielded `[key, value]` (two args, matching `each`), and the "element" an aggregate returns is the two-element `[key, value]` list.

- `find`/`detect` — first matching `[k, v]` pair (`nil` if none)
- `any?`/`all?`/`none?` — booleans over `block([k, v])`
- `count { |k, v| … }` — number of truthy pairs
- `sort_by` — new array of `[k, v]` pairs ordered by the block key
- `min_by`/`max_by` — the extremal `[k, v]` pair (first-on-tie; `nil` on empty)

All non-mutating.

## Tests

Vitest — all **115 pass**: `find`/`detect`, `any?`/`all?`/`none?`, `count`, `sort_by` (→ `[[c,3],[b,2],[a,1]]`), `min_by`/`max_by`, empty-hash `min_by` → nil, a receiver-unchanged assertion, and `respond_to?`.

## Checklist
- [x] CHANGELOG.md (0.1.18 → **0.1.19**), README Hash catalog updated
- [x] `npx vitest run` green (115/115)
- [x] Security review passed (native `Map` iteration + fresh array returns → no prototype pollution; identical to sibling array arms)
- [x] Restored unrelated package-lock churn; only the 5 intended oop files committed

Reference = Python #7957. Backends: Go #7962, Rust #7966, JS #7968, **TS = this PR**. With this, the Hash Enumerable aggregates are at full parity across Python/Go/Rust/JS/TS. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)