### PR TITLE
feat(cobol): signed numerics PIC S9… with overpunch DISPLAY (PL08 v0.6)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.0 — signed numerics (PIC S9…)
+
+- **`PIC S9…` signed numeric fields.** The leading `S` marks the field signed and
+  bears no storage position (`S9(4)` is still 4 digits). `picture.rs` parses it
+  (and rejects a misplaced `S`, or `S` on a non-numeric field); the operational
+  sign is carried alongside the magnitude digits on each item.
+- **Sign is preserved** through `MOVE` and arithmetic into a signed receiver; an
+  unsigned receiver still drops the sign to magnitude (unchanged). Zero is always
+  unsigned.
+- **`DISPLAY` overpunch.** A signed field displays its sign as a trailing
+  ("zoned decimal") overpunch on the units digit under the default
+  `SIGN IS TRAILING`: `+123` → `12C`, `−123` → `12L`, `0` → `00{`. This is the
+  authentic COBOL rendering of a `DISPLAY`-usage signed field.
+- Deferred to a later PR: the explicit `SIGN` clause and its `SEPARATE` /
+  `LEADING` variants (this PR is the default trailing-overpunch sign only).
+
 ## 0.5.0 — COMPUTE / arithmetic expressions (PL08)
 
 - Executes `COMPUTE target [ROUNDED] = <expr> [ON SIZE ERROR …]`.

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -18,15 +18,17 @@ let out = run_cobol(source)?; // everything the program DISPLAYed
 
 ## Scope
 
-A small but **fully correct** slice, growing one quirk at a time: unsigned
-numeric-display (`9`/`V`) and character (`X`/`A`) pictures; the item tree from
+A small but **fully correct** slice, growing one quirk at a time: numeric-display
+(`9`/`V`, and signed `S9…` with trailing-overpunch `DISPLAY`) and character
+(`X`/`A`) pictures; the item tree from
 level numbers; `VALUE` initialisation; figurative `ZERO`/`SPACE`; `MOVE` with
 the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; fixed-point
 decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
 toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
 parentheses), `ROUNDED`, and `ON SIZE ERROR`; and `IF … ELSE` with numeric and
-alphanumeric comparison. Anything not yet modelled (signed `S`, editing
-pictures, `COMP`, `PERFORM`, `GO TO`, `EVALUATE`, tables, files, and every other
-verb) returns a descriptive `RuntimeError` — never wrong output. See PL08 for the
+alphanumeric comparison. Anything not yet modelled (the explicit `SIGN` clause
+with `SEPARATE`/`LEADING`, editing pictures, `COMP`, `PERFORM`, `GO TO`,
+`EVALUATE`, tables, files, and every other verb) returns a descriptive
+`RuntimeError` — never wrong output. See PL08 for the
 roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -21,6 +21,10 @@ struct Item {
     level: u32,
     picture: Option<Picture>,
     storage: String,
+    /// The operational sign of a signed numeric item (`PIC S9…`). The `storage`
+    /// digits are always the magnitude; this carries the sign separately. Always
+    /// `false` for unsigned and non-numeric items (they drop any sign).
+    neg: bool,
     children: Vec<usize>,
 }
 
@@ -55,6 +59,30 @@ fn fill_fig(f: &Fig, n: usize) -> String {
         Fig::Zero => "0".repeat(n),
         Fig::Space => " ".repeat(n),
     }
+}
+
+/// Overpunch the sign onto the trailing (units) digit of a magnitude digit
+/// string — the ASCII "zoned decimal" encoding COBOL uses to `DISPLAY` a signed
+/// numeric-display field under the default `SIGN IS TRAILING`. The units digit
+/// `d` becomes:
+///
+/// | d | 0 1 2 3 4 5 6 7 8 9 |
+/// |---|---------------------|
+/// | + | { A B C D E F G H I |
+/// | − | } J K L M N O P Q R |
+///
+/// So `+123` → `12C` and `−123` → `12L`. A non-digit units position (there is
+/// none for a real numeric field) is passed through unchanged.
+fn overpunch_trailing(magnitude: &str, neg: bool) -> String {
+    const POS: [char; 10] = ['{', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'];
+    const NEG: [char; 10] = ['}', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R'];
+    let mut chars: Vec<char> = magnitude.chars().collect();
+    if let Some(last) = chars.last_mut() {
+        if let Some(d) = last.to_digit(10) {
+            *last = if neg { NEG[d as usize] } else { POS[d as usize] };
+        }
+    }
+    chars.into_iter().collect()
 }
 
 /// The running machine: the item table, a name→index map, and captured output.
@@ -103,6 +131,7 @@ impl Machine {
                 level: def.level,
                 picture,
                 storage,
+                neg: false,
                 children: Vec::new(),
             });
 
@@ -345,7 +374,7 @@ impl Machine {
     fn numeric_dims(&self, name: &str) -> Result<(usize, usize), RuntimeError> {
         let idx = *self.by_name.get(name).ok_or_else(|| RuntimeError::UndefinedName(name.into()))?;
         match &self.items[idx].picture {
-            Some(Picture::Numeric { int_digits, dec_digits }) => Ok((*int_digits, *dec_digits)),
+            Some(Picture::Numeric { int_digits, dec_digits, .. }) => Ok((*int_digits, *dec_digits)),
             _ => Err(RuntimeError::Unsupported(format!("arithmetic on non-numeric field {name}"))),
         }
     }
@@ -483,8 +512,8 @@ impl Machine {
             .clone()
             .ok_or_else(|| RuntimeError::Unsupported("MOVE into a group item".into()))?;
 
-        let new_storage = match picture {
-            Picture::Numeric { int_digits, dec_digits } => {
+        let (new_storage, new_neg) = match picture {
+            Picture::Numeric { int_digits, dec_digits, signed } => {
                 let d = match src {
                     Src::Num(d) => d,
                     Src::Fig(Fig::Zero) => Decimal::zero(),
@@ -497,7 +526,10 @@ impl Machine {
                         ))
                     }
                 };
-                move_into_numeric(&d, int_digits, dec_digits)
+                // A signed field keeps the sign (except on zero, which is
+                // unsigned); an unsigned field drops it to magnitude.
+                let neg = signed && d.neg && !d.is_zero();
+                (move_into_numeric(&d, int_digits, dec_digits), neg)
             }
             Picture::Alphanumeric { size } | Picture::Alphabetic { size } => {
                 let chars = match src {
@@ -506,10 +538,11 @@ impl Machine {
                     Src::Fig(Fig::Zero) => "0".repeat(size),
                     Src::Fig(Fig::Space) => " ".repeat(size),
                 };
-                move_into_char(&chars, size)
+                (move_into_char(&chars, size), false)
             }
         };
         self.items[dst].storage = new_storage;
+        self.items[dst].neg = new_neg;
         Ok(())
     }
 
@@ -544,12 +577,13 @@ impl Machine {
     }
 
     /// A numeric item's value as a [`Decimal`], split by its implied decimal.
+    /// A signed item carries its stored operational sign.
     fn item_as_decimal(&self, idx: usize) -> Decimal {
         let item = &self.items[idx];
         if let Some(Picture::Numeric { int_digits, .. }) = &item.picture {
             let int: String = item.storage.chars().take(*int_digits).collect();
             let frac: String = item.storage.chars().skip(*int_digits).collect();
-            Decimal { neg: false, int, frac }
+            Decimal { neg: item.neg, int, frac }
         } else {
             Decimal::zero()
         }
@@ -570,12 +604,14 @@ impl Machine {
     }
 
     /// An item's stored image (elementary → its storage; group → its children).
+    /// A signed numeric item shows its sign as a trailing **overpunch** on the
+    /// units digit — COBOL's default `DISPLAY` of a `PIC S9…` field.
     fn item_image(&self, idx: usize) -> String {
         let item = &self.items[idx];
-        if item.picture.is_some() {
-            item.storage.clone()
-        } else {
-            self.group_image(idx)
+        match &item.picture {
+            Some(Picture::Numeric { signed: true, .. }) => overpunch_trailing(&item.storage, item.neg),
+            Some(_) => item.storage.clone(),
+            None => self.group_image(idx),
         }
     }
 

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -9,10 +9,11 @@
 //! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
 //! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), and `IF … ELSE`
-//! (numeric and alphanumeric comparison) over unsigned numeric-display and
-//! character pictures — and returns a descriptive error for anything not yet
-//! modelled, rather than producing wrong output. The roadmap toward full COBOL
-//! (signed numerics, editing pictures, `PERFORM`, tables, files, later
+//! (numeric and alphanumeric comparison) over numeric-display (`9`/`V`, and
+//! signed `S` with trailing-overpunch display) and character pictures — and
+//! returns a descriptive error for anything not yet modelled, rather than
+//! producing wrong output. The roadmap toward full COBOL (the `SIGN` clause and
+//! `SEPARATE`/`LEADING` variants, editing pictures, `PERFORM`, tables, files, later
 //! standards) is in PL08.
 //!
 //! ```
@@ -633,19 +634,82 @@ mod tests {
         }
     }
 
+    // ----------------------------------------------------------------------
+    // Signed numerics (PIC S9…) — sign carried through, overpunch on DISPLAY
+    // ----------------------------------------------------------------------
+
+    /// Run a program with a signed receiver `N PIC <pic>` initialised to
+    /// `value`, then the body, returning what it DISPLAYed.
+    fn run_signed(pic: &str, value: &str, body: &[&str]) -> String {
+        let mut lines = vec![
+            "IDENTIFICATION DIVISION.".to_string(),
+            "PROGRAM-ID. P.".to_string(),
+            "DATA DIVISION.".to_string(),
+            "WORKING-STORAGE SECTION.".to_string(),
+            format!("01  N  PIC {pic} VALUE {value}."),
+            "PROCEDURE DIVISION.".to_string(),
+            "MAIN.".to_string(),
+        ];
+        lines.extend(body.iter().map(|s| format!("    {s}")));
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        run_cobol(&program(&refs)).unwrap()
+    }
+
     #[test]
-    fn signed_picture_is_unsupported_not_wrong() {
-        let err = run_cobol(&program(&[
+    fn signed_value_displays_with_trailing_overpunch() {
+        // -123 in S9(3): magnitude "123", units 3 → 'L' (negative). → "12L".
+        assert_eq!(run_signed("S9(3)", "-123", &["DISPLAY N.", "STOP RUN."]), "12L\n");
+        // +123 → units 3 → 'C' (positive). → "12C".
+        assert_eq!(run_signed("S9(3)", "123", &["DISPLAY N.", "STOP RUN."]), "12C\n");
+        // Zero is unsigned: units 0 → '{' (positive). → "00{".
+        assert_eq!(run_signed("S9(3)", "0", &["DISPLAY N.", "STOP RUN."]), "00{\n");
+    }
+
+    #[test]
+    fn signed_field_keeps_sign_through_arithmetic() {
+        // 3 - 5 = -2 into a signed receiver → magnitude 2, negative → "0K"
+        // (units 2 → 'K'). An unsigned receiver would show "02".
+        assert_eq!(
+            run_signed("S9(2)", "3", &["SUBTRACT 5 FROM N.", "DISPLAY N.", "STOP RUN."]),
+            "0K\n"
+        );
+    }
+
+    #[test]
+    fn signed_value_used_in_arithmetic_carries_its_sign() {
+        // N = -10; ADD 4 → -6 → "0O" (units 6 → 'O', negative).
+        assert_eq!(
+            run_signed("S9(2)", "-10", &["ADD 4 TO N.", "DISPLAY N.", "STOP RUN."]),
+            "0O\n"
+        );
+    }
+
+    #[test]
+    fn moving_signed_into_unsigned_drops_the_sign() {
+        // A signed source moved into an unsigned receiver keeps only magnitude.
+        let out = run_cobol(&program(&[
             "IDENTIFICATION DIVISION.",
             "PROGRAM-ID. P.",
             "DATA DIVISION.",
             "WORKING-STORAGE SECTION.",
-            "01  N  PIC S9(3).",
+            "01  S  PIC S9(3) VALUE -45.",
+            "01  U  PIC 9(3) VALUE 0.",
             "PROCEDURE DIVISION.",
             "MAIN.",
+            "    MOVE S TO U.",
+            "    DISPLAY U.",
             "    STOP RUN.",
         ]))
-        .unwrap_err();
-        assert!(matches!(err, RuntimeError::UnsupportedPicture(_)), "got {err:?}");
+        .unwrap();
+        assert_eq!(out, "045\n");
+    }
+
+    #[test]
+    fn compute_into_signed_receiver_shows_negative_overpunch() {
+        // COMPUTE N = 2 - 9 = -7 into S9(2) → "0P" (units 7 → 'P', negative).
+        assert_eq!(
+            run_signed("S9(2)", "0", &["COMPUTE N = 2 - 9.", "DISPLAY N.", "STOP RUN."]),
+            "0P\n"
+        );
     }
 }

--- a/code/packages/rust/cobol-runtime/src/picture.rs
+++ b/code/packages/rust/cobol-runtime/src/picture.rs
@@ -4,10 +4,10 @@
 //! storage-bearing character positions; a numeric field's implied decimal point
 //! (`V`) and default operational sign (`S`) occupy none.
 //!
-//! v0.1 models three pure categories — unsigned numeric-display (`9` with an
-//! optional `V`), alphanumeric (`X`), and alphabetic (`A`) — each with `(n)`
-//! repetition. Everything else (`S`, `P`, editing symbols, mixed classes)
-//! returns [`RuntimeError::UnsupportedPicture`]; those are the next PRs.
+//! It models numeric-display (`9` with an optional `V` and an optional leading
+//! `S` operational sign), alphanumeric (`X`), and alphabetic (`A`) — each with
+//! `(n)` repetition. Everything else (`P` scaling, editing symbols, mixed
+//! classes) returns [`RuntimeError::UnsupportedPicture`]; those are the next PRs.
 
 use crate::error::RuntimeError;
 
@@ -19,9 +19,12 @@ const MAX_PICTURE_SIZE: usize = 65_535;
 /// A parsed PICTURE clause.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Picture {
-    /// Unsigned numeric-display: `int_digits` positions before the implied
-    /// decimal point and `dec_digits` after it. `PIC 9(3)V99` → {3, 2}.
-    Numeric { int_digits: usize, dec_digits: usize },
+    /// Numeric-display: `int_digits` positions before the implied decimal point
+    /// and `dec_digits` after it. `PIC 9(3)V99` → {3, 2}. `signed` is set by a
+    /// leading `S` (`PIC S9(3)`), which bears no storage position but lets the
+    /// field hold and display a sign; an unsigned field drops any sign to
+    /// magnitude on receipt.
+    Numeric { int_digits: usize, dec_digits: usize, signed: bool },
     /// Alphanumeric (`X`): `size` character positions.
     Alphanumeric { size: usize },
     /// Alphabetic (`A`): `size` character positions.
@@ -32,7 +35,8 @@ impl Picture {
     /// Number of storage-bearing character positions.
     pub fn size(&self) -> usize {
         match self {
-            Picture::Numeric { int_digits, dec_digits } => int_digits + dec_digits,
+            // The `S` sign bears no storage position, so size ignores it.
+            Picture::Numeric { int_digits, dec_digits, .. } => int_digits + dec_digits,
             Picture::Alphanumeric { size } | Picture::Alphabetic { size } => *size,
         }
     }
@@ -56,30 +60,43 @@ impl Picture {
         // real source is upper-case, but be forgiving.
         let up: Vec<char> = symbols.iter().map(|c| c.to_ascii_uppercase()).collect();
 
-        let all_x = up.iter().all(|&c| c == 'X');
-        let all_a = up.iter().all(|&c| c == 'A');
-        let numeric = up.iter().all(|&c| c == '9' || c == 'V');
-
-        if all_x {
-            return Ok(Picture::Alphanumeric { size: up.len() });
+        // A leading `S` marks a signed numeric field and bears no storage
+        // position; strip it and remember. `S` anywhere but the front is invalid.
+        let signed = up.first() == Some(&'S');
+        let body = if signed { &up[1..] } else { &up[..] };
+        if body.iter().any(|&c| c == 'S') || (signed && body.is_empty()) {
+            return Err(RuntimeError::UnsupportedPicture(pic.to_string()));
         }
-        if all_a {
-            return Ok(Picture::Alphabetic { size: up.len() });
+
+        let all_x = body.iter().all(|&c| c == 'X');
+        let all_a = body.iter().all(|&c| c == 'A');
+        let numeric = body.iter().all(|&c| c == '9' || c == 'V');
+
+        // `S` only makes sense on a numeric field.
+        if signed && !numeric {
+            return Err(RuntimeError::UnsupportedPicture(pic.to_string()));
+        }
+
+        if !signed && all_x {
+            return Ok(Picture::Alphanumeric { size: body.len() });
+        }
+        if !signed && all_a {
+            return Ok(Picture::Alphabetic { size: body.len() });
         }
         if numeric {
             // At most one V, splitting integer and fractional digits.
-            if up.iter().filter(|&&c| c == 'V').count() > 1 {
+            if body.iter().filter(|&&c| c == 'V').count() > 1 {
                 return Err(RuntimeError::UnsupportedPicture(pic.to_string()));
             }
-            let v_at = up.iter().position(|&c| c == 'V');
+            let v_at = body.iter().position(|&c| c == 'V');
             let (int_digits, dec_digits) = match v_at {
-                Some(i) => (i, up.len() - i - 1),
-                None => (up.len(), 0),
+                Some(i) => (i, body.len() - i - 1),
+                None => (body.len(), 0),
             };
-            return Ok(Picture::Numeric { int_digits, dec_digits });
+            return Ok(Picture::Numeric { int_digits, dec_digits, signed });
         }
 
-        // Signed (S), scaling (P), editing symbols, or a mixed class — not v0.1.
+        // Scaling (P), editing symbols, or a mixed class — not yet modelled.
         Err(RuntimeError::UnsupportedPicture(pic.to_string()))
     }
 }
@@ -140,13 +157,13 @@ mod tests {
 
     #[test]
     fn numeric_with_implied_decimal() {
-        assert_eq!(Picture::parse("9(3)V99").unwrap(), Picture::Numeric { int_digits: 3, dec_digits: 2 });
+        assert_eq!(Picture::parse("9(3)V99").unwrap(), Picture::Numeric { int_digits: 3, dec_digits: 2, signed: false });
         assert_eq!(Picture::parse("9(3)V99").unwrap().size(), 5);
     }
 
     #[test]
     fn plain_integer_and_expanded_forms_agree() {
-        assert_eq!(Picture::parse("999").unwrap(), Picture::Numeric { int_digits: 3, dec_digits: 0 });
+        assert_eq!(Picture::parse("999").unwrap(), Picture::Numeric { int_digits: 3, dec_digits: 0, signed: false });
         assert_eq!(Picture::parse("9(3)").unwrap(), Picture::parse("999").unwrap());
     }
 
@@ -158,8 +175,25 @@ mod tests {
     }
 
     #[test]
-    fn signed_and_editing_are_unsupported_not_wrong() {
-        assert!(Picture::parse("S9(4)").is_err());
+    fn signed_numeric_pictures() {
+        // A leading S makes the field signed but adds no storage position.
+        assert_eq!(
+            Picture::parse("S9(4)").unwrap(),
+            Picture::Numeric { int_digits: 4, dec_digits: 0, signed: true }
+        );
+        assert_eq!(Picture::parse("S9(4)").unwrap().size(), 4);
+        assert_eq!(
+            Picture::parse("S9(3)V99").unwrap(),
+            Picture::Numeric { int_digits: 3, dec_digits: 2, signed: true }
+        );
+    }
+
+    #[test]
+    fn misplaced_sign_and_editing_are_unsupported_not_wrong() {
+        // S is only valid as the leading symbol, and only on a numeric field.
+        assert!(Picture::parse("9S9").is_err());
+        assert!(Picture::parse("SX(3)").is_err());
+        assert!(Picture::parse("S").is_err());
         assert!(Picture::parse("ZZ9").is_err());
         assert!(Picture::parse("9(3)PPP").is_err());
     }

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -134,7 +134,10 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
    fixed 12 fractional digits, not the standard's composite intermediate-precision
    rule; `**` supports non-negative integer exponents only (bounded at 1024).
    Both are flagged for a later precision/exponent-faithfulness PR.
-6. **Signed numerics + overpunch** display and the `SIGN` clause.
+6. **v0.6 — signed numerics** (this PR): `PIC S9…` fields carry an operational
+   sign through `MOVE`/arithmetic/`COMPUTE`; `DISPLAY` renders it as the default
+   trailing "zoned" overpunch on the units digit (`−123` → `12L`). The explicit
+   `SIGN` clause and its `SEPARATE`/`LEADING` variants are deferred.
 7. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
 7. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`, `TIMES`,
    `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.


### PR DESCRIPTION
## Summary

Adds signed numeric fields (`PIC S9…`) to the COBOL runtime — the sign is
carried through `MOVE`/arithmetic/`COMPUTE` and rendered on `DISPLAY` as COBOL's
default trailing "zoned decimal" overpunch. Pure runtime change (the frontend
already lexes `S` in pictures).

> ⚠️ **Stacked on #8018 (`feat/cobol-compute-runtime`).** Merge #8018 first; this
> PR's base retargets to `main` afterward (its babysit cron handles the rebase).

### What it does (cobol-runtime 0.6.0)
- **`picture.rs`** parses a leading `S` → `Numeric { …, signed: true }` (no
  storage position — `S9(4)` is still 4 digits); rejects a misplaced `S` or `S`
  on a non-numeric field.
- **`interp.rs`** gives each `Item` a `neg` flag beside its magnitude digits.
  `MOVE`/arithmetic into a signed receiver preserve the sign (exact zero is
  always unsigned); an unsigned receiver still drops to magnitude. `item_as_decimal`
  reads the sign back so signed values feed arithmetic and comparison correctly.
- **`DISPLAY` overpunch** on the units digit under the default `SIGN IS TRAILING`:
  `+123` → `12C`, `−123` → `12L`, `0` → `00{`.

### Deferred
The explicit `SIGN` clause and its `SEPARATE` / `LEADING` variants (this PR is
the default trailing-overpunch sign only) — noted in PL08.

## Tests
64 runtime tests + doctest (overpunch DISPLAY of ±/zero, sign through
`SUBTRACT`/`ADD`/`COMPUTE`, signed→unsigned drops the sign, picture parsing of
`S9…` and rejection of misplaced `S`). Warning-free. Security review PASSED
(no panics: `to_digit`→0..9 bounds the overpunch table; sign correctness
verified; unsigned still drops sign). README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)