### PR TITLE
feat(cobol): IF conditional branching + parser depth-cap DoS fix (PL08 v0.4)

### DIFF
--- a/code/packages/rust/cobol-parser/CHANGELOG.md
+++ b/code/packages/rust/cobol-parser/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.1 — depth-cap hardening
+
+- **Security (DoS):** opt into the shared parser's recursion-depth cap
+  (`DEFAULT_MAX_RULE_DEPTH`) in both `create_cobol_parser` and `try_parse_cobol`.
+  Deeply-nested syntax (e.g. thousands of nested `IF … IF … IF …`) recurses once
+  per level through the generic `parse_rule`; without the cap it overflowed the
+  *native* stack — an uncatchable `SIGSEGV`/abort that a `Result`-returning entry
+  point cannot report. It now surfaces as a recoverable "input nests deeper than
+  the supported limit" parse error. Regression test added.
+
 ## 0.1.0 — COBOL-60 parser (PL07)
 
 - Grammar-driven parser over `code/grammars/cobol/cobol.grammar`, wrapping

--- a/code/packages/rust/cobol-parser/Cargo.toml
+++ b/code/packages/rust/cobol-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Parser for COBOL-60 — parses COBOL source into a generic parse tree using the grammar-driven parser and the cobol.grammar file."
 

--- a/code/packages/rust/cobol-parser/src/lib.rs
+++ b/code/packages/rust/cobol-parser/src/lib.rs
@@ -34,16 +34,22 @@
 //! - [`try_parse_cobol`] — the fully fallible form (lexical *and* parse errors → `Err`).
 
 use coding_adventures_cobol_lexer::{tokenize_cobol, try_tokenize_cobol};
-use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser, DEFAULT_MAX_RULE_DEPTH};
 
 mod _grammar;
 
 /// Create a [`GrammarParser`] wired to the COBOL grammar and tokens (with the
 /// lexer's column-strip hook), ready to call `.parse()`. Uses the panicking
 /// tokenizer; for the fully fallible path use [`try_parse_cobol`].
+///
+/// The parser opts into the shared recursion-depth cap
+/// ([`DEFAULT_MAX_RULE_DEPTH`]). Deeply-nested syntax — e.g. hundreds of nested
+/// `IF … IF … IF …` — recurses once per level through `parse_rule`; without a
+/// cap that overflows the *native* stack, an uncatchable process abort. With
+/// the cap it surfaces as a recoverable [`GrammarParseError`] instead.
 pub fn create_cobol_parser(source: &str) -> GrammarParser {
     let tokens = tokenize_cobol(source);
-    GrammarParser::new(tokens, _grammar::parser_grammar())
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(DEFAULT_MAX_RULE_DEPTH)
 }
 
 /// Parse COBOL-60 `source` into a [`GrammarASTNode`] CST rooted at `"program"`.
@@ -59,6 +65,7 @@ pub fn parse_cobol(source: &str) -> GrammarASTNode {
 pub fn try_parse_cobol(source: &str) -> Result<GrammarASTNode, String> {
     let tokens = try_tokenize_cobol(source)?;
     GrammarParser::new(tokens, _grammar::parser_grammar())
+        .with_max_depth(DEFAULT_MAX_RULE_DEPTH)
         .parse()
         .map_err(|e| format!("{e}"))
 }
@@ -284,6 +291,32 @@ mod tests {
     fn missing_procedure_division_is_error() {
         let src = program(&["IDENTIFICATION DIVISION.", "PROGRAM-ID. P."]);
         assert!(try_parse_cobol(&src).is_err());
+    }
+
+    /// Deeply-nested `IF … IF … IF …` recurses once per level through the
+    /// generic `parse_rule`. Without the depth cap this overflows the native
+    /// stack — an uncatchable process abort. With [`DEFAULT_MAX_RULE_DEPTH`]
+    /// (opted into by [`create_cobol_parser`] / [`try_parse_cobol`]) it must
+    /// come back as a recoverable `Err`. One `IF` per card so the fixed
+    /// 80-column format doesn't truncate them; a statement flows freely across
+    /// cards, so the nest is genuinely deep. 4096 levels is far past the cap.
+    #[test]
+    fn deeply_nested_if_is_a_clean_error_not_a_stack_overflow() {
+        let mut lines: Vec<String> = vec![
+            "IDENTIFICATION DIVISION.".into(),
+            "PROGRAM-ID. P.".into(),
+            "PROCEDURE DIVISION.".into(),
+            "MAIN.".into(),
+        ];
+        for _ in 0..4096 {
+            lines.push("    IF GROSS-PAY IS GREATER THAN ZERO".into());
+        }
+        lines.push("        DISPLAY ZERO.".into());
+        lines.push("    STOP RUN.".into());
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let err = try_parse_cobol(&program(&refs)).unwrap_err();
+        assert!(err.to_lowercase().contains("nest") || err.to_lowercase().contains("depth"),
+            "depth refusal should be self-explanatory, got: {err}");
     }
 
     /// A lexical error (stray `@` in the code area) surfaces as an `Err`.

--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -13,6 +13,10 @@
   stop-flag that unwinds nested IFs).
 - Remaining control flow (`PERFORM`, `GO TO`, `EVALUATE`, `END-IF`) and `COMPUTE`
   stay deferred. Roadmap in PL08.
+- **DoS hardening:** deeply-nested `IF … IF … IF …` (the first construct that
+  nests) can no longer overflow the native stack — `cobol-parser` 0.1.1 opts into
+  the parser's depth cap, so it returns a clean parse error end to end.
+  Regression test added here too.
 
 
 ## 0.3.0 — DIVIDE (PL08)

--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.0 — IF / conditional branching (PL08)
+
+- `IF cond THEN… [ELSE …]` with the current grammar's simple relational
+  condition (`[IS] [NOT] (GREATER [THAN] | LESS [THAN] | EQUAL [TO])`).
+- Comparison is **numeric** when both operands are numeric (exact, digit-string
+  based — any size, sign-aware, differing fraction lengths compare equal) and
+  **alphanumeric** otherwise (space-padded to equal length, COBOL's rule);
+  figurative constants take the other operand's category/length.
+- Both branches may hold multiple statements; branches nest, and a `STOP RUN`
+  inside a branch ends the whole program (statement execution now returns a
+  stop-flag that unwinds nested IFs).
+- Remaining control flow (`PERFORM`, `GO TO`, `EVALUATE`, `END-IF`) and `COMPUTE`
+  stay deferred. Roadmap in PL08.
+
+
 ## 0.3.0 — DIVIDE (PL08)
 
 - `DIVIDE a INTO b [GIVING g]` — result = b / a. Fixed-point division computed to

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -23,8 +23,9 @@ numeric-display (`9`/`V`) and character (`X`/`A`) pictures; the item tree from
 level numbers; `VALUE` initialisation; figurative `ZERO`/`SPACE`; `MOVE` with
 the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; and fixed-point
 decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
-toward zero into the receiver; divide-by-zero is a clean error). Anything not yet
-modelled (signed `S`, `COMPUTE`, `ROUNDED`/`ON SIZE ERROR`, editing pictures,
-`COMP`, `PERFORM`, tables, files, and every other verb) returns a descriptive
+toward zero into the receiver; divide-by-zero is a clean error); and `IF … ELSE`
+with numeric and alphanumeric comparison. Anything not yet modelled (signed `S`,
+`COMPUTE`, `ROUNDED`/`ON SIZE ERROR`, editing pictures, `COMP`, `PERFORM`,
+`GO TO`, `EVALUATE`, tables, files, and every other verb) returns a descriptive
 `RuntimeError` — never wrong output. See PL08 for the roadmap toward full COBOL
 and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -3,7 +3,7 @@
 
 use crate::error::RuntimeError;
 use crate::picture::Picture;
-use crate::program::{Fig, Lit, Operand, Program, Stmt};
+use crate::program::{Cond, Fig, Lit, Operand, Program, RelOp, Stmt};
 use crate::value::{add, div, move_into_char, move_into_numeric, mul, sub, Decimal};
 use std::collections::HashMap;
 
@@ -28,6 +28,25 @@ enum Src {
 /// rather than panicking or wrapping.
 fn checked(r: Option<Decimal>) -> Result<Decimal, RuntimeError> {
     r.ok_or_else(|| RuntimeError::Unsupported("arithmetic overflow (result exceeds ~38 digits)".into()))
+}
+
+/// The character form of a source value for an alphanumeric comparison (a
+/// figurative yields `""` here — it is expanded to the other operand's length
+/// by the caller).
+fn src_chars(src: &Src) -> String {
+    match src {
+        Src::Chars(s) => s.clone(),
+        Src::Num(d) => d.digits(),
+        Src::Fig(_) => String::new(),
+    }
+}
+
+/// Expand a figurative constant to `n` characters.
+fn fill_fig(f: &Fig, n: usize) -> String {
+    match f {
+        Fig::Zero => "0".repeat(n),
+        Fig::Space => " ".repeat(n),
+    }
 }
 
 /// The running machine: the item table, a name→index map, and captured output.
@@ -122,25 +141,79 @@ impl Machine {
 
     /// Run the procedure division and return the captured console output.
     pub fn run(mut self, program: &Program) -> Result<String, RuntimeError> {
-        for para in &program.paragraphs {
+        'outer: for para in &program.paragraphs {
             for stmt in &para.stmts {
-                match stmt {
-                    Stmt::StopRun => return Ok(self.output),
-                    Stmt::Display(ops) => self.exec_display(ops)?,
-                    Stmt::Move { src, dsts } => self.exec_move(src, dsts)?,
-                    Stmt::Add { operands, to, giving } => self.exec_add(operands, to, giving)?,
-                    Stmt::Subtract { operands, from, giving } => {
-                        self.exec_subtract(operands, from, giving)?
-                    }
-                    Stmt::Multiply { a, by, giving } => self.exec_multiply(a, by, giving)?,
-                    Stmt::Divide { divisor, dividend, giving } => {
-                        self.exec_divide(divisor, dividend, giving)?
-                    }
+                if self.exec_stmt(stmt)? {
+                    break 'outer; // STOP RUN
                 }
             }
         }
         // Falling off the end of the procedure division ends the run too.
         Ok(self.output)
+    }
+
+    /// Execute one statement. Returns `true` if it requested `STOP RUN` (which
+    /// unwinds nested `IF` branches and ends the program).
+    fn exec_stmt(&mut self, stmt: &Stmt) -> Result<bool, RuntimeError> {
+        match stmt {
+            Stmt::StopRun => return Ok(true),
+            Stmt::Display(ops) => self.exec_display(ops)?,
+            Stmt::Move { src, dsts } => self.exec_move(src, dsts)?,
+            Stmt::Add { operands, to, giving } => self.exec_add(operands, to, giving)?,
+            Stmt::Subtract { operands, from, giving } => self.exec_subtract(operands, from, giving)?,
+            Stmt::Multiply { a, by, giving } => self.exec_multiply(a, by, giving)?,
+            Stmt::Divide { divisor, dividend, giving } => {
+                self.exec_divide(divisor, dividend, giving)?
+            }
+            Stmt::If { cond, then_branch, else_branch } => {
+                let branch = if self.eval_cond(cond)? { then_branch } else { else_branch };
+                for s in branch {
+                    if self.exec_stmt(s)? {
+                        return Ok(true); // STOP RUN inside the branch
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Evaluate a relational condition. Numeric when both sides are numeric;
+    /// otherwise an alphanumeric (space-padded) character comparison — COBOL's
+    /// rule. Figurative constants take the category/length of the other operand.
+    fn eval_cond(&self, cond: &Cond) -> Result<bool, RuntimeError> {
+        use std::cmp::Ordering;
+        let l = self.src_from_operand(&cond.left)?;
+        let r = self.src_from_operand(&cond.right)?;
+
+        let ordering = match (&l, &r) {
+            (Src::Num(a), Src::Num(b)) => a.cmp_value(b),
+            (Src::Num(a), Src::Fig(Fig::Zero)) => a.cmp_value(&Decimal::zero()),
+            (Src::Fig(Fig::Zero), Src::Num(b)) => Decimal::zero().cmp_value(b),
+            _ => {
+                // Alphanumeric comparison: build each side's characters, expand a
+                // figurative to the other operand's length, then space-pad both
+                // to equal length and compare.
+                let mut ls = src_chars(&l);
+                let mut rs = src_chars(&r);
+                if let Src::Fig(f) = &l {
+                    ls = fill_fig(f, rs.len().max(1));
+                }
+                if let Src::Fig(f) = &r {
+                    rs = fill_fig(f, ls.len().max(1));
+                }
+                let width = ls.len().max(rs.len());
+                let lp = format!("{ls:<width$}");
+                let rp = format!("{rs:<width$}");
+                lp.cmp(&rp)
+            }
+        };
+
+        let base = match cond.op {
+            RelOp::Greater => ordering == Ordering::Greater,
+            RelOp::Less => ordering == Ordering::Less,
+            RelOp::Equal => ordering == Ordering::Equal,
+        };
+        Ok(base ^ cond.negated)
     }
 
     fn exec_display(&mut self, ops: &[Operand]) -> Result<(), RuntimeError> {

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -405,6 +405,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn deeply_nested_if_errors_rather_than_overflowing_the_stack() {
+        // A crafted source can nest `IF`s far past anything real COBOL does.
+        // Parsing that recurses once per level; without the parser's depth cap
+        // it overflows the *native* stack and aborts the process — uncatchable,
+        // not a RuntimeError. `cobol-parser` opts into the cap, so end-to-end
+        // this comes back as a clean parse error. One `IF` per card so the
+        // fixed 80-column format doesn't truncate them (a statement flows
+        // freely across cards, so the nest is real). 4096 is far past the cap.
+        let mut lines: Vec<String> = vec![
+            "IDENTIFICATION DIVISION.".into(),
+            "PROGRAM-ID. P.".into(),
+            "DATA DIVISION.".into(),
+            "WORKING-STORAGE SECTION.".into(),
+            "01  N  PIC 9(3) VALUE 5.".into(),
+            "PROCEDURE DIVISION.".into(),
+            "MAIN.".into(),
+        ];
+        for _ in 0..4096 {
+            lines.push("    IF N GREATER 0".into());
+        }
+        lines.push("    DISPLAY \"DEEP\".".into());
+        lines.push("    STOP RUN.".into());
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let err = run_cobol(&program(&refs)).unwrap_err();
+        assert!(matches!(err, RuntimeError::Parse(_)), "got {err:?}");
+        assert!(err.to_string().to_lowercase().contains("nest"), "message should explain: {err}");
+    }
+
     // ----------------------------------------------------------------------
     // Honest failure: unmodelled features error, they do not run wrong.
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -6,12 +6,12 @@
 //! [PL08](../../../specs/PL08-cobol-runtime.md).
 //!
 //! It implements a *small but fully correct* slice — `MOVE` / `DISPLAY` /
-//! `STOP RUN` and fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`
-//! over unsigned numeric-display and character pictures — and returns a
-//! descriptive error for anything not yet modelled, rather than producing wrong
-//! output. The roadmap toward full COBOL (signed numerics, `COMPUTE`,
-//! `ROUNDED`/`ON SIZE ERROR`, editing pictures, `PERFORM`, tables, files, later
-//! standards) is in PL08.
+//! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
+//! and `IF … ELSE` (numeric and alphanumeric comparison) over unsigned
+//! numeric-display and character pictures — and returns a descriptive error for
+//! anything not yet modelled, rather than producing wrong output. The roadmap
+//! toward full COBOL (signed numerics, `COMPUTE`, `ROUNDED`/`ON SIZE ERROR`,
+//! editing pictures, `PERFORM`, tables, files, later standards) is in PL08.
 //!
 //! ```
 //! use coding_adventures_cobol_runtime::run_cobol;
@@ -323,6 +323,86 @@ mod tests {
         ]))
         .unwrap_err();
         assert!(matches!(err, RuntimeError::DivideByZero), "got {err:?}");
+    }
+
+    // ----------------------------------------------------------------------
+    // IF — conditions and branching
+    // ----------------------------------------------------------------------
+
+    /// Run a program with `01 N PIC 9(3) VALUE <n>` and the given procedure body.
+    fn run_if(n: &str, body: &[&str]) -> String {
+        let mut lines = vec![
+            "IDENTIFICATION DIVISION.".to_string(),
+            "PROGRAM-ID. P.".to_string(),
+            "DATA DIVISION.".to_string(),
+            "WORKING-STORAGE SECTION.".to_string(),
+            format!("01  N  PIC 9(3) VALUE {n}."),
+            "PROCEDURE DIVISION.".to_string(),
+            "MAIN.".to_string(),
+        ];
+        lines.extend(body.iter().map(|s| format!("    {s}")));
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        run_cobol(&program(&refs)).unwrap()
+    }
+
+    #[test]
+    fn if_numeric_true_and_false_branches() {
+        // N=5 > 3 → THEN.
+        assert_eq!(
+            run_if("5", &["IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".", "STOP RUN."]),
+            "BIG\n"
+        );
+        // N=1 not > 3 → ELSE.
+        assert_eq!(
+            run_if("1", &["IF N GREATER 3 DISPLAY \"BIG\" ELSE DISPLAY \"SMALL\".", "STOP RUN."]),
+            "SMALL\n"
+        );
+    }
+
+    #[test]
+    fn if_equal_less_and_negated() {
+        assert_eq!(run_if("7", &["IF N EQUAL 7 DISPLAY \"EQ\".", "STOP RUN."]), "EQ\n");
+        assert_eq!(run_if("2", &["IF N LESS 5 DISPLAY \"LT\".", "STOP RUN."]), "LT\n");
+        // IS NOT GREATER: 3 is not > 5 → true.
+        assert_eq!(run_if("3", &["IF N IS NOT GREATER THAN 5 DISPLAY \"OK\".", "STOP RUN."]), "OK\n");
+        // A false condition with no ELSE displays nothing.
+        assert_eq!(run_if("9", &["IF N LESS 5 DISPLAY \"NO\".", "STOP RUN."]), "");
+    }
+
+    #[test]
+    fn if_then_branch_runs_multiple_statements() {
+        // THEN branch has two statements; both run when the condition holds.
+        assert_eq!(
+            run_if("5", &["IF N GREATER 3 MOVE 8 TO N DISPLAY N.", "STOP RUN."]),
+            "008\n"
+        );
+    }
+
+    #[test]
+    fn if_alphanumeric_comparison_space_pads() {
+        // "AB" vs "AB " (space-padded) compare equal.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  W  PIC X(4) VALUE \"AB\".",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    IF W EQUAL \"AB\" DISPLAY \"MATCH\" ELSE DISPLAY \"NO\".",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "MATCH\n");
+    }
+
+    #[test]
+    fn stop_run_inside_a_branch_ends_the_program() {
+        // The STOP RUN is inside the THEN branch; the trailing DISPLAY never runs.
+        assert_eq!(
+            run_if("5", &["IF N GREATER 3 DISPLAY \"IN\" STOP RUN.", "DISPLAY \"AFTER\".", "STOP RUN."]),
+            "IN\n"
+        );
     }
 
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -70,6 +70,8 @@ pub enum Stmt {
     Multiply { a: Operand, by: Operand, giving: Option<String> },
     /// `DIVIDE a INTO b [GIVING g]` — result = b/a, stored in g or b.
     Divide { divisor: Operand, dividend: Operand, giving: Option<String> },
+    /// `IF cond then… [ELSE else…]`.
+    If { cond: Cond, then_branch: Vec<Stmt>, else_branch: Vec<Stmt> },
     StopRun,
 }
 
@@ -78,6 +80,23 @@ pub enum Stmt {
 pub enum Operand {
     Ident(String),
     Lit(Lit),
+}
+
+/// A simple relational condition: `left <relop> right`, optionally negated.
+#[derive(Debug, Clone)]
+pub struct Cond {
+    pub left: Operand,
+    pub op: RelOp,
+    pub negated: bool,
+    pub right: Operand,
+}
+
+/// The relational operator of a condition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelOp {
+    Greater,
+    Less,
+    Equal,
 }
 
 // ---------------------------------------------------------------------------
@@ -321,8 +340,64 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             let mut it = ops.into_iter();
             Ok(Stmt::Divide { divisor: it.next().unwrap(), dividend: it.next().unwrap(), giving })
         }
+        "if_stmt" => {
+            // Children in order: IF, condition, then-statements…, [ELSE,
+            // else-statements…]. Split the statement nodes at the ELSE keyword.
+            let cond_node = child_node(verb, "condition")
+                .ok_or_else(|| RuntimeError::Unsupported("IF without a condition".into()))?;
+            let cond = read_condition(cond_node)?;
+            let mut then_branch = Vec::new();
+            let mut else_branch = Vec::new();
+            let mut seen_else = false;
+            for child in &verb.children {
+                match child {
+                    ASTNodeOrToken::Token(t) if t.value == "ELSE" && t.effective_type_name() == "KEYWORD" => {
+                        seen_else = true;
+                    }
+                    ASTNodeOrToken::Node(n) if n.rule_name == "statement" => {
+                        let stmt = read_statement(n)?;
+                        if seen_else {
+                            else_branch.push(stmt);
+                        } else {
+                            then_branch.push(stmt);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Stmt::If { cond, then_branch, else_branch })
+        }
         other => Err(RuntimeError::Unsupported(format!("the {} verb", verb_name(other)))),
     }
+}
+
+/// Read a `condition` node (`operand relop operand`).
+fn read_condition(cond: &GrammarASTNode) -> Result<Cond, RuntimeError> {
+    let operands = child_nodes(cond, "operand");
+    if operands.len() != 2 {
+        return Err(RuntimeError::Unsupported("condition must be `operand relop operand`".into()));
+    }
+    let left = read_operand(operands[0])?;
+    let right = read_operand(operands[1])?;
+    let relop = child_node(cond, "relop")
+        .ok_or_else(|| RuntimeError::Unsupported("condition without a relational operator".into()))?;
+    let toks = child_tokens(relop);
+    let negated = toks.iter().any(|(k, v)| k == "KEYWORD" && v == "NOT");
+    let op = toks
+        .iter()
+        .find_map(|(k, v)| {
+            if k != "KEYWORD" {
+                return None;
+            }
+            match v.as_str() {
+                "GREATER" => Some(RelOp::Greater),
+                "LESS" => Some(RelOp::Less),
+                "EQUAL" => Some(RelOp::Equal),
+                _ => None,
+            }
+        })
+        .ok_or_else(|| RuntimeError::Unsupported("unrecognised relational operator".into()))?;
+    Ok(Cond { left, op, negated, right })
 }
 
 /// All `operand` child nodes of a verb, read to typed [`Operand`]s.

--- a/code/packages/rust/cobol-runtime/src/value.rs
+++ b/code/packages/rust/cobol-runtime/src/value.rs
@@ -57,6 +57,27 @@ impl Decimal {
         self.int.chars().chain(self.frac.chars()).all(|c| c == '0')
     }
 
+    /// Compare two decimals by numeric value. Works on the digit strings (not
+    /// `i128`) so it is exact for numbers of any size. `-0` compares equal to
+    /// `+0`.
+    pub fn cmp_value(&self, other: &Decimal) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        let neg_self = self.neg && !self.is_zero();
+        let neg_other = other.neg && !other.is_zero();
+        match (neg_self, neg_other) {
+            (false, true) => return Ordering::Greater,
+            (true, false) => return Ordering::Less,
+            _ => {}
+        }
+        let mag = magnitude_cmp(self, other);
+        // If both are negative, the larger magnitude is the smaller value.
+        if neg_self {
+            mag.reverse()
+        } else {
+            mag
+        }
+    }
+
     /// This value as a signed `i128` scaled by `10^scale` (i.e. with exactly
     /// `scale` fractional digits). Returns `None` if it overflows `i128`
     /// (~38 digits — beyond any real COBOL numeric field) or if truncating the
@@ -140,6 +161,27 @@ fn pow10(exp: usize) -> Option<i128> {
         v = v.checked_mul(10)?;
     }
     Some(v)
+}
+
+/// Compare the unsigned magnitudes of two decimals: integer part first (by
+/// significant length, then digit-by-digit), then the fractional part
+/// (zero-padded to equal length).
+fn magnitude_cmp(a: &Decimal, b: &Decimal) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let ai = a.int.trim_start_matches('0');
+    let bi = b.int.trim_start_matches('0');
+    match ai.len().cmp(&bi.len()) {
+        Ordering::Equal => {}
+        o => return o,
+    }
+    match ai.cmp(bi) {
+        Ordering::Equal => {}
+        o => return o,
+    }
+    let width = a.frac.len().max(b.frac.len());
+    let af = format!("{:0<width$}", a.frac);
+    let bf = format!("{:0<width$}", b.frac);
+    af.cmp(&bf)
 }
 
 /// Move a numeric value into a numeric receiver of `int_digits` integer
@@ -282,5 +324,23 @@ mod tests {
     #[test]
     fn division_by_zero_returns_none() {
         assert_eq!(div(&d("5"), &d("0"), 2), None);
+    }
+
+    #[test]
+    fn decimal_comparison() {
+        use std::cmp::Ordering::*;
+        assert_eq!(d("5").cmp_value(&d("3")), Greater);
+        assert_eq!(d("3").cmp_value(&d("5")), Less);
+        assert_eq!(d("42").cmp_value(&d("42")), Equal);
+        // Different fraction lengths, same value.
+        assert_eq!(d("1.5").cmp_value(&d("1.50")), Equal);
+        assert_eq!(d("1.50").cmp_value(&d("1.5")), Equal);
+        // Magnitude by significant integer length.
+        assert_eq!(d("100").cmp_value(&d("99")), Greater);
+        assert_eq!(d("007").cmp_value(&d("7")), Equal);
+        // Signs: negatives order below positives; -0 == +0.
+        assert_eq!(d("-2").cmp_value(&d("3")), Less);
+        assert_eq!(d("-2").cmp_value(&d("-5")), Greater);
+        assert_eq!(d("-0").cmp_value(&d("0")), Equal);
     }
 }

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -122,15 +122,17 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
 
 1. **v0.1 — execution spine** (merged): data model + `MOVE`/`DISPLAY`/`STOP RUN`.
 2. **v0.2 — arithmetic** (merged): fixed-point `ADD`/`SUBTRACT`/`MULTIPLY`.
-3. **v0.3 — `DIVIDE`** (this PR): fixed-point division + divide-by-zero.
-4. **`COMPUTE`, `ROUNDED`, `ON SIZE ERROR`** — expression evaluation and the
+3. **v0.3 — `DIVIDE`** (merged): fixed-point division + divide-by-zero.
+4. **v0.4 — `IF … ELSE`** (this PR): conditional branching; numeric and
+   alphanumeric comparison; `STOP RUN` unwinds nested branches.
+5. **`COMPUTE`, `ROUNDED`, `ON SIZE ERROR`** — expression evaluation and the
    rounding/overflow clauses (these also widen the frontend grammar); then
    **signed numerics + overpunch** display and the `SIGN` clause.
-4. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
-5. **Control flow** — `IF … ELSE … END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
-   `TIMES`, `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
-6. **Conditions** — level-88 condition-names.
-7. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.
+6. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+7. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`, `TIMES`,
+   `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
+8. **Conditions** — level-88 condition-names.
+9. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.
 8. **File I/O** — `SELECT`/`FD`, sequential then indexed/relative, `OPEN`/`READ`/
    `WRITE`/`REWRITE`/`CLOSE`.
 9. **Later standards** — layer COBOL-61/68/74/85/2002/2014 features on the solid

--- a/lessons.md
+++ b/lessons.md
@@ -1467,3 +1467,32 @@ before pushing: `grep -rnE "const [a-z0-9_]+ [a-z_]+\[[0-9]*\]\[" src/`.
 gcc on several pedantic ISO-C rules. "Verified under gcc/clang locally" does not
 cover the ubuntu gcc arm — the pure-ISO guarantee is only firm once CI's gcc has
 run. Watch babysit CI to green, don't assume from a local build.
+
+## Lesson: new grammar frontends must opt into the parser's recursion depth cap
+
+**Context:** Adding `IF` to the COBOL runtime introduced the first *nestable*
+construct. A security review found that deeply-nested `IF … IF … IF …` (one per
+80-column card, so a statement flows across cards and the nest is real)
+overflowed the native stack — an uncatchable `SIGSEGV`/abort that a
+`Result`-returning entry point cannot report.
+
+**Cause:** `parser::GrammarParser::new(...)` defaults `max_depth` to
+`usize::MAX` — the recursion-depth guard is **opt-in**. `cobol-parser` built the
+parser with `GrammarParser::new(...)` and never chained `.with_max_depth(...)`,
+so every deep nest recursed once per level through `parse_rule` with no ceiling.
+The shared parser already HAS the fix (`DEFAULT_MAX_RULE_DEPTH = 128`, below the
+~192–224 overflow point on a 2 MB thread); the frontend just wasn't using it.
+
+**Fix:** Every frontend that constructs a `GrammarParser` must chain
+`.with_max_depth(DEFAULT_MAX_RULE_DEPTH)` on *all* construction paths (both the
+panicking and the `try_` entry points). Deep nesting then returns a clean
+"input nests deeper than the supported limit" parse error. This transitively
+bounds any *runtime* tree-walk (e.g. a recursive `exec_stmt`) too, since the CST
+can no longer be built deeper than the cap.
+
+**Blind spot / grep before pushing a new frontend:**
+`grep -rn "GrammarParser::new" code/packages/rust/<lang>-parser/src/` — every hit
+that lacks a following `.with_max_depth(` is an unguarded native-stack DoS. This
+is the same class as the closurec/json-parser deep-recursion DoS
+(project_closurec_deep_recursion_dos): a nestable construct is the trigger, and
+the mitigation belongs at the parser layer, not the runtime.


### PR DESCRIPTION
## Summary

Adds `IF … ELSE` conditional branching to the COBOL runtime (PL08 v0.4), and
hardens `cobol-parser` against a native-stack-overflow DoS that the IF feature
surfaced.

### `IF … ELSE` (cobol-runtime 0.4.0)
- `IF cond THEN… [ELSE …]` over the grammar's relational condition
  (`[IS] [NOT] (GREATER [THAN] | LESS [THAN] | EQUAL [TO])`).
- Comparison is **numeric** when both operands are numeric (exact, digit-string
  based — any size, sign-aware, `1.5 == 1.50`, `007 == 7`) and **alphanumeric**
  otherwise (space-padded to equal length, COBOL's rule). Figurative constants
  take the other operand's category/length.
- Both branches may hold multiple statements and nest; a `STOP RUN` inside a
  branch ends the whole program (execution returns a stop-flag that unwinds
  nested IFs).

### Security fix — parser recursion depth cap (cobol-parser 0.1.1)
`IF` is the first construct that nests, and a security review found that
deeply-nested `IF … IF … IF …` recurses once per level through the shared
`GrammarParser::parse_rule`. `cobol-parser` was building the parser with the
default **unlimited** cap (`GrammarParser::new` defaults `max_depth` to
`usize::MAX`; the cap is opt-in), so a ~4096-deep nest overflowed the native
stack — an uncatchable `SIGSEGV`/abort a `Result`-returning entry point cannot
report.

Fixed at the correct layer: `create_cobol_parser` and `try_parse_cobol` now opt
into `DEFAULT_MAX_RULE_DEPTH` (128), same as the other frontends. Deep nesting
now returns a clean `"input nests deeper than the supported limit"` parse error.
This transitively bounds the runtime's recursive `exec_stmt` walk too.

## Tests
- cobol-runtime: 47 unit tests + doctest (IF numeric/alphanumeric/negated/nested,
  STOP-RUN-in-branch, deep-nesting → clean `RuntimeError::Parse`).
- cobol-parser: 10 tests incl. 4096-deep nested IF → clean error, not a crash.
- Warning-free. Two-round security review PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)