### PR TITLE
feat(sir-go): Hash Enumerable breadth (group_by/partition/flat_map/reduce/inject/sum)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.28.0 — Hash Enumerable breadth: `group_by` / `partition` / `flat_map` / `reduce` / `inject` / `sum`
+
+Mirrors the Python `sir-runtime-oop` v0.1.20 reference (PR #7978) into the Go
+backend's emitted runtime (`_sir_hash_block_method` + `_sir_hash_responds`).
+The block is yielded `(key, value)` (two arguments) — except `reduce`/`inject`,
+which follow Ruby's memo convention and yield `(memo, [key, value])` (the pair
+as one second argument).  Every "element" a result carries is the two-element
+`[key, value]` Array (`&Seq{key, value}`).
+
+- `group_by { |k, v| … }` — a Hash of block key → Array of `[k, v]` pairs, in
+  first-seen key order.
+- `partition { |k, v| … }` — `[[matching pairs], [non-matching pairs]]`.
+- `flat_map`/`collect_concat { |k, v| … }` — one-level splice of block results.
+- `reduce`/`inject(init) { |memo, (k, v)| … }` — fold; a seedless `reduce`
+  starts from the first pair, and an empty seedless `reduce` returns `nil`.
+- `sum(init = 0) { |k, v| … }` — `init` plus the polymorphic-`+` (`_sir_plus`)
+  sum of the block results.
+
+`_sir_hash_responds` now advertises all of the above (the hash block dispatch
+already forwards the positional args before the block, so `reduce`/`sum` read
+their seed).
+
+Exec-proof: `tests/compile_and_run_hash_methods.rs` gains
+`hash_enumerable_breadth_compile_and_run`, running `group_by` (even-value
+predicate ⇒ bool-keyed Hash of pairs), `partition`, `flat_map`, `reduce(0)`, and
+`sum(100)` under real `go run`, diffed against the Python reference semantics.
+
 ## 0.27.0 — Hash Enumerable aggregates: `find` / `any?` / `all?` / `none?` / `count` / `sort_by` / `min_by` / `max_by`
 
 Mirrors the Python `sir-runtime-oop` v0.1.19 reference (PR #7957) into the Go

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -187,7 +187,8 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `length`, `empty?`, `each`/`each_pair`, `each_key`, `each_value`, `map`,
 `select`/`filter`, `reject`, `transform_values`, `transform_keys`, and the
 Enumerable aggregates `find`/`detect`, `any?`/`all?`/`none?`, `count`,
-`sort_by`, `min_by`/`max_by`;
+`sort_by`, `min_by`/`max_by`, `group_by`, `partition`,
+`flat_map`/`collect_concat`, `reduce`/`inject`, `sum`;
 **String** `length`/`size`, `upcase`, `downcase`, `reverse`, `strip`/`lstrip`/
 `rstrip`, `empty?`, `include?`, `start_with?`, `end_with?`, `split`, `chars`,
 `to_i`, `to_f`, `to_sym`; **Numeric** `abs`, `to_i`, `to_f`, `even?`, `odd?`,

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1719,7 +1719,9 @@ func _sir_hash_responds(name string) bool {
 	case "each", "each_pair", "each_key", "each_value", "map",
 		"select", "filter", "reject", "transform_values", "transform_keys",
 		"find", "detect", "any?", "all?", "none?", "count",
-		"sort_by", "min_by", "max_by":
+		"sort_by", "min_by", "max_by",
+		"group_by", "partition", "flat_map", "collect_concat",
+		"reduce", "inject", "sum":
 		return true
 	}
 	return false
@@ -2654,6 +2656,85 @@ func _sir_hash_block_method(recv *Map, name string, args []Value, block *Closure
 			}
 		}
 		return &Seq{Items: []Value{best.Key, best.Val}}, true
+	// ── Enumerable breadth (grouping / folding / flattening) ───────
+	//
+	// The block is yielded (key, value) two args (except `reduce`/`inject`,
+	// which follow Ruby's memo convention and yield (memo, [key, value]) — the
+	// pair as ONE second argument).  Every "element" a result carries is the
+	// two-element [key, value] Array (`&Seq{key, value}`).
+	case "group_by":
+		// A Hash of block key → Array of [k, v] pairs, in first-seen key order.
+		acc := _sir_map_lit([]Value{}, []Value{})
+		for _, e := range recv.Entries {
+			k := _sir_apply(block, []Value{e.Key, e.Val})
+			pair := &Seq{Items: []Value{e.Key, e.Val}}
+			if seq, ok := _sir_map_get(acc, k).(*Seq); ok && seq != nil {
+				seq.Items = append(seq.Items, pair)
+			} else {
+				_sir_map_set(acc, k, &Seq{Items: []Value{pair}})
+			}
+		}
+		return acc, true
+	case "partition":
+		// `[matching pairs, non-matching pairs]`, order preserved.
+		yes := []Value{}
+		no := []Value{}
+		for _, e := range recv.Entries {
+			pair := &Seq{Items: []Value{e.Key, e.Val}}
+			if _sir_truthy(_sir_apply(block, []Value{e.Key, e.Val})) {
+				yes = append(yes, pair)
+			} else {
+				no = append(no, pair)
+			}
+		}
+		return &Seq{Items: []Value{&Seq{Items: yes}, &Seq{Items: no}}}, true
+	case "flat_map", "collect_concat":
+		// Map each pair through the block, splicing one level: an Array result
+		// contributes its elements, a scalar is appended as-is.
+		out := []Value{}
+		for _, e := range recv.Entries {
+			r := _sir_apply(block, []Value{e.Key, e.Val})
+			if s, ok := r.(*Seq); ok {
+				out = append(out, s.Items...)
+			} else {
+				out = append(out, r)
+			}
+		}
+		return &Seq{Items: out}, true
+	case "reduce", "inject":
+		// `reduce(init) { |memo, (k, v)| … }` folds the pairs; a seedless
+		// `reduce` starts from the first pair.  The block yields the pair as ONE
+		// second argument.  Empty seedless reduce ⇒ nil.
+		pairs := make([]Value, len(recv.Entries))
+		for i, e := range recv.Entries {
+			pairs[i] = &Seq{Items: []Value{e.Key, e.Val}}
+		}
+		var acc Value
+		var rest []Value
+		if len(args) > 0 {
+			acc = args[0]
+			rest = pairs
+		} else if len(pairs) > 0 {
+			acc = pairs[0]
+			rest = pairs[1:]
+		} else {
+			return nil, true
+		}
+		for _, pair := range rest {
+			acc = _sir_apply(block, []Value{acc, pair})
+		}
+		return acc, true
+	case "sum":
+		// `sum(init = 0) { |k, v| … }` — `init` plus the polymorphic-`+` sum of
+		// the block results (Hash#sum requires a block).
+		var acc Value = int64(0)
+		if len(args) > 0 {
+			acc = args[0]
+		}
+		for _, e := range recv.Entries {
+			acc = _sir_plus([]Value{acc, _sir_apply(block, []Value{e.Key, e.Val})})
+		}
+		return acc, true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
@@ -416,3 +416,115 @@ fn hash_enumerable_aggregates_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+/// Demo for the Hash Enumerable *breadth* batch (group_by / partition /
+/// flat_map / reduce / sum).  Block yields (key, value) — except `reduce`,
+/// which yields (memo, [key, value]).  Results carry `[key, value]` pairs.
+fn breadth_module() -> Module {
+    // { |k, v| v } — the value (sort/sum projection).
+    let by_val = lambda_fn2("__lam_val", "k", "v", var_p("v"));
+    // { |k, v| v.even? } — even-value predicate (group_by / partition).
+    let is_even = lambda_fn2("__lam_even", "k", "v", method(var_p("v"), "even?", vec![]));
+    // { |k, v| [k, v] } — echo the pair (flat_map, so it flattens to k, v, …).
+    let echo_pair = lambda_fn2(
+        "__lam_pair",
+        "k",
+        "v",
+        Expr::SeqLit { items: vec![var_p("k"), var_p("v")], span: s() },
+    );
+    // { |acc, pair| acc + pair[1] } — fold the values (reduce memo convention).
+    let add_val = lambda_fn2(
+        "__lam_addval",
+        "acc",
+        "pair",
+        builtin(
+            "+",
+            vec![
+                var_p("acc"),
+                Expr::SeqIndex {
+                    seq: Box::new(var_p("pair")),
+                    index: Box::new(ilit(1)),
+                    span: s(),
+                },
+            ],
+        ),
+    );
+
+    let stmts = vec![
+        // {a:1,b:2,c:3,d:4}.group_by { |k,v| v.even? }
+        //   → {#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "group_by",
+            vec![closure("__lam_even")],
+        )),
+        // {a:1,b:2,c:3,d:4}.partition { |k,v| v.even? }
+        //   → [[[b, 2], [d, 4]], [[a, 1], [c, 3]]]
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "partition",
+            vec![closure("__lam_even")],
+        )),
+        // {a:1,b:2}.flat_map { |k,v| [k, v] } → [a, 1, b, 2]
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2)]),
+            "flat_map",
+            vec![closure("__lam_pair")],
+        )),
+        // {a:1,b:2,c:3,d:4}.reduce(0) { |acc, (k,v)| acc + v } → 10
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "reduce",
+            vec![ilit(0), closure("__lam_addval")],
+        )),
+        // {a:1,b:2,c:3,d:4}.sum(100) { |k,v| v } → 110
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2), ("c", 3), ("d", 4)]),
+            "sum",
+            vec![ilit(100), closure("__lam_val")],
+        )),
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![by_val, is_even, echo_pair, add_val, main])
+}
+
+#[test]
+fn hash_enumerable_breadth_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&breadth_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "breadth");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "{#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}", // group_by { even? }
+            "[[[b, 2], [d, 4]], [[a, 1], [c, 3]]]",         // partition { even? }
+            "[a, 1, b, 2]",                                 // flat_map { [k, v] }
+            "10",                                           // reduce(0) { acc + v }
+            "110",                                          // sum(100) { v }
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Mirrors the Python `sir-runtime-oop` v0.1.20 reference (#7978) into the **Go backend** (`semantic-ir-to-go`) — first backend of the Hash Enumerable breadth cascade. The block is yielded `(key, value)` (two args) — except `reduce`/`inject`, which follow Ruby's memo convention and yield `(memo, [key, value])`. Results carry `[key, value]` pairs (`&Seq{key, value}`).

- `group_by { |k,v| … }` — Hash of block key → Array of `[k, v]` pairs (first-seen key order).
- `partition { |k,v| … }` — `[[matching pairs], [non-matching pairs]]`.
- `flat_map`/`collect_concat` — one-level splice of block results.
- `reduce`/`inject(init) { |memo,(k,v)| … }` — fold; seedless from first pair; empty seedless → `nil`.
- `sum(init=0) { |k,v| … }` — `init` plus the polymorphic-`+` (`_sir_plus`) sum of block results.

`_sir_hash_responds` advertises all of the above. The dispatch already forwards the positional args before the block, so `reduce`/`sum` read their seed. Structurally identical to the existing `_sir_array_block_method` arms.

## Exec-proof

`tests/compile_and_run_hash_methods.rs` gains `hash_enumerable_breadth_compile_and_run`, run under real `go run`:
- `group_by { v.even? }` → `{#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}` (bool-keyed Hash of pairs)
- `partition { v.even? }` → `[[[b, 2], [d, 4]], [[a, 1], [c, 3]]]`
- `flat_map { [k, v] }` → `[a, 1, b, 2]`
- `reduce(0) { |acc,(k,v)| acc + v }` → `10`; `sum(100) { v }` → `110`

Diffed against the Python reference. `cargo test -p semantic-ir-to-go --test compile_and_run_hash_methods` passes (3/3).

## Checklist
- [x] CHANGELOG.md (0.27.0 → **0.28.0**), README Hash catalog updated
- [x] Exec-proof green under `go run`
- [x] Security review passed (identical shape to reviewed sibling array arms; comma-ok type-asserts, no new panic/injection/DoS)

Cascade: reference = #7978. Go = this PR; Rust/JS/TS follow one-per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)