### PR TITLE
feat(matlab-to-semantic-ir): MATLAB CST -> SIR22 frontend (HML01 §3, v0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -228,6 +228,7 @@ members = [
     "cobol-parser",
     "matlab-runtime",
     "matlab-repl",
+    "matlab-to-semantic-ir",
     "octave-runtime",
     "octave-repl",
     "maxima-runtime",

--- a/code/packages/rust/matlab-to-semantic-ir/BUILD
+++ b/code/packages/rust/matlab-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p matlab-to-semantic-ir -- --nocapture

--- a/code/packages/rust/matlab-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/matlab-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p matlab-to-semantic-ir -- --nocapture

--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -30,9 +30,47 @@
   node at all yet), `switch`/`try`/`global`/`persistent`, cell arrays,
   anonymous functions, auto-vivification on indexed assignment, and
   chained assignment.
-- 62 tests: 54 unit tests over lowering shapes and rejected constructs, 5
-  validator/capability-rejection tests (mirroring the SIR22/SIR23 core
-  verification pattern), 3 end-to-end tests that actually execute lowered
-  MATLAB through `semantic-ir-to-javascript` and `node` (gated on `node`
-  availability).
+- 66 tests: 57 unit tests over lowering shapes, rejected constructs, and
+  the DoS-guard regressions below, 5 validator/capability-rejection tests
+  (mirroring the SIR22/SIR23 core verification pattern), 3 end-to-end
+  tests that actually execute lowered MATLAB through
+  `semantic-ir-to-javascript` and `node` (gated on `node` availability).
 - Marks `matlab-to-semantic-ir` done in `HML01-math-to-semantic-ir.md` §3.
+
+### Fixed (security review, before first push)
+
+- **DoS: unbounded native-stack recursion on a flat arithmetic chain.**
+  MATLAB's grammar collapses a flat run of `+`/`-`/`*`/... (no parens) into
+  one CST node with many children, so a long unparenthesized chain never
+  trips the ordinary grammar-nesting depth guard. Two compounding bugs,
+  both confirmed to crash (SIGABRT) on a 60,000-term chain during review:
+  (1) `build_additive`/`build_multiplicative` re-derived each operand's
+  scalar-ness by calling `expr_is_known_scalar` on the *entire
+  already-accumulated* left tree at every fold step — O(chain length)
+  stack on the final step alone — fixed by tracking scalar-ness
+  incrementally (O(1) per step) instead; (2) even with (1) fixed, folding
+  N operands left-associatively still builds an N-deep binary `Expr` tree,
+  and that depth is what every later recursive pass over it (the
+  validator, any backend, even `Drop`) pays for regardless of how cheaply
+  it was built — fixed by capping the operand *count* itself
+  (`check_chain_length`, applied to `additive`/`multiplicative`/
+  `comparison`/`logical_or`/`logical_and`) at `MAX_EXPR_DEPTH`, rejecting a
+  pathological chain before building anything. `expr_is_known_scalar` also
+  gained its own depth cap as defense in depth.
+- **DoS (masked, not yet independently exploitable): index/call arguments
+  reset the expression-depth counter instead of threading it.**
+  `lower_index_args`/`lower_call_args`/`lower_one_index_arg` called the
+  depth-*resetting* `lower_expr` instead of continuing the caller's depth,
+  so a chain of nested indexing/calls (`A(A(A(...))))`) never accumulated
+  against `MAX_EXPR_DEPTH` — each level silently restarted its own budget.
+  Currently masked by `coding-adventures-matlab-parser`'s own independent
+  nesting limit (which rejects sufficiently deep source first), but that
+  is a different crate's protection, not this one's — fixed by threading
+  `depth + 1` through all three functions via `lower_expr_d`, mirroring
+  `python-to-semantic-ir`'s `lower_expr_in` pattern.
+- **Test-only, LOW severity: predictable temp-file path in
+  `tests/e2e_node.rs`.** The end-to-end harness wrote to a predictable
+  path under the shared system temp directory via `std::fs::write`, which
+  follows an existing symlink; switched to
+  `OpenOptions::new().write(true).create_new(true)`, which fails instead
+  of following one.

--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## [0.1.0] - 2026-07-11
+
+### Added
+
+- Initial `matlab-to-semantic-ir` frontend crate (HML01 §3), the first to
+  target SIR22 (array/matrix domain): `compile`/`compile_source` lowering
+  `coding-adventures-matlab-parser`'s `GrammarASTNode` CST into a
+  `semantic_ir::Module`.
+- Supported: literals (int/float/string), assignment (`LetStarBinding` on
+  first occurrence, `Assign` on re-assignment), arithmetic
+  (`+ - * / \ ^` and their dotted elementwise forms), comparisons, logical
+  `&& || & &`, unary `+ - ~`, ranges (`a:b`, `a:step:b`), transpose (`'`
+  and `.'`), matrix literals (`ArrayLit`), indexing (read → `IndexGet`,
+  write → `Stmt::IndexSet`) with 1-based → 0-based translation at lowering
+  time, `if`/`elseif`/`else`, `while`, `for i = a:b`, single/zero-output
+  function definitions and calls, and `disp` (mapped onto the shared SIR
+  `print` builtin).
+- A conservative, purely syntactic scalar/array disambiguation heuristic
+  for MATLAB's shape-polymorphic operators (`expr_is_known_scalar`):
+  literal-derived operands take a plain `BuiltinCall`, everything else
+  takes the SIR22 `ElementwiseOp`/`MatMul` path.
+- Explicit, disclosed scope limits (each rejected with a clear
+  `MatlabLowerError`, never silently mis-lowered): stepped/matrix-valued
+  `for` loops, `end`-relative indexing, matrix division (`/`/`\` between
+  non-scalars — `array-runtime` has no linear-solve kernel), matrix power,
+  multi-output functions, nested function definitions,
+  `break`/`continue`/`return` (semantic-ir has no early-exit control-flow
+  node at all yet), `switch`/`try`/`global`/`persistent`, cell arrays,
+  anonymous functions, auto-vivification on indexed assignment, and
+  chained assignment.
+- 62 tests: 54 unit tests over lowering shapes and rejected constructs, 5
+  validator/capability-rejection tests (mirroring the SIR22/SIR23 core
+  verification pattern), 3 end-to-end tests that actually execute lowered
+  MATLAB through `semantic-ir-to-javascript` and `node` (gated on `node`
+  availability).
+- Marks `matlab-to-semantic-ir` done in `HML01-math-to-semantic-ir.md` §3.

--- a/code/packages/rust/matlab-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/matlab-to-semantic-ir/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "matlab-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "MATLAB CST → narrow-waist Semantic IR (SIR22 array/matrix domain). Fourth frontend for the SIR10 narrow-waist IR, first to target SIR22."
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-matlab-parser = { path = "../matlab-parser" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode`
+# whose leaf tokens are `lexer::token::Token`; we walk both directly.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# The scalar-only (non-array) subset of a lowered module can round-trip
+# through the JS backend and actually execute with the system `node`
+# (gated on availability). Array/matrix (SIR22) codegen is not yet
+# implemented by this backend, so those tests instead verify structural
+# validity plus the capability-rejection path (see README "Testing").
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/matlab-to-semantic-ir/README.md
+++ b/code/packages/rust/matlab-to-semantic-ir/README.md
@@ -1,0 +1,72 @@
+# matlab-to-semantic-ir
+
+MATLAB CST → narrow-waist Semantic IR. The first frontend to target
+[SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md), the array/matrix
+domain extension of the SIR10 narrow-waist IR (see
+[HML01](../../../specs/HML01-math-to-semantic-ir.md)).
+
+## Where this fits
+
+```
+MATLAB source
+   │
+   ▼  coding_adventures_matlab_parser::try_parse_matlab(src)
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  matlab_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR16 + SIR22)
+```
+
+The lowered `Module` can then be validated (`semantic_ir::validate`) and
+handed to any SIR backend (e.g. `semantic-ir-to-javascript`) — "write the
+MATLAB frontend once, target every SIR backend" is the whole point of this
+narrow-waist design.
+
+## Usage
+
+```rust
+use matlab_to_semantic_ir::compile_source;
+
+let module = compile_source("x = 1 + 2;\n", "demo")?;
+```
+
+## Scope (v0.1.0)
+
+MATLAB is a large language; this first cut covers a well-defined,
+extensively tested subset and returns a clean `MatlabLowerError` for
+anything outside it, rather than silently mis-lowering. See `src/lower.rs`'s
+module doc comment for the exact supported-construct list and every
+deliberate, disclosed scope limit (stepped/matrix-valued `for` loops,
+`end`-relative indexing, matrix division, multi-output functions, nested
+functions, `break`/`continue`/`return` — semantic-ir has no early-exit
+control-flow node at all yet, a whole-IR gap rather than something specific
+to this frontend — `switch`/`try`/`global`, cell arrays, and lambdas).
+
+### Scalar/array disambiguation
+
+MATLAB's `+ - * / \ ^` are polymorphic between scalar and matrix operands at
+*runtime*; this frontend has no shape/type inference, so it uses a
+conservative, purely syntactic heuristic on the lowered expression tree (see
+`expr_is_known_scalar` in `src/lower.rs`): an operand counts as "known
+scalar" only if it is built transitively from literal numbers. This means
+ordinary *variable* arithmetic (a loop accumulator, a function parameter,
+...) always takes the array-domain (`ElementwiseOp`/`MatMul`) path, even
+when the value is a genuine runtime scalar — a real limitation, not a bug,
+documented (and demonstrated) in `tests/test_validator.rs`.
+
+### Testing
+
+- `tests/test_lower.rs` — unit tests over every lowering rule and every
+  documented scope limit's rejection.
+- `tests/test_validator.rs` — every lowered module passes
+  `semantic_ir::validate`; a module using SIR22 nodes is correctly
+  *rejected* by `semantic-ir-to-javascript`'s capability check (that backend
+  does not implement SIR22 codegen yet), mirroring the same
+  capability-rejection verification pattern used to land SIR22/SIR23
+  themselves.
+- `tests/e2e_node.rs` — the one class of MATLAB program that currently
+  avoids the array domain entirely (purely literal arithmetic) is lowered,
+  emitted as JavaScript, and **actually executed with `node`**, gated on
+  `node` availability. A genuine array/matrix round-trip through a real
+  backend arrives with `semantic-ir-to-javascript`'s SIR22 codegen (separate,
+  not-yet-shipped follow-on work per HML01 §4).

--- a/code/packages/rust/matlab-to-semantic-ir/README.md
+++ b/code/packages/rust/matlab-to-semantic-ir/README.md
@@ -56,8 +56,11 @@ documented (and demonstrated) in `tests/test_validator.rs`.
 
 ### Testing
 
-- `tests/test_lower.rs` — unit tests over every lowering rule and every
-  documented scope limit's rejection.
+- `tests/test_lower.rs` — unit tests over every lowering rule, every
+  documented scope limit's rejection, and a DoS-guard regression pair
+  (`a_pathologically_long_flat_{additive,multiplicative}_chain_is_cleanly_rejected`)
+  reproducing a native-stack-overflow bug security review caught and this
+  crate fixed before its first push — see `CHANGELOG.md`'s "Fixed" entry.
 - `tests/test_validator.rs` — every lowered module passes
   `semantic_ir::validate`; a module using SIR22 nodes is correctly
   *rejected* by `semantic-ir-to-javascript`'s capability check (that backend

--- a/code/packages/rust/matlab-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lib.rs
@@ -1,0 +1,60 @@
+//! # matlab-to-semantic-ir
+//!
+//! MATLAB CST → narrow-waist Semantic IR, **v0.1.0**.
+//!
+//! This is the first frontend to target [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md),
+//! the array/matrix domain extension of the SIR10 narrow-waist IR (see
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)). It consumes the
+//! generic `GrammarASTNode` CST produced by the `coding-adventures-matlab-parser`
+//! crate and emits a [`semantic_ir::Module`].
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! MATLAB source
+//!    │
+//!    ▼  coding_adventures_matlab_parser::try_parse_matlab(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  matlab_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR16 + SIR22)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use matlab_to_semantic_ir::compile_source;
+//! let module = compile_source("x = 1 + 2;\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+//!
+//! ## Scope (v0.1.0)
+//!
+//! MATLAB is a large language; this first cut covers a well-defined subset
+//! and returns a clean [`MatlabLowerError`] — rather than silently
+//! mis-lowering — for anything outside it. See `lower.rs`'s module doc
+//! comment for the exact supported-construct list and the documented,
+//! deliberate scope limits (stepped/matrix-valued `for` loops, matrix
+//! division `/`/`\`, matrix power, multi-output functions, `end`-relative
+//! indexing, `break`/`continue`/`return`, `switch`/`try`/cell arrays/
+//! lambdas/`global`).
+
+mod lower;
+pub use lower::{compile, MatlabLowerError};
+
+/// Parse `source` as MATLAB and lower it into a [`semantic_ir::Module`] in
+/// one step, mirroring every other `-to-semantic-ir` frontend's
+/// `compile_source` convenience wrapper.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, MatlabLowerError> {
+    let tree = coding_adventures_matlab_parser::try_parse_matlab(source).map_err(|msg| {
+        MatlabLowerError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        }
+    })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -811,7 +811,13 @@ impl Lowerer {
                     ),
                 ));
             }
-            let indices = self.lower_index_args(call_suffix, ctx)?;
+            // A fresh statement's own expression tree gets its own
+            // `MAX_EXPR_DEPTH` budget (depth 0), matching the `rhs` lowering
+            // just below and every other statement-boundary expression in
+            // this file -- see `lower_index_args`'s doc comment for why
+            // *nested* index/call positions instead thread the caller's
+            // depth rather than restarting.
+            let indices = self.lower_index_args(call_suffix, ctx, 0)?;
             let value = self.lower_expr(rhs, ctx)?;
             return Ok(Lowered::Stmt(Box::new(Stmt::IndexSet {
                 target: Box::new(Expr::VarRef {
@@ -942,6 +948,7 @@ impl Lowerer {
         if !has_op {
             return Ok(None);
         }
+        self.check_chain_length(node)?;
         let mut acc: Option<Expr> = None;
         for child in &node.children {
             if let ASTNodeOrToken::Node(n) = child {
@@ -987,6 +994,7 @@ impl Lowerer {
         if !has_op {
             return Ok(None);
         }
+        self.check_chain_length(node)?;
         let mut acc: Option<Expr> = None;
         let mut pending: Option<String> = None;
         for child in &node.children {
@@ -1081,7 +1089,16 @@ impl Lowerer {
         if !has_op {
             return Ok(None);
         }
-        let mut acc: Option<Expr> = None;
+        self.check_chain_length(node)?;
+        // `acc` tracks the accumulated `Expr` *and* whether it is itself
+        // known-scalar, updated incrementally (O(1) per fold step) rather
+        // than re-derived by calling `expr_is_known_scalar` on the
+        // ever-growing `lhs` at every step -- that re-walk would cost
+        // O(chain length) stack on the final step of an ordinary flat
+        // `1 + 1 + ... + 1` chain (no parens, so `MAX_EXPR_DEPTH`'s
+        // grammar-nesting guard never engages), an uncatchable stack
+        // overflow on a long enough chain.
+        let mut acc: Option<(Expr, bool)> = None;
         let mut pending: Option<String> = None;
         for child in &node.children {
             match child {
@@ -1090,9 +1107,12 @@ impl Lowerer {
                 }
                 ASTNodeOrToken::Node(n) => {
                     let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    let operand_scalar = expr_is_known_scalar(&operand);
                     acc = Some(match (acc.take(), pending.take()) {
-                        (None, _) => operand,
-                        (Some(lhs), Some(op)) => self.build_additive(lhs, operand, &op),
+                        (None, _) => (operand, operand_scalar),
+                        (Some((lhs, lhs_scalar)), Some(op)) => {
+                            self.build_additive(lhs, lhs_scalar, operand, operand_scalar, &op)
+                        }
                         (Some(_), None) => {
                             return Err(
                                 self.err_at(node, "malformed additive expression".to_string())
@@ -1104,20 +1124,36 @@ impl Lowerer {
             }
         }
         match acc {
-            Some(e) => Ok(Some(e)),
+            Some((e, _)) => Ok(Some(e)),
             None => Err(self.err_at(node, "empty additive expression".to_string())),
         }
     }
 
-    fn build_additive(&mut self, lhs: Expr, rhs: Expr, op: &str) -> Expr {
+    /// Combine one fold step of an additive chain. `lhs_scalar`/`rhs_scalar`
+    /// are the caller's already-known scalar-ness of each operand (see
+    /// `try_additive`'s doc comment on why these are threaded rather than
+    /// re-derived); returns the built `Expr` plus whether *it* is itself
+    /// known-scalar (`lhs_scalar && rhs_scalar`, matching the `BuiltinCall`
+    /// condition below), for the next fold step to reuse in turn.
+    fn build_additive(
+        &mut self,
+        lhs: Expr,
+        lhs_scalar: bool,
+        rhs: Expr,
+        rhs_scalar: bool,
+        op: &str,
+    ) -> (Expr, bool) {
         let span = lhs.span().clone();
-        if expr_is_known_scalar(&lhs) && expr_is_known_scalar(&rhs) {
-            Expr::BuiltinCall {
-                name: op.to_string(),
-                args: vec![lhs, rhs],
-                effects: EffectSet::PURE,
-                span,
-            }
+        if lhs_scalar && rhs_scalar {
+            (
+                Expr::BuiltinCall {
+                    name: op.to_string(),
+                    args: vec![lhs, rhs],
+                    effects: EffectSet::PURE,
+                    span,
+                },
+                true,
+            )
         } else {
             // `Expr::ElementwiseOp` requires `MatrixOps` + `ArrayColumnMajor`
             // per the validator's own ground truth -- not `NDArrays`.
@@ -1128,12 +1164,15 @@ impl Lowerer {
             } else {
                 ElementwiseOpKind::Sub
             };
-            Expr::ElementwiseOp {
-                op: kind,
-                lhs: Box::new(lhs),
-                rhs: Box::new(rhs),
-                span,
-            }
+            (
+                Expr::ElementwiseOp {
+                    op: kind,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                    span,
+                },
+                false,
+            )
         }
     }
 
@@ -1151,7 +1190,11 @@ impl Lowerer {
         if !has_op {
             return Ok(None);
         }
-        let mut acc: Option<Expr> = None;
+        self.check_chain_length(node)?;
+        // See `try_additive`'s doc comment: `acc` tracks scalar-ness
+        // incrementally alongside the accumulated `Expr` rather than
+        // re-deriving it by re-walking the growing tree every fold step.
+        let mut acc: Option<(Expr, bool)> = None;
         let mut pending: Option<String> = None;
         for child in &node.children {
             match child {
@@ -1160,11 +1203,17 @@ impl Lowerer {
                 }
                 ASTNodeOrToken::Node(n) => {
                     let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    let operand_scalar = expr_is_known_scalar(&operand);
                     acc = Some(match (acc.take(), pending.take()) {
-                        (None, _) => operand,
-                        (Some(lhs), Some(op)) => {
-                            self.build_multiplicative(lhs, operand, &op, node)?
-                        }
+                        (None, _) => (operand, operand_scalar),
+                        (Some((lhs, lhs_scalar)), Some(op)) => self.build_multiplicative(
+                            lhs,
+                            lhs_scalar,
+                            operand,
+                            operand_scalar,
+                            &op,
+                            node,
+                        )?,
                         (Some(_), None) => {
                             return Err(self.err_at(
                                 node,
@@ -1177,123 +1226,162 @@ impl Lowerer {
             }
         }
         match acc {
-            Some(e) => Ok(Some(e)),
+            Some((e, _)) => Ok(Some(e)),
             None => Err(self.err_at(node, "empty multiplicative expression".to_string())),
         }
     }
 
+    /// `lhs_scalar`/`rhs_scalar` are the caller's already-known scalar-ness
+    /// of each operand -- see `try_additive`'s doc comment on why these are
+    /// threaded rather than re-derived by calling `expr_is_known_scalar` on
+    /// the growing accumulator at every fold step (the same unbounded-
+    /// recursion hazard applies here identically). Returns the built `Expr`
+    /// plus whether it is itself known-scalar, for the next fold step.
     fn build_multiplicative(
         &mut self,
         lhs: Expr,
+        lhs_scalar: bool,
         rhs: Expr,
+        rhs_scalar: bool,
         op: &str,
         node: &GrammarASTNode,
-    ) -> Result<Expr, MatlabLowerError> {
+    ) -> Result<(Expr, bool), MatlabLowerError> {
         let span = lhs.span().clone();
-        let lhs_scalar = expr_is_known_scalar(&lhs);
-        let rhs_scalar = expr_is_known_scalar(&rhs);
         match op {
             ".*" => {
                 if lhs_scalar && rhs_scalar {
-                    Ok(Expr::BuiltinCall {
-                        name: "*".to_string(),
-                        args: vec![lhs, rhs],
-                        effects: EffectSet::PURE,
-                        span,
-                    })
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "*".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
                 } else {
                     self.observed.add(Feature::MatrixOps);
                     self.observed.add(Feature::ArrayColumnMajor);
-                    Ok(Expr::ElementwiseOp {
-                        op: ElementwiseOpKind::Mul,
-                        lhs: Box::new(lhs),
-                        rhs: Box::new(rhs),
-                        span,
-                    })
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Mul,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
                 }
             }
             "./" => {
                 if lhs_scalar && rhs_scalar {
-                    Ok(Expr::BuiltinCall {
-                        name: "/".to_string(),
-                        args: vec![lhs, rhs],
-                        effects: EffectSet::PURE,
-                        span,
-                    })
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
                 } else {
                     self.observed.add(Feature::MatrixOps);
                     self.observed.add(Feature::ArrayColumnMajor);
-                    Ok(Expr::ElementwiseOp {
-                        op: ElementwiseOpKind::Div,
-                        lhs: Box::new(lhs),
-                        rhs: Box::new(rhs),
-                        span,
-                    })
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Div,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
                 }
             }
             ".\\" => {
                 if lhs_scalar && rhs_scalar {
-                    Ok(Expr::BuiltinCall {
-                        name: "/".to_string(),
-                        args: vec![rhs, lhs],
-                        effects: EffectSet::PURE,
-                        span,
-                    })
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![rhs, lhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
                 } else {
                     self.observed.add(Feature::MatrixOps);
                     self.observed.add(Feature::ArrayColumnMajor);
-                    Ok(Expr::ElementwiseOp {
-                        op: ElementwiseOpKind::Div,
-                        lhs: Box::new(rhs),
-                        rhs: Box::new(lhs),
-                        span,
-                    })
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Div,
+                            lhs: Box::new(rhs),
+                            rhs: Box::new(lhs),
+                            span,
+                        },
+                        false,
+                    ))
                 }
             }
             "*" => {
                 if lhs_scalar && rhs_scalar {
-                    Ok(Expr::BuiltinCall {
-                        name: "*".to_string(),
-                        args: vec![lhs, rhs],
-                        effects: EffectSet::PURE,
-                        span,
-                    })
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "*".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
                 } else if lhs_scalar || rhs_scalar {
                     self.observed.add(Feature::MatrixOps);
                     self.observed.add(Feature::ArrayColumnMajor);
-                    Ok(Expr::ElementwiseOp {
-                        op: ElementwiseOpKind::Mul,
-                        lhs: Box::new(lhs),
-                        rhs: Box::new(rhs),
-                        span,
-                    })
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Mul,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
                 } else {
                     self.observed.add(Feature::MatrixOps);
                     self.observed.add(Feature::ArrayColumnMajor);
-                    Ok(Expr::MatMul {
-                        lhs: Box::new(lhs),
-                        rhs: Box::new(rhs),
-                        span,
-                    })
+                    Ok((
+                        Expr::MatMul {
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
                 }
             }
             "/" => {
                 if lhs_scalar && rhs_scalar {
-                    Ok(Expr::BuiltinCall {
-                        name: "/".to_string(),
-                        args: vec![lhs, rhs],
-                        effects: EffectSet::PURE,
-                        span,
-                    })
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![lhs, rhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
                 } else if lhs_scalar || rhs_scalar {
                     self.observed.add(Feature::MatrixOps);
                     self.observed.add(Feature::ArrayColumnMajor);
-                    Ok(Expr::ElementwiseOp {
-                        op: ElementwiseOpKind::Div,
-                        lhs: Box::new(lhs),
-                        rhs: Box::new(rhs),
-                        span,
-                    })
+                    Ok((
+                        Expr::ElementwiseOp {
+                            op: ElementwiseOpKind::Div,
+                            lhs: Box::new(lhs),
+                            rhs: Box::new(rhs),
+                            span,
+                        },
+                        false,
+                    ))
                 } else {
                     Err(self.err_at(
                         node,
@@ -1305,12 +1393,15 @@ impl Lowerer {
             }
             "\\" => {
                 if lhs_scalar && rhs_scalar {
-                    Ok(Expr::BuiltinCall {
-                        name: "/".to_string(),
-                        args: vec![rhs, lhs],
-                        effects: EffectSet::PURE,
-                        span,
-                    })
+                    Ok((
+                        Expr::BuiltinCall {
+                            name: "/".to_string(),
+                            args: vec![rhs, lhs],
+                            effects: EffectSet::PURE,
+                            span,
+                        },
+                        true,
+                    ))
                 } else {
                     Err(self.err_at(
                         node,
@@ -1461,7 +1552,7 @@ impl Lowerer {
                         })?;
                         if ctx.locals.contains(&name) || ctx.params.contains(&name) {
                             let span = self.span_of(primary);
-                            let indices = self.lower_index_args(suffix, ctx)?;
+                            let indices = self.lower_index_args(suffix, ctx, depth + 1)?;
                             acc = Some(Expr::IndexGet {
                                 target: Box::new(Expr::VarRef {
                                     name,
@@ -1479,7 +1570,7 @@ impl Lowerer {
                             // this there would be no way for a lowered MATLAB
                             // program to produce observable output at all.
                             let span = self.span_of(primary);
-                            let args = self.lower_call_args(suffix, ctx)?;
+                            let args = self.lower_call_args(suffix, ctx, depth + 1)?;
                             if args.len() != 1 {
                                 return Err(self.err_at(
                                     primary,
@@ -1494,7 +1585,7 @@ impl Lowerer {
                             });
                         } else if self.function_names.contains(&name) {
                             let span = self.span_of(primary);
-                            let args = self.lower_call_args(suffix, ctx)?;
+                            let args = self.lower_call_args(suffix, ctx, depth + 1)?;
                             acc = Some(Expr::DirectCall {
                                 fn_name: name,
                                 args,
@@ -1515,7 +1606,7 @@ impl Lowerer {
                             .take()
                             .expect("acc is set after the first suffix in the fold");
                         let span = base.span().clone();
-                        let indices = self.lower_index_args(suffix, ctx)?;
+                        let indices = self.lower_index_args(suffix, ctx, depth + 1)?;
                         acc = Some(Expr::IndexGet {
                             target: Box::new(base),
                             indices,
@@ -1639,11 +1730,24 @@ impl Lowerer {
     // indexing / call arguments
     // -------------------------------------------------------------------
 
+    /// `depth` is the *enclosing expression's* depth, not a fresh count --
+    /// each index argument is lowered via [`Self::lower_expr_d`] at
+    /// `depth + 1`, not the depth-resetting [`Self::lower_expr`], so that a
+    /// chain of nested indexing (`A(A(A(...))))`) actually accumulates
+    /// against [`MAX_EXPR_DEPTH`] instead of each level silently restarting
+    /// its own budget (the bug this comment exists to prevent regressing).
     fn lower_index_args(
         &mut self,
         call_suffix: &GrammarASTNode,
         ctx: &mut FunctionCtx,
+        depth: usize,
     ) -> Result<Vec<IndexArg>, MatlabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                call_suffix,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
         // `Expr::IndexGet`/`Stmt::IndexSet` only require `NDArrays` per the
         // validator's own ground truth.
         self.observed.add(Feature::NDArrays);
@@ -1654,7 +1758,7 @@ impl Lowerer {
         let mut out = Vec::new();
         for arg in child_nodes(arg_list) {
             if arg.rule_name == "arg" {
-                out.push(self.lower_one_index_arg(arg, ctx)?);
+                out.push(self.lower_one_index_arg(arg, ctx, depth + 1)?);
             }
         }
         Ok(out)
@@ -1663,11 +1767,14 @@ impl Lowerer {
     /// Lower one index-position argument, translating 1-based MATLAB
     /// indexing to the IR's 0-based convention: a literal integer index
     /// constant-folds (`A(3)` → `Scalar(IntLit(2))`); anything else emits
-    /// `BuiltinCall("-", [idx, 1])` (`A(i)` → `Scalar(i - 1)`).
+    /// `BuiltinCall("-", [idx, 1])` (`A(i)` → `Scalar(i - 1)`). See
+    /// [`Self::lower_index_args`] on why `depth` is threaded rather than
+    /// restarted.
     fn lower_one_index_arg(
         &mut self,
         arg: &GrammarASTNode,
         ctx: &mut FunctionCtx,
+        depth: usize,
     ) -> Result<IndexArg, MatlabLowerError> {
         if let Some(tok) = arg.token() {
             if tok.value == ":" {
@@ -1678,7 +1785,7 @@ impl Lowerer {
             [only] => *only,
             _ => return Err(self.err_at(arg, "malformed index argument".to_string())),
         };
-        let idx = self.lower_expr(inner, ctx)?;
+        let idx = self.lower_expr_d(inner, ctx, depth)?;
         let span = idx.span().clone();
         let shifted = match idx {
             Expr::IntLit { value, .. } => Expr::IntLit {
@@ -1701,11 +1808,21 @@ impl Lowerer {
         Ok(IndexArg::Scalar(Box::new(shifted)))
     }
 
+    /// See [`Self::lower_index_args`] on why `depth` is the caller's
+    /// enclosing depth (threaded via [`Self::lower_expr_d`]), not a fresh
+    /// count restarted via the depth-resetting [`Self::lower_expr`].
     fn lower_call_args(
         &mut self,
         call_suffix: &GrammarASTNode,
         ctx: &mut FunctionCtx,
+        depth: usize,
     ) -> Result<Vec<Expr>, MatlabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                call_suffix,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
         let arg_list = match self.first_child_named(call_suffix, "arg_list") {
             Some(a) => a,
             None => return Ok(vec![]),
@@ -1727,7 +1844,7 @@ impl Lowerer {
                 [only] => *only,
                 _ => return Err(self.err_at(arg, "malformed call argument".to_string())),
             };
-            out.push(self.lower_expr(inner, ctx)?);
+            out.push(self.lower_expr_d(inner, ctx, depth + 1)?);
         }
         Ok(out)
     }
@@ -1814,6 +1931,45 @@ impl Lowerer {
             column: node.start_column.unwrap_or(1),
         }
     }
+
+    /// Reject a same-precedence operator chain (`additive`/`multiplicative`/
+    /// `comparison`/`logical_or`/`logical_and`) with more than
+    /// `MAX_EXPR_DEPTH` operands.
+    ///
+    /// The MATLAB grammar collapses a flat run of `+`/`-`/`*`/... into ONE
+    /// CST node with many children rather than nesting through parens, so a
+    /// long unparenthesized chain never trips the ordinary grammar-nesting
+    /// depth guard. But folding N operands left-associatively still builds
+    /// an N-deep *binary* `Expr` tree — and that tree's own depth is what
+    /// matters for every later recursive pass over it (this crate's own
+    /// scalar-ness check, but just as much the shared validator, any
+    /// backend's emit pass, and even plain `Drop`, none of which cap
+    /// depth themselves). A 60,000-term chain was confirmed to overflow
+    /// the native stack during security review, even after fixing this
+    /// file's own O(1)-per-fold-step scalar tracking, precisely because
+    /// the resulting tree was still 60,000 levels deep regardless of how
+    /// cheaply each level was built. Capping the operand *count* here — not
+    /// just the construction cost — is the only fix that actually bounds
+    /// the tree, so this check is deliberately unconditional (it does not
+    /// try to distinguish "still cheap to build" from "already too deep to
+    /// ever safely walk again").
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), MatlabLowerError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "expression chain too long ({operand_count} operands, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
+            ));
+        }
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1859,12 +2015,34 @@ fn number_literal_expr(tok: &Token, span: &Span) -> Expr {
 /// disambiguation" section — this is a syntactic, non-evaluating check on
 /// the *lowered* expression tree, not full constant folding.
 fn expr_is_known_scalar(e: &Expr) -> bool {
+    expr_is_known_scalar_d(e, 0)
+}
+
+/// Depth-capped core of [`expr_is_known_scalar`]. This is defense in depth,
+/// not the primary fix for deep recursion here: every call site that folds a
+/// *chain* of same-precedence operators (`build_additive`/
+/// `build_multiplicative`) tracks each operand's scalar-ness incrementally
+/// instead of re-deriving it by re-walking the whole accumulated left-hand
+/// tree on every fold step -- re-deriving it that way would cost O(depth)
+/// stack per step (O(chain length) at the final step) for an ordinary flat
+/// `1 + 1 + 1 + ... + 1` chain, which has no bound at all from
+/// `MAX_EXPR_DEPTH` (that guard counts *grammar nesting*, not the length of
+/// one flat repetition -- a long unparenthesized chain never nests at the
+/// CST level). This cap only protects a caller that (incorrectly) invokes
+/// `expr_is_known_scalar` on a re-walked accumulator in the future;
+/// returning `false` past the cap is always semantically safe, since a
+/// "not provably scalar" verdict only ever falls through to the equally
+/// correct array-domain node.
+fn expr_is_known_scalar_d(e: &Expr, depth: usize) -> bool {
+    if depth > MAX_EXPR_DEPTH {
+        return false;
+    }
     match e {
         Expr::IntLit { .. } | Expr::FloatLit { .. } => true,
         Expr::BuiltinCall { name, args, .. }
             if matches!(name.as_str(), "+" | "-" | "*" | "/" | "neg") =>
         {
-            args.iter().all(expr_is_known_scalar)
+            args.iter().all(|a| expr_is_known_scalar_d(a, depth + 1))
         }
         _ => false,
     }

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -1,0 +1,1910 @@
+//! The lowering pass from `coding_adventures_matlab_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0**.
+//!
+//! # Scope
+//!
+//! MATLAB is large; this first cut covers a well-defined, testable subset
+//! and returns a clean [`MatlabLowerError`] for anything outside it, rather
+//! than silently mis-lowering:
+//!
+//! **Supported:**
+//! - Literals: `NUMBER` (int- or float-shaped by lexeme), `STRING`, matrix
+//!   literals `[1 2; 3 4]` → [`Expr::ArrayLit`].
+//! - Variables (`NAME`), assignment (`x = expr`; first occurrence →
+//!   `LetStarBinding`, later re-assignment → `Assign`, mirroring every
+//!   other SIR frontend).
+//! - Arithmetic: `+`/`-` always lower to [`Expr::ElementwiseOp`] (MATLAB has
+//!   no non-elementwise reading of these, per the SIR22 spec) *unless both
+//!   operands are provably scalar* (see "Scalar/array disambiguation"
+//!   below), in which case a plain `BuiltinCall` is emitted instead — both
+//!   forms are semantically identical for scalars, so this is purely an
+//!   optimisation that also happens to let scalar-only MATLAB programs
+//!   round-trip through backends that do not yet implement SIR22 codegen.
+//!   `.* ./ .\ .^` always lower to `ElementwiseOp` (unambiguous). Bare `*`
+//!   disambiguates to [`Expr::MatMul`] vs. `ElementwiseOp` per the same
+//!   scalar rule; bare `/`/`\` (mrdivide/mldivide — matrix division) are
+//!   **unsupported** outside the scalar case, since `array-runtime` has no
+//!   linear-solve kernel to map onto yet.
+//! - Comparisons (`== ~= < > <= >=`), logical `&& || & &` (short-circuit
+//!   and elementwise forms are **not** distinguished — both lower to the
+//!   same `LogicalAnd`/`LogicalOr`, a disclosed simplification), unary
+//!   `+ - ~`.
+//! - Ranges `a:b` (as a value, and specialised for `for i = a:b`) →
+//!   [`Expr::Range`].
+//! - Transpose `'`/`.'` → [`Expr::Transpose`].
+//! - Indexing `A(i, j, ...)` (read → [`Expr::IndexGet`], write →
+//!   [`Stmt::IndexSet`]) with 1-based → 0-based translation at lowering
+//!   time (SIR10's "disambiguation is the frontend's job"); `:` →
+//!   [`IndexArg::Whole`].
+//! - Control flow `if`/`elseif`/`else`, `while`.
+//! - Function definitions `function [out =] name(params) ... end` (single
+//!   or zero output only) and calls to them ([`Expr::DirectCall`]).
+//! - `disp(x)` — the one recognised builtin, mapped onto the SIR `print`
+//!   builtin every backend already implements (needed so a lowered
+//!   program can produce any observable output at all). Every other
+//!   identifier that is neither a known variable nor a known user
+//!   function is rejected rather than guessed at.
+//!
+//! **Deliberately out of scope for v0.1.0** (each rejected with an explicit
+//! [`MatlabLowerError`], not silently mis-lowered):
+//! - Stepped (`a:step:b`) or matrix-valued `for` loops — only
+//!   `for i = a:b` is supported; the exclusive-stop conversion (`b + 1`) is
+//!   exact only for a unit step.
+//! - `end`-relative indexing (`A(end)`, `A(end-1)`) — no `size`/`length`
+//!   builtin is wired up yet to resolve it.
+//! - Matrix power (`A^2` with a non-scalar base), matrix division `/`/`\`
+//!   between non-scalars (mrdivide/mldivide — no backend kernel exists).
+//! - Multi-output functions (`[a, b] = f(...)`), nested function
+//!   definitions, `break`/`continue`/`return` (semantic-ir has no
+//!   early-exit control-flow node at all yet — this is a whole-IR gap, not
+//!   specific to this frontend), `switch`/`try`/`global`/`persistent`,
+//!   cell arrays, anonymous functions (`@(...)  ...`), auto-vivification
+//!   on indexed assignment to an undeclared variable, and chained
+//!   assignment (`a = b = c`).
+//!
+//! # Scalar/array disambiguation
+//!
+//! MATLAB's `+ - * / \ ^` are polymorphic between scalar and matrix
+//! operands at *runtime*; this frontend has no shape/type inference, so it
+//! uses a conservative, purely syntactic heuristic on the **already-lowered**
+//! operand [`Expr`]s (see [`expr_is_known_scalar`]): an operand is "known
+//! scalar" iff it is a bare `IntLit`/`FloatLit`, or a `BuiltinCall` of
+//! `+ - * / neg` whose own arguments are (transitively) known-scalar. This
+//! correctly folds chains like `1 + 2 * 3` but does not attempt full
+//! constant evaluation (e.g. it will not recognise `(2 + 3)` inside a
+//! larger *variable* expression as scalar) — falling through to the
+//! array-domain node in an ambiguous case is always semantically safe
+//! (either correct, since `array_runtime`'s elementwise kernel already
+//! broadcasts a genuine runtime scalar against anything, or an honest
+//! "unsupported" error), just occasionally more conservative than a full
+//! type-inference pass would be.
+
+use std::collections::HashSet;
+
+use lexer::token::{Token, TokenType};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, IndexArg,
+    Metadata, Module, Param, ParamKind, Scope, Span, Stmt,
+};
+
+/// Maximum expression-nesting depth. Mirrors every other SIR frontend's
+/// identically-named, identically-justified guard: turns pathologically
+/// deep (but parseable) input into a clean [`MatlabLowerError`] instead of
+/// a native (uncatchable) stack overflow.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Maximum statement-block nesting depth (each `if`/`while`/`for` body, or
+/// a `function` body, re-enters the block lowerer one level deeper).
+const MAX_BLOCK_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<matlab>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during MATLAB → SIR lowering.
+///
+/// Mirrors `PythonLowerError`/`TwigLowerError`'s shape exactly (`message` +
+/// 1-based `line`/`column`) so tooling can treat every SIR frontend
+/// uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatlabLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for MatlabLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MatlabLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for MatlabLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed MATLAB CST (rooted at the `program` rule) into a SIR
+/// module.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, MatlabLowerError> {
+    Lowerer::new(module_name).lower_file(tree)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// One lowered top-level / body statement: either a `Stmt` or a bare
+/// expression (an expression statement).
+enum Lowered {
+    Stmt(Box<Stmt>),
+    Expr(Expr),
+}
+
+/// Per-function name-resolution context. MATLAB scopes a variable to its
+/// *whole enclosing function* (no block scoping), so — unlike a
+/// closure-supporting frontend — there is no capture set here at all;
+/// `locals` simply accumulates for the function's lifetime and is never
+/// rewound when leaving an `if`/`while`/`for` body (that would be wrong
+/// for MATLAB: a variable first assigned inside an `if` remains visible
+/// afterward). The one place `locals` *is* temporarily extended and then
+/// rewound is a `for`-loop variable, whose scope genuinely is the loop
+/// (mirroring every other SIR frontend's identical loop-variable handling).
+struct FunctionCtx {
+    params: HashSet<String>,
+    locals: Vec<String>,
+}
+
+impl FunctionCtx {
+    fn new(params: HashSet<String>) -> Self {
+        Self {
+            params,
+            locals: Vec::new(),
+        }
+    }
+
+    fn top_level() -> Self {
+        Self::new(HashSet::new())
+    }
+}
+
+struct Lowerer {
+    module_name: String,
+    /// Features observed while lowering, used to build the manifest so it
+    /// declares *exactly* what the module emits.
+    observed: FeatureManifest,
+    /// Every top-level `function` name, collected in a first pass so a call
+    /// to a function defined later in the file resolves as
+    /// [`Expr::DirectCall`] regardless of textual order.
+    function_names: HashSet<String>,
+    /// The lowered top-level functions, in definition order. `main` is
+    /// appended last by [`Self::lower_file`].
+    functions: Vec<Function>,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+            function_names: HashSet::new(),
+            functions: Vec::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // for-loop variable scope: mark/rewind (the ONE place MATLAB truly
+    // does introduce a scope narrower than the whole function).
+    // -------------------------------------------------------------------
+
+    fn scope_mark(ctx: &FunctionCtx) -> usize {
+        ctx.locals.len()
+    }
+
+    fn scope_rewind(ctx: &mut FunctionCtx, mark: usize) {
+        ctx.locals.truncate(mark);
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program` → collect function names, then lower
+    // -------------------------------------------------------------------
+
+    fn lower_file(&mut self, program: &GrammarASTNode) -> Result<Module, MatlabLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        // Every value this frontend lowers has `sir_type: None` -- MATLAB
+        // has no static type declarations anywhere -- which is itself what
+        // the validator's ground truth treats as "using" dynamic typing
+        // (see `semantic-ir/src/validator.rs`'s own comment to that
+        // effect), so this is unconditionally true for every module.
+        self.observed.add(Feature::DynamicTyping);
+
+        self.collect_function_names(program)?;
+
+        let mut ctx = FunctionCtx::top_level();
+        let mut items: Vec<Lowered> = Vec::new();
+        for stmt_line in child_nodes(program) {
+            if stmt_line.rule_name != "statement_line" {
+                continue;
+            }
+            let stmt = match self.first_child_named(stmt_line, "statement") {
+                Some(s) => s,
+                None => continue, // a bare terminator (blank line) -- nothing to lower
+            };
+            let kids = child_nodes(stmt);
+            let inner = match kids.as_slice() {
+                [only] => *only,
+                _ => return Err(self.err_at(stmt, "malformed statement".to_string())),
+            };
+            if inner.rule_name == "func_def" {
+                let f = self.lower_func_def(inner)?;
+                self.functions.push(f);
+                continue;
+            }
+            if let Some(item) = self.lower_statement_body_item(inner, &mut ctx, 0)? {
+                items.push(item);
+            }
+        }
+
+        let span = Span::point(FILE, 1, 1);
+        let main_body =
+            assemble_stmts_only(items, Expr::NilLit { span: span.clone() }, span.clone());
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: main_body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        let mut functions = std::mem::take(&mut self.functions);
+        functions.push(main);
+
+        let metadata = Metadata::new()
+            .with_source_language("matlab")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions,
+            globals: vec![],
+            metadata,
+            span,
+        })
+    }
+
+    /// Pass 1: collect every top-level `function`'s name, so a call
+    /// anywhere in the file — regardless of textual order — resolves as
+    /// [`Expr::DirectCall`]. Nested function definitions are rejected (as
+    /// an explicit error) when actually lowered, not here.
+    fn collect_function_names(&mut self, program: &GrammarASTNode) -> Result<(), MatlabLowerError> {
+        for stmt_line in child_nodes(program) {
+            if stmt_line.rule_name != "statement_line" {
+                continue;
+            }
+            let stmt = match self.first_child_named(stmt_line, "statement") {
+                Some(s) => s,
+                None => continue,
+            };
+            let kids = child_nodes(stmt);
+            let inner = match kids.as_slice() {
+                [only] => *only,
+                _ => continue,
+            };
+            if inner.rule_name == "func_def" {
+                let name = self.func_def_name(inner)?;
+                self.function_names.insert(name);
+            }
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // function definitions
+    // -------------------------------------------------------------------
+
+    /// The function's own name: a bare `NAME` token directly under
+    /// `func_def` (distinct from the *output variable*'s name, which lives
+    /// one level deeper inside `func_returns` and is therefore invisible to
+    /// this direct scan).
+    fn func_def_name(&self, def: &GrammarASTNode) -> Result<String, MatlabLowerError> {
+        def.children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| self.err_at(def, "malformed function definition: no name".to_string()))
+    }
+
+    /// Lower a `func_def` into a top-level [`Function`]. MATLAB functions
+    /// have no `return`-expression; the designated output variable's final
+    /// value *is* the return value, so the body's trailing [`Block::value`]
+    /// is synthesised as a `VarRef` to it (or `NilLit` for a function with
+    /// no output).
+    fn lower_func_def(&mut self, def: &GrammarASTNode) -> Result<Function, MatlabLowerError> {
+        let span = self.span_of(def);
+        let name = self.func_def_name(def)?;
+
+        let mut output: Option<String> = None;
+        if let Some(returns) = self.first_child_named(def, "func_returns") {
+            if !child_nodes(returns).is_empty() {
+                // `LBRACKET [name_list] RBRACKET EQ` shape -- multi-output.
+                return Err(self.err_at(
+                    returns,
+                    "unsupported: multiple output arguments (`[a, b] = f(...)`) are out of scope for v0.1.0"
+                        .to_string(),
+                ));
+            }
+            let out_name = returns
+                .children
+                .iter()
+                .find_map(|c| match c {
+                    ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.clone()),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    self.err_at(returns, "malformed function return clause".to_string())
+                })?;
+            output = Some(out_name);
+        }
+
+        let mut param_names: Vec<String> = Vec::new();
+        if let Some(name_list) = self.first_child_named(def, "name_list") {
+            param_names.extend(name_list.children.iter().filter_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.clone()),
+                _ => None,
+            }));
+        }
+
+        let body_node = self
+            .first_child_named(def, "block_body")
+            .ok_or_else(|| self.err_at(def, "malformed function: no body".to_string()))?;
+
+        let mut ctx = FunctionCtx::new(param_names.iter().cloned().collect());
+        let items = self.lower_body_items(body_node, &mut ctx, 0)?;
+
+        let value = match &output {
+            Some(out_name) => Expr::VarRef {
+                name: out_name.clone(),
+                scope: Scope::Local,
+                span: span.clone(),
+            },
+            None => Expr::NilLit { span: span.clone() },
+        };
+        let body = assemble_stmts_only(items, value, span.clone());
+
+        Ok(Function {
+            name,
+            params: param_names
+                .into_iter()
+                .map(|p| Param {
+                    name: p,
+                    sir_type: None,
+                    kind: ParamKind::Required,
+                    default: None,
+                    span: span.clone(),
+                })
+                .collect(),
+            return_type: None,
+            captures: vec![],
+            body,
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // statement bodies (shared by `if`/`while`/`for`/`function` bodies)
+    // -------------------------------------------------------------------
+
+    fn lower_body_items(
+        &mut self,
+        body_node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Vec<Lowered>, MatlabLowerError> {
+        let mut items = Vec::new();
+        for stmt_line in child_nodes(body_node) {
+            if stmt_line.rule_name == "statement_line" {
+                if let Some(item) = self.lower_statement_line(stmt_line, ctx, depth)? {
+                    items.push(item);
+                }
+            }
+        }
+        Ok(items)
+    }
+
+    fn lower_block_body(
+        &mut self,
+        block_body: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Block, MatlabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                block_body,
+                format!("control-flow nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        let items = self.lower_body_items(block_body, ctx, depth)?;
+        let span = self.span_of(block_body);
+        Ok(assemble_stmts_only(
+            items,
+            Expr::NilLit { span: span.clone() },
+            span,
+        ))
+    }
+
+    fn lower_statement_line(
+        &mut self,
+        stmt_line: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Lowered>, MatlabLowerError> {
+        let stmt = match self.first_child_named(stmt_line, "statement") {
+            Some(s) => s,
+            None => return Ok(None), // a bare terminator (blank line)
+        };
+        let kids = child_nodes(stmt);
+        let inner = match kids.as_slice() {
+            [only] => *only,
+            _ => return Err(self.err_at(stmt, "malformed statement".to_string())),
+        };
+        self.lower_statement_body_item(inner, ctx, depth)
+    }
+
+    /// Dispatch one `statement` alternative that is *not* a top-level
+    /// `func_def` (that case is handled directly by [`Self::lower_file`]).
+    /// Reached here, `func_def` can only mean a *nested* definition, which
+    /// this frontend does not support.
+    fn lower_statement_body_item(
+        &mut self,
+        inner: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Lowered>, MatlabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                inner,
+                format!("control-flow nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        match inner.rule_name.as_str() {
+            "func_def" => Err(self.err_at(
+                inner,
+                "unsupported: nested function definitions are out of scope for v0.1.0".to_string(),
+            )),
+            "if_stmt" => Ok(Some(Lowered::Expr(self.lower_if(inner, ctx, depth)?))),
+            "while_stmt" => Ok(Some(Lowered::Stmt(Box::new(
+                self.lower_while(inner, ctx, depth)?,
+            )))),
+            "for_stmt" => Ok(Some(Lowered::Stmt(Box::new(
+                self.lower_for(inner, ctx, depth)?,
+            )))),
+            "switch_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `switch` is out of scope for v0.1.0".to_string(),
+            )),
+            "try_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `try`/`catch` is out of scope for v0.1.0".to_string(),
+            )),
+            "break_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `break` has no SIR equivalent yet".to_string(),
+            )),
+            "continue_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `continue` has no SIR equivalent yet".to_string(),
+            )),
+            "return_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: early `return` has no SIR equivalent yet (a function's output \
+                 variable at its final statement is the only supported return mechanism)"
+                    .to_string(),
+            )),
+            "global_stmt" => Err(self.err_at(
+                inner,
+                "unsupported: `global`/`persistent` are out of scope for v0.1.0".to_string(),
+            )),
+            _ => self.lower_statement_expr(inner, ctx, depth).map(Some),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // control flow
+    // -------------------------------------------------------------------
+
+    fn lower_if(
+        &mut self,
+        if_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, MatlabLowerError> {
+        struct Clause<'a> {
+            cond: &'a GrammarASTNode,
+            body: &'a GrammarASTNode,
+        }
+        let mut clauses: Vec<Clause> = Vec::new();
+        let mut else_body: Option<&GrammarASTNode> = None;
+
+        let kids = child_nodes(if_stmt);
+        let mut it = kids.into_iter();
+        let cond0 = it
+            .next()
+            .ok_or_else(|| self.err_at(if_stmt, "malformed if: no condition".to_string()))?;
+        let body0 = it
+            .next()
+            .ok_or_else(|| self.err_at(if_stmt, "malformed if: no body".to_string()))?;
+        clauses.push(Clause {
+            cond: cond0,
+            body: body0,
+        });
+        for rest in it {
+            match rest.rule_name.as_str() {
+                "elseif_clause" => match child_nodes(rest).as_slice() {
+                    [c, b] => clauses.push(Clause { cond: c, body: b }),
+                    _ => return Err(self.err_at(rest, "malformed elseif clause".to_string())),
+                },
+                "else_clause" => match child_nodes(rest).as_slice() {
+                    [b] => else_body = Some(b),
+                    _ => return Err(self.err_at(rest, "malformed else clause".to_string())),
+                },
+                other => {
+                    return Err(self.err_at(
+                        rest,
+                        format!("unexpected `{other}` inside if statement"),
+                    ))
+                }
+            }
+        }
+
+        let if_span = self.span_of(if_stmt);
+        let mut else_branch: Block = match else_body {
+            Some(b) => self.lower_block_body(b, ctx, depth + 1)?,
+            None => empty_block(if_span.clone()),
+        };
+        for clause in clauses.into_iter().rev() {
+            let cond = self.lower_expr(clause.cond, ctx)?;
+            let then_branch = self.lower_block_body(clause.body, ctx, depth + 1)?;
+            let span = cond.span().clone();
+            let folded = Expr::If {
+                cond: Box::new(cond),
+                then_branch: Box::new(then_branch),
+                else_branch: Box::new(else_branch),
+                span,
+            };
+            else_branch = value_block(folded);
+        }
+        match else_branch.value {
+            Expr::If { .. } => Ok(else_branch.value),
+            other => Ok(other),
+        }
+    }
+
+    fn lower_while(
+        &mut self,
+        while_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Stmt, MatlabLowerError> {
+        let (cond_node, body_node) = match child_nodes(while_stmt).as_slice() {
+            [c, b] => (*c, *b),
+            _ => {
+                return Err(self.err_at(
+                    while_stmt,
+                    "malformed while: expected condition and body".to_string(),
+                ))
+            }
+        };
+        let cond = self.lower_expr(cond_node, ctx)?;
+        let body = self.lower_block_body(body_node, ctx, depth + 1)?;
+        self.observed.add(Feature::Loops);
+        Ok(Stmt::While {
+            cond,
+            body,
+            span: self.span_of(while_stmt),
+        })
+    }
+
+    /// Lower `for NAME = a:b ... end` into [`Stmt::ForRange`]. Only the
+    /// unit-step, two-operand range form is supported (see the module doc
+    /// comment's scope note); `ForRange` is half-open, but MATLAB's `a:b`
+    /// is inclusive, so the exclusive bound is `b + 1` — exact for any
+    /// `a`/`b` (not just integers) precisely because the step is fixed at 1.
+    fn lower_for(
+        &mut self,
+        for_stmt: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Stmt, MatlabLowerError> {
+        let span = self.span_of(for_stmt);
+        let var = for_stmt
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.type_ == TokenType::Name => Some(t.value.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| self.err_at(for_stmt, "malformed for: no loop variable".to_string()))?;
+
+        let (iter_node, body_node) = match child_nodes(for_stmt).as_slice() {
+            [i, b] => (*i, *b),
+            _ => {
+                return Err(self.err_at(
+                    for_stmt,
+                    "malformed for: expected range and body".to_string(),
+                ))
+            }
+        };
+
+        let range_node = self.peel_to_named(iter_node, "colon_expr", 0);
+        let (start_n, stop_n) = match range_node {
+            Some(r) => match child_nodes(r).as_slice() {
+                [s, e] => (*s, *e),
+                _ => {
+                    return Err(self.err_at(
+                        r,
+                        "unsupported: stepped for-loop ranges (`for i = a:step:b`) are out of \
+                         scope for v0.1.0"
+                            .to_string(),
+                    ))
+                }
+            },
+            None => {
+                return Err(self.err_at(
+                    iter_node,
+                    "unsupported: `for` over a non-range expression is out of scope for v0.1.0 \
+                     (only `for NAME = a:b` is supported)"
+                        .to_string(),
+                ))
+            }
+        };
+
+        let start = self.lower_expr(start_n, ctx)?;
+        let stop_val = self.lower_expr(stop_n, ctx)?;
+        let stop_span = stop_val.span().clone();
+        let stop = Expr::BuiltinCall {
+            name: "+".to_string(),
+            args: vec![
+                stop_val,
+                Expr::IntLit {
+                    value: 1,
+                    span: stop_span.clone(),
+                },
+            ],
+            effects: EffectSet::PURE,
+            span: stop_span,
+        };
+        let step = Expr::IntLit {
+            value: 1,
+            span: span.clone(),
+        };
+
+        self.observed.add(Feature::Loops);
+        let mark = Self::scope_mark(ctx);
+        ctx.locals.push(var.clone());
+        let body = self.lower_block_body(body_node, ctx, depth + 1)?;
+        Self::scope_rewind(ctx, mark);
+
+        Ok(Stmt::ForRange {
+            var,
+            start,
+            stop,
+            step,
+            body,
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // assignment
+    // -------------------------------------------------------------------
+
+    /// Lower a `statement`'s `expr` alternative: either a value expression
+    /// (a bare function call, e.g. `disp(x)`) or an assignment. MATLAB's
+    /// own grammar folds assignment *into* the expression precedence chain
+    /// (`expr = assignment`, `assignment = logical_or [ EQ assignment ]`),
+    /// so this peels down to the `assignment` rule specifically (wherever
+    /// it lands in the collapsed tree) rather than assuming a fixed depth.
+    fn lower_statement_expr(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Lowered, MatlabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        if node.rule_name != "assignment" {
+            return match child_nodes(node).as_slice() {
+                [only] if node.children.len() == 1 => {
+                    self.lower_statement_expr(only, ctx, depth + 1)
+                }
+                _ => {
+                    let expr = self.lower_expr(node, ctx)?;
+                    Ok(Lowered::Expr(expr))
+                }
+            };
+        }
+        match child_nodes(node).as_slice() {
+            [lhs] if node.children.len() == 1 => {
+                let expr = self.lower_expr(lhs, ctx)?;
+                Ok(Lowered::Expr(expr))
+            }
+            [lhs, rhs] => {
+                if rhs.rule_name == "assignment" && child_nodes(rhs).len() == 2 {
+                    return Err(self.err_at(
+                        rhs,
+                        "unsupported: chained assignment (`a = b = c`) is out of scope for v0.1.0"
+                            .to_string(),
+                    ));
+                }
+                self.lower_assignment(node, lhs, rhs, ctx)
+            }
+            _ => Err(self.err_at(node, "malformed assignment".to_string())),
+        }
+    }
+
+    fn lower_assignment(
+        &mut self,
+        assign_node: &GrammarASTNode,
+        lhs: &GrammarASTNode,
+        rhs: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Lowered, MatlabLowerError> {
+        let span = self.span_of(assign_node);
+
+        if let Some(name) = self.bare_name(lhs) {
+            let value = self.lower_expr(rhs, ctx)?;
+            if ctx.locals.contains(&name) || ctx.params.contains(&name) {
+                self.observed.add(Feature::MutableBindings);
+                return Ok(Lowered::Stmt(Box::new(Stmt::Assign {
+                    name,
+                    scope: Scope::Local,
+                    value,
+                    span,
+                })));
+            }
+            ctx.locals.push(name.clone());
+            return Ok(Lowered::Stmt(Box::new(Stmt::LetStarBinding {
+                name,
+                sir_type: None,
+                value,
+                span,
+            })));
+        }
+
+        if let Some((base_name, call_suffix)) = self.indexed_target(lhs) {
+            if !(ctx.locals.contains(&base_name) || ctx.params.contains(&base_name)) {
+                return Err(self.err_at(
+                    lhs,
+                    format!(
+                        "cannot index-assign into `{base_name}`: not previously assigned \
+                         (auto-vivification is out of scope for v0.1.0)"
+                    ),
+                ));
+            }
+            let indices = self.lower_index_args(call_suffix, ctx)?;
+            let value = self.lower_expr(rhs, ctx)?;
+            return Ok(Lowered::Stmt(Box::new(Stmt::IndexSet {
+                target: Box::new(Expr::VarRef {
+                    name: base_name,
+                    scope: Scope::Local,
+                    span: span.clone(),
+                }),
+                indices,
+                value: Box::new(value),
+                span,
+            })));
+        }
+
+        Err(self.err_at(
+            lhs,
+            "unsupported: assignment target is not a bare name or a simple index expression"
+                .to_string(),
+        ))
+    }
+
+    // -------------------------------------------------------------------
+    // expressions: precedence dispatch
+    // -------------------------------------------------------------------
+
+    fn lower_expr(&mut self, node: &GrammarASTNode, ctx: &mut FunctionCtx) -> Result<Expr, MatlabLowerError> {
+        self.lower_expr_d(node, ctx, 0)
+    }
+
+    fn lower_expr_d(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, MatlabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match node.rule_name.as_str() {
+            "logical_or" | "bit_or" => {
+                if let Some(e) = self.try_logical(node, ctx, depth, true)? {
+                    return Ok(e);
+                }
+            }
+            "logical_and" | "bit_and" => {
+                if let Some(e) = self.try_logical(node, ctx, depth, false)? {
+                    return Ok(e);
+                }
+            }
+            "comparison" => {
+                if let Some(e) = self.try_comparison(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "colon_expr" => {
+                if let Some(e) = self.lower_colon(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "additive" => {
+                if let Some(e) = self.try_additive(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "multiplicative" => {
+                if let Some(e) = self.try_multiplicative(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "unary" => {
+                if let Some(e) = self.lower_unary(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "power" => {
+                if let Some(e) = self.try_power(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "postfix" => {
+                if let Some(e) = self.lower_postfix(node, ctx, depth)? {
+                    return Ok(e);
+                }
+            }
+            "assignment" => {
+                // The RHS of a real assignment is itself grammatically
+                // labelled `assignment` (`assignment = logical_or [ EQ
+                // assignment ]`) even when it carries no further `=` --
+                // that's an ordinary wrapper to peel through, not a nested
+                // assignment attempt. Only an *actual* `[ EQ assignment ]`
+                // suffix reaching here (assignment used where a plain value
+                // is expected, e.g. as a function argument) is an error.
+                return match child_nodes(node).as_slice() {
+                    [only] if node.children.len() == 1 => {
+                        self.lower_expr_d(only, ctx, depth + 1)
+                    }
+                    _ => Err(self.err_at(
+                        node,
+                        "unsupported: assignment used as a value expression".to_string(),
+                    )),
+                };
+            }
+            _ => {}
+        }
+        match child_nodes(node).as_slice() {
+            [only] if node.children.len() == 1 => self.lower_expr_d(only, ctx, depth + 1),
+            _ => Err(self.err_at(
+                node,
+                format!("unsupported: `{}` (deferred)", node.rule_name),
+            )),
+        }
+    }
+
+    fn try_logical(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+        is_or: bool,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        let ops: &[&str] = if is_or { &["||", "|"] } else { &["&&", "&"] };
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if ops.contains(&t.value.as_str())));
+        if !has_op {
+            return Ok(None);
+        }
+        let mut acc: Option<Expr> = None;
+        for child in &node.children {
+            if let ASTNodeOrToken::Node(n) = child {
+                let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                acc = Some(match acc.take() {
+                    None => operand,
+                    Some(lhs) => {
+                        let span = lhs.span().clone();
+                        if is_or {
+                            Expr::LogicalOr {
+                                lhs: Box::new(lhs),
+                                rhs: Box::new(operand),
+                                span,
+                            }
+                        } else {
+                            Expr::LogicalAnd {
+                                lhs: Box::new(lhs),
+                                rhs: Box::new(operand),
+                                span,
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty logical expression".to_string())),
+        }
+    }
+
+    fn try_comparison(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        const OPS: &[&str] = &["==", "~=", "<=", ">=", "<", ">"];
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str())));
+        if !has_op {
+            return Ok(None);
+        }
+        let mut acc: Option<Expr> = None;
+        let mut pending: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str()) => {
+                    pending = Some(match t.value.as_str() {
+                        "==" => "=".to_string(),
+                        "~=" => "!=".to_string(),
+                        other => other.to_string(),
+                    });
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    acc = Some(match (acc.take(), pending.take()) {
+                        (None, _) => operand,
+                        (Some(lhs), Some(op)) => {
+                            let span = lhs.span().clone();
+                            Expr::BuiltinCall {
+                                name: op,
+                                args: vec![lhs, operand],
+                                effects: EffectSet::PURE,
+                                span,
+                            }
+                        }
+                        (Some(_), None) => {
+                            return Err(self.err_at(node, "malformed comparison".to_string()))
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty comparison".to_string())),
+        }
+    }
+
+    fn lower_colon(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        if node.rule_name != "colon_expr" {
+            return Ok(None);
+        }
+        let kids = child_nodes(node);
+        let span = self.span_of(node);
+        match kids.as_slice() {
+            [only] => self.lower_expr_d(only, ctx, depth + 1).map(Some),
+            [start, stop] => {
+                // `Expr::Range` only requires `Feature::NDArrays` per the
+                // validator's own ground truth (a bare range is not itself
+                // a matrix op).
+                self.observed.add(Feature::NDArrays);
+                let start_e = self.lower_expr_d(start, ctx, depth + 1)?;
+                let stop_e = self.lower_expr_d(stop, ctx, depth + 1)?;
+                Ok(Some(Expr::Range {
+                    start: Box::new(start_e),
+                    step: None,
+                    stop: Box::new(stop_e),
+                    span,
+                }))
+            }
+            [start, step, stop] => {
+                self.observed.add(Feature::NDArrays);
+                let start_e = self.lower_expr_d(start, ctx, depth + 1)?;
+                let step_e = self.lower_expr_d(step, ctx, depth + 1)?;
+                let stop_e = self.lower_expr_d(stop, ctx, depth + 1)?;
+                Ok(Some(Expr::Range {
+                    start: Box::new(start_e),
+                    step: Some(Box::new(step_e)),
+                    stop: Box::new(stop_e),
+                    span,
+                }))
+            }
+            _ => Err(self.err_at(node, "malformed range expression".to_string())),
+        }
+    }
+
+    fn try_additive(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == "+" || t.value == "-"));
+        if !has_op {
+            return Ok(None);
+        }
+        let mut acc: Option<Expr> = None;
+        let mut pending: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if t.value == "+" || t.value == "-" => {
+                    pending = Some(t.value.clone());
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    acc = Some(match (acc.take(), pending.take()) {
+                        (None, _) => operand,
+                        (Some(lhs), Some(op)) => self.build_additive(lhs, operand, &op),
+                        (Some(_), None) => {
+                            return Err(
+                                self.err_at(node, "malformed additive expression".to_string())
+                            )
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty additive expression".to_string())),
+        }
+    }
+
+    fn build_additive(&mut self, lhs: Expr, rhs: Expr, op: &str) -> Expr {
+        let span = lhs.span().clone();
+        if expr_is_known_scalar(&lhs) && expr_is_known_scalar(&rhs) {
+            Expr::BuiltinCall {
+                name: op.to_string(),
+                args: vec![lhs, rhs],
+                effects: EffectSet::PURE,
+                span,
+            }
+        } else {
+            // `Expr::ElementwiseOp` requires `MatrixOps` + `ArrayColumnMajor`
+            // per the validator's own ground truth -- not `NDArrays`.
+            self.observed.add(Feature::MatrixOps);
+            self.observed.add(Feature::ArrayColumnMajor);
+            let kind = if op == "+" {
+                ElementwiseOpKind::Add
+            } else {
+                ElementwiseOpKind::Sub
+            };
+            Expr::ElementwiseOp {
+                op: kind,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                span,
+            }
+        }
+    }
+
+    fn try_multiplicative(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        const OPS: &[&str] = &["*", "/", "\\", ".*", "./", ".\\"];
+        let has_op = node
+            .children
+            .iter()
+            .any(|c| matches!(c, ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str())));
+        if !has_op {
+            return Ok(None);
+        }
+        let mut acc: Option<Expr> = None;
+        let mut pending: Option<String> = None;
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) if OPS.contains(&t.value.as_str()) => {
+                    pending = Some(t.value.clone());
+                }
+                ASTNodeOrToken::Node(n) => {
+                    let operand = self.lower_expr_d(n, ctx, depth + 1)?;
+                    acc = Some(match (acc.take(), pending.take()) {
+                        (None, _) => operand,
+                        (Some(lhs), Some(op)) => {
+                            self.build_multiplicative(lhs, operand, &op, node)?
+                        }
+                        (Some(_), None) => {
+                            return Err(self.err_at(
+                                node,
+                                "malformed multiplicative expression".to_string(),
+                            ))
+                        }
+                    });
+                }
+                ASTNodeOrToken::Token(_) => {}
+            }
+        }
+        match acc {
+            Some(e) => Ok(Some(e)),
+            None => Err(self.err_at(node, "empty multiplicative expression".to_string())),
+        }
+    }
+
+    fn build_multiplicative(
+        &mut self,
+        lhs: Expr,
+        rhs: Expr,
+        op: &str,
+        node: &GrammarASTNode,
+    ) -> Result<Expr, MatlabLowerError> {
+        let span = lhs.span().clone();
+        let lhs_scalar = expr_is_known_scalar(&lhs);
+        let rhs_scalar = expr_is_known_scalar(&rhs);
+        match op {
+            ".*" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok(Expr::BuiltinCall {
+                        name: "*".to_string(),
+                        args: vec![lhs, rhs],
+                        effects: EffectSet::PURE,
+                        span,
+                    })
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok(Expr::ElementwiseOp {
+                        op: ElementwiseOpKind::Mul,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                        span,
+                    })
+                }
+            }
+            "./" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok(Expr::BuiltinCall {
+                        name: "/".to_string(),
+                        args: vec![lhs, rhs],
+                        effects: EffectSet::PURE,
+                        span,
+                    })
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok(Expr::ElementwiseOp {
+                        op: ElementwiseOpKind::Div,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                        span,
+                    })
+                }
+            }
+            ".\\" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok(Expr::BuiltinCall {
+                        name: "/".to_string(),
+                        args: vec![rhs, lhs],
+                        effects: EffectSet::PURE,
+                        span,
+                    })
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok(Expr::ElementwiseOp {
+                        op: ElementwiseOpKind::Div,
+                        lhs: Box::new(rhs),
+                        rhs: Box::new(lhs),
+                        span,
+                    })
+                }
+            }
+            "*" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok(Expr::BuiltinCall {
+                        name: "*".to_string(),
+                        args: vec![lhs, rhs],
+                        effects: EffectSet::PURE,
+                        span,
+                    })
+                } else if lhs_scalar || rhs_scalar {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok(Expr::ElementwiseOp {
+                        op: ElementwiseOpKind::Mul,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                        span,
+                    })
+                } else {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok(Expr::MatMul {
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                        span,
+                    })
+                }
+            }
+            "/" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok(Expr::BuiltinCall {
+                        name: "/".to_string(),
+                        args: vec![lhs, rhs],
+                        effects: EffectSet::PURE,
+                        span,
+                    })
+                } else if lhs_scalar || rhs_scalar {
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    Ok(Expr::ElementwiseOp {
+                        op: ElementwiseOpKind::Div,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                        span,
+                    })
+                } else {
+                    Err(self.err_at(
+                        node,
+                        "unsupported: matrix right division `/` (mrdivide) has no backend \
+                         kernel yet"
+                            .to_string(),
+                    ))
+                }
+            }
+            "\\" => {
+                if lhs_scalar && rhs_scalar {
+                    Ok(Expr::BuiltinCall {
+                        name: "/".to_string(),
+                        args: vec![rhs, lhs],
+                        effects: EffectSet::PURE,
+                        span,
+                    })
+                } else {
+                    Err(self.err_at(
+                        node,
+                        "unsupported: matrix left division `\\` (mldivide) has no backend \
+                         kernel yet"
+                            .to_string(),
+                    ))
+                }
+            }
+            other => Err(self.err_at(node, format!("unsupported multiplicative operator `{other}`"))),
+        }
+    }
+
+    fn lower_unary(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        if node.rule_name != "unary" || node.children.len() != 2 {
+            return Ok(None);
+        }
+        let sign = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) => Some(t.value.clone()),
+                ASTNodeOrToken::Node(_) => None,
+            })
+            .ok_or_else(|| self.err_at(node, "malformed unary expression".to_string()))?;
+        let inner_node = *child_nodes(node)
+            .first()
+            .ok_or_else(|| self.err_at(node, "malformed unary expression: no operand".to_string()))?;
+        let operand = self.lower_expr_d(inner_node, ctx, depth + 1)?;
+        let span = operand.span().clone();
+        let result = match sign.as_str() {
+            "+" => operand,
+            "-" => match operand {
+                Expr::IntLit { value, span } => Expr::IntLit {
+                    value: value.wrapping_neg(),
+                    span,
+                },
+                Expr::FloatLit { value, span } => Expr::FloatLit { value: -value, span },
+                other => Expr::BuiltinCall {
+                    name: "neg".to_string(),
+                    args: vec![other],
+                    effects: EffectSet::PURE,
+                    span,
+                },
+            },
+            "~" => Expr::BuiltinCall {
+                name: "not".to_string(),
+                args: vec![operand],
+                effects: EffectSet::PURE,
+                span,
+            },
+            other => return Err(self.err_at(node, format!("unsupported unary operator `{other}`"))),
+        };
+        Ok(Some(result))
+    }
+
+    fn try_power(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        if node.rule_name != "power" {
+            return Ok(None);
+        }
+        let op = node.children.iter().find_map(|c| match c {
+            ASTNodeOrToken::Token(t) if t.value == "^" || t.value == ".^" => Some(t.value.clone()),
+            _ => None,
+        });
+        let op = match op {
+            Some(o) => o,
+            None => return Ok(None),
+        };
+        let (base, exp) = match child_nodes(node).as_slice() {
+            [b, e] => (*b, *e),
+            _ => return Err(self.err_at(node, "malformed power expression".to_string())),
+        };
+        let _ = op; // both `^` and `.^` lower identically (see module scope note)
+        let base_e = self.lower_expr_d(base, ctx, depth + 1)?;
+        let exp_e = self.lower_expr_d(exp, ctx, depth + 1)?;
+        let span = base_e.span().clone();
+        self.observed.add(Feature::MatrixOps);
+        self.observed.add(Feature::ArrayColumnMajor);
+        Ok(Some(Expr::ElementwiseOp {
+            op: ElementwiseOpKind::Pow,
+            lhs: Box::new(base_e),
+            rhs: Box::new(exp_e),
+            span,
+        }))
+    }
+
+    // -------------------------------------------------------------------
+    // postfix: transpose / call / index
+    // -------------------------------------------------------------------
+
+    fn lower_postfix(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Option<Expr>, MatlabLowerError> {
+        if node.rule_name != "postfix" {
+            return Ok(None);
+        }
+        let kids = child_nodes(node);
+        let (primary, suffixes) = match kids.split_first() {
+            Some((p, rest)) => (*p, rest),
+            None => return Err(self.err_at(node, "malformed postfix expression".to_string())),
+        };
+        if suffixes.is_empty() {
+            return self.lower_primary(primary, ctx, depth + 1).map(Some);
+        }
+
+        let mut acc: Option<Expr> = None;
+        let mut first = true;
+        for suffix in suffixes {
+            match suffix.rule_name.as_str() {
+                "transpose_suffix" => {
+                    let target = match acc.take() {
+                        Some(e) => e,
+                        None => self.lower_primary(primary, ctx, depth + 1)?,
+                    };
+                    let tok = suffix
+                        .token()
+                        .ok_or_else(|| self.err_at(suffix, "malformed transpose suffix".to_string()))?;
+                    let conjugate = tok.value == "'";
+                    let span = target.span().clone();
+                    self.observed.add(Feature::MatrixOps);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    acc = Some(Expr::Transpose {
+                        target: Box::new(target),
+                        conjugate,
+                        span,
+                    });
+                }
+                "call_suffix" => {
+                    if first {
+                        let name = self.primary_bare_name(primary).ok_or_else(|| {
+                            self.err_at(
+                                primary,
+                                "unsupported: call/index target is not a bare name".to_string(),
+                            )
+                        })?;
+                        if ctx.locals.contains(&name) || ctx.params.contains(&name) {
+                            let span = self.span_of(primary);
+                            let indices = self.lower_index_args(suffix, ctx)?;
+                            acc = Some(Expr::IndexGet {
+                                target: Box::new(Expr::VarRef {
+                                    name,
+                                    scope: Scope::Local,
+                                    span: span.clone(),
+                                }),
+                                indices,
+                                span,
+                            });
+                        } else if name == "disp" {
+                            // The one builtin this frontend recognises: MATLAB's
+                            // `disp` maps onto the SIR `print` builtin every
+                            // backend already implements, matching every other
+                            // frontend's own "print"/"puts" convention. Without
+                            // this there would be no way for a lowered MATLAB
+                            // program to produce observable output at all.
+                            let span = self.span_of(primary);
+                            let args = self.lower_call_args(suffix, ctx)?;
+                            if args.len() != 1 {
+                                return Err(self.err_at(
+                                    primary,
+                                    "`disp` takes exactly one argument".to_string(),
+                                ));
+                            }
+                            acc = Some(Expr::BuiltinCall {
+                                name: "print".to_string(),
+                                args,
+                                effects: EffectSet::PURE,
+                                span,
+                            });
+                        } else if self.function_names.contains(&name) {
+                            let span = self.span_of(primary);
+                            let args = self.lower_call_args(suffix, ctx)?;
+                            acc = Some(Expr::DirectCall {
+                                fn_name: name,
+                                args,
+                                effects: EffectSet::PURE,
+                                span,
+                            });
+                        } else {
+                            return Err(self.err_at(
+                                primary,
+                                format!(
+                                    "unsupported: unknown identifier `{name}` (not a known \
+                                     variable or user function)"
+                                ),
+                            ));
+                        }
+                    } else {
+                        let base = acc
+                            .take()
+                            .expect("acc is set after the first suffix in the fold");
+                        let span = base.span().clone();
+                        let indices = self.lower_index_args(suffix, ctx)?;
+                        acc = Some(Expr::IndexGet {
+                            target: Box::new(base),
+                            indices,
+                            span,
+                        });
+                    }
+                }
+                "cell_suffix" | "field_suffix" => {
+                    return Err(self.err_at(
+                        suffix,
+                        format!("unsupported: `{}` is out of scope for v0.1.0", suffix.rule_name),
+                    ))
+                }
+                other => return Err(self.err_at(suffix, format!("unsupported postfix suffix `{other}`"))),
+            }
+            first = false;
+        }
+        Ok(acc)
+    }
+
+    fn lower_primary(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, MatlabLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        if let Some(tok) = node.token() {
+            let span = self.span_of(node);
+            return match tok.type_ {
+                TokenType::Number => Ok(number_literal_expr(tok, &span)),
+                TokenType::String => Ok(Expr::StrLit {
+                    value: tok.value.clone(),
+                    span,
+                }),
+                TokenType::Name => {
+                    let name = tok.value.clone();
+                    if ctx.params.contains(&name) {
+                        Ok(Expr::VarRef {
+                            name,
+                            scope: Scope::Param,
+                            span,
+                        })
+                    } else if ctx.locals.contains(&name) {
+                        Ok(Expr::VarRef {
+                            name,
+                            scope: Scope::Local,
+                            span,
+                        })
+                    } else {
+                        Err(self.err_at(
+                            node,
+                            format!("undefined variable `{name}` (not previously assigned)"),
+                        ))
+                    }
+                }
+                _ => Err(self.err_at(node, format!("unsupported literal token `{}`", tok.value))),
+            };
+        }
+        let only = match child_nodes(node).as_slice() {
+            [only] => *only,
+            _ => return Err(self.err_at(node, "malformed primary expression".to_string())),
+        };
+        match only.rule_name.as_str() {
+            "matrix_literal" => self.lower_matrix_literal(only, ctx, depth + 1),
+            "cell_literal" => Err(self.err_at(
+                only,
+                "unsupported: cell arrays are out of scope for v0.1.0".to_string(),
+            )),
+            "lambda" => Err(self.err_at(
+                only,
+                "unsupported: anonymous functions (`@(...) ...`) are out of scope for v0.1.0"
+                    .to_string(),
+            )),
+            "group" => match child_nodes(only).as_slice() {
+                [inner] => self.lower_expr_d(inner, ctx, depth + 1),
+                _ => Err(self.err_at(only, "malformed parenthesised expression".to_string())),
+            },
+            other => Err(self.err_at(only, format!("unsupported: `{other}` (deferred)"))),
+        }
+    }
+
+    fn lower_matrix_literal(
+        &mut self,
+        node: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+        depth: usize,
+    ) -> Result<Expr, MatlabLowerError> {
+        if depth > MAX_BLOCK_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("matrix literal nesting too deep (exceeds {MAX_BLOCK_DEPTH} levels)"),
+            ));
+        }
+        // `Expr::ArrayLit` requires `NDArrays` + `ArrayColumnMajor` (not
+        // `MatrixOps`) per the validator's own ground truth.
+        self.observed.add(Feature::NDArrays);
+        self.observed.add(Feature::ArrayColumnMajor);
+        let span = self.span_of(node);
+        let mut rows: Vec<Vec<Expr>> = Vec::new();
+        if let Some(matrix_rows) = self.first_child_named(node, "matrix_rows") {
+            for row in child_nodes(matrix_rows) {
+                if row.rule_name == "matrix_row" {
+                    let mut cells = Vec::new();
+                    for cell in child_nodes(row) {
+                        cells.push(self.lower_expr_d(cell, ctx, depth + 1)?);
+                    }
+                    rows.push(cells);
+                }
+            }
+        }
+        Ok(Expr::ArrayLit { rows, span })
+    }
+
+    // -------------------------------------------------------------------
+    // indexing / call arguments
+    // -------------------------------------------------------------------
+
+    fn lower_index_args(
+        &mut self,
+        call_suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Vec<IndexArg>, MatlabLowerError> {
+        // `Expr::IndexGet`/`Stmt::IndexSet` only require `NDArrays` per the
+        // validator's own ground truth.
+        self.observed.add(Feature::NDArrays);
+        let arg_list = match self.first_child_named(call_suffix, "arg_list") {
+            Some(a) => a,
+            None => return Ok(vec![]),
+        };
+        let mut out = Vec::new();
+        for arg in child_nodes(arg_list) {
+            if arg.rule_name == "arg" {
+                out.push(self.lower_one_index_arg(arg, ctx)?);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Lower one index-position argument, translating 1-based MATLAB
+    /// indexing to the IR's 0-based convention: a literal integer index
+    /// constant-folds (`A(3)` → `Scalar(IntLit(2))`); anything else emits
+    /// `BuiltinCall("-", [idx, 1])` (`A(i)` → `Scalar(i - 1)`).
+    fn lower_one_index_arg(
+        &mut self,
+        arg: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<IndexArg, MatlabLowerError> {
+        if let Some(tok) = arg.token() {
+            if tok.value == ":" {
+                return Ok(IndexArg::Whole);
+            }
+        }
+        let inner = match child_nodes(arg).as_slice() {
+            [only] => *only,
+            _ => return Err(self.err_at(arg, "malformed index argument".to_string())),
+        };
+        let idx = self.lower_expr(inner, ctx)?;
+        let span = idx.span().clone();
+        let shifted = match idx {
+            Expr::IntLit { value, .. } => Expr::IntLit {
+                value: value - 1,
+                span,
+            },
+            other => Expr::BuiltinCall {
+                name: "-".to_string(),
+                args: vec![
+                    other,
+                    Expr::IntLit {
+                        value: 1,
+                        span: span.clone(),
+                    },
+                ],
+                effects: EffectSet::PURE,
+                span,
+            },
+        };
+        Ok(IndexArg::Scalar(Box::new(shifted)))
+    }
+
+    fn lower_call_args(
+        &mut self,
+        call_suffix: &GrammarASTNode,
+        ctx: &mut FunctionCtx,
+    ) -> Result<Vec<Expr>, MatlabLowerError> {
+        let arg_list = match self.first_child_named(call_suffix, "arg_list") {
+            Some(a) => a,
+            None => return Ok(vec![]),
+        };
+        let mut out = Vec::new();
+        for arg in child_nodes(arg_list) {
+            if arg.rule_name != "arg" {
+                continue;
+            }
+            if let Some(tok) = arg.token() {
+                if tok.value == ":" {
+                    return Err(self.err_at(
+                        arg,
+                        "unsupported: `:` is not a valid function-call argument".to_string(),
+                    ));
+                }
+            }
+            let inner = match child_nodes(arg).as_slice() {
+                [only] => *only,
+                _ => return Err(self.err_at(arg, "malformed call argument".to_string())),
+            };
+            out.push(self.lower_expr(inner, ctx)?);
+        }
+        Ok(out)
+    }
+
+    // -------------------------------------------------------------------
+    // target resolution (assignment LHS)
+    // -------------------------------------------------------------------
+
+    fn bare_name(&self, node: &GrammarASTNode) -> Option<String> {
+        let postfix = self.peel_to_named(node, "postfix", 0)?;
+        match child_nodes(postfix).as_slice() {
+            [primary] => self.primary_bare_name(primary),
+            _ => None,
+        }
+    }
+
+    fn indexed_target<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+    ) -> Option<(String, &'a GrammarASTNode)> {
+        let postfix = self.peel_to_named(node, "postfix", 0)?;
+        match child_nodes(postfix).as_slice() {
+            [primary, suffix] if suffix.rule_name == "call_suffix" => {
+                self.primary_bare_name(primary).map(|name| (name, *suffix))
+            }
+            _ => None,
+        }
+    }
+
+    fn primary_bare_name(&self, primary: &GrammarASTNode) -> Option<String> {
+        let tok = primary.token()?;
+        if tok.type_ == TokenType::Name {
+            Some(tok.value.clone())
+        } else {
+            None
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // small tree helpers
+    // -------------------------------------------------------------------
+
+    /// Peel through a chain of single-Node-child wrapper rules until
+    /// reaching a node named `name`, or return `None` if the chain
+    /// branches or runs out of depth first.
+    fn peel_to_named<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+        name: &str,
+        depth: usize,
+    ) -> Option<&'a GrammarASTNode> {
+        if depth > MAX_EXPR_DEPTH {
+            return None;
+        }
+        if node.rule_name == name {
+            return Some(node);
+        }
+        match child_nodes(node).as_slice() {
+            [only] if node.children.len() == 1 => self.peel_to_named(only, name, depth + 1),
+            _ => None,
+        }
+    }
+
+    fn first_child_named<'a>(
+        &self,
+        node: &'a GrammarASTNode,
+        kind: &str,
+    ) -> Option<&'a GrammarASTNode> {
+        child_nodes(node).into_iter().find(|n| n.rule_name == kind)
+    }
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::point(
+            FILE,
+            node.start_line.unwrap_or(1),
+            node.start_column.unwrap_or(1),
+        )
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> MatlabLowerError {
+        MatlabLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// A `NUMBER` lexeme is a float if it has a decimal point or exponent,
+/// otherwise an int; an integer lexeme too large for `i64` falls back to a
+/// float rather than silently truncating or erroring.
+fn number_literal_expr(tok: &Token, span: &Span) -> Expr {
+    let text = &tok.value;
+    if text.contains('.') || text.contains('e') || text.contains('E') {
+        Expr::FloatLit {
+            value: text.parse::<f64>().unwrap_or(0.0),
+            span: span.clone(),
+        }
+    } else {
+        match text.parse::<i64>() {
+            Ok(v) => Expr::IntLit {
+                value: v,
+                span: span.clone(),
+            },
+            Err(_) => Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span: span.clone(),
+            },
+        }
+    }
+}
+
+/// Is `e` provably a scalar? See the module doc comment's "Scalar/array
+/// disambiguation" section — this is a syntactic, non-evaluating check on
+/// the *lowered* expression tree, not full constant folding.
+fn expr_is_known_scalar(e: &Expr) -> bool {
+    match e {
+        Expr::IntLit { .. } | Expr::FloatLit { .. } => true,
+        Expr::BuiltinCall { name, args, .. }
+            if matches!(name.as_str(), "+" | "-" | "*" | "/" | "neg") =>
+        {
+            args.iter().all(expr_is_known_scalar)
+        }
+        _ => false,
+    }
+}
+
+/// An empty `Block` whose value is `NilLit`.
+fn empty_block(span: Span) -> Block {
+    Block {
+        stmts: vec![],
+        value: Expr::NilLit { span: span.clone() },
+        span,
+    }
+}
+
+/// A `Block` with no statements whose value is `expr`.
+fn value_block(expr: Expr) -> Block {
+    let span = expr.span().clone();
+    Block {
+        stmts: vec![],
+        value: expr,
+        span,
+    }
+}
+
+/// Assemble a list of lowered items into a `Block` whose every item is a
+/// statement (bare expressions wrapped as `ExprStmt`) and whose value is
+/// always `value` — unlike a script-oriented frontend, MATLAB has no
+/// "trailing expression is the result" convention at any body level
+/// (scripts have no return value; only a function's designated output
+/// variable does, and that is threaded in explicitly by the caller).
+fn assemble_stmts_only(items: Vec<Lowered>, value: Expr, span: Span) -> Block {
+    let stmts: Vec<Stmt> = items
+        .into_iter()
+        .map(|item| match item {
+            Lowered::Stmt(s) => *s,
+            Lowered::Expr(expr) => {
+                let s = expr.span().clone();
+                Stmt::ExprStmt { expr, span: s }
+            }
+        })
+        .collect();
+    Block { stmts, value, span }
+}

--- a/code/packages/rust/matlab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/e2e_node.rs
@@ -1,0 +1,106 @@
+//! End-to-end round-trip: MATLAB → SIR → JavaScript → `node`.
+//!
+//! Mirrors `javascript-to-semantic-ir`'s own `e2e_node.rs` harness exactly:
+//! lower a MATLAB program to SIR with this crate, validate the module, emit
+//! JavaScript with the merged `semantic-ir-to-javascript` backend (a
+//! dev-dependency), write it to a temp file, and **execute it with
+//! `node`**, asserting the printed output.
+//!
+//! As `test_validator.rs`'s module doc comment explains, this crate's
+//! "scalar fast path" only recognises *purely literal* arithmetic as
+//! provably scalar — any variable-involving arithmetic takes the
+//! `ElementwiseOp`/`MatMul` path, which the JS backend does not implement
+//! codegen for yet. So, for now, only a purely-literal MATLAB program can
+//! make it all the way through this pipeline; that is exactly what this
+//! test proves, gated on `node` availability like its JS counterpart.
+
+use std::process::Command;
+
+use matlab_to_semantic_ir::compile_source;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_via_node(name: &str, src: &str) -> String {
+    let module = compile_source(src, "prog").expect("lowering should succeed");
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for {name}: {:?}",
+        report.issues
+    );
+    let artifact =
+        semantic_ir_to_javascript::compile(&module).expect("backend emit should succeed");
+
+    let mut path = std::env::temp_dir();
+    path.push(format!("matlab_sir_e2e_{name}_{}.js", std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+
+    let output = Command::new("node").arg(&path).output().expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "node failed for {name}: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn a_function_over_pure_literals_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping a_function_over_pure_literals_runs_in_node: `node` not available");
+        return;
+    }
+    let out = run_via_node(
+        "literal_function",
+        "function r = seven()\n  r = 3 + 4;\nend\ndisp(seven());\n",
+    );
+    assert_eq!(out, "7");
+}
+
+#[test]
+fn nested_literal_arithmetic_runs_in_node() {
+    if !node_available() {
+        eprintln!("skipping nested_literal_arithmetic_runs_in_node: `node` not available");
+        return;
+    }
+    // `2 * 3 + 4 * 5` -- both multiplications are literal*literal (the
+    // scalar fast path), and the outer addition is then built from two
+    // already-known-scalar BuiltinCall results, so the whole expression
+    // stays on the plain-BuiltinCall path transitively.
+    let out = run_via_node(
+        "nested_literal_arithmetic",
+        "disp(2 * 3 + 4 * 5);\n",
+    );
+    assert_eq!(out, "26");
+}
+
+#[test]
+fn a_call_before_its_textual_definition_runs_in_node() {
+    if !node_available() {
+        eprintln!(
+            "skipping a_call_before_its_textual_definition_runs_in_node: `node` not available"
+        );
+        return;
+    }
+    // Proves the two-pass function-name collection resolves a forward
+    // reference correctly all the way through actual execution, not just
+    // at the lowered-Module-shape level. `double_seven`'s own body stays
+    // on the pure-literal path (composing its result with a further `*`
+    // outside the function -- e.g. `2 * double_seven()` -- would push the
+    // whole expression onto the ElementwiseOp path instead, since a
+    // DirectCall result is never provably scalar; see this file's module
+    // doc comment).
+    let out = run_via_node(
+        "forward_reference",
+        "disp(double_seven());\nfunction r = double_seven()\n  r = 3 + 4 + 3 + 4;\nend\n",
+    );
+    assert_eq!(out, "14");
+}

--- a/code/packages/rust/matlab-to-semantic-ir/tests/e2e_node.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/e2e_node.rs
@@ -14,6 +14,8 @@
 //! make it all the way through this pipeline; that is exactly what this
 //! test proves, gated on `node` availability like its JS counterpart.
 
+use std::fs::OpenOptions;
+use std::io::Write as _;
 use std::process::Command;
 
 use matlab_to_semantic_ir::compile_source;
@@ -39,7 +41,20 @@ fn run_via_node(name: &str, src: &str) -> String {
 
     let mut path = std::env::temp_dir();
     path.push(format!("matlab_sir_e2e_{name}_{}.js", std::process::id()));
-    std::fs::write(&path, &artifact.source).expect("write temp js");
+    // `create_new` fails if the path already exists (including as a
+    // symlink) instead of following it -- unlike `std::fs::write`, which
+    // truncates through a symlink at this predictable, shared-temp-dir
+    // path. Each test uses a unique name+PID, so this should never
+    // legitimately collide; if it does, failing loudly is correct for a
+    // test rather than silently overwriting whatever the path pointed to.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .expect("create temp js (create_new, not following an existing symlink)");
+    file.write_all(artifact.source.as_bytes())
+        .expect("write temp js");
+    drop(file);
 
     let output = Command::new("node").arg(&path).output().expect("spawn node");
     let _ = std::fs::remove_file(&path);

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,614 @@
+use matlab_to_semantic_ir::compile_source;
+use semantic_ir::{ElementwiseOpKind, Expr, Function, IndexArg, Module, Stmt};
+
+fn compile_ok(src: &str) -> Module {
+    compile_source(src, "prog").unwrap_or_else(|e| panic!("expected lowering to succeed: {e}"))
+}
+
+fn main_fn(m: &Module) -> &Function {
+    m.functions.iter().find(|f| f.name == "main").expect("main function")
+}
+
+fn user_fn<'a>(m: &'a Module, name: &str) -> &'a Function {
+    m.functions
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("expected a function named `{name}`"))
+}
+
+// ── literals, assignment ────────────────────────────────────────────────
+
+#[test]
+fn integer_literal_assignment_is_a_let_star_binding() {
+    let m = compile_ok("x = 42;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { name, value, .. } => {
+            assert_eq!(name, "x");
+            assert!(matches!(value, Expr::IntLit { value: 42, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn float_literal_is_recognised_by_decimal_point() {
+    let m = compile_ok("x = 2.5;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::FloatLit { value, .. } if (*value - 2.5).abs() < 1e-9));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn string_literal_lowers_to_str_lit() {
+    let m = compile_ok("s = \"hello\";\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::StrLit { value, .. } if value == "hello"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn reassignment_of_a_known_local_is_assign_not_let() {
+    let m = compile_ok("x = 1;\nx = 2;\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[0], Stmt::LetStarBinding { .. }));
+    assert!(matches!(main.body.stmts[1], Stmt::Assign { .. }));
+}
+
+#[test]
+fn manifest_declares_mutable_bindings_on_reassignment() {
+    let m = compile_ok("x = 1;\nx = 2;\n");
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::MutableBindings));
+}
+
+// ── arithmetic: scalar fast path vs array-domain ────────────────────────
+
+#[test]
+fn scalar_addition_of_two_literals_is_a_plain_builtin_call() {
+    let m = compile_ok("y = 1 + 2;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::BuiltinCall { name, args, .. } => {
+                assert_eq!(name, "+");
+                assert_eq!(args.len(), 2);
+            }
+            other => panic!("expected a plain BuiltinCall(\"+\"), got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn addition_involving_a_variable_is_elementwise() {
+    let m = compile_ok("x = 1;\ny = x + 2;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Add, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::MatrixOps));
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::ArrayColumnMajor));
+}
+
+#[test]
+fn subtraction_chain_of_literals_folds_transitively_to_a_builtin_chain() {
+    // `1 - 2 - 3` -- both operands of the outer subtraction are themselves
+    // known-scalar (the inner BuiltinCall("-", [1, 2]) recurses correctly).
+    let m = compile_ok("y = 1 - 2 - 3;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn matrix_star_between_two_variables_is_matmul() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = [5 6; 7 8];\nC = A * B;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::MatMul { .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn scalar_times_matrix_broadcasts_as_elementwise() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = 2 * A;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Mul, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn dot_star_is_always_elementwise_even_for_two_literals() {
+    let m = compile_ok("y = 2 .* 3;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "*"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn matrix_right_division_between_variables_is_unsupported() {
+    let err = compile_source("A = [1 2; 3 4];\nB = [1 0; 0 1];\nC = A / B;\n", "prog")
+        .expect_err("mrdivide between non-scalars should be rejected");
+    assert!(err.message.contains("mrdivide"));
+}
+
+#[test]
+fn matrix_left_division_is_unsupported() {
+    let err = compile_source("A = [1 2; 3 4];\nB = [1 0; 0 1];\nC = A \\ B;\n", "prog")
+        .expect_err("mldivide should be rejected");
+    assert!(err.message.contains("mldivide"));
+}
+
+#[test]
+fn scalar_backslash_division_is_supported() {
+    let m = compile_ok("y = 2 \\ 10;\n"); // 10 / 2 = 5
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "/"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn power_always_lowers_to_elementwise_pow() {
+    let m = compile_ok("y = 2 ^ 10;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(
+                value,
+                Expr::ElementwiseOp { op: ElementwiseOpKind::Pow, .. }
+            ));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+// ── comparisons, logical, unary ─────────────────────────────────────────
+
+#[test]
+fn equality_comparison_normalises_to_the_shared_builtin_name() {
+    let m = compile_ok("y = (1 == 2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "="));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn not_equal_normalises_from_tilde_eq_spelling() {
+    let m = compile_ok("y = (1 ~= 2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "!="));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_and_or_lower_to_dedicated_nodes() {
+    let m = compile_ok("y = (1 && 0) || 1;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::LogicalOr { .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn unary_minus_on_a_literal_constant_folds() {
+    let m = compile_ok("y = -5;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::IntLit { value: -5, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn unary_minus_on_a_variable_is_a_neg_builtin_call() {
+    let m = compile_ok("x = 5;\ny = -x;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "neg"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn logical_not_lowers_to_a_not_builtin_call() {
+    let m = compile_ok("x = 1;\ny = ~x;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "not"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+// ── ranges, transpose, matrices ─────────────────────────────────────────
+
+#[test]
+fn colon_range_as_a_value_lowers_to_range_with_no_step() {
+    let m = compile_ok("v = 1:5;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Range { step: None, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn stepped_colon_range_as_a_value_carries_a_step() {
+    let m = compile_ok("v = 0:2:10;\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Range { step: Some(_), .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn transpose_marks_conjugate_true_and_elem_transpose_false() {
+    let m = compile_ok("A = [1 2; 3 4];\nB = A';\nC = A.';\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Transpose { conjugate: true, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::Transpose { conjugate: false, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn matrix_literal_lowers_to_array_lit_with_row_major_syntax_rows() {
+    let m = compile_ok("A = [1 2 3; 4 5 6];\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::ArrayLit { rows, .. } => {
+                assert_eq!(rows.len(), 2);
+                assert_eq!(rows[0].len(), 3);
+                assert_eq!(rows[1].len(), 3);
+            }
+            other => panic!("expected ArrayLit, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::ArrayColumnMajor));
+}
+
+#[test]
+fn empty_matrix_literal_lowers_to_zero_rows() {
+    let m = compile_ok("A = [];\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::ArrayLit { rows, .. } => assert!(rows.is_empty()),
+            other => panic!("expected ArrayLit, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+// ── indexing ─────────────────────────────────────────────────────────────
+
+#[test]
+fn literal_index_constant_folds_the_one_based_to_zero_based_shift() {
+    let m = compile_ok("A = [1 2 3];\ny = A(2);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::IndexGet { indices, .. } => match indices.as_slice() {
+                [IndexArg::Scalar(idx)] => {
+                    assert!(matches!(**idx, Expr::IntLit { value: 1, .. }));
+                }
+                other => panic!("expected one Scalar index arg, got {other:?}"),
+            },
+            other => panic!("expected IndexGet, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn variable_index_emits_a_runtime_minus_one_shift() {
+    let m = compile_ok("A = [1 2 3];\ni = 2;\ny = A(i);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[2] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::IndexGet { indices, .. } => match indices.as_slice() {
+                [IndexArg::Scalar(idx)] => {
+                    assert!(matches!(**idx, Expr::BuiltinCall { .. }));
+                }
+                other => panic!("expected one Scalar index arg, got {other:?}"),
+            },
+            other => panic!("expected IndexGet, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn bare_colon_index_lowers_to_whole() {
+    let m = compile_ok("A = [1 2; 3 4];\ny = A(:, 1);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { value, .. } => match value {
+            Expr::IndexGet { indices, .. } => {
+                assert_eq!(indices.len(), 2);
+                assert!(matches!(indices[0], IndexArg::Whole));
+            }
+            other => panic!("expected IndexGet, got {other:?}"),
+        },
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn indexed_assignment_lowers_to_index_set() {
+    let m = compile_ok("A = [1 2 3];\nA(2) = 9;\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[1], Stmt::IndexSet { .. }));
+}
+
+#[test]
+fn indexed_assignment_into_an_undeclared_variable_is_rejected() {
+    let err = compile_source("A(1) = 9;\n", "prog")
+        .expect_err("auto-vivification is out of scope for v0.1.0");
+    assert!(err.message.contains("not previously assigned"));
+}
+
+#[test]
+fn end_relative_indexing_is_rejected() {
+    let err = compile_source("A = [1 2 3];\ny = A(end);\n", "prog")
+        .expect_err("`end`-relative indexing should be rejected");
+    // `end` is retagged to an ordinary NAME by the parser, so it surfaces as
+    // an undefined-variable error rather than a dedicated message -- still
+    // correctly rejected, not silently mis-lowered.
+    assert!(err.message.contains("end"));
+}
+
+// ── control flow ─────────────────────────────────────────────────────────
+
+#[test]
+fn if_else_lowers_to_an_expr_if_wrapped_as_an_expr_stmt() {
+    let m = compile_ok("x = 1;\nif x > 0\n  x = 2;\nelse\n  x = 3;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt { expr, .. } => assert!(matches!(expr, Expr::If { .. })),
+        other => panic!("expected ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn elseif_chain_nests_correctly() {
+    let m = compile_ok(
+        "x = 1;\nif x == 1\n  y = 1;\nelseif x == 2\n  y = 2;\nelse\n  y = 3;\nend\n",
+    );
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ExprStmt {
+            expr: Expr::If { else_branch, .. },
+            ..
+        } => {
+            assert!(matches!(else_branch.value, Expr::If { .. }));
+        }
+        other => panic!("expected nested ExprStmt(If), got {other:?}"),
+    }
+}
+
+#[test]
+fn while_loop_lowers_to_stmt_while() {
+    let m = compile_ok("x = 0;\nwhile x < 10\n  x = x + 1;\nend\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[1], Stmt::While { .. }));
+    assert!(m.manifest.iter().any(|f| f == semantic_ir::Feature::Loops));
+}
+
+#[test]
+fn for_loop_over_a_simple_range_lowers_to_for_range() {
+    let m = compile_ok("total = 0;\nfor i = 1:5\n  total = total + i;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[1] {
+        Stmt::ForRange { var, start, .. } => {
+            assert_eq!(var, "i");
+            assert!(matches!(start, Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected ForRange, got {other:?}"),
+    }
+}
+
+#[test]
+fn stepped_for_loop_is_rejected() {
+    let err = compile_source("for i = 1:2:10\n  x = i;\nend\n", "prog")
+        .expect_err("stepped for-loops are out of scope for v0.1.0");
+    assert!(err.message.contains("stepped"));
+}
+
+// ── functions ──────────────────────────────────────────────────────────
+
+#[test]
+fn single_output_function_body_ends_with_a_varref_to_the_output() {
+    let m = compile_ok("function y = square(x)\n  y = x * x;\nend\n");
+    let f = user_fn(&m, "square");
+    assert_eq!(f.params.len(), 1);
+    assert_eq!(f.params[0].name, "x");
+    assert!(matches!(&f.body.value, Expr::VarRef { name, .. } if name == "y"));
+}
+
+#[test]
+fn void_function_body_ends_with_nil_lit() {
+    let m = compile_ok("function greet(name)\n  disp(name);\nend\n");
+    let f = user_fn(&m, "greet");
+    assert!(matches!(f.body.value, Expr::NilLit { .. }));
+}
+
+#[test]
+fn a_function_call_before_its_textual_definition_resolves_via_the_two_pass_collection() {
+    let m = compile_ok("y = square(3);\nfunction r = square(x)\n  r = x * x;\nend\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::DirectCall { fn_name, .. } if fn_name == "square"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+}
+
+#[test]
+fn multi_output_functions_are_rejected() {
+    let err = compile_source("function [a, b] = pair()\n  a = 1;\n  b = 2;\nend\n", "prog")
+        .expect_err("multi-output functions are out of scope for v0.1.0");
+    assert!(err.message.contains("multiple output"));
+}
+
+#[test]
+fn nested_function_definitions_are_rejected() {
+    let err = compile_source(
+        "function outer()\n  function inner()\n  end\nend\n",
+        "prog",
+    )
+    .expect_err("nested function definitions are out of scope for v0.1.0");
+    assert!(err.message.contains("nested"));
+}
+
+#[test]
+fn disp_lowers_to_the_print_builtin() {
+    let m = compile_ok("disp(1);\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::ExprStmt { expr, .. } => {
+            assert!(matches!(expr, Expr::BuiltinCall { name, .. } if name == "print"));
+        }
+        other => panic!("expected ExprStmt(BuiltinCall(\"print\")), got {other:?}"),
+    }
+}
+
+#[test]
+fn calling_an_unknown_identifier_is_rejected() {
+    let err = compile_source("y = zeros(3);\n", "prog")
+        .expect_err("unregistered builtins should be rejected, not guessed at");
+    assert!(err.message.contains("unknown identifier"));
+}
+
+// ── explicitly out-of-scope constructs ──────────────────────────────────
+
+#[test]
+fn break_is_rejected() {
+    let err = compile_source("while 1\n  break;\nend\n", "prog").expect_err("break unsupported");
+    assert!(err.message.contains("break"));
+}
+
+#[test]
+fn continue_is_rejected() {
+    let err =
+        compile_source("while 1\n  continue;\nend\n", "prog").expect_err("continue unsupported");
+    assert!(err.message.contains("continue"));
+}
+
+#[test]
+fn return_is_rejected() {
+    let err = compile_source("function f()\n  return;\nend\n", "prog")
+        .expect_err("early return unsupported");
+    assert!(err.message.contains("return"));
+}
+
+#[test]
+fn switch_is_rejected() {
+    let err = compile_source("switch 1\n  case 1\n    x = 1;\nend\n", "prog")
+        .expect_err("switch unsupported");
+    assert!(err.message.contains("switch"));
+}
+
+#[test]
+fn try_catch_is_rejected() {
+    let err = compile_source("try\n  x = 1;\nend\n", "prog").expect_err("try unsupported");
+    assert!(err.message.contains("try"));
+}
+
+#[test]
+fn global_is_rejected() {
+    let err = compile_source("global x;\n", "prog").expect_err("global unsupported");
+    assert!(err.message.contains("global"));
+}
+
+#[test]
+fn cell_literal_is_rejected() {
+    let err = compile_source("c = {1, 2};\n", "prog").expect_err("cell arrays unsupported");
+    assert!(err.message.contains("cell"));
+}
+
+#[test]
+fn anonymous_function_is_rejected() {
+    let err = compile_source("f = @(x) x + 1;\n", "prog").expect_err("lambdas unsupported");
+    assert!(err.message.contains("nonymous"));
+}
+
+#[test]
+fn chained_assignment_is_rejected() {
+    let err = compile_source("a = b = 1;\n", "prog").expect_err("chained assignment unsupported");
+    assert!(err.message.contains("chained"));
+}
+
+#[test]
+fn parse_error_is_reported_as_a_lower_error() {
+    let err = compile_source("x = ;\n", "prog").expect_err("malformed source should fail to parse");
+    assert!(err.message.contains("parse error"));
+}

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_lower.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use matlab_to_semantic_ir::compile_source;
 use semantic_ir::{ElementwiseOpKind, Expr, Function, IndexArg, Module, Stmt};
 
@@ -611,4 +613,98 @@ fn chained_assignment_is_rejected() {
 fn parse_error_is_reported_as_a_lower_error() {
     let err = compile_source("x = ;\n", "prog").expect_err("malformed source should fail to parse");
     assert!(err.message.contains("parse error"));
+}
+
+// ── security regression: flat arithmetic chains must not overflow the ────
+// native stack ─────────────────────────────────────────────────────────
+//
+// The MATLAB grammar collapses a flat run of same-precedence operators
+// (`1 + 1 + 1 + ...`) into ONE CST node with many children -- it never
+// nests via parens, so a long unparenthesized chain never trips the
+// ordinary grammar-nesting depth guard the way `((((...))))` does. Two
+// related bugs were confirmed (and fixed) here during security review,
+// both reproduced with a 60,000-term chain that crashed the pre-fix code
+// with a real stack overflow (SIGABRT):
+//
+// 1. `build_additive`/`build_multiplicative` used to re-derive each
+//    operand's scalar-ness by calling `expr_is_known_scalar` on the
+//    entire *already-accumulated* left-hand tree at every fold step --
+//    O(chain length) native stack on the final step alone. Fixed by
+//    tracking scalar-ness incrementally (O(1) per fold step) instead.
+// 2. Even with (1) fixed, folding N operands left-associatively still
+//    builds an N-deep binary `Expr` tree, and that tree's *own* depth is
+//    what every later recursive pass over it pays for (the validator, any
+//    backend's emit, even plain `Drop` -- none of which cap depth
+//    themselves). No amount of construction-time cleverness bounds an
+//    already-N-deep tree, so `check_chain_length` now rejects a chain
+//    longer than `MAX_EXPR_DEPTH` operands outright, before building
+//    anything -- the same "reject cleanly rather than build something
+//    nobody can safely walk again" principle `MAX_EXPR_DEPTH` already
+//    applies to grammar nesting.
+//
+// These tests are the adversarial repro that caught both bugs, kept as a
+// permanent regression guard: the pathological chain that used to crash
+// must now fail cleanly and quickly, while an ordinary chain well under
+// the cap must still lower correctly.
+
+fn flat_additive_chain_source(terms: usize) -> String {
+    let mut src = String::with_capacity(terms * 2 + 8);
+    src.push_str("y = 1");
+    for _ in 1..terms {
+        src.push_str("+1");
+    }
+    src.push_str(";\n");
+    src
+}
+
+fn flat_multiplicative_chain_source(terms: usize) -> String {
+    let mut src = String::with_capacity(terms * 2 + 8);
+    src.push_str("y = 1");
+    for _ in 1..terms {
+        src.push_str("*1");
+    }
+    src.push_str(";\n");
+    src
+}
+
+#[test]
+fn a_pathologically_long_flat_additive_chain_is_cleanly_rejected() {
+    // 60,000 terms matches the exact size the security review used to
+    // reproduce the crash against the pre-fix code. It must now fail with
+    // a clean, fast error instead of overflowing the native stack.
+    let src = flat_additive_chain_source(60_000);
+    let start = Instant::now();
+    let err = compile_source(&src, "prog")
+        .expect_err("a 60,000-term chain must be rejected, not built into an unwalkable tree");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "rejecting a 60,000-term chain took {elapsed:?} -- expected a fast, early check"
+    );
+    assert!(err.message.contains("too long"));
+}
+
+#[test]
+fn a_pathologically_long_flat_multiplicative_chain_is_cleanly_rejected() {
+    let src = flat_multiplicative_chain_source(60_000);
+    let err = compile_source(&src, "prog")
+        .expect_err("a 60,000-term chain must be rejected, not built into an unwalkable tree");
+    assert!(err.message.contains("too long"));
+}
+
+#[test]
+fn an_ordinary_length_flat_additive_chain_still_lowers_correctly() {
+    // Well under the cap -- confirms the guard doesn't reject legitimate
+    // (if unusually long) hand-written expressions, and that the
+    // incremental scalar-tracking fix still produces the correct fast
+    // path for a chain longer than any single test above it exercises.
+    let src = flat_additive_chain_source(100);
+    let m = compile_ok(&src);
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { value, .. } => {
+            assert!(matches!(value, Expr::BuiltinCall { name, .. } if name == "+"));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
 }

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,110 @@
+//! Structural verification of lowered modules: every module this frontend
+//! produces must pass the shared SIR validator, and any module using the
+//! SIR22 array/matrix domain must be correctly *rejected* by a backend that
+//! does not declare `Feature::NDArrays`/`MatrixOps` — mirroring exactly the
+//! capability-rejection verification pattern used to land SIR22/SIR23
+//! themselves (a real `Module`, checked through the actual
+//! `Backend::check_module` path, not an isolated unit assertion).
+//!
+//! `semantic-ir-to-javascript` does not yet implement codegen for the
+//! SIR22 nodes (`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/
+//! `IndexGet`/`IndexSet` all panic with "not accepted yet" if ever reached
+//! post-check — see that backend's `emit.rs`), so these tests confirm the
+//! *gate* works, not that codegen runs; a genuine array/matrix round-trip
+//! through a real backend is future work tracked separately (see this
+//! crate's README).
+//!
+//! Note on scope: the "scalar fast path" described in `lower.rs`'s module
+//! doc comment only recognises operands built *purely from literals* as
+//! provably scalar — any *variable* (a function parameter, a loop counter,
+//! an accumulator, ...) is never provably scalar without real shape
+//! inference, so ordinary variable arithmetic (`total + i`, `x * x` for a
+//! parameter `x`, ...) always takes the `ElementwiseOp`/`MatMul` path and
+//! therefore always needs `MatrixOps`/`ArrayColumnMajor` declared — even
+//! though, at runtime, such values are almost always genuine scalars. This
+//! is why only a *purely-literal* program can round-trip through the
+//! current JS backend today; seeing `control_flow_and_loops_validate`
+//! below need the array-domain features makes that limitation concrete
+//! rather than a claim in a doc comment.
+
+use matlab_to_semantic_ir::compile_source;
+use semantic_ir::backend::Backend;
+use semantic_ir_to_javascript::JavaScriptBackend;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for `{src}`: {:?}",
+        report.issues
+    );
+    module
+}
+
+#[test]
+fn a_purely_literal_program_validates_and_the_js_backend_accepts_it() {
+    // Every operand on every arithmetic op here is a literal (or built
+    // transitively from one), so `expr_is_known_scalar` holds throughout
+    // and no SIR22 node is ever emitted -- the one shape of MATLAB program
+    // this frontend can currently take all the way through the JS backend.
+    let module = assert_valid("function r = seven()\n  r = 3 + 4;\nend\ndisp(seven());\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a purely-literal module, got: {errors:?}"
+    );
+}
+
+#[test]
+fn control_flow_with_a_variable_accumulator_validates_but_needs_array_features() {
+    let module = assert_valid(
+        "total = 0;\nfor i = 1:10\n  if i > 5\n    total = total + i;\n  end\nend\ndisp(total);\n",
+    );
+    // See the module doc comment above: `total + i` involves two
+    // variables, never provably scalar, so this ordinary accumulator loop
+    // already needs the array-domain features declared.
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::MatrixOps));
+}
+
+#[test]
+fn a_matrix_program_validates_but_the_js_backend_rejects_it() {
+    let module = assert_valid("A = [1 2; 3 4];\nB = A * A;\ndisp(B);\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::MatrixOps));
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        !errors.is_empty(),
+        "expected the JS backend to reject a module using SIR22 array/matrix features \
+         (codegen for them isn't implemented there yet)"
+    );
+}
+
+#[test]
+fn an_indexing_program_validates_but_the_js_backend_rejects_it() {
+    let module = assert_valid("A = [1 2 3];\nA(2) = 9;\ndisp(A(2));\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        !errors.is_empty(),
+        "expected the JS backend to reject a module using IndexGet/IndexSet"
+    );
+}
+
+#[test]
+fn a_range_and_transpose_program_validates_but_the_js_backend_rejects_it() {
+    let module = assert_valid("A = [1 2; 3 4];\nv = 1:5;\nB = A';\ndisp(B);\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        !errors.is_empty(),
+        "expected the JS backend to reject a module using Range/Transpose"
+    );
+}

--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -91,10 +91,23 @@ pub fn compile_source(source: &str, module_name: &str)
     -> Result<semantic_ir::Module, <Lang>LowerError>;
 ```
 
-- **`matlab-to-semantic-ir`** — walks the `matlab-parser` CST, emits SIR22
-  (array/matrix domain) nodes. 1-based-to-0-based index translation happens
-  here, at lowering time — per SIR10's "disambiguation is the frontend's
-  job," the IR never carries a language's indexing convention implicitly.
+- **`matlab-to-semantic-ir`** (✅ v0.1.0 shipped) — walks the `matlab-parser`
+  CST, emits SIR22 (array/matrix domain) nodes. 1-based-to-0-based index
+  translation happens here, at lowering time — per SIR10's "disambiguation
+  is the frontend's job," the IR never carries a language's indexing
+  convention implicitly. A well-scoped first cut (literals, assignment,
+  arithmetic/comparison/logical operators, ranges, transpose, indexing,
+  `if`/`while`/`for`, single-output functions, `disp`) rather than full
+  MATLAB — each excluded construct (stepped/matrix-valued `for`,
+  `end`-relative indexing, matrix division, multi-output functions, nested
+  functions, `break`/`continue`/`return`, `switch`/`try`/`global`, cell
+  arrays, lambdas) returns an explicit error rather than being silently
+  mis-lowered. Scalar-vs-array disambiguation for `+ - * / \ ^` is a
+  syntactic heuristic on literal operands only (real shape inference is a
+  follow-up), which means only *purely-literal* MATLAB arithmetic currently
+  round-trips through the JS backend (SIR22 codegen for the array-domain
+  nodes is separate, not-yet-shipped follow-on work — the frontend/backend
+  split described in this spec).
 - **`octave-to-semantic-ir`** — a thin wrapper: run `octave-runtime`'s
   existing `octavify` source-rewrite shim, then delegate to
   `matlab-to-semantic-ir::compile_source`. Mirrors how `octave-runtime`


### PR DESCRIPTION
## Summary
- First frontend to target [SIR22](code/specs/SIR22-array-matrix-semantic-ir.md) (array/matrix domain): lowers `coding-adventures-matlab-parser`'s `GrammarASTNode` CST into a `semantic_ir::Module`.
- Well-scoped v0.1.0: literals, assignment, arithmetic/comparison/logical operators, ranges, transpose, indexing (1-based → 0-based at lowering time), `if`/`while`/`for`, single-output functions, `disp`. Every excluded construct (stepped/matrix-valued `for`, `end`-relative indexing, matrix division, multi-output functions, nested functions, `break`/`continue`/`return`, `switch`/`try`/`global`, cell arrays, lambdas, chained assignment) returns an explicit `MatlabLowerError` rather than being silently mis-lowered.
- Scalar/array disambiguation for MATLAB's shape-polymorphic `+ - * / \ ^` is a conservative syntactic heuristic (`expr_is_known_scalar`) on the lowered expression tree — literal-derived operands take a plain `BuiltinCall`, everything else takes the SIR22 `ElementwiseOp`/`MatMul` path. Ordinary variable arithmetic always needs the array-domain features declared, even for a genuine runtime scalar — a disclosed limitation, not a bug (see `tests/test_validator.rs`).
- Marks `matlab-to-semantic-ir` done in `HML01-math-to-semantic-ir.md` §3. Front 3 (SIR) rotation turn.

## Security
Two rounds of `/security-review`. Round 1 found and this PR fixes:
- **HIGH**: a flat, unparenthesized arithmetic chain (`1+1+1+...`) crashed with a real stack overflow at 60,000 terms — `MAX_EXPR_DEPTH`'s grammar-nesting guard never engages for a flat chain since the grammar doesn't nest it. Fixed by tracking scalar-ness incrementally (was re-walking the whole accumulated tree per fold step) *and* capping the operand count itself (`check_chain_length`) before building an unwalkably-deep tree at all.
- **MEDIUM** (masked today by `matlab-parser`'s own nesting cap, not this crate's): index/call arguments reset the expression-depth counter instead of threading it, so nested indexing (`A(A(A(...))))`) never accumulated against the depth guard. Fixed by threading depth through, mirroring `python-to-semantic-ir`'s pattern.
- **LOW** (test-only): predictable temp-file path in the e2e harness, hardened with `create_new`.

Round 2 confirmed all three fixed and empirically re-tested (including chain types round 1 didn't cover) — passed clean.

## Test plan
- [x] `cargo test -p matlab-to-semantic-ir` — 66/66 pass (57 unit, 5 validator/capability-rejection, 3 real `node`-execution e2e, 1 doctest)
- [x] `cargo clippy -p matlab-to-semantic-ir --all-targets` — zero warnings on this crate
- [x] Permanent regression tests reproduce the exact 60,000-term crash and confirm clean, fast rejection
- [x] Two independent `/security-review` rounds, round 2 passed clean
- [x] Spec (`HML01-math-to-semantic-ir.md`) kept in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)