### PR TITLE
feat(sir-runtime-oop): Hash Enumerable breadth (group_by/partition/flat_map/reduce/inject/sum) — final backend

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.20] - 2026-07-11
+
+### Added
+
+- **`Hash` Enumerable breadth** (`hashBlockMethod` + `HASH_BLOCK_METHODS`):
+  `group_by`, `partition`, `flat_map`/`collect_concat`, `reduce`/`inject`, `sum`
+  — the FINAL backend of this cross-backend batch (Python reference #7978, then
+  Go #7983 / Rust #7989 / JS #7993). Ruby's `Hash` mixes in `Enumerable`, so
+  these iterate the hash as `[key, value]` pairs and yield the two-arg
+  `(key, value)` **except** `reduce`/`inject`, which follow Ruby's memo
+  convention and yield `(memo, [k, v])` — the pair as ONE argument.
+  - `group_by { |k, v| key }` → a Hash (`Map`) of block key → Array of the
+    `[k, v]` pairs that produced it, in first-seen key order.
+  - `partition { |k, v| pred }` → `[[matching pairs], [rest pairs]]`.
+  - `flat_map`/`collect_concat { |k, v| … }` → map then concatenate one level.
+  - `reduce`/`inject` → memo fold; explicit seed or first pair; empty seedless
+    → `nil`.
+  - `sum(init = 0) { |k, v| … }` → numeric fold seeded at `0` (or the seed arg).
+
+### Changed
+
+- **`hashBlockMethod` signature** now takes `(recv, name, args, block)` (was
+  `(recv, name, block)`), and the dispatch call site passes the positional args
+  before the block — so `reduce`/`sum` can read a seed argument. Mirrors the
+  same change the Python reference made in #7978. `arrayBlockMethod` already had
+  this shape.
+
 ## [0.1.19] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -75,7 +75,10 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 (proc-lenient), predicates routed through SIR `truthy`; (item **M1c**) the
 **`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/
 `select`/`transform_values`/`transform_keys`/ Enumerable aggregates
-`find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/…); and (item **M1c**) the
+`find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by` and Enumerable
+breadth `group_by`/`partition`/`flat_map`/`collect_concat`/`reduce`/`inject`/`sum`
+(all yielding the `[k, v]` pair; `reduce`/`inject` use Ruby's `(memo, pair)`
+convention)/…); and (item **M1c**) the
 **`String`** catalog (`length`,
 `upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
 `chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -632,6 +632,13 @@ const HASH_BLOCK_METHODS = new Set<string>([
   "sort_by",
   "min_by",
   "max_by",
+  "group_by",
+  "partition",
+  "flat_map",
+  "collect_concat",
+  "reduce",
+  "inject",
+  "sum",
 ]);
 
 // Non-block `String` methods (M1c).  A Ruby `String` is a JS `string`, which is
@@ -1230,7 +1237,12 @@ function hashMethod(recv: Map<Val, Val>, name: string, args: Val[]): Val | typeo
 
 /** Block-taking `Hash` methods; the block receives `[key, value]` (or a single
  * key/value for `each_key`/`each_value`). Returns `MISS` if not a block method. */
-function hashBlockMethod(recv: Map<Val, Val>, name: string, block: Closure): Val | typeof MISS {
+function hashBlockMethod(
+  recv: Map<Val, Val>,
+  name: string,
+  args: Val[],
+  block: Closure,
+): Val | typeof MISS {
   switch (name) {
     case "each":
     case "each_pair":
@@ -1326,6 +1338,76 @@ function hashBlockMethod(recv: Map<Val, Val>, name: string, block: Closure): Val
         }
       }
       return bestPair;
+    }
+    // ── Enumerable breadth (block-taking reshape / fold) ─────────────────────
+    //
+    // Same `[key, value]`-pair iteration as the aggregates: every method yields
+    // `(key, value)` EXCEPT `reduce`/`inject`, which follow Ruby's memo
+    // convention and yield `(memo, pair)` — the `[k, v]` Array as ONE argument.
+    case "group_by": {
+      // A Hash (`Map`) of block key -> Array of the `[k, v]` pairs that produced
+      // it, in first-seen key order (mirrors Array#group_by, which also returns
+      // a Map).
+      const groups = new Map<Val, Val>();
+      for (const [k, v] of [...recv]) {
+        const key = apply(block, [k, v]);
+        const bucket = groups.get(key);
+        if (Array.isArray(bucket)) bucket.push([k, v]);
+        else groups.set(key, [[k, v]]);
+      }
+      return groups;
+    }
+    case "partition": {
+      // `[[matching pairs], [rest pairs]]`, each a fresh Array of `[k, v]` pairs.
+      const yes: Val[] = [];
+      const no: Val[] = [];
+      for (const [k, v] of [...recv]) {
+        if (truthy(apply(block, [k, v]))) yes.push([k, v]);
+        else no.push([k, v]);
+      }
+      return [yes, no];
+    }
+    case "flat_map":
+    case "collect_concat": {
+      // Map each pair then concatenate one level: an Array result splices its
+      // elements, a scalar is appended as-is.
+      const out: Val[] = [];
+      for (const [k, v] of [...recv]) {
+        const mapped = apply(block, [k, v]);
+        if (Array.isArray(mapped)) out.push(...mapped);
+        else out.push(mapped);
+      }
+      return out;
+    }
+    case "reduce":
+    case "inject": {
+      // Ruby's memo fold.  Unlike every other method here (which yields the
+      // two-arg pair), `reduce` yields `(memo, pair)` — the `[k, v]` Array as
+      // ONE argument.  With an explicit seed the fold starts there; without one
+      // it seeds from the first pair; an empty seedless reduce is `nil`.
+      const pairs: Val[] = [...recv].map(([k, v]: [Val, Val]): Val => [k, v]);
+      let acc: Val;
+      let rest: Val[];
+      if (args.length > 0) {
+        acc = args[0];
+        rest = pairs;
+      } else if (pairs.length > 0) {
+        acc = pairs[0];
+        rest = pairs.slice(1);
+      } else {
+        return null;
+      }
+      for (const pair of rest) acc = apply(block, [acc, pair]);
+      return acc;
+    }
+    case "sum": {
+      // Numeric fold seeded at `0` (or the explicit seed arg) over the block
+      // results — the same `+` accumulation Array#sum uses.
+      let acc: Val = args.length > 0 ? args[0] : 0;
+      for (const [k, v] of [...recv]) {
+        acc = (acc as number) + (apply(block, [k, v]) as number);
+      }
+      return acc;
     }
     default:
       return MISS;
@@ -1918,7 +2000,7 @@ export function callMethod(recv: Val, name: string, ...args: Val[]): Val {
   } else if (recv instanceof Map) {
     const last = args[args.length - 1];
     if (HASH_BLOCK_METHODS.has(name) && args.length > 0 && last instanceof Closure) {
-      const blkResult = hashBlockMethod(recv, name, last);
+      const blkResult = hashBlockMethod(recv, name, args.slice(0, -1), last);
       if (blkResult !== MISS) return blkResult;
     }
     const hashResult = hashMethod(recv, name, args);

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -593,6 +593,57 @@ describe("built-in method catalog: Hash (M1c)", () => {
     ]);
   });
 
+  it("block Enumerable breadth (group_by/partition/flat_map/reduce/inject/sum)", () => {
+    // Hash mixes in Enumerable: every method yields [key, value] EXCEPT
+    // reduce/inject, which follow Ruby's memo convention and yield (memo, pair)
+    // — the [k, v] pair as ONE argument.  Mirrors the Python (#7978), Go
+    // (#7983), Rust (#7989), and JS (#7993) references.
+    const h = new Map<Val, Val>([["a", 1], ["b", 2], ["c", 3], ["d", 4]]);
+    const isEven = new Closure((k: Val, v: Val) => (v as number) % 2 === 0);
+    // group_by → a Hash: block key -> Array of [k, v] pairs (first-seen order).
+    expect(callMethod(h, "group_by", isEven)).toEqual(
+      new Map<Val, Val>([
+        [false, [["a", 1], ["c", 3]]],
+        [true, [["b", 2], ["d", 4]]],
+      ]),
+    );
+    // partition → [[matching pairs], [rest pairs]].
+    expect(callMethod(h, "partition", isEven)).toEqual([
+      [["b", 2], ["d", 4]],
+      [["a", 1], ["c", 3]],
+    ]);
+    // flat_map { |k, v| [k, v] } → one-level splice.
+    expect(
+      callMethod(
+        new Map<Val, Val>([["a", 1], ["b", 2]]),
+        "flat_map",
+        new Closure((k: Val, v: Val) => [k, v]),
+      ),
+    ).toEqual(["a", 1, "b", 2]);
+    // sum { |k, v| v } → 10 (seed defaults to 0).
+    expect(callMethod(h, "sum", new Closure((k: Val, v: Val) => v))).toBe(10);
+    // reduce(100) { |acc, pair| acc + pair[1] } → 110 (memo yields the pair).
+    expect(
+      callMethod(h, "reduce", 100, new Closure((acc: Val, pair: Val) => (acc as number) + ((pair as Val[])[1] as number))),
+    ).toBe(110);
+    // inject seedless { |acc, pair| … } seeds from the first [k, v] pair.
+    expect(
+      callMethod(
+        new Map<Val, Val>([["a", 1], ["b", 2]]),
+        "inject",
+        new Closure((acc: Val, pair: Val) => [(acc as Val[])[0], ((acc as Val[])[1] as number) + ((pair as Val[])[1] as number)]),
+      ),
+    ).toEqual(["a", 3]);
+    // Empty seedless reduce → nil; receiver unchanged throughout.
+    expect(callMethod(new Map<Val, Val>(), "reduce", new Closure((a: Val, p: Val) => a))).toBeNull();
+    expect([...h.entries()]).toEqual([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+      ["d", 4],
+    ]);
+  });
+
   it("respond_to? honesty + nil floor", () => {
     const h = new Map<Val, Val>([["a", 1]]);
     expect(callMethod(h, "respond_to?", "keys")).toBe(true);


### PR DESCRIPTION
Mirrors the Python reference ([#7978](https://github.com/adhithyan15/coding-adventures/pull/7978)), Go ([#7983](https://github.com/adhithyan15/coding-adventures/pull/7983)), Rust ([#7989](https://github.com/adhithyan15/coding-adventures/pull/7989)), and JS ([#7993](https://github.com/adhithyan15/coding-adventures/pull/7993)) into the **TS reference library** (`@coding-adventures/sir-runtime-oop`) — **completing the Hash Enumerable breadth cascade across all five backends**.

Ruby's `Hash` mixes in `Enumerable`, so every method iterates the hash as `[k, v]` pairs and yields the two-arg `(k, v)` **except** `reduce`/`inject`, which follow Ruby's memo convention and yield `(memo, [k, v])` — the pair as ONE argument.

## Methods (`hashBlockMethod` + `HASH_BLOCK_METHODS`)
- `group_by { |k,v| key }` → `Map`: key → Array of `[k,v]` pairs (first-seen order)
- `partition { |k,v| pred }` → `[[matching pairs], [rest pairs]]`
- `flat_map`/`collect_concat { |k,v| … }` → one-level concat
- `reduce`/`inject` → memo fold; explicit seed or first pair; empty seedless → `nil`
- `sum(init=0) { |k,v| … }` → numeric fold over block results

## Signature change (mirrors Python #7978)
`hashBlockMethod` now takes `(recv, name, args, block)` — was `(recv, name, block)` — and the dispatch call site passes `args.slice(0, -1)` (positional args before the block) so `reduce`/`sum` can read a seed argument. `arrayBlockMethod` already had this shape.

## Tests
New vitest `block Enumerable breadth` case asserts return values for group_by/partition/flat_map/sum/`reduce(100)`/seedless-`inject`, empty-reduce → `nil`, and receiver-unchanged. Full suite green (**116 tests**). Version 0.1.19 → 0.1.20; CHANGELOG + README updated. Security review passed.

Note: the TS lib's `rubyInspect` already renders a Hash correctly (its own `{k=>v}` inspect convention), so no display change was needed here (unlike the JS backend). Pre-existing tsc `@types/node` + strict-null noise in the unchanged `min_by`/`max_by` arms is unrelated (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)