### PR TITLE
feat(javascript-parser): bridge private methods → ClassMember::Method with a private key (CLOC12.178)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.42.0] - 2026-07-11
+
+### Added — CLOC12.178 PR1: bridge private methods → `ClassMember::Method` with a private key
+
+A private class method (`class C { #m(){} }`) parses as its own
+`private_method_definition` grammar node (distinct from `method_definition`),
+which `convert_class_element` previously declined (dropping the file to
+WHITESPACE_ONLY). It now dispatches that node to the new
+`convert_private_method_definition`, producing a `ClassMember::Method` whose key
+is a `PropertyKey::PrivateName` (javascript-ast 0.36.0):
+
+- The key is the node's leading `PRIVATE_NAME` token (`#m`), lowered by the
+  shared `private_name_key` helper (the `#` stripped, re-added by the emitter) —
+  exactly as a private *field* key.
+- The `static` modifier lives *inside* the `private_method_definition` node (the
+  grammar's `[ "static" ]`), unlike a public method's `static` (on the
+  `class_element`), so it is read here. `static #m(){}` works.
+- Params and body reuse the shared `convert_formal_parameters` /
+  `convert_formal_parameter` / `convert_function_body`, mirroring
+  `convert_method_definition`. The kind is always `Method` (a private name can
+  never be the `constructor`).
+- The private **getter / setter / generator** forms (`get #x(){}`, `set #x(v){}`,
+  `*#m(){}`) carry accessor / evaluation semantics not yet modelled, so — like a
+  public generator method — they DECLINE (safe WHITESPACE_ONLY), never a
+  mis-emit. A later slice.
+
+5 new bridge tests (the former `class_private_method_still_declines` flipped to
+success; a `class_private_getter_still_declines` guards the decline path); full
+parser suite (212 tests) green. MINOR.
+
 ## [0.41.0] - 2026-07-11
 
 ### Added — CLOC12.177 PR2: bridge private class fields → `PropertyKey::PrivateName`

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1230,9 +1230,10 @@ fn convert_class_heritage(node: &GrammarASTNode) -> Result<Expression, BridgeErr
 /// otherwise the `async` would be silently dropped, a semantics-changing
 /// miscompile. (Declining the member drops the whole file to WHITESPACE_ONLY.)
 ///
-/// `private_method_definition`, `static_block`, and `async_method` member nodes
-/// are forms this slice does not model — they DECLINE (safe WHITESPACE_ONLY
-/// fallback) rather than surface a mis-emit.
+/// `static_block` (CLOC12.176), `private_method_definition` (CLOC12.178), and
+/// `class_field_declaration` (CLOC12.175) member nodes are modelled; an
+/// `async_method` node is a form this slice does not model — it DECLINES (safe
+/// WHITESPACE_ONLY fallback) rather than surface a mis-emit.
 fn convert_class_element(node: &GrammarASTNode) -> Result<ClassMember, BridgeError> {
     // A `class_element` carries at most one *word* modifier — `static` (which
     // we model) or `async` (which we do not). It may also carry a benign
@@ -1252,18 +1253,20 @@ fn convert_class_element(node: &GrammarASTNode) -> Result<ClassMember, BridgeErr
             }
         }
     }
-    // The member itself is a *single* child node. Three shapes are modelled:
+    // The member itself is a *single* child node. Four shapes are modelled:
     // a plain `method_definition` (→ `ClassMember::Method`), a
-    // `class_field_declaration` (→ `ClassMember::Field`, CLOC12.175 PR2), and a
-    // `static_block` (→ `ClassMember::StaticBlock`, CLOC12.176 PR2). The
-    // grammar's `async_method` / `private_method_definition` nodes are forms
-    // this slice does not represent, so they DECLINE (safe WHITESPACE_ONLY
-    // fallback). (Because these are *distinct nodes*, not just leading tokens,
-    // the node kind must be checked.)
+    // `class_field_declaration` (→ `ClassMember::Field`, CLOC12.175 PR2), a
+    // `static_block` (→ `ClassMember::StaticBlock`, CLOC12.176 PR2), and a
+    // `private_method_definition` (→ `ClassMember::Method` with a private key,
+    // CLOC12.178 PR1). The grammar's `async_method` node is a form this slice
+    // does not represent, so it DECLINES (safe WHITESPACE_ONLY fallback).
+    // (Because these are *distinct nodes*, not just leading tokens, the node
+    // kind must be checked.)
     //
-    // A `static_block` carries its own leading `Token("static")` *inside* the
-    // node (not on the `class_element`), so the modifier loop above never sees
-    // it — `is_static` stays false and the static-block arm ignores it.
+    // A `static_block` — and a `private_method_definition` — carry their own
+    // leading `Token("static")` *inside* the node (not on the `class_element`),
+    // so the modifier loop above never sees it: `is_static` from `class_element`
+    // stays false and each arm reads `static` from inside the member node.
     let member = node_children(node)
         .into_iter()
         .next()
@@ -1272,6 +1275,9 @@ fn convert_class_element(node: &GrammarASTNode) -> Result<ClassMember, BridgeErr
         "method_definition" => Ok(ClassMember::Method(convert_method_definition(member, is_static)?)),
         "class_field_declaration" => Ok(ClassMember::Field(convert_class_field(member)?)),
         "static_block" => Ok(ClassMember::StaticBlock(convert_static_block(member)?)),
+        "private_method_definition" => {
+            Ok(ClassMember::Method(convert_private_method_definition(member)?))
+        }
         _ => Err(unsupported(member)),
     }
 }
@@ -1322,7 +1328,7 @@ fn convert_static_block(node: &GrammarASTNode) -> Result<BlockStatement, BridgeE
 /// `property_name` node. [`private_name_key`] detects it and lowers it to a
 /// [`PropertyKey::PrivateName`] (CLOC12.177 PR2); an ordinary keyed field is
 /// unchanged. (A private *method* `#m(){}` is a separate `private_method_definition`
-/// grammar node — a later slice.)
+/// grammar node, lowered by [`convert_private_method_definition`], CLOC12.178 PR1.)
 ///
 /// If a class-member node carries a bare **private-name** token (`#x`), lower it
 /// to a [`PropertyKey::PrivateName`]; otherwise return `None`.
@@ -1498,6 +1504,91 @@ fn convert_method_definition(
         },
         // Computed keys are declined above, so a bridged method is never
         // computed today.
+        computed: false,
+        is_static,
+    })
+}
+
+/// Convert a `private_method_definition` node into a [`MethodDefinition`] whose
+/// key is a [`PropertyKey::PrivateName`] — a private class method `#m(){}`
+/// (CLOC12.178 PR1).
+///
+/// Grammar (es2025 `private_method_definition`):
+///
+/// ```text
+///   [ "static" ] PRIVATE_NAME LPAREN [ formal_parameters ] RPAREN LBRACE function_body RBRACE
+/// | [ "static" ] "get" PRIVATE_NAME ...          // private getter
+/// | [ "static" ] "set" PRIVATE_NAME ...          // private setter
+/// | [ "static" ] STAR   PRIVATE_NAME ...          // private generator
+/// ```
+///
+/// This slice models the **plain** form (optionally `static`). The private
+/// getter / setter / generator forms carry accessor or evaluation semantics not
+/// yet represented, so — like a public generator method — they DECLINE via
+/// `UnsupportedSyntax` (safe WHITESPACE_ONLY fallback), never a mis-emit.
+///
+/// Two shape differences from a public `method_definition`:
+/// - the key is a bare `PRIVATE_NAME` token (`#m`), lowered by
+///   [`private_name_key`] exactly as a private *field* key is — never a
+///   `property_name` node; and
+/// - the `static` modifier lives *inside* this node (the grammar's
+///   `[ "static" ]`), not on the enclosing `class_element`, so it is read here.
+///
+/// A private name can never be the `constructor` (`#constructor` is a
+/// SyntaxError), so the kind is always [`MethodKind::Method`]. Params and body
+/// reuse the shared [`convert_formal_parameters`] / [`convert_formal_parameter`]
+/// / [`convert_function_body`], mirroring [`convert_method_definition`].
+fn convert_private_method_definition(node: &GrammarASTNode) -> Result<MethodDefinition, BridgeError> {
+    // Read `static` (inside this node) and detect the accessor / generator forms
+    // this slice declines. `get` / `set` / `*` all precede the PRIVATE_NAME as
+    // direct token children (params live under `formal_parameter(s)` *nodes*, so
+    // a parameter literally named `get` cannot be confused for the modifier).
+    let mut is_static = false;
+    let mut decline = false;
+    for c in &node.children {
+        if let ASTNodeOrToken::Token(t) = c {
+            match t.value.as_str() {
+                "static" => is_static = true,
+                "get" | "set" | "*" | "async" => decline = true,
+                _ => {}
+            }
+        }
+    }
+    if decline {
+        return Err(unsupported(node));
+    }
+
+    let key = private_name_key(node)
+        .ok_or_else(|| internal(node, "private_method_definition: missing PRIVATE_NAME"))?;
+
+    // Params: a lone `formal_parameter` OR a `formal_parameters` wrapper.
+    let mut params = Vec::new();
+    for n in node_children(node) {
+        match n.rule_name.as_str() {
+            "formal_parameters" => params.extend(convert_formal_parameters(n)?),
+            "formal_parameter" => params.push(convert_formal_parameter(n)?),
+            _ => {}
+        }
+    }
+
+    // Body: the `function_body` node, or an empty block for `#m(){}`.
+    let body = match node_children(node).into_iter().find(|n| n.rule_name == "function_body") {
+        Some(b) => convert_function_body(b)?,
+        None => BlockStatement { cv: None, body: vec![] },
+    };
+
+    Ok(MethodDefinition {
+        cv: None,
+        key,
+        kind: MethodKind::Method,
+        value: FunctionExpression {
+            cv: None,
+            id: None,
+            params,
+            body,
+            generator: false,
+            is_async: false,
+        },
         computed: false,
         is_static,
     })
@@ -3902,13 +3993,71 @@ mod tests {
             if matches!(&f.key, PropertyKey::Identifier(id) if id.name == "y")));
     }
 
+    /// Pull the sole `ClassMember::Method` out of `x = class { … };`.
+    fn method_of(src: &str) -> MethodDefinition {
+        let c = class_of(src);
+        assert_eq!(c.body.len(), 1, "expected exactly one member");
+        match &c.body[0] {
+            ClassMember::Method(m) => m.clone(),
+            other => panic!("expected a method member, got {other:?}"),
+        }
+    }
+
     #[test]
-    fn class_private_method_still_declines() {
-        // `#m(){}` — a private *method* is a separate `private_method_definition`
-        // grammar node, not yet bridged; it still DECLINES (safe WHITESPACE_ONLY),
-        // never a mis-emit. (A later slice.)
+    fn class_private_method() {
+        // `#m(){}` — a private method is a separate `private_method_definition`
+        // grammar node; the bridge lowers it to a `ClassMember::Method` whose key
+        // is a `PropertyKey::PrivateName` (CLOC12.178 PR1).
+        let m = method_of("w = class { #m(){} };");
+        assert!(!m.is_static);
+        assert!(!m.computed);
+        assert!(matches!(m.kind, MethodKind::Method));
+        assert!(
+            matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "m"),
+            "expected a private-name key `#m` (stored bare), got {:?}",
+            m.key
+        );
+        assert!(m.value.params.is_empty());
+        assert!(m.value.body.body.is_empty());
+    }
+
+    #[test]
+    fn class_private_method_with_params_and_body() {
+        // `#add(a,b){ return a+b; }` — params and a body are collected.
+        let m = method_of("w = class { #add(a, b){ return a + b; } };");
+        assert!(matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "add"));
+        assert_eq!(m.value.params.len(), 2);
+        assert_eq!(m.value.body.body.len(), 1);
+    }
+
+    #[test]
+    fn class_static_private_method() {
+        // `static #m(){}` — the `static` keyword lives INSIDE the
+        // `private_method_definition` node (unlike a public method's `static`,
+        // which sits on the `class_element`); `is_static` is read from there.
+        let m = method_of("w = class { static #m(){} };");
+        assert!(m.is_static);
+        assert!(matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "m"));
+    }
+
+    #[test]
+    fn class_private_method_and_field_interleave() {
+        // A private method and a private field coexist in source order.
+        let c = class_of("w = class { #x = 1; #m(){} };");
+        assert_eq!(c.body.len(), 2);
+        assert!(matches!(&c.body[0], ClassMember::Field(f)
+            if matches!(&f.key, PropertyKey::PrivateName(p) if p.name == "x")));
+        assert!(matches!(&c.body[1], ClassMember::Method(m)
+            if matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "m")));
+    }
+
+    #[test]
+    fn class_private_getter_still_declines() {
+        // `get #x(){}` — a private *getter* carries accessor semantics this slice
+        // does not model; it still DECLINES (safe WHITESPACE_ONLY), never a
+        // mis-emit. (A later slice.)
         assert!(matches!(
-            bridge("w = class { #m(){} };"),
+            bridge("w = class { get #x(){} };"),
             Err(BridgeError::UnsupportedSyntax { .. })
         ));
     }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.17] - 2026-07-11
+
+### Added — CLOC12.178: private methods end-to-end
+
+Picks up javascript-parser 0.42.0, whose bridge now lowers a
+`private_method_definition` node to a `ClassMember::Method` with a
+`PropertyKey::PrivateName` key. A private method now survives the full closurec
+pipeline. New e2e diff fixture `tests/diff/simple-private-method/`:
+`class C { #m(){ return 1 + 2 } }` → `class C{#m(){return 3}}` at SIMPLE.
+
+The fixture proves the SIMPLE pipeline descends INTO the private method's body:
+`1 + 2` folds to `3`. Before this bridge change the private method declined,
+dropping the file to WHITESPACE_ONLY (`class C{#m(){return 1+2}};`, arithmetic
+intact). Version-synced cli.spec.json + tests/diff/help-markdown/expected.stdout.
+PATCH.
+
 ## [0.234.16] - 2026-07-11
 
 ### Added — CLOC12.177 PR2: private class fields end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.16"
+version = "0.234.17"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.16",
+  "version": "0.234.17",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.16
+Version: 0.234.17
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-private-method/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-private-method/expected.stdout
@@ -1,0 +1,1 @@
+class C{#m(){return 3}}

--- a/code/programs/rust/closurec/tests/diff/simple-private-method/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-private-method/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-private-method/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-private-method/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-private-method/input/a.js
@@ -1,0 +1,1 @@
+class C { #m(){ return 1 + 2 } }

--- a/code/programs/rust/closurec/tests/diff_simple_private_method.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_private_method.rs
@@ -1,0 +1,83 @@
+//! Integration test for the `tests/diff/simple-private-method/` fixture.
+//!
+//! Exercises a **private class method** (`#m(){}`, a `ClassMember::Method` whose
+//! key is a `PropertyKey::PrivateName`) end-to-end at SIMPLE — the CLOC12.178
+//! bridge of the `private_method_definition` grammar node, on top of the
+//! `PropertyKey::PrivateName` node + emit arms (CLOC12.177).
+//!
+//! The fixture is `class C { #m(){ return 1 + 2 } }` compiled at SIMPLE.
+//! Two facts prove the whole pipeline ran through the private method:
+//!   1. the class round-trips with a `#`-prefixed method key — proving the bridge
+//!      lowered the `private_method_definition` node to a `ClassMember::Method`
+//!      the emitter can print, not a WHITESPACE_ONLY fallback; and
+//!   2. the method body folds — `1 + 2` → `3` — proving the SIMPLE pipeline
+//!      descended INTO the private method's body. A WHITESPACE_ONLY fallback
+//!      would leave `1+2` intact.
+//! Were the bridge to decline the private method, the file would drop to
+//! WHITESPACE_ONLY (`class C{#m(){return 1+2}};`) and assertion (2) would fail.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-private-method/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_private_method_folds_body() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-private-method/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture. Strip spaces so the checks are
+    // insensitive to inter-token whitespace.
+    let a = actual.replace(' ', "");
+    // (1) the class round-tripped with a private `#m` method key — proving the
+    //     bridge lowered the `private_method_definition` node.
+    assert!(
+        (a.contains("classC{") || a.contains("class C{")) && a.contains("#m("),
+        "private-method class did not round-trip with a `#m(` key: {actual}"
+    );
+    // (2) the method body folded — proving the pipeline descended INTO the private
+    //     method's body (`1+2`→`3`). A WHITESPACE_ONLY fallback would leave the
+    //     arithmetic intact.
+    assert!(
+        a.contains("return3"),
+        "private method body did not fold to `return 3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+    // (3) a class *declaration* emits bare — NO trailing `;` after the closing
+    //     `}` and NO wrapping paren (a WHITESPACE_ONLY fallback appends `;`).
+    let t = actual.trim_end_matches('\n');
+    assert!(
+        t.ends_with('}') && !t.ends_with("};") && !t.starts_with('('),
+        "class declaration must emit bare (no trailing `;`, no wrap): {actual}"
+    );
+}


### PR DESCRIPTION
## CLOC12.178 — bridge private methods `#m()`

Bridges the last private class-member shape: a private method `class C { #m(){} }`, which parses as its own `private_method_definition` grammar node (distinct from `method_definition`) and was declined until now. Builds on CLOC12.177's `PropertyKey::PrivateName` (node + emitter + bridge for private *fields*).

### javascript-parser (MINOR 0.41.0 → 0.42.0)
- New `convert_private_method_definition` dispatched from `convert_class_element`. Reads the key from the node's leading `PRIVATE_NAME` token via the shared `private_name_key` helper (`#` stripped, re-added by the emitter).
- The `static` modifier lives **inside** the `private_method_definition` node (grammar's `[ "static" ]`), unlike a public method's `static` (on the `class_element`), so it's read here. `static #m(){}` works.
- Params + body reuse the shared `convert_formal_parameters` / `convert_formal_parameter` / `convert_function_body`. Kind is always `Method` (a private name can never be `constructor`).
- Private **getter / setter / generator / async** forms carry semantics not yet modelled — like a public generator method they DECLINE (safe WHITESPACE_ONLY), never a mis-emit. The distinguishing `get`/`set`/`*`/`async` token precedes the `PRIVATE_NAME` as a direct token child, so the decline scan can't be bypassed.
- 5 new bridge tests (former decline test flipped to success; a getter-declines guard); full parser suite (212 tests) green.

### closurec (PATCH 0.234.16 → 0.234.17)
- New e2e diff fixture `tests/diff/simple-private-method/`: `class C { #m(){ return 1 + 2 } }` → `class C{#m(){return 3}}` at SIMPLE. The body's `1 + 2` folds to `3`, proving the pipeline descended INTO the private method. Before this change it declined → WHITESPACE_ONLY (`class C{#m(){return 1+2}};`).
- Version-synced `cli.spec.json` + `tests/diff/help-markdown/expected.stdout`.

### Verification
- Grammar shape confirmed (es2025 `private_method_definition`).
- `cargo test -p coding-adventures-javascript-parser` → 212 pass
- `cargo test --test diff_simple_private_method --test diff_help_markdown --test diff_version_banner` → pass
- Security review (Rust, general-purpose subagent): **PASSED** — decline logic can't be bypassed, no panics, no new recursion.

The emitter already prints `#m(){}` (covered in CLOC12.177's private-name conformance port #8004), so this node arc needs no separate emit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)