### PR TITLE
feat(sha256-native): Kotlin native-through-Rust binding (reuses sha256_native_jni)

### DIFF
--- a/code/packages/kotlin/sha256-native/.gitignore
+++ b/code/packages/kotlin/sha256-native/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/sha256-native/BUILD
+++ b/code/packages/kotlin/sha256-native/BUILD
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release && gradle test

--- a/code/packages/kotlin/sha256-native/BUILD_windows
+++ b/code/packages/kotlin/sha256-native/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build --manifest-path ..\..\rust\Cargo.toml -p sha256-native-jni --release && gradle test

--- a/code/packages/kotlin/sha256-native/CHANGELOG.md
+++ b/code/packages/kotlin/sha256-native/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog — sha256-native (Kotlin)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: native-through-Rust SHA-256 for Kotlin — establishes the
+  Kotlin JVM native pattern, **reusing the existing `sha256_native_jni` cdylib**
+  (from `java/sha256-native`) with no new Rust crate and no workspace change.
+- `Sha256Native.sha256` / `sha256Hex` and a streaming `Hasher` (`AutoCloseable`,
+  `Cleaner`-managed native handle) with `update` / non-destructive `digest` /
+  `hexDigest` / `copy`.
+- Kotlin `object Native` `external` functions resolve to the same
+  `Java_com_codingadventures_sha256native_Native_*` JNI exports as the Java
+  binding.
+- 8 tests through JNI: FIPS 180-4 vectors (incl. one-million-'a'), digest size,
+  streaming parity, byte-at-a-time, non-destructive digest, copy independence,
+  closed-handle guarding. `gradle test` green against the shared cdylib.

--- a/code/packages/kotlin/sha256-native/README.md
+++ b/code/packages/kotlin/sha256-native/README.md
@@ -1,0 +1,34 @@
+# sha256-native (Kotlin)
+
+**Native-through-Rust** SHA-256 for Kotlin — companion to the pure-Kotlin
+`sha256` package. Calls the Rust `coding_adventures_sha256` crate through JNI,
+**reusing the exact same `sha256_native_jni` cdylib as `java/sha256-native`** —
+no new Rust crate.
+
+Kotlin's `object Native` `external` functions resolve to the same
+`Java_com_codingadventures_sha256native_Native_*` exports, so the one Rust JNI
+library serves both the Java and Kotlin bindings.
+
+## API (`com.codingadventures.sha256native.Sha256Native`)
+
+```kotlin
+Sha256Native.sha256Hex("abc".toByteArray())
+// ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+Sha256Native.Hasher().use { h ->
+    h.update("ab".toByteArray())
+    h.update("c".toByteArray())
+    h.hexDigest()          // same digest, incremental
+}
+```
+
+`sha256(ByteArray) -> ByteArray`, `sha256Hex(ByteArray) -> String`, and a
+`Hasher` (`AutoCloseable`, `Cleaner`-managed handle) with `update` /
+non-destructive `digest` / `hexDigest` / `copy`.
+
+## Building
+
+```
+cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release
+gradle test   # sets -Djava.library.path to rust/target/release
+```

--- a/code/packages/kotlin/sha256-native/build.gradle.kts
+++ b/code/packages/kotlin/sha256-native/build.gradle.kts
@@ -1,0 +1,38 @@
+// Kotlin sha256 native binding — JNI over the Rust `sha256_native_jni` cdylib
+// (the SAME cdylib used by java/sha256-native; no new Rust crate). Build it:
+//   cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    val rustReleaseDir = projectDir.parentFile.parentFile
+        .resolve("rust/target/release")
+        .absolutePath
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+    testLogging { events("passed", "skipped", "failed") }
+}

--- a/code/packages/kotlin/sha256-native/required_capabilities.json
+++ b/code/packages/kotlin/sha256-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://coding-adventures.example/schemas/required_capabilities/v1.json",
+  "version": 1,
+  "package": "kotlin/sha256-native",
+  "capabilities": ["ffi:call"],
+  "justification": "ffi:call — loads the sha256_native_jni cdylib via System.loadLibrary and calls its JNI methods to compute SHA-256 in Rust. No network, filesystem, or process access."
+}

--- a/code/packages/kotlin/sha256-native/settings.gradle.kts
+++ b/code/packages/kotlin/sha256-native/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "sha256-native"

--- a/code/packages/kotlin/sha256-native/src/main/kotlin/com/codingadventures/sha256native/Native.kt
+++ b/code/packages/kotlin/sha256-native/src/main/kotlin/com/codingadventures/sha256native/Native.kt
@@ -1,0 +1,20 @@
+package com.codingadventures.sha256native
+
+/**
+ * JNI bindings to the `sha256_native_jni` Rust cdylib (shared with
+ * `java/sha256-native`), which wraps `coding_adventures_sha256`. The external
+ * methods resolve to the same `Java_com_codingadventures_sha256native_Native_*`
+ * exports, so Kotlin reuses the existing cdylib with no new Rust crate.
+ */
+internal object Native {
+    init {
+        System.loadLibrary("sha256_native_jni")
+    }
+
+    external fun nativeDigest(data: ByteArray): ByteArray
+    external fun nativeHasherNew(): Long
+    external fun nativeHasherUpdate(handle: Long, data: ByteArray)
+    external fun nativeHasherDigest(handle: Long): ByteArray
+    external fun nativeHasherClone(handle: Long): Long
+    external fun nativeHasherFree(handle: Long)
+}

--- a/code/packages/kotlin/sha256-native/src/main/kotlin/com/codingadventures/sha256native/Sha256Native.kt
+++ b/code/packages/kotlin/sha256-native/src/main/kotlin/com/codingadventures/sha256native/Sha256Native.kt
@@ -1,0 +1,82 @@
+package com.codingadventures.sha256native
+
+import java.lang.ref.Cleaner
+
+/**
+ * Native-through-Rust SHA-256 for Kotlin — the companion to the pure-Kotlin
+ * `sha256` package. Calls the Rust `coding_adventures_sha256` crate through JNI,
+ * reusing the same `sha256_native_jni` cdylib as `java/sha256-native`.
+ */
+object Sha256Native {
+
+    private val cleaner: Cleaner = Cleaner.create()
+    private const val HEX = "0123456789abcdef"
+
+    /** The 32-byte SHA-256 digest of [data] (computed in Rust). */
+    fun sha256(data: ByteArray): ByteArray = Native.nativeDigest(data)
+
+    /** The 64-character lowercase hex digest of [data] (computed in Rust). */
+    fun sha256Hex(data: ByteArray): String = toHex(sha256(data))
+
+    internal fun toHex(bytes: ByteArray): String {
+        val out = CharArray(bytes.size * 2)
+        for (i in bytes.indices) {
+            val v = bytes[i].toInt() and 0xff
+            out[i * 2] = HEX[v ushr 4]
+            out[i * 2 + 1] = HEX[v and 0x0f]
+        }
+        return String(out)
+    }
+
+    /**
+     * A streaming SHA-256 hasher backed by a native Rust hasher. [AutoCloseable];
+     * the native handle is freed by [close] (idempotent) with a [Cleaner] net.
+     * [digest] is non-destructive.
+     */
+    class Hasher private constructor(handle: Long) : AutoCloseable {
+
+        // The handle lives in a separate holder so the Cleaner action does not
+        // capture the Hasher (which would keep it reachable and defeat the GC).
+        private class State(@JvmField var handle: Long) : Runnable {
+            override fun run() {
+                if (handle != 0L) {
+                    Native.nativeHasherFree(handle)
+                    handle = 0L
+                }
+            }
+        }
+
+        private val state = State(handle)
+        private val cleanable: Cleaner.Cleanable = cleaner.register(this, state)
+
+        constructor() : this(Native.nativeHasherNew())
+
+        private fun checkOpen() {
+            check(state.handle != 0L) { "hasher is closed" }
+        }
+
+        /** Feed more bytes into the hash. */
+        fun update(data: ByteArray) {
+            checkOpen()
+            Native.nativeHasherUpdate(state.handle, data)
+        }
+
+        /** The 32-byte digest of all data fed so far (non-destructive). */
+        fun digest(): ByteArray {
+            checkOpen()
+            return Native.nativeHasherDigest(state.handle)
+        }
+
+        /** The 64-character lowercase hex digest string. */
+        fun hexDigest(): String = toHex(digest())
+
+        /** An independent copy of this hasher (its own native handle). */
+        fun copy(): Hasher {
+            checkOpen()
+            return Hasher(Native.nativeHasherClone(state.handle))
+        }
+
+        /** Free the native handle. Idempotent. */
+        override fun close() = cleanable.clean()
+    }
+}

--- a/code/packages/kotlin/sha256-native/src/test/kotlin/com/codingadventures/sha256native/Sha256NativeTest.kt
+++ b/code/packages/kotlin/sha256-native/src/test/kotlin/com/codingadventures/sha256native/Sha256NativeTest.kt
@@ -1,0 +1,72 @@
+package com.codingadventures.sha256native
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class Sha256NativeTest {
+    private fun a(s: String) = s.toByteArray(Charsets.UTF_8)
+
+    @Test fun fipsVectors() {
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Sha256Native.sha256Hex(a("")))
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", Sha256Native.sha256Hex(a("abc")))
+        assertEquals("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+            Sha256Native.sha256Hex(a("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")))
+    }
+
+    @Test fun millionA() {
+        val data = ByteArray(1_000_000) { 'a'.code.toByte() }
+        assertEquals("cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0", Sha256Native.sha256Hex(data))
+    }
+
+    @Test fun digestIs32Bytes() {
+        assertEquals(32, Sha256Native.sha256(a("")).size)
+        assertEquals(32, Sha256Native.sha256(a("hello world")).size)
+    }
+
+    @Test fun streamingMatchesOneShot() {
+        Sha256Native.Hasher().use { h ->
+            h.update(a("ab")); h.update(a("c"))
+            assertContentEquals(Sha256Native.sha256(a("abc")), h.digest())
+        }
+    }
+
+    @Test fun streamingByteAtATime() {
+        val data = ByteArray(100) { it.toByte() }
+        Sha256Native.Hasher().use { h ->
+            for (x in data) h.update(byteArrayOf(x))
+            assertContentEquals(Sha256Native.sha256(data), h.digest())
+        }
+    }
+
+    @Test fun streamingEmptyAndNonDestructive() {
+        Sha256Native.Hasher().use { e -> assertContentEquals(Sha256Native.sha256(a("")), e.digest()) }
+        Sha256Native.Hasher().use { h ->
+            h.update(a("abc"))
+            assertContentEquals(h.digest(), h.digest())
+            h.update(a("d"))
+            assertContentEquals(Sha256Native.sha256(a("abcd")), h.digest())
+        }
+    }
+
+    @Test fun copyIsIndependent() {
+        Sha256Native.Hasher().use { h ->
+            h.update(a("ab"))
+            h.copy().use { h2 ->
+                h2.update(a("c")); h.update(a("x"))
+                assertContentEquals(Sha256Native.sha256(a("abc")), h2.digest())
+                assertContentEquals(Sha256Native.sha256(a("abx")), h.digest())
+            }
+        }
+    }
+
+    @Test fun usingClosedThrows() {
+        val h = Sha256Native.Hasher()
+        h.update(a("abc"))
+        h.close()
+        assertFailsWith<IllegalStateException> { h.update(a("x")) }
+        assertFailsWith<IllegalStateException> { h.digest() }
+        h.close()
+    }
+}


### PR DESCRIPTION
## What

Establishes the **Kotlin JVM native pattern** — and demonstrates that Kotlin **reuses the existing `sha256_native_jni` cdylib** (from `java/sha256-native`, already on `main`) with **no new Rust crate and no `Cargo.toml` change**. One JNI library now serves both the Java and Kotlin bindings.

Kotlin's `object Native` `external` functions resolve to the same `Java_com_codingadventures_sha256native_Native_*` exports (the Rust side ignores the second JNI arg, so an object's instance-method mangling works unchanged). `Sha256Native` wrapper: `sha256`/`sha256Hex` + a `Hasher` (`AutoCloseable`, `Cleaner`-managed handle) with `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Why it matters

This is the leanest native binding in the campaign — pure reuse of already-merged Rust infrastructure. It proves the `jni-bridge` cdylib is genuinely shared across the JVM languages, exactly as intended.

## Verification

- **8 tests through JNI** (`kotlin.test`) — FIPS 180-4 vectors (incl. one-million-'a'), digest size, streaming parity, byte-at-a-time, non-destructive digest, copy independence, closed-handle guarding. `gradle test` green against the shared cdylib — **confirms Kotlin JNI symbol resolution works with zero `UnsatisfiedLinkError`**.
- **Security review passed** (Kotlin side; Rust reused + previously reviewed): `Cleaner` action holds the handle in a separate `State` (no `Hasher` capture), `close()` frees exactly once (idempotent `Cleanable.clean` + `handle != 0L` guard), `copy()` clones a fresh handle (no aliasing), `checkOpen` guards post-close use, `toHex` sign-safe.

BUILD: `cargo build --manifest-path ../../rust/Cargo.toml -p sha256-native-jni --release && gradle test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)