### PR TITLE
feat(sir-rust): Hash Enumerable breadth (group_by/partition/flat_map/reduce/inject/sum)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.30.0 — Hash Enumerable breadth: `group_by` / `partition` / `flat_map` / `collect_concat` / `reduce` / `inject` / `sum`
+
+Mirrors the Python `sir-runtime-oop` reference (PR #7978) and the Go backend
+(PR #7983) into the Rust backend's inline `__sir` runtime (`map_method` block
+arms + the `Value::Map` `respond_to?` arm), completing the Hash Enumerable
+reshape/fold surface.  Ruby's `Hash` mixes in `Enumerable`, so every method
+here iterates the hash as a sequence of `[key, value]` pairs.  All yield the
+two-arg `(key, value)` EXCEPT `reduce`/`inject`, which follow Ruby's memo
+convention and yield `(memo, [k, v])` — the pair as ONE argument.
+
+- `group_by { |k, v| key }` — a Hash mapping each block key to the Array of the
+  `[k, v]` pairs that produced it, in first-seen key order and insertion order.
+- `partition { |k, v| pred }` — `[[matching pairs], [rest pairs]]`, each a fresh
+  Array of `[k, v]` pairs preserving order.
+- `flat_map`/`collect_concat { |k, v| … }` — map each pair then concatenate one
+  level: an Array result splices its elements, a scalar is appended as-is.
+- `reduce`/`inject` — Ruby's memo fold over the `[k, v]` pairs; with an explicit
+  seed the fold starts there, without one it seeds from the first pair (an empty
+  seedless reduce is `nil`).
+- `sum(init = 0) { |k, v| … }` — numeric fold seeded at `0` (or the explicit
+  seed arg) over the block results, reusing the polymorphic `plus` helper so
+  integer-only inputs stay `Int` while any float promotes.
+
+Every arm SNAPSHOTS the entries into an owned `Vec` before iterating, so no
+`RefCell` borrow is held across `apply_closure` — the never-panic floor holds
+even against a block that reentrantly mutates the same hash.
+
+Exec-proof: `tests/compile_and_run_hash_catalog.rs` gains
+`hash_enumerable_breadth_compile_and_run`, running `group_by`/`partition`
+(even-value predicate), `flat_map` (pair projection), `sum` (value projection),
+and `reduce(100)` (memo `acc + pair[1]`, indexed via `SeqIndex`) under real
+`rustc`, diffed against the Python/Go reference semantics.
+
 ## 0.29.0 — Hash Enumerable aggregates: `find` / `any?` / `all?` / `none?` / `count` / `sort_by` / `min_by` / `max_by`
 
 Mirrors the Python `sir-runtime-oop` v0.1.19 reference (PR #7957) into the Rust

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -145,9 +145,11 @@ rather than panicking:
   - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,
     `fetch`, `to_a`, `merge`, `dig` (nested), `invert`, `store`/`[]=`, `delete`,
     `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,
-    `reject`, `transform_values`, `transform_keys`, and the Enumerable
+    `reject`, `transform_values`, `transform_keys`, the Enumerable
     aggregates `find`/`detect`, `any?`/`all?`/`none?`, `count`, `sort_by`,
-    `min_by`/`max_by`.
+    `min_by`/`max_by`, and the Enumerable breadth `group_by`, `partition`,
+    `flat_map`/`collect_concat`, `reduce`/`inject`, `sum` (all yielding the
+    `[k, v]` pair — `reduce`/`inject` follow Ruby's `(memo, pair)` convention).
   - **String** (`Str`): `length`, `upcase`, `downcase`, `reverse`, `strip`,
     `include?`, `split`, char-set `tr`/`count`/`delete`/`squeeze` (literal
     sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1481,6 +1481,9 @@ pub const RUNTIME: &str = r##"mod __sir {
                     // Enumerable aggregates (Hash includes Enumerable)
                     | "find" | "detect" | "any?" | "all?" | "none?" | "count"
                     | "sort_by" | "min_by" | "max_by"
+                    // Enumerable breadth (block-taking reshape/fold)
+                    | "group_by" | "partition" | "flat_map" | "collect_concat"
+                    | "reduce" | "inject" | "sum"
             ),
             Value::Str(_) => matches!(
                 name,
@@ -2538,6 +2541,112 @@ pub const RUNTIME: &str = r##"mod __sir {
                         }
                     }
                     best.map(|(_, (k, v))| seq_lit(vec![k, v])).unwrap_or(Value::Nil)
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `group_by { |k, v| key }` — a Hash mapping each block key to the
+            // Array of the `[k, v]` pairs that produced it, in first-seen key
+            // order and insertion order.  (Hash includes Enumerable, so the
+            // element grouped is the two-element pair, matching Ruby.)
+            "group_by" => match &block {
+                Some(b) => {
+                    // Snapshot into an owned Vec FIRST so no `RefCell` borrow of
+                    // the receiver is held while the user block runs — a block
+                    // that reentrantly mutates the same hash cannot double-
+                    // borrow-panic (the never-panic floor).
+                    let snapshot = entries_rc.borrow().clone();
+                    let acc = map_lit(vec![]);
+                    for (k, v) in snapshot {
+                        let key = apply_closure(b, vec![k.clone(), v.clone()]);
+                        let bucket = match map_get(&acc, &key) {
+                            seq @ Value::Seq(_) => seq,
+                            _ => seq_lit(vec![]),
+                        };
+                        if let Value::Seq(inner) = &bucket {
+                            inner.borrow_mut().push(seq_lit(vec![k, v]));
+                        }
+                        map_set(&acc, key, bucket);
+                    }
+                    acc
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `partition { |k, v| pred }` — `[[matching pairs], [rest pairs]]`,
+            // each a fresh Array of `[k, v]` pairs preserving insertion order.
+            "partition" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    let mut yes = Vec::new();
+                    let mut no = Vec::new();
+                    for (k, v) in snapshot {
+                        if truthy(&apply_closure(b, vec![k.clone(), v.clone()])) {
+                            yes.push(seq_lit(vec![k, v]));
+                        } else {
+                            no.push(seq_lit(vec![k, v]));
+                        }
+                    }
+                    seq_lit(vec![seq_lit(yes), seq_lit(no)])
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `flat_map`/`collect_concat { |k, v| … }` — map each pair then
+            // concatenate one level: an Array result splices its elements, a
+            // scalar is appended as-is.
+            "flat_map" | "collect_concat" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    let mut out = Vec::new();
+                    for (k, v) in snapshot {
+                        match apply_closure(b, vec![k, v]) {
+                            Value::Seq(inner) => out.extend(inner.borrow().clone()),
+                            other => out.push(other),
+                        }
+                    }
+                    seq_lit(out)
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `reduce`/`inject` — Ruby's memo fold.  Unlike the two-arg `(k, v)`
+            // yield every other Enumerable method here uses, `reduce` follows
+            // Ruby's memo convention: the block receives `(memo, pair)` where
+            // `pair` is the `[k, v]` Array as ONE argument.  With an explicit
+            // seed the fold starts there over every pair; without one it seeds
+            // from the first pair (an empty seedless reduce is `nil`).
+            "reduce" | "inject" => {
+                let b = match &block {
+                    Some(b) => b,
+                    None => return unknown_method(&recv, name),
+                };
+                let snapshot = entries_rc.borrow().clone();
+                let pairs: Vec<Value> =
+                    snapshot.into_iter().map(|(k, v)| seq_lit(vec![k, v])).collect();
+                let (mut acc, rest): (Value, &[Value]) =
+                    if let Some(seed) = pos.into_iter().next() {
+                        (seed, &pairs[..])
+                    } else if let Some((head, tail)) = pairs.split_first() {
+                        (head.clone(), tail)
+                    } else {
+                        return Value::Nil;
+                    };
+                for pair in rest {
+                    acc = apply_closure(b, vec![acc, pair.clone()]);
+                }
+                acc
+            }
+            // `sum(init = 0) { |k, v| … }` — numeric fold seeded at `0` (or the
+            // explicit seed arg, matching Ruby `sum(init)` and the Python/TS
+            // reference's `total = args[0] if args else 0`) over the block
+            // results.  Each step reuses the polymorphic `plus` helper, so
+            // integer-only inputs stay `Int` while any float promotes.
+            "sum" => match &block {
+                Some(b) => {
+                    let seed = pos.into_iter().next().unwrap_or(Value::Int(0));
+                    let snapshot = entries_rc.borrow().clone();
+                    let mut acc = seed;
+                    for (k, v) in snapshot {
+                        acc = plus(vec![acc, apply_closure(b, vec![k, v])]);
+                    }
+                    acc
                 }
                 None => unknown_method(&recv, name),
             },

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -423,3 +423,124 @@ fn hash_enumerable_aggregates_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+// ── Hash Enumerable breadth (group_by / partition / flat_map / reduce / sum) ──
+//
+// These block-taking reshape/fold methods complete the Rust `map_method`
+// Enumerable surface, mirroring the Go/Python reference (#7978, #7983).  Every
+// method yields the two-arg `(k, v)` pair EXCEPT `reduce`/`inject`, which
+// follow Ruby's memo convention and yield `(memo, [k, v])` — the pair as ONE
+// argument.  Expected values are exactly what the Python reference produces.
+
+/// `[a, b, …]` array literal from element expressions.
+fn seq_lit_e(items: Vec<Expr>) -> Expr {
+    Expr::SeqLit { items, span: s() }
+}
+
+/// `xs[i]` — SIR-native indexing (NOT the `[]` method envelope).
+fn seqidx(seq: Expr, index: Expr) -> Expr {
+    Expr::SeqIndex { seq: Box::new(seq), index: Box::new(index), span: s() }
+}
+
+/// `a op b` builtin (used for the polymorphic `+` in the `reduce` block).
+fn binop(name: &str, lhs: Expr, rhs: Expr) -> Expr {
+    Expr::BuiltinCall { name: name.into(), args: vec![lhs, rhs], effects: EffectSet::PURE, span: s() }
+}
+
+fn breadth_demo() -> Module {
+    let block_fns = vec![
+        // { |k, v| v.even? } — the group/partition predicate.
+        block_fn("__b_even", &["k", "v"], method(param("v"), "even?", vec![])),
+        // { |k, v| [k, v] } — flat_map projection that splices the pair.
+        block_fn("__b_pair", &["k", "v"], seq_lit_e(vec![param("k"), param("v")])),
+        // { |k, v| v } — sum projection.
+        block_fn("__b_val", &["k", "v"], param("v")),
+        // { |acc, pair| acc + pair[1] } — reduce over `(memo, [k, v])`; the
+        // pair arrives as ONE arg, so the value is `pair[1]` via `SeqIndex`
+        // (never the array `[]` method, which the Go mirror learned the hard
+        // way — see #7983).
+        block_fn("__b_add", &["acc", "pair"], binop("+", param("acc"), seqidx(param("pair"), ilit(1)))),
+    ];
+    let main_stmts = vec![
+        // {a:1,b:2,c:3,d:4}.group_by { |k,v| v.even? }
+        //   → {#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}  (first-seen keys)
+        print_stmt(method(abcd_map(), "group_by", vec![block("__b_even")])),
+        // .partition { |k,v| v.even? } → [[[b, 2], [d, 4]], [[a, 1], [c, 3]]]
+        print_stmt(method(abcd_map(), "partition", vec![block("__b_even")])),
+        // {a:1,b:2}.flat_map { |k,v| [k,v] } → [a, 1, b, 2]  (one-level splice)
+        print_stmt(method(
+            map_lit(vec![(symlit("a"), ilit(1)), (symlit("b"), ilit(2))]),
+            "flat_map",
+            vec![block("__b_pair")],
+        )),
+        // {a:1,b:2,c:3,d:4}.sum { |k,v| v } → 10  (seed defaults to 0)
+        print_stmt(method(abcd_map(), "sum", vec![block("__b_val")])),
+        // {a:1,b:2,c:3,d:4}.reduce(100) { |acc,pair| acc + pair[1] } → 110
+        print_stmt(method(abcd_map(), "reduce", vec![ilit(100), block("__b_add")])),
+    ];
+    demo_module(main_stmts, block_fns)
+}
+
+#[test]
+fn hash_enumerable_breadth_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&breadth_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_hash_breadth_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_hash_breadth_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "{#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}", // group_by { even? }
+            "[[[b, 2], [d, 4]], [[a, 1], [c, 3]]]",         // partition { even? }
+            "[a, 1, b, 2]",                                 // flat_map { [k, v] }
+            "10",                                           // sum { v }
+            "110",                                          // reduce(100) { acc + pair[1] }
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Mirrors the Python reference ([#7978](https://github.com/adhithyan15/coding-adventures/pull/7978)) and the Go backend ([#7983](https://github.com/adhithyan15/coding-adventures/pull/7983)) into the **Rust** backend's inline `__sir` runtime, completing the Hash Enumerable reshape/fold surface in `map_method`.

Ruby's `Hash` mixes in `Enumerable`, so every method iterates the hash as a sequence of `[k, v]` pairs and yields the two-arg `(k, v)` **except** `reduce`/`inject`, which follow Ruby's memo convention and yield `(memo, [k, v])` — the pair as ONE argument.

## Methods
- `group_by { |k,v| key }` → Hash key → Array of `[k,v]` pairs (first-seen key order)
- `partition { |k,v| pred }` → `[[matching pairs], [rest pairs]]`
- `flat_map`/`collect_concat { |k,v| … }` → one-level concat (Seq splices, scalar appends)
- `reduce`/`inject` → memo fold; explicit seed or first pair; empty seedless → `nil`
- `sum(init=0) { |k,v| … }` → polymorphic-`plus` fold over block results

## Safety
Every block-invoking arm **snapshots** entries into an owned `Vec` before iterating, so no `RefCell` borrow is held across `apply_closure` — the never-panic floor holds even against a block that reentrantly mutates the same hash. Names added to the `Value::Map` `respond_to?` arm.

## Exec-proof
`tests/compile_and_run_hash_catalog.rs` gains `hash_enumerable_breadth_compile_and_run`, compiling emitted Rust with real `rustc` and diffing stdout against the Python/Go reference:

```
{#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}   # group_by { even? }
[[[b, 2], [d, 4]], [[a, 1], [c, 3]]]           # partition { even? }
[a, 1, b, 2]                                   # flat_map { [k, v] }
10                                             # sum { v }
110                                            # reduce(100) { acc + pair[1] }
```

`reduce`'s `pair[1]` uses `Expr::SeqIndex` (not the array `[]` method), per the Go mirror lesson. Version 0.29.0 → 0.30.0; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)