### PR TITLE
feat(apl): apl-lexer crate (MA05 §6, MA-4c)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -235,6 +235,7 @@ members = [
     "wolfram-parser",
     "wolfram-runtime",
     "wolfram-repl",
+    "apl-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/apl-lexer/BUILD
+++ b/code/packages/rust/apl-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-apl-lexer -- --nocapture

--- a/code/packages/rust/apl-lexer/BUILD_windows
+++ b/code/packages/rust/apl-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-apl-lexer -- --nocapture

--- a/code/packages/rust/apl-lexer/CHANGELOG.md
+++ b/code/packages/rust/apl-lexer/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [0.1.0] - 2026-07-11
+
+### Added
+
+- Initial grammar-driven Rust APL tokenizer (MA05 §6, task MA-4c).
+- Statically linked compiled token grammar (`code/grammars/apl/apl.tokens`),
+  covering the historical-core subset fixed by MA-4a: dense numeric arrays,
+  the primitive function glyphs, the three operators (reduce/scan/outer
+  product), assignment, parenthesised grouping, and `⍝` line comments.
+- No pre/post-tokenize hooks needed — every APL primitive in this subset is
+  a single dedicated Unicode code point, so there is no character-overloading
+  disambiguation to do at the lexer level (unlike MATLAB's `'` or Wolfram's
+  bracketed-newline handling).

--- a/code/packages/rust/apl-lexer/Cargo.toml
+++ b/code/packages/rust/apl-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-apl-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "APL lexer backed by statically compiled grammar data"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/apl-lexer/README.md
+++ b/code/packages/rust/apl-lexer/README.md
@@ -1,0 +1,40 @@
+# coding-adventures-apl-lexer
+
+APL tokenizer backed by `code/grammars/apl/apl.tokens`, compiled to Rust and
+statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the historical-core subset fixed by
+[MA05 §4](../../../specs/MA05-apl-language.md): dense numeric arrays, the
+primitive functions `+ - × ÷ ⌈ ⌊ ⍴ ⍳ , = ≠ < ≤ ≥ >`, the operators `/`
+(reduce), `\` (scan), and `∘.` (outer product), assignment `←`, parenthesised
+grouping, and `⍝` line comments.
+
+Every APL primitive in this subset is a single dedicated Unicode code point
+(see MA05 §3 bullet 4), so — unlike MATLAB's `'` or Wolfram's bracketed
+newlines — there is no character-overloading disambiguation to do at the
+lexer level. Which of a glyph's two readings (monadic/dyadic) applies is
+decided by the *parser* production that matches it, not by this crate.
+
+## Usage
+
+```rust
+use coding_adventures_apl_lexer::tokenize_apl;
+
+let tokens = tokenize_apl("A←⍳5\nB←+/A");
+```
+
+`tokenize_apl` panics on a malformed source string (there is no recoverable
+lexer error to report to a caller yet); use `create_apl_lexer` directly if
+you need the `Result`-returning `GrammarLexer::tokenize` instead.
+
+## Where this fits
+
+`apl-lexer` is the first of the two frontend crates for APL (MA-4c); the
+sibling `apl-parser` crate (MA-4d) consumes this crate's token stream against
+`code/grammars/apl/apl.grammar` to build the `GrammarASTNode` CST that a
+future `apl-runtime` will evaluate.

--- a/code/packages/rust/apl-lexer/required_capabilities.json
+++ b/code/packages/rust/apl-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/apl-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/apl-lexer/src/_grammar.rs
+++ b/code/packages/rust/apl-lexer/src/_grammar.rs
@@ -1,0 +1,216 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: apl.tokens
+// Regenerate with: grammar-tools compile-tokens apl.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"OUTER"#.to_string(),
+                pattern: r#"∘."#.to_string(),
+                is_regex: false,
+                line_number: 40,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ARROW"#.to_string(),
+                pattern: r#"←"#.to_string(),
+                is_regex: false,
+                line_number: 51,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 56,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 57,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"TIMES"#.to_string(),
+                pattern: r#"×"#.to_string(),
+                is_regex: false,
+                line_number: 58,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DIVIDE"#.to_string(),
+                pattern: r#"÷"#.to_string(),
+                is_regex: false,
+                line_number: 59,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CEILING"#.to_string(),
+                pattern: r#"⌈"#.to_string(),
+                is_regex: false,
+                line_number: 60,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"FLOOR"#.to_string(),
+                pattern: r#"⌊"#.to_string(),
+                is_regex: false,
+                line_number: 61,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RHO"#.to_string(),
+                pattern: r#"⍴"#.to_string(),
+                is_regex: false,
+                line_number: 62,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"IOTA"#.to_string(),
+                pattern: r#"⍳"#.to_string(),
+                is_regex: false,
+                line_number: 63,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RAVEL"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 64,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 66,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NE"#.to_string(),
+                pattern: r#"≠"#.to_string(),
+                is_regex: false,
+                line_number: 67,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LT"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 68,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"≤"#.to_string(),
+                is_regex: false,
+                line_number: 69,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#"≥"#.to_string(),
+                is_regex: false,
+                line_number: 70,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GT"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 71,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"REDUCE"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 81,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SCAN"#.to_string(),
+                pattern: r#"\"#.to_string(),
+                is_regex: false,
+                line_number: 82,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 84,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 85,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"¯?[0-9]+(\.[0-9]+)?([Ee]¯?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 101,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[A-Za-z][A-Za-z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 102,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEWLINE"#.to_string(),
+                pattern: r#"\r?\n"#.to_string(),
+                is_regex: true,
+                line_number: 117,
+                alias: None,
+            },
+        ],
+        keywords: vec![],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t]+"#.to_string(),
+                is_regex: true,
+                line_number: 120,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMENT"#.to_string(),
+                pattern: r#"⍝[^\r\n]*"#.to_string(),
+                is_regex: true,
+                line_number: 121,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: None,
+        error_definitions: vec![],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/apl-lexer/src/lib.rs
+++ b/code/packages/rust/apl-lexer/src/lib.rs
@@ -1,0 +1,27 @@
+//! Grammar-driven APL tokenizer.
+//!
+//! The token grammar is compiled into this crate at build time, so runtime
+//! callers do not need filesystem access to `code/grammars/apl`.
+//!
+//! Per MA05 §3 bullet 4, every APL primitive in this historical-core subset
+//! is a single dedicated Unicode code point (see `code/grammars/apl/apl.tokens`),
+//! so this crate needs no pre/post-tokenize hooks — unlike, say, `wolfram-lexer`,
+//! which strips bracketed newlines. Which glyph reading applies (monadic vs.
+//! dyadic) is a parser-production concern, not a lexer one (MA05 §3 bullet 3).
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+pub fn create_apl_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+pub fn tokenize_apl(source: &str) -> Vec<Token> {
+    let mut lexer = create_apl_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|err| panic!("APL tokenization failed: {err}"))
+}

--- a/code/packages/rust/apl-lexer/tests/test_tokenizer.rs
+++ b/code/packages/rust/apl-lexer/tests/test_tokenizer.rs
@@ -1,0 +1,124 @@
+use coding_adventures_apl_lexer::tokenize_apl;
+use lexer::token::TokenType;
+
+fn token_types(source: &str) -> Vec<String> {
+    tokenize_apl(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.effective_type_name().to_string())
+        .collect()
+}
+
+fn token_values(source: &str) -> Vec<String> {
+    tokenize_apl(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.value)
+        .collect()
+}
+
+#[test]
+fn tokenizes_every_primitive_function_glyph() {
+    // One glyph per row of MA05 §4's listed order: conjugate/add,
+    // negate/subtract, sign/multiply, reciprocal/divide, ceiling·floor,
+    // max·min, shape/reshape, index-generator/index-of, ravel/catenate,
+    // plus the six comparison glyphs.
+    assert_eq!(
+        token_types("+ - × ÷ ⌈ ⌊ ⍴ ⍳ , = ≠ < ≤ ≥ >"),
+        vec![
+            "PLUS", "MINUS", "TIMES", "DIVIDE", "CEILING", "FLOOR", "RHO", "IOTA", "RAVEL", "EQ",
+            "NE", "LT", "LE", "GE", "GT",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_operators_grouping_and_assignment() {
+    assert_eq!(
+        token_types("A←(+/ B)"),
+        vec![
+            "NAME", "ARROW", "LPAREN", "PLUS", "REDUCE", "NAME", "RPAREN",
+        ]
+    );
+    assert_eq!(token_types("+\\ B"), vec!["PLUS", "SCAN", "NAME"]);
+    assert_eq!(token_types("∘.×"), vec!["OUTER", "TIMES"]);
+}
+
+#[test]
+fn outer_is_not_confused_with_a_bare_jot_or_a_bare_dot() {
+    // OUTER ("∘.") is declared as a single two-codepoint token ahead of any
+    // rule that could confuse it — the grammar's longest-match-first
+    // convention (SECTION 1 of apl.tokens). There is no standalone "jot"
+    // token in this subset, so a jot immediately followed by a dot must
+    // always lex as one OUTER token, never as two.
+    assert_eq!(token_types("∘.="), vec!["OUTER", "EQ"]);
+}
+
+#[test]
+fn tokenizes_dense_numeric_arrays_via_vector_stranding() {
+    // MA05 §4 scopes this cut to dense numeric arrays; stranding (juxtaposed
+    // literals separated only by whitespace, e.g. `1 2 3`) is a NUMBER NUMBER
+    // NUMBER token sequence at the lexer level — grouping into one array
+    // literal is the parser's job, not the lexer's.
+    assert_eq!(
+        token_types("1 2 3"),
+        vec!["NUMBER", "NUMBER", "NUMBER"]
+    );
+    assert_eq!(token_values("1 2 3"), vec!["1", "2", "3"]);
+}
+
+#[test]
+fn tokenizes_high_minus_negative_numbers_distinctly_from_the_minus_function() {
+    // ¯ (U+00AF, macron) is APL's historical negative-literal sign, distinct
+    // from the MINUS function glyph `-` (see apl.tokens SECTION 4) — so `¯3`
+    // is one NUMBER token, but `A-B` keeps `-` as its own MINUS token.
+    assert_eq!(token_types("¯3"), vec!["NUMBER"]);
+    assert_eq!(token_values("¯3"), vec!["¯3"]);
+    assert_eq!(token_types("A-B"), vec!["NAME", "MINUS", "NAME"]);
+    assert_eq!(token_types("A -¯3"), vec!["NAME", "MINUS", "NUMBER"]);
+}
+
+#[test]
+fn tokenizes_numbers_with_decimal_and_high_minus_exponent() {
+    assert_eq!(token_types("1.5E¯3"), vec!["NUMBER"]);
+    assert_eq!(token_values("1.5E¯3"), vec!["1.5E¯3"]);
+    assert_eq!(token_values("3.14"), vec!["3.14"]);
+}
+
+#[test]
+fn tokenizes_plain_ascii_names() {
+    assert_eq!(token_types("VAR1 x Result"), vec!["NAME", "NAME", "NAME"]);
+}
+
+#[test]
+fn skips_whitespace_and_line_comments() {
+    assert_eq!(
+        token_types("⍝ a whole comment line\nA←1"),
+        vec!["NEWLINE", "NAME", "ARROW", "NUMBER"]
+    );
+    assert_eq!(
+        token_types("A←1 ⍝ trailing comment\nB←2"),
+        vec!["NAME", "ARROW", "NUMBER", "NEWLINE", "NAME", "ARROW", "NUMBER"]
+    );
+}
+
+#[test]
+fn newline_is_its_own_significant_token() {
+    assert_eq!(
+        token_types("A←1\nB←2"),
+        vec!["NAME", "ARROW", "NUMBER", "NEWLINE", "NAME", "ARROW", "NUMBER"]
+    );
+}
+
+#[test]
+fn tokenizes_the_ma05_kickoff_example_end_to_end() {
+    // `A←⍳5` then `B←+/A` — index-generator followed by a sum-reduce,
+    // MA05's own running example for this historical-core subset.
+    assert_eq!(
+        token_types("A←⍳5\nB←+/A"),
+        vec![
+            "NAME", "ARROW", "IOTA", "NUMBER", "NEWLINE", "NAME", "ARROW", "PLUS", "REDUCE",
+            "NAME",
+        ]
+    );
+}

--- a/code/specs/MA05-apl-language.md
+++ b/code/specs/MA05-apl-language.md
@@ -189,7 +189,15 @@ apl-repl/     src/{lib.rs, main.rs}       ← MA-4e (the `apl` binary)
   patterns, 8 rules, zero cross-validation warnings — every declared token
   is referenced). Files: `code/grammars/apl/apl.tokens`,
   `code/grammars/apl/apl.grammar`.
-- **MA-4c — `apl-lexer`.** Single-codepoint glyph tokens, `⍝` line comments.
+- **MA-4c — `apl-lexer`** (✅ done): a thin wrapper crate over the shared
+  `GrammarLexer`, mirroring `macsyma-lexer`'s shape exactly (no pre/post-
+  tokenize hooks needed — every glyph in this subset is single-codepoint and
+  unambiguous, per §3 bullet 4). Statically compiles
+  `code/grammars/apl/apl.tokens` at build time via `grammar-tools
+  generate-rust-compiled-grammars`. 10 tests cover every primitive function
+  glyph, the reduce/scan/outer-product operators, assignment/grouping,
+  vector-stranded numeric literals, high-minus (`¯`) negative literals kept
+  distinct from the `MINUS` function token, and `⍝` line comments.
 - **MA-4d — `apl-parser`.** The `value_expr`/`function_expr` grammar,
   monadic/dyadic application, reduce/scan/outer-product operator
   productions. **Acceptance criteria includes a recursion-depth cap**: §3's


### PR DESCRIPTION
## Summary
- New `apl-lexer` crate: a thin wrapper over the shared `GrammarLexer`, mirroring `macsyma-lexer`'s shape exactly (no pre/post-tokenize hooks needed — every glyph in this historical-core APL subset is a single dedicated Unicode code point per MA05 §3 bullet 4).
- Statically compiles `code/grammars/apl/apl.tokens` into `src/_grammar.rs` at build time via `grammar-tools generate-rust-compiled-grammars` — no filesystem access at runtime.
- 10 tests cover every primitive function glyph, the reduce/scan/outer-product operators, assignment/grouping, vector-stranded numeric literals, high-minus (`¯`) negative literals kept distinct from the `MINUS` function token, and `⍝` line comments.
- Marks MA-4c done in `MA05-apl-language.md` §6; unblocks MA-4d (`apl-parser`).

Front 2 (new-language) rotation turn — continues the APL track after MA-4b (`apl.tokens`/`apl.grammar`, #7782, merged).

## Test plan
- [x] `cargo test -p coding-adventures-apl-lexer` — 10/10 pass
- [x] `cargo clippy -p coding-adventures-apl-lexer --all-targets` — zero warnings on this crate
- [x] Two independent `/security-review` passes — both PASSED, one non-blocking LOW/INFO note (panic-on-error convenience wrapper, matches established `macsyma-lexer`/`wolfram-lexer` precedent)
- [x] Spec (`MA05-apl-language.md`) kept in sync — MA-4c marked done with delivery details

🤖 Generated with [Claude Code](https://claude.com/claude-code)