### PR TITLE
feat(sir-js): Hash to_h (block + no-block) + each_with_index + each_with_object

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.29.0 — Hash `to_h` (block + no-block) / `each_with_index` / `each_with_object`
+
+Mirrors the Python reference (PR #8009), Go (PR #8015), and Rust (PR #8020)
+into the JS backend's inline `hashMethod` (+ the `HASH_METHODS` `respond_to?`
+set), rounding out Hash's Enumerable iteration surface.
+
+- `to_h` **without** a block → a shallow copy of the hash (`new Map(recv)`, so
+  mutating it does not alias the receiver).
+- `to_h { |k, v| [new_k, new_v] }` → a NEW `Map` from the block-returned
+  `[k, v]` pairs; the block is yielded the two args `(k, v)`; a non-pair result
+  (checked `Array.isArray` + length 2) is skipped, and a later pair with a
+  duplicate key wins (Ruby's rule / `Map.set`).
+- `each_with_index { |(k, v), i| … }` → yields each `[k, v]` pair with its
+  0-based index, returns the receiver.
+- `each_with_object(memo) { |(k, v), memo| … }` → yields each `[k, v]` pair with
+  the memo, returns the memo; no-memo arg returns the receiver.
+
+Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass
+the element as a single `[k, v]` JS Array (the second block param is the
+index/memo), matching Ruby's Enumerable convention.  (A printed hash already
+renders `{k: v}` after the display fix in 0.28.0.)
+
+Exec-proof: `tests/run_with_node.rs` gains `hash_to_h_and_indexed_iteration`,
+running to_h (copy + re-map), each_with_index (observed pair+index yield, returns
+self), and each_with_object (observed pair+memo yield, returns memo, and no-memo
+passthrough) under real `node`, diffed against the Python/Go/Rust reference.
+
 ## 0.28.0 — Hash Enumerable breadth: `group_by` / `partition` / `flat_map` / `collect_concat` / `reduce` / `inject` / `sum` (+ Hash display)
 
 Mirrors the Python reference (PR #7978), the Go backend (PR #7983), and the Rust

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -942,6 +942,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "sort_by", "min_by", "max_by",
     "group_by", "partition", "flat_map", "collect_concat",
     "reduce", "inject", "sum",
+    "to_h", "each_with_index", "each_with_object",
   ]);
   function hashMethod(recv, name, args) {
     switch (name) {
@@ -1191,6 +1192,47 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         let acc = args.length >= 2 ? args[0] : 0;
         for (const [k, v] of recv) { acc = acc + blk(k, v); }
         return acc;
+      }
+      case "to_h": {
+        // WITHOUT a block, a shallow copy of the hash (a fresh `Map`, so
+        // mutating it never aliases the receiver).  WITH a block
+        // `{ |k, v| [new_k, new_v] }`, a NEW hash from the `[k, v]` pairs the
+        // block returns: the block is yielded the two args `(k, v)` (matching
+        // `each`), a non-pair result is skipped (Ruby raises TypeError,
+        // deferred to the typed-error cascade), and a later pair with a
+        // duplicate key wins (Ruby's rule, and how `Map.set` behaves).
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return new Map(recv); }
+        const out = new Map();
+        for (const [k, v] of recv) {
+          const pair = blk(k, v);
+          if (Array.isArray(pair) && pair.length === 2) { out.set(pair[0], pair[1]); }
+        }
+        return out;
+      }
+      case "each_with_index": {
+        // Yields each `[k, v]` pair with its 0-based index and returns the
+        // receiver.  Unlike the two-arg `(k, v)` yield of `each`, the element
+        // arrives as a single `[k, v]` Array (the second block param is the
+        // index), matching Ruby's Enumerable convention.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        let i = 0;
+        for (const [k, v] of recv) { blk([k, v], i); i++; }
+        return recv;
+      }
+      case "each_with_object": {
+        // `each_with_object(memo) { |(k, v), memo| … }` — yields each `[k, v]`
+        // pair with the memo object and returns the (mutated) memo.  Like
+        // `each_with_index`, the element is the single `[k, v]` pair (the second
+        // block param is the memo).  With no memo argument the receiver is
+        // returned unchanged.
+        const blk = args[args.length - 1];
+        if (typeof blk !== "function") { return HASH_MISS; }
+        if (args.length < 2) { return recv; }
+        const memo = args[0];
+        for (const [k, v] of recv) { blk([k, v], memo); }
+        return memo;
       }
     }
     return HASH_MISS;

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2908,3 +2908,101 @@ fn hash_enumerable_breadth() {
         );
     }
 }
+
+// ── Ruby Hash to_h / each_with_index / each_with_object ────────────────────
+//
+// Rounds out Hash's Enumerable iteration surface, mirroring the Python (#8009),
+// Go (#8015), and Rust (#8020) references.  `to_h` has a no-block (shallow copy)
+// and a block (re-map) form; `each_with_index`/`each_with_object` yield the
+// [k, v] PAIR as a single argument alongside the index/memo (Ruby's Enumerable
+// convention — contrast `each`'s two-arg (k, v) yield).
+#[test]
+fn hash_to_h_and_indexed_iteration() {
+    let mk = |pairs: Vec<(&str, Expr)>| Expr::MapLit {
+        entries: pairs.into_iter().map(|(k, v)| MapEntry { key: str_(k), value: v }).collect(),
+        span: sp(),
+    };
+    let ab = || mk(vec![("a", int(1)), ("b", int(2))]);
+    let block_fns = vec![
+        // { |k, v| [k, v * 2] } — re-map each pair, doubling the value.
+        func(
+            "__t_dbl",
+            vec![param("k"), param("v")],
+            vec![],
+            seq(vec![param_ref("k"), bc("*", vec![param_ref("v"), int(2)])]),
+        ),
+        // { |pair, i| print [pair, i] } — observe the (pair, index) yield.
+        func(
+            "__t_pi",
+            vec![param("pair"), param("i")],
+            vec![print(seq(vec![param_ref("pair"), param_ref("i")]))],
+            Expr::NilLit { span: sp() },
+        ),
+        // { |pair, memo| print [pair, memo] } — observe the (pair, memo) yield.
+        func(
+            "__t_pm",
+            vec![param("pair"), param("memo")],
+            vec![print(seq(vec![param_ref("pair"), param_ref("memo")]))],
+            Expr::NilLit { span: sp() },
+        ),
+    ];
+    let stmts = vec![
+        // {a:1,b:2}.to_h (no block) → a shallow copy: {a: 1, b: 2}
+        print(method(ab(), "to_h", vec![])),
+        // {a:1,b:2}.to_h { |k, v| [k, v * 2] } → {a: 2, b: 4}
+        print(method(ab(), "to_h", vec![method_closure("__t_dbl")])),
+        // {a:1,b:2}.each_with_index { |pair, i| print [pair, i] }
+        //   → "[[a, 1], 0]", "[[b, 2], 1]", then the returned self "{a: 1, b: 2}"
+        print(method(ab(), "each_with_index", vec![method_closure("__t_pi")])),
+        // {a:1,b:2}.each_with_object(0) { |pair, memo| print [pair, memo] }
+        //   → "[[a, 1], 0]", "[[b, 2], 0]", then the returned memo "0"
+        print(method(ab(), "each_with_object", vec![int(0), method_closure("__t_pm")])),
+        // {a:1}.each_with_object { |pair, memo| … } with NO memo arg → returns
+        // the receiver unchanged (the block is never called): "{a: 1}"
+        print(method(mk(vec![("a", int(1))]), "each_with_object", vec![method_closure("__t_pm")])),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let mut functions = vec![main];
+    functions.extend(block_fns);
+    let module = Module {
+        name: "hashtoh".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Maps,
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions,
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "hashtoh") {
+        assert_eq!(
+            stdout,
+            "{a: 1, b: 2}\n\
+             {a: 2, b: 4}\n\
+             [[a, 1], 0]\n\
+             [[b, 2], 1]\n\
+             {a: 1, b: 2}\n\
+             [[a, 1], 0]\n\
+             [[b, 2], 0]\n\
+             0\n\
+             {a: 1}"
+        );
+    }
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8009](https://github.com/adhithyan15/coding-adventures/pull/8009)), Go ([#8015](https://github.com/adhithyan15/coding-adventures/pull/8015)), and Rust ([#8020](https://github.com/adhithyan15/coding-adventures/pull/8020)) into the **JS** backend's inline `hashMethod` (+ the `HASH_METHODS` `respond_to?` set), rounding out Hash's Enumerable iteration surface.

## Methods
- `to_h` **without** a block → shallow copy (`new Map(recv)`, no alias of receiver).
- `to_h { |k,v| [new_k, new_v] }` → new `Map` from block-returned `[k, v]` pairs; block yields two args `(k, v)`; non-pair result skipped (checked `Array.isArray` + length 2); last colliding key wins.
- `each_with_index { |(k,v), i| … }` → yields each `[k, v]` pair + 0-based index; returns the receiver.
- `each_with_object(memo) { |(k,v), memo| … }` → yields each `[k, v]` pair + memo; returns the memo; no-memo arg returns the receiver.

Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass the element as a single `[k, v]` JS Array (2nd block param is index/memo) — Ruby's Enumerable convention. A printed hash already renders `{k: v}` (display fix in 0.28.0).

## Exec-proof
`tests/run_with_node.rs` gains `hash_to_h_and_indexed_iteration`, run under real `node`, diffed against the Python/Go/Rust reference:

```
{a: 1, b: 2}     # to_h (no block) → shallow copy
{a: 2, b: 4}     # to_h { [k, v*2] }
[[a, 1], 0]      # each_with_index yields ([a,1], 0)
[[b, 2], 1]
{a: 1, b: 2}     # each_with_index returns self
[[a, 1], 0]      # each_with_object yields ([a,1], 0)
[[b, 2], 0]
0                # each_with_object returns the memo
{a: 1}           # each_with_object with no memo → returns self
```

Full JS suite green (109 lib + 75 node). Version 0.28.0 → 0.29.0; CHANGELOG updated. Security review passed. Remaining mirror: **TS** (final backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)