### PR TITLE
feat(sir-runtime-oop): Hash to_h (block + no-block) + each_with_index + each_with_object — Python reference

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.21] - 2026-07-11
+
+### Added
+
+- **`Hash#to_h`, `Hash#each_with_index`, `Hash#each_with_object`** — rounding out
+  Hash's Enumerable iteration surface.
+  - `to_h` **without** a block (`_hash_method` + `_HASH_METHODS`) returns a
+    shallow copy of the hash (a fresh `dict`, so mutating it does not alias the
+    receiver).
+  - `to_h { |k, v| [new_k, new_v] }` (`_hash_block_method` + `_HASH_BLOCK_METHODS`)
+    returns a NEW hash whose entries are the `[k, v]` pairs the block returns;
+    the block is yielded the two args `(key, value)` and colliding new keys keep
+    the LAST pair (Ruby's rule).
+  - `each_with_index { |(k, v), i| … }` yields each `[k, v]` pair with its
+    0-based position and returns the receiver.
+  - `each_with_object(memo) { |(k, v), memo| … }` yields each `[k, v]` pair with
+    the memo and returns the (mutated) memo; with no memo argument the receiver
+    is returned unchanged.
+  - Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object`
+    pass the element as a single `[k, v]` pair (the second block param is the
+    index/memo), matching Ruby's Enumerable convention.
+- This is the Python reference for the next cross-backend mirror (Go/Rust/JS/TS
+  to follow).
+
 ## [0.1.20] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -75,7 +75,7 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 `flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
-(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/`group_by`/`partition`/`flat_map`/`reduce`/`sum`/…);
+(`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/`to_h`/`each_with_index`/`each_with_object`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/`group_by`/`partition`/`flat_map`/`reduce`/`sum`/…);
 and (item
 **M1c**) the **`String`** catalog (`length`, `upcase`/`downcase`/`capitalize`,
 `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`, `chars`/`bytes`, `split`,

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.20"
+version = "0.1.21"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -628,6 +628,7 @@ _HASH_METHODS = frozenset(
         "length",
         "empty?",
         "to_a",
+        "to_h",
         "dig",
         "store",
         "[]=",
@@ -667,6 +668,9 @@ _HASH_BLOCK_METHODS = frozenset(
         "reduce",
         "inject",
         "sum",
+        "to_h",
+        "each_with_index",
+        "each_with_object",
     }
 )
 
@@ -1179,6 +1183,12 @@ def _hash_method(recv: dict[Val, Val], name: str, args: list[Val]) -> Val:
         return len(recv) == 0
     if name == "to_a":
         return [[key, value] for key, value in recv.items()]
+    if name == "to_h":
+        # ``Hash#to_h`` with NO block returns a shallow copy of the hash (Ruby
+        # returns ``self`` re-wrapped; a fresh ``dict`` matches the value
+        # semantics without aliasing the receiver).  The block form lives in
+        # ``_hash_block_method`` (it re-maps each pair to a new ``[k, v]``).
+        return dict(recv)
     if name == "dig":
         # v0: single-level dig; nested dig is a documented follow-up.
         return recv.get(args[0])
@@ -1327,6 +1337,38 @@ def _hash_block_method(recv: dict[Val, Val], name: str, args: list[Val], block: 
         for key, value in recv.items():
             total = total + apply(block, [key, value])
         return total
+    if name == "to_h":
+        # ``Hash#to_h { |k, v| [new_k, new_v] }`` — a NEW hash whose entries are
+        # the ``[k, v]`` pairs the block returns.  The block is yielded the two
+        # arguments ``(key, value)`` (matching ``each``) and MUST return a
+        # two-element ``[k, v]`` pair; a later pair with a duplicate key wins
+        # (Ruby's rule, and how ``dict`` assignment already behaves).
+        result: dict[Val, Val] = {}
+        for key, value in recv.items():
+            pair = apply(block, [key, value])
+            result[pair[0]] = pair[1]
+        return result
+    if name == "each_with_index":
+        # ``each_with_index { |(k, v), i| … }`` — yields each ``[k, v]`` pair
+        # together with its 0-based position and returns the receiver.  Unlike
+        # the two-arg ``(k, v)`` yield of ``each``, the element here arrives as a
+        # single ``[k, v]`` pair (the second block param is the index), matching
+        # Ruby's Enumerable convention.
+        for index, (key, value) in enumerate(recv.items()):
+            apply(block, [[key, value], index])
+        return recv
+    if name == "each_with_object":
+        # ``each_with_object(memo) { |(k, v), memo| … }`` — yields each ``[k, v]``
+        # pair with the memo object and returns the (mutated) memo.  Like
+        # ``each_with_index``, the element is the single ``[k, v]`` pair (the
+        # second block param is the memo).  With no memo argument the receiver is
+        # returned unchanged.
+        if not args:
+            return recv
+        memo = args[0]
+        for key, value in recv.items():
+            apply(block, [[key, value], memo])
+        return memo
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -585,6 +585,52 @@ def test_hash_enumerable_grouping_folding() -> None:
     assert list(h.items()) == [("a", 1), ("b", 2), ("c", 3), ("d", 4)]
 
 
+def test_hash_to_h_and_indexed_iteration() -> None:
+    # `to_h` (no block) returns a shallow copy; mutating it leaves the source
+    # untouched.  `to_h { |k, v| [nk, nv] }` re-maps each pair.  Indexed/object
+    # iteration (`each_with_index`, `each_with_object`) yields the [k, v] pair
+    # as ONE argument alongside the index/memo (the second block param), matching
+    # Ruby's Enumerable convention (contrast `each`'s two-arg (k, v) yield).
+    h = {"a": 1, "b": 2, "c": 3}
+    # to_h, no block → a fresh equal dict that does not alias the receiver.
+    copy = oop.call_method(h, "to_h")
+    assert copy == {"a": 1, "b": 2, "c": 3}
+    copy["z"] = 99
+    assert "z" not in h
+    # to_h with a block re-maps each [k, v] → [new_k, new_v]; here upcase the key
+    # and double the value.
+    assert oop.call_method(h, "to_h", Closure(lambda k, v: [k.upper(), v * 2])) == {
+        "A": 2,
+        "B": 4,
+        "C": 6,
+    }
+    # to_h block whose new keys collide → the LAST pair wins (Ruby's rule).
+    assert oop.call_method(h, "to_h", Closure(lambda k, v: ["k", v])) == {"k": 3}
+    # each_with_index yields ([k, v], i) and returns the receiver.
+    seen: list[Val] = []
+    result = oop.call_method(
+        h, "each_with_index", Closure(lambda pair, i: seen.append([pair, i]))
+    )
+    assert seen == [[["a", 1], 0], [["b", 2], 1], [["c", 3], 2]]
+    assert result is h
+    # each_with_object(memo) yields ([k, v], memo) and returns the memo; here we
+    # accumulate the values into a running total wrapped in a list.
+    total = oop.call_method(
+        h,
+        "each_with_object",
+        [0],
+        Closure(lambda pair, memo: memo.__setitem__(0, memo[0] + pair[1])),
+    )
+    assert total == [6]
+    # each_with_object with NO memo argument returns the receiver unchanged.
+    assert oop.call_method(h, "each_with_object", Closure(lambda pair, memo: None)) is h
+    # respond_to? advertises the new methods; source hash unchanged throughout.
+    assert oop.call_method(h, "respond_to?", "to_h") is True
+    assert oop.call_method(h, "respond_to?", "each_with_index") is True
+    assert oop.call_method(h, "respond_to?", "each_with_object") is True
+    assert h == {"a": 1, "b": 2, "c": 3}
+
+
 def test_hash_respond_to_and_no_method_error_floor() -> None:
     assert oop.call_method({"a": 1}, "respond_to?", "keys") is True
     assert oop.call_method({"a": 1}, "respond_to?", "each") is True


### PR DESCRIPTION
Rounds out Hash's Enumerable iteration surface. **Python reference** for the next cross-backend cascade (Go → Rust → JS → TS mirrors to follow).

## Methods
- `to_h` **without** a block → shallow copy of the hash (fresh `dict`, does not alias the receiver).
- `to_h { |k,v| [new_k, new_v] }` → a NEW hash from the block-returned `[k, v]` pairs; block yields two args `(k, v)`; colliding new keys keep the LAST pair (Ruby's rule).
- `each_with_index { |(k,v), i| … }` → yields each `[k, v]` pair with its 0-based index; returns the receiver.
- `each_with_object(memo) { |(k,v), memo| … }` → yields each `[k, v]` pair with the memo; returns the (mutated) memo; no-memo arg returns the receiver unchanged.

Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass the element as a single `[k, v]` pair (the second block param is the index/memo) — Ruby's Enumerable convention.

## Tests
`test_hash_to_h_and_indexed_iteration` covers to_h copy-not-alias, block re-map, key-collision (last wins), each_with_index tuple + return-self, each_with_object accumulate + return-memo + no-memo passthrough, `respond_to?`, receiver-unchanged. **127 tests pass, 97% coverage; ruff clean.** Version 0.1.20 → 0.1.21; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)