### PR TITLE
feat(javascript-ast): private class-member names (#x / #m()) — PropertyKey::PrivateName atomic node (CLOC12.177 PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.41.0] - 2026-07-11
+
+### Added — CLOC12.177 PR1: emit private class-member names (`#x`)
+
+`javascript-ast` 0.36.0 added `PropertyKey::PrivateName`. `emit_property_key`
+gains a `PrivateName` arm that prints `#` followed by the stored bare name — so a
+private field (`class C{#x=1;}`), a bare private field (`class C{#x;}`), a static
+private field (`class C{static #x=1;}`), and a private method (`class C{#m(){}}`)
+all print correctly. No quote/shorten logic applies (a private name is a hard
+token boundary, unlike a string key). 5 emit tests. MINOR.
+
 ## [0.40.1] - 2026-07-11
 
 ### Added — CLOC12.176 PR3: CodePrinter static-block conformance port

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.40.1"
+version = "0.41.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -76,7 +76,7 @@ use coding_adventures_javascript_ast::{
     ClassDeclaration, FunctionDeclaration, FunctionExpression,
     FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
     MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem, SequenceExpression,
-    ObjectMember, Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
+    ObjectMember, PrivateName, Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
     RegExpLiteral,
     UndefinedLiteral, VarKind, VariableDeclaration, VariableDeclarator, WhileStatement,
@@ -2102,6 +2102,15 @@ impl<'a> Emitter<'a> {
     fn emit_property_key(&mut self, k: &PropertyKey) {
         match k {
             PropertyKey::Identifier(i) => self.emit_identifier(i),
+            // A **private name** — `#x`. The stored `name` omits the leading
+            // `#` (mirroring `Identifier`), so we prepend it here. A private
+            // name is always a hard token boundary, so no quote/shorten logic
+            // applies (unlike a string key); it prints verbatim.
+            PropertyKey::PrivateName(p) => {
+                self.maybe_map(&p.cv);
+                self.write_str("#");
+                self.write_str(&p.name);
+            }
             PropertyKey::StringLiteral(s) => {
                 // Quote-stripping minification, matching Closure's CodePrinter:
                 // a string key whose DECODED value is a valid identifier name may
@@ -3772,6 +3781,75 @@ mod tests {
     fn bare_field_has_no_value() {
         // `class C{y;}` — a bare field: just the key and the terminator.
         assert_eq!(emit_class_decl("C", None, vec![field("y", None, false)]), "class C{y;}");
+    }
+
+    // ---- private-name keys (CLOC12.177) ------------------------------
+
+    /// A private **field** — `#x = 1`. The stored name omits the `#`; the
+    /// emitter prepends it.
+    fn private_field(name: &str, value: Option<Expression>, is_static: bool) -> ClassMember {
+        ClassMember::Field(PropertyDefinition {
+            cv: None,
+            key: PropertyKey::PrivateName(PrivateName { cv: None, name: name.to_string() }),
+            value,
+            computed: false,
+            is_static,
+        })
+    }
+
+    /// A private **method** — `#m(){}`.
+    fn private_method(name: &str) -> ClassMember {
+        ClassMember::Method(MethodDefinition {
+            cv: None,
+            key: PropertyKey::PrivateName(PrivateName { cv: None, name: name.to_string() }),
+            kind: MethodKind::Method,
+            value: method_fn(),
+            computed: false,
+            is_static: false,
+        })
+    }
+
+    #[test]
+    fn private_field_prints_hash() {
+        // `class C{#x=1;}` — the `#` is prepended to the stored bare name.
+        assert_eq!(
+            emit_class_decl("C", None, vec![private_field("x", Some(num(1.0)), false)]),
+            "class C{#x=1;}"
+        );
+    }
+
+    #[test]
+    fn bare_private_field() {
+        // `class C{#x;}` — a bare private field, no initializer.
+        assert_eq!(emit_class_decl("C", None, vec![private_field("x", None, false)]), "class C{#x;}");
+    }
+
+    #[test]
+    fn static_private_field() {
+        // `class C{static #x=1;}` — `static` stacks before the private key.
+        assert_eq!(
+            emit_class_decl("C", None, vec![private_field("x", Some(num(1.0)), true)]),
+            "class C{static #x=1;}"
+        );
+    }
+
+    #[test]
+    fn private_method_prints_hash() {
+        // `class C{#m(){}}` — a private method key also prints `#`.
+        assert_eq!(emit_class_decl("C", None, vec![private_method("m")]), "class C{#m(){}}");
+    }
+
+    #[test]
+    fn private_and_public_members_interleave() {
+        // `class C{#x=1;m(){}}` — a private field and a public method coexist.
+        assert_eq!(
+            emit_class_decl(
+                "C",
+                None,
+                vec![private_field("x", Some(num(1.0)), false), method("m", MethodKind::Method, false)],
+            ),
+            "class C{#x=1;m(){}}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.85.17] - 2026-07-11
+
+### Added — CLOC12.177 PR1: `PropertyKey::PrivateName` arms
+
+`javascript-ast` 0.36.0 added the `PropertyKey::PrivateName` variant. The three
+exhaustive `PropertyKey` matches gain an arm: the object-literal key rebuild
+passes a private name through unchanged (unreachable in valid input — an object
+literal never holds a private key — but the match must stay exhaustive), and the
+two `Object.keys`/`Object.entries` key-name extractors decline the fold on a
+private name (same as a computed key). PATCH.
+
 ## [0.85.16] - 2026-07-11
 
 ### Added — CLOC12.176 PR1: `ClassMember::StaticBlock` arm

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.85.16"
+version = "0.85.17"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -722,6 +722,10 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                         key: match &p.key {
                             // Identifier / literal keys: pass through.
                             PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
+                            // A private name (`#x`) is only legal as a class-member
+                            // key, never in an object literal — but the match must
+                            // stay exhaustive, so pass it through unchanged.
+                            PropertyKey::PrivateName(p) => PropertyKey::PrivateName(p.clone()),
                             PropertyKey::StringLiteral(s) => PropertyKey::StringLiteral(s.clone()),
                             PropertyKey::NumericLiteral(n) => PropertyKey::NumericLiteral(n.clone()),
                             PropertyKey::Expression(e) => {
@@ -5117,6 +5121,10 @@ fn fold_object_entries_pairs(properties: &[ObjectMember]) -> Option<Vec<Expressi
             PropertyKey::StringLiteral(s) => s.value.clone(),
             PropertyKey::NumericLiteral(n) => format_js_number(n.value),
             PropertyKey::Expression(_) => return None, // computed
+            // A private name is not a public property key — an object literal
+            // can never hold one, and `Object.keys/entries` would not enumerate
+            // it — so decline the fold (same as a computed key).
+            PropertyKey::PrivateName(_) => return None,
         };
         // A non-computed `{__proto__: v}` is the §B.3.1 prototype setter, not an
         // own property, so `Object.entries` would not enumerate it — decline.
@@ -5194,6 +5202,10 @@ fn fold_object_keys_names(properties: &[ObjectMember]) -> Option<Vec<Expression>
             PropertyKey::StringLiteral(s) => s.value.clone(),
             PropertyKey::NumericLiteral(n) => format_js_number(n.value),
             PropertyKey::Expression(_) => return None, // computed
+            // A private name is not a public property key — an object literal
+            // can never hold one, and `Object.keys/entries` would not enumerate
+            // it — so decline the fold (same as a computed key).
+            PropertyKey::PrivateName(_) => return None,
         };
         // NOTE (previously: a `contains('\\')` decline guarded against escapes).
         // A `PropertyKey::StringLiteral`'s `value` now holds the DECODED property

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.20.17] - 2026-07-11
+
+### Added — CLOC12.177 PR1: `PropertyKey::PrivateName` arm
+
+The object-literal key-rebuild match gains a `PropertyKey::PrivateName` arm that
+passes the key through unchanged (a private name never occurs in an object
+literal, but the match must stay exhaustive after `javascript-ast` 0.36.0 added
+the variant). PATCH.
+
 ## [0.20.16] - 2026-07-11
 
 ### Added — CLOC12.176 PR1: `ClassMember::StaticBlock` arm

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.20.16"
+version = "0.20.17"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -1426,6 +1426,9 @@ fn dce_expression(expr: &Expression, st: &mut DceState) -> Expression {
                         kind: p.kind,
                         key: match &p.key {
                             PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
+                            // A private name (`#x`) never occurs in an object
+                            // literal, but the match must stay exhaustive.
+                            PropertyKey::PrivateName(p) => PropertyKey::PrivateName(p.clone()),
                             PropertyKey::StringLiteral(s) => {
                                 PropertyKey::StringLiteral(s.clone())
                             }

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.20.17] - 2026-07-11
+
+### Added — CLOC12.177 PR1: `PropertyKey::PrivateName` arm
+
+The object-literal key-rebuild match gains a `PropertyKey::PrivateName` arm that
+passes the key through unchanged (a private name never occurs in an object
+literal, but the match must stay exhaustive after `javascript-ast` 0.36.0 added
+the variant). PATCH.
+
 ## [0.20.16] - 2026-07-11
 
 ### Added — CLOC12.176 PR1: `ClassMember::StaticBlock` arm

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.20.16"
+version = "0.20.17"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -1603,6 +1603,9 @@ fn fold_expression(expr: &Expression, st: &mut FoldState) -> Expression {
                         kind: p.kind,
                         key: match &p.key {
                             PropertyKey::Identifier(i) => PropertyKey::Identifier(i.clone()),
+                            // A private name (`#x`) never occurs in an object
+                            // literal, but the match must stay exhaustive.
+                            PropertyKey::PrivateName(p) => PropertyKey::PrivateName(p.clone()),
                             PropertyKey::StringLiteral(s) => {
                                 PropertyKey::StringLiteral(s.clone())
                             }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.12.17] - 2026-07-11
+
+### Added — CLOC12.177 PR1: `PropertyKey::PrivateName` arm
+
+The computed-key walk gains a `PropertyKey::PrivateName` arm (a no-op): a private
+name is not an identifier reference — it names a slot in the class's private
+brand, resolved lexically at parse time, never through scope — so it binds and
+references nothing. Keeps the match exhaustive after `javascript-ast` 0.36.0
+added the variant. PATCH.
+
 ## [0.12.16] - 2026-07-11
 
 ### Added — CLOC12.176 PR1: `ClassMember::StaticBlock` arm

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.12.16"
+version = "0.12.17"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -1093,6 +1093,10 @@ fn walk_property(
                 });
             }
             PropertyKey::StringLiteral(_) | PropertyKey::NumericLiteral(_) => {}
+            // A private name (`#x`) is not an identifier *reference* — it names a
+            // slot in the class's private brand, resolved lexically at parse
+            // time, never through scope. It binds and references nothing here.
+            PropertyKey::PrivateName(_) => {}
             PropertyKey::Expression(e) => walk_expression(e, ctx, analysis, pending),
         }
     }

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.36.0] - 2026-07-11
+
+### Added — CLOC12.177 PR1: private class-member names (`#x` / `#m()`)
+
+New `PrivateName { cv, name }` struct and a `PropertyKey::PrivateName(PrivateName)`
+variant — the key of a private class field (`#x = 1`) or method (`#m(){}`),
+ESTree's `PrivateIdentifier`. The `name` holds the bare name **without** the
+leading `#` (mirroring `Identifier`); the emitter prepends it.
+
+Because `PropertyKey` is `#[serde(untagged)]`, a bare `{ cv, name }` `PrivateName`
+would be structurally identical to an `Identifier` and the deserializer would
+silently pick whichever variant comes first (a `#x` key round-tripping back as a
+plain `x` — data loss). The payload therefore serializes under the distinct key
+`private_name` (`#[serde(rename)]`), giving the variant a unique required field;
+the Rust field stays `name` for API symmetry. Two round-trip tests pin this.
+
+MINOR. Member *access* (`this.#x`) is a distinct later node.
+
 ## [0.35.0] - 2026-07-11
 
 ### Added — CLOC12.176 PR1: `ClassMember::StaticBlock` (static initialization blocks)

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/expression.rs
+++ b/code/packages/rust/javascript-ast/src/expression.rs
@@ -991,11 +991,42 @@ pub enum PropertyKind {
     Set,
 }
 
+/// A **private name** — `#x` — the key of a private class member
+/// (`class C { #x = 1; #m(){} }`) and, later, the property of a private
+/// member access (`this.#x`). ESTree calls this a `PrivateIdentifier`.
+///
+/// Mirrors [`Identifier`]: the `name` field holds the bare name **without**
+/// the leading `#` (so `#x` stores `"x"`); the emitter prepends the `#`.
+///
+/// # Why `name` serializes as `private_name`
+///
+/// [`PropertyKey`] is `#[serde(untagged)]`, so a variant is chosen during
+/// deserialization by *structural shape*. A `PrivateName { cv, name }` would
+/// be byte-for-byte identical to an [`Identifier`] (`{ cv, name }`), and the
+/// untagged deserializer would greedily pick whichever variant appears first —
+/// a private `#x` key would silently round-trip back as a plain `x`
+/// identifier (data loss + a mis-emit). Serializing the payload under the
+/// distinct key `private_name` gives the variant a unique required field, so
+/// `{ "name": … }` deserializes as [`Identifier`] and `{ "private_name": … }`
+/// as [`PrivateName`], with no ambiguity. The Rust field stays `name` for API
+/// symmetry with [`Identifier`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PrivateName {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    #[serde(rename = "private_name")]
+    pub name: String,
+}
+
 /// The key side of a [`Property`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PropertyKey {
     Identifier(Identifier),
+    /// A private class-member key — `#x` / `#m()`. Only legal inside a class
+    /// body; never in an object literal. Disambiguated from `Identifier` in
+    /// the untagged enum by [`PrivateName`]'s `private_name` serde key.
+    PrivateName(PrivateName),
     StringLiteral(StringLiteral),
     NumericLiteral(NumericLiteral),
     /// When the property is `[expr]: value` (computed = true).
@@ -1115,7 +1146,9 @@ pub enum ClassMember {
     /// It has no name, no key, no parameter list, and no initializer — only a
     /// body, which is exactly a [`BlockStatement`]'s statement list, so the
     /// variant wraps `BlockStatement` directly rather than re-modelling it.
-    /// (Private members `#x` and decorators are later additive variants.)
+    /// (A member's *private* key `#x` is modelled by [`PropertyKey::PrivateName`]
+    /// on the `Field`/`Method` variants above; decorators are a later additive
+    /// variant.)
     StaticBlock(BlockStatement),
 }
 
@@ -1419,6 +1452,49 @@ mod tests {
         assert_eq!(traced.clone(), roundtrip(traced.clone()));
         assert_eq!(untraced.clone(), roundtrip(untraced.clone()));
         assert_eq!(type_tag(&traced), "Identifier");
+    }
+
+    // ---- PropertyKey::PrivateName (CLOC12.177) -----------------------
+
+    /// A `PropertyKey::PrivateName` round-trips as a `PrivateName` — NOT as an
+    /// `Identifier`. This is the whole point of the `private_name` serde key:
+    /// the untagged `PropertyKey` enum would otherwise pick `Identifier` (the
+    /// first structurally-matching variant) and silently lose the private-ness.
+    #[test]
+    fn private_name_key_roundtrips_and_stays_private() {
+        let key = PropertyKey::PrivateName(PrivateName { cv: None, name: "x".to_string() });
+        let json = serde_json::to_string(&key).expect("serialize");
+        // The distinguishing serde key must be present (and NOT the plain `name`
+        // that an `Identifier` would use).
+        assert!(
+            json.contains("private_name"),
+            "PrivateName must serialize under `private_name`, got {json}"
+        );
+        let back: PropertyKey = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(key, back);
+        assert!(
+            matches!(back, PropertyKey::PrivateName(_)),
+            "a private key must not round-trip back as another PropertyKey variant"
+        );
+    }
+
+    /// The traced form (a live `cv`) round-trips too, and a plain
+    /// `PropertyKey::Identifier` still deserializes as `Identifier` — proving the
+    /// new variant did not perturb the existing untagged disambiguation.
+    #[test]
+    fn private_name_traced_and_identifier_key_unaffected() {
+        let traced =
+            PropertyKey::PrivateName(PrivateName { cv: Some("pk.1".to_string()), name: "m".to_string() });
+        let j = serde_json::to_string(&traced).expect("serialize");
+        assert_eq!(traced, serde_json::from_str::<PropertyKey>(&j).expect("deserialize"));
+
+        let ident = PropertyKey::Identifier(Identifier { cv: None, name: "x".to_string() });
+        let ji = serde_json::to_string(&ident).expect("serialize");
+        let back: PropertyKey = serde_json::from_str(&ji).expect("deserialize");
+        assert!(
+            matches!(back, PropertyKey::Identifier(_)),
+            "a plain identifier key must still round-trip as Identifier, got {back:?}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -140,7 +140,7 @@ pub use expression::{
     ChainExpression, LogicalOperator, MemberExpression,
     NewExpression,
     NullLiteral, NumericLiteral, ObjectExpression, ObjectMember, OptionalCallExpression,
-    OptionalMemberExpression, Property, PropertyKey, PropertyKind,
+    OptionalMemberExpression, PrivateName, Property, PropertyKey, PropertyKind,
     RegExpLiteral,
     SequenceExpression, SpreadElement,
     StringLiteral, TaggedTemplateExpression, TemplateElement, TemplateLiteral, UnaryExpression, UnaryOperator,


### PR DESCRIPTION
## CLOC12.177 PR1 — private class-member names (atomic node)

First PR in the private-member arc. Adds the atomic typed-AST node for a **private class-member key** — a private field (`class C { #x = 1; }`) or method (`class C { #m(){} }`), ESTree's `PrivateIdentifier` — in ONE commit spanning the AST, emitter, and every downstream pass that matches `PropertyKey` exhaustively.

### javascript-ast (MINOR 0.35.0 → 0.36.0)
- New `PrivateName { cv, name }` struct + `PropertyKey::PrivateName(PrivateName)` variant. `name` holds the bare name **without** the leading `#` (mirroring `Identifier`); the emitter prepends it.
- **Serde disambiguation**: `PropertyKey` is `#[serde(untagged)]`, so a bare `{cv,name}` `PrivateName` would be structurally identical to `Identifier` — the deserializer would silently pick whichever variant came first (a `#x` key round-tripping back as `x` — data loss + mis-emit). The payload serializes under the distinct key `private_name` (`#[serde(rename)]`), giving the variant a unique required field; the Rust field stays `name`. Two round-trip tests pin this.

### closure-emitter (MINOR 0.40.1 → 0.41.0)
- `emit_property_key` gains a `PrivateName` arm printing `#`+name (no quote/shorten logic — a private name is a hard token boundary). 5 emit tests: `#x=1;`, bare `#x;`, `static #x=1;`, `#m(){}`, private/public interleave.

### Pass crates (PATCH) — conservative arms
- **constant-fold** 0.85.16→17: object-literal key rebuild passes through; the two `Object.keys`/`Object.entries` extractors decline the fold (like a computed key).
- **dce** 0.20.16→17, **fold-control-flow** 0.20.16→17: object-literal key rebuild passes through.
- **scope-analyzer** 0.12.16→17: no-op — a private name resolves lexically at parse time, never through scope.
- rename / rename-properties / rename-globals / inline / inline-variables use `if let` (non-exhaustive) and already fall through — a private name is correctly **not** renamed via the public-property channel (separate namespace).

### Verification
- All 6 modified crates' full test suites pass (0 failures)
- Security review (Rust, general-purpose subagent): **PASSED** — verified the serde disambiguation is sound (disjoint required-field shapes; a private key cannot be silently reinterpreted as a public identifier)

PR2 will bridge the grammar `PRIVATE_NAME` token → `PropertyKey::PrivateName` + a closurec e2e fixture; PR3 the CodePrinter conformance port. Member *access* (`this.#x`) is a distinct later node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)