### PR TITLE
feat(javascript-parser): bridge private accessors get #x()/set #x() (CLOC12.179)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.43.0] - 2026-07-11
+
+### Added — CLOC12.179: bridge private accessors (`get #x()` / `set #x()`)
+
+`convert_private_method_definition` (CLOC12.178) declined the private *accessor*
+forms; it now lowers them. A private getter (`get #x(){}`) becomes a
+`ClassMember::Method` with `MethodKind::Get` and a `PropertyKey::PrivateName`
+key; a private setter (`set #x(v){}`) becomes `MethodKind::Set` with its single
+parameter. The `get` / `set` keyword precedes the `PRIVATE_NAME` token as a
+direct token child (read alongside `static`), so `static get #x(){}` also works.
+
+Still declined: the private **generator** (`*#m(){}`) and **async** forms — like
+a public generator method, they DECLINE (safe WHITESPACE_ONLY), never a mis-emit.
+
+4 new bridge tests (private getter, private setter, static private getter; the
+former `class_private_getter_still_declines` replaced by a
+`class_private_generator_still_declines` guard). MINOR.
+
 ## [0.42.0] - 2026-07-11
 
 ### Added — CLOC12.178 PR1: bridge private methods → `ClassMember::Method` with a private key

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.42.0"
+version = "0.43.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1522,9 +1522,10 @@ fn convert_method_definition(
 /// | [ "static" ] STAR   PRIVATE_NAME ...          // private generator
 /// ```
 ///
-/// This slice models the **plain** form (optionally `static`). The private
-/// getter / setter / generator forms carry accessor or evaluation semantics not
-/// yet represented, so — like a public generator method — they DECLINE via
+/// This slice models the **plain** method and the **get / set accessor** forms
+/// (each optionally `static`) — `#m(){}`, `get #x(){}`, `set #x(v){}`. The
+/// private *generator* (`*#m(){}`) and *async* forms carry evaluation semantics
+/// not yet represented, so — like a public generator method — they DECLINE via
 /// `UnsupportedSyntax` (safe WHITESPACE_ONLY fallback), never a mis-emit.
 ///
 /// Two shape differences from a public `method_definition`:
@@ -1535,21 +1536,27 @@ fn convert_method_definition(
 ///   `[ "static" ]`), not on the enclosing `class_element`, so it is read here.
 ///
 /// A private name can never be the `constructor` (`#constructor` is a
-/// SyntaxError), so the kind is always [`MethodKind::Method`]. Params and body
-/// reuse the shared [`convert_formal_parameters`] / [`convert_formal_parameter`]
-/// / [`convert_function_body`], mirroring [`convert_method_definition`].
+/// SyntaxError), so the kind is a plain [`MethodKind::Method`] or the
+/// [`MethodKind::Get`] / [`MethodKind::Set`] accessor. Params and body reuse the
+/// shared [`convert_formal_parameters`] / [`convert_formal_parameter`] /
+/// [`convert_function_body`], mirroring [`convert_method_definition`].
 fn convert_private_method_definition(node: &GrammarASTNode) -> Result<MethodDefinition, BridgeError> {
-    // Read `static` (inside this node) and detect the accessor / generator forms
-    // this slice declines. `get` / `set` / `*` all precede the PRIVATE_NAME as
-    // direct token children (params live under `formal_parameter(s)` *nodes*, so
-    // a parameter literally named `get` cannot be confused for the modifier).
+    // Read `static` and the `get` / `set` accessor keyword (inside this node);
+    // decline the generator / async forms this slice does not model. All of
+    // `static` / `get` / `set` / `*` / `async` precede the PRIVATE_NAME as direct
+    // token children (params live under `formal_parameter(s)` *nodes*, so a
+    // parameter literally named `get` cannot be confused for the modifier).
     let mut is_static = false;
+    let mut saw_get = false;
+    let mut saw_set = false;
     let mut decline = false;
     for c in &node.children {
         if let ASTNodeOrToken::Token(t) = c {
             match t.value.as_str() {
                 "static" => is_static = true,
-                "get" | "set" | "*" | "async" => decline = true,
+                "get" => saw_get = true,
+                "set" => saw_set = true,
+                "*" | "async" => decline = true,
                 _ => {}
             }
         }
@@ -1577,10 +1584,21 @@ fn convert_private_method_definition(node: &GrammarASTNode) -> Result<MethodDefi
         None => BlockStatement { cv: None, body: vec![] },
     };
 
+    // A private name can never be the `constructor` (`#constructor` is a
+    // SyntaxError), so the only kinds are the plain method and the get/set
+    // accessors.
+    let kind = if saw_get {
+        MethodKind::Get
+    } else if saw_set {
+        MethodKind::Set
+    } else {
+        MethodKind::Method
+    };
+
     Ok(MethodDefinition {
         cv: None,
         key,
-        kind: MethodKind::Method,
+        kind,
         value: FunctionExpression {
             cv: None,
             id: None,
@@ -4052,12 +4070,42 @@ mod tests {
     }
 
     #[test]
-    fn class_private_getter_still_declines() {
-        // `get #x(){}` — a private *getter* carries accessor semantics this slice
-        // does not model; it still DECLINES (safe WHITESPACE_ONLY), never a
+    fn class_private_getter() {
+        // `get #x(){}` — a private getter lowers to a `MethodKind::Get` method
+        // with a private-name key (CLOC12.179).
+        let m = method_of("w = class { get #x(){} };");
+        assert!(matches!(m.kind, MethodKind::Get));
+        assert!(matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "x"));
+        assert!(m.value.params.is_empty());
+    }
+
+    #[test]
+    fn class_private_setter() {
+        // `set #x(v){}` — a private setter lowers to a `MethodKind::Set` method
+        // with a private-name key and its single parameter.
+        let m = method_of("w = class { set #x(v){} };");
+        assert!(matches!(m.kind, MethodKind::Set));
+        assert!(matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "x"));
+        assert_eq!(m.value.params.len(), 1);
+    }
+
+    #[test]
+    fn class_static_private_getter() {
+        // `static get #x(){}` — the `static` and `get` keywords both precede the
+        // private key inside the node.
+        let m = method_of("w = class { static get #x(){} };");
+        assert!(m.is_static);
+        assert!(matches!(m.kind, MethodKind::Get));
+        assert!(matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "x"));
+    }
+
+    #[test]
+    fn class_private_generator_still_declines() {
+        // `*#m(){}` — a private *generator* carries evaluation semantics this
+        // slice does not model; it still DECLINES (safe WHITESPACE_ONLY), never a
         // mis-emit. (A later slice.)
         assert!(matches!(
-            bridge("w = class { get #x(){} };"),
+            bridge("w = class { *#m(){} };"),
             Err(BridgeError::UnsupportedSyntax { .. })
         ));
     }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.18] - 2026-07-11
+
+### Added — CLOC12.179: private accessors end-to-end
+
+Picks up javascript-parser 0.43.0, whose bridge now lowers a private getter /
+setter (`get #x(){}`, `set #x(v){}`) to a `ClassMember::Method` with
+`MethodKind::Get` / `MethodKind::Set` and a `PropertyKey::PrivateName` key. A
+private accessor now survives the full closurec pipeline. New e2e diff fixture
+`tests/diff/simple-private-getter/`:
+`class C { get #x(){ return 1 + 2 } }` → `class C{get #x(){return 3}}` at SIMPLE.
+
+The fixture proves the SIMPLE pipeline descends INTO the getter's body: `1 + 2`
+folds to `3`. Before this bridge extension the private getter declined, dropping
+the file to WHITESPACE_ONLY (`class C{get #x(){return 1+2}};`). Version-synced
+cli.spec.json + tests/diff/help-markdown/expected.stdout. PATCH.
+
 ## [0.234.17] - 2026-07-11
 
 ### Added — CLOC12.178: private methods end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.17"
+version = "0.234.18"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.17",
+  "version": "0.234.18",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.17
+Version: 0.234.18
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-private-getter/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-private-getter/expected.stdout
@@ -1,0 +1,1 @@
+class C{get #x(){return 3}}

--- a/code/programs/rust/closurec/tests/diff/simple-private-getter/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-private-getter/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-private-getter/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-private-getter/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-private-getter/input/a.js
@@ -1,0 +1,1 @@
+class C { get #x(){ return 1 + 2 } }

--- a/code/programs/rust/closurec/tests/diff_simple_private_getter.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_private_getter.rs
@@ -1,0 +1,83 @@
+//! Integration test for the `tests/diff/simple-private-getter/` fixture.
+//!
+//! Exercises a **private accessor** (`get #x(){}`, a `ClassMember::Method` with
+//! `MethodKind::Get` and a `PropertyKey::PrivateName` key) end-to-end at SIMPLE —
+//! the CLOC12.179 bridge extension of the `private_method_definition` node to the
+//! get/set accessor forms, on top of the private-method bridge (CLOC12.178) and
+//! the `PropertyKey::PrivateName` node + emit arms (CLOC12.177).
+//!
+//! The fixture is `class C { get #x(){ return 1 + 2 } }` compiled at SIMPLE.
+//! Two facts prove the whole pipeline ran through the private accessor:
+//!   1. the class round-trips with a `get #x` accessor — proving the bridge
+//!      lowered the `private_method_definition` node (get form) to a
+//!      `ClassMember::Method`, not a WHITESPACE_ONLY fallback; and
+//!   2. the accessor body folds — `1 + 2` → `3` — proving the SIMPLE pipeline
+//!      descended INTO the getter's body. A WHITESPACE_ONLY fallback would leave
+//!      `1+2` intact.
+//! Before this bridge extension a private getter DECLINED, dropping the file to
+//! WHITESPACE_ONLY (`class C{get #x(){return 1+2}};`) and assertion (2) failed.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-private-getter/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_private_getter_folds_body() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-private-getter/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // Guard the *point* of the fixture. (The `get #x` needs its inter-token
+    // space, so only strip for the fold check where it doesn't matter.)
+    // (1) the class round-tripped with a `get #x` private accessor.
+    assert!(
+        actual.contains("get #x("),
+        "private getter did not round-trip with a `get #x(` accessor: {actual}"
+    );
+    // (2) the accessor body folded — proving the pipeline descended INTO the
+    //     getter's body (`1+2`→`3`). A WHITESPACE_ONLY fallback would leave the
+    //     arithmetic intact.
+    let a = actual.replace(' ', "");
+    assert!(
+        a.contains("return3"),
+        "private getter body did not fold to `return 3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+    // (3) a class *declaration* emits bare — NO trailing `;` after the closing
+    //     `}` and NO wrapping paren (a WHITESPACE_ONLY fallback appends `;`).
+    let t = actual.trim_end_matches('\n');
+    assert!(
+        t.ends_with('}') && !t.ends_with("};") && !t.starts_with('('),
+        "class declaration must emit bare (no trailing `;`, no wrap): {actual}"
+    );
+}


### PR DESCRIPTION
## CLOC12.179 — bridge private accessors `get #x()` / `set #x()`

Completes the private class-member family: a private getter/setter, which `convert_private_method_definition` (CLOC12.178) declined until now — dropping the file to WHITESPACE_ONLY and losing all optimization.

### javascript-parser (MINOR 0.42.0 → 0.43.0)
- `convert_private_method_definition` now lowers the accessor forms: `get #x(){}` → `MethodKind::Get`, `set #x(v){}` → `MethodKind::Set`, each with a `PropertyKey::PrivateName` key. The `get`/`set` keyword precedes the `PRIVATE_NAME` token as a direct token child (read alongside `static`), so `static get #x(){}` works.
- Still declined: the private **generator** (`*#m(){}`) and **async** forms — like a public generator method, they DECLINE (safe WHITESPACE_ONLY), never a mis-emit.
- 4 new bridge tests (private getter / setter / static private getter; former decline test replaced by a `class_private_generator_still_declines` guard); full parser suite (215) green.

### closurec (PATCH 0.234.17 → 0.234.18)
- New e2e diff fixture `tests/diff/simple-private-getter/`: `class C { get #x(){ return 1 + 2 } }` → `class C{get #x(){return 3}}` at SIMPLE. The getter body's `1 + 2` folds to `3`, proving the pipeline descended INTO the accessor. Before this change it declined → WHITESPACE_ONLY (`class C{get #x(){return 1+2}};`).
- Version-synced `cli.spec.json` + `tests/diff/help-markdown/expected.stdout`.

### Verification
- Grammar/parse-tree shape confirmed (es2025 `private_method_definition` get/set forms).
- `cargo test -p coding-adventures-javascript-parser` → 215 pass
- `cargo test --test diff_simple_private_getter --test diff_help_markdown --test diff_version_banner` → pass
- Security review (Rust, general-purpose subagent): **PASSED** — decline-before-kind logic is sound, no panics, no new recursion.

The emitter already prints `get #x(){}` (covered by CLOC12.177's private-name conformance port), so this needs no separate emit PR.

**Spec-first finding:** private member *access* (`this.#x`) already round-trips correctly at SIMPLE/WHITESPACE/ADVANCED (modelled as a plain `Identifier` property that nothing renames), so an `Expression::PrivateName` node for it would be fidelity-only — deferred as low-value. Private accessors were the real gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)