### PR TITLE
feat(sir-go): Hash to_h (block + no-block) + each_with_index + each_with_object

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.29.0 — Hash `to_h` (block + no-block) / `each_with_index` / `each_with_object`
+
+Mirrors the Python reference (PR #8009) into the Go backend's inline `__sir`
+runtime, rounding out Hash's Enumerable iteration surface (`_sir_hash_method` for
+the no-block `to_h`, `_sir_hash_block_method` for the block forms, plus the
+`_sir_hash_responds` `respond_to?` arm).
+
+- `to_h` **without** a block → a shallow copy of the hash (a fresh `*Map`, so
+  mutating it does not alias the receiver's entries).
+- `to_h { |k, v| [new_k, new_v] }` → a NEW hash from the block-returned `[k, v]`
+  pairs; the block is yielded the two args `(k, v)`; a non-pair result is skipped
+  (never-raise floor — Ruby's TypeError is deferred to the typed-error cascade),
+  and a later pair with a duplicate key wins (Ruby's rule, `_sir_map_set`).
+- `each_with_index { |(k, v), i| … }` → yields each `[k, v]` pair with its
+  0-based index, returns the receiver.
+- `each_with_object(memo) { |(k, v), memo| … }` → yields each `[k, v]` pair with
+  the memo, returns the (mutated) memo; no-memo arg returns the receiver.
+
+Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass
+the element as a single `[k, v]` `*Seq` (the second block param is the
+index/memo), matching Ruby's Enumerable convention.
+
+Exec-proof: `tests/compile_and_run_hash_methods.rs` gains
+`hash_to_h_and_indexed_iteration_compile_and_run`, running to_h (copy + re-map),
+each_with_index (observed pair+index yield, returns self), and each_with_object
+(observed pair+memo yield, returns memo, and no-memo passthrough) under real
+`go run`, diffed against the Python reference semantics.
+
 ## 0.28.0 — Hash Enumerable breadth: `group_by` / `partition` / `flat_map` / `reduce` / `inject` / `sum`
 
 Mirrors the Python `sir-runtime-oop` v0.1.20 reference (PR #7978) into the Go

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -188,7 +188,8 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `select`/`filter`, `reject`, `transform_values`, `transform_keys`, and the
 Enumerable aggregates `find`/`detect`, `any?`/`all?`/`none?`, `count`,
 `sort_by`, `min_by`/`max_by`, `group_by`, `partition`,
-`flat_map`/`collect_concat`, `reduce`/`inject`, `sum`;
+`flat_map`/`collect_concat`, `reduce`/`inject`, `sum`, `to_h` (block +
+no-block), `each_with_index`, `each_with_object`;
 **String** `length`/`size`, `upcase`, `downcase`, `reverse`, `strip`/`lstrip`/
 `rstrip`, `empty?`, `include?`, `start_with?`, `end_with?`, `split`, `chars`,
 `to_i`, `to_f`, `to_sym`; **Numeric** `abs`, `to_i`, `to_f`, `even?`, `odd?`,

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1713,7 +1713,7 @@ func _sir_hash_responds(name string) bool {
 	switch name {
 	// Non-block Hash methods.
 	case "keys", "values", "has_key?", "key?", "include?", "member?",
-		"has_value?", "value?", "size", "length", "empty?", "fetch":
+		"has_value?", "value?", "size", "length", "empty?", "fetch", "to_h":
 		return true
 	// Block-taking Hash methods.
 	case "each", "each_pair", "each_key", "each_value", "map",
@@ -1721,7 +1721,8 @@ func _sir_hash_responds(name string) bool {
 		"find", "detect", "any?", "all?", "none?", "count",
 		"sort_by", "min_by", "max_by",
 		"group_by", "partition", "flat_map", "collect_concat",
-		"reduce", "inject", "sum":
+		"reduce", "inject", "sum",
+		"each_with_index", "each_with_object":
 		return true
 	}
 	return false
@@ -2365,6 +2366,18 @@ func _sir_hash_method(recv *Map, name string, args []Value) (Value, bool) {
 			out[i] = &Seq{Items: []Value{e.Key, e.Val}}
 		}
 		return &Seq{Items: out}, true
+	case "to_h":
+		// Ruby `Hash#to_h` with NO block → a shallow copy of the hash (Ruby
+		// returns `self`; a fresh `*Map` matches the value semantics without
+		// aliasing the receiver's entries).  The block form (which re-maps each
+		// pair to a new `[k, v]`) lives in `_sir_hash_block_method`.
+		keys := make([]Value, len(recv.Entries))
+		vals := make([]Value, len(recv.Entries))
+		for i, e := range recv.Entries {
+			keys[i] = e.Key
+			vals[i] = e.Val
+		}
+		return _sir_map_lit(keys, vals), true
 	case "dig":
 		// Ruby `Hash#dig(k, …)` — a NESTED lookup that walks one key per
 		// argument, returning nil the moment a level is missing (never
@@ -2735,6 +2748,45 @@ func _sir_hash_block_method(recv *Map, name string, args []Value, block *Closure
 			acc = _sir_plus([]Value{acc, _sir_apply(block, []Value{e.Key, e.Val})})
 		}
 		return acc, true
+	case "to_h":
+		// `Hash#to_h { |k, v| [new_k, new_v] }` — a NEW hash from the `[k, v]`
+		// pairs the block returns.  The block is yielded the two args `(k, v)`
+		// (matching `each`) and must return a 2-element `*Seq`; a non-pair result
+		// is skipped (the never-raise floor — Ruby raises TypeError, deferred to
+		// the typed-error cascade), and a later pair with a duplicate key wins
+		// (Ruby's rule, and how `_sir_map_set` already behaves).
+		acc := _sir_map_lit([]Value{}, []Value{})
+		for _, e := range recv.Entries {
+			r := _sir_apply(block, []Value{e.Key, e.Val})
+			if pair, ok := r.(*Seq); ok && len(pair.Items) == 2 {
+				_sir_map_set(acc, pair.Items[0], pair.Items[1])
+			}
+		}
+		return acc, true
+	case "each_with_index":
+		// `each_with_index { |(k, v), i| … }` — yields each `[k, v]` pair with
+		// its 0-based index and returns the receiver.  Unlike the two-arg
+		// `(k, v)` yield of `each`, the element arrives as a single `[k, v]`
+		// `*Seq` (the second block param is the index), matching Ruby's
+		// Enumerable convention.
+		for i, e := range recv.Entries {
+			_sir_apply(block, []Value{&Seq{Items: []Value{e.Key, e.Val}}, int64(i)})
+		}
+		return recv, true
+	case "each_with_object":
+		// `each_with_object(memo) { |(k, v), memo| … }` — yields each `[k, v]`
+		// pair with the memo object and returns the (mutated) memo.  Like
+		// `each_with_index`, the element is the single `[k, v]` pair (the second
+		// block param is the memo).  With no memo argument the receiver is
+		// returned unchanged.
+		if len(args) == 0 {
+			return recv, true
+		}
+		memo := args[0]
+		for _, e := range recv.Entries {
+			_sir_apply(block, []Value{&Seq{Items: []Value{e.Key, e.Val}}, memo})
+		}
+		return memo, true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_hash_methods.rs
@@ -528,3 +528,108 @@ fn hash_enumerable_breadth_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+// ── Hash to_h / each_with_index / each_with_object ─────────────────────────
+//
+// Rounds out Hash's Enumerable iteration surface, mirroring the Python
+// reference (#8009).  `to_h` has a no-block (shallow copy) and a block (re-map)
+// form; `each_with_index`/`each_with_object` yield the `[k, v]` PAIR as a single
+// argument alongside the index/memo (Ruby's Enumerable convention — contrast
+// `each`'s two-arg `(k, v)` yield).
+fn to_h_module() -> Module {
+    // { |k, v| [k, v * 2] } — re-map each pair, doubling the value.
+    let dbl = lambda_fn2(
+        "__lam_dbl",
+        "k",
+        "v",
+        Expr::SeqLit {
+            items: vec![var_p("k"), builtin("*", vec![var_p("v"), ilit(2)])],
+            span: s(),
+        },
+    );
+    // { |pair, i| print [pair, i] } — observe the (pair, index) yield.
+    let print_pi = lambda_fn2(
+        "__lam_pi",
+        "pair",
+        "i",
+        builtin("print", vec![Expr::SeqLit { items: vec![var_p("pair"), var_p("i")], span: s() }]),
+    );
+    // { |pair, memo| print [pair, memo] } — observe the (pair, memo) yield.
+    let print_pm = lambda_fn2(
+        "__lam_pm",
+        "pair",
+        "memo",
+        builtin("print", vec![Expr::SeqLit { items: vec![var_p("pair"), var_p("memo")], span: s() }]),
+    );
+
+    let stmts = vec![
+        // {a:1,b:2}.to_h (no block) → a shallow copy: {a: 1, b: 2}
+        print_stmt(method(map_of(vec![("a", 1), ("b", 2)]), "to_h", vec![])),
+        // {a:1,b:2}.to_h { |k, v| [k, v * 2] } → {a: 2, b: 4}
+        print_stmt(method(map_of(vec![("a", 1), ("b", 2)]), "to_h", vec![closure("__lam_dbl")])),
+        // {a:1,b:2}.each_with_index { |pair, i| print [pair, i] }
+        //   → "[[a, 1], 0]", "[[b, 2], 1]", then the returned self "{a: 1, b: 2}"
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2)]),
+            "each_with_index",
+            vec![closure("__lam_pi")],
+        )),
+        // {a:1,b:2}.each_with_object(0) { |pair, memo| print [pair, memo] }
+        //   → "[[a, 1], 0]", "[[b, 2], 0]", then the returned memo "0"
+        print_stmt(method(
+            map_of(vec![("a", 1), ("b", 2)]),
+            "each_with_object",
+            vec![ilit(0), closure("__lam_pm")],
+        )),
+        // {a:1}.each_with_object { |pair, memo| … } with NO memo arg → returns
+        // the receiver unchanged (the block is never called): "{a: 1}"
+        print_stmt(method(map_of(vec![("a", 1)]), "each_with_object", vec![closure("__lam_pm")])),
+    ];
+
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: s() }, span: s() },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    };
+
+    program(vec![dbl, print_pi, print_pm, main])
+}
+
+#[test]
+fn hash_to_h_and_indexed_iteration_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let artifact = compile(&to_h_module()).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "toh");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "{a: 1, b: 2}",   // to_h (no block) → shallow copy
+            "{a: 2, b: 4}",   // to_h { [k, v*2] } → re-mapped
+            "[[a, 1], 0]",    // each_with_index yields ([a,1], 0)
+            "[[b, 2], 1]",    // each_with_index yields ([b,2], 1)
+            "{a: 1, b: 2}",   // each_with_index returns self
+            "[[a, 1], 0]",    // each_with_object yields ([a,1], 0)
+            "[[b, 2], 0]",    // each_with_object yields ([b,2], 0)
+            "0",              // each_with_object returns the memo
+            "{a: 1}",         // each_with_object with no memo → returns self
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8009](https://github.com/adhithyan15/coding-adventures/pull/8009)) into the **Go** backend's inline `__sir` runtime, rounding out Hash's Enumerable iteration surface (`_sir_hash_method` for no-block `to_h`, `_sir_hash_block_method` for the block forms, + the `_sir_hash_responds` `respond_to?` arm).

## Methods
- `to_h` **without** a block → shallow copy (fresh `*Map`, no alias of receiver entries).
- `to_h { |k,v| [new_k, new_v] }` → new hash from block-returned `[k, v]` pairs; block yields two args `(k, v)`; non-pair result skipped (never-raise floor); last colliding key wins.
- `each_with_index { |(k,v), i| … }` → yields each `[k, v]` pair + 0-based index; returns the receiver.
- `each_with_object(memo) { |(k,v), memo| … }` → yields each `[k, v]` pair + memo; returns the memo; no-memo arg returns the receiver.

Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass the element as a single `[k, v]` `*Seq` (2nd block param is index/memo) — Ruby's Enumerable convention.

## Safety
Never-panic floor holds: `to_h`'s block return is a **checked** type-assertion + length guard (`if pair, ok := r.(*Seq); ok && len(pair.Items) == 2`) before indexing, so a bad block return is skipped, not panicked on.

## Exec-proof
`tests/compile_and_run_hash_methods.rs` gains `hash_to_h_and_indexed_iteration_compile_and_run`, run under real `go run`, diffed against the Python reference:

```
{a: 1, b: 2}     # to_h (no block) → shallow copy
{a: 2, b: 4}     # to_h { [k, v*2] }
[[a, 1], 0]      # each_with_index yields ([a,1], 0)
[[b, 2], 1]
{a: 1, b: 2}     # each_with_index returns self
[[a, 1], 0]      # each_with_object yields ([a,1], 0)
[[b, 2], 0]
0                # each_with_object returns the memo
{a: 1}           # each_with_object with no memo → returns self
```

Version 0.28.0 → 0.29.0; CHANGELOG + README updated. Lib tests 97 green; clippy clean (crate). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)