### PR TITLE
feat(cobol): fixed-point decimal arithmetic — ADD/SUBTRACT/MULTIPLY (PL08 v0.2)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.0 — Fixed-point decimal arithmetic (PL08)
+
+- `ADD` / `SUBTRACT` / `MULTIPLY` with the current grammar's forms
+  (`ADD op… TO name [GIVING g]`, `SUBTRACT op… FROM name [GIVING g]`,
+  `MULTIPLY a BY b [GIVING g]`).
+- Exact fixed-point decimal maths on a scaled `i128`: addition/subtraction align
+  by the implied decimal point (result keeps the wider fraction); multiplication
+  sums the operands' fractional lengths. The result is then `MOVE`d into the
+  receiver's picture, so COBOL's silent truncation applies. Overflow beyond ~38
+  digits returns a `RuntimeError` (never panics or wraps).
+- Unsigned receivers keep the magnitude (e.g. `SUBTRACT 5 FROM 3` stores 2) —
+  signed `S` fields and `ROUNDED`/`ON SIZE ERROR` (which need frontend clauses)
+  and `DIVIDE` remain deferred (descriptive errors). Roadmap in PL08.
+
+
 ## 0.1.0 — COBOL runtime, execution spine (PL08)
 
 - `run_cobol(source) -> Result<String, RuntimeError>`: parse (via cobol-parser),

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -16,12 +16,14 @@ use coding_adventures_cobol_runtime::run_cobol;
 let out = run_cobol(source)?; // everything the program DISPLAYed
 ```
 
-## Scope (v0.1)
+## Scope
 
-A small but **fully correct** slice: unsigned numeric-display (`9`/`V`) and
-character (`X`/`A`) pictures; the item tree from level numbers; `VALUE`
-initialisation; figurative `ZERO`/`SPACE`; `MOVE` with the exact
-justify/pad/truncate rules; `DISPLAY`; `STOP RUN`. Anything not yet modelled
-(signed `S`, editing pictures, `COMP`, arithmetic, `PERFORM`, tables, files, and
-every other verb) returns a descriptive `RuntimeError` — never wrong output. See
-PL08 for the roadmap toward full COBOL and later standards.
+A small but **fully correct** slice, growing one quirk at a time: unsigned
+numeric-display (`9`/`V`) and character (`X`/`A`) pictures; the item tree from
+level numbers; `VALUE` initialisation; figurative `ZERO`/`SPACE`; `MOVE` with
+the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; and fixed-point
+decimal `ADD`/`SUBTRACT`/`MULTIPLY` (decimal-point aligned, truncating into the
+receiver). Anything not yet modelled (signed `S`, `DIVIDE`, `ROUNDED`/`ON SIZE
+ERROR`, editing pictures, `COMP`, `PERFORM`, tables, files, and every other verb)
+returns a descriptive `RuntimeError` — never wrong output. See PL08 for the
+roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -4,7 +4,7 @@
 use crate::error::RuntimeError;
 use crate::picture::Picture;
 use crate::program::{Fig, Lit, Operand, Program, Stmt};
-use crate::value::{move_into_char, move_into_numeric, Decimal};
+use crate::value::{add, move_into_char, move_into_numeric, mul, sub, Decimal};
 use std::collections::HashMap;
 
 /// One field in the data model. Elementary items carry a picture and character
@@ -21,6 +21,13 @@ enum Src {
     Num(Decimal),
     Chars(String),
     Fig(Fig),
+}
+
+/// Turn an arithmetic result into a `Result`, reporting `i128` overflow (a value
+/// beyond ~38 digits — larger than any real COBOL numeric field) as an error
+/// rather than panicking or wrapping.
+fn checked(r: Option<Decimal>) -> Result<Decimal, RuntimeError> {
+    r.ok_or_else(|| RuntimeError::Unsupported("arithmetic overflow (result exceeds ~38 digits)".into()))
 }
 
 /// The running machine: the item table, a name→index map, and captured output.
@@ -121,6 +128,11 @@ impl Machine {
                     Stmt::StopRun => return Ok(self.output),
                     Stmt::Display(ops) => self.exec_display(ops)?,
                     Stmt::Move { src, dsts } => self.exec_move(src, dsts)?,
+                    Stmt::Add { operands, to, giving } => self.exec_add(operands, to, giving)?,
+                    Stmt::Subtract { operands, from, giving } => {
+                        self.exec_subtract(operands, from, giving)?
+                    }
+                    Stmt::Multiply { a, by, giving } => self.exec_multiply(a, by, giving)?,
                 }
             }
         }
@@ -146,6 +158,87 @@ impl Machine {
             self.move_into(idx, value)?;
         }
         Ok(())
+    }
+
+    // ----------------------------------------------------------------------
+    // Arithmetic (fixed-point decimal, truncating; unsigned receivers)
+    // ----------------------------------------------------------------------
+
+    /// `ADD op… TO name [GIVING g]` → (name + op1 + … + opN) into g or name.
+    fn exec_add(
+        &mut self,
+        operands: &[Operand],
+        to: &str,
+        giving: &Option<String>,
+    ) -> Result<(), RuntimeError> {
+        let mut acc = self.named_decimal(to)?;
+        for op in operands {
+            acc = checked(add(&acc, &self.operand_decimal(op)?))?;
+        }
+        self.store_number(giving.as_deref().unwrap_or(to), acc)
+    }
+
+    /// `SUBTRACT op… FROM name [GIVING g]` → (name − op1 − … − opN) into g or name.
+    fn exec_subtract(
+        &mut self,
+        operands: &[Operand],
+        from: &str,
+        giving: &Option<String>,
+    ) -> Result<(), RuntimeError> {
+        let mut acc = self.named_decimal(from)?;
+        for op in operands {
+            acc = checked(sub(&acc, &self.operand_decimal(op)?))?;
+        }
+        self.store_number(giving.as_deref().unwrap_or(from), acc)
+    }
+
+    /// `MULTIPLY a BY b [GIVING g]` → (a × b) into g, or into b when no GIVING.
+    fn exec_multiply(
+        &mut self,
+        a: &Operand,
+        by: &Operand,
+        giving: &Option<String>,
+    ) -> Result<(), RuntimeError> {
+        let product = checked(mul(&self.operand_decimal(a)?, &self.operand_decimal(by)?))?;
+        let target = match (giving, by) {
+            (Some(g), _) => g.clone(),
+            (None, Operand::Ident(name)) => name.clone(),
+            (None, _) => {
+                return Err(RuntimeError::Unsupported(
+                    "MULTIPLY … BY <literal> without GIVING has no receiver".into(),
+                ))
+            }
+        };
+        self.store_number(&target, product)
+    }
+
+    /// The numeric value of an operand (numeric literal, `ZERO`, or numeric
+    /// item). Non-numeric operands are an error — you cannot do arithmetic on
+    /// an alphanumeric value.
+    fn operand_decimal(&self, op: &Operand) -> Result<Decimal, RuntimeError> {
+        match self.src_from_operand(op)? {
+            Src::Num(d) => Ok(d),
+            Src::Fig(Fig::Zero) => Ok(Decimal::zero()),
+            Src::Fig(Fig::Space) | Src::Chars(_) => {
+                Err(RuntimeError::Unsupported("arithmetic on a non-numeric operand".into()))
+            }
+        }
+    }
+
+    /// The numeric value of a named field (must be a numeric item).
+    fn named_decimal(&self, name: &str) -> Result<Decimal, RuntimeError> {
+        let idx = *self.by_name.get(name).ok_or_else(|| RuntimeError::UndefinedName(name.into()))?;
+        match &self.items[idx].picture {
+            Some(p) if p.is_numeric() => Ok(self.item_as_decimal(idx)),
+            _ => Err(RuntimeError::Unsupported(format!("arithmetic on non-numeric field {name}"))),
+        }
+    }
+
+    /// Store a computed number into a named receiver (reshaped to its picture;
+    /// an unsigned receiver keeps the magnitude).
+    fn store_number(&mut self, name: &str, value: Decimal) -> Result<(), RuntimeError> {
+        let idx = *self.by_name.get(name).ok_or_else(|| RuntimeError::UndefinedName(name.into()))?;
+        self.move_into(idx, Src::Num(value))
     }
 
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -5,12 +5,13 @@
 //! PROCEDURE DIVISION, capturing everything `DISPLAY`ed. See
 //! [PL08](../../../specs/PL08-cobol-runtime.md).
 //!
-//! This is v0.1 — the execution spine. It implements a *small but fully
-//! correct* slice (`MOVE` / `DISPLAY` / `STOP RUN` over unsigned numeric-display
-//! and character pictures) and returns a descriptive error for anything not yet
-//! modelled, rather than producing wrong output. The roadmap toward full COBOL
-//! (arithmetic, editing pictures, `PERFORM`, tables, files, later standards) is
-//! in PL08.
+//! It implements a *small but fully correct* slice — `MOVE` / `DISPLAY` /
+//! `STOP RUN` and fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` over
+//! unsigned numeric-display and character pictures — and returns a descriptive
+//! error for anything not yet modelled, rather than producing wrong output. The
+//! roadmap toward full COBOL (signed numerics, `DIVIDE`, `ROUNDED`/`ON SIZE
+//! ERROR`, editing pictures, `PERFORM`, tables, files, later standards) is in
+//! PL08.
 //!
 //! ```
 //! use coding_adventures_cobol_runtime::run_cobol;
@@ -226,25 +227,93 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------
+    // Fixed-point decimal arithmetic
+    // ----------------------------------------------------------------------
+
+    /// Run a program whose WORKING-STORAGE is one field `R PIC <pic>`, execute
+    /// `body`, then `DISPLAY R` — returns R's displayed digits.
+    fn compute(pic: &str, body: &[&str], extra_ws: &[&str]) -> String {
+        let mut lines = vec![
+            "IDENTIFICATION DIVISION.".to_string(),
+            "PROGRAM-ID. P.".to_string(),
+            "DATA DIVISION.".to_string(),
+            "WORKING-STORAGE SECTION.".to_string(),
+            format!("01  R  PIC {pic}."),
+        ];
+        lines.extend(extra_ws.iter().map(|s| s.to_string()));
+        lines.push("PROCEDURE DIVISION.".to_string());
+        lines.push("MAIN.".to_string());
+        lines.extend(body.iter().map(|s| format!("    {s}")));
+        lines.push("    DISPLAY R.".to_string());
+        lines.push("    STOP RUN.".to_string());
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        run_cobol(&program(&refs)).unwrap()
+    }
+
+    #[test]
+    fn add_to_accumulates_into_the_receiver() {
+        // R starts 10; ADD 5 3 TO R → 18.
+        assert_eq!(compute("9(3)", &["MOVE 10 TO R.", "ADD 5 3 TO R."], &[]), "018\n");
+    }
+
+    #[test]
+    fn add_giving_leaves_the_to_field_unchanged() {
+        // ADD 2 3 TO A GIVING R → R = 2+3+A(=100) = 105; A untouched.
+        let out = compute(
+            "9(3)",
+            &["ADD 2 3 TO A GIVING R."],
+            &["01  A  PIC 9(3) VALUE 100."],
+        );
+        assert_eq!(out, "105\n");
+    }
+
+    #[test]
+    fn subtract_from_and_unsigned_receiver_keeps_magnitude() {
+        // SUBTRACT 3 FROM R(=10) → 7.
+        assert_eq!(compute("9(3)", &["MOVE 10 TO R.", "SUBTRACT 3 FROM R."], &[]), "007\n");
+        // SUBTRACT 5 FROM R(=3) → -2, but R is unsigned → stores magnitude 2.
+        assert_eq!(compute("9(3)", &["MOVE 3 TO R.", "SUBTRACT 5 FROM R."], &[]), "002\n");
+    }
+
+    #[test]
+    fn multiply_fixed_point_truncates_into_receiver() {
+        // 2.5 * 2.5 = 6.25 → into PIC 9(3)V9 truncates to "0062".
+        let out = compute("9(3)V9", &["MULTIPLY 2.5 BY 2.5 GIVING R."], &[]);
+        assert_eq!(out, "0062\n");
+    }
+
+    #[test]
+    fn multiply_by_updates_the_by_field_without_giving() {
+        // MOVE 6 TO R; MULTIPLY 7 BY R → R = 42.
+        assert_eq!(compute("9(3)", &["MOVE 6 TO R.", "MULTIPLY 7 BY R."], &[]), "042\n");
+    }
+
+    #[test]
+    fn decimal_add_aligns_the_implied_point() {
+        // R PIC 9(2)V99 (4 digits) starts 1.50; ADD 2.25 TO R → 3.75 → "0375".
+        assert_eq!(compute("9(2)V99", &["MOVE 1.5 TO R.", "ADD 2.25 TO R."], &[]), "0375\n");
+    }
+
+    // ----------------------------------------------------------------------
     // Honest failure: unmodelled features error, they do not run wrong.
     // ----------------------------------------------------------------------
 
     #[test]
     fn unsupported_verb_is_a_clear_error() {
+        // PERFORM is not yet executed (control flow is a later PR).
         let err = run_cobol(&program(&[
             "IDENTIFICATION DIVISION.",
             "PROGRAM-ID. P.",
-            "DATA DIVISION.",
-            "WORKING-STORAGE SECTION.",
-            "01  N  PIC 9(3).",
             "PROCEDURE DIVISION.",
             "MAIN.",
-            "    ADD 1 TO N.",
+            "    PERFORM SUB.",
+            "    STOP RUN.",
+            "SUB.",
             "    STOP RUN.",
         ]))
         .unwrap_err();
         assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
-        assert!(err.to_string().contains("ADD"), "message should name the verb: {err}");
+        assert!(err.to_string().contains("PERFORM"), "message should name the verb: {err}");
     }
 
     #[test]

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -62,6 +62,12 @@ pub struct Paragraph {
 pub enum Stmt {
     Display(Vec<Operand>),
     Move { src: Operand, dsts: Vec<String> },
+    /// `ADD op… TO name [GIVING g]` — result = op1+…+name, stored in g or name.
+    Add { operands: Vec<Operand>, to: String, giving: Option<String> },
+    /// `SUBTRACT op… FROM name [GIVING g]` — result = name-(op1+…), in g or name.
+    Subtract { operands: Vec<Operand>, from: String, giving: Option<String> },
+    /// `MULTIPLY a BY b [GIVING g]` — result = a*b, stored in g or b.
+    Multiply { a: Operand, by: Operand, giving: Option<String> },
     StopRun,
 }
 
@@ -267,8 +273,57 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 Err(RuntimeError::Unsupported("STOP <literal> (only STOP RUN in v0.1)".into()))
             }
         }
+        "add_stmt" => {
+            // ADD op… TO name [GIVING g]: operands are `operand` nodes; the
+            // direct NAME tokens are [to] or [to, giving].
+            let operands = read_operands(verb)?;
+            let (to, giving) = read_target_and_giving(verb)?;
+            Ok(Stmt::Add { operands, to, giving })
+        }
+        "subtract_stmt" => {
+            let operands = read_operands(verb)?;
+            let (from, giving) = read_target_and_giving(verb)?;
+            Ok(Stmt::Subtract { operands, from, giving })
+        }
+        "multiply_stmt" => {
+            // MULTIPLY a BY b [GIVING g]: two operand nodes; a direct NAME token
+            // only when GIVING is present.
+            let ops = read_operands(verb)?;
+            if ops.len() != 2 {
+                return Err(RuntimeError::Unsupported("MULTIPLY needs exactly two operands".into()));
+            }
+            let has_giving = child_tokens(verb).iter().any(|(k, v)| k == "KEYWORD" && v == "GIVING");
+            let names: Vec<String> = child_tokens(verb)
+                .into_iter()
+                .filter(|(k, _)| k == "NAME")
+                .map(|(_, v)| v)
+                .collect();
+            let giving = if has_giving { names.into_iter().next() } else { None };
+            let mut it = ops.into_iter();
+            Ok(Stmt::Multiply { a: it.next().unwrap(), by: it.next().unwrap(), giving })
+        }
         other => Err(RuntimeError::Unsupported(format!("the {} verb", verb_name(other)))),
     }
+}
+
+/// All `operand` child nodes of a verb, read to typed [`Operand`]s.
+fn read_operands(verb: &GrammarASTNode) -> Result<Vec<Operand>, RuntimeError> {
+    child_nodes(verb, "operand").into_iter().map(read_operand).collect()
+}
+
+/// The target NAME and optional GIVING NAME of an `ADD … TO`/`SUBTRACT … FROM`.
+/// The direct NAME tokens are `[target]` or `[target, giving]`.
+fn read_target_and_giving(verb: &GrammarASTNode) -> Result<(String, Option<String>), RuntimeError> {
+    let names: Vec<String> = child_tokens(verb)
+        .into_iter()
+        .filter(|(k, _)| k == "NAME")
+        .map(|(_, v)| v)
+        .collect();
+    let mut it = names.into_iter();
+    let target = it
+        .next()
+        .ok_or_else(|| RuntimeError::Unsupported("arithmetic statement without a target".into()))?;
+    Ok((target, it.next()))
 }
 
 /// Human-friendly verb name from a grammar rule name (`move_stmt` → `MOVE`).

--- a/code/packages/rust/cobol-runtime/src/value.rs
+++ b/code/packages/rust/cobol-runtime/src/value.rs
@@ -51,6 +51,56 @@ impl Decimal {
     pub fn digits(&self) -> String {
         format!("{}{}", self.int, self.frac)
     }
+
+    /// This value as a signed `i128` scaled by `10^scale` (i.e. with exactly
+    /// `scale` fractional digits). Returns `None` if it overflows `i128`
+    /// (~38 digits — beyond any real COBOL numeric field) or if truncating the
+    /// fraction to `scale` digits would lose precision (callers pick a `scale`
+    /// large enough that it never does). This is the integer form on which exact
+    /// fixed-point add/subtract/multiply are performed.
+    fn to_scaled(&self, scale: usize) -> Option<i128> {
+        if self.frac.len() > scale {
+            return None;
+        }
+        let int = if self.int.is_empty() { "0" } else { self.int.as_str() };
+        let frac = format!("{:0<width$}", self.frac, width = scale);
+        let combined = format!("{int}{frac}");
+        let mag: i128 = combined.parse().ok()?;
+        Some(if self.neg { -mag } else { mag })
+    }
+
+    /// Rebuild a [`Decimal`] from a signed `i128` scaled by `10^scale`.
+    fn from_scaled(v: i128, scale: usize) -> Decimal {
+        let neg = v < 0;
+        // Zero-pad so there is always at least one integer digit.
+        let s = format!("{:0>width$}", v.unsigned_abs(), width = scale + 1);
+        let split = s.len() - scale;
+        Decimal { neg, int: s[..split].to_string(), frac: s[split..].to_string() }
+    }
+}
+
+/// Exact fixed-point addition. The result keeps the larger of the two operands'
+/// fractional lengths, so no precision is lost. `None` on `i128` overflow.
+pub fn add(a: &Decimal, b: &Decimal) -> Option<Decimal> {
+    let scale = a.frac.len().max(b.frac.len());
+    let r = a.to_scaled(scale)?.checked_add(b.to_scaled(scale)?)?;
+    Some(Decimal::from_scaled(r, scale))
+}
+
+/// Exact fixed-point subtraction (`a - b`).
+pub fn sub(a: &Decimal, b: &Decimal) -> Option<Decimal> {
+    let scale = a.frac.len().max(b.frac.len());
+    let r = a.to_scaled(scale)?.checked_sub(b.to_scaled(scale)?)?;
+    Some(Decimal::from_scaled(r, scale))
+}
+
+/// Exact fixed-point multiplication. The result's fractional length is the sum
+/// of the operands' — the standard COBOL composite before truncation into a
+/// receiver.
+pub fn mul(a: &Decimal, b: &Decimal) -> Option<Decimal> {
+    let (sa, sb) = (a.frac.len(), b.frac.len());
+    let r = a.to_scaled(sa)?.checked_mul(b.to_scaled(sb)?)?;
+    Some(Decimal::from_scaled(r, sa + sb))
 }
 
 /// Move a numeric value into a numeric receiver of `int_digits` integer
@@ -133,5 +183,44 @@ mod tests {
         assert_eq!(move_into_char("HI", 5), "HI   ");
         assert_eq!(move_into_char("HELLO WORLD", 5), "HELLO");
         assert_eq!(move_into_char("EXACT", 5), "EXACT");
+    }
+
+    // ----------------------------------------------------------------------
+    // Fixed-point decimal arithmetic
+    // ----------------------------------------------------------------------
+
+    fn d(s: &str) -> Decimal {
+        Decimal::parse_literal(s).unwrap()
+    }
+
+    #[test]
+    fn decimal_add_aligns_by_the_point() {
+        // 1.5 + 2.25 = 3.75 (result keeps the wider fraction)
+        assert_eq!(add(&d("1.5"), &d("2.25")).unwrap(), d("3.75"));
+        // 7 + 8 = 15
+        assert_eq!(add(&d("7"), &d("8")).unwrap(), d("15"));
+    }
+
+    #[test]
+    fn decimal_sub_can_go_negative() {
+        // 3 - 5 = -2 (sign carried; an unsigned receiver later drops it)
+        assert_eq!(sub(&d("3"), &d("5")).unwrap(), d("-2"));
+        assert_eq!(sub(&d("10.00"), &d("0.25")).unwrap(), d("9.75"));
+    }
+
+    #[test]
+    fn decimal_mul_sums_fraction_lengths() {
+        // 1.5 * 2.5 = 3.75; fraction length = 1 + 1 = 2
+        let r = mul(&d("1.5"), &d("2.5")).unwrap();
+        assert_eq!(r, Decimal { neg: false, int: "3".into(), frac: "75".into() });
+        // 12 * 12 = 144
+        assert_eq!(mul(&d("12"), &d("12")).unwrap(), d("144"));
+    }
+
+    #[test]
+    fn arithmetic_result_moves_into_receiver_truncating() {
+        // (2.5 * 2.5 = 6.25) moved into PIC 9(3)V9 → "0062" (low-order truncated).
+        let r = mul(&d("2.5"), &d("2.5")).unwrap();
+        assert_eq!(move_into_numeric(&r, 3, 1), "0062");
     }
 }

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -103,20 +103,27 @@ rather than producing wrong output.
 - `DISPLAY` (items and literals, concatenated, newline-terminated).
 - `STOP RUN`.
 
+**Added in v0.2:** fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` (the
+current grammar's `TO`/`FROM`/`BY` + `GIVING` forms) — decimal-point aligned,
+truncating into the receiver, unsigned receivers keeping the magnitude; overflow
+beyond ~38 digits is an error, never a panic.
+
 **Deferred to later PRs (return `RuntimeError::Unsupported` for now):**
-signed `S` numerics and overpunch-sign display; `P` scaling; editing pictures
+signed `S` numerics and overpunch-sign display; `P` scaling; `DIVIDE` and
+`ROUNDED`/`ON SIZE ERROR` (the latter need frontend clauses); editing pictures
 (`Z * $ , . + - CR DB B 0 /`); `USAGE COMP`/`COMP-3` (binary / packed decimal);
 group `MOVE`; name qualification (`OF`/`IN`); `REDEFINES`/`OCCURS`; and every
-verb other than `MOVE`/`DISPLAY`/`STOP RUN`.
+verb not listed above.
 
 ## Roadmap toward full COBOL
 
 Each item is a run-verified PR; the runtime grows one quirk at a time.
 
-1. **v0.1 — execution spine** (this PR): data model + `MOVE`/`DISPLAY`/`STOP RUN`.
-2. **Signed numerics + overpunch** display; `SIGN` clause.
-3. **Arithmetic** — `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE`/`COMPUTE`, fixed-point
-   decimal, `ROUNDED`, `ON SIZE ERROR`, `GIVING`.
+1. **v0.1 — execution spine** (merged): data model + `MOVE`/`DISPLAY`/`STOP RUN`.
+2. **v0.2 — arithmetic** (this PR): fixed-point `ADD`/`SUBTRACT`/`MULTIPLY`.
+3. **Remaining arithmetic** — `DIVIDE`, `COMPUTE`, `ROUNDED`, `ON SIZE ERROR`
+   (the last two also widen the frontend grammar); then **signed numerics +
+   overpunch** display and the `SIGN` clause.
 4. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
 5. **Control flow** — `IF … ELSE … END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
    `TIMES`, `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.


### PR DESCRIPTION
## COBOL now computes

Building on the merged runtime spine (#7986), this executes the arithmetic verbs the frontend already parses — **`ADD` / `SUBTRACT` / `MULTIPLY`** — with faithful **fixed-point decimal** semantics.

```cobol
000010 01  R  PIC 9(3)V9.
       ...
000050     MULTIPLY 2.5 BY 2.5 GIVING R.   *> 6.25 → truncated into 9(3)V9 → "0062"
000060     DISPLAY R.
```

### What's implemented (faithfully)
- **The verb forms in the current grammar**: `ADD op… TO name [GIVING g]`, `SUBTRACT op… FROM name [GIVING g]`, `MULTIPLY a BY b [GIVING g]`.
- **Exact fixed-point decimal maths** on a scaled `i128` (`value.rs` `add`/`sub`/`mul`): add/subtract **align by the implied decimal point** (result keeps the wider fraction); multiply **sums the operands' fractional lengths** (the standard COBOL composite). The result is then `MOVE`d into the receiver's picture, so **COBOL's silent truncation applies**.
- **Unsigned receivers keep the magnitude** — `SUBTRACT 5 FROM 3` stores `2`.
- **Overflow** beyond ~38 digits (larger than any real COBOL field) returns a `RuntimeError` via `checked_*` — never a panic or silent wrap.

### Honest scoping
`DIVIDE`, `COMPUTE`, `ROUNDED`/`ON SIZE ERROR` (the last two also need frontend grammar clauses), and signed `S` numerics return descriptive errors. Roadmap in [PL08](code/specs/PL08-cobol-runtime.md).

### Verification
- **34 tests + a doctest**, each asserting **exact `DISPLAY` output**: `ADD…TO` accumulation, `ADD…GIVING`, `SUBTRACT…FROM` (incl. unsigned magnitude), `MULTIPLY…BY`/`…GIVING`, decimal-point-aligned add, fixed-point truncation. Warning-free.
- Security review passed: all new `i128` arithmetic paths are panic-free (checked ops, guarded slicing, `unsigned_abs` safe on `i128::MIN`); the scaled-`format!` allocation is bounded by the existing `MAX_PICTURE_SIZE` cap with no amplification.

Second PR of the runtime arc (PL08); follows #7986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)