### PR TITLE
fix(sql-planner,sql-vm): multi-arg MAX/MIN are the scalar functions (Stream A)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.5 — Multi-argument MAX/MIN are the scalar functions
+
+Stream A correctness fix: `SELECT MAX(3, 9, 5)` returned `3` (the first argument)
+instead of `9`, because the planner treated *every* `MIN`/`MAX` as the aggregate.
+Two-or-more-argument `MIN`/`MAX` are the SCALAR largest/smallest functions and
+are now dispatched as such (sql-planner 0.2.0 gates on arity; sql-vm 0.4.2 adds
+the scalar builtin); the single-argument aggregate forms are unchanged. Three
+new differential-oracle cases (`scalar_max_min`, `scalar_max_null`, plus an
+`agg_max_min_still_work` regression guard) diff against real bundled SQLite.
+
 ## 0.5.4 — IIF(x, y, z) — the function form of CASE
 
 Stream B, corpus growth. `IIF(x, y, z)` now works — SQLite's function-form

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -492,6 +492,33 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT IIF(n > 5, 'big', 'small') AS r FROM t ORDER BY id",
     },
+    // Multi-argument MAX/MIN are the SCALAR forms (return the largest/smallest
+    // argument, NULL if any is NULL) — distinct from the 1-arg aggregate.
+    Case {
+        id: "scalar_max_min",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, n INTEGER)",
+            "INSERT INTO t VALUES (1, 7), (2, 20)",
+        ],
+        query: "SELECT MAX(n, 10, 3) AS mx, MIN(n, 10, 3) AS mn FROM t ORDER BY id",
+    },
+    Case {
+        id: "scalar_max_null",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, n INTEGER)",
+            "INSERT INTO t VALUES (1, 5), (2, NULL)",
+        ],
+        query: "SELECT MAX(n, 3) AS r FROM t ORDER BY id",
+    },
+    // The single-argument aggregate MAX/MIN still work (regression guard).
+    Case {
+        id: "agg_max_min_still_work",
+        setup: &[
+            "CREATE TABLE t (dept TEXT, sal INTEGER)",
+            "INSERT INTO t VALUES ('a', 10), ('a', 30), ('b', 20)",
+        ],
+        query: "SELECT dept, MAX(sal), MIN(sal) FROM t GROUP BY dept ORDER BY dept",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.0] - Unreleased
+
+### Fixed
+
+- **Multi-argument `MIN`/`MAX` are now the SCALAR functions, not the aggregate.**
+  `MIN`/`MAX` are overloaded in SQL: one argument is the aggregate (min/max over
+  a column), but two-or-more is the scalar that returns the smallest/largest of
+  its arguments. Both aggregate-detection sites (`try_plan_as_aggregate` and
+  `plan_function_call`) previously treated *any* `MIN`/`MAX` as the aggregate, so
+  `SELECT MAX(3, 9, 5)` used only the first argument and returned `3` instead of
+  `9`. They now check the argument count (new `call_arg_count` helper) and leave
+  the 2+-argument form as a `FunctionCall`, routed to the VM's `call_builtin`.
+
 ## [0.1.0] — 2026-06-30
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1117,6 +1117,14 @@ fn try_plan_as_aggregate(func_call: &GrammarASTNode) -> Option<AggregateItem> {
         _ => return None,
     };
 
+    // `MIN`/`MAX` are overloaded: with a single argument they are the aggregate
+    // (min/max over a column), but with two-or-more they are the SCALAR function
+    // that returns the smallest/largest of its arguments. Only the aggregate form
+    // is collected here; the multi-argument form is left to `plan_function_call`.
+    if matches!(agg_func, AggFunc::Min | AggFunc::Max) && call_arg_count(func_call) >= 2 {
+        return None;
+    }
+
     // Check for star argument: COUNT(*).
     let has_star = has_token(func_call, "*");
     let distinct = has_token(func_call, "DISTINCT");
@@ -2083,6 +2091,13 @@ fn plan_function_call(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         "MAX" => Some(AggFunc::Max),
         _ => None,
     };
+    // `MIN(a, b, …)` / `MAX(a, b, …)` with two-or-more arguments are the SCALAR
+    // largest/smallest functions, not the aggregate; fall through to the plain
+    // `FunctionCall` path so the VM's `call_builtin` handles them.
+    let agg_func = match agg_func {
+        Some(AggFunc::Min | AggFunc::Max) if call_arg_count(node) >= 2 => None,
+        other => other,
+    };
 
     let has_star = has_token(node, "*");
     let distinct = has_token(node, "DISTINCT");
@@ -2214,6 +2229,21 @@ where
 // ===========================================================================
 
 /// Find the first child node with a specific `rule_name`.
+/// Count the top-level arguments of a `function_call` node — the number of
+/// expression children inside its `value_list`. Used to distinguish the
+/// single-argument aggregate `MIN`/`MAX` from the two-or-more-argument scalar
+/// forms. A call with no `value_list` (`COUNT(*)` or no args) counts as 0.
+fn call_arg_count(node: &GrammarASTNode) -> usize {
+    find_node(node, "value_list")
+        .map(|vl| {
+            vl.children
+                .iter()
+                .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
 fn find_node<'a>(node: &'a GrammarASTNode, rule: &str) -> Option<&'a GrammarASTNode> {
     for child in &node.children {
         if let ASTNodeOrToken::Node(n) = child {

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.2] - Unreleased
+
+### Added
+
+- **Scalar `MAX(a, b, …)` / `MIN(a, b, …)`** (two-or-more arguments): return the
+  largest / smallest argument, or NULL if any argument is NULL, comparing with
+  SQL value order. The single-argument aggregate forms are unchanged (compiled to
+  `FinalizeAgg`); the planner (sql-planner 0.2.0) now routes only the multi-arg
+  calls here. Fixes `SELECT MAX(3, 9, 5)` returning `3` instead of `9`.
+
 ## [0.4.1] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1428,6 +1428,34 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             Ok(SqlValue::Text(lit))
         }
 
+        "MAX" | "MIN" => {
+            // The SCALAR forms of MAX/MIN — two-or-more arguments — return the
+            // largest / smallest argument, or NULL if ANY argument is NULL
+            // (SQLite semantics). The single-argument forms are the AGGREGATE
+            // max/min and are compiled to `FinalizeAgg`, never reaching here; the
+            // planner routes only the 2+-argument calls to `call_builtin`.
+            if args.is_empty() {
+                return Err(VmError::TypeMismatch(format!("{name} expects at least 1 arg")));
+            }
+            if args.iter().any(|a| matches!(a, SqlValue::Null)) {
+                return Ok(SqlValue::Null);
+            }
+            let want_max = name == "MAX";
+            let mut best = args[0].clone();
+            for a in &args[1..] {
+                let ord = sql_cmp(a, &best);
+                let take = if want_max {
+                    ord == std::cmp::Ordering::Greater
+                } else {
+                    ord == std::cmp::Ordering::Less
+                };
+                if take {
+                    best = a.clone();
+                }
+            }
+            Ok(best)
+        }
+
         "IIF" => {
             // IIF(x, y, z) — SQLite's function-form conditional, equivalent to
             // `CASE WHEN x THEN y ELSE z END`: `y` when `x` is truthy (SQL
@@ -3672,6 +3700,21 @@ mod tests {
         assert_eq!(q(SqlValue::Int(-7)), "-7");
         assert_eq!(q(SqlValue::Text("it's".into())), "'it''s'"); // inner quote doubled
         assert_eq!(q(SqlValue::Blob(vec![0xde, 0xad])), "X'DEAD'");
+    }
+
+    #[test]
+    fn builtin_scalar_max_min() {
+        let mx = |vs: Vec<SqlValue>| call_builtin("MAX", vs).unwrap();
+        let mn = |vs: Vec<SqlValue>| call_builtin("MIN", vs).unwrap();
+        assert_eq!(mx(vec![SqlValue::Int(3), SqlValue::Int(9), SqlValue::Int(5)]), SqlValue::Int(9));
+        assert_eq!(mn(vec![SqlValue::Int(3), SqlValue::Int(9), SqlValue::Int(5)]), SqlValue::Int(3));
+        // Any NULL argument → NULL.
+        assert_eq!(mx(vec![SqlValue::Int(1), SqlValue::Null, SqlValue::Int(3)]), SqlValue::Null);
+        // Text ordering.
+        assert_eq!(
+            mn(vec![SqlValue::Text("b".into()), SqlValue::Text("a".into()), SqlValue::Text("c".into())]),
+            SqlValue::Text("a".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Stream A — correctness fix: multi-argument MAX/MIN are the *scalar* functions

`MIN`/`MAX` are overloaded in SQL: **one** argument is the aggregate (min/max over a column), but **two-or-more** is the scalar function returning the smallest/largest of its arguments. mini-sqlite treated *every* `MIN`/`MAX` as the aggregate, so:

```sql
SELECT MAX(3, 9, 5);   -- returned 3 (the first arg!), should be 9
SELECT MIN(3, 9, 5);   -- returned 3 (correct only by luck)
```

### The fix
- **sql-planner (0.2.0)** — both aggregate-detection sites (`try_plan_as_aggregate`, `plan_function_call`) now check the argument count (new `call_arg_count` helper) and leave `MIN`/`MAX` with ≥2 args as a plain `FunctionCall`, routed to the VM's `call_builtin`. `COUNT`/`SUM`/`AVG` and single-arg `MIN`/`MAX` are unchanged.
- **sql-vm (0.4.2)** — new scalar `MAX`/`MIN` arm: returns the largest/smallest argument by SQL value order, or **NULL if any argument is NULL** (SQLite semantics). The single-arg aggregate forms still compile to `FinalizeAgg` and never reach here.

### Verification
- Diffed against real bundled SQLite: `max(3,9,5)=9`, `min(3,9,5)=3`, `max(1,NULL,3)=NULL`, `min('b','a','c')='a'`, and — crucially — 1-arg aggregate `MAX/MIN` + `GROUP BY` still correct.
- **3 new differential-oracle cases** (`scalar_max_min`, `scalar_max_null`, and an `agg_max_min_still_work` regression guard) + a sql-vm unit test.
- Full affected set green (sql-planner is central): **sql-planner (57)**, sql-codegen, **sql-vm (84)**, mini-sqlite (45 lib + oracle + file-backed + integration + doctest). My code fmt + clippy clean.
- Security review **passed** (panic-safe: arity-guarded before indexing; O(n) over query-bounded args; the rerouted `FunctionCall→CallBuiltin` path is the standard scalar path with a matching builtin arm — no unhandled instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
