### PR TITLE
feat(sir-rust): Hash to_h (block + no-block) + each_with_index + each_with_object

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.31.0 — Hash `to_h` (block + no-block) / `each_with_index` / `each_with_object`
+
+Mirrors the Python reference (PR #8009) and the Go backend (PR #8015) into the
+Rust backend's inline `__sir` runtime (`map_method` gains the arms; the
+`Value::Map` `respond_to?` arm gains the names), rounding out Hash's Enumerable
+iteration surface.
+
+- `to_h` **without** a block → a shallow copy of the hash (a fresh `Map`, so
+  mutating it never aliases the receiver's entries).
+- `to_h { |k, v| [new_k, new_v] }` → a NEW hash from the block-returned `[k, v]`
+  pairs; the block is yielded the two args `(k, v)`; a non-pair result is skipped
+  (never-panic floor — Ruby's TypeError is deferred to the typed-error cascade),
+  and a later pair with a duplicate key wins (Ruby's rule, `map_set`).
+- `each_with_index { |(k, v), i| … }` → yields each `[k, v]` pair with its
+  0-based index, returns the receiver.
+- `each_with_object(memo) { |(k, v), memo| … }` → yields each `[k, v]` pair with
+  the memo, returns the (mutated) memo; no-memo arg returns the receiver.
+
+Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass
+the element as a single `[k, v]` pair (the second block param is the
+index/memo), matching Ruby's Enumerable convention.  Every block-invoking arm
+SNAPSHOTS the entries into an owned `Vec` before iterating, so no `RefCell`
+borrow is held across `apply_closure` — the never-panic floor holds against a
+reentrant hash mutation.
+
+Exec-proof: `tests/compile_and_run_hash_catalog.rs` gains
+`hash_to_h_and_indexed_iteration_compile_and_run`, running to_h (copy + re-map),
+each_with_index (observed pair+index yield, returns self), and each_with_object
+(observed pair+memo yield, returns memo, and no-memo passthrough) under real
+`rustc`, diffed against the Python/Go reference semantics.
+
 ## 0.30.0 — Hash Enumerable breadth: `group_by` / `partition` / `flat_map` / `collect_concat` / `reduce` / `inject` / `sum`
 
 Mirrors the Python `sir-runtime-oop` reference (PR #7978) and the Go backend

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -147,9 +147,12 @@ rather than panicking:
     `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,
     `reject`, `transform_values`, `transform_keys`, the Enumerable
     aggregates `find`/`detect`, `any?`/`all?`/`none?`, `count`, `sort_by`,
-    `min_by`/`max_by`, and the Enumerable breadth `group_by`, `partition`,
+    `min_by`/`max_by`, the Enumerable breadth `group_by`, `partition`,
     `flat_map`/`collect_concat`, `reduce`/`inject`, `sum` (all yielding the
-    `[k, v]` pair — `reduce`/`inject` follow Ruby's `(memo, pair)` convention).
+    `[k, v]` pair — `reduce`/`inject` follow Ruby's `(memo, pair)` convention),
+    and `to_h` (block + no-block), `each_with_index`, `each_with_object` (the
+    last two yield the `[k, v]` pair as a single argument alongside the
+    index/memo).
   - **String** (`Str`): `length`, `upcase`, `downcase`, `reverse`, `strip`,
     `include?`, `split`, char-set `tr`/`count`/`delete`/`squeeze` (literal
     sets), and justify `ljust`/`rjust`/`center`/`swapcase` (rune-aware; `center`

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1484,6 +1484,8 @@ pub const RUNTIME: &str = r##"mod __sir {
                     // Enumerable breadth (block-taking reshape/fold)
                     | "group_by" | "partition" | "flat_map" | "collect_concat"
                     | "reduce" | "inject" | "sum"
+                    // Enumerable iteration / conversion
+                    | "to_h" | "each_with_index" | "each_with_object"
             ),
             Value::Str(_) => matches!(
                 name,
@@ -2648,6 +2650,67 @@ pub const RUNTIME: &str = r##"mod __sir {
                     }
                     acc
                 }
+                None => unknown_method(&recv, name),
+            },
+            // `Hash#to_h` — WITHOUT a block, a shallow copy of the hash (a fresh
+            // `Map` so mutating it never aliases the receiver's entries).  WITH a
+            // block `{ |k, v| [new_k, new_v] }`, a NEW hash from the `[k, v]`
+            // pairs the block returns: the block is yielded the two args
+            // `(k, v)` (matching `each`), a non-pair result is skipped (the
+            // never-panic floor — Ruby raises TypeError, deferred to the
+            // typed-error cascade), and a later pair with a duplicate key wins
+            // (Ruby's rule, `map_set`).  The block form snapshots the entries
+            // first so a reentrant mutation cannot double-borrow-panic.
+            "to_h" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    let acc = map_lit(vec![]);
+                    for (k, v) in snapshot {
+                        if let Value::Seq(pair) = apply_closure(b, vec![k, v]) {
+                            let items = pair.borrow();
+                            if items.len() == 2 {
+                                let nk = items[0].clone();
+                                let nv = items[1].clone();
+                                drop(items);
+                                map_set(&acc, nk, nv);
+                            }
+                        }
+                    }
+                    acc
+                }
+                None => map_lit(entries_rc.borrow().clone()),
+            },
+            // `each_with_index { |(k, v), i| … }` — yields each `[k, v]` pair
+            // with its 0-based index and returns the receiver.  Unlike the
+            // two-arg `(k, v)` yield of `each`, the element arrives as a single
+            // `[k, v]` pair (the second block param is the index), matching
+            // Ruby's Enumerable convention.
+            "each_with_index" => match &block {
+                Some(b) => {
+                    let snapshot = entries_rc.borrow().clone();
+                    for (i, (k, v)) in snapshot.into_iter().enumerate() {
+                        apply_closure(b, vec![seq_lit(vec![k, v]), Value::Int(i as i64)]);
+                    }
+                    recv
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `each_with_object(memo) { |(k, v), memo| … }` — yields each
+            // `[k, v]` pair with the memo object and returns the (mutated) memo.
+            // Like `each_with_index`, the element is the single `[k, v]` pair
+            // (the second block param is the memo).  With no memo argument the
+            // receiver is returned unchanged.
+            "each_with_object" => match &block {
+                Some(b) => match pos.into_iter().next() {
+                    Some(memo) => {
+                        let snapshot = entries_rc.borrow().clone();
+                        for (k, v) in snapshot {
+                            apply_closure(b, vec![seq_lit(vec![k, v]), memo.clone()]);
+                        }
+                        memo
+                    }
+                    None => recv,
+                },
                 None => unknown_method(&recv, name),
             },
             _ => no_method_error(&recv, name),

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_hash_catalog.rs
@@ -544,3 +544,141 @@ fn hash_enumerable_breadth_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+// ── Hash to_h / each_with_index / each_with_object ─────────────────────────
+//
+// Rounds out Hash's Enumerable iteration surface, mirroring the Python
+// reference (#8009) and the Go backend (#8015).  `to_h` has a no-block (shallow
+// copy) and a block (re-map) form; `each_with_index`/`each_with_object` yield
+// the `[k, v]` PAIR as a single argument alongside the index/memo (Ruby's
+// Enumerable convention — contrast `each`'s two-arg `(k, v)` yield).
+
+/// A two-parameter block that `print`s `[p1, p2]` and returns nil — used to
+/// observe the `(pair, index)` / `(pair, memo)` yields.
+fn block_fn_print2(name: &str, p1: &str, p2: &str) -> Function {
+    let mk = |n: &str| semantic_ir::Param {
+        name: n.into(),
+        kind: semantic_ir::ParamKind::Required,
+        sir_type: None,
+        default: None,
+        span: s(),
+    };
+    Function {
+        name: name.into(),
+        params: vec![mk(p1), mk(p2)],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![print_stmt(seq_lit_e(vec![param(p1), param(p2)]))],
+            value: Expr::NilLit { span: s() },
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+fn to_h_demo() -> Module {
+    let block_fns = vec![
+        // { |k, v| [k, v * 2] } — re-map each pair, doubling the value.
+        block_fn(
+            "__b_dbl",
+            &["k", "v"],
+            seq_lit_e(vec![param("k"), binop("*", param("v"), ilit(2))]),
+        ),
+        // { |pair, i| print [pair, i] } — observe the (pair, index) yield.
+        block_fn_print2("__b_pi", "pair", "i"),
+        // { |pair, memo| print [pair, memo] } — observe the (pair, memo) yield.
+        block_fn_print2("__b_pm", "pair", "memo"),
+    ];
+    let ab = || map_lit(vec![(symlit("a"), ilit(1)), (symlit("b"), ilit(2))]);
+    let main_stmts = vec![
+        // {a:1,b:2}.to_h (no block) → a shallow copy: {a: 1, b: 2}
+        print_stmt(method(ab(), "to_h", vec![])),
+        // {a:1,b:2}.to_h { |k, v| [k, v * 2] } → {a: 2, b: 4}
+        print_stmt(method(ab(), "to_h", vec![block("__b_dbl")])),
+        // {a:1,b:2}.each_with_index { |pair, i| print [pair, i] }
+        //   → "[[a, 1], 0]", "[[b, 2], 1]", then the returned self "{a: 1, b: 2}"
+        print_stmt(method(ab(), "each_with_index", vec![block("__b_pi")])),
+        // {a:1,b:2}.each_with_object(0) { |pair, memo| print [pair, memo] }
+        //   → "[[a, 1], 0]", "[[b, 2], 0]", then the returned memo "0"
+        print_stmt(method(ab(), "each_with_object", vec![ilit(0), block("__b_pm")])),
+        // {a:1}.each_with_object { |pair, memo| … } with NO memo arg → returns
+        // the receiver unchanged (the block is never called): "{a: 1}"
+        print_stmt(method(
+            map_lit(vec![(symlit("a"), ilit(1))]),
+            "each_with_object",
+            vec![block("__b_pm")],
+        )),
+    ];
+    demo_module(main_stmts, block_fns)
+}
+
+#[test]
+fn hash_to_h_and_indexed_iteration_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&to_h_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_hash_toh_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_hash_toh_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "{a: 1, b: 2}", // to_h (no block) → shallow copy
+            "{a: 2, b: 4}", // to_h { [k, v*2] } → re-mapped
+            "[[a, 1], 0]",  // each_with_index yields ([a,1], 0)
+            "[[b, 2], 1]",  // each_with_index yields ([b,2], 1)
+            "{a: 1, b: 2}", // each_with_index returns self
+            "[[a, 1], 0]",  // each_with_object yields ([a,1], 0)
+            "[[b, 2], 0]",  // each_with_object yields ([b,2], 0)
+            "0",            // each_with_object returns the memo
+            "{a: 1}",       // each_with_object with no memo → returns self
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8009](https://github.com/adhithyan15/coding-adventures/pull/8009)) and Go backend ([#8015](https://github.com/adhithyan15/coding-adventures/pull/8015)) into the **Rust** backend's inline `__sir` runtime (`map_method` arms + the `Value::Map` `respond_to?` arm), rounding out Hash's Enumerable iteration surface.

## Methods
- `to_h` **without** a block → shallow copy (fresh `Map`, no alias of receiver entries).
- `to_h { |k,v| [new_k, new_v] }` → new hash from block-returned `[k, v]` pairs; block yields two args `(k, v)`; non-pair result skipped (never-panic floor); last colliding key wins.
- `each_with_index { |(k,v), i| … }` → yields each `[k, v]` pair + 0-based index; returns the receiver.
- `each_with_object(memo) { |(k,v), memo| … }` → yields each `[k, v]` pair + memo; returns the memo; no-memo arg returns the receiver.

Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass the element as a single `[k, v]` pair (2nd block param is index/memo) — Ruby's Enumerable convention.

## Safety
Every block-invoking arm **snapshots** entries into an owned `Vec` before iterating — no `RefCell` borrow held across `apply_closure`, so a reentrant hash mutation cannot `BorrowMutError` (never-panic floor). `to_h`'s block return is a checked `Value::Seq` + `len == 2` extraction before indexing (bad returns skipped).

## Exec-proof
`tests/compile_and_run_hash_catalog.rs` gains `hash_to_h_and_indexed_iteration_compile_and_run`, run under real `rustc`, diffed against the Python/Go reference:

```
{a: 1, b: 2}     # to_h (no block) → shallow copy
{a: 2, b: 4}     # to_h { [k, v*2] }
[[a, 1], 0]      # each_with_index yields ([a,1], 0)
[[b, 2], 1]
{a: 1, b: 2}     # each_with_index returns self
[[a, 1], 0]      # each_with_object yields ([a,1], 0)
[[b, 2], 0]
0                # each_with_object returns the memo
{a: 1}           # each_with_object with no memo → returns self
```

Version 0.30.0 → 0.31.0; CHANGELOG + README updated. Lib tests 123 green; clippy clean (crate). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)