### PR TITLE
feat(javascript-parser): bridge generator methods *m(){} (CLOC12.181)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.45.0] - 2026-07-11
+
+### Added — CLOC12.181: bridge generator methods (`*m(){}`)
+
+`convert_method_definition` already detected the leading `*` token (`saw_star`)
+but then DECLINED the method (dropping the file to WHITESPACE_ONLY) as a
+conservative measure. That decline is now stale: `yield` is a modelled
+`YieldExpression` (CLOC12.163), a top-level generator *function* already bridges,
+and the emitter's `emit_class_member` already reprints the `*` from the value's
+`generator` flag. So a generator method now bridges by setting
+`generator: saw_star` on the method's `FunctionExpression` value — a
+generator's `FunctionExpression` flows through every optimization pass exactly
+like a `function*`.
+
+Covers both `class C { *gen(){} }` (declaration) and `x = class { *gen(){} }`
+(expression), plus `static *gen(){}`. The `constructor` classification is guarded
+against a stray `*` (`*constructor(){}` is a SyntaxError — a generator is never a
+constructor). Accessor generators (`get`/`set` + `*`) are grammatically
+impossible; private generator methods (`*#m(){}`) remain declined in
+`convert_private_method_definition` (a later slice).
+
+2 former decline tests flipped to success
+(`class_generator_method_bridges`, `class_decl_generator_method_bridges`); a new
+`class_static_generator_method_bridges` test covers the static form. Async
+methods (`async_method`) still DECLINE one level up (grammar-blocked).
+
 ## [0.44.0] - 2026-07-11
 
 ### Added — CLOC12.180: bridge computed member keys (`[expr]`)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1411,13 +1411,14 @@ fn convert_class_field(node: &GrammarASTNode) -> Result<PropertyDefinition, Brid
 /// ```
 ///
 /// **Modifier tokens precede the `property_name` node.** `get` / `set` mark an
-/// accessor; a `*` (generator) marks a form this slice does not model yet — it
-/// DECLINES via `UnsupportedSyntax` (safe WHITESPACE_ONLY fallback) rather than
-/// emit a plain method and silently drop the `*` (a semantics-changing
-/// miscompile). A key literally named `get` (`get(){}`) parses with the
-/// `property_name` node *first* — no leading accessor token — so it is correctly
-/// an ordinary [`MethodKind::Method`]. (An `async` method is a *separate*
-/// grammar node, `async_method`, declined one level up in
+/// accessor; a `*` marks a **generator method** (`*gen(){}`), bridged since
+/// CLOC12.181 by setting the `value`'s `generator` flag so the emitter re-prints
+/// the `*` (`yield` inside the body is already a modelled `YieldExpression`, and
+/// a generator's `FunctionExpression` value flows through every pass exactly like
+/// a top-level `function*` — CLOC12.163). A key literally named `get`
+/// (`get(){}`) parses with the `property_name` node *first* — no leading accessor
+/// token — so it is correctly an ordinary [`MethodKind::Method`]. (An `async`
+/// method is a *separate* grammar node, `async_method`, declined one level up in
 /// [`convert_class_element`], so `async` never reaches here.)
 ///
 /// **`constructor`.** A non-static, non-accessor method whose key is the plain
@@ -1449,11 +1450,11 @@ fn convert_method_definition(
         }
     }
 
-    // Generator methods carry evaluation semantics this slice does not model —
-    // DECLINE so the whole file falls back rather than mis-emit.
-    if saw_star {
-        return Err(unsupported(node));
-    }
+    // A generator method (`*gen(){}`) is bridged (CLOC12.181): `saw_star` sets
+    // the value's `generator` flag below and the emitter re-prints the `*`. No
+    // decline is needed — `yield` inside the body is a modelled `YieldExpression`
+    // and a generator `FunctionExpression` flows through every pass exactly like
+    // a top-level `function*`.
 
     let key_node = node_children(node)
         .into_iter()
@@ -1468,8 +1469,11 @@ fn convert_method_definition(
     } else if saw_set {
         MethodKind::Set
     } else if !is_static
+        && !saw_star
         && matches!(&key, PropertyKey::Identifier(id) if id.name == "constructor")
     {
+        // `*constructor(){}` is a SyntaxError in real JS — a generator is never a
+        // constructor, so a stray `*` guards the `constructor` classification.
         MethodKind::Constructor
     } else {
         MethodKind::Method
@@ -1504,7 +1508,8 @@ fn convert_method_definition(
             id: None,
             params,
             body,
-            generator: false,
+            // `*gen(){}` → a generator method; the emitter re-prints the `*`.
+            generator: saw_star,
             is_async: false,
         },
         computed,
@@ -3876,12 +3881,27 @@ mod tests {
     }
 
     #[test]
-    fn class_generator_method_declines() {
-        // `*gen(){}` carries generator semantics not modelled here — DECLINE.
-        assert!(matches!(
-            bridge("x = class { *gen(){} };"),
-            Err(BridgeError::UnsupportedSyntax { .. })
-        ));
+    fn class_generator_method_bridges() {
+        // `*gen(){}` — a generator method bridges (CLOC12.181): plain method
+        // `kind`, and the value's `generator` flag is set so the emitter reprints
+        // the `*`. `yield` in the body is a modelled `YieldExpression`.
+        let c = class_of("x = class { *gen(){ yield 1 } };");
+        let ClassMember::Method(m) = &c.body[0] else { panic!("expected a method member") };
+        assert_eq!(m.kind, MethodKind::Method);
+        assert!(m.value.generator);
+        assert!(!m.value.is_async);
+        assert!(matches!(&m.key, PropertyKey::Identifier(id) if id.name == "gen"));
+    }
+
+    #[test]
+    fn class_static_generator_method_bridges() {
+        // `static *gen(){}` — the `static` modifier lives on the enclosing
+        // `class_element`; the `*` still sets the generator flag.
+        let c = class_of("x = class { static *gen(){} };");
+        let ClassMember::Method(m) = &c.body[0] else { panic!("expected a method member") };
+        assert!(m.is_static);
+        assert!(m.value.generator);
+        assert_eq!(m.kind, MethodKind::Method);
     }
 
     #[test]
@@ -4311,13 +4331,13 @@ mod tests {
     }
 
     #[test]
-    fn class_decl_generator_method_declines() {
-        // `*m(){}` is a generator method — a form this slice does not model, so
-        // the whole file DECLINES to WHITESPACE_ONLY (never a miscompile).
-        assert!(matches!(
-            bridge("class C { *m(){} }"),
-            Err(BridgeError::UnsupportedSyntax { .. })
-        ));
+    fn class_decl_generator_method_bridges() {
+        // `*m(){}` in a class *declaration* bridges (CLOC12.181): the value's
+        // `generator` flag is set so the emitter reprints the `*`.
+        let c = class_decl_of("class C { *m(){} }");
+        let ClassMember::Method(m) = &c.body[0] else { panic!("expected a method member") };
+        assert!(m.value.generator);
+        assert_eq!(m.kind, MethodKind::Method);
     }
 
     #[test]

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.20] - 2026-07-11
+
+### Added — CLOC12.181: generator methods end-to-end
+
+Picks up javascript-parser 0.45.0, whose bridge now sets the `generator` flag on
+a `*m(){}` method's `FunctionExpression` value instead of declining. A generator
+method — `class C { *gen(){} }` or `x = class { *gen(){} }`, optionally `static`
+— now survives the full closurec pipeline instead of dropping to WHITESPACE_ONLY.
+New e2e diff fixture `tests/diff/simple-generator-method/`:
+`class C { *gen(){ return 1 + 2 } }` → `class C{*gen(){return 3}}` at SIMPLE.
+
+The fixture proves two things at once: the `*gen` head round-trips (the emitter
+reprinted the `*` from the propagated `generator` flag), and the SIMPLE pipeline
+descends INTO the generator method's body (`return 1 + 2` folds to `return 3`).
+Before this bridge change the generator method declined, dropping the file to
+WHITESPACE_ONLY (`class C{*gen(){return 1+2}};`).
+Version-synced cli.spec.json + tests/diff/help-markdown/expected.stdout. PATCH.
+
 ## [0.234.19] - 2026-07-11
 
 ### Added — CLOC12.180: computed member keys end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.19"
+version = "0.234.20"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.19",
+  "version": "0.234.20",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.19
+Version: 0.234.20
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-generator-method/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-generator-method/expected.stdout
@@ -1,0 +1,1 @@
+class C{*gen(){return 3}}

--- a/code/programs/rust/closurec/tests/diff/simple-generator-method/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-generator-method/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-generator-method/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-generator-method/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-generator-method/input/a.js
@@ -1,0 +1,1 @@
+class C { *gen(){ return 1 + 2 } }

--- a/code/programs/rust/closurec/tests/diff_simple_generator_method.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_generator_method.rs
@@ -1,0 +1,82 @@
+//! Integration test for the `tests/diff/simple-generator-method/` fixture.
+//!
+//! Exercises a **generator method** (`*gen(){…}`, a `MethodDefinition` whose
+//! `value` [`FunctionExpression`] has `generator: true`) end-to-end at SIMPLE —
+//! the CLOC12.181 bridge of the `*` generator marker in `convert_method_definition`.
+//! The typed AST (`FunctionExpression.generator`) and emitter (`emit_class_member`
+//! reprints the `*`) already supported generators; only the bridge declined the
+//! method form (a public generator *function* already bridged at CLOC12.163).
+//!
+//! The fixture is `class C { *gen(){ return 1 + 2 } }` compiled at SIMPLE.
+//! Two facts prove the whole pipeline ran through the generator method:
+//!   1. the class round-trips with a `*gen` head — proving the bridge set the
+//!      `generator` flag (and the emitter reprinted the `*`), not a
+//!      WHITESPACE_ONLY fallback; and
+//!   2. the body folds — `return 1 + 2` → `return 3` — proving the SIMPLE
+//!      pipeline descended INTO the generator method's body. A WHITESPACE_ONLY
+//!      fallback would leave `1+2` intact.
+//! Before this bridge change a generator method DECLINED, dropping the file to
+//! WHITESPACE_ONLY (`class C{*gen(){return 1+2}};`) and assertion (2) failed.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-generator-method/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_generator_method_folds_body() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-generator-method/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    let a = actual.replace(' ', "");
+    // (1) the class round-tripped with a `*gen` generator-method head.
+    assert!(
+        (a.contains("classC{") || a.contains("class C{")) && a.contains("*gen("),
+        "generator method did not round-trip with a `*gen` head: {actual}"
+    );
+    // (2) the body folded — proving the pipeline descended INTO the method body
+    //     (`return 1+2`→`return 3`). A WHITESPACE_ONLY fallback would leave the
+    //     arithmetic intact.
+    assert!(
+        a.contains("return3"),
+        "generator method body did not fold to `return 3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+    // (3) a class *declaration* emits bare — NO wrapping paren (a WHITESPACE_ONLY
+    //     fallback for a class *expression* would wrap; a declaration must not).
+    let t = actual.trim_end_matches('\n');
+    assert!(
+        t.ends_with('}') && !t.starts_with('('),
+        "class declaration must emit bare (no wrap): {actual}"
+    );
+}


### PR DESCRIPTION
## CLOC12.181 — bridge generator methods `*m(){}`

`convert_method_definition` already detected the leading `*` (`saw_star`) but then **DECLINED** the method, dropping the whole file to `WHITESPACE_ONLY`. That conservatism is now stale:

- `yield` is a modelled `YieldExpression` (CLOC12.163),
- a top-level generator **function** already bridges, and
- the emitter's `emit_class_member` already reprints the `*` from the value's `generator` flag.

So a generator method now bridges by setting `generator: saw_star` on the method value's `FunctionExpression` — a generator `FunctionExpression` flows through every optimization pass exactly like a `function*`.

### Scope
- Class **declaration** (`class C { *gen(){} }`) and **expression** (`x = class { *gen(){} }`) forms, plus `static *gen(){}`.
- The `constructor` classification is guarded against a stray `*` (`*constructor(){}` is a SyntaxError — a generator is never a constructor).
- Private generator methods (`*#m(){}`) remain declined in `convert_private_method_definition` (a later slice). Async methods (`async_method`) still decline one level up (grammar-blocked).

### Changes
- **javascript-parser 0.44.0 → 0.45.0** (new capability): remove the `saw_star` decline; set `generator: saw_star`; guard constructor against `*`.
- **closurec 0.234.19 → 0.234.20** (patch) + trio-synced `cli.spec.json` + `tests/diff/help-markdown/expected.stdout`.
- 2 former decline tests flipped to success (`class_generator_method_bridges`, `class_decl_generator_method_bridges`) + new `class_static_generator_method_bridges`.
- e2e fixture `tests/diff/simple-generator-method/`: `class C { *gen(){ return 1 + 2 } }` → `class C{*gen(){return 3}}` at SIMPLE. Proves the `*gen` head round-trips **and** the pipeline descends into the body (`return 1 + 2` → `return 3`).

### Verification
- 217 javascript-parser tests green.
- closurec diff suite green (incl. new `diff_simple_generator_method`).
- security-review PASSED (no vulnerabilities; single bool-flag propagation, no new I/O/recursion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)