### PR TITLE
feat(sir-runtime-oop): Hash to_h (block + no-block) + each_with_index + each_with_object — final backend

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.21] - 2026-07-11
+
+### Added
+
+- **`Hash#to_h`, `Hash#each_with_index`, `Hash#each_with_object`** — the FINAL
+  backend of this cross-backend batch (Python reference #8009, then Go #8015 /
+  Rust #8020 / JS #8024), rounding out Hash's Enumerable iteration surface.
+  - `to_h` **without** a block (`hashMethod` + `HASH_METHODS`) → a shallow copy
+    of the hash (`new Map(recv)`, so mutating it does not alias the receiver).
+  - `to_h { |k, v| [new_k, new_v] }` (`hashBlockMethod` + `HASH_BLOCK_METHODS`)
+    → a NEW hash from the block-returned `[k, v]` pairs; the block is yielded the
+    two args `(k, v)`; a non-pair result (checked `Array.isArray` + length 2) is
+    skipped, and colliding new keys keep the LAST pair (Ruby's rule).
+  - `each_with_index { |(k, v), i| … }` → yields each `[k, v]` pair with its
+    0-based index, returns the receiver.
+  - `each_with_object(memo) { |(k, v), memo| … }` → yields each `[k, v]` pair
+    with the memo, returns the memo; with no memo argument the receiver is
+    returned unchanged.
+  - Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object`
+    pass the element as a single `[k, v]` Array (the second block param is the
+    index/memo), matching Ruby's Enumerable convention.
+
 ## [0.1.20] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -78,7 +78,9 @@ methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
 `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by` and Enumerable
 breadth `group_by`/`partition`/`flat_map`/`collect_concat`/`reduce`/`inject`/`sum`
 (all yielding the `[k, v]` pair; `reduce`/`inject` use Ruby's `(memo, pair)`
-convention)/…); and (item **M1c**) the
+convention), and `to_h` (block + no-block)/`each_with_index`/`each_with_object`
+(the last two yield the `[k, v]` pair as a single argument alongside the
+index/memo)/…); and (item **M1c**) the
 **`String`** catalog (`length`,
 `upcase`/`downcase`/`capitalize`, `reverse`, `strip`/`lstrip`/`rstrip`, `chomp`,
 `chars`/`bytes`, `split`, `include?`/`start_with?`/`end_with?`/`index`, `replace`,

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -602,6 +602,7 @@ const HASH_METHODS = new Set<string>([
   "length",
   "empty?",
   "to_a",
+  "to_h",
   "dig",
   "store",
   "[]=",
@@ -639,6 +640,9 @@ const HASH_BLOCK_METHODS = new Set<string>([
   "reduce",
   "inject",
   "sum",
+  "to_h",
+  "each_with_index",
+  "each_with_object",
 ]);
 
 // Non-block `String` methods (M1c).  A Ruby `String` is a JS `string`, which is
@@ -1210,6 +1214,11 @@ function hashMethod(recv: Map<Val, Val>, name: string, args: Val[]): Val | typeo
       return recv.size === 0;
     case "to_a":
       return [...recv.entries()].map(([k, v]: [Val, Val]) => [k, v]);
+    case "to_h":
+      // `Hash#to_h` with NO block → a shallow copy of the hash (a fresh `Map`,
+      // so mutating it never aliases the receiver).  The block form (which
+      // re-maps each pair to a new `[k, v]`) lives in `hashBlockMethod`.
+      return new Map<Val, Val>(recv);
     case "dig":
       // v0: single-level dig.
       return recv.has(args[0]) ? recv.get(args[0]) : null;
@@ -1408,6 +1417,40 @@ function hashBlockMethod(
         acc = (acc as number) + (apply(block, [k, v]) as number);
       }
       return acc;
+    }
+    case "to_h": {
+      // `Hash#to_h { |k, v| [new_k, new_v] }` — a NEW hash from the `[k, v]`
+      // pairs the block returns.  The block is yielded the two args `(k, v)`
+      // (matching `each`) and must return a two-element `[k, v]` pair; a
+      // non-pair result is skipped (Ruby raises TypeError, deferred to the
+      // typed-error cascade), and a later pair with a duplicate key wins
+      // (Ruby's rule, and how `Map.set` behaves).
+      const out = new Map<Val, Val>();
+      for (const [k, v] of [...recv]) {
+        const pair = apply(block, [k, v]);
+        if (Array.isArray(pair) && pair.length === 2) { out.set(pair[0], pair[1]); }
+      }
+      return out;
+    }
+    case "each_with_index": {
+      // Yields each `[k, v]` pair with its 0-based index and returns the
+      // receiver.  Unlike the two-arg `(k, v)` yield of `each`, the element
+      // arrives as a single `[k, v]` Array (the second block param is the
+      // index), matching Ruby's Enumerable convention.
+      let i = 0;
+      for (const [k, v] of [...recv]) { apply(block, [[k, v], i]); i++; }
+      return recv;
+    }
+    case "each_with_object": {
+      // `each_with_object(memo) { |(k, v), memo| … }` — yields each `[k, v]`
+      // pair with the memo object and returns the (mutated) memo.  Like
+      // `each_with_index`, the element is the single `[k, v]` pair (the second
+      // block param is the memo).  With no memo argument the receiver is
+      // returned unchanged.
+      if (args.length === 0) { return recv; }
+      const memo = args[0];
+      for (const [k, v] of [...recv]) { apply(block, [[k, v], memo]); }
+      return memo;
     }
     default:
       return MISS;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -644,6 +644,51 @@ describe("built-in method catalog: Hash (M1c)", () => {
     ]);
   });
 
+  it("to_h + indexed/object iteration (to_h/each_with_index/each_with_object)", () => {
+    // `to_h` has a no-block (shallow copy) and a block (re-map) form.
+    // `each_with_index`/`each_with_object` yield the [k, v] PAIR as ONE argument
+    // alongside the index/memo (Ruby's Enumerable convention — contrast `each`'s
+    // two-arg (k, v) yield).  Mirrors Python #8009 / Go #8015 / Rust #8020 / JS
+    // #8024.
+    const h = new Map<Val, Val>([["a", 1], ["b", 2], ["c", 3]]);
+    // to_h (no block) → a fresh equal Map that does not alias the receiver.
+    const copy = callMethod(h, "to_h") as Map<Val, Val>;
+    expect(copy).toEqual(new Map<Val, Val>([["a", 1], ["b", 2], ["c", 3]]));
+    copy.set("z", 99);
+    expect(h.has("z")).toBe(false);
+    // to_h with a block re-maps each [k, v] → [new_k, new_v] (upcase key, double
+    // value).
+    expect(
+      callMethod(h, "to_h", new Closure((k: Val, v: Val) => [(k as string).toUpperCase(), (v as number) * 2])),
+    ).toEqual(new Map<Val, Val>([["A", 2], ["B", 4], ["C", 6]]));
+    // to_h block whose new keys collide → the LAST pair wins (Ruby's rule).
+    expect(callMethod(h, "to_h", new Closure((k: Val, v: Val) => ["k", v]))).toEqual(
+      new Map<Val, Val>([["k", 3]]),
+    );
+    // to_h block returning a non-pair is skipped (never-throw floor).
+    expect(callMethod(h, "to_h", new Closure((k: Val, v: Val) => v))).toEqual(new Map<Val, Val>());
+    // each_with_index yields ([k, v], i) and returns the receiver.
+    const seen: Val[] = [];
+    const ewiResult = callMethod(
+      h, "each_with_index", new Closure((pair: Val, i: Val) => { seen.push([pair, i]); return null; }),
+    );
+    expect(seen).toEqual([[["a", 1], 0], [["b", 2], 1], [["c", 3], 2]]);
+    expect(ewiResult).toBe(h);
+    // each_with_object(memo) yields ([k, v], memo) and returns the memo; here we
+    // accumulate the values into a running total wrapped in an array.
+    const total = callMethod(
+      h, "each_with_object", [0], new Closure((pair: Val, memo: Val) => { (memo as Val[])[0] = ((memo as Val[])[0] as number) + ((pair as Val[])[1] as number); return null; }),
+    );
+    expect(total).toEqual([6]);
+    // each_with_object with NO memo argument returns the receiver unchanged.
+    expect(callMethod(h, "each_with_object", new Closure((pair: Val, memo: Val) => null))).toBe(h);
+    // respond_to? advertises the new methods; source hash unchanged throughout.
+    expect(callMethod(h, "respond_to?", "to_h")).toBe(true);
+    expect(callMethod(h, "respond_to?", "each_with_index")).toBe(true);
+    expect(callMethod(h, "respond_to?", "each_with_object")).toBe(true);
+    expect([...h.entries()]).toEqual([["a", 1], ["b", 2], ["c", 3]]);
+  });
+
   it("respond_to? honesty + nil floor", () => {
     const h = new Map<Val, Val>([["a", 1]]);
     expect(callMethod(h, "respond_to?", "keys")).toBe(true);


### PR DESCRIPTION
Mirrors the Python reference ([#8009](https://github.com/adhithyan15/coding-adventures/pull/8009)), Go ([#8015](https://github.com/adhithyan15/coding-adventures/pull/8015)), Rust ([#8020](https://github.com/adhithyan15/coding-adventures/pull/8020)), and JS ([#8024](https://github.com/adhithyan15/coding-adventures/pull/8024)) into the **TS reference library** (`@coding-adventures/sir-runtime-oop`) — **completing the Hash `to_h`/`each_with_index`/`each_with_object` cascade across all five backends**.

## Methods
- `to_h` **without** a block (`hashMethod`) → shallow copy (`new Map(recv)`, no alias).
- `to_h { |k,v| [new_k, new_v] }` (`hashBlockMethod`) → new hash from block-returned `[k, v]` pairs; block yields two args `(k, v)`; non-pair result skipped (checked `Array.isArray` + length 2); last colliding key wins.
- `each_with_index { |(k,v), i| … }` → yields each `[k, v]` pair + 0-based index; returns the receiver.
- `each_with_object(memo) { |(k,v), memo| … }` → yields each `[k, v]` pair + memo; returns the memo; no-memo arg returns the receiver.

Unlike `each`'s two-arg `(k, v)` yield, `each_with_index`/`each_with_object` pass the element as a single `[k, v]` Array (2nd block param is index/memo) — Ruby's Enumerable convention.

## Tests
New vitest `to_h + indexed/object iteration` case asserts to_h copy-not-alias, block re-map, key-collision (last wins), non-pair skip, each_with_index pair+index + return-self, each_with_object accumulate + return-memo + no-memo passthrough, `respond_to?`. Full suite green (**117 tests**). Version 0.1.20 → 0.1.21; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)