### PR TITLE
feat(md5-native): JVM native-through-Rust binding + md5-native-jni crate

### DIFF
--- a/code/packages/java/md5-native/.gitignore
+++ b/code/packages/java/md5-native/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/java/md5-native/BUILD
+++ b/code/packages/java/md5-native/BUILD
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release && gradle test

--- a/code/packages/java/md5-native/BUILD_windows
+++ b/code/packages/java/md5-native/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build --manifest-path ..\..\rust\Cargo.toml -p md5-native-jni --release && gradle test

--- a/code/packages/java/md5-native/CHANGELOG.md
+++ b/code/packages/java/md5-native/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — md5-native (Java)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: native-through-Rust MD5 for the JVM — reuses the JVM native
+  pattern (Rust cdylib + jni-bridge JNI + System.loadLibrary) established by
+  `java/sha256-native`, specialised to MD5's 16-byte digest.
+- Calls `coding_adventures_md5` through the `md5_native_jni` cdylib: `sumMd5` /
+  `hexString` and a streaming `Digest` (`AutoCloseable`, `update` /
+  non-destructive `digest` / `hexDigest` / `copy`, `Cleaner`-managed handle).
+- 9 JUnit tests through JNI: RFC 1321 vectors (incl. 0x00..0xFF), block
+  boundaries, streaming parity, byte-at-a-time, non-destructive digest, copy
+  independence, closed-handle guarding. `gradle test` green against the cdylib.

--- a/code/packages/java/md5-native/README.md
+++ b/code/packages/java/md5-native/README.md
@@ -1,0 +1,30 @@
+# md5-native (Java)
+
+**Native-through-Rust** MD5 for the JVM — companion to the pure-Java `md5`
+package. Calls the Rust `coding_adventures_md5` crate through JNI (the
+`md5_native_jni` cdylib, built with the zero-dependency `jni-bridge`). Reuses the
+JVM native pattern established by `java/sha256-native`.
+
+> **Security:** MD5 is cryptographically broken — checksum use only.
+
+## API (`com.codingadventures.md5native.Md5Native`)
+
+```java
+Md5Native.hexString("abc".getBytes(StandardCharsets.UTF_8)); // 900150983cd24fb0d6963f7d28e17f72
+try (Md5Native.Digest h = new Md5Native.Digest()) {
+    h.update("ab".getBytes());
+    h.update("c".getBytes());
+    h.hexDigest();
+}
+```
+
+`sumMd5(byte[]) -> byte[]` (16 bytes), `hexString(byte[]) -> String`, and a
+`Digest` (`AutoCloseable`) with `update` / non-destructive `digest` / `hexDigest`
+/ `copy`, its native handle freed by `close()` with a `Cleaner` safety net.
+
+## Building
+
+```
+cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release
+gradle test   # sets -Djava.library.path to rust/target/release
+```

--- a/code/packages/java/md5-native/build.gradle.kts
+++ b/code/packages/java/md5-native/build.gradle.kts
@@ -1,0 +1,37 @@
+// Java md5 native binding — JNI over the Rust `md5_native_jni` cdylib.
+// Build the cdylib first:
+//   cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    java
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = "21"
+    targetCompatibility = "21"
+    options.release.set(21)
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    val rustReleaseDir = projectDir.parentFile.parentFile
+        .resolve("rust/target/release")
+        .absolutePath
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+    testLogging { events("passed", "skipped", "failed") }
+}

--- a/code/packages/java/md5-native/required_capabilities.json
+++ b/code/packages/java/md5-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://coding-adventures.example/schemas/required_capabilities/v1.json",
+  "version": 1,
+  "package": "java/md5-native",
+  "capabilities": ["ffi:call"],
+  "justification": "ffi:call — loads the md5_native_jni cdylib via System.loadLibrary and calls its JNI methods to compute MD5 in Rust. No network, filesystem, or process access."
+}

--- a/code/packages/java/md5-native/settings.gradle.kts
+++ b/code/packages/java/md5-native/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "md5-native"

--- a/code/packages/java/md5-native/src/main/java/com/codingadventures/md5native/Md5Native.java
+++ b/code/packages/java/md5-native/src/main/java/com/codingadventures/md5native/Md5Native.java
@@ -1,0 +1,103 @@
+package com.codingadventures.md5native;
+
+import java.lang.ref.Cleaner;
+
+/**
+ * Native-through-Rust MD5 for the JVM — companion to the pure-Java {@code md5}
+ * package. Calls the Rust {@code coding_adventures_md5} crate through JNI (the
+ * {@code md5_native_jni} cdylib). Mirrors {@code java/sha256-native} (16-byte
+ * digest).
+ *
+ * <p><b>Security:</b> MD5 is cryptographically broken — checksum use only.
+ */
+public final class Md5Native {
+
+    private static final Cleaner CLEANER = Cleaner.create();
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private Md5Native() {
+    }
+
+    /** The 16-byte MD5 digest of {@code data} (computed in Rust). */
+    public static byte[] sumMd5(byte[] data) {
+        return Native.nativeDigest(data);
+    }
+
+    /** The 32-character lowercase hex digest of {@code data} (computed in Rust). */
+    public static String hexString(byte[] data) {
+        return toHex(sumMd5(data));
+    }
+
+    static String toHex(byte[] bytes) {
+        char[] out = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xff;
+            out[i * 2] = HEX[v >>> 4];
+            out[i * 2 + 1] = HEX[v & 0x0f];
+        }
+        return new String(out);
+    }
+
+    /** A streaming MD5 hasher backed by a native Rust hasher. {@link AutoCloseable}. */
+    public static final class Digest implements AutoCloseable {
+
+        private static final class State implements Runnable {
+            long handle;
+
+            State(long handle) {
+                this.handle = handle;
+            }
+
+            @Override
+            public void run() {
+                if (handle != 0) {
+                    Native.nativeHasherFree(handle);
+                    handle = 0;
+                }
+            }
+        }
+
+        private final State state;
+        private final Cleaner.Cleanable cleanable;
+
+        public Digest() {
+            this.state = new State(Native.nativeHasherNew());
+            this.cleanable = CLEANER.register(this, state);
+        }
+
+        private Digest(long handle) {
+            this.state = new State(handle);
+            this.cleanable = CLEANER.register(this, state);
+        }
+
+        private void checkOpen() {
+            if (state.handle == 0) {
+                throw new IllegalStateException("digest is closed");
+            }
+        }
+
+        public void update(byte[] data) {
+            checkOpen();
+            Native.nativeHasherUpdate(state.handle, data);
+        }
+
+        public byte[] digest() {
+            checkOpen();
+            return Native.nativeHasherDigest(state.handle);
+        }
+
+        public String hexDigest() {
+            return toHex(digest());
+        }
+
+        public Digest copy() {
+            checkOpen();
+            return new Digest(Native.nativeHasherClone(state.handle));
+        }
+
+        @Override
+        public void close() {
+            cleanable.clean();
+        }
+    }
+}

--- a/code/packages/java/md5-native/src/main/java/com/codingadventures/md5native/Native.java
+++ b/code/packages/java/md5-native/src/main/java/com/codingadventures/md5native/Native.java
@@ -1,0 +1,27 @@
+package com.codingadventures.md5native;
+
+/**
+ * JNI bindings to the {@code md5_native_jni} Rust cdylib, which wraps the
+ * pure-Rust {@code coding_adventures_md5} crate. Each {@code native} method maps
+ * to a {@code Java_com_codingadventures_md5native_Native_*} function.
+ */
+final class Native {
+    static {
+        System.loadLibrary("md5_native_jni");
+    }
+
+    private Native() {
+    }
+
+    static native byte[] nativeDigest(byte[] data);
+
+    static native long nativeHasherNew();
+
+    static native void nativeHasherUpdate(long handle, byte[] data);
+
+    static native byte[] nativeHasherDigest(long handle);
+
+    static native long nativeHasherClone(long handle);
+
+    static native void nativeHasherFree(long handle);
+}

--- a/code/packages/java/md5-native/src/test/java/com/codingadventures/md5native/Md5NativeTest.java
+++ b/code/packages/java/md5-native/src/test/java/com/codingadventures/md5native/Md5NativeTest.java
@@ -1,0 +1,99 @@
+package com.codingadventures.md5native;
+
+import org.junit.jupiter.api.Test;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import static org.junit.jupiter.api.Assertions.*;
+
+class Md5NativeTest {
+    private static byte[] a(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void rfcVectors() {
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", Md5Native.hexString(a("")));
+        assertEquals("0cc175b9c0f1b6a831c399e269772661", Md5Native.hexString(a("a")));
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", Md5Native.hexString(a("abc")));
+        assertEquals("f96b697d7cb7938d525a2f31aaf161d0", Md5Native.hexString(a("message digest")));
+    }
+
+    @Test
+    void bytes0To255() {
+        byte[] data = new byte[256];
+        for (int i = 0; i < 256; i++) data[i] = (byte) i;
+        assertEquals("e2c865db4162bed963bfaa9ef6ac18f0", Md5Native.hexString(data));
+    }
+
+    @Test
+    void digestIs16Bytes() {
+        assertEquals(16, Md5Native.sumMd5(a("")).length);
+        assertEquals(16, Md5Native.sumMd5(a("hello world")).length);
+    }
+
+    @Test
+    void blockBoundariesDistinct() {
+        Set<String> seen = new HashSet<>();
+        for (int n : new int[]{0, 55, 56, 63, 64, 127, 128}) {
+            seen.add(Md5Native.hexString(new byte[n]));
+        }
+        assertEquals(7, seen.size());
+    }
+
+    @Test
+    void streamingMatchesOneShot() {
+        try (Md5Native.Digest h = new Md5Native.Digest()) {
+            h.update(a("ab"));
+            h.update(a("c"));
+            assertArrayEquals(Md5Native.sumMd5(a("abc")), h.digest());
+        }
+    }
+
+    @Test
+    void streamingByteAtATime() {
+        byte[] data = new byte[100];
+        for (int i = 0; i < 100; i++) data[i] = (byte) i;
+        try (Md5Native.Digest h = new Md5Native.Digest()) {
+            for (byte b : data) h.update(new byte[]{b});
+            assertArrayEquals(Md5Native.sumMd5(data), h.digest());
+        }
+    }
+
+    @Test
+    void streamingEmptyAndNonDestructive() {
+        try (Md5Native.Digest e = new Md5Native.Digest()) {
+            assertArrayEquals(Md5Native.sumMd5(a("")), e.digest());
+        }
+        try (Md5Native.Digest h = new Md5Native.Digest()) {
+            h.update(a("abc"));
+            assertArrayEquals(h.digest(), h.digest());
+            h.update(a("d"));
+            assertArrayEquals(Md5Native.sumMd5(a("abcd")), h.digest());
+        }
+    }
+
+    @Test
+    void copyIsIndependent() {
+        try (Md5Native.Digest h = new Md5Native.Digest()) {
+            h.update(a("ab"));
+            try (Md5Native.Digest h2 = h.copy()) {
+                h2.update(a("c"));
+                h.update(a("x"));
+                assertArrayEquals(Md5Native.sumMd5(a("abc")), h2.digest());
+                assertArrayEquals(Md5Native.sumMd5(a("abx")), h.digest());
+            }
+        }
+    }
+
+    @Test
+    void usingClosedThrows() {
+        Md5Native.Digest h = new Md5Native.Digest();
+        h.update(a("abc"));
+        h.close();
+        assertThrows(IllegalStateException.class, () -> h.update(a("x")));
+        assertThrows(IllegalStateException.class, h::digest);
+        h.close();
+    }
+}

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -822,6 +822,7 @@ members = [
     "conduit-dart-bridge",
     "irc-server-native-jni",
     "sha256-native-jni",
+    "md5-native-jni",
     "irc-server-capi",
     "smart-home-core",
     "smart-home-capability-cage",

--- a/code/packages/rust/md5-native-jni/BUILD
+++ b/code/packages/rust/md5-native-jni/BUILD
@@ -1,0 +1,1 @@
+cargo test --manifest-path ../Cargo.toml -p md5-native-jni

--- a/code/packages/rust/md5-native-jni/BUILD_windows
+++ b/code/packages/rust/md5-native-jni/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test --manifest-path ..\Cargo.toml -p md5-native-jni

--- a/code/packages/rust/md5-native-jni/CHANGELOG.md
+++ b/code/packages/rust/md5-native-jni/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog — md5-native-jni
+
+## 0.1.0 — 2026-07-11
+
+### Added
+- JNI bridge over `coding_adventures_md5` via `jni-bridge`: nativeDigest(byte[])
+  + opaque long-pointer streaming hasher. Used by `java/md5-native`.

--- a/code/packages/rust/md5-native-jni/Cargo.toml
+++ b/code/packages/rust/md5-native-jni/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "md5-native-jni"
+version = "0.1.0"
+edition = "2021"
+description = "JNI native library bridging Java/Kotlin to the Rust coding_adventures_md5 crate"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "md5_native_jni"
+
+[dependencies]
+jni-bridge = { path = "../jni-bridge" }
+coding_adventures_md5 = { path = "../md5" }

--- a/code/packages/rust/md5-native-jni/README.md
+++ b/code/packages/rust/md5-native-jni/README.md
@@ -1,0 +1,5 @@
+# md5-native-jni
+
+JNI bridge over `coding_adventures_md5` via `jni-bridge`. cdylib
+`libmd5_native_jni.{so,dylib,dll}` loaded via System.loadLibrary("md5_native_jni").
+Used by `java/md5-native`. MD5 is broken — checksum use only.

--- a/code/packages/rust/md5-native-jni/src/lib.rs
+++ b/code/packages/rust/md5-native-jni/src/lib.rs
@@ -1,0 +1,96 @@
+//! `md5-native-jni` — a JNI bridge from Java/Kotlin to the Rust
+//! `coding_adventures_md5` crate. Each `native` method on
+//! `com.codingadventures.md5native.Native` maps to a
+//! `Java_com_codingadventures_md5native_Native_*` export. Loaded via
+//! `System.loadLibrary("md5_native_jni")`. Mirrors `sha256-native-jni`
+//! (16-byte digest). MD5 is broken — checksum use only.
+#![allow(non_snake_case, clippy::missing_safety_doc)]
+
+use jni_bridge::{jbyteArray, jclass, jlong, jni_get_byte_array, jni_new_byte_array_from, JNIEnv};
+
+use coding_adventures_md5::{sum_md5, Digest};
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_md5native_Native_nativeDigest(
+    env: *mut JNIEnv,
+    _class: jclass,
+    data: jbyteArray,
+) -> jbyteArray {
+    let input = jni_get_byte_array(env, data);
+    jni_new_byte_array_from(env, &sum_md5(&input))
+}
+
+#[no_mangle]
+pub extern "C" fn Java_com_codingadventures_md5native_Native_nativeHasherNew(
+    _env: *mut JNIEnv,
+    _class: jclass,
+) -> jlong {
+    Box::into_raw(Box::new(Digest::new())) as jlong
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_md5native_Native_nativeHasherUpdate(
+    env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+    data: jbyteArray,
+) {
+    if h == 0 {
+        return;
+    }
+    let hasher = &mut *(h as *mut Digest);
+    let input = jni_get_byte_array(env, data);
+    hasher.update(&input);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_md5native_Native_nativeHasherDigest(
+    env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+) -> jbyteArray {
+    if h == 0 {
+        return jni_new_byte_array_from(env, &[]);
+    }
+    let hasher = &*(h as *mut Digest);
+    jni_new_byte_array_from(env, &hasher.sum_md5())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_md5native_Native_nativeHasherClone(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+) -> jlong {
+    if h == 0 {
+        return 0;
+    }
+    let hasher = &*(h as *mut Digest);
+    Box::into_raw(Box::new(hasher.clone_digest())) as jlong
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_codingadventures_md5native_Native_nativeHasherFree(
+    _env: *mut JNIEnv,
+    _class: jclass,
+    h: jlong,
+) {
+    if h != 0 {
+        drop(Box::from_raw(h as *mut Digest));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn digest_and_streaming_agree() {
+        let one = sum_md5(b"abc");
+        let mut h = Digest::new();
+        h.update(b"ab");
+        h.update(b"c");
+        assert_eq!(h.sum_md5(), one);
+        let hex: String = one.iter().map(|b| format!("{:02x}", b)).collect();
+        assert_eq!(hex, "900150983cd24fb0d6963f7d28e17f72");
+    }
+}


### PR DESCRIPTION
## What

Applies the **JVM/JNI native pattern** (established by `java/sha256-native`) to `md5` — proving that template reuses too. Companion to the pure-Java `md5` package.

- **`rust/md5-native-jni`** — a cdylib exporting `Java_com_codingadventures_md5native_Native_*` over `coding_adventures_md5` via the zero-dep `jni-bridge`. One `rust/` workspace-member line (distinct from `sha256-native-jni`'s → no conflict).
- **`java/md5-native`** — `Native.java` + `Md5Native` wrapper (`sumMd5`/`hexString` + a `Digest` `AutoCloseable` with a `Cleaner`-managed handle). `build.gradle.kts` sets `-Djava.library.path` to `rust/target/release`.

## Verification

- **1 Rust unit test** + **9 JUnit tests through JNI** — RFC 1321 vectors (incl. `0x00..0xFF`), block boundaries, streaming parity, byte-at-a-time, non-destructive digest, copy independence, closed-handle guarding. `gradle test` green.
- **Security review passed**: every native deref guarded by `h != 0`; `Box` into/from_raw paired; Cleaner action holds the handle in a separate `State` (no `Digest` capture); `close()` frees exactly once; `copy()` clones a fresh handle (no aliasing); 16-byte digest is data-driven (no leftover 32).

BUILD: `cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release && gradle test`.

> **Security note:** MD5 is cryptographically broken — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)