### PR TITLE
feat(cobol): PERFORM para [n TIMES] — out-of-line paragraph invocation (PL08 v0.7)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.7.0 — PERFORM (out-of-line paragraph invocation)
+
+- **`PERFORM para [n TIMES]`** runs a named paragraph out of line and returns to
+  the statement after the `PERFORM`. The `Machine` now indexes paragraphs by name
+  and executes them by cloning their statement list (so a performed paragraph and
+  the top-level fall-through share one execution path).
+- The `TIMES` count is a value: `≤ 0` runs the paragraph zero times (COBOL's
+  rule), a fractional count truncates, and an absurd (non-`usize`) count is a
+  clean error.
+- **`STOP RUN`** inside a performed paragraph ends the whole program (the
+  stop-flag propagates out of the `PERFORM`).
+- **Recursion guard:** a paragraph that performs itself (directly or in a cycle)
+  is bounded by `MAX_PERFORM_DEPTH` (100) and fails with a clean error instead of
+  overflowing the native stack.
+- Deferred to later PRs: `PERFORM … THRU`, `… UNTIL`, `… VARYING`, the inline
+  form, and `GO TO`.
+
 ## 0.6.0 — signed numerics (PIC S9…)
 
 - **`PIC S9…` signed numeric fields.** The leading `S` marks the field signed and

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -26,9 +26,10 @@ the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; fixed-point
 decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
 toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
-parentheses), `ROUNDED`, and `ON SIZE ERROR`; and `IF … ELSE` with numeric and
-alphanumeric comparison. Anything not yet modelled (the explicit `SIGN` clause
-with `SEPARATE`/`LEADING`, editing pictures, `COMP`, `PERFORM`, `GO TO`,
-`EVALUATE`, tables, files, and every other verb) returns a descriptive
-`RuntimeError` — never wrong output. See PL08 for the
+parentheses), `ROUNDED`, and `ON SIZE ERROR`; `IF … ELSE` with numeric and
+alphanumeric comparison; and `PERFORM para [n TIMES]` (out-of-line paragraph
+invocation, with a recursion guard). Anything not yet modelled (the explicit
+`SIGN` clause with `SEPARATE`/`LEADING`, editing pictures, `COMP`,
+`PERFORM … THRU`/`UNTIL`/`VARYING`, `GO TO`, `EVALUATE`, tables, files, and every
+other verb) returns a descriptive `RuntimeError` — never wrong output. See PL08 for the
 roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -3,9 +3,18 @@
 
 use crate::error::RuntimeError;
 use crate::picture::Picture;
-use crate::program::{ArithOp, Cond, Expr, Fig, Lit, Operand, Program, RelOp, Stmt};
+use crate::program::{ArithOp, Cond, Expr, Fig, Lit, Operand, Paragraph, Program, RelOp, Stmt};
 use crate::value::{add, div, move_into_char, move_into_numeric, mul, pow, round, sub, Decimal};
 use std::collections::HashMap;
+
+/// Deepest chain of nested/recursive `PERFORM`s before we bail out with a clean
+/// error. A paragraph that performs itself (directly or in a cycle) would
+/// otherwise recurse until the native stack overflows — an uncatchable abort.
+/// Each level spends several (debug-sized) frames — `exec_perform` →
+/// `run_stmts` → `exec_stmt` → `exec_perform` — so the cap sits well under the
+/// ~200-level overflow point of a default 2 MiB worker/test stack. Real programs
+/// never nest `PERFORM` anywhere near this deep.
+const MAX_PERFORM_DEPTH: usize = 100;
 
 /// Fractional precision COMPUTE carries through an intermediate **division**
 /// before the final round/truncate into the receiver. COBOL's standard defines
@@ -85,17 +94,36 @@ fn overpunch_trailing(magnitude: &str, neg: bool) -> String {
     chars.into_iter().collect()
 }
 
-/// The running machine: the item table, a name→index map, and captured output.
+/// The running machine: the item table, a name→index map, the procedure's
+/// paragraphs (with a name→index map for `PERFORM` targets), and captured output.
 pub struct Machine {
     items: Vec<Item>,
     by_name: HashMap<String, usize>,
+    paragraphs: Vec<Paragraph>,
+    para_index: HashMap<String, usize>,
+    /// Current `PERFORM` nesting depth, bounded by [`MAX_PERFORM_DEPTH`].
+    perform_depth: usize,
     output: String,
 }
 
 impl Machine {
     /// Build the data model from a program's WORKING-STORAGE and initialise it.
     pub fn new(program: &Program) -> Result<Machine, RuntimeError> {
-        let mut m = Machine { items: Vec::new(), by_name: HashMap::new(), output: String::new() };
+        // Index paragraphs by name for PERFORM lookup. A duplicated name keeps
+        // its first occurrence (a PERFORM of an ambiguous name is unusual; the
+        // first definition wins rather than erroring at build time).
+        let mut para_index = HashMap::new();
+        for (i, p) in program.paragraphs.iter().enumerate() {
+            para_index.entry(p.name.clone()).or_insert(i);
+        }
+        let mut m = Machine {
+            items: Vec::new(),
+            by_name: HashMap::new(),
+            paragraphs: program.paragraphs.clone(),
+            para_index,
+            perform_depth: 0,
+            output: String::new(),
+        };
         m.build_items(program)?;
         Ok(m)
     }
@@ -177,12 +205,15 @@ impl Machine {
     // ----------------------------------------------------------------------
 
     /// Run the procedure division and return the captured console output.
-    pub fn run(mut self, program: &Program) -> Result<String, RuntimeError> {
-        'outer: for para in &program.paragraphs {
-            for stmt in &para.stmts {
-                if self.exec_stmt(stmt)? {
-                    break 'outer; // STOP RUN
-                }
+    pub fn run(mut self, _program: &Program) -> Result<String, RuntimeError> {
+        // Execute paragraphs top to bottom (COBOL falls through paragraph
+        // boundaries). We clone each paragraph's statements to run them, since
+        // executing borrows `self` mutably while the paragraphs live in `self`.
+        let count = self.paragraphs.len();
+        for i in 0..count {
+            let stmts = self.paragraphs[i].stmts.clone();
+            if self.run_stmts(&stmts)? {
+                break; // STOP RUN
             }
         }
         // Falling off the end of the procedure division ends the run too.
@@ -205,6 +236,7 @@ impl Machine {
             Stmt::Compute { target, rounded, expr, on_size_error } => {
                 return self.exec_compute(target, *rounded, expr, on_size_error);
             }
+            Stmt::Perform { target, times } => return self.exec_perform(target, times),
             Stmt::If { cond, then_branch, else_branch } => {
                 let branch = if self.eval_cond(cond)? { then_branch } else { else_branch };
                 return self.run_stmts(branch);
@@ -223,6 +255,57 @@ impl Machine {
             }
         }
         Ok(false)
+    }
+
+    /// `PERFORM target [n TIMES]` — run one paragraph out of line, `n` times
+    /// (default 1), then return. A `TIMES` count that is zero or negative runs
+    /// the paragraph zero times (COBOL's rule); a fractional count truncates.
+    /// Nesting is bounded by [`MAX_PERFORM_DEPTH`] so a self-performing paragraph
+    /// fails with a clean error instead of overflowing the stack. Returns `true`
+    /// if a `STOP RUN` fired inside.
+    fn exec_perform(&mut self, target: &str, times: &Option<Operand>) -> Result<bool, RuntimeError> {
+        let idx = *self
+            .para_index
+            .get(target)
+            .ok_or_else(|| RuntimeError::UndefinedName(target.into()))?;
+
+        // Resolve the repeat count: a non-negative integer; ≤ 0 → zero times.
+        let n: usize = match times {
+            None => 1,
+            Some(op) => {
+                let d = self.operand_decimal(op)?;
+                if d.neg {
+                    0
+                } else {
+                    let int = d.int.trim_start_matches('0');
+                    if int.is_empty() {
+                        0
+                    } else {
+                        int.parse::<usize>().map_err(|_| {
+                            RuntimeError::Unsupported("PERFORM … TIMES count is too large".into())
+                        })?
+                    }
+                }
+            }
+        };
+
+        self.perform_depth += 1;
+        if self.perform_depth > MAX_PERFORM_DEPTH {
+            self.perform_depth -= 1;
+            return Err(RuntimeError::Unsupported(
+                "PERFORM nesting too deep (a paragraph performing itself?)".into(),
+            ));
+        }
+        let stmts = self.paragraphs[idx].stmts.clone();
+        let mut stop = false;
+        for _ in 0..n {
+            if self.run_stmts(&stmts)? {
+                stop = true;
+                break;
+            }
+        }
+        self.perform_depth -= 1;
+        Ok(stop)
     }
 
     /// Evaluate a relational condition. Numeric when both sides are numeric;

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -297,15 +297,24 @@ impl Machine {
             ));
         }
         let stmts = self.paragraphs[idx].stmts.clone();
-        let mut stop = false;
+        // Capture the outcome rather than `?`-ing out of the loop, so the depth
+        // counter is restored on every path (including an error).
+        let mut outcome = Ok(false);
         for _ in 0..n {
-            if self.run_stmts(&stmts)? {
-                stop = true;
-                break;
+            match self.run_stmts(&stmts) {
+                Ok(true) => {
+                    outcome = Ok(true); // STOP RUN — stop repeating
+                    break;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    outcome = Err(e);
+                    break;
+                }
             }
         }
         self.perform_depth -= 1;
-        Ok(stop)
+        outcome
     }
 
     /// Evaluate a relational condition. Numeric when both sides are numeric;

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -8,13 +8,14 @@
 //! It implements a *small but fully correct* slice — `MOVE` / `DISPLAY` /
 //! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
-//! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), and `IF … ELSE`
-//! (numeric and alphanumeric comparison) over numeric-display (`9`/`V`, and
+//! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), `IF … ELSE`
+//! (numeric and alphanumeric comparison), and `PERFORM para [n TIMES]`
+//! (out-of-line paragraph invocation) over numeric-display (`9`/`V`, and
 //! signed `S` with trailing-overpunch display) and character pictures — and
 //! returns a descriptive error for anything not yet modelled, rather than
 //! producing wrong output. The roadmap toward full COBOL (the `SIGN` clause and
-//! `SEPARATE`/`LEADING` variants, editing pictures, `PERFORM`, tables, files, later
-//! standards) is in PL08.
+//! `SEPARATE`/`LEADING` variants, editing pictures, `PERFORM … THRU`/`UNTIL`/
+//! `VARYING`, `GO TO`, tables, files, later standards) is in PL08.
 //!
 //! ```
 //! use coding_adventures_cobol_runtime::run_cobol;
@@ -581,20 +582,138 @@ mod tests {
 
     #[test]
     fn unsupported_verb_is_a_clear_error() {
-        // PERFORM is not yet executed (control flow is a later PR).
+        // GO TO is not yet executed (it is a later control-flow PR).
         let err = run_cobol(&program(&[
             "IDENTIFICATION DIVISION.",
             "PROGRAM-ID. P.",
             "PROCEDURE DIVISION.",
             "MAIN.",
-            "    PERFORM SUB.",
-            "    STOP RUN.",
+            "    GO TO SUB.",
             "SUB.",
             "    STOP RUN.",
         ]))
         .unwrap_err();
         assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
-        assert!(err.to_string().contains("PERFORM"), "message should name the verb: {err}");
+        assert!(err.to_string().contains("GO"), "message should name the verb: {err}");
+    }
+
+    // ----------------------------------------------------------------------
+    // PERFORM — out-of-line paragraph invocation
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn perform_runs_a_paragraph_then_returns() {
+        // MAIN performs GREET, then continues to its own DISPLAY.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM GREET.",
+            "    DISPLAY \"BACK\".",
+            "    STOP RUN.",
+            "GREET.",
+            "    DISPLAY \"HI\".",
+        ]))
+        .unwrap();
+        // HI (from the perform), BACK (after it returns), then STOP RUN — the
+        // GREET paragraph does NOT run a second time by fall-through.
+        assert_eq!(out, "HI\nBACK\n");
+    }
+
+    #[test]
+    fn perform_n_times_repeats() {
+        // PERFORM TICK 3 TIMES accumulates COUNT 1,2,3.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  COUNT  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM TICK 3 TIMES.",
+            "    STOP RUN.",
+            "TICK.",
+            "    ADD 1 TO COUNT.",
+            "    DISPLAY COUNT.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "1\n2\n3\n");
+    }
+
+    #[test]
+    fn perform_zero_or_negative_times_runs_never() {
+        // A zero count performs the paragraph zero times.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  N  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM NOISE N TIMES.",
+            "    DISPLAY \"DONE\".",
+            "    STOP RUN.",
+            "NOISE.",
+            "    DISPLAY \"X\".",
+        ]))
+        .unwrap();
+        assert_eq!(out, "DONE\n");
+    }
+
+    #[test]
+    fn perform_of_unknown_paragraph_is_an_error() {
+        let err = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM NOWHERE.",
+            "    STOP RUN.",
+        ]))
+        .unwrap_err();
+        assert!(matches!(err, RuntimeError::UndefinedName(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn self_performing_paragraph_errors_not_overflows() {
+        // LOOP performs itself: without the depth cap this recurses until the
+        // native stack overflows. The cap turns it into a clean error.
+        let err = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM LOOP.",
+            "    STOP RUN.",
+            "LOOP.",
+            "    PERFORM LOOP.",
+        ]))
+        .unwrap_err();
+        assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
+        assert!(err.to_string().to_lowercase().contains("deep"), "message should explain: {err}");
+    }
+
+    #[test]
+    fn stop_run_inside_a_performed_paragraph_ends_the_program() {
+        // The STOP RUN inside DONE ends everything; MAIN's trailing DISPLAY
+        // never runs.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM DONE.",
+            "    DISPLAY \"AFTER\".",
+            "    STOP RUN.",
+            "DONE.",
+            "    DISPLAY \"IN\".",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "IN\n");
     }
 
     #[test]

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -50,9 +50,7 @@ pub enum Fig {
 /// A named paragraph of statements.
 #[derive(Debug, Clone)]
 pub struct Paragraph {
-    /// The paragraph name — a `PERFORM` / `GO TO` target. Captured now; branched
-    /// on once those verbs land (the next control-flow PR).
-    #[allow(dead_code)]
+    /// The paragraph name — a `PERFORM` (and, later, `GO TO`) target.
     pub name: String,
     pub stmts: Vec<Stmt>,
 }
@@ -80,6 +78,9 @@ pub enum Stmt {
         expr: Expr,
         on_size_error: Vec<Stmt>,
     },
+    /// `PERFORM para [n TIMES]` — run a paragraph out of line, optionally a
+    /// fixed number of times, then return to the statement after the PERFORM.
+    Perform { target: String, times: Option<Operand> },
     /// `IF cond then… [ELSE else…]`.
     If { cond: Cond, then_branch: Vec<Stmt>, else_branch: Vec<Stmt> },
     StopRun,
@@ -396,6 +397,24 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 None => Vec::new(),
             };
             Ok(Stmt::Compute { target, rounded, expr, on_size_error })
+        }
+        "perform_stmt" => {
+            // PERFORM target [THROUGH/THRU target2] [operand TIMES]. The target
+            // is the first direct NAME token; the optional `TIMES` count is an
+            // `operand` node. The THRU range form is deferred.
+            let target = first_token(verb, "NAME")
+                .ok_or_else(|| RuntimeError::Unsupported("PERFORM without a target paragraph".into()))?;
+            if child_tokens(verb)
+                .iter()
+                .any(|(k, v)| k == "KEYWORD" && (v == "THRU" || v == "THROUGH"))
+            {
+                return Err(RuntimeError::Unsupported("PERFORM … THRU (range form)".into()));
+            }
+            let times = match child_node(verb, "operand") {
+                Some(op) => Some(read_operand(op)?),
+                None => None,
+            };
+            Ok(Stmt::Perform { target, times })
         }
         "if_stmt" => {
             // Children in order: IF, condition, then-statements…, [ELSE,

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -138,8 +138,12 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
    sign through `MOVE`/arithmetic/`COMPUTE`; `DISPLAY` renders it as the default
    trailing "zoned" overpunch on the units digit (`−123` → `12L`). The explicit
    `SIGN` clause and its `SEPARATE`/`LEADING` variants are deferred.
-7. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
-7. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`, `TIMES`,
+7. **v0.7 — `PERFORM para [n TIMES]`** (this PR): out-of-line paragraph
+   invocation with return, an integer repeat count (`≤ 0` runs zero times), and a
+   recursion-depth guard against a self-performing paragraph. `PERFORM … THRU`,
+   `… UNTIL`, `… VARYING`, and the inline form are deferred.
+8. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+9. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
    `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
 8. **Conditions** — level-88 condition-names.
 9. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.


### PR DESCRIPTION
## Summary

Adds `PERFORM para [n TIMES]` — the runtime's first paragraph-level control flow.
A `PERFORM` runs a named paragraph out of line and returns to the statement after
it. The grammar already parsed `perform_stmt`; the runtime previously errored on it.

### What it does (cobol-runtime 0.7.0)
- **`program.rs`**: `Stmt::Perform { target, times }` + `perform_stmt` reader
  (target NAME + optional `operand TIMES`; the `THRU` range form is deferred).
- **`interp.rs`**: the `Machine` now indexes paragraphs by name and executes a
  paragraph by cloning its statement list. The `TIMES` count is a value: `≤ 0`
  runs zero times (COBOL's rule), a fractional count truncates, and an absurd
  (non-`usize`) count is a clean error. `STOP RUN` inside a performed paragraph
  ends the whole program.

### Hardening
- **Recursion guard** (`MAX_PERFORM_DEPTH = 100`): a paragraph that performs
  itself — directly or in a cycle — fails with a clean error instead of
  overflowing the native stack (cap sits well below the ~200-level overflow point
  of a 2 MiB stack; the depth counter is restored on every exit path).

### Deferred
`PERFORM … THRU` / `… UNTIL` / `… VARYING`, the inline form, and `GO TO`.

## Tests
70 runtime tests + doctest (perform-then-return, `n TIMES` repeat, zero/negative
count, unknown paragraph → error, self-perform → clean error not overflow,
`STOP RUN` inside a performed paragraph). Warning-free. Security review PASSED.
README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)