### PR TITLE
feat(storage-sqlite): read WITHOUT ROWID tables end-to-end

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.5.7 — Read `WITHOUT ROWID` tables from real .sqlite files
+
+Querying a `WITHOUT ROWID` table in a real `.sqlite` file now works through the
+whole pipeline; previously it failed with `unexpected b-tree page type` because
+such tables live in an *index* b-tree, not a table b-tree. Delivered by
+`sqlite-file` 0.7.0 (`read_without_rowid_table` over `walk_index`) and
+storage-sqlite 0.4.0 (`WITHOUT ROWID` detection + read path). A new
+`file_backed` differential test builds real `WITHOUT ROWID` tables (scalar /
+TEXT / composite primary keys, and an 800-row table spanning interior index
+pages) and diffs mini-sqlite against real bundled SQLite.
+
 ## 0.5.6 — Two-argument TRIM/LTRIM/RTRIM (character-set trimming)
 
 Grows the SQL scalar surface: `TRIM(x, y)`, `LTRIM(x, y)`, and `RTRIM(x, y)`

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/file_backed.rs
+++ b/code/packages/rust/mini-sqlite/tests/file_backed.rs
@@ -226,3 +226,63 @@ fn list_indexes_matches_real_sqlite() {
 
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
+
+/// `WITHOUT ROWID` tables — stored in an index b-tree, not a table b-tree — read
+/// end-to-end through the full pipeline and match real SQLite. Covers a scalar
+/// INTEGER primary key, a TEXT primary key, a composite primary key, and a large
+/// table whose index b-tree spans multiple levels (interior pages), so the
+/// interior-key emission in `walk_index` is exercised through the whole engine.
+#[test]
+fn without_rowid_tables_match_real_sqlite() {
+    // A big WITHOUT ROWID table (800 rows → a two-level index b-tree) plus two
+    // small ones exercising TEXT and composite primary keys.
+    let mut setup = vec![
+        "CREATE TABLE kv (k INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID".to_string(),
+        "CREATE TABLE names (name TEXT PRIMARY KEY, age INTEGER) WITHOUT ROWID".to_string(),
+        "CREATE TABLE pairs (a INTEGER, b INTEGER, note TEXT, PRIMARY KEY (a, b)) WITHOUT ROWID"
+            .to_string(),
+        "INSERT INTO names VALUES ('Ada', 36), ('Grace', 45), ('Alan', 41)".to_string(),
+        "INSERT INTO pairs VALUES (1, 2, 'x'), (1, 3, 'y'), (2, 1, 'z')".to_string(),
+    ];
+    let mut big = String::from("INSERT INTO kv VALUES ");
+    for i in 0..800 {
+        if i > 0 {
+            big.push(',');
+        }
+        big.push_str(&format!("({i}, 'val{i}')"));
+    }
+    setup.push(big);
+    let setup_refs: Vec<&str> = setup.iter().map(String::as_str).collect();
+    let path = build_sqlite_file(&setup_refs);
+
+    let conn = connect(path.to_str().unwrap()).expect("open file-backed connection");
+
+    // Each check: (query, column count). Diff mini-sqlite against real SQLite.
+    let checks: &[(&str, usize)] = &[
+        // Interior-page keys must appear: a full scan of the 800-row table.
+        ("SELECT COUNT(*) FROM kv", 1),
+        // Spot rows from across the tree (small, mid, and the maximum key).
+        ("SELECT k, v FROM kv WHERE k IN (0, 5, 400, 799) ORDER BY k", 2),
+        ("SELECT k FROM kv WHERE k >= 797 ORDER BY k", 1),
+        ("SELECT SUM(k) FROM kv", 1),
+        // TEXT primary key.
+        ("SELECT name, age FROM names ORDER BY name", 2),
+        ("SELECT name FROM names WHERE age > 40 ORDER BY age", 1),
+        // Composite primary key — every column is stored in the record.
+        ("SELECT a, b, note FROM pairs ORDER BY a, b", 3),
+    ];
+    for (q, ncols) in checks {
+        let mut cur = conn
+            .execute(q, &[])
+            .unwrap_or_else(|e| panic!("mini failed on {q}: {e:?}"));
+        let mine: Vec<Vec<String>> = cur
+            .fetchall()
+            .iter()
+            .map(|row| row.iter().map(norm_mini).collect())
+            .collect();
+        let theirs = real_rows(&path, q, *ncols);
+        assert_eq!(mine, theirs, "WITHOUT ROWID divergence on: {q}");
+    }
+
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}

--- a/code/packages/rust/sqlite-file/CHANGELOG.md
+++ b/code/packages/rust/sqlite-file/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — sqlite-file
 
+## 0.7.0 - Unreleased
+
+Phase E5 (cont.): the **name-based convenience reader** for `WITHOUT ROWID`
+tables, so callers no longer need to hand-resolve a root page and pick the right
+b-tree walker.
+
+### Added
+
+- **`read_without_rowid_table(bytes, name) -> Vec<Vec<SqlValue>>`** — the
+  `WITHOUT ROWID` sibling of `read_table`. It resolves the table's root page from
+  `sqlite_schema`, walks its **index** b-tree via `btree::walk_index`, and
+  decodes each record into columns. There is no rowid, so it returns bare column
+  vectors (not `(rowid, columns)`); the record holds every column in declared
+  order, exactly like a rowid table.
+
 ## 0.6.0 - Unreleased
 
 Phase E5: **index b-tree walking** — the raw-file primitive behind `WITHOUT

--- a/code/packages/rust/sqlite-file/Cargo.toml
+++ b/code/packages/rust/sqlite-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-file"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A small, zero-dependency reader for the SQLite on-disk file format — the read subset the Engram Anki-package importer needs — reimplemented from scratch to keep the Engram stack free of the bundled-C `rusqlite` crate."
 license = "MIT"

--- a/code/packages/rust/sqlite-file/src/lib.rs
+++ b/code/packages/rust/sqlite-file/src/lib.rs
@@ -65,4 +65,6 @@ pub use error::SqliteError;
 pub use header::{Header, TextEncoding};
 pub use pager::Pager;
 pub use record::SqlValue;
-pub use schema::{read_schema, read_table, table_root_page, SchemaEntry};
+pub use schema::{
+    read_schema, read_table, read_without_rowid_table, table_root_page, SchemaEntry,
+};

--- a/code/packages/rust/sqlite-file/src/schema.rs
+++ b/code/packages/rust/sqlite-file/src/schema.rs
@@ -57,6 +57,25 @@ pub fn read_table(data: &[u8], name: &str) -> Result<Vec<(i64, Vec<SqlValue>)>, 
         .collect()
 }
 
+/// Read a `WITHOUT ROWID` table by name, returning each row's decoded columns.
+///
+/// A `WITHOUT ROWID` table has no rowid: it stores its rows in an *index* b-tree
+/// keyed by the primary key, so this walks that tree via
+/// [`crate::btree::walk_index`] rather than [`crate::btree::walk_table`]. Each
+/// record still holds every column in the table's declared order — exactly like
+/// an ordinary table's record, only the rowid is absent — so no column needs to
+/// be reconstructed from a rowid. Order is unspecified (an index b-tree yields no
+/// natural rowid ordering); callers sort in SQL when it matters.
+pub fn read_without_rowid_table(data: &[u8], name: &str) -> Result<Vec<Vec<SqlValue>>, SqliteError> {
+    let (header, pager) = Pager::open(data)?;
+    let root_page = table_root_page_from(&pager, &header, name)?;
+    let records = btree::walk_index(&pager, &header, root_page)?;
+    records
+        .into_iter()
+        .map(|record| record::decode(&record).ok_or(SqliteError::Corrupt("bad table row")))
+        .collect()
+}
+
 fn read_schema_from(pager: &Pager<'_>, header: &Header) -> Result<Vec<SchemaEntry>, SqliteError> {
     let rows = btree::walk_table(pager, header, 1)?;
     rows.into_iter()

--- a/code/packages/rust/storage-sqlite/CHANGELOG.md
+++ b/code/packages/rust/storage-sqlite/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog — storage-sqlite
 
+## 0.4.0 — `WITHOUT ROWID` tables read end-to-end
+
+`SqliteFileBackend::scan` now reads `WITHOUT ROWID` tables. These store their
+rows in an *index* b-tree (keyed by the primary key, no rowid), which the
+table-only read path rejected as `unexpected b-tree page type`.
+
+- `scan` detects the `WITHOUT ROWID` clause (checked only in the text after the
+  column-list parens, so a column named like the clause can't false-positive)
+  and reads such tables via `sqlite_file::read_without_rowid_table` (built on
+  `walk_index`) instead of `read_table`.
+- The per-row assembly is factored into a shared `build_row` helper. A rowid
+  table still materializes its `INTEGER PRIMARY KEY` column from the rowid; a
+  `WITHOUT ROWID` table passes `None` for the rowid because the record already
+  stores every column, including the primary key, directly. REAL affinity is
+  applied on both paths.
+- Verified end-to-end against real bundled SQLite (in mini-sqlite's
+  `file_backed` tests): scalar / TEXT / composite primary keys, plus an 800-row
+  table whose index b-tree spans interior pages.
+
 ## 0.3.0 — `list_indexes` reports the file's real indexes
 
 `Backend::list_indexes` was a stub returning `Vec::new()`; it now reports the

--- a/code/packages/rust/storage-sqlite/Cargo.toml
+++ b/code/packages/rust/storage-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-storage-sqlite"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A file-backed storage engine for the mini-sqlite pipeline: exposes a real .sqlite database as a sql-backend Backend, so the SQL engine can query it unmodified. The Rust sibling of python/storage-sqlite; read-only for now (built on the zero-dep sqlite-file reader)."
 license = "MIT"

--- a/code/packages/rust/storage-sqlite/src/lib.rs
+++ b/code/packages/rust/storage-sqlite/src/lib.rs
@@ -44,7 +44,10 @@ use coding_adventures_sql_backend::{
     Backend, BackendError, ColumnDef, Cursor, IndexDef, ListRowIterator, Row, RowIterator,
     SqlValue, TransactionHandle,
 };
-use sqlite_file::{read_schema, read_table, SchemaEntry, SqlValue as FileValue, SqliteError};
+use sqlite_file::{
+    read_schema, read_table, read_without_rowid_table, SchemaEntry, SqlValue as FileValue,
+    SqliteError,
+};
 
 /// A read-only [`Backend`] over the bytes of a SQLite database file.
 ///
@@ -133,6 +136,60 @@ fn file_value_to_backend(value: FileValue) -> SqlValue {
         FileValue::Real(f) => SqlValue::Float(f),
         FileValue::Text(s) => SqlValue::Text(s),
         FileValue::Blob(b) => SqlValue::Blob(b),
+    }
+}
+
+/// Assemble one query-engine [`Row`] from a record's raw column values.
+///
+/// `rowid` is `Some` for an ordinary table (so an `INTEGER PRIMARY KEY` column,
+/// stored as `NULL` in the record, can be materialized from it) and `None` for a
+/// `WITHOUT ROWID` table (which stores every column directly and has no rowid).
+/// REAL affinity is applied either way: an integer stored in a REAL column is
+/// presented back as a float, matching SQLite's integer-storage optimization.
+fn build_row(values: &[FileValue], columns: &[ParsedColumn], rowid: Option<i64>) -> Row {
+    let mut row: Row = BTreeMap::new();
+    for (i, col) in columns.iter().enumerate() {
+        let decoded = values
+            .get(i)
+            .cloned()
+            .map(file_value_to_backend)
+            .unwrap_or(SqlValue::Null);
+        // Materialize a rowid-alias column from the rowid, but only for a rowid
+        // table (`rowid.is_some()`); a WITHOUT ROWID table stores the value.
+        let value = match (col.is_rowid_alias, &decoded, rowid) {
+            (true, SqlValue::Null, Some(r)) => SqlValue::Int(r),
+            _ => decoded,
+        };
+        let value = match value {
+            SqlValue::Int(n) if col.real_affinity => SqlValue::Float(n as f64),
+            other => other,
+        };
+        row.insert(col.name.clone(), value);
+    }
+    row
+}
+
+/// Does this `CREATE TABLE` declare a `WITHOUT ROWID` table? Such a table stores
+/// its rows in an index b-tree keyed by the primary key — read via
+/// [`read_without_rowid_table`], not [`read_table`].
+///
+/// The `WITHOUT ROWID` clause follows the closing paren of the column list, so we
+/// test only the text *after* the outermost parentheses (case-insensitively, with
+/// whitespace normalized). Checking the whole SQL would risk a false positive
+/// from a column name or string literal that happened to contain the words.
+fn is_without_rowid(create_sql: &str) -> bool {
+    // The column list's closing paren is the last `)` in a well-formed CREATE
+    // TABLE (any inner `PRIMARY KEY(...)` closes before it).
+    match create_sql.rfind(')') {
+        Some(idx) => {
+            let tail: String = create_sql[idx + 1..]
+                .to_ascii_uppercase()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            tail.contains("WITHOUT ROWID")
+        }
+        None => false,
     }
 }
 
@@ -434,39 +491,33 @@ impl Backend for SqliteFileBackend {
             .ok_or_else(|| BackendError::TableNotFound {
                 table: table.to_string(),
             })?;
-        let columns = parse_create_columns(entry.sql.as_deref().unwrap_or(""));
+        let create_sql = entry.sql.as_deref().unwrap_or("");
+        let columns = parse_create_columns(create_sql);
 
-        // Decode every row of the table from the on-disk b-tree.
-        let raw = read_table(&self.data, &entry.name).map_err(|e| BackendError::Internal {
-            message: e.to_string(),
-        })?;
-
-        let mut rows: Vec<Row> = Vec::with_capacity(raw.len());
-        for (rowid, values) in raw {
-            let mut row: Row = BTreeMap::new();
-            for (i, col) in columns.iter().enumerate() {
-                let decoded = values
-                    .get(i)
-                    .cloned()
-                    .map(file_value_to_backend)
-                    .unwrap_or(SqlValue::Null);
-                // Materialize an INTEGER PRIMARY KEY column from the rowid — the
-                // record stores NULL for it.
-                let value = if col.is_rowid_alias && matches!(decoded, SqlValue::Null) {
-                    SqlValue::Int(rowid)
-                } else {
-                    decoded
-                };
-                // Apply REAL affinity: an integer stored in a REAL column is read
-                // back as a float (SQLite's integer-storage space optimization).
-                let value = match value {
-                    SqlValue::Int(i) if col.real_affinity => SqlValue::Float(i as f64),
-                    other => other,
-                };
-                row.insert(col.name.clone(), value);
-            }
-            rows.push(row);
-        }
+        let rows: Vec<Row> = if is_without_rowid(create_sql) {
+            // A `WITHOUT ROWID` table lives in an index b-tree keyed by its
+            // primary key. It has no rowid, so we read it through `walk_index`
+            // (via `read_without_rowid_table`) and build each row with `None` for
+            // the rowid — the record already stores every column, including the
+            // primary key, directly.
+            let raw = read_without_rowid_table(&self.data, &entry.name).map_err(|e| {
+                BackendError::Internal {
+                    message: e.to_string(),
+                }
+            })?;
+            raw.into_iter()
+                .map(|values| build_row(&values, &columns, None))
+                .collect()
+        } else {
+            // Ordinary rowid table: walk the table b-tree, and materialize an
+            // INTEGER PRIMARY KEY column from the rowid (the record stores NULL).
+            let raw = read_table(&self.data, &entry.name).map_err(|e| BackendError::Internal {
+                message: e.to_string(),
+            })?;
+            raw.into_iter()
+                .map(|(rowid, values)| build_row(&values, &columns, Some(rowid)))
+                .collect()
+        };
         Ok(Box::new(ListRowIterator::new(rows)))
     }
 


### PR DESCRIPTION
## Summary

Phase E5 (cont.), **Stream C** — the second half of the `WITHOUT ROWID`
capability. The [previous PR](https://github.com/adhithyan15/coding-adventures/pull/8013)
added the `walk_index` file-format primitive; **this wires it all the way up**,
so querying a `WITHOUT ROWID` table in a real `.sqlite` file now works through
the whole mini-sqlite pipeline. Before this, such a query failed with
`unexpected b-tree page type` — these tables live in an **index** b-tree, not a
table b-tree.

## Changes

**`sqlite-file` (0.6.0 → 0.7.0)**
- New `read_without_rowid_table(bytes, name) -> Vec<Vec<SqlValue>>`, the
  `WITHOUT ROWID` sibling of `read_table`: resolve the root page from
  `sqlite_schema`, walk the index b-tree via `walk_index`, decode each record.
  No rowid, so it returns bare column vectors; the record holds every column in
  declared order, exactly like a rowid table.

**`storage-sqlite` (0.3.0 → 0.4.0)**
- `scan` detects the `WITHOUT ROWID` clause and dispatches to the index reader
  instead of `read_table`. Detection checks only the text **after** the
  column-list parens (the last `)`), so a column name or string literal
  containing the words can't false-positive; a detection mismatch on a hostile
  file degrades to a clean `Err` (the wrong walker rejects the page type), never
  a silent wrong result.
- Per-row assembly is factored into a shared `build_row` helper. A rowid table
  still materializes its `INTEGER PRIMARY KEY` column from the rowid; a
  `WITHOUT ROWID` table passes `None` (the record stores every column, including
  the PK, directly). REAL affinity is applied on both paths.

## Security

Reviewed as untrusted-file parsing before push. No new unbounded work or
allocation — `read_without_rowid_table` inherits `walk_index`'s cycle and
amplification guards; `is_without_rowid` slices at an ASCII `)` boundary (UTF-8
safe); `build_row` uses bounds-safe `values.get(i)`; every detection mismatch
degrades to a clean `Err`. **Review passed, no findings.**

## Verification

End-to-end **differential test** in mini-sqlite's `file_backed.rs`: builds real
`WITHOUT ROWID` tables via `rusqlite` and diffs mini-sqlite against real bundled
SQLite —
- scalar `INTEGER PRIMARY KEY`, `TEXT PRIMARY KEY`, and composite `PRIMARY KEY (a,b)`;
- an **800-row** table whose index b-tree spans interior pages, so interior-key
  emission in `walk_index` is exercised through the full engine
  (`COUNT(*)`, `SUM`, `WHERE ... IN`, range scans, `ORDER BY`).

Full affected set green: `sqlite-file` 39, `storage-sqlite`, `mini-sqlite`
(`file_backed` 5). The rowid-table read path is unchanged.

`mini-sqlite` 0.5.6 → 0.5.7; CHANGELOGs updated for all three crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
