### PR TITLE
feat(sir-js): Hash Enumerable breadth (group_by/partition/flat_map/reduce/inject/sum) + Hash display

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.28.0 — Hash Enumerable breadth: `group_by` / `partition` / `flat_map` / `collect_concat` / `reduce` / `inject` / `sum` (+ Hash display)
+
+Mirrors the Python reference (PR #7978), the Go backend (PR #7983), and the Rust
+backend (PR #7989) into the JS backend's inline `hashMethod` (+ the `HASH_METHODS`
+`respond_to?` set), completing the Hash Enumerable reshape/fold surface.  Ruby's
+`Hash` mixes in `Enumerable`, so every method iterates the hash as `[key, value]`
+pairs and yields the two-arg `(key, value)` EXCEPT `reduce`/`inject`, which follow
+Ruby's memo convention and yield `(memo, [k, v])` — the pair as ONE argument.
+
+- `group_by { |k, v| key }` — a `Map` from each block key to the Array of the
+  `[k, v]` pairs that produced it, in first-seen key order (mirrors Array#group_by,
+  which also returns a `Map`).
+- `partition { |k, v| pred }` — `[[matching pairs], [rest pairs]]`.
+- `flat_map`/`collect_concat { |k, v| … }` — map then concatenate one level (an
+  Array result splices, a scalar appends).
+- `reduce`/`inject` — Ruby's memo fold over the `[k, v]` pairs; explicit seed or
+  first pair; empty seedless → `nil`.
+- `sum(init = 0) { |k, v| … }` — numeric fold seeded at `0` (or the seed arg) over
+  the block results (native `+`, same as Array#sum).
+
+**Hash display fix:** `formatSeen` previously had no `Map` branch, so a printed
+Hash rendered as `[object Map]` (every prior hash test called `.to_a` first, so
+this was never exercised).  A Hash now renders `{k: v, …}` — the same surface the
+Go/Rust backends emit — so a printed `group_by` result round-trips identically
+across backends.  Cycle-guarded via `seen` like Arrays (`{...}` on a self-cycle).
+
+Exec-proof: `tests/run_with_node.rs` gains `hash_enumerable_breadth`, running
+`group_by`/`partition` (even-value predicate), `flat_map` (pair projection), `sum`
+(value projection), and `reduce(100)` (memo `acc + pair[1]` via `SeqIndex`) under
+real `node`, diffed against the Python/Go/Rust reference semantics.
+
 ## 0.27.0 — Hash Enumerable aggregates: `find` / `any?` / `all?` / `none?` / `count` / `sort_by` / `min_by` / `max_by`
 
 Mirrors the Python `sir-runtime-oop` v0.1.19 reference (PR #7957) into the

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -130,6 +130,19 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       seen.delete(v);
       return "[" + body + "]";
     }
+    // A Ruby Hash is a JS `Map`.  It renders `{k: v, …}` (colon-space between
+    // key and value, comma-space between pairs) — the SAME surface the Go/Rust
+    // backends emit, so a printed hash (e.g. a `group_by` result) round-trips
+    // identically across backends.  Cycle-guarded via `seen` like Arrays.
+    if (v instanceof Map) {
+      if (seen.has(v)) { return "{...}"; }
+      seen.add(v);
+      const body = [...v]
+        .map(([k, val]) => formatSeen(k, seen) + ": " + formatSeen(val, seen))
+        .join(", ");
+      seen.delete(v);
+      return "{" + body + "}";
+    }
     return String(v);
   }
 
@@ -927,6 +940,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "map", "select", "filter", "reject", "transform_values", "transform_keys",
     "find", "detect", "any?", "all?", "none?", "count",
     "sort_by", "min_by", "max_by",
+    "group_by", "partition", "flat_map", "collect_concat",
+    "reduce", "inject", "sum",
   ]);
   function hashMethod(recv, name, args) {
     switch (name) {
@@ -1108,6 +1123,74 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           }
         }
         return bestPair;
+      }
+      // ── Enumerable breadth (block-taking reshape / fold) ─────────
+      //
+      // Same [key, value]-pair iteration as the aggregates above: every method
+      // yields (key, value) EXCEPT `reduce`/`inject`, which follow Ruby's memo
+      // convention and yield (memo, pair) — the [k, v] Array as ONE argument.
+      case "group_by": {
+        // A Map from each block key to the Array of the [k, v] pairs that
+        // produced it, in first-seen key order (mirrors Array#group_by, which
+        // also returns a Map).
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        const groups = new Map();
+        for (const [k, v] of recv) {
+          const gk = blk(k, v);
+          const bucket = groups.get(gk);
+          if (bucket) { bucket.push([k, v]); } else { groups.set(gk, [[k, v]]); }
+        }
+        return groups;
+      }
+      case "partition": {
+        // [[matching pairs], [rest pairs]] — each a fresh Array of [k, v] pairs.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        const yes = [];
+        const no = [];
+        for (const [k, v] of recv) {
+          if (truthy(blk(k, v))) { yes.push([k, v]); } else { no.push([k, v]); }
+        }
+        return [yes, no];
+      }
+      case "flat_map": case "collect_concat": {
+        // Map each pair then concatenate one level: an Array result splices its
+        // elements, a scalar is appended as-is.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        const out = [];
+        for (const [k, v] of recv) {
+          const r = blk(k, v);
+          if (Array.isArray(r)) { out.push(...r); } else { out.push(r); }
+        }
+        return out;
+      }
+      case "reduce": case "inject": {
+        // Ruby's memo fold.  Unlike every other method here (which yields the
+        // two-arg pair), `reduce` yields (memo, pair) — the [k, v] Array as ONE
+        // argument.  `reduce(seed) { … }` seeds from the arg; seedless seeds
+        // from the first pair; an empty seedless reduce is nil.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        const pairs = [...recv]; // Map iteration yields [k, v] Arrays
+        let acc;
+        let start;
+        if (args.length >= 2) { acc = args[0]; start = 0; }
+        else if (pairs.length > 0) { acc = pairs[0]; start = 1; }
+        else { return null; }
+        for (let i = start; i < pairs.length; i++) { acc = blk(acc, pairs[i]); }
+        return acc;
+      }
+      case "sum": {
+        // Numeric fold seeded at 0 (or the explicit seed arg) over the block
+        // results — the same native `+` accumulation Array#sum uses, so
+        // integer inputs stay integers and any float promotes.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        let acc = args.length >= 2 ? args[0] : 0;
+        for (const [k, v] of recv) { acc = acc + blk(k, v); }
+        return acc;
       }
     }
     return HASH_MISS;

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2816,3 +2816,95 @@ fn hash_enumerable_aggregates() {
         );
     }
 }
+
+// ── Ruby Hash Enumerable breadth (group_by/partition/flat_map/reduce/sum) ──
+//
+// Same [key, value]-pair iteration as the aggregates: every method yields
+// (key, value) EXCEPT reduce/inject, which follow Ruby's memo convention and
+// yield (memo, [k, v]) — the pair as ONE argument.  Mirrors the Python (#7978),
+// Go (#7983), and Rust (#7989) references.
+#[test]
+fn hash_enumerable_breadth() {
+    let mk = |pairs: Vec<(&str, Expr)>| Expr::MapLit {
+        entries: pairs.into_iter().map(|(k, v)| MapEntry { key: str_(k), value: v }).collect(),
+        span: sp(),
+    };
+    let abcd = || mk(vec![("a", int(1)), ("b", int(2)), ("c", int(3)), ("d", int(4))]);
+    let block_fns = vec![
+        // { |k, v| v.even? } — group/partition predicate.
+        func("__hb_even", vec![param("k"), param("v")], vec![], method(param_ref("v"), "even?", vec![])),
+        // { |k, v| [k, v] } — flat_map projection that splices the pair.
+        func("__hb_pair", vec![param("k"), param("v")], vec![], seq(vec![param_ref("k"), param_ref("v")])),
+        // { |k, v| v } — sum projection.
+        func("__hb_val", vec![param("k"), param("v")], vec![], param_ref("v")),
+        // { |acc, pair| acc + pair[1] } — reduce over (memo, [k, v]); the pair
+        // arrives as ONE arg, so the value is `pair[1]` via SeqIndex (never the
+        // array `[]` method — the Go/Rust mirror lesson).
+        func(
+            "__hb_add",
+            vec![param("acc"), param("pair")],
+            vec![],
+            bc("+", vec![
+                param_ref("acc"),
+                Expr::SeqIndex { seq: Box::new(param_ref("pair")), index: Box::new(int(1)), span: sp() },
+            ]),
+        ),
+    ];
+    let stmts = vec![
+        // {a:1,b:2,c:3,d:4}.group_by { |k,v| v.even? }
+        //   → {#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}  (first-seen keys)
+        print(method(abcd(), "group_by", vec![method_closure("__hb_even")])),
+        // .partition { |k,v| v.even? } → [[[b, 2], [d, 4]], [[a, 1], [c, 3]]]
+        print(method(abcd(), "partition", vec![method_closure("__hb_even")])),
+        // {a:1,b:2}.flat_map { |k,v| [k,v] } → [a, 1, b, 2]  (one-level splice)
+        print(method(
+            mk(vec![("a", int(1)), ("b", int(2))]),
+            "flat_map",
+            vec![method_closure("__hb_pair")],
+        )),
+        // {a:1,b:2,c:3,d:4}.sum { |k,v| v } → 10  (seed defaults to 0)
+        print(method(abcd(), "sum", vec![method_closure("__hb_val")])),
+        // {a:1,b:2,c:3,d:4}.reduce(100) { |acc,pair| acc + pair[1] } → 110
+        print(method(abcd(), "reduce", vec![int(100), method_closure("__hb_add")])),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let mut functions = vec![main];
+    functions.extend(block_fns);
+    let module = Module {
+        name: "hashbreadth".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "hashbreadth") {
+        assert_eq!(
+            stdout,
+            "{#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}\n\
+             [[[b, 2], [d, 4]], [[a, 1], [c, 3]]]\n\
+             [a, 1, b, 2]\n\
+             10\n\
+             110"
+        );
+    }
+}


### PR DESCRIPTION
Mirrors the Python reference ([#7978](https://github.com/adhithyan15/coding-adventures/pull/7978)), Go ([#7983](https://github.com/adhithyan15/coding-adventures/pull/7983)), and Rust ([#7989](https://github.com/adhithyan15/coding-adventures/pull/7989)) backends into the **JS** backend's inline `hashMethod` (+ the `HASH_METHODS` `respond_to?` set), completing the Hash Enumerable reshape/fold surface.

Ruby's `Hash` mixes in `Enumerable`, so every method iterates the hash as `[k, v]` pairs and yields the two-arg `(k, v)` **except** `reduce`/`inject`, which follow Ruby's memo convention and yield `(memo, [k, v])` — the pair as ONE argument.

## Methods
- `group_by { |k,v| key }` → `Map`: key → Array of `[k,v]` pairs (first-seen order; mirrors Array#group_by which also returns a `Map`)
- `partition { |k,v| pred }` → `[[matching pairs], [rest pairs]]`
- `flat_map`/`collect_concat { |k,v| … }` → one-level concat
- `reduce`/`inject` → memo fold; explicit seed or first pair; empty seedless → `nil`
- `sum(init=0) { |k,v| … }` → native-`+` fold over block results

## Hash display fix
`formatSeen` had **no `Map` branch**, so a printed Hash rendered as `[object Map]` — every prior hash test called `.to_a` before printing, so this latent gap was never exercised. A `group_by` result is a Hash that must print as `{...}` for parity. A Hash now renders `{k: v, …}` (the same surface Go/Rust emit), cycle-guarded via `seen` like Arrays (`{...}` on a self-cycle). This is orthogonal to the bool/nil display convention (which it inherits via the existing `SIR_DISPLAY_RUBY` branches).

## Exec-proof
`tests/run_with_node.rs` gains `hash_enumerable_breadth`, run under real `node`, diffed against the Python/Go/Rust reference:

```
{#f: [[a, 1], [c, 3]], #t: [[b, 2], [d, 4]]}   # group_by { even? }
[[[b, 2], [d, 4]], [[a, 1], [c, 3]]]           # partition { even? }
[a, 1, b, 2]                                   # flat_map { [k, v] }
10                                             # sum { v }
110                                            # reduce(100) { acc + pair[1] }
```

`reduce`'s `pair[1]` uses `SeqIndex` (not the array `[]` method), per the Go/Rust lesson. Full JS suite green (109 lib + 74 node). Version 0.27.0 → 0.28.0; CHANGELOG updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)