### PR TITLE
feat(javascript-parser): bridge static-init blocks → ClassMember::StaticBlock (CLOC12.176 PR2)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.40.0] - 2026-07-11
+
+### Added — CLOC12.176 PR2: bridge static-init blocks → `ClassMember::StaticBlock`
+
+The grammar already parses a static initialization block (`static { … }`) as a
+`static_block` node inside `class_element`, but the bridge declined it (dropping
+the file to WHITESPACE_ONLY). `convert_class_element` now dispatches a
+`static_block` member to the new `convert_static_block`, producing
+`ClassMember::StaticBlock(BlockStatement)` (javascript-ast 0.35.0):
+
+- The block **body** reuses the shared statement converter (`convert_statement`),
+  so the full statement surface is reachable — expression statements
+  (`x = 1;`), lexical declarations (`let z = 2;` → `Statement::Declaration`),
+  and multiple statements in source order. Identical shape to
+  `convert_block_statement`.
+- The leading `static` keyword lives *inside* the `static_block` node (not
+  hoisted onto `class_element` like a method/field modifier), so the existing
+  modifier loop never sees it — `is_static` stays false and the static-block arm
+  ignores it. No special modifier handling is needed.
+- An empty block (`static {}`) maps to an empty `body`.
+
+Works in both class-expression and class-declaration bodies (shared conversion);
+a static block and a field/method coexist in one body in source order.
+5 new bridge tests. MINOR.
+
 ## [0.39.0] - 2026-07-11
 
 ### Added — CLOC12.175 PR2: bridge class fields → `ClassMember::Field`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1252,13 +1252,18 @@ fn convert_class_element(node: &GrammarASTNode) -> Result<ClassMember, BridgeErr
             }
         }
     }
-    // The member itself is a *single* child node. Two shapes are modelled:
-    // a plain `method_definition` (→ `ClassMember::Method`) and a
-    // `class_field_declaration` (→ `ClassMember::Field`, CLOC12.175 PR2). The
-    // grammar's `async_method` / `private_method_definition` / `static_block`
-    // nodes are forms this slice does not represent, so they DECLINE (safe
-    // WHITESPACE_ONLY fallback). (Because these are *distinct nodes*, not just
-    // leading tokens, the node kind must be checked.)
+    // The member itself is a *single* child node. Three shapes are modelled:
+    // a plain `method_definition` (→ `ClassMember::Method`), a
+    // `class_field_declaration` (→ `ClassMember::Field`, CLOC12.175 PR2), and a
+    // `static_block` (→ `ClassMember::StaticBlock`, CLOC12.176 PR2). The
+    // grammar's `async_method` / `private_method_definition` nodes are forms
+    // this slice does not represent, so they DECLINE (safe WHITESPACE_ONLY
+    // fallback). (Because these are *distinct nodes*, not just leading tokens,
+    // the node kind must be checked.)
+    //
+    // A `static_block` carries its own leading `Token("static")` *inside* the
+    // node (not on the `class_element`), so the modifier loop above never sees
+    // it — `is_static` stays false and the static-block arm ignores it.
     let member = node_children(node)
         .into_iter()
         .next()
@@ -1266,8 +1271,33 @@ fn convert_class_element(node: &GrammarASTNode) -> Result<ClassMember, BridgeErr
     match member.rule_name.as_str() {
         "method_definition" => Ok(ClassMember::Method(convert_method_definition(member, is_static)?)),
         "class_field_declaration" => Ok(ClassMember::Field(convert_class_field(member)?)),
+        "static_block" => Ok(ClassMember::StaticBlock(convert_static_block(member)?)),
         _ => Err(unsupported(member)),
     }
+}
+
+/// Convert a `static_block` node into a [`BlockStatement`] — a class
+/// static-initialization block `static { … }` (CLOC12.176 PR2).
+///
+/// ```text
+///   static_block = [ Token("static"), Token("{"),
+///                    Node(statement)*,
+///                    Token("}") ]
+/// ```
+///
+/// The block body is exactly a statement list — the *same* shape as a plain
+/// `{ … }` [`convert_block_statement`] — so each `statement` node child is
+/// lowered by the shared [`convert_statement`], covering the full statement
+/// surface (including `let` / `const` / `var`, which map to
+/// `Statement::Declaration`). Tokens (`static`, the braces) are ignored by
+/// [`node_children`], so the leading `static` needs no special handling. An
+/// empty block (`static {}`) yields an empty `body`. Because every statement is
+/// routed through the shared converter, any unmodelled body statement makes the
+/// converter DECLINE (safe WHITESPACE_ONLY fallback) rather than mis-emit.
+fn convert_static_block(node: &GrammarASTNode) -> Result<BlockStatement, BridgeError> {
+    let stmts: Result<Vec<Statement>, _> =
+        node_children(node).into_iter().map(convert_statement).collect();
+    Ok(BlockStatement { cv: None, body: stmts? })
 }
 
 /// Convert a `class_field_declaration` node into a [`PropertyDefinition`] — a
@@ -3798,6 +3828,79 @@ mod tests {
             bridge("w = class { #x = 1; };"),
             Err(BridgeError::UnsupportedSyntax { .. })
         ));
+    }
+
+    // -----------------------------------------------------------------
+    // ClassMember::StaticBlock bridging (CLOC12.176 PR2)
+    // -----------------------------------------------------------------
+
+    /// Pull the sole `ClassMember::StaticBlock` body out of
+    /// `x = class { static { … } };`.
+    fn static_block_of(src: &str) -> BlockStatement {
+        let c = class_of(src);
+        assert_eq!(c.body.len(), 1, "expected exactly one member");
+        match &c.body[0] {
+            ClassMember::StaticBlock(b) => b.clone(),
+            other => panic!("expected a static-block member, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn class_static_block_empty() {
+        // `static {}` — an empty static block maps to an empty body. The block's
+        // OWN leading `static` token (inside `static_block`, not on the
+        // `class_element`) needs no handling.
+        let b = static_block_of("y = class { static {} };");
+        assert!(b.body.is_empty());
+    }
+
+    #[test]
+    fn class_static_block_with_statement() {
+        // `static { x = 1; }` — one expression statement in the body.
+        use coding_adventures_javascript_ast::statement::TaggedStatement;
+        let b = static_block_of("y = class { static { x = 1; } };");
+        assert_eq!(b.body.len(), 1);
+        assert!(matches!(
+            &b.body[0],
+            Statement::Tagged(TaggedStatement::ExpressionStatement(_))
+        ));
+    }
+
+    #[test]
+    fn class_static_block_with_declaration() {
+        // `static { let z = 2; }` — a lexical declaration in a static block maps
+        // to `Statement::Declaration` via the shared statement converter, proving
+        // the full statement surface (not just expressions) is reachable.
+        let b = static_block_of("y = class { static { let z = 2; } };");
+        assert_eq!(b.body.len(), 1);
+        assert!(matches!(
+            &b.body[0],
+            Statement::Declaration(Declaration::VariableDeclaration(_))
+        ));
+    }
+
+    #[test]
+    fn class_static_block_multiple_statements() {
+        // `static { x = 1; y = 2; }` — statement order is preserved.
+        use coding_adventures_javascript_ast::statement::TaggedStatement;
+        let b = static_block_of("y = class { static { x = 1; y = 2; } };");
+        assert_eq!(b.body.len(), 2);
+        assert!(b
+            .body
+            .iter()
+            .all(|s| matches!(s, Statement::Tagged(TaggedStatement::ExpressionStatement(_)))));
+    }
+
+    #[test]
+    fn class_static_block_and_field_interleave() {
+        // A static block and a field coexist in one body, in source order.
+        let c = class_of("w = class { x = 1; static { y = 2; } m(){} };");
+        assert_eq!(c.body.len(), 3);
+        assert!(matches!(&c.body[0], ClassMember::Field(f)
+            if matches!(&f.key, PropertyKey::Identifier(id) if id.name == "x")));
+        assert!(matches!(&c.body[1], ClassMember::StaticBlock(b) if b.body.len() == 1));
+        assert!(matches!(&c.body[2], ClassMember::Method(m)
+            if matches!(&m.key, PropertyKey::Identifier(id) if id.name == "m")));
     }
 
     #[test]

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.15] - 2026-07-11
+
+### Added — CLOC12.176 PR2: static-init blocks end-to-end
+
+Picks up javascript-parser 0.40.0, whose bridge now produces
+`ClassMember::StaticBlock`. A `static { … }` block now survives the full closurec
+pipeline. New e2e diff fixture `tests/diff/simple-static-block/`:
+`class C { static { x = 1 + 2 } }` → `class C{static{x=3}}` at SIMPLE.
+
+The fixture proves the SIMPLE pipeline descends INTO the block's statement list:
+the body's `1 + 2` folds to `3`. Before this bridge change the `static_block`
+member declined, dropping the file to WHITESPACE_ONLY
+(`class C{static{x=1+2}};`, arithmetic intact). The existing WHITESPACE_ONLY
+fixtures (`minify_class_static_block`, `minify_class_static_blocks`) exercise the
+emitter's grammar-AST path; this one exercises the typed-AST bridge + fold path.
+PATCH.
+
 ## [0.234.14] - 2026-07-11
 
 ### Added — CLOC12.175 PR2: class fields end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.14"
+version = "0.234.15"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.14",
+  "version": "0.234.15",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.14
+Version: 0.234.15
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-static-block/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-static-block/expected.stdout
@@ -1,0 +1,1 @@
+class C{static{x=3}}

--- a/code/programs/rust/closurec/tests/diff/simple-static-block/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-static-block/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-static-block/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-static-block/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-static-block/input/a.js
@@ -1,0 +1,1 @@
+class C { static { x = 1 + 2 } }

--- a/code/programs/rust/closurec/tests/diff_simple_static_block.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_static_block.rs
@@ -1,0 +1,85 @@
+//! Integration test for the `tests/diff/simple-static-block/` fixture.
+//!
+//! Exercises **static initialization blocks** (`ClassMember::StaticBlock` /
+//! `BlockStatement`) end-to-end at SIMPLE — the CLOC12.176 arc's bridge (PR2) on
+//! top of the node + emit + pass arms (PR1).
+//!
+//! The fixture is `class C { static { x = 1 + 2 } }` compiled at SIMPLE.
+//! Two facts prove the whole pipeline ran through the static block:
+//!   1. the class declaration round-trips — proving the bridge built a real
+//!      `ClassDeclaration` whose body holds a `ClassMember::StaticBlock` the
+//!      emitter can print, not a WHITESPACE_ONLY fallback; and
+//!   2. the block body folds — `1 + 2` → `3` INSIDE `static { … }` — proving
+//!      the SIMPLE pipeline descended into the block's statement list (the
+//!      shared statement converter feeds the constant-fold `StaticBlock` arm
+//!      added in PR1). A WHITESPACE_ONLY fallback would leave `1+2` intact.
+//! Were the bridge to decline the `static_block` member, the file would drop to
+//! WHITESPACE_ONLY (`class C{static{x=1+2}};`) and assertion (2) would fail.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-static-block/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_static_block_folds_body() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-static-block/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture. Strip spaces so the checks are
+    // insensitive to inter-token whitespace.
+    let a = actual.replace(' ', "");
+    // (1) the class declaration round-tripped — proving the bridge built a real
+    //     `ClassDeclaration` with a static-block member, not a WHITESPACE_ONLY
+    //     pass.
+    assert!(
+        a.contains("classC{") || a.contains("class C{"),
+        "class declaration did not round-trip: {actual}"
+    );
+    // (2) the static block body folded — proving the pipeline descended INTO the
+    //     block's statement list (`1+2`→`3`). A WHITESPACE_ONLY fallback would
+    //     leave the arithmetic intact.
+    assert!(
+        a.contains("static{x=3}"),
+        "static block body did not fold to `x=3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+    // (3) a class *declaration* emits bare — NO trailing `;` after the closing
+    //     `}` and NO wrapping paren (mirrors simple-class-decl; a
+    //     WHITESPACE_ONLY fallback appends `;`).
+    let t = actual.trim_end_matches('\n');
+    assert!(
+        t.ends_with('}') && !t.ends_with("};") && !t.starts_with('('),
+        "class declaration must emit bare (no trailing `;`, no wrap): {actual}"
+    );
+}


### PR DESCRIPTION
## CLOC12.176 PR2 — bridge static-init blocks

Second PR in the static-init-block (`static { … }`) arc. PR1 (#7974, merged) added the atomic `ClassMember::StaticBlock` node + emitter arm + all downstream pass match-arms. This PR flips the bridge on so the node is actually produced from parsed JS, and proves the whole pipeline descends into the block.

### javascript-parser (MINOR 0.39.0 → 0.40.0)
- `convert_class_element` dispatches a `static_block` member to the new `convert_static_block`, producing `ClassMember::StaticBlock(BlockStatement)`.
- The block body reuses the shared `convert_statement`, so the full statement surface is reachable (expression statements, lexical declarations → `Statement::Declaration`, multiple statements in order). Identical shape to `convert_block_statement`.
- The leading `static` keyword lives *inside* the `static_block` node (not hoisted onto `class_element`), so the modifier loop never sees it — no special handling needed.
- 5 new bridge tests.

### closurec (PATCH 0.234.14 → 0.234.15)
- New e2e diff fixture `tests/diff/simple-static-block/`: `class C { static { x = 1 + 2 } }` → `class C{static{x=3}}` at SIMPLE. The body's `1 + 2` folds to `3`, proving the SIMPLE pipeline descended INTO the block's statement list. Before this change the member declined → WHITESPACE_ONLY (`class C{static{x=1+2}};`, unfolded).
- Version-synced `cli.spec.json` + `tests/diff/help-markdown/expected.stdout`.

### Verification
- `cargo test -p coding-adventures-javascript-parser --lib static_block` → 5 pass
- `cargo test --test diff_simple_static_block --test diff_help_markdown --test diff_version_banner` → pass
- Security review (Rust, general-purpose subagent): **PASSED — no findings**

PR3 (CodePrinter emit conformance port) follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)