### PR TITLE
fix(sql-vm): ROUND clamps a negative digit count to zero (SQLite semantics)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.9 — Fix ROUND with a negative digit count
+
+Stream A correctness fix (sql-vm 0.4.5): `ROUND(x, n)` with a negative `n` now
+matches SQLite, which treats it as zero digits rather than rounding to
+tens/hundreds — `ROUND(2.567, -1)` returned `0.0` but SQLite gives `3.0`
+(= `ROUND(2.567, 0)`), and `ROUND(12.5, -1)` = `13.0`. A new differential-oracle
+case (`round_negative_digits`) diffs against real bundled SQLite.
+
 ## 0.5.8 — CONCAT / CONCAT_WS / SUBSTRING string functions
 
 Grows the SQL scalar surface (sql-vm 0.4.4): `CONCAT(x, …)` joins all arguments

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -585,6 +585,16 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT SUBSTRING(s, 2) AS a, SUBSTRING(s, 2, 3) AS b FROM t ORDER BY id",
     },
+    // ROUND with a NEGATIVE digit count is treated as zero digits (SQLite never
+    // rounds to tens/hundreds): round(2.567,-1) = round(2.567,0) = 3.0, not 0.0.
+    Case {
+        id: "round_negative_digits",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, x REAL)",
+            "INSERT INTO t VALUES (1, 2.567), (2, 12.5)",
+        ],
+        query: "SELECT ROUND(x, -1) AS a, ROUND(x, -5) AS b, ROUND(x, 1) AS c FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.5] - Unreleased
+
+### Fixed
+
+- **`ROUND(x, n)` with a negative digit count** now matches SQLite, which treats
+  a negative `n` as zero rather than rounding to tens/hundreds:
+  `ROUND(2.567, -1)` = `ROUND(2.567, 0)` = `3.0` (was `0.0`), and
+  `ROUND(12.5, -1)` = `13.0`. Positive/zero digit counts, round-half-away-from-
+  zero, and NULL propagation are unchanged.
+
 ## [0.4.4] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1326,6 +1326,11 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             } else {
                 0
             };
+            // SQLite treats a NEGATIVE digit count as zero — it never rounds to
+            // tens/hundreds. `round(2.567, -1)` is `round(2.567, 0)` = `3.0`, not
+            // `0.0`. Clamp the low end here (leaving large positive counts alone,
+            // where the value is already unchanged within f64 precision).
+            let digits = digits.max(0);
             // Round half away from zero (SQLite semantics), to `digits` decimal places.
             let factor = 10_f64.powi(digits);
             let rounded = (x * factor).round() / factor;
@@ -3980,5 +3985,33 @@ mod tests {
                 call_builtin("SUBSTR", args).unwrap(),
             );
         }
+    }
+
+    #[test]
+    fn builtin_round_clamps_negative_digits_to_zero() {
+        let round = |x: f64, d: Option<i64>| {
+            let mut args = vec![SqlValue::Float(x)];
+            if let Some(d) = d {
+                args.push(SqlValue::Int(d));
+            }
+            call_builtin("ROUND", args).unwrap()
+        };
+        // Positive / zero digit counts are unchanged.
+        assert_eq!(round(2.567, None), SqlValue::Float(3.0));
+        assert_eq!(round(2.567, Some(0)), SqlValue::Float(3.0));
+        assert_eq!(round(2.567, Some(2)), SqlValue::Float(2.57));
+        // Round half away from zero.
+        assert_eq!(round(2.5, None), SqlValue::Float(3.0));
+        assert_eq!(round(-2.5, None), SqlValue::Float(-3.0));
+        // A NEGATIVE digit count behaves as 0 — NOT tens/hundreds rounding.
+        assert_eq!(round(2.567, Some(-1)), SqlValue::Float(3.0));
+        assert_eq!(round(2.567, Some(-5)), SqlValue::Float(3.0));
+        assert_eq!(round(12.5, Some(-1)), SqlValue::Float(13.0));
+        // NULL propagation on either argument.
+        assert_eq!(call_builtin("ROUND", vec![SqlValue::Null]).unwrap(), SqlValue::Null);
+        assert_eq!(
+            call_builtin("ROUND", vec![SqlValue::Float(2.5), SqlValue::Null]).unwrap(),
+            SqlValue::Null
+        );
     }
 }


### PR DESCRIPTION
## Summary

**Stream A** correctness fix. Probing real SQLite surfaced a wrong result:
`ROUND(2.567, -1)` returned `0.0` in mini-sqlite but SQLite gives `3.0`. SQLite
treats a **negative** second argument as zero digits — it never rounds to
tens/hundreds:

```
round(2.567, -1)  ->  3.0    (= round(2.567, 0), NOT 0.0)
round(2.567, -5)  ->  3.0
round(12.5,  -1)  ->  13.0   (round half away from zero, at 0 digits)
```

The fix is a one-line clamp (`digits = digits.max(0)`) before computing the
power-of-ten factor. Positive/zero digit counts, round-half-away-from-zero, and
NULL propagation are unchanged.

## Security

Reviewed before push. The clamp only raises negative values to 0, strictly
narrowing the domain fed to `powi`; no new panic, overflow, NaN/inf, allocation,
or DoS (the pre-existing arity + NULL checks are untouched). **Review passed, no
findings.**

## Verification

- `sql-vm`: **92 lib tests** (new `builtin_round_clamps_negative_digits_to_zero`
  covering negative, zero, positive, round-half-away, and NULL cases).
- **mini-sqlite differential oracle:** new case `round_negative_digits` diffs
  against real bundled SQLite and matches. Full mini-sqlite suite green.

This increment also came out of a broad conformance probe; the findings (which
next-capability lanes are clean vs blocked vs rabbit-holes) are recorded to
project memory to guide future rotations — notably that bundled SQLite's
`float→text` is *approximate* (not correctly-rounded), booleans-as-a-distinct-type
is a cross-cutting refactor, and the bundled build omits math functions.

`sql-vm` 0.4.4 → 0.4.5, `mini-sqlite` 0.5.8 → 0.5.9; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
