### PR TITLE
feat(cobol): COMPUTE runtime — expression eval, ROUNDED, ON SIZE ERROR (PL08 v0.5)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.0 — COMPUTE / arithmetic expressions (PL08)
+
+- Executes `COMPUTE target [ROUNDED] = <expr> [ON SIZE ERROR …]`.
+- **Expression evaluation** over the parser's precedence-layered tree: `+ - * /`,
+  `**` (exponentiation, right-associative, non-negative integer exponents;
+  negative/fractional/oversized exponents are a clean error), unary sign, and
+  parentheses. Names must resolve to numeric items.
+- **`ROUNDED`** rounds half away from zero to the receiver's decimal places;
+  without it the result truncates (toward zero), consistent with the other verbs.
+- **`ON SIZE ERROR`** runs its statements and leaves the receiver unchanged when
+  the result's integer part overflows the receiver, or when a division by zero
+  occurs in the expression. Without a handler, overflow truncates high-order
+  digits silently (as `MOVE` does) and a zero divisor stays a hard
+  `DivideByZero` error.
+- Division inside an expression is carried to a fixed 12-digit intermediate
+  fractional precision, then rounded/truncated into the receiver — a documented
+  simplification of the standard's composite intermediate-precision rules (see
+  PL08); to be refined in a later PR.
+- Exponentiation is bounded (`MAX_POW_EXP = 1024`) so a hostile `A ** huge`
+  cannot spin the repeated-multiply loop.
+
 ## 0.4.0 — IF / conditional branching (PL08)
 
 - `IF cond THEN… [ELSE …]` with the current grammar's simple relational

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -21,11 +21,12 @@ let out = run_cobol(source)?; // everything the program DISPLAYed
 A small but **fully correct** slice, growing one quirk at a time: unsigned
 numeric-display (`9`/`V`) and character (`X`/`A`) pictures; the item tree from
 level numbers; `VALUE` initialisation; figurative `ZERO`/`SPACE`; `MOVE` with
-the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; and fixed-point
+the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; fixed-point
 decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
-toward zero into the receiver; divide-by-zero is a clean error); and `IF … ELSE`
-with numeric and alphanumeric comparison. Anything not yet modelled (signed `S`,
-`COMPUTE`, `ROUNDED`/`ON SIZE ERROR`, editing pictures, `COMP`, `PERFORM`,
-`GO TO`, `EVALUATE`, tables, files, and every other verb) returns a descriptive
-`RuntimeError` — never wrong output. See PL08 for the roadmap toward full COBOL
-and later standards.
+toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
+precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
+parentheses), `ROUNDED`, and `ON SIZE ERROR`; and `IF … ELSE` with numeric and
+alphanumeric comparison. Anything not yet modelled (signed `S`, editing
+pictures, `COMP`, `PERFORM`, `GO TO`, `EVALUATE`, tables, files, and every other
+verb) returns a descriptive `RuntimeError` — never wrong output. See PL08 for the
+roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -3,9 +3,17 @@
 
 use crate::error::RuntimeError;
 use crate::picture::Picture;
-use crate::program::{Cond, Fig, Lit, Operand, Program, RelOp, Stmt};
-use crate::value::{add, div, move_into_char, move_into_numeric, mul, sub, Decimal};
+use crate::program::{ArithOp, Cond, Expr, Fig, Lit, Operand, Program, RelOp, Stmt};
+use crate::value::{add, div, move_into_char, move_into_numeric, mul, pow, round, sub, Decimal};
 use std::collections::HashMap;
+
+/// Fractional precision COMPUTE carries through an intermediate **division**
+/// before the final round/truncate into the receiver. COBOL's standard defines
+/// an intricate composite intermediate precision; we use a fixed generous scale
+/// here (correct to this many places, then rounded to the receiver). This is a
+/// documented simplification — see PL08 — not the full standard rule. 12 places
+/// stays comfortably inside `i128` for realistic magnitudes.
+const COMPUTE_DIV_SCALE: usize = 12;
 
 /// One field in the data model. Elementary items carry a picture and character
 /// storage; group items (no picture) are the concatenation of their children.
@@ -165,13 +173,24 @@ impl Machine {
             Stmt::Divide { divisor, dividend, giving } => {
                 self.exec_divide(divisor, dividend, giving)?
             }
+            Stmt::Compute { target, rounded, expr, on_size_error } => {
+                return self.exec_compute(target, *rounded, expr, on_size_error);
+            }
             Stmt::If { cond, then_branch, else_branch } => {
                 let branch = if self.eval_cond(cond)? { then_branch } else { else_branch };
-                for s in branch {
-                    if self.exec_stmt(s)? {
-                        return Ok(true); // STOP RUN inside the branch
-                    }
-                }
+                return self.run_stmts(branch);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Execute a sequence of statements, short-circuiting on `STOP RUN` (the
+    /// returned `true` propagates up to unwind any enclosing branches). Shared by
+    /// `IF` branches and `COMPUTE … ON SIZE ERROR` handlers.
+    fn run_stmts(&mut self, stmts: &[Stmt]) -> Result<bool, RuntimeError> {
+        for s in stmts {
+            if self.exec_stmt(s)? {
+                return Ok(true);
             }
         }
         Ok(false)
@@ -319,10 +338,109 @@ impl Machine {
 
     /// The number of fractional digit positions of a named numeric receiver.
     fn numeric_dec_digits(&self, name: &str) -> Result<usize, RuntimeError> {
+        Ok(self.numeric_dims(name)?.1)
+    }
+
+    /// The `(int_digits, dec_digits)` of a named numeric receiver.
+    fn numeric_dims(&self, name: &str) -> Result<(usize, usize), RuntimeError> {
         let idx = *self.by_name.get(name).ok_or_else(|| RuntimeError::UndefinedName(name.into()))?;
         match &self.items[idx].picture {
-            Some(Picture::Numeric { dec_digits, .. }) => Ok(*dec_digits),
+            Some(Picture::Numeric { int_digits, dec_digits }) => Ok((*int_digits, *dec_digits)),
             _ => Err(RuntimeError::Unsupported(format!("arithmetic on non-numeric field {name}"))),
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // COMPUTE — expression evaluation, ROUNDED, ON SIZE ERROR
+    // ----------------------------------------------------------------------
+
+    /// `COMPUTE target [ROUNDED] = expr [ON SIZE ERROR …]`.
+    ///
+    /// Evaluate the expression, round or truncate to the receiver's decimal
+    /// places, and store it — unless the result's integer part overflows the
+    /// receiver (or a division by zero occurred). On such a **size error**: run
+    /// the `ON SIZE ERROR` statements and leave the receiver unchanged if a
+    /// handler was given; otherwise fall back to COBOL's handler-less behaviour
+    /// (overflow truncates silently like `MOVE`; a zero divisor is a hard error).
+    fn exec_compute(
+        &mut self,
+        target: &str,
+        rounded: bool,
+        expr: &Expr,
+        on_size_error: &[Stmt],
+    ) -> Result<bool, RuntimeError> {
+        let (int_digits, dec_digits) = self.numeric_dims(target)?;
+
+        let value = match self.eval_expr(expr) {
+            Ok(v) => v,
+            // Division by zero is a size-error condition: the handler catches it;
+            // without one it stays a hard DivideByZero (as bare DIVIDE does).
+            Err(RuntimeError::DivideByZero) if !on_size_error.is_empty() => {
+                return self.run_stmts(on_size_error);
+            }
+            Err(e) => return Err(e),
+        };
+
+        // Round (half away from zero) or leave full precision for the store to
+        // truncate at the receiver's decimal places.
+        let final_value = if rounded {
+            checked(round(&value, dec_digits))?
+        } else {
+            value
+        };
+
+        // Size error = the integer part does not fit. (Fractional truncation is
+        // never a size error.)
+        if final_value.int.trim_start_matches('0').len() > int_digits {
+            if on_size_error.is_empty() {
+                // No handler: COBOL truncates the high-order digits silently,
+                // exactly as move_into_numeric already does.
+                self.store_number(target, final_value)?;
+                return Ok(false);
+            }
+            return self.run_stmts(on_size_error);
+        }
+
+        self.store_number(target, final_value)?;
+        Ok(false)
+    }
+
+    /// Evaluate an arithmetic expression to an exact [`Decimal`]. Division is
+    /// carried to [`COMPUTE_DIV_SCALE`] fractional digits; a zero divisor is a
+    /// [`RuntimeError::DivideByZero`] (which `COMPUTE`'s caller may turn into a
+    /// size error). Names must resolve to numeric items.
+    fn eval_expr(&self, e: &Expr) -> Result<Decimal, RuntimeError> {
+        match e {
+            Expr::Num(s) => Decimal::parse_literal(s)
+                .ok_or_else(|| RuntimeError::Unsupported(format!("numeric literal {s}"))),
+            Expr::Var(name) => self.named_decimal(name),
+            Expr::Unary { neg, operand } => {
+                let mut d = self.eval_expr(operand)?;
+                if *neg && !d.is_zero() {
+                    d.neg = !d.neg;
+                }
+                Ok(d)
+            }
+            Expr::Binary { op, left, right } => {
+                let a = self.eval_expr(left)?;
+                let b = self.eval_expr(right)?;
+                match op {
+                    ArithOp::Add => checked(add(&a, &b)),
+                    ArithOp::Sub => checked(sub(&a, &b)),
+                    ArithOp::Mul => checked(mul(&a, &b)),
+                    ArithOp::Div => {
+                        if b.is_zero() {
+                            return Err(RuntimeError::DivideByZero);
+                        }
+                        checked(div(&a, &b, COMPUTE_DIV_SCALE))
+                    }
+                    ArithOp::Pow => pow(&a, &b).ok_or_else(|| {
+                        RuntimeError::Unsupported(
+                            "COMPUTE ** with a negative, fractional, or oversized exponent".into(),
+                        )
+                    }),
+                }
+            }
         }
     }
 

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -544,6 +544,36 @@ mod tests {
         assert!(matches!(err, RuntimeError::DivideByZero), "got {err:?}");
     }
 
+    #[test]
+    fn compute_huge_flat_operator_chain_errors_not_overflows() {
+        // A flat `A + A + A + …` chain uses grammar repetition, so the parser's
+        // recursion-depth cap does not bound its *width*. Folding it builds a
+        // tree that deep, which would overflow the native stack in eval (and in
+        // the recursive Drop). The operand budget turns it into a clean error
+        // instead. 5000 terms is far past MAX_EXPR_OPERANDS (1024). Split across
+        // cards so the 80-column format doesn't truncate the expression.
+        let mut lines = vec![
+            "IDENTIFICATION DIVISION.".to_string(),
+            "PROGRAM-ID. P.".to_string(),
+            "DATA DIVISION.".to_string(),
+            "WORKING-STORAGE SECTION.".to_string(),
+            "01  A  PIC 9(3) VALUE 1.".to_string(),
+            "01  R  PIC 9(9) VALUE 0.".to_string(),
+            "PROCEDURE DIVISION.".to_string(),
+            "MAIN.".to_string(),
+            "    COMPUTE R = A".to_string(),
+        ];
+        for _ in 0..5000 {
+            lines.push("        + A".to_string());
+        }
+        lines.push("        .".to_string());
+        lines.push("    STOP RUN.".to_string());
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let err = run_cobol(&program(&refs)).unwrap_err();
+        assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
+        assert!(err.to_string().contains("too large"), "message should explain: {err}");
+    }
+
     // ----------------------------------------------------------------------
     // Honest failure: unmodelled features error, they do not run wrong.
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -7,11 +7,13 @@
 //!
 //! It implements a *small but fully correct* slice — `MOVE` / `DISPLAY` /
 //! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
-//! and `IF … ELSE` (numeric and alphanumeric comparison) over unsigned
-//! numeric-display and character pictures — and returns a descriptive error for
-//! anything not yet modelled, rather than producing wrong output. The roadmap
-//! toward full COBOL (signed numerics, `COMPUTE`, `ROUNDED`/`ON SIZE ERROR`,
-//! editing pictures, `PERFORM`, tables, files, later standards) is in PL08.
+//! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
+//! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), and `IF … ELSE`
+//! (numeric and alphanumeric comparison) over unsigned numeric-display and
+//! character pictures — and returns a descriptive error for anything not yet
+//! modelled, rather than producing wrong output. The roadmap toward full COBOL
+//! (signed numerics, editing pictures, `PERFORM`, tables, files, later
+//! standards) is in PL08.
 //!
 //! ```
 //! use coding_adventures_cobol_runtime::run_cobol;
@@ -432,6 +434,114 @@ mod tests {
         let err = run_cobol(&program(&refs)).unwrap_err();
         assert!(matches!(err, RuntimeError::Parse(_)), "got {err:?}");
         assert!(err.to_string().to_lowercase().contains("nest"), "message should explain: {err}");
+    }
+
+    // ----------------------------------------------------------------------
+    // COMPUTE — expression evaluation, ROUNDED, ON SIZE ERROR
+    // ----------------------------------------------------------------------
+
+    /// Build a program with three numeric inputs and one receiver `R`, run the
+    /// given procedure body, and return what it DISPLAYed. `A`, `B`, `C` are
+    /// `9(3)`; `R` is whatever `r_pic` says.
+    fn run_compute(a: &str, b: &str, c: &str, r_pic: &str, body: &[&str]) -> Result<String, RuntimeError> {
+        let mut lines = vec![
+            "IDENTIFICATION DIVISION.".to_string(),
+            "PROGRAM-ID. P.".to_string(),
+            "DATA DIVISION.".to_string(),
+            "WORKING-STORAGE SECTION.".to_string(),
+            format!("01  A  PIC 9(3) VALUE {a}."),
+            format!("01  B  PIC 9(3) VALUE {b}."),
+            format!("01  C  PIC 9(3) VALUE {c}."),
+            format!("01  R  PIC {r_pic} VALUE 0."),
+            "PROCEDURE DIVISION.".to_string(),
+            "MAIN.".to_string(),
+        ];
+        lines.extend(body.iter().map(|s| format!("    {s}")));
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        run_cobol(&program(&refs))
+    }
+
+    #[test]
+    fn compute_respects_operator_precedence() {
+        // A + B * C = 10 + 3*2 = 16 → stored in 9(4)V99 → "001600".
+        let out = run_compute("10", "3", "2", "9(4)V99",
+            &["COMPUTE R = A + B * C.", "DISPLAY R.", "STOP RUN."]).unwrap();
+        assert_eq!(out, "001600\n");
+    }
+
+    #[test]
+    fn compute_parentheses_override_precedence() {
+        // (A + B) * C = (10 + 3) * 2 = 26 → "002600".
+        let out = run_compute("10", "3", "2", "9(4)V99",
+            &["COMPUTE R = (A + B) * C.", "DISPLAY R.", "STOP RUN."]).unwrap();
+        assert_eq!(out, "002600\n");
+    }
+
+    #[test]
+    fn compute_exponentiation_and_unary_minus() {
+        // C ** B = 2 ** 3 = 8 → "000800".
+        let out = run_compute("10", "3", "2", "9(4)V99",
+            &["COMPUTE R = C ** B.", "DISPLAY R.", "STOP RUN."]).unwrap();
+        assert_eq!(out, "000800\n");
+        // Unary minus then stored into an unsigned receiver keeps the magnitude:
+        // A - (A + B) = 10 - 13 = -3 → magnitude 3 → "000300".
+        let out = run_compute("10", "3", "2", "9(4)V99",
+            &["COMPUTE R = A - (A + B).", "DISPLAY R.", "STOP RUN."]).unwrap();
+        assert_eq!(out, "000300\n");
+    }
+
+    #[test]
+    fn compute_division_truncates_then_rounds() {
+        // A / B = 10 / 3 = 3.333… → truncated into V99 → "0003.33" = "000333".
+        let out = run_compute("10", "3", "2", "9(4)V99",
+            &["COMPUTE R = A / B.", "DISPLAY R.", "STOP RUN."]).unwrap();
+        assert_eq!(out, "000333\n");
+        // With ROUNDED to two places, 3.333… → 3.33 (the third place is < 5).
+        let out = run_compute("20", "3", "2", "9(4)V99",
+            &["COMPUTE R ROUNDED = A / B.", "DISPLAY R.", "STOP RUN."]).unwrap();
+        // 20 / 3 = 6.666… → rounds to 6.67 → "000667".
+        assert_eq!(out, "000667\n");
+    }
+
+    #[test]
+    fn compute_on_size_error_fires_on_overflow() {
+        // A * A * A = 10^3 = 1000, but R is only 9(2) (max 99): integer overflow
+        // → the ON SIZE ERROR handler runs and R is left unchanged (still 0).
+        let out = run_compute("10", "3", "2", "9(2)", &[
+            "COMPUTE R = A * A * A",
+            "    ON SIZE ERROR DISPLAY \"TOO BIG\".",
+            "DISPLAY R.",
+            "STOP RUN.",
+        ]).unwrap();
+        assert_eq!(out, "TOO BIG\n00\n");
+    }
+
+    #[test]
+    fn compute_overflow_without_handler_truncates() {
+        // Same overflow but no handler: COBOL truncates high-order digits
+        // silently (1000 into 9(2) keeps the low "00").
+        let out = run_compute("10", "3", "2", "9(2)",
+            &["COMPUTE R = A * A * A.", "DISPLAY R.", "STOP RUN."]).unwrap();
+        assert_eq!(out, "00\n");
+    }
+
+    #[test]
+    fn compute_on_size_error_catches_divide_by_zero() {
+        // Dividing by (C - C) = 0 is a size-error condition; the handler runs.
+        let out = run_compute("10", "3", "2", "9(4)V99", &[
+            "COMPUTE R = A / (C - C)",
+            "    ON SIZE ERROR DISPLAY \"DIV ZERO\".",
+            "DISPLAY R.",
+            "STOP RUN.",
+        ]).unwrap();
+        assert_eq!(out, "DIV ZERO\n000000\n");
+    }
+
+    #[test]
+    fn compute_divide_by_zero_without_handler_is_an_error() {
+        let err = run_compute("10", "3", "2", "9(4)V99",
+            &["COMPUTE R = A / (C - C).", "DISPLAY R.", "STOP RUN."]).unwrap_err();
+        assert!(matches!(err, RuntimeError::DivideByZero), "got {err:?}");
     }
 
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -387,7 +387,7 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 .any(|(k, v)| k == "KEYWORD" && v == "ROUNDED");
             let expr_node = child_node(verb, "arith_expr")
                 .ok_or_else(|| RuntimeError::Unsupported("COMPUTE without an expression".into()))?;
-            let expr = read_arith_expr(expr_node)?;
+            let expr = read_arith_expr_bounded(expr_node)?;
             let on_size_error = match child_node(verb, "size_error") {
                 Some(se) => child_nodes(se, "statement")
                     .into_iter()
@@ -466,38 +466,59 @@ fn read_condition(cond: &GrammarASTNode) -> Result<Cond, RuntimeError> {
 // left-to-right (left-associative); `**` folds right-to-left (COBOL's
 // right-associative exponentiation). A single operand with no operator collapses
 // to the operand itself, so `COMPUTE X = A` carries no spurious tree nodes.
+//
+// DoS bound: the grammar's `{ … }` repetition is *flat* (no rule recursion), so
+// the parser's recursion-depth cap does NOT limit how *wide* a chain can be —
+// `A + A + … + A` with N terms is one node with 2N−1 children at bounded parse
+// depth. Folding that yields an N-deep `Expr` tree, and both `eval_expr` and the
+// recursive `Drop` of `Box<Expr>` would then overflow the native stack. So a
+// single [`MAX_EXPR_OPERANDS`] budget is threaded through the whole expression
+// (counting every primary, across parenthesised levels too); exhausting it is a
+// clean `RuntimeError`, which keeps the folded tree — hence the eval/Drop
+// recursion depth — bounded.
+
+/// Largest number of primaries (`NUMBER`/`NAME`/parenthesised group) a single
+/// `COMPUTE` expression may contain. Real expressions have a handful; the cap is
+/// only a native-stack backstop against a hostile flat chain.
+const MAX_EXPR_OPERANDS: usize = 1024;
+
+/// Read a `COMPUTE` expression, bounding its size against a stack-overflow DoS.
+fn read_arith_expr_bounded(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+    let mut budget = MAX_EXPR_OPERANDS;
+    read_arith_expr(node, &mut budget)
+}
 
 /// `arith_expr = arith_term { ( "+" | "-" ) arith_term }` — additive, left-assoc.
-fn read_arith_expr(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+fn read_arith_expr(node: &GrammarASTNode, budget: &mut usize) -> Result<Expr, RuntimeError> {
     read_binary_chain(node, read_arith_term, |t| match t {
         "PLUS" => Some(ArithOp::Add),
         "MINUS" => Some(ArithOp::Sub),
         _ => None,
-    })
+    }, budget)
 }
 
 /// `arith_term = arith_factor { ( "*" | "/" ) arith_factor }` — multiplicative.
-fn read_arith_term(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+fn read_arith_term(node: &GrammarASTNode, budget: &mut usize) -> Result<Expr, RuntimeError> {
     read_binary_chain(node, read_arith_factor, |t| match t {
         "STAR" => Some(ArithOp::Mul),
         "SLASH" => Some(ArithOp::Div),
         _ => None,
-    })
+    }, budget)
 }
 
 /// `arith_factor = arith_unary { "**" arith_unary }` — exponentiation, folded
 /// right-associatively so `A ** B ** C` = `A ** (B ** C)`.
-fn read_arith_factor(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+fn read_arith_factor(node: &GrammarASTNode, budget: &mut usize) -> Result<Expr, RuntimeError> {
     let units = child_nodes(node, "arith_unary");
     let mut rev = units.iter().rev();
     let last = rev
         .next()
         .ok_or_else(|| RuntimeError::Unsupported("empty arithmetic factor".into()))?;
-    let mut expr = read_arith_unary(last)?;
+    let mut expr = read_arith_unary(last, budget)?;
     for u in rev {
         expr = Expr::Binary {
             op: ArithOp::Pow,
-            left: Box::new(read_arith_unary(u)?),
+            left: Box::new(read_arith_unary(u, budget)?),
             right: Box::new(expr),
         };
     }
@@ -506,19 +527,23 @@ fn read_arith_factor(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
 
 /// `arith_unary = [ "+" | "-" ] arith_primary` — a leading minus negates; a
 /// leading plus is a no-op.
-fn read_arith_unary(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+fn read_arith_unary(node: &GrammarASTNode, budget: &mut usize) -> Result<Expr, RuntimeError> {
     let neg = child_tokens(node).iter().any(|(k, _)| k == "MINUS");
     let prim = child_node(node, "arith_primary")
         .ok_or_else(|| RuntimeError::Unsupported("unary operator without an operand".into()))?;
-    let e = read_arith_primary(prim)?;
+    let e = read_arith_primary(prim, budget)?;
     Ok(if neg { Expr::Unary { neg: true, operand: Box::new(e) } } else { e })
 }
 
-/// `arith_primary = NUMBER | NAME | "(" arith_expr ")"`.
-fn read_arith_primary(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+/// `arith_primary = NUMBER | NAME | "(" arith_expr ")"`. Charges one unit of the
+/// expression's operand budget.
+fn read_arith_primary(node: &GrammarASTNode, budget: &mut usize) -> Result<Expr, RuntimeError> {
+    *budget = budget
+        .checked_sub(1)
+        .ok_or_else(|| RuntimeError::Unsupported("COMPUTE expression too large".into()))?;
     // A parenthesised sub-expression recurses back to the top of the cascade.
     if let Some(inner) = child_node(node, "arith_expr") {
-        return read_arith_expr(inner);
+        return read_arith_expr(inner, budget);
     }
     for (k, v) in child_tokens(node) {
         match k.as_str() {
@@ -532,18 +557,20 @@ fn read_arith_primary(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
 
 /// Fold a `head { op tail }` node into a left-associative binary tree. `sub`
 /// reads each operand node; `map_op` maps an operator token's type name to an
-/// [`ArithOp`] (returning `None` for tokens that are not operators).
+/// [`ArithOp`] (returning `None` for tokens that are not operators). `budget`
+/// bounds the total operand count (see [`MAX_EXPR_OPERANDS`]).
 fn read_binary_chain(
     node: &GrammarASTNode,
-    sub: fn(&GrammarASTNode) -> Result<Expr, RuntimeError>,
+    sub: fn(&GrammarASTNode, &mut usize) -> Result<Expr, RuntimeError>,
     map_op: fn(&str) -> Option<ArithOp>,
+    budget: &mut usize,
 ) -> Result<Expr, RuntimeError> {
     let mut expr: Option<Expr> = None;
     let mut pending: Option<ArithOp> = None;
     for child in &node.children {
         match child {
             ASTNodeOrToken::Node(n) => {
-                let operand = sub(n)?;
+                let operand = sub(n, budget)?;
                 expr = Some(match (expr.take(), pending.take()) {
                     (Some(left), Some(op)) => Expr::Binary {
                         op,

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -70,9 +70,45 @@ pub enum Stmt {
     Multiply { a: Operand, by: Operand, giving: Option<String> },
     /// `DIVIDE a INTO b [GIVING g]` — result = b/a, stored in g or b.
     Divide { divisor: Operand, dividend: Operand, giving: Option<String> },
+    /// `COMPUTE target [ROUNDED] = expr [ON SIZE ERROR stmts…]` — evaluate an
+    /// arithmetic expression and store it in `target`, rounding instead of
+    /// truncating when `rounded`, running `on_size_error` when the result
+    /// overflows the receiver (or a division by zero occurs).
+    Compute {
+        target: String,
+        rounded: bool,
+        expr: Expr,
+        on_size_error: Vec<Stmt>,
+    },
     /// `IF cond then… [ELSE else…]`.
     If { cond: Cond, then_branch: Vec<Stmt>, else_branch: Vec<Stmt> },
     StopRun,
+}
+
+/// An arithmetic expression tree (the operand of `COMPUTE`). Operator precedence
+/// and grouping are already resolved by the grammar's rule cascade, so this is a
+/// plain binary tree — no precedence logic lives here.
+#[derive(Debug, Clone)]
+pub enum Expr {
+    /// A numeric literal (its source text, parsed to a value at evaluation).
+    Num(String),
+    /// A data-name reference (must resolve to a numeric item).
+    Var(String),
+    /// A unary minus (`neg == true`); unary plus is folded away by the reader.
+    Unary { neg: bool, operand: Box<Expr> },
+    /// A binary operation `left <op> right`.
+    Binary { op: ArithOp, left: Box<Expr>, right: Box<Expr> },
+}
+
+/// The binary arithmetic operators COMPUTE understands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    /// Exponentiation (`**`), right-associative.
+    Pow,
 }
 
 /// A statement operand: a data-name or a literal.
@@ -340,6 +376,27 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             let mut it = ops.into_iter();
             Ok(Stmt::Divide { divisor: it.next().unwrap(), dividend: it.next().unwrap(), giving })
         }
+        "compute_stmt" => {
+            // COMPUTE target [ROUNDED] = <expr> [ON SIZE ERROR stmts…].
+            // The one direct NAME token is the receiver; expression names live
+            // deeper, inside the arith_* nodes.
+            let target = first_token(verb, "NAME")
+                .ok_or_else(|| RuntimeError::Unsupported("COMPUTE without a receiver".into()))?;
+            let rounded = child_tokens(verb)
+                .iter()
+                .any(|(k, v)| k == "KEYWORD" && v == "ROUNDED");
+            let expr_node = child_node(verb, "arith_expr")
+                .ok_or_else(|| RuntimeError::Unsupported("COMPUTE without an expression".into()))?;
+            let expr = read_arith_expr(expr_node)?;
+            let on_size_error = match child_node(verb, "size_error") {
+                Some(se) => child_nodes(se, "statement")
+                    .into_iter()
+                    .map(read_statement)
+                    .collect::<Result<Vec<_>, _>>()?,
+                None => Vec::new(),
+            };
+            Ok(Stmt::Compute { target, rounded, expr, on_size_error })
+        }
         "if_stmt" => {
             // Children in order: IF, condition, then-statements…, [ELSE,
             // else-statements…]. Split the statement nodes at the ELSE keyword.
@@ -398,6 +455,114 @@ fn read_condition(cond: &GrammarASTNode) -> Result<Cond, RuntimeError> {
         })
         .ok_or_else(|| RuntimeError::Unsupported("unrecognised relational operator".into()))?;
     Ok(Cond { left, op, negated, right })
+}
+
+// ---------------------------------------------------------------------------
+// Arithmetic expressions (COMPUTE)
+// ---------------------------------------------------------------------------
+//
+// The grammar's rule cascade already encodes precedence, so each reader here
+// just folds one level's operands into a binary tree. `+ - * /` fold
+// left-to-right (left-associative); `**` folds right-to-left (COBOL's
+// right-associative exponentiation). A single operand with no operator collapses
+// to the operand itself, so `COMPUTE X = A` carries no spurious tree nodes.
+
+/// `arith_expr = arith_term { ( "+" | "-" ) arith_term }` — additive, left-assoc.
+fn read_arith_expr(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+    read_binary_chain(node, read_arith_term, |t| match t {
+        "PLUS" => Some(ArithOp::Add),
+        "MINUS" => Some(ArithOp::Sub),
+        _ => None,
+    })
+}
+
+/// `arith_term = arith_factor { ( "*" | "/" ) arith_factor }` — multiplicative.
+fn read_arith_term(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+    read_binary_chain(node, read_arith_factor, |t| match t {
+        "STAR" => Some(ArithOp::Mul),
+        "SLASH" => Some(ArithOp::Div),
+        _ => None,
+    })
+}
+
+/// `arith_factor = arith_unary { "**" arith_unary }` — exponentiation, folded
+/// right-associatively so `A ** B ** C` = `A ** (B ** C)`.
+fn read_arith_factor(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+    let units = child_nodes(node, "arith_unary");
+    let mut rev = units.iter().rev();
+    let last = rev
+        .next()
+        .ok_or_else(|| RuntimeError::Unsupported("empty arithmetic factor".into()))?;
+    let mut expr = read_arith_unary(last)?;
+    for u in rev {
+        expr = Expr::Binary {
+            op: ArithOp::Pow,
+            left: Box::new(read_arith_unary(u)?),
+            right: Box::new(expr),
+        };
+    }
+    Ok(expr)
+}
+
+/// `arith_unary = [ "+" | "-" ] arith_primary` — a leading minus negates; a
+/// leading plus is a no-op.
+fn read_arith_unary(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+    let neg = child_tokens(node).iter().any(|(k, _)| k == "MINUS");
+    let prim = child_node(node, "arith_primary")
+        .ok_or_else(|| RuntimeError::Unsupported("unary operator without an operand".into()))?;
+    let e = read_arith_primary(prim)?;
+    Ok(if neg { Expr::Unary { neg: true, operand: Box::new(e) } } else { e })
+}
+
+/// `arith_primary = NUMBER | NAME | "(" arith_expr ")"`.
+fn read_arith_primary(node: &GrammarASTNode) -> Result<Expr, RuntimeError> {
+    // A parenthesised sub-expression recurses back to the top of the cascade.
+    if let Some(inner) = child_node(node, "arith_expr") {
+        return read_arith_expr(inner);
+    }
+    for (k, v) in child_tokens(node) {
+        match k.as_str() {
+            "NUMBER" => return Ok(Expr::Num(v)),
+            "NAME" => return Ok(Expr::Var(v)),
+            _ => {}
+        }
+    }
+    Err(RuntimeError::Unsupported("empty arithmetic primary".into()))
+}
+
+/// Fold a `head { op tail }` node into a left-associative binary tree. `sub`
+/// reads each operand node; `map_op` maps an operator token's type name to an
+/// [`ArithOp`] (returning `None` for tokens that are not operators).
+fn read_binary_chain(
+    node: &GrammarASTNode,
+    sub: fn(&GrammarASTNode) -> Result<Expr, RuntimeError>,
+    map_op: fn(&str) -> Option<ArithOp>,
+) -> Result<Expr, RuntimeError> {
+    let mut expr: Option<Expr> = None;
+    let mut pending: Option<ArithOp> = None;
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Node(n) => {
+                let operand = sub(n)?;
+                expr = Some(match (expr.take(), pending.take()) {
+                    (Some(left), Some(op)) => Expr::Binary {
+                        op,
+                        left: Box::new(left),
+                        right: Box::new(operand),
+                    },
+                    // First operand (or a malformed chain missing its operator):
+                    // take the operand as the running expression.
+                    (_, _) => operand,
+                });
+            }
+            ASTNodeOrToken::Token(t) => {
+                if let Some(op) = map_op(t.effective_type_name()) {
+                    pending = Some(op);
+                }
+            }
+        }
+    }
+    expr.ok_or_else(|| RuntimeError::Unsupported("empty arithmetic expression".into()))
 }
 
 /// All `operand` child nodes of a verb, read to typed [`Operand`]s.

--- a/code/packages/rust/cobol-runtime/src/value.rs
+++ b/code/packages/rust/cobol-runtime/src/value.rs
@@ -154,6 +154,64 @@ pub fn div(num: &Decimal, den: &Decimal, result_scale: usize) -> Option<Decimal>
     Some(Decimal::from_scaled(scaled, result_scale))
 }
 
+/// The largest `COMPUTE … ** n` exponent we evaluate. Real COBOL exponents are
+/// tiny; the cap exists so a hostile `A ** 999999999` cannot spin the
+/// repeated-multiply loop (a base of 0 or 1 never overflows to stop it early).
+/// Anything larger returns `None` → a clean `RuntimeError`.
+pub const MAX_POW_EXP: u128 = 1024;
+
+/// Exponentiation `base ** exp` for a **non-negative integer** `exp` (repeated
+/// multiplication). Returns `None` for a negative or fractional exponent (COBOL
+/// allows those — reciprocals and roots — but they are a later PR), for an
+/// exponent past [`MAX_POW_EXP`], or on `i128` overflow of an intermediate
+/// product. `base ** 0 == 1` (including `0 ** 0`, per COBOL).
+pub fn pow(base: &Decimal, exp: &Decimal) -> Option<Decimal> {
+    // Reject negative and fractional exponents (unsupported for now).
+    if exp.neg && !exp.is_zero() {
+        return None;
+    }
+    if exp.frac.chars().any(|c| c != '0') {
+        return None;
+    }
+    let e: u128 = if exp.is_zero() {
+        0
+    } else {
+        // Parse the integer magnitude; an over-long literal fails to parse.
+        exp.int.trim_start_matches('0').parse().ok()?
+    };
+    if e > MAX_POW_EXP {
+        return None;
+    }
+    let mut result = Decimal { neg: false, int: "1".into(), frac: String::new() };
+    for _ in 0..e {
+        result = mul(&result, base)?;
+    }
+    Some(result)
+}
+
+/// Round `value` to `scale` fractional digits, **half away from zero** — COBOL's
+/// `ROUNDED`. If the value already has `scale` or fewer fractional digits it is
+/// returned unchanged. `None` only on `i128` overflow of the magnitude (a value
+/// beyond ~38 digits).
+pub fn round(value: &Decimal, scale: usize) -> Option<Decimal> {
+    if value.frac.len() <= scale {
+        return Some(value.clone());
+    }
+    let int = if value.int.is_empty() { "0" } else { value.int.as_str() };
+    let frac_keep = &value.frac[..scale];
+    // The first dropped digit decides the round (half away from zero).
+    let first_dropped = value.frac.as_bytes()[scale] - b'0';
+    let combined = format!("{int}{frac_keep}");
+    let mut mag: i128 = combined.parse().ok()?;
+    if first_dropped >= 5 {
+        mag = mag.checked_add(1)?;
+    }
+    let mut d = Decimal::from_scaled(mag, scale);
+    // Preserve the sign, except a rounded-to-zero magnitude is unsigned.
+    d.neg = value.neg && mag != 0;
+    Some(d)
+}
+
 /// `10^exp` as `i128`, or `None` on overflow.
 fn pow10(exp: usize) -> Option<i128> {
     let mut v: i128 = 1;
@@ -324,6 +382,44 @@ mod tests {
     #[test]
     fn division_by_zero_returns_none() {
         assert_eq!(div(&d("5"), &d("0"), 2), None);
+    }
+
+    #[test]
+    fn exponentiation_integer_powers() {
+        assert_eq!(pow(&d("2"), &d("10")).unwrap(), d("1024"));
+        assert_eq!(pow(&d("5"), &d("0")).unwrap(), d("1")); // x**0 = 1
+        assert_eq!(pow(&d("0"), &d("0")).unwrap(), d("1")); // 0**0 = 1 (COBOL)
+        assert_eq!(pow(&d("10"), &d("3")).unwrap(), d("1000"));
+        // Fractional base: 1.5**2 = 2.25 (fraction lengths sum through mul).
+        assert_eq!(pow(&d("1.5"), &d("2")).unwrap(), d("2.25"));
+    }
+
+    #[test]
+    fn exponentiation_unsupported_and_bounded() {
+        // Negative and fractional exponents are not yet supported → None.
+        assert_eq!(pow(&d("2"), &d("-1")), None);
+        assert_eq!(pow(&d("2"), &d("0.5")), None);
+        // An exponent past the cap is refused (not spun) even for base 1.
+        assert_eq!(pow(&d("1"), &d("100000")), None);
+        // A huge integer base overflows i128 within a few multiplies → None.
+        assert_eq!(pow(&d("1000000000000"), &d("10")), None);
+    }
+
+    #[test]
+    fn rounding_half_away_from_zero() {
+        // Round to 2 places.
+        assert_eq!(round(&d("3.14159"), 2).unwrap(), d("3.14"));
+        assert_eq!(round(&d("2.675"), 2).unwrap(), d("2.68")); // .5 rounds up
+        assert_eq!(round(&d("2.674"), 2).unwrap(), d("2.67"));
+        // Round to 0 places (integer).
+        assert_eq!(round(&d("2.5"), 0).unwrap(), d("3"));
+        assert_eq!(round(&d("2.4"), 0).unwrap(), d("2"));
+        // Carry propagates: 9.99 → 10.0 at 1 place.
+        assert_eq!(round(&d("9.99"), 1).unwrap(), d("10.0"));
+        // Already within scale: unchanged.
+        assert_eq!(round(&d("1.5"), 2).unwrap(), d("1.5"));
+        // Rounds to zero → unsigned zero.
+        assert_eq!(round(&d("-0.004"), 2).unwrap(), d("0.00"));
     }
 
     #[test]

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -123,12 +123,19 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
 1. **v0.1 — execution spine** (merged): data model + `MOVE`/`DISPLAY`/`STOP RUN`.
 2. **v0.2 — arithmetic** (merged): fixed-point `ADD`/`SUBTRACT`/`MULTIPLY`.
 3. **v0.3 — `DIVIDE`** (merged): fixed-point division + divide-by-zero.
-4. **v0.4 — `IF … ELSE`** (this PR): conditional branching; numeric and
+4. **v0.4 — `IF … ELSE`** (merged): conditional branching; numeric and
    alphanumeric comparison; `STOP RUN` unwinds nested branches.
-5. **`COMPUTE`, `ROUNDED`, `ON SIZE ERROR`** — expression evaluation and the
-   rounding/overflow clauses (these also widen the frontend grammar); then
-   **signed numerics + overpunch** display and the `SIGN` clause.
-6. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+5. **v0.5 — `COMPUTE`** (this PR): evaluate precedence-layered arithmetic
+   expressions (`+ - * / **`, unary sign, parentheses) over the parser's tree;
+   `ROUNDED` (half away from zero) vs default truncation; `ON SIZE ERROR` on
+   integer overflow or division by zero (receiver unchanged, handler runs;
+   without a handler, overflow truncates silently and a zero divisor is a hard
+   error). **Known simplification:** intermediate **division** precision is a
+   fixed 12 fractional digits, not the standard's composite intermediate-precision
+   rule; `**` supports non-negative integer exponents only (bounded at 1024).
+   Both are flagged for a later precision/exponent-faithfulness PR.
+6. **Signed numerics + overpunch** display and the `SIGN` clause.
+7. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
 7. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`, `TIMES`,
    `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
 8. **Conditions** — level-88 condition-names.

--- a/lessons.md
+++ b/lessons.md
@@ -1496,3 +1496,35 @@ that lacks a following `.with_max_depth(` is an unguarded native-stack DoS. This
 is the same class as the closurec/json-parser deep-recursion DoS
 (project_closurec_deep_recursion_dos): a nestable construct is the trigger, and
 the mitigation belongs at the parser layer, not the runtime.
+
+## Lesson: grammar `{ }` repetition width is NOT bounded by the parser depth cap
+
+**Context:** After hardening `cobol-parser` with `.with_max_depth(DEFAULT_MAX_RULE_DEPTH)`
+(which stops deeply-*nested* input like `IF … IF …` or `((((…))))` from
+overflowing the native stack), the COMPUTE runtime added an expression evaluator.
+A security review found a *second*, distinct stack-overflow DoS that the depth
+cap does **not** catch: a flat operator chain `COMPUTE R = A + A + A + … + A`
+with tens of thousands of terms.
+
+**Cause:** The depth cap counts *rule recursion* (`parse_rule` re-entry). But a
+grammar repetition `arith_expr = arith_term { ("+"|"-") arith_term }` is a **flat
+loop** in the parser — it appends children without recursing, so N terms produce
+ONE `arith_expr` CST node with 2N−1 children at *bounded* parse depth, for
+arbitrarily large N (there is no token/source-size cap). The consumer then folded
+those children into an N-deep left-nested `Expr` tree, and both the tree-walking
+`eval_expr` and the **recursive `Drop` of `Box<Expr>`** recursed N frames deep →
+uncatchable `SIGSEGV` on a few hundred KB of source.
+
+**Fix:** Any reader that folds a grammar *repetition* into a *recursive* tree
+(binary-operator chains, list-of-list structures, etc.) must bound the operand
+count itself — the parser's depth cap won't. Here: thread a single
+`MAX_EXPR_OPERANDS` (1024) budget through every expression reader, charged once
+per primary (across parenthesised levels too, so nested parens can't multiply it),
+returning a clean `RuntimeError` when exhausted. That bounds the folded tree
+height, hence both eval and Drop recursion.
+
+**Blind spot / how to catch it:** when reviewing a new tree-walking evaluator,
+ask two *separate* questions — (1) is nesting depth bounded? (parser cap) and
+(2) is repetition *width* bounded? (needs its own budget). They are different
+axes; the depth cap only answers the first. Cross-refs the depth-cap lesson above
+and [[project_closurec_deep_recursion_dos]].


### PR DESCRIPTION
## Summary

Makes `COMPUTE` **execute** — the runtime half of the verb whose grammar landed
in #8011. It evaluates the parser's precedence-layered arithmetic tree and stores
the result, with `ROUNDED` and `ON SIZE ERROR`.

> ⚠️ **Stacked on #8011 (`feat/cobol-compute`)** — needs the COMPUTE grammar.
> Merge #8011 first; this PR's base retargets to `main` afterward (the babysit
> cron handles the rebase).

### What it does (cobol-runtime 0.5.0)
- **Expression evaluation** over the CST tree: `+ - * /`, `**` (right-assoc,
  non-negative integer exponents), unary sign, parentheses. Precedence is already
  baked into the tree, so the evaluator is a plain post-order walk.
- **`ROUNDED`** rounds half away from zero to the receiver's decimal places;
  default is truncation toward zero (consistent with the other verbs).
- **`ON SIZE ERROR`** runs its statements (receiver unchanged) when the result's
  integer part overflows the receiver, or when a division by zero occurs in the
  expression. Without a handler: overflow truncates high-order digits silently
  (like `MOVE`), and a zero divisor stays a hard `DivideByZero`.

### Hardening
- **Exponentiation** is bounded (`MAX_POW_EXP = 1024`) so `A ** huge` can't spin.
- **Expression size** is bounded (`MAX_EXPR_OPERANDS = 1024`). A security review
  caught that a *flat* chain `A + A + … + A` uses grammar repetition, so the
  parser's recursion-depth cap doesn't bound its width — folding it would build a
  tree deep enough to overflow the native stack in `eval_expr` and in `Drop`. A
  threaded operand budget turns that into a clean error. Regression test with a
  5000-term chain. (Two-round security review PASSED.)

### Known simplification (documented in PL08)
Intermediate **division** precision is a fixed 12 fractional digits, not the
standard's composite intermediate-precision rule — flagged for a later PR.

## Tests
59 runtime tests + doctest (precedence, parentheses, `**`, unary minus,
division truncate/ROUNDED, ON SIZE ERROR on overflow and divide-by-zero,
handler-less truncation, hard divide-by-zero, flat-chain DoS guard). Warning-free.
README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)