### PR TITLE
feat(sir-oop-py): Hash Enumerable breadth part 2 (group_by/partition/flat_map/reduce/inject/sum)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.20] - 2026-07-11
+
+### Added
+
+- **`Hash` Enumerable breadth part 2** (`_hash_block_method` +
+  `_HASH_BLOCK_METHODS`): `group_by`, `partition`, `flat_map`/`collect_concat`,
+  `reduce`/`inject`, and `sum` (block form).  Ruby's `Hash` iterates as
+  `[key, value]` pairs, so `group_by`/`partition` collect `[k, v]` pairs
+  (`{a:1,b:2}.group_by { |k,v| v.even? }` → `{false: [[:a,1]], true: [[:b,2]]}`),
+  `flat_map` flattens one level of block results, and `sum(init) { |k, v| … }`
+  folds the block results onto `init`.  `reduce`/`inject` follow Ruby's memo
+  convention — the block is yielded `[memo, [k, v]]` (the pair as one argument,
+  matching `h.inject(0) { |sum, (k, v)| … }`); a seedless `reduce` starts from
+  the first pair and an empty seedless `reduce` returns `nil`.
+- `_hash_block_method` now receives the positional `args` preceding the block
+  (mirroring `_array_block_method`), so `reduce`/`inject`/`sum` can read their
+  seed/initial value.
+
+  Reference implementation for a cross-backend cascade (Go/Rust/JS/TS follow).
+
 ## [0.1.19] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -75,7 +75,7 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 `flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
-(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/…);
+(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/`group_by`/`partition`/`flat_map`/`reduce`/`sum`/…);
 and (item
 **M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
 `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.19"
+version = "0.1.20"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -660,6 +660,13 @@ _HASH_BLOCK_METHODS = frozenset(
         "sort_by",
         "min_by",
         "max_by",
+        "group_by",
+        "partition",
+        "flat_map",
+        "collect_concat",
+        "reduce",
+        "inject",
+        "sum",
     }
 )
 
@@ -1190,10 +1197,12 @@ def _hash_method(recv: dict[Val, Val], name: str, args: list[Val]) -> Val:
     return _MISS
 
 
-def _hash_block_method(recv: dict[Val, Val], name: str, block: Closure) -> Val:
+def _hash_block_method(recv: dict[Val, Val], name: str, args: list[Val], block: Closure) -> Val:
     """Block-taking ``Hash`` methods; the block receives ``[key, value]`` (or a
-    single key/value for ``each_key``/``each_value``).  Returns :data:`_MISS` if
-    ``name`` is not a hash block method."""
+    single key/value for ``each_key``/``each_value``).  ``args`` holds the
+    positional arguments preceding the block (e.g. the seed for
+    ``reduce``/``inject`` or the initial value for ``sum``).  Returns
+    :data:`_MISS` if ``name`` is not a hash block method."""
     if name in ("each", "each_pair"):
         for key, value in list(recv.items()):
             apply(block, [key, value])
@@ -1261,6 +1270,63 @@ def _hash_block_method(recv: dict[Val, Val], name: str, block: Closure) -> Val:
             ([k, v] for k, v in recv.items()),
             key=lambda pair: apply(block, [pair[0], pair[1]]),
         )
+    # ── Enumerable breadth (grouping / folding / flattening) ───────────────
+    #
+    # A second batch of ``Enumerable`` block methods on ``Hash``.  Like the
+    # aggregates above, the block is yielded ``[key, value]`` (two arguments)
+    # and every "element" a result contains is a two-element ``[key, value]``
+    # list — except ``reduce``/``inject``, which follow Ruby's memo convention
+    # and yield ``[memo, [key, value]]`` (the pair as a single second argument,
+    # matching ``h.inject(0) { |sum, (k, v)| … }``).
+    if name == "group_by":
+        # A Hash of block key -> list of ``[k, v]`` pairs, in first-seen key
+        # order.  Keys must be hashable (dict-based Hash model).
+        groups: dict[Val, list[Val]] = {}
+        for key, value in recv.items():
+            groups.setdefault(apply(block, [key, value]), []).append([key, value])
+        return groups
+    if name == "partition":
+        # ``[[matching pairs], [non-matching pairs]]``.
+        yes: list[Val] = []
+        no: list[Val] = []
+        for key, value in recv.items():
+            (yes if truthy(apply(block, [key, value])) else no).append([key, value])
+        return [yes, no]
+    if name in ("flat_map", "collect_concat"):
+        # Map each pair through the block, flattening one level of any list
+        # result (a non-list result is appended as-is).
+        out: list[Val] = []
+        for key, value in recv.items():
+            mapped = apply(block, [key, value])
+            if isinstance(mapped, list):
+                out.extend(mapped)
+            else:
+                out.append(mapped)
+        return out
+    if name in ("reduce", "inject"):
+        # ``reduce(init) { |memo, (k, v)| … }`` folds the pairs; a seedless
+        # ``reduce`` starts from the first pair (Ruby's rule).  Yields the pair
+        # as ONE argument (the memo convention), so an empty seedless reduce is
+        # ``nil``.
+        pairs = [[key, value] for key, value in recv.items()]
+        if args:
+            acc: Val = args[0]
+            rest = pairs
+        elif pairs:
+            acc = pairs[0]
+            rest = pairs[1:]
+        else:
+            return None
+        for pair in rest:
+            acc = apply(block, [acc, pair])
+        return acc
+    if name == "sum":
+        # ``sum(init = 0) { |k, v| … }`` — ``init`` plus the sum of the block
+        # results (Hash#sum requires a block, since raw pairs are not addable).
+        total: Val = args[0] if args else 0
+        for key, value in recv.items():
+            total = total + apply(block, [key, value])
+        return total
     return _MISS
 
 
@@ -1924,7 +1990,7 @@ def call_method(recv: Val, name: str, *args: Val) -> Val:
             return result
     elif isinstance(recv, dict):
         if name in _HASH_BLOCK_METHODS and arg_list and isinstance(arg_list[-1], Closure):
-            result = _hash_block_method(recv, name, arg_list[-1])
+            result = _hash_block_method(recv, name, arg_list[:-1], arg_list[-1])
             if result is not _MISS:
                 return result
         result = _hash_method(recv, name, arg_list)

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -545,6 +545,46 @@ def test_hash_enumerable_aggregates() -> None:
     assert oop.call_method(h, "respond_to?", "sort_by") is True
 
 
+def test_hash_enumerable_grouping_folding() -> None:
+    # Enumerable breadth part 2: group_by/partition/flat_map/reduce/sum. The
+    # block is yielded [key, value] and results carry [key, value] pairs;
+    # reduce follows Ruby's memo convention (memo, pair).
+    h = {"a": 1, "b": 2, "c": 3, "d": 4}
+    # group_by { |k, v| v.even? } → {False: [[a,1],[c,3]], True: [[b,2],[d,4]]}
+    assert oop.call_method(h, "group_by", Closure(lambda k, v: v % 2 == 0)) == {
+        False: [["a", 1], ["c", 3]],
+        True: [["b", 2], ["d", 4]],
+    }
+    # partition { |k, v| v > 2 } → [[[c,3],[d,4]], [[a,1],[b,2]]]
+    assert oop.call_method(h, "partition", Closure(lambda k, v: v > 2)) == [
+        [["c", 3], ["d", 4]],
+        [["a", 1], ["b", 2]],
+    ]
+    # flat_map { |k, v| [k, v] } → [a, 1, b, 2, c, 3, d, 4]  (one-level flatten)
+    assert oop.call_method(h, "flat_map", Closure(lambda k, v: [k, v])) == [
+        "a", 1, "b", 2, "c", 3, "d", 4,
+    ]
+    # collect_concat alias behaves identically.
+    assert oop.call_method({"a": 1}, "collect_concat", Closure(lambda k, v: [v])) == [1]
+    # reduce(0) { |sum, (k, v)| sum + v } → 10
+    assert oop.call_method(h, "reduce", 0, Closure(lambda acc, pair: acc + pair[1])) == 10
+    # inject (seedless) starts the memo from the first [k, v] pair, then folds
+    # later pairs; here it appends each later value → [a, 1, 2].
+    assert (
+        oop.call_method({"a": 1, "b": 2}, "inject", Closure(lambda acc, pair: acc + [pair[1]]))
+        == ["a", 1, 2]
+    )
+    # empty seedless reduce → nil
+    assert oop.call_method({}, "reduce", Closure(lambda acc, pair: acc)) is None
+    # sum(0) { |k, v| v } → 10 ; sum(100) { |k, v| v } → 110
+    assert oop.call_method(h, "sum", 0, Closure(lambda k, v: v)) == 10
+    assert oop.call_method(h, "sum", 100, Closure(lambda k, v: v)) == 110
+    # respond_to? advertises the new methods; receiver unchanged throughout.
+    assert oop.call_method(h, "respond_to?", "group_by") is True
+    assert oop.call_method(h, "respond_to?", "reduce") is True
+    assert list(h.items()) == [("a", 1), ("b", 2), ("c", 3), ("d", 4)]
+
+
 def test_hash_respond_to_and_no_method_error_floor() -> None:
     assert oop.call_method({"a": 1}, "respond_to?", "keys") is True
     assert oop.call_method({"a": 1}, "respond_to?", "each") is True


### PR DESCRIPTION
## Summary

**Reference PR** kicking off a second Hash Enumerable cascade. Ruby's `Hash` iterates as `[key, value]` pairs; this adds the grouping/folding/flattening block methods to the Python `sir-runtime-oop` reference (`_hash_block_method` + `_HASH_BLOCK_METHODS`):

| method | behavior |
|---|---|
| `group_by { \|k,v\| key }` | Hash of key → list of `[k, v]` pairs (first-seen order) |
| `partition { \|k,v\| pred }` | `[[matching pairs], [non-matching pairs]]` |
| `flat_map`/`collect_concat` | one-level flatten of block results |
| `reduce`/`inject(init) { \|memo,(k,v)\| }` | fold; memo convention (pair as one arg); seedless → first pair; empty seedless → `nil` |
| `sum(init=0) { \|k,v\| }` | `init` + Σ block results |

### Notable infra change
`_hash_block_method` now also receives the **positional args before the block** (mirroring `_array_block_method`'s `(recv, name, args, block)`), so `reduce`/`inject`/`sum` can read their seed/initial value. The single dispatch call site is updated to pass `arg_list[:-1]`.

## Tests
`test_hash_enumerable_grouping_folding` covers all arms incl. seedless `inject`, empty-`reduce` → nil, `sum` with init, and receiver-unchanged. **pytest 126 passing, 97% cov; ruff clean.**

## Checklist
- [x] CHANGELOG.md (0.1.19 → **0.1.20**), README Hash catalog updated
- [x] pytest green (97% cov), ruff clean
- [x] Security review passed (explicit-switch dispatch; the signature/dispatch change has exactly one caller, matching the sibling array/numeric pattern)

Follows reference-first delivery; Go/Rust/JS/TS mirrors land one-per-PR after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)