### PR TITLE
feat(apl-parser): APL parser crate (MA05 §6, MA-4d, v0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -239,6 +239,7 @@ members = [
     "wolfram-runtime",
     "wolfram-repl",
     "apl-lexer",
+    "apl-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/apl-parser/BUILD
+++ b/code/packages/rust/apl-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-apl-parser -- --nocapture

--- a/code/packages/rust/apl-parser/BUILD_windows
+++ b/code/packages/rust/apl-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-apl-parser -- --nocapture

--- a/code/packages/rust/apl-parser/CHANGELOG.md
+++ b/code/packages/rust/apl-parser/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## [0.1.0] - 2026-07-11
+
+### Added
+
+- Initial grammar-driven Rust APL parser (MA05 §6, task MA-4d): consumes
+  `apl-lexer`'s token stream, drives it through the compiled
+  `code/grammars/apl/apl.grammar` (the two-nonterminal `value_expr`/
+  `function_expr` design), and produces a `GrammarASTNode` CST rooted at
+  `program`. Exposes `create_apl_parser`/`parse_apl`/`try_parse_apl`,
+  matching every sibling parser crate's established shape.
+- Ships with a recursion-depth cap (`MAX_RULE_DEPTH = 150`) from day one —
+  unlike `macsyma-parser`/`matlab-parser`/`wolfram-parser`, which retrofitted
+  their caps in a later release, this crate never had the unguarded gap.
+  Derived via the same throwaway-isolated-subprocess binary-search
+  methodology as those three crates, not copied from them: measured crash
+  floor is 209 safe / 210 crashing on a bare ~2 MiB stack thread — *lower*
+  than the ~275-280 measured for the other three grammars, the opposite of
+  the "APL's shallower one-precedence-tier grammar should have a
+  same-or-higher floor" prediction (a real instance of the DoS-guard
+  verification lesson: reasoning from a sibling crate's finding is not a
+  substitute for measuring this crate's own grammar). `150` (~28% headroom)
+  permits 72 real `(...)` nesting levels — measured directly (72 parses
+  cleanly, 73 trips the cap) — comfortably more than
+  MACSYMA/MATLAB/Wolfram's ~14, since each APL nesting level costs far fewer
+  `parse_rule` frames despite the lower absolute floor.
+- 19 tests: one per grammar production (literals/stranding, assignment
+  including right-associative chaining, monadic/dyadic application, the
+  right-to-left dyadic chain, reduce/scan/outer-product operators,
+  parenthesised grouping, every comparison and primitive function glyph,
+  comments/blank lines, multi-line programs, malformed-input rejection) plus
+  the 3 depth-cap regression tests every sibling parser crate carries.
+- Marks MA-4d done in `MA05-apl-language.md` §6.

--- a/code/packages/rust/apl-parser/Cargo.toml
+++ b/code/packages/rust/apl-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-apl-parser"
+version = "0.1.0"
+edition = "2021"
+description = "APL parser backed by statically compiled grammar data"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-apl-lexer = { path = "../apl-lexer" }

--- a/code/packages/rust/apl-parser/README.md
+++ b/code/packages/rust/apl-parser/README.md
@@ -1,0 +1,40 @@
+# coding-adventures-apl-parser
+
+APL parser backed by `code/grammars/apl/apl.grammar`, compiled to Rust and
+statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+Consumes the token stream from `apl-lexer` (MA-4c) and drives it through
+`apl.grammar`'s two-nonterminal design (`value_expr`/`function_expr`, see
+[MA05 §3](../../../specs/MA05-apl-language.md)) to produce a `GrammarASTNode`
+CST rooted at `program` — the second of the two frontend crates for APL
+(MA-4d); the sibling `apl-runtime` crate (MA-4e) will walk this tree to
+evaluate.
+
+## Usage
+
+```rust
+use coding_adventures_apl_parser::try_parse_apl;
+
+let tree = try_parse_apl("A←⍳5\nB←+/A\n")?;
+assert_eq!(tree.rule_name, "program");
+```
+
+`parse_apl`/`create_apl_parser` panic on a lexical or syntax error;
+`try_parse_apl` returns a `Result` instead.
+
+## Recursion-depth guard
+
+`create_apl_parser` opts the shared `GrammarParser` into a recursion-depth
+cap (`MAX_RULE_DEPTH = 150`), empirically derived via the same binary-search
+methodology as `macsyma-parser`/`matlab-parser`/`wolfram-parser`'s own caps
+— not copied from them. See `src/lib.rs`'s `MAX_RULE_DEPTH` doc comment for
+the full derivation, including a genuinely counter-intuitive finding: APL's
+much shallower grammar (no precedence cascade at all) turned out to have a
+*lower* raw crash floor than the other three languages' deeper cascades, the
+opposite of the natural "fewer rule calls per level → higher floor" guess —
+confirmed only by measuring, not by reasoning about the rule-chain shape.

--- a/code/packages/rust/apl-parser/required_capabilities.json
+++ b/code/packages/rust/apl-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/apl-parser",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/apl-parser/src/_grammar.rs
+++ b/code/packages/rust/apl-parser/src/_grammar.rs
@@ -1,0 +1,121 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: apl.grammar
+// Regenerate with: grammar-tools compile-grammar apl.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"line"#.to_string() }) },
+            line_number: 71,
+        },
+        GrammarRule {
+            name: r#"line"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 73,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            line_number: 77,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"ARROW"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"value_expr"#.to_string() },
+            ] },
+            line_number: 84,
+        },
+        GrammarRule {
+            name: r#"value_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::RuleReference { name: r#"function_expr"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"value_expr"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"function_expr"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"value_expr"#.to_string() },
+                ] },
+            ] },
+            line_number: 95,
+        },
+        GrammarRule {
+            name: r#"term"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() }) },
+                ] },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"value_expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 104,
+        },
+        GrammarRule {
+            name: r#"function_atom"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"TIMES"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DIVIDE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"CEILING"#.to_string() },
+                GrammarElement::TokenReference { name: r#"FLOOR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RHO"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IOTA"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RAVEL"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+            ] },
+            line_number: 117,
+        },
+        GrammarRule {
+            name: r#"function_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"function_atom"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::TokenReference { name: r#"REDUCE"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"SCAN"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"OUTER"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"function_atom"#.to_string() },
+                ] },
+            ] },
+            line_number: 129,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/apl-parser/src/lib.rs
+++ b/code/packages/rust/apl-parser/src/lib.rs
@@ -1,0 +1,317 @@
+//! Grammar-driven APL parser.
+//!
+//! The parser grammar is compiled into this crate at build time, so runtime
+//! callers do not need filesystem access to `code/grammars/apl`.
+
+use coding_adventures_apl_lexer::create_apl_lexer;
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+mod _grammar;
+
+/// Recursion-depth cap for the APL [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep `(((…)))` nesting recurses once per
+/// `parse_rule` call and can overflow the *native* thread stack — an
+/// uncatchable process abort — before this crate's own `Result`-returning
+/// entry points ever get a chance to report anything).
+///
+/// # Why not just copy `macsyma-parser`/`matlab-parser`/`wolfram-parser`'s
+/// `200`
+///
+/// APL's grammar (`code/grammars/apl/apl.grammar`) is much shallower than
+/// any other frontend in this repo: there is no precedence cascade to climb
+/// at all (MA05 §3 bullet 2 — "one precedence tier"), so the parenthesised-
+/// nesting cycle is just `value_expr -> term -> ( value_expr ) -> term ->
+/// …`, about 3 named-rule calls per source-nesting level versus MACSYMA's
+/// 13, MATLAB's 15, or Wolfram's 20. Before measuring, the natural guess was
+/// that this shallower cycle would put APL's raw-frame crash floor in the
+/// same ballpark as (or even above) those three grammars' ~275-280, since
+/// `macsyma-parser`'s own doc comment found its floor "empirically
+/// indistinguishable from Wolfram's" despite very different rule-chain
+/// depth — suggesting the floor is dominated by shared engine overhead, not
+/// by which grammar's rules are matched. **That guess turned out wrong** —
+/// see below — which is exactly the DoS-guard-verification lesson in
+/// practice: reasoning about a guard's safety is not a substitute for
+/// measuring it, even when the reasoning is grounded in a real empirical
+/// finding from a sibling crate.
+///
+/// # How this number was derived
+///
+/// Following the exact methodology behind `DEFAULT_MAX_RULE_DEPTH` and every
+/// sibling parser crate's own cap: a throwaway, isolated subprocess (never
+/// run in-process — a genuine overflow aborts the whole process, so this
+/// must be explored somewhere a crash is safe) built `((((…5…))))` with
+/// thousands of nesting levels through this crate's own grammar, and
+/// binary-searched — on a worker thread with the **default ~2 MiB stack**
+/// (what a production caller's thread, and `cargo test`'s own per-test
+/// thread, actually get, no `stack_size` override) — for the
+/// `with_max_depth` value at which the parse stops overflowing and starts
+/// returning a clean `Err`. Result (debug build, this toolchain, stable
+/// across repeated trials): safe at 209, overflowing at 210 — *lower* than
+/// the ~275-280 measured for MACSYMA/MATLAB/Wolfram, the opposite of the
+/// "shallower cycle → same-or-higher floor" guess above. APL's shorter
+/// per-level rule-chain evidently costs more native stack per call (larger
+/// local-variable footprint in the specific `match_element` arms this
+/// grammar's alternation/optional shapes hit) than the saving from making
+/// fewer calls — the two effects don't net out the way the naive
+/// per-level-count reasoning assumed. ~209 `parse_rule` frames is the hard
+/// ceiling this grammar can reach on a 2 MiB stack.
+///
+/// 150 sits ~28% below that empirically confirmed crash floor (209 safe /
+/// 210 crashing) — comparable headroom to the other three crates' own
+/// margin — while permitting 72 real nesting levels of legitimate `(...)`
+/// grouping (measured directly: 72 parses cleanly, 73 trips the cap),
+/// comfortably beyond anything a hand-written APL expression needs. This is
+/// well above MACSYMA/MATLAB/Wolfram's ~14 levels despite APL's *lower* raw
+/// crash floor, because each of those levels still only costs APL ~3 frames
+/// against their ~13-20 — the fewer-frames-per-level effect wins out even
+/// though the absolute floor is lower.
+const MAX_RULE_DEPTH: usize = 150;
+
+/// Create a [`GrammarParser`] wired to the APL grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+///
+/// # Panics
+///
+/// Panics if tokenization fails. Use [`try_parse_apl`] for a `Result`.
+pub fn create_apl_parser(source: &str) -> GrammarParser {
+    let tokens = create_apl_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|err| panic!("APL tokenization failed: {err}"));
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse APL source into a syntax tree rooted at the `program` rule.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_apl`] for a
+/// `Result`.
+pub fn parse_apl(source: &str) -> GrammarASTNode {
+    create_apl_parser(source)
+        .parse()
+        .unwrap_or_else(|err| panic!("APL parse failed: {err}"))
+}
+
+/// Parse APL source, returning a `Result` instead of panicking on a lexical
+/// or syntax error.
+pub fn try_parse_apl(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = create_apl_lexer(source)
+        .tokenize()
+        .map_err(|err| err.to_string())?;
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar)
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------
+    // Parsing correctness — one example per grammar production (MA05 §3/§4)
+    // -------------------------------------------------------------------
+
+    fn rule_names(node: &GrammarASTNode) -> Vec<String> {
+        use parser::grammar_parser::ASTNodeOrToken;
+        node.children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n.rule_name.clone()),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_bare_number_parses_as_a_scalar_value_expr() {
+        let ast = parse_apl("5\n");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn stranded_numbers_form_one_term() {
+        // `1 2 3` is a single 3-element vector term, not three statements.
+        let ast = try_parse_apl("1 2 3\n").expect("stranding should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn simple_assignment_parses() {
+        let ast = try_parse_apl("A←5\n").expect("assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn chained_assignment_is_right_associative() {
+        // A←B←3 assigns 3 to both B and A (MA05 §4 / the grammar's own doc
+        // comment on `assignment`).
+        let ast = try_parse_apl("A←B←3\n").expect("chained assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn monadic_application_parses() {
+        // ⍴ with nothing to its left is monadic (shape-of).
+        let ast = try_parse_apl("⍴A\n").expect("monadic application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn dyadic_application_parses() {
+        let ast = try_parse_apl("A+B\n").expect("dyadic application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn right_to_left_dyadic_chain_parses_as_one_value_expr() {
+        // 2×3+4 is 2×(3+4) -- a single right-recursive value_expr, not three
+        // separate statements. This is the grammar's own "one precedence
+        // tier, right-to-left" design (MA05 §3 bullet 2).
+        let ast = try_parse_apl("2×3+4\n").expect("chain should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn reduce_operator_parses() {
+        let ast = try_parse_apl("+/A\n").expect("reduce should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn scan_operator_parses() {
+        let ast = try_parse_apl("+\\A\n").expect("scan should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn outer_product_operator_parses() {
+        let ast = try_parse_apl("A∘.×B\n").expect("outer product should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn parenthesised_grouping_parses() {
+        let ast = try_parse_apl("(A+B)×C\n").expect("grouping should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn comparison_function_atoms_parse() {
+        for op in ["=", "≠", "<", "≤", "≥", ">"] {
+            let src = format!("A{op}B\n");
+            try_parse_apl(&src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn every_primitive_function_atom_parses_monadically() {
+        for op in ["+", "-", "×", "÷", "⌈", "⌊", "⍴", "⍳", ","] {
+            let src = format!("{op}A\n");
+            try_parse_apl(&src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn a_comment_line_and_a_blank_line_both_parse() {
+        // `⍝` comments are stripped by the lexer's skip pattern (MA-4c); a
+        // bare NEWLINE is its own `line` alternative.
+        let ast = try_parse_apl("⍝ just a comment\n\nA←1\n").expect("should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_multi_line_program_parses_into_multiple_lines() {
+        let ast = try_parse_apl("A←1\nB←2\nA+B\n").expect("multi-line program should parse");
+        // Every non-blank line contributes one `line` child.
+        let lines = rule_names(&ast);
+        assert_eq!(lines.iter().filter(|n| *n == "line").count(), 3);
+    }
+
+    #[test]
+    fn malformed_input_is_rejected_not_panicking() {
+        // A bare operator with no operands is not a valid value_expr.
+        assert!(try_parse_apl("←←←\n").is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- mirrors the exact methodology
+    // used to validate `parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH` and
+    // every sibling parser crate's own cap (see e.g. `macsyma-parser`'s
+    // identically-shaped tests), but exercises the REAL APL grammar and this
+    // crate's actual `MAX_RULE_DEPTH` (500).
+    // -------------------------------------------------------------------
+
+    /// Build `n` nested parens around a `5`, e.g. `((5))` for `n == 2`.
+    fn nested_paren_source(n: usize) -> String {
+        format!("{}5{}\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    /// Deeply-nested input must produce a recoverable error, not overflow the
+    /// native stack (an uncatchable process abort). We parse 5000 levels —
+    /// far past `MAX_RULE_DEPTH` — on a worker thread with a generous 32 MiB
+    /// stack, so the *guard* is what stops the recursion, not the stack
+    /// running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("apl-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = nested_paren_source(5000);
+                let result = try_parse_apl(&source);
+                assert!(
+                    result.is_err(),
+                    "deeply-nested input must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured boundary
+    /// still parses cleanly, and one layer deeper cleanly trips the guard.
+    /// These exact boundary counts (72 legitimate levels) were found
+    /// empirically by binary-searching `create_apl_parser` against
+    /// increasing nesting counts — see `MAX_RULE_DEPTH`'s doc comment.
+    #[test]
+    fn test_nesting_up_to_cap_still_parses() {
+        let ok_source = nested_paren_source(72);
+        let ast = try_parse_apl(&ok_source).expect("72 levels must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = nested_paren_source(73);
+        assert!(
+            try_parse_apl(&tripped_source).is_err(),
+            "one nesting level past the cap's measured limit must fail"
+        );
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip *before*
+    /// the native stack overflows on a default-stack thread — otherwise a
+    /// production caller (e.g. a future `apl-runtime`, or `cargo test`'s own
+    /// per-test thread) would still crash. We parse far-too-deep input on a
+    /// worker thread with **no** `stack_size` override (the same ~2 MiB a
+    /// default thread gets). A clean `Err` (not a `join()` failure from a
+    /// crashed thread) proves `MAX_RULE_DEPTH` sits safely below the native
+    /// overflow point on the default stack.
+    #[test]
+    fn test_opt_in_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = nested_paren_source(5000);
+            let result = try_parse_apl(&source);
+            assert!(result.is_err(), "deeply-nested input must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+}

--- a/code/packages/rust/apl-parser/src/lib.rs
+++ b/code/packages/rust/apl-parser/src/lib.rs
@@ -245,7 +245,7 @@ mod tests {
     // used to validate `parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH` and
     // every sibling parser crate's own cap (see e.g. `macsyma-parser`'s
     // identically-shaped tests), but exercises the REAL APL grammar and this
-    // crate's actual `MAX_RULE_DEPTH` (500).
+    // crate's actual `MAX_RULE_DEPTH` (150).
     // -------------------------------------------------------------------
 
     /// Build `n` nested parens around a `5`, e.g. `((5))` for `n == 2`.

--- a/code/specs/MA05-apl-language.md
+++ b/code/specs/MA05-apl-language.md
@@ -198,18 +198,23 @@ apl-repl/     src/{lib.rs, main.rs}       ← MA-4e (the `apl` binary)
   glyph, the reduce/scan/outer-product operators, assignment/grouping,
   vector-stranded numeric literals, high-minus (`¯`) negative literals kept
   distinct from the `MINUS` function token, and `⍝` line comments.
-- **MA-4d — `apl-parser`.** The `value_expr`/`function_expr` grammar,
-  monadic/dyadic application, reduce/scan/outer-product operator
-  productions. **Acceptance criteria includes a recursion-depth cap**: §3's
-  right-recursive `value_expr = term | term function_expr value_expr` rule
-  recurses once per chained dyadic primitive with no bound as specified, so
-  a long unbroken chain (`1+2+3+4+…`, thousands deep) is a stack-overflow
-  DoS on a naive recursive-descent implementation — the same class of issue
-  already found in this repo's shared grammar parser for another frontend
-  (the `closurec` deep-recursion crash, which lives in the shared parser,
-  not the language-specific bridge). Fix once in the shared `GrammarParser`
-  if not already capped, so every grammar-driven frontend benefits, not
-  just APL.
+- **MA-4d — `apl-parser`** (✅ done): the `value_expr`/`function_expr`
+  grammar, monadic/dyadic application, reduce/scan/outer-product operator
+  productions — `create_apl_parser`/`parse_apl`/`try_parse_apl`, mirroring
+  every sibling parser crate's shape exactly. **Shipped with its recursion-
+  depth cap from day one** (the shared `GrammarParser`'s guard is per-caller
+  opt-in, not a single global fix — a lone constant can't be safe for every
+  grammar at once, since rule-chain depth per source-nesting level varies
+  wildly; see `macsyma-parser`/`matlab-parser`/`wolfram-parser`'s own
+  retrofitted caps, task #12/PR #7928). `apl-parser`'s own empirically-
+  derived `MAX_RULE_DEPTH = 150` (72 real nesting levels) produced a
+  genuinely counter-intuitive finding: despite APL's much shallower one-
+  precedence-tier grammar (no cascade to climb, ~3 rule calls per nesting
+  level versus MACSYMA/MATLAB/Wolfram's 13-20), its raw native-stack crash
+  floor (209 frames) measured *lower* than theirs (~275-280) — the opposite
+  of the natural "fewer calls per level → higher floor" prediction. See
+  `apl-parser/src/lib.rs`'s `MAX_RULE_DEPTH` doc comment for the full
+  derivation.
 - **MA-4e — `apl-runtime` + `apl-repl` + the `apl` binary.** A working REPL:
   right-to-left evaluation, the primitives in §4, `⍴`/`⍳` array
   construction, reduce/scan/outer-product lowered onto AR-2.


### PR DESCRIPTION
## Summary
- Second frontend crate for APL: consumes `apl-lexer`'s token stream, drives it through the compiled `code/grammars/apl/apl.grammar` (the two-nonterminal `value_expr`/`function_expr` design from MA-4b), and produces a `GrammarASTNode` CST rooted at `program` — `create_apl_parser`/`parse_apl`/`try_parse_apl`, mirroring every sibling parser crate's shape.
- Ships with a recursion-depth cap (`MAX_RULE_DEPTH = 150`) from day one, per MA05 §6's own acceptance criteria — unlike `macsyma-parser`/`matlab-parser`/`wolfram-parser`, which retrofitted their caps later, this crate never had the unguarded gap.
- The cap was derived empirically (throwaway isolated-subprocess binary search, not copied from the other three crates) and produced a genuinely counter-intuitive result: APL's much shallower grammar (no precedence cascade at all) has a *lower* raw native-stack crash floor (209 safe / 210 crashing) than MACSYMA/MATLAB/Wolfram's deeper cascades (~275-280) — the opposite of the natural "fewer rule calls per level → higher floor" prediction. `150` (~28% headroom) still permits 72 real `(...)` nesting levels, comfortably more than the other three crates' ~14, since each APL level costs far fewer frames despite the lower absolute floor.
- Marks MA-4d done in `MA05-apl-language.md` §6. Front 2 rotation turn, unblocks MA-4e (`apl-runtime`).

## Test plan
- [x] `cargo test -p coding-adventures-apl-parser` — 19/19 pass (one per grammar production + 3 depth-cap regression tests)
- [x] `cargo clippy -p coding-adventures-apl-parser --all-targets` — zero warnings on this crate
- [x] `/security-review` passed clean — verified both `create_apl_parser` and `try_parse_apl`'s separately-constructed code paths actually apply the depth cap (not just one of the two), traced the shared engine's depth-check to confirm it precedes recursion (not after-the-fact accounting), and independently ran the 3 depth tests including a default-~2MiB-stack thread parsing 5000 nesting levels without crashing. One LOW/INFO doc-comment typo found and fixed in a follow-up commit (stale "500" reference from an earlier draft, before the real 150 was measured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)