### PR TITLE
feat(sha256-native): JVM native-through-Rust binding + sha256-native-jni crate

### DIFF
--- a/code/packages/java/sha256-native/.gitignore
+++ b/code/packages/java/sha256-native/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/sha256-native/BUILD
+++ b/code/packages/java/sha256-native/BUILD
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release && gradle test

--- a/code/packages/java/sha256-native/BUILD_windows
+++ b/code/packages/java/sha256-native/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build --manifest-path ..\..\rust\Cargo.toml -p sha256-native-jni --release && gradle test

--- a/code/packages/java/sha256-native/CHANGELOG.md
+++ b/code/packages/java/sha256-native/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — sha256-native (Java)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: native-through-Rust SHA-256 for the JVM — establishes the
+  "Rust cdylib + jni-bridge JNI + System.loadLibrary" JVM native pattern.
+- Calls `coding_adventures_sha256` through the `sha256_native_jni` cdylib:
+  `sha256(byte[])` / `sha256Hex(byte[])` and a streaming `Hasher` (an
+  `AutoCloseable` with `update` / non-destructive `digest` / `hexDigest` /
+  `copy`), backed by an opaque `long` peer pointer freed via `close()` with a
+  `Cleaner` safety net.
+- `build.gradle.kts` sets `-Djava.library.path` to the Rust `target/release`.
+- 9 JUnit tests through JNI: FIPS 180-4 vectors (incl. one-million-'a'), block
+  boundaries, streaming parity, byte-at-a-time, non-destructive digest, copy
+  independence, and closed-handle guarding. `gradle test` green against the
+  linked Rust cdylib.

--- a/code/packages/java/sha256-native/README.md
+++ b/code/packages/java/sha256-native/README.md
@@ -1,0 +1,48 @@
+# sha256-native (Java)
+
+**Native-through-Rust** SHA-256 for the JVM. Instead of reimplementing the
+algorithm (that's the pure-Java `sha256` package), this calls the Rust
+`coding_adventures_sha256` crate through JNI — via the `sha256_native_jni`
+cdylib and the zero-dependency `jni-bridge` (no `jni` crate, no bindgen).
+
+This is the first JVM `*-native` package for a hash in the campaign, and it
+establishes the JVM native pattern:
+
+```
+rust/sha256-native-jni/   ← Rust cdylib exporting Java_..._native* (uses jni-bridge)
+java/sha256-native/
+    src/main/java/.../Native.java        ← System.loadLibrary + native methods
+    src/main/java/.../Sha256Native.java  ← public wrapper
+```
+
+The JVM finds `libsha256_native_jni.{so,dylib}` via `-Djava.library.path`,
+pointed at the Rust workspace's `target/release` by `build.gradle.kts`.
+
+## API (`com.codingadventures.sha256native.Sha256Native`)
+
+```java
+Sha256Native.sha256Hex("abc".getBytes(StandardCharsets.UTF_8));
+// ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+try (Sha256Native.Hasher h = new Sha256Native.Hasher()) {
+    h.update("ab".getBytes());
+    h.update("c".getBytes());
+    String hex = h.hexDigest();      // same digest, computed incrementally
+    Sha256Native.Hasher snap = h.copy(); // independent copy
+}
+```
+
+- `sha256(byte[]) -> byte[]`, `sha256Hex(byte[]) -> String`.
+- `Hasher` (an `AutoCloseable`) — `update` / non-destructive `digest` /
+  `hexDigest` / `copy`. It owns a native handle freed by `close()` (idempotent),
+  with a `Cleaner` safety net if `close()` is missed.
+
+## Building and testing
+
+The BUILD compiles the Rust cdylib in the workspace, then runs `gradle test`
+(which sets `java.library.path` to `rust/target/release`):
+
+```
+cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release
+gradle test
+```

--- a/code/packages/java/sha256-native/build.gradle.kts
+++ b/code/packages/java/sha256-native/build.gradle.kts
@@ -1,0 +1,49 @@
+// Build configuration for the Java sha256 native binding.
+//
+// A thin JNI layer over the Rust `sha256_native_jni` cdylib, which wraps the
+// pure-Rust `coding_adventures_sha256` crate. The cdylib must be built first:
+//
+//   cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release
+//
+// The BUILD script runs that command before invoking `gradle test`.
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+
+    // Point the JVM's native library search path at the Rust release build.
+    // projectDir = code/packages/java/sha256-native, so its parent's parent is
+    // code/packages, and the Rust workspace builds into rust/target/release.
+    val rustReleaseDir = projectDir.parentFile.parentFile
+        .resolve("rust/target/release")
+        .absolutePath
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/code/packages/java/sha256-native/required_capabilities.json
+++ b/code/packages/java/sha256-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://coding-adventures.example/schemas/required_capabilities/v1.json",
+  "version": 1,
+  "package": "java/sha256-native",
+  "capabilities": ["ffi:call"],
+  "justification": "ffi:call — loads the sha256_native_jni cdylib via System.loadLibrary and calls its JNI methods to compute SHA-256 in Rust. No network, filesystem, or process access."
+}

--- a/code/packages/java/sha256-native/settings.gradle.kts
+++ b/code/packages/java/sha256-native/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sha256-native"

--- a/code/packages/java/sha256-native/src/main/java/com/codingadventures/sha256native/Native.java
+++ b/code/packages/java/sha256-native/src/main/java/com/codingadventures/sha256native/Native.java
@@ -1,0 +1,39 @@
+package com.codingadventures.sha256native;
+
+/**
+ * JNI bindings to the {@code sha256_native_jni} Rust cdylib, which wraps the
+ * pure-Rust {@code coding_adventures_sha256} crate. Each {@code native} method
+ * maps to a {@code Java_com_codingadventures_sha256native_Native_*} function in
+ * {@code code/packages/rust/sha256-native-jni/src/lib.rs}.
+ *
+ * <p>The streaming hasher is represented as an opaque {@code long} peer pointer
+ * to a Rust {@code Sha256Hasher}. A {@code 0} handle is a safe no-op on every
+ * native call.
+ */
+final class Native {
+
+    static {
+        System.loadLibrary("sha256_native_jni");
+    }
+
+    private Native() {
+    }
+
+    /** One-shot: the 32-byte SHA-256 digest of {@code data}. */
+    static native byte[] nativeDigest(byte[] data);
+
+    /** Allocate a streaming hasher; returns its peer pointer. */
+    static native long nativeHasherNew();
+
+    /** Feed {@code data} into the hasher at {@code handle}. */
+    static native void nativeHasherUpdate(long handle, byte[] data);
+
+    /** The current 32-byte digest of the hasher (non-destructive). */
+    static native byte[] nativeHasherDigest(long handle);
+
+    /** An independent copy of the hasher; returns a new peer pointer. */
+    static native long nativeHasherClone(long handle);
+
+    /** Free a hasher peer pointer. */
+    static native void nativeHasherFree(long handle);
+}

--- a/code/packages/java/sha256-native/src/main/java/com/codingadventures/sha256native/Sha256Native.java
+++ b/code/packages/java/sha256-native/src/main/java/com/codingadventures/sha256native/Sha256Native.java
@@ -1,0 +1,119 @@
+package com.codingadventures.sha256native;
+
+import java.lang.ref.Cleaner;
+
+/**
+ * Native-through-Rust SHA-256 for the JVM — the companion to the pure-Java
+ * {@code sha256} package. Instead of reimplementing the algorithm, it calls the
+ * Rust {@code coding_adventures_sha256} crate through JNI (the
+ * {@code sha256_native_jni} cdylib).
+ *
+ * <p>The one-shot API ({@link #sha256(byte[])} / {@link #sha256Hex(byte[])}) is
+ * stateless. The streaming {@link Hasher} owns a native handle and is an
+ * {@link AutoCloseable}; it also registers with a {@link Cleaner} so the native
+ * memory is reclaimed even if {@code close()} is missed.
+ */
+public final class Sha256Native {
+
+    private static final Cleaner CLEANER = Cleaner.create();
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private Sha256Native() {
+    }
+
+    /** The 32-byte SHA-256 digest of {@code data} (computed in Rust). */
+    public static byte[] sha256(byte[] data) {
+        return Native.nativeDigest(data);
+    }
+
+    /** The 64-character lowercase hex digest of {@code data} (computed in Rust). */
+    public static String sha256Hex(byte[] data) {
+        return toHex(sha256(data));
+    }
+
+    static String toHex(byte[] bytes) {
+        char[] out = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xff;
+            out[i * 2] = HEX[v >>> 4];
+            out[i * 2 + 1] = HEX[v & 0x0f];
+        }
+        return new String(out);
+    }
+
+    /**
+     * A streaming SHA-256 hasher backed by a native Rust hasher. Feed data with
+     * {@link #update}; {@link #digest} is non-destructive. Call {@link #close}
+     * (or use try-with-resources) to free the native handle promptly; a
+     * {@link Cleaner} is the safety net if you forget.
+     */
+    public static final class Hasher implements AutoCloseable {
+
+        // The handle lives in a separate object so the Cleaner action does not
+        // capture the Hasher (which would keep it reachable and defeat the GC).
+        private static final class State implements Runnable {
+            long handle;
+
+            State(long handle) {
+                this.handle = handle;
+            }
+
+            @Override
+            public void run() {
+                if (handle != 0) {
+                    Native.nativeHasherFree(handle);
+                    handle = 0;
+                }
+            }
+        }
+
+        private final State state;
+        private final Cleaner.Cleanable cleanable;
+
+        /** Create a new streaming hasher. */
+        public Hasher() {
+            this.state = new State(Native.nativeHasherNew());
+            this.cleanable = CLEANER.register(this, state);
+        }
+
+        private Hasher(long handle) {
+            this.state = new State(handle);
+            this.cleanable = CLEANER.register(this, state);
+        }
+
+        private void checkOpen() {
+            if (state.handle == 0) {
+                throw new IllegalStateException("hasher is closed");
+            }
+        }
+
+        /** Feed more bytes into the hash. */
+        public void update(byte[] data) {
+            checkOpen();
+            Native.nativeHasherUpdate(state.handle, data);
+        }
+
+        /** The 32-byte digest of all data fed so far (non-destructive). */
+        public byte[] digest() {
+            checkOpen();
+            return Native.nativeHasherDigest(state.handle);
+        }
+
+        /** The 64-character lowercase hex digest string. */
+        public String hexDigest() {
+            return toHex(digest());
+        }
+
+        /** An independent copy of this hasher (its own native handle). */
+        public Hasher copy() {
+            checkOpen();
+            return new Hasher(Native.nativeHasherClone(state.handle));
+        }
+
+        /** Free the native handle. Idempotent; safe to call more than once. */
+        @Override
+        public void close() {
+            cleanable.clean();
+        }
+    }
+}

--- a/code/packages/java/sha256-native/src/test/java/com/codingadventures/sha256native/Sha256NativeTest.java
+++ b/code/packages/java/sha256-native/src/test/java/com/codingadventures/sha256native/Sha256NativeTest.java
@@ -1,0 +1,106 @@
+package com.codingadventures.sha256native;
+
+import org.junit.jupiter.api.Test;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Exercises the Rust SHA-256 through JNI, asserting FIPS 180-4 answers. */
+class Sha256NativeTest {
+
+    private static byte[] a(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void fipsVectors() {
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            Sha256Native.sha256Hex(a("")));
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            Sha256Native.sha256Hex(a("abc")));
+        assertEquals("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+            Sha256Native.sha256Hex(a("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")));
+    }
+
+    @Test
+    void millionA() {
+        byte[] data = new byte[1_000_000];
+        Arrays.fill(data, (byte) 'a');
+        assertEquals("cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+            Sha256Native.sha256Hex(data));
+    }
+
+    @Test
+    void digestIs32Bytes() {
+        assertEquals(32, Sha256Native.sha256(a("")).length);
+        assertEquals(32, Sha256Native.sha256(a("hello world")).length);
+    }
+
+    @Test
+    void blockBoundariesDistinct() {
+        Set<String> seen = new HashSet<>();
+        for (int n : new int[]{55, 56, 63, 64, 127, 128}) {
+            byte[] d = Sha256Native.sha256(new byte[n]);
+            assertEquals(32, d.length);
+            seen.add(Sha256Native.toHex(d));
+        }
+        assertEquals(6, seen.size());
+    }
+
+    @Test
+    void streamingMatchesOneShot() {
+        try (Sha256Native.Hasher h = new Sha256Native.Hasher()) {
+            h.update(a("ab"));
+            h.update(a("c"));
+            assertArrayEquals(Sha256Native.sha256(a("abc")), h.digest());
+        }
+    }
+
+    @Test
+    void streamingByteAtATime() {
+        byte[] data = new byte[100];
+        for (int i = 0; i < 100; i++) data[i] = (byte) i;
+        try (Sha256Native.Hasher h = new Sha256Native.Hasher()) {
+            for (byte b : data) h.update(new byte[]{b});
+            assertArrayEquals(Sha256Native.sha256(data), h.digest());
+        }
+    }
+
+    @Test
+    void streamingEmptyAndNonDestructive() {
+        try (Sha256Native.Hasher e = new Sha256Native.Hasher()) {
+            assertArrayEquals(Sha256Native.sha256(a("")), e.digest());
+        }
+        try (Sha256Native.Hasher h = new Sha256Native.Hasher()) {
+            h.update(a("abc"));
+            assertArrayEquals(h.digest(), h.digest());
+            h.update(a("d"));
+            assertArrayEquals(Sha256Native.sha256(a("abcd")), h.digest());
+        }
+    }
+
+    @Test
+    void copyIsIndependent() {
+        try (Sha256Native.Hasher h = new Sha256Native.Hasher()) {
+            h.update(a("ab"));
+            try (Sha256Native.Hasher h2 = h.copy()) {
+                h2.update(a("c"));
+                h.update(a("x"));
+                assertArrayEquals(Sha256Native.sha256(a("abc")), h2.digest());
+                assertArrayEquals(Sha256Native.sha256(a("abx")), h.digest());
+            }
+        }
+    }
+
+    @Test
+    void usingClosedHasherThrows() {
+        Sha256Native.Hasher h = new Sha256Native.Hasher();
+        h.update(a("abc"));
+        h.close();
+        assertThrows(IllegalStateException.class, () -> h.update(a("x")));
+        assertThrows(IllegalStateException.class, h::digest);
+        h.close(); // idempotent
+    }
+}

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -820,6 +820,7 @@ members = [
     "conduit-capi",
     "conduit-dart-bridge",
     "irc-server-native-jni",
+    "sha256-native-jni",
     "irc-server-capi",
     "smart-home-core",
     "smart-home-capability-cage",

--- a/code/packages/rust/sha256-native-jni/BUILD
+++ b/code/packages/rust/sha256-native-jni/BUILD
@@ -1,0 +1,1 @@
+cargo test --manifest-path ../Cargo.toml -p sha256-native-jni

--- a/code/packages/rust/sha256-native-jni/BUILD_windows
+++ b/code/packages/rust/sha256-native-jni/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test --manifest-path ..\Cargo.toml -p sha256-native-jni

--- a/code/packages/rust/sha256-native-jni/CHANGELOG.md
+++ b/code/packages/rust/sha256-native-jni/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — sha256-native-jni
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: JNI bridge over `coding_adventures_sha256` via `jni-bridge`.
+- `nativeDigest(byte[]) -> byte[]` and an opaque `long`-pointer streaming hasher
+  (`nativeHasherNew` / `Update` / `Digest` / `Clone` / `Free`).
+- Used by `java/sha256-native` (`System.loadLibrary("sha256_native_jni")`).

--- a/code/packages/rust/sha256-native-jni/Cargo.toml
+++ b/code/packages/rust/sha256-native-jni/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sha256-native-jni"
+version = "0.1.0"
+edition = "2021"
+description = "JNI native library bridging Java/Kotlin to the Rust coding_adventures_sha256 crate"
+publish = false
+
+[lib]
+# cdylib → libsha256_native_jni.{so,dylib,dll}, loaded via
+# System.loadLibrary("sha256_native_jni"). The `lib` crate type lets the
+# pure-Rust helpers be unit-tested without a JVM.
+crate-type = ["cdylib", "lib"]
+name = "sha256_native_jni"
+
+[dependencies]
+jni-bridge = { path = "../jni-bridge" }
+coding_adventures_sha256 = { path = "../sha256" }

--- a/code/packages/rust/sha256-native-jni/README.md
+++ b/code/packages/rust/sha256-native-jni/README.md
@@ -1,0 +1,10 @@
+# sha256-native-jni
+
+JNI native library bridging Java/Kotlin to the Rust `coding_adventures_sha256`
+crate. Compiles to a cdylib (`libsha256_native_jni.{so,dylib,dll}`) loaded via
+`System.loadLibrary("sha256_native_jni")`.
+
+Each `native` method on `com.codingadventures.sha256native.Native` maps to a
+`Java_com_codingadventures_sha256native_Native_*` export. Used by
+`java/sha256-native`. Uses the zero-dependency `jni-bridge` (no `jni` crate, no
+bindgen).

--- a/code/packages/rust/sha256-native-jni/src/lib.rs
+++ b/code/packages/rust/sha256-native-jni/src/lib.rs
@@ -1,0 +1,128 @@
+//! `sha256-native-jni` — a JNI bridge from Java/Kotlin to the Rust
+//! `coding_adventures_sha256` crate.
+//!
+//! Each `native` method on `com.codingadventures.sha256native.Native` maps to a
+//! `Java_com_codingadventures_sha256native_Native_*` export here. The JVM loads
+//! the compiled cdylib via `System.loadLibrary("sha256_native_jni")`.
+//!
+//! ## Design
+//!
+//! * `nativeDigest(byte[])` → `byte[]` — one-shot digest; the input `byte[]` is
+//!   copied into a Rust `Vec<u8>` and the 32-byte result into a fresh `byte[]`.
+//! * The streaming hasher is an opaque **`long` peer pointer**
+//!   (`Box::into_raw` / `Box::from_raw`): `nativeHasherNew` returns it,
+//!   `nativeHasherUpdate` / `nativeHasherDigest` / `nativeHasherClone` operate on
+//!   it, and `nativeHasherFree` reclaims it. Every call validates the pointer
+//!   against 0, so a null handle is a safe no-op.
+//!
+//! There is no callback into the JVM, so no thread attachment or global-ref
+//! machinery is needed.
+
+// JNI entry points are `Java_<Pkg>_<Class>_<method>` (not snake_case) and share
+// one uniform safety contract (called by the JVM), so per-fn `# Safety` docs
+// would be noise.
+#![allow(non_snake_case, clippy::missing_safety_doc)]
+
+use jni_bridge::{
+    jbyteArray, jclass, jlong, jni_get_byte_array, jni_new_byte_array_from, JNIEnv,
+};
+
+use coding_adventures_sha256::{sha256, Sha256Hasher};
+
+/// `nativeDigest(byte[] data) -> byte[]` — the 32-byte SHA-256 digest.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_sha256native_Native_nativeDigest(
+    env: *mut JNIEnv,
+    _class: jclass,
+    data: jbyteArray,
+) -> jbyteArray {
+    let input = jni_get_byte_array(env, data);
+    let digest = sha256(&input);
+    jni_new_byte_array_from(env, &digest)
+}
+
+/// `nativeHasherNew() -> long` — allocate a streaming hasher, return its pointer.
+#[no_mangle]
+pub extern "C" fn Java_com_codingadventures_sha256native_Native_nativeHasherNew(
+    _env: *mut JNIEnv,
+    _class: jclass,
+) -> jlong {
+    Box::into_raw(Box::new(Sha256Hasher::new())) as jlong
+}
+
+/// `nativeHasherUpdate(long h, byte[] data)` — feed bytes into the hasher.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_sha256native_Native_nativeHasherUpdate(
+    env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+    data: jbyteArray,
+) {
+    if h == 0 {
+        return;
+    }
+    let hasher = &mut *(h as *mut Sha256Hasher);
+    let input = jni_get_byte_array(env, data);
+    hasher.update(&input);
+}
+
+/// `nativeHasherDigest(long h) -> byte[]` — the current 32-byte digest
+/// (non-destructive). A null handle yields an empty array.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_sha256native_Native_nativeHasherDigest(
+    env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+) -> jbyteArray {
+    if h == 0 {
+        return jni_new_byte_array_from(env, &[]);
+    }
+    let hasher = &*(h as *mut Sha256Hasher);
+    jni_new_byte_array_from(env, &hasher.digest())
+}
+
+/// `nativeHasherClone(long h) -> long` — an independent copy (0 if `h` is 0).
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_sha256native_Native_nativeHasherClone(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+) -> jlong {
+    if h == 0 {
+        return 0;
+    }
+    let hasher = &*(h as *mut Sha256Hasher);
+    Box::into_raw(Box::new(hasher.clone_hasher())) as jlong
+}
+
+/// `nativeHasherFree(long h)` — free a hasher handle. A 0 handle is a no-op.
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_sha256native_Native_nativeHasherFree(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+) {
+    if h != 0 {
+        drop(Box::from_raw(h as *mut Sha256Hasher));
+    }
+}
+
+// Pure-Rust unit tests (no JVM): exercise the digest logic the JNI layer wraps.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_and_streaming_agree() {
+        let one_shot = sha256(b"abc");
+        let mut h = Sha256Hasher::new();
+        h.update(b"ab");
+        h.update(b"c");
+        assert_eq!(h.digest(), one_shot);
+        let hex: String = one_shot.iter().map(|b| format!("{:02x}", b)).collect();
+        assert_eq!(
+            hex,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+}


### PR DESCRIPTION
## What

**Establishes the JVM (Java/Kotlin) native-through-Rust pattern via JNI** — the second half of unblocking the native story (the Swift native pattern is a companion PR). Adds a native companion to the pure-Java `sha256` package.

Two pieces:
1. **`rust/sha256-native-jni`** — a cdylib exporting `Java_com_codingadventures_sha256native_Native_*` over `coding_adventures_sha256`, using the **zero-dependency `jni-bridge`** (no `jni` crate, no bindgen). `nativeDigest(byte[]) -> byte[]` plus an opaque `long`-peer-pointer streaming hasher. Added as one `rust/` workspace member (next to the existing `irc-server-native-jni`).
2. **`java/sha256-native`** — `Native.java` (`System.loadLibrary` + native decls) and a `Sha256Native` wrapper: `sha256`/`sha256Hex` plus a `Hasher` (`AutoCloseable`) owning the native handle, freed by `close()` (idempotent) with a `Cleaner` safety net. `build.gradle.kts` sets `-Djava.library.path` to `rust/target/release`.

## Why it matters

Every prior Java/Kotlin/Swift package in the campaign was a *pure* port. This is the first JVM binding that reuses the Rust implementation via JNI — and the same cdylib + pattern directly unblocks a future **Kotlin** native binding too.

## Verification

- **1 Rust unit test** (`cargo test`, no JVM) + **9 JUnit tests through JNI** — FIPS 180-4 vectors (incl. one-million-'a'), block boundaries, streaming parity, byte-at-a-time, non-destructive digest, copy independence, closed-handle guarding. All green; full BUILD sequence green locally (Java 21 + Gradle 8.14 + cargo).
- **Security review passed**: every native deref guarded by `h != 0`; `Box` into/from_raw paired (no double-free/UAF); Cleaner action holds the handle in a separate `State` (no `Hasher` capture); `Cleanable.clean()` idempotent → free exactly once; `copy()` clones a fresh handle so no two `Hasher`s alias one pointer; `toHex` sign-safe. The raw-pointer trust model matches the established `irc-server-native`.

BUILD: `cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release && gradle test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)