### PR TITLE
feat(md5-native): Kotlin native-through-Rust binding (reuses md5-native-jni)

### DIFF
--- a/code/packages/kotlin/md5-native/.gitignore
+++ b/code/packages/kotlin/md5-native/.gitignore
@@ -1,0 +1,4 @@
+/.gradle/
+/gradle-build/
+/build/
+/out/

--- a/code/packages/kotlin/md5-native/BUILD
+++ b/code/packages/kotlin/md5-native/BUILD
@@ -1,0 +1,1 @@
+cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release && gradle test

--- a/code/packages/kotlin/md5-native/BUILD_windows
+++ b/code/packages/kotlin/md5-native/BUILD_windows
@@ -1,0 +1,1 @@
+cargo build --manifest-path ..\..\rust\Cargo.toml -p md5-native-jni --release && gradle test

--- a/code/packages/kotlin/md5-native/CHANGELOG.md
+++ b/code/packages/kotlin/md5-native/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog — md5-native (Kotlin)
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial release: native-through-Rust MD5 for Kotlin, reusing the existing
+  `md5_native_jni` cdylib (from `java/md5-native`) with no new Rust crate.
+- `Md5Native.sumMd5` / `hexString` and a streaming `Digest` (`AutoCloseable`,
+  `Cleaner`-managed handle) with `update` / non-destructive `digest` /
+  `hexDigest` / `copy`.
+- 8 tests through JNI: RFC 1321 vectors (incl. 0x00..0xFF), digest size,
+  streaming parity, byte-at-a-time, non-destructive digest, copy independence,
+  closed-handle guarding. `gradle test` green against the shared cdylib.

--- a/code/packages/kotlin/md5-native/README.md
+++ b/code/packages/kotlin/md5-native/README.md
@@ -1,0 +1,22 @@
+# md5-native (Kotlin)
+
+**Native-through-Rust** MD5 for Kotlin — companion to the pure-Kotlin `md5`
+package. Calls the Rust `coding_adventures_md5` crate through JNI, **reusing the
+same `md5_native_jni` cdylib as `java/md5-native`** (no new Rust crate). Kotlin's
+`object Native` `external` functions resolve to the same
+`Java_com_codingadventures_md5native_Native_*` exports.
+
+> **Security:** MD5 is cryptographically broken — checksum use only.
+
+## API (`com.codingadventures.md5native.Md5Native`)
+
+`sumMd5(ByteArray) -> ByteArray` (16 bytes), `hexString(ByteArray) -> String`,
+and a `Digest` (`AutoCloseable`, `Cleaner`-managed handle) with `update` /
+non-destructive `digest` / `hexDigest` / `copy`.
+
+## Building
+
+```
+cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release
+gradle test
+```

--- a/code/packages/kotlin/md5-native/build.gradle.kts
+++ b/code/packages/kotlin/md5-native/build.gradle.kts
@@ -1,0 +1,38 @@
+// Kotlin md5 native binding — JNI over the Rust `md5_native_jni` cdylib (the SAME
+// cdylib used by java/md5-native; no new Rust crate). Build it:
+//   cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release
+
+layout.buildDirectory = file("gradle-build")
+
+plugins {
+    kotlin("jvm") version "2.1.20"
+    `java-library`
+}
+
+group = "com.codingadventures"
+version = "0.1.0"
+
+repositories {
+    mavenCentral()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+    }
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    val rustReleaseDir = projectDir.parentFile.parentFile
+        .resolve("rust/target/release")
+        .absolutePath
+    jvmArgs("-Djava.library.path=$rustReleaseDir")
+    testLogging { events("passed", "skipped", "failed") }
+}

--- a/code/packages/kotlin/md5-native/required_capabilities.json
+++ b/code/packages/kotlin/md5-native/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://coding-adventures.example/schemas/required_capabilities/v1.json",
+  "version": 1,
+  "package": "kotlin/md5-native",
+  "capabilities": ["ffi:call"],
+  "justification": "ffi:call — loads the md5_native_jni cdylib via System.loadLibrary and calls its JNI methods to compute MD5 in Rust. No network, filesystem, or process access."
+}

--- a/code/packages/kotlin/md5-native/settings.gradle.kts
+++ b/code/packages/kotlin/md5-native/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "md5-native"

--- a/code/packages/kotlin/md5-native/src/main/kotlin/com/codingadventures/md5native/Md5Native.kt
+++ b/code/packages/kotlin/md5-native/src/main/kotlin/com/codingadventures/md5native/Md5Native.kt
@@ -1,0 +1,73 @@
+package com.codingadventures.md5native
+
+import java.lang.ref.Cleaner
+
+/**
+ * Native-through-Rust MD5 for Kotlin — companion to the pure-Kotlin `md5`
+ * package. Calls the Rust `coding_adventures_md5` crate through JNI, reusing the
+ * same `md5_native_jni` cdylib as `java/md5-native`.
+ *
+ * **Security:** MD5 is cryptographically broken — checksum use only.
+ */
+object Md5Native {
+
+    private val cleaner: Cleaner = Cleaner.create()
+    private const val HEX = "0123456789abcdef"
+
+    /** The 16-byte MD5 digest of [data] (computed in Rust). */
+    fun sumMd5(data: ByteArray): ByteArray = Native.nativeDigest(data)
+
+    /** The 32-character lowercase hex digest of [data] (computed in Rust). */
+    fun hexString(data: ByteArray): String = toHex(sumMd5(data))
+
+    internal fun toHex(bytes: ByteArray): String {
+        val out = CharArray(bytes.size * 2)
+        for (i in bytes.indices) {
+            val v = bytes[i].toInt() and 0xff
+            out[i * 2] = HEX[v ushr 4]
+            out[i * 2 + 1] = HEX[v and 0x0f]
+        }
+        return String(out)
+    }
+
+    /** A streaming MD5 hasher backed by a native Rust hasher. [AutoCloseable]. */
+    class Digest private constructor(handle: Long) : AutoCloseable {
+
+        private class State(@JvmField var handle: Long) : Runnable {
+            override fun run() {
+                if (handle != 0L) {
+                    Native.nativeHasherFree(handle)
+                    handle = 0L
+                }
+            }
+        }
+
+        private val state = State(handle)
+        private val cleanable: Cleaner.Cleanable = cleaner.register(this, state)
+
+        constructor() : this(Native.nativeHasherNew())
+
+        private fun checkOpen() {
+            check(state.handle != 0L) { "digest is closed" }
+        }
+
+        fun update(data: ByteArray) {
+            checkOpen()
+            Native.nativeHasherUpdate(state.handle, data)
+        }
+
+        fun digest(): ByteArray {
+            checkOpen()
+            return Native.nativeHasherDigest(state.handle)
+        }
+
+        fun hexDigest(): String = toHex(digest())
+
+        fun copy(): Digest {
+            checkOpen()
+            return Digest(Native.nativeHasherClone(state.handle))
+        }
+
+        override fun close() = cleanable.clean()
+    }
+}

--- a/code/packages/kotlin/md5-native/src/main/kotlin/com/codingadventures/md5native/Native.kt
+++ b/code/packages/kotlin/md5-native/src/main/kotlin/com/codingadventures/md5native/Native.kt
@@ -1,0 +1,21 @@
+package com.codingadventures.md5native
+
+/**
+ * JNI bindings to the `md5_native_jni` Rust cdylib (shared with
+ * `java/md5-native`), which wraps `coding_adventures_md5`. The external methods
+ * resolve to the same `Java_com_codingadventures_md5native_Native_*` exports, so
+ * Kotlin reuses the existing cdylib with no new Rust crate. MD5 is broken —
+ * checksum use only.
+ */
+internal object Native {
+    init {
+        System.loadLibrary("md5_native_jni")
+    }
+
+    external fun nativeDigest(data: ByteArray): ByteArray
+    external fun nativeHasherNew(): Long
+    external fun nativeHasherUpdate(handle: Long, data: ByteArray)
+    external fun nativeHasherDigest(handle: Long): ByteArray
+    external fun nativeHasherClone(handle: Long): Long
+    external fun nativeHasherFree(handle: Long)
+}

--- a/code/packages/kotlin/md5-native/src/test/kotlin/com/codingadventures/md5native/Md5NativeTest.kt
+++ b/code/packages/kotlin/md5-native/src/test/kotlin/com/codingadventures/md5native/Md5NativeTest.kt
@@ -1,0 +1,72 @@
+package com.codingadventures.md5native
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class Md5NativeTest {
+    private fun a(s: String) = s.toByteArray(Charsets.UTF_8)
+
+    @Test fun rfcVectors() {
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", Md5Native.hexString(a("")))
+        assertEquals("0cc175b9c0f1b6a831c399e269772661", Md5Native.hexString(a("a")))
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", Md5Native.hexString(a("abc")))
+        assertEquals("f96b697d7cb7938d525a2f31aaf161d0", Md5Native.hexString(a("message digest")))
+    }
+
+    @Test fun bytes0To255() {
+        val data = ByteArray(256) { it.toByte() }
+        assertEquals("e2c865db4162bed963bfaa9ef6ac18f0", Md5Native.hexString(data))
+    }
+
+    @Test fun digestIs16Bytes() {
+        assertEquals(16, Md5Native.sumMd5(a("")).size)
+        assertEquals(16, Md5Native.sumMd5(a("hello world")).size)
+    }
+
+    @Test fun streamingMatchesOneShot() {
+        Md5Native.Digest().use { h ->
+            h.update(a("ab")); h.update(a("c"))
+            assertContentEquals(Md5Native.sumMd5(a("abc")), h.digest())
+        }
+    }
+
+    @Test fun streamingByteAtATime() {
+        val data = ByteArray(100) { it.toByte() }
+        Md5Native.Digest().use { h ->
+            for (x in data) h.update(byteArrayOf(x))
+            assertContentEquals(Md5Native.sumMd5(data), h.digest())
+        }
+    }
+
+    @Test fun streamingEmptyAndNonDestructive() {
+        Md5Native.Digest().use { e -> assertContentEquals(Md5Native.sumMd5(a("")), e.digest()) }
+        Md5Native.Digest().use { h ->
+            h.update(a("abc"))
+            assertContentEquals(h.digest(), h.digest())
+            h.update(a("d"))
+            assertContentEquals(Md5Native.sumMd5(a("abcd")), h.digest())
+        }
+    }
+
+    @Test fun copyIsIndependent() {
+        Md5Native.Digest().use { h ->
+            h.update(a("ab"))
+            h.copy().use { h2 ->
+                h2.update(a("c")); h.update(a("x"))
+                assertContentEquals(Md5Native.sumMd5(a("abc")), h2.digest())
+                assertContentEquals(Md5Native.sumMd5(a("abx")), h.digest())
+            }
+        }
+    }
+
+    @Test fun usingClosedThrows() {
+        val h = Md5Native.Digest()
+        h.update(a("abc"))
+        h.close()
+        assertFailsWith<IllegalStateException> { h.update(a("x")) }
+        assertFailsWith<IllegalStateException> { h.digest() }
+        h.close()
+    }
+}


### PR DESCRIPTION
## What

Native-through-Rust MD5 for Kotlin, **reusing the existing `md5_native_jni` cdylib** (from `java/md5-native`, already on `main`) with **no new Rust crate and no `Cargo.toml` change** — exactly as `kotlin/sha256-native` reused `sha256_native_jni`. Companion to the pure-Kotlin `md5` package.

Kotlin's `object Native` `external` functions resolve to the same `Java_com_codingadventures_md5native_Native_*` exports. `Md5Native` wrapper: `sumMd5`/`hexString` + a `Digest` (`AutoCloseable`, `Cleaner`-managed handle) with `update` / non-destructive `digest` / `hexDigest` / `copy`.

## Verification

- **8 tests through JNI** (`kotlin.test`) — RFC 1321 vectors (incl. `0x00..0xFF`), digest size, streaming parity, byte-at-a-time, non-destructive digest, copy independence, closed-handle guarding. `gradle test` green against the shared cdylib.
- **Security review passed** (Kotlin side): `Cleaner` action holds the handle in a separate `State` (no `Digest` capture), `close()` frees exactly once, `copy()` clones a fresh handle (no aliasing), `checkOpen` guards post-close use, `toHex` sign-safe, no hardcoded size.

BUILD: `cargo build --manifest-path ../../rust/Cargo.toml -p md5-native-jni --release && gradle test`.

> **Security note:** MD5 is cryptographically broken — checksum use only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)