### PR TITLE
feat(sql-vm): IIF(x, y, z) — the function form of CASE (Stream B)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.4 — IIF(x, y, z) — the function form of CASE
+
+Stream B, corpus growth. `IIF(x, y, z)` now works — SQLite's function-form
+conditional (`CASE WHEN x THEN y ELSE z END`), a pure-`sql-vm` addition (0.4.1)
+that covers much of `CASE`'s utility while full `CASE`/`CAST`/window syntax
+remains blocked on a stale generated grammar. One new differential-oracle case
+(`iif`) diffs mini-sqlite against real bundled SQLite. No mini-sqlite `src/`
+change.
+
 ## 0.5.3 — More scalar functions: SIGN / UNICODE / CHAR / ZEROBLOB / QUOTE
 
 Stream B, corpus-growth phase. Five more common scalar functions now work:

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -483,6 +483,15 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT QUOTE(s) AS qs, QUOTE(n) AS qn FROM t ORDER BY id",
     },
+    // IIF(x, y, z) — the function form of CASE WHEN x THEN y ELSE z END.
+    Case {
+        id: "iif",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, n INTEGER)",
+            "INSERT INTO t VALUES (1, 8), (2, 2), (3, NULL)",
+        ],
+        query: "SELECT IIF(n > 5, 'big', 'small') AS r FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.1] - Unreleased
+
+### Added
+
+- **`IIF(x, y, z)`** — SQLite's function-form conditional, equivalent to
+  `CASE WHEN x THEN y ELSE z END`: returns `y` when `x` is truthy (SQL
+  three-valued logic — a NULL or falsy `x` selects `z`), reusing the engine's
+  `is_truthy` helper. Unit-tested and validated against real SQLite by the
+  mini-sqlite differential oracle. (A pure-VM partial for `CASE`, which is
+  blocked on a stale generated grammar — see the mini-sqlite notes.)
+
 ## [0.4.0] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1428,6 +1428,24 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             Ok(SqlValue::Text(lit))
         }
 
+        "IIF" => {
+            // IIF(x, y, z) — SQLite's function-form conditional, equivalent to
+            // `CASE WHEN x THEN y ELSE z END`: `y` when `x` is truthy (SQL
+            // three-valued logic — a NULL or falsy `x` picks `z`). Arguments are
+            // already evaluated here; since this engine's expressions have no
+            // side effects, eagerly evaluating both branches is observationally
+            // identical to CASE's short-circuit.
+            if args.len() != 3 {
+                return Err(VmError::TypeMismatch(format!("IIF expects 3 args, got {}", args.len())));
+            }
+            let pick_then = is_truthy(&args[0]);
+            let mut it = args.into_iter();
+            let _cond = it.next();
+            let y = it.next().unwrap();
+            let z = it.next().unwrap();
+            Ok(if pick_then { y } else { z })
+        }
+
         other => {
             // Unknown function — return NULL rather than crashing.
             // This matches SQLite's behaviour for unrecognised scalar functions.
@@ -3654,5 +3672,18 @@ mod tests {
         assert_eq!(q(SqlValue::Int(-7)), "-7");
         assert_eq!(q(SqlValue::Text("it's".into())), "'it''s'"); // inner quote doubled
         assert_eq!(q(SqlValue::Blob(vec![0xde, 0xad])), "X'DEAD'");
+    }
+
+    #[test]
+    fn builtin_iif_selects_by_truthiness() {
+        let iif = |x: SqlValue| {
+            call_builtin("IIF", vec![x, SqlValue::Text("yes".into()), SqlValue::Text("no".into())]).unwrap()
+        };
+        assert_eq!(iif(SqlValue::Int(1)), SqlValue::Text("yes".into()));
+        assert_eq!(iif(SqlValue::Int(0)), SqlValue::Text("no".into()));
+        assert_eq!(iif(SqlValue::Null), SqlValue::Text("no".into())); // NULL → falsy
+        assert_eq!(iif(SqlValue::Bool(true)), SqlValue::Text("yes".into()));
+        // Wrong arity is a type error, not a panic.
+        assert!(call_builtin("IIF", vec![SqlValue::Int(1), SqlValue::Int(2)]).is_err());
     }
 }


### PR DESCRIPTION
## Stream B — `IIF(x, y, z)`, the function form of CASE

`IIF(x, y, z)` now works — SQLite's function-form conditional, equivalent to `CASE WHEN x THEN y ELSE z END`. It returns `y` when `x` is truthy (SQL three-valued logic — a NULL or falsy `x` selects `z`), reusing the engine's existing `is_truthy` helper. A pure-`sql-vm` addition (parses as a function call, **zero grammar work**).

### Why not full CASE?
While wiring this up I found the full `CASE`/`CAST`/window syntax is blocked by a **stale generated grammar**: `code/grammars/sql/sql.grammar` already *defines* `case_expr`, `cast_expr`, and `window_func_call` (and the `primary` rule references them), and the keywords are in `sql.tokens` — but the committed `sql-parser/src/_grammar.rs` is stale (`grep -c CASE` → 0) and the AST/planner/codegen handle none of them. Regenerating pulls in all three half-wired features at once, so full CASE is a coordinated multi-crate effort deferred to its own sequence. **IIF covers much of CASE's real-world utility today** with none of that risk.

### Verification
- New `sql-vm` unit test (truthiness selection + arity-error) + a new differential-oracle case (`iif`) that diffs mini-sqlite against real bundled SQLite (`rusqlite`, **dev-dep**) — matches.
- Full **sql-vm** (83) + **mini-sqlite** (45 lib + oracle + 4 file-backed + 11 integration + doctest) suites green; new code fmt + clippy clean.
- Security review **passed** (arity-guarded, O(1) value selection — no allocation/DoS, no injection, returns a data value never re-executed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
