### PR TITLE
feat(cobol): DIVIDE — fixed-point division + divide-by-zero (PL08 v0.3)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.3.0 — DIVIDE (PL08)
+
+- `DIVIDE a INTO b [GIVING g]` — result = b / a. Fixed-point division computed to
+  the receiver's fractional precision and **truncated toward zero** (COBOL's
+  behaviour absent `ROUNDED`): `10 / 3` into `9(3)V99` → `"00333"`.
+- **Divide by zero** (no `ON SIZE ERROR` to catch it) surfaces as
+  `RuntimeError::DivideByZero`, never a panic. Intermediate scaling uses checked
+  `i128` arithmetic (overflow → error).
+- Remaining arithmetic — `COMPUTE`, `ROUNDED`/`ON SIZE ERROR` (need frontend
+  clauses) — and signed `S` numerics stay deferred. Roadmap in PL08.
+
+
 ## 0.2.0 — Fixed-point decimal arithmetic (PL08)
 
 - `ADD` / `SUBTRACT` / `MULTIPLY` with the current grammar's forms

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -22,8 +22,9 @@ A small but **fully correct** slice, growing one quirk at a time: unsigned
 numeric-display (`9`/`V`) and character (`X`/`A`) pictures; the item tree from
 level numbers; `VALUE` initialisation; figurative `ZERO`/`SPACE`; `MOVE` with
 the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; and fixed-point
-decimal `ADD`/`SUBTRACT`/`MULTIPLY` (decimal-point aligned, truncating into the
-receiver). Anything not yet modelled (signed `S`, `DIVIDE`, `ROUNDED`/`ON SIZE
-ERROR`, editing pictures, `COMP`, `PERFORM`, tables, files, and every other verb)
-returns a descriptive `RuntimeError` — never wrong output. See PL08 for the
-roadmap toward full COBOL and later standards.
+decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
+toward zero into the receiver; divide-by-zero is a clean error). Anything not yet
+modelled (signed `S`, `COMPUTE`, `ROUNDED`/`ON SIZE ERROR`, editing pictures,
+`COMP`, `PERFORM`, tables, files, and every other verb) returns a descriptive
+`RuntimeError` — never wrong output. See PL08 for the roadmap toward full COBOL
+and later standards.

--- a/code/packages/rust/cobol-runtime/src/error.rs
+++ b/code/packages/rust/cobol-runtime/src/error.rs
@@ -16,6 +16,8 @@ pub enum RuntimeError {
     UnsupportedPicture(String),
     /// A statement or construct the v0.1 runtime does not yet execute.
     Unsupported(String),
+    /// `DIVIDE` by zero with no `ON SIZE ERROR` clause to catch it.
+    DivideByZero,
 }
 
 impl fmt::Display for RuntimeError {
@@ -30,6 +32,7 @@ impl fmt::Display for RuntimeError {
                 write!(f, "unsupported PICTURE in runtime v0.1: {p}")
             }
             RuntimeError::Unsupported(m) => write!(f, "unsupported in runtime v0.1: {m}"),
+            RuntimeError::DivideByZero => write!(f, "divide by zero"),
         }
     }
 }

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -4,7 +4,7 @@
 use crate::error::RuntimeError;
 use crate::picture::Picture;
 use crate::program::{Fig, Lit, Operand, Program, Stmt};
-use crate::value::{add, move_into_char, move_into_numeric, mul, sub, Decimal};
+use crate::value::{add, div, move_into_char, move_into_numeric, mul, sub, Decimal};
 use std::collections::HashMap;
 
 /// One field in the data model. Elementary items carry a picture and character
@@ -133,6 +133,9 @@ impl Machine {
                         self.exec_subtract(operands, from, giving)?
                     }
                     Stmt::Multiply { a, by, giving } => self.exec_multiply(a, by, giving)?,
+                    Stmt::Divide { divisor, dividend, giving } => {
+                        self.exec_divide(divisor, dividend, giving)?
+                    }
                 }
             }
         }
@@ -210,6 +213,44 @@ impl Machine {
             }
         };
         self.store_number(&target, product)
+    }
+
+    /// `DIVIDE a INTO b [GIVING g]` → (b ÷ a), truncated to the receiver's
+    /// decimal places, stored in g, or in b (the dividend) when no GIVING.
+    fn exec_divide(
+        &mut self,
+        divisor: &Operand,
+        dividend: &Operand,
+        giving: &Option<String>,
+    ) -> Result<(), RuntimeError> {
+        let d = self.operand_decimal(divisor)?;
+        if d.is_zero() {
+            return Err(RuntimeError::DivideByZero);
+        }
+        let n = self.operand_decimal(dividend)?;
+        let target = match (giving, dividend) {
+            (Some(g), _) => g.clone(),
+            (None, Operand::Ident(name)) => name.clone(),
+            (None, _) => {
+                return Err(RuntimeError::Unsupported(
+                    "DIVIDE … INTO <literal> without GIVING has no receiver".into(),
+                ))
+            }
+        };
+        // Compute to the receiver's fractional precision (COBOL truncates there
+        // absent ROUNDED); store_number then aligns the integer part.
+        let scale = self.numeric_dec_digits(&target)?;
+        let quotient = checked(div(&n, &d, scale))?;
+        self.store_number(&target, quotient)
+    }
+
+    /// The number of fractional digit positions of a named numeric receiver.
+    fn numeric_dec_digits(&self, name: &str) -> Result<usize, RuntimeError> {
+        let idx = *self.by_name.get(name).ok_or_else(|| RuntimeError::UndefinedName(name.into()))?;
+        match &self.items[idx].picture {
+            Some(Picture::Numeric { dec_digits, .. }) => Ok(*dec_digits),
+            _ => Err(RuntimeError::Unsupported(format!("arithmetic on non-numeric field {name}"))),
+        }
     }
 
     /// The numeric value of an operand (numeric literal, `ZERO`, or numeric

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -6,12 +6,12 @@
 //! [PL08](../../../specs/PL08-cobol-runtime.md).
 //!
 //! It implements a *small but fully correct* slice — `MOVE` / `DISPLAY` /
-//! `STOP RUN` and fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` over
-//! unsigned numeric-display and character pictures — and returns a descriptive
-//! error for anything not yet modelled, rather than producing wrong output. The
-//! roadmap toward full COBOL (signed numerics, `DIVIDE`, `ROUNDED`/`ON SIZE
-//! ERROR`, editing pictures, `PERFORM`, tables, files, later standards) is in
-//! PL08.
+//! `STOP RUN` and fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`
+//! over unsigned numeric-display and character pictures — and returns a
+//! descriptive error for anything not yet modelled, rather than producing wrong
+//! output. The roadmap toward full COBOL (signed numerics, `COMPUTE`,
+//! `ROUNDED`/`ON SIZE ERROR`, editing pictures, `PERFORM`, tables, files, later
+//! standards) is in PL08.
 //!
 //! ```
 //! use coding_adventures_cobol_runtime::run_cobol;
@@ -292,6 +292,37 @@ mod tests {
     fn decimal_add_aligns_the_implied_point() {
         // R PIC 9(2)V99 (4 digits) starts 1.50; ADD 2.25 TO R → 3.75 → "0375".
         assert_eq!(compute("9(2)V99", &["MOVE 1.5 TO R.", "ADD 2.25 TO R."], &[]), "0375\n");
+    }
+
+    #[test]
+    fn divide_into_giving_truncates_to_receiver_decimals() {
+        // 10 / 3 = 3.333… → into PIC 9(3)V99 truncates to 3.33 → "00333".
+        assert_eq!(compute("9(3)V99", &["DIVIDE 3 INTO 10 GIVING R."], &[]), "00333\n");
+        // 10 / 4 = 2.5 → into PIC 9(3) (no decimals) truncates to 2 → "002".
+        assert_eq!(compute("9(3)", &["DIVIDE 4 INTO 10 GIVING R."], &[]), "002\n");
+    }
+
+    #[test]
+    fn divide_into_without_giving_updates_the_dividend() {
+        // MOVE 20 TO R; DIVIDE 5 INTO R → R = 20/5 = 4.
+        assert_eq!(compute("9(3)", &["MOVE 20 TO R.", "DIVIDE 5 INTO R."], &[]), "004\n");
+    }
+
+    #[test]
+    fn divide_by_zero_is_a_clear_error() {
+        let err = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  R  PIC 9(3).",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    DIVIDE 0 INTO 10 GIVING R.",
+            "    STOP RUN.",
+        ]))
+        .unwrap_err();
+        assert!(matches!(err, RuntimeError::DivideByZero), "got {err:?}");
     }
 
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -68,6 +68,8 @@ pub enum Stmt {
     Subtract { operands: Vec<Operand>, from: String, giving: Option<String> },
     /// `MULTIPLY a BY b [GIVING g]` — result = a*b, stored in g or b.
     Multiply { a: Operand, by: Operand, giving: Option<String> },
+    /// `DIVIDE a INTO b [GIVING g]` — result = b/a, stored in g or b.
+    Divide { divisor: Operand, dividend: Operand, giving: Option<String> },
     StopRun,
 }
 
@@ -301,6 +303,23 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             let giving = if has_giving { names.into_iter().next() } else { None };
             let mut it = ops.into_iter();
             Ok(Stmt::Multiply { a: it.next().unwrap(), by: it.next().unwrap(), giving })
+        }
+        "divide_stmt" => {
+            // DIVIDE a INTO b [GIVING g]: first operand is the divisor, second
+            // the dividend; result = b / a.
+            let ops = read_operands(verb)?;
+            if ops.len() != 2 {
+                return Err(RuntimeError::Unsupported("DIVIDE needs exactly two operands".into()));
+            }
+            let has_giving = child_tokens(verb).iter().any(|(k, v)| k == "KEYWORD" && v == "GIVING");
+            let names: Vec<String> = child_tokens(verb)
+                .into_iter()
+                .filter(|(k, _)| k == "NAME")
+                .map(|(_, v)| v)
+                .collect();
+            let giving = if has_giving { names.into_iter().next() } else { None };
+            let mut it = ops.into_iter();
+            Ok(Stmt::Divide { divisor: it.next().unwrap(), dividend: it.next().unwrap(), giving })
         }
         other => Err(RuntimeError::Unsupported(format!("the {} verb", verb_name(other)))),
     }

--- a/code/packages/rust/cobol-runtime/src/value.rs
+++ b/code/packages/rust/cobol-runtime/src/value.rs
@@ -52,6 +52,11 @@ impl Decimal {
         format!("{}{}", self.int, self.frac)
     }
 
+    /// Whether this value is zero (all digit positions are `0`).
+    pub fn is_zero(&self) -> bool {
+        self.int.chars().chain(self.frac.chars()).all(|c| c == '0')
+    }
+
     /// This value as a signed `i128` scaled by `10^scale` (i.e. with exactly
     /// `scale` fractional digits). Returns `None` if it overflows `i128`
     /// (~38 digits — beyond any real COBOL numeric field) or if truncating the
@@ -101,6 +106,40 @@ pub fn mul(a: &Decimal, b: &Decimal) -> Option<Decimal> {
     let (sa, sb) = (a.frac.len(), b.frac.len());
     let r = a.to_scaled(sa)?.checked_mul(b.to_scaled(sb)?)?;
     Some(Decimal::from_scaled(r, sa + sb))
+}
+
+/// Fixed-point division `num / den`, truncated (toward zero, as COBOL does
+/// without `ROUNDED`) to exactly `result_scale` fractional digits.
+///
+/// Returns `None` on `i128` overflow of the intermediate scaling; the caller is
+/// expected to have already rejected a zero divisor (`den == 0` here also yields
+/// `None`, but a zero divisor should surface as [`RuntimeError::DivideByZero`]).
+///
+/// Derivation: with `num = N/10^sn` and `den = D/10^sd`, the value scaled by
+/// `10^result_scale` is `floor( (N · 10^(sd + result_scale)) / (D · 10^sn) )`.
+pub fn div(num: &Decimal, den: &Decimal, result_scale: usize) -> Option<Decimal> {
+    let (sn, sd) = (num.frac.len(), den.frac.len());
+    let n = num.to_scaled(sn)?;
+    let d = den.to_scaled(sd)?;
+    if d == 0 {
+        return None;
+    }
+    // Scale the numerator up and the denominator up so the quotient carries
+    // `result_scale` fractional digits.
+    let numerator = n.checked_mul(pow10(sd + result_scale)?)?;
+    let denominator = d.checked_mul(pow10(sn)?)?;
+    // i128 division truncates toward zero — exactly COBOL's un-rounded behaviour.
+    let scaled = numerator.checked_div(denominator)?;
+    Some(Decimal::from_scaled(scaled, result_scale))
+}
+
+/// `10^exp` as `i128`, or `None` on overflow.
+fn pow10(exp: usize) -> Option<i128> {
+    let mut v: i128 = 1;
+    for _ in 0..exp {
+        v = v.checked_mul(10)?;
+    }
+    Some(v)
 }
 
 /// Move a numeric value into a numeric receiver of `int_digits` integer
@@ -222,5 +261,26 @@ mod tests {
         // (2.5 * 2.5 = 6.25) moved into PIC 9(3)V9 → "0062" (low-order truncated).
         let r = mul(&d("2.5"), &d("2.5")).unwrap();
         assert_eq!(move_into_numeric(&r, 3, 1), "0062");
+    }
+
+    #[test]
+    fn division_truncates_toward_zero() {
+        // 10 / 4 = 2.5 → to 0 decimals truncates to 2.
+        assert_eq!(div(&d("10"), &d("4"), 0).unwrap(), d("2"));
+        // 10 / 3 = 3.333… → to 2 decimals truncates to 3.33.
+        assert_eq!(div(&d("10"), &d("3"), 2).unwrap(), d("3.33"));
+        // Exact: 9 / 3 = 3.00 at 2 decimals.
+        assert_eq!(div(&d("9"), &d("3"), 2).unwrap(), d("3.00"));
+    }
+
+    #[test]
+    fn division_of_fractional_operands() {
+        // 7.5 / 2.5 = 3.0
+        assert_eq!(div(&d("7.5"), &d("2.5"), 1).unwrap(), d("3.0"));
+    }
+
+    #[test]
+    fn division_by_zero_returns_none() {
+        assert_eq!(div(&d("5"), &d("0"), 2), None);
     }
 }

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -103,14 +103,15 @@ rather than producing wrong output.
 - `DISPLAY` (items and literals, concatenated, newline-terminated).
 - `STOP RUN`.
 
-**Added in v0.2:** fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` (the
-current grammar's `TO`/`FROM`/`BY` + `GIVING` forms) — decimal-point aligned,
-truncating into the receiver, unsigned receivers keeping the magnitude; overflow
-beyond ~38 digits is an error, never a panic.
+**Added in v0.2 / v0.3:** fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` /
+`DIVIDE` (the current grammar's `TO`/`FROM`/`BY`/`INTO` + `GIVING` forms) —
+decimal-point aligned, truncating toward zero into the receiver, unsigned
+receivers keeping the magnitude; overflow beyond ~38 digits is an error (never a
+panic), and divide-by-zero surfaces as `RuntimeError::DivideByZero`.
 
-**Deferred to later PRs (return `RuntimeError::Unsupported` for now):**
-signed `S` numerics and overpunch-sign display; `P` scaling; `DIVIDE` and
-`ROUNDED`/`ON SIZE ERROR` (the latter need frontend clauses); editing pictures
+**Deferred to later PRs (return a descriptive `RuntimeError` for now):**
+signed `S` numerics and overpunch-sign display; `P` scaling; `COMPUTE` and
+`ROUNDED`/`ON SIZE ERROR` (which need frontend clauses); editing pictures
 (`Z * $ , . + - CR DB B 0 /`); `USAGE COMP`/`COMP-3` (binary / packed decimal);
 group `MOVE`; name qualification (`OF`/`IN`); `REDEFINES`/`OCCURS`; and every
 verb not listed above.
@@ -120,10 +121,11 @@ verb not listed above.
 Each item is a run-verified PR; the runtime grows one quirk at a time.
 
 1. **v0.1 — execution spine** (merged): data model + `MOVE`/`DISPLAY`/`STOP RUN`.
-2. **v0.2 — arithmetic** (this PR): fixed-point `ADD`/`SUBTRACT`/`MULTIPLY`.
-3. **Remaining arithmetic** — `DIVIDE`, `COMPUTE`, `ROUNDED`, `ON SIZE ERROR`
-   (the last two also widen the frontend grammar); then **signed numerics +
-   overpunch** display and the `SIGN` clause.
+2. **v0.2 — arithmetic** (merged): fixed-point `ADD`/`SUBTRACT`/`MULTIPLY`.
+3. **v0.3 — `DIVIDE`** (this PR): fixed-point division + divide-by-zero.
+4. **`COMPUTE`, `ROUNDED`, `ON SIZE ERROR`** — expression evaluation and the
+   rounding/overflow clauses (these also widen the frontend grammar); then
+   **signed numerics + overpunch** display and the `SIGN` clause.
 4. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
 5. **Control flow** — `IF … ELSE … END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
    `TIMES`, `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.


### PR DESCRIPTION
## COBOL divides

Completes the four basic arithmetic verbs. Builds on the runtime (#7986) and arithmetic (#7990), both merged.

`DIVIDE a INTO b [GIVING g]` → result = b ÷ a:
```cobol
000050     DIVIDE 3 INTO 10 GIVING R.   *> R PIC 9(3)V99 → "00333"  (10/3 truncated to 2 dp)
```

### Faithful semantics
- **Fixed-point division** computed to the receiver's fractional precision and **truncated toward zero** — COBOL's behaviour absent `ROUNDED`. (`10 / 3` into `9(3)V99` → `"00333"`; `10 / 4` into `9(3)` → `"002"`.)
- **Divide by zero** (no `ON SIZE ERROR` to catch it) → `RuntimeError::DivideByZero`, detected before division via `Decimal::is_zero()`. **Never a panic.**
- `DIVIDE … INTO b` without `GIVING` stores into `b` (the dividend); the result is `MOVE`d into the receiver so truncation/alignment apply.
- Intermediate scaling uses checked `i128` (`pow10` bails on overflow → clean error).

### Honest scoping
`COMPUTE`, `ROUNDED`/`ON SIZE ERROR` (need frontend clauses), and signed `S` numerics stay deferred. Roadmap in [PL08](code/specs/PL08-cobol-runtime.md).

### Verification
- **40 tests + doctest**, each asserting exact output: division truncation, fractional operands, divide-by-zero, `DIVIDE … INTO … GIVING` and without-`GIVING`. Warning-free.
- Security review passed: all division paths panic-free (checked `i128`, `pow10` overflow-bailing, `checked_div` divisor provably non-zero).

Third PR of the runtime arc (PL08); follows #7986, #7990. With this the runtime does all four basic arithmetic verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)