### PR TITLE
feat(cobol): GO TO — unconditional transfer + program-counter execution (PL08 v0.8)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.8.0 — GO TO (unconditional transfer) + program-counter execution
+
+- **`GO TO para`** transfers control unconditionally to a paragraph. The
+  procedure division now runs as a **program counter** over paragraphs: after a
+  paragraph, control falls through to the next unless a `GO TO` jumped the counter
+  or `STOP RUN` ended the program.
+- The statement control signal changed from a stop-`bool` to a `Flow`
+  (`Normal` / `Stop` / `GoTo(idx)`) that unwinds out of enclosing
+  `IF`/`PERFORM`/`ON SIZE ERROR` up to the top-level loop.
+- **`GO TO` back-edges form loops** (`IF … GO TO LOOP`) — driven iteratively by
+  the program counter, so a loop never grows the native stack.
+- A `GO TO` inside a performed paragraph transfers control at the top level
+  (abandoning the `PERFORM`'s return) — the honest reading of "GO TO out of a
+  range". `GO TO … DEPENDING ON`, `ALTER`, and range-return niceties are deferred.
+
 ## 0.7.0 — PERFORM (out-of-line paragraph invocation)
 
 - **`PERFORM para [n TIMES]`** runs a named paragraph out of line and returns to

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -27,9 +27,11 @@ decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
 toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
 parentheses), `ROUNDED`, and `ON SIZE ERROR`; `IF … ELSE` with numeric and
-alphanumeric comparison; and `PERFORM para [n TIMES]` (out-of-line paragraph
-invocation, with a recursion guard). Anything not yet modelled (the explicit
-`SIGN` clause with `SEPARATE`/`LEADING`, editing pictures, `COMP`,
-`PERFORM … THRU`/`UNTIL`/`VARYING`, `GO TO`, `EVALUATE`, tables, files, and every
-other verb) returns a descriptive `RuntimeError` — never wrong output. See PL08 for the
+alphanumeric comparison; `PERFORM para [n TIMES]` (out-of-line paragraph
+invocation, with a recursion guard); and `GO TO para` (unconditional transfer,
+run as a program counter over paragraphs, so back-edge loops work). Anything not
+yet modelled (the explicit `SIGN` clause with `SEPARATE`/`LEADING`, editing
+pictures, `COMP`, `PERFORM … THRU`/`UNTIL`/`VARYING`, `GO TO … DEPENDING`,
+`EVALUATE`, tables, files, and every other verb) returns a descriptive
+`RuntimeError` — never wrong output. See PL08 for the
 roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -44,6 +44,25 @@ enum Src {
     Fig(Fig),
 }
 
+/// The control-flow signal an executed statement (or block of statements)
+/// produces. Most statements are [`Flow::Normal`]; the two transfers unwind out
+/// of any enclosing `IF`/`PERFORM`/handler up to the top-level program-counter
+/// loop in [`Machine::run`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Flow {
+    /// Continue with the next statement (and, at a paragraph's end, fall through
+    /// to the following paragraph).
+    Normal,
+    /// `STOP RUN` — end the whole program.
+    Stop,
+    /// `GO TO` — transfer control to the paragraph at this index. Because it
+    /// unwinds to the top-level loop, a `GO TO` inside a performed paragraph
+    /// transfers control there (abandoning the `PERFORM`'s return) — the honest
+    /// reading of "GO TO out of a range", and enough for structured top-level
+    /// flow. (`GO TO … DEPENDING`/`ALTER` and range-return niceties are later.)
+    GoTo(usize),
+}
+
 /// Turn an arithmetic result into a `Result`, reporting `i128` overflow (a value
 /// beyond ~38 digits — larger than any real COBOL numeric field) as an error
 /// rather than panicking or wrapping.
@@ -205,26 +224,32 @@ impl Machine {
     // ----------------------------------------------------------------------
 
     /// Run the procedure division and return the captured console output.
+    ///
+    /// Execution is a **program counter** over paragraphs: after a paragraph's
+    /// statements run, control falls through to the next paragraph, unless a
+    /// `GO TO` jumped the counter or a `STOP RUN` ended the program. The loop is
+    /// iterative, so a `GO TO` back-edge (a COBOL loop) never grows the stack.
+    /// Each paragraph's statements are cloned to run them, since executing
+    /// borrows `self` mutably while the paragraphs live in `self`.
     pub fn run(mut self, _program: &Program) -> Result<String, RuntimeError> {
-        // Execute paragraphs top to bottom (COBOL falls through paragraph
-        // boundaries). We clone each paragraph's statements to run them, since
-        // executing borrows `self` mutably while the paragraphs live in `self`.
         let count = self.paragraphs.len();
-        for i in 0..count {
-            let stmts = self.paragraphs[i].stmts.clone();
-            if self.run_stmts(&stmts)? {
-                break; // STOP RUN
+        let mut pc = 0;
+        while pc < count {
+            let stmts = self.paragraphs[pc].stmts.clone();
+            match self.run_stmts(&stmts)? {
+                Flow::Normal => pc += 1,        // fall through
+                Flow::Stop => break,            // STOP RUN
+                Flow::GoTo(target) => pc = target, // jump
             }
         }
         // Falling off the end of the procedure division ends the run too.
         Ok(self.output)
     }
 
-    /// Execute one statement. Returns `true` if it requested `STOP RUN` (which
-    /// unwinds nested `IF` branches and ends the program).
-    fn exec_stmt(&mut self, stmt: &Stmt) -> Result<bool, RuntimeError> {
+    /// Execute one statement, returning its control-flow [`Flow`] signal.
+    fn exec_stmt(&mut self, stmt: &Stmt) -> Result<Flow, RuntimeError> {
         match stmt {
-            Stmt::StopRun => return Ok(true),
+            Stmt::StopRun => return Ok(Flow::Stop),
             Stmt::Display(ops) => self.exec_display(ops)?,
             Stmt::Move { src, dsts } => self.exec_move(src, dsts)?,
             Stmt::Add { operands, to, giving } => self.exec_add(operands, to, giving)?,
@@ -237,33 +262,42 @@ impl Machine {
                 return self.exec_compute(target, *rounded, expr, on_size_error);
             }
             Stmt::Perform { target, times } => return self.exec_perform(target, times),
+            Stmt::GoTo { target } => {
+                let idx = *self
+                    .para_index
+                    .get(target)
+                    .ok_or_else(|| RuntimeError::UndefinedName(target.clone()))?;
+                return Ok(Flow::GoTo(idx));
+            }
             Stmt::If { cond, then_branch, else_branch } => {
                 let branch = if self.eval_cond(cond)? { then_branch } else { else_branch };
                 return self.run_stmts(branch);
             }
         }
-        Ok(false)
+        Ok(Flow::Normal)
     }
 
-    /// Execute a sequence of statements, short-circuiting on `STOP RUN` (the
-    /// returned `true` propagates up to unwind any enclosing branches). Shared by
-    /// `IF` branches and `COMPUTE … ON SIZE ERROR` handlers.
-    fn run_stmts(&mut self, stmts: &[Stmt]) -> Result<bool, RuntimeError> {
+    /// Execute a sequence of statements, short-circuiting on the first non-normal
+    /// [`Flow`] (a `STOP RUN` or `GO TO`), which propagates up to unwind any
+    /// enclosing `IF`/`PERFORM`/handler. Shared by `IF` branches,
+    /// `COMPUTE … ON SIZE ERROR` handlers, and performed paragraphs.
+    fn run_stmts(&mut self, stmts: &[Stmt]) -> Result<Flow, RuntimeError> {
         for s in stmts {
-            if self.exec_stmt(s)? {
-                return Ok(true);
+            match self.exec_stmt(s)? {
+                Flow::Normal => {}
+                other => return Ok(other),
             }
         }
-        Ok(false)
+        Ok(Flow::Normal)
     }
 
     /// `PERFORM target [n TIMES]` — run one paragraph out of line, `n` times
     /// (default 1), then return. A `TIMES` count that is zero or negative runs
     /// the paragraph zero times (COBOL's rule); a fractional count truncates.
     /// Nesting is bounded by [`MAX_PERFORM_DEPTH`] so a self-performing paragraph
-    /// fails with a clean error instead of overflowing the stack. Returns `true`
-    /// if a `STOP RUN` fired inside.
-    fn exec_perform(&mut self, target: &str, times: &Option<Operand>) -> Result<bool, RuntimeError> {
+    /// fails with a clean error instead of overflowing the stack. A `STOP RUN`
+    /// or `GO TO` inside stops the repetition and propagates as its [`Flow`].
+    fn exec_perform(&mut self, target: &str, times: &Option<Operand>) -> Result<Flow, RuntimeError> {
         let idx = *self
             .para_index
             .get(target)
@@ -299,14 +333,15 @@ impl Machine {
         let stmts = self.paragraphs[idx].stmts.clone();
         // Capture the outcome rather than `?`-ing out of the loop, so the depth
         // counter is restored on every path (including an error).
-        let mut outcome = Ok(false);
+        let mut outcome = Ok(Flow::Normal);
         for _ in 0..n {
             match self.run_stmts(&stmts) {
-                Ok(true) => {
-                    outcome = Ok(true); // STOP RUN — stop repeating
+                Ok(Flow::Normal) => {}
+                // STOP RUN or GO TO — stop repeating and propagate it upward.
+                Ok(other) => {
+                    outcome = Ok(other);
                     break;
                 }
-                Ok(false) => {}
                 Err(e) => {
                     outcome = Err(e);
                     break;
@@ -489,7 +524,7 @@ impl Machine {
         rounded: bool,
         expr: &Expr,
         on_size_error: &[Stmt],
-    ) -> Result<bool, RuntimeError> {
+    ) -> Result<Flow, RuntimeError> {
         let (int_digits, dec_digits) = self.numeric_dims(target)?;
 
         let value = match self.eval_expr(expr) {
@@ -517,13 +552,13 @@ impl Machine {
                 // No handler: COBOL truncates the high-order digits silently,
                 // exactly as move_into_numeric already does.
                 self.store_number(target, final_value)?;
-                return Ok(false);
+                return Ok(Flow::Normal);
             }
             return self.run_stmts(on_size_error);
         }
 
         self.store_number(target, final_value)?;
-        Ok(false)
+        Ok(Flow::Normal)
     }
 
     /// Evaluate an arithmetic expression to an exact [`Decimal`]. Division is

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -9,13 +9,14 @@
 //! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
 //! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), `IF … ELSE`
-//! (numeric and alphanumeric comparison), and `PERFORM para [n TIMES]`
-//! (out-of-line paragraph invocation) over numeric-display (`9`/`V`, and
+//! (numeric and alphanumeric comparison), `PERFORM para [n TIMES]`
+//! (out-of-line paragraph invocation), and `GO TO para` (unconditional transfer,
+//! including back-edge loops) over numeric-display (`9`/`V`, and
 //! signed `S` with trailing-overpunch display) and character pictures — and
 //! returns a descriptive error for anything not yet modelled, rather than
 //! producing wrong output. The roadmap toward full COBOL (the `SIGN` clause and
 //! `SEPARATE`/`LEADING` variants, editing pictures, `PERFORM … THRU`/`UNTIL`/
-//! `VARYING`, `GO TO`, tables, files, later standards) is in PL08.
+//! `VARYING`, `GO TO … DEPENDING`, tables, files, later standards) is in PL08.
 //!
 //! ```
 //! use coding_adventures_cobol_runtime::run_cobol;
@@ -582,19 +583,103 @@ mod tests {
 
     #[test]
     fn unsupported_verb_is_a_clear_error() {
-        // GO TO is not yet executed (it is a later control-flow PR).
+        // ACCEPT is parsed but not yet executed (console input is a later PR).
+        let err = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  N  PIC 9(3).",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    ACCEPT N.",
+            "    STOP RUN.",
+        ]))
+        .unwrap_err();
+        assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
+        assert!(err.to_string().contains("ACCEPT"), "message should name the verb: {err}");
+    }
+
+    // ----------------------------------------------------------------------
+    // GO TO — unconditional paragraph transfer, and GO TO loops
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn go_to_transfers_control_and_skips_fallthrough() {
+        // GO TO SKIP jumps past MIDDLE; "MIDDLE" is never displayed.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    DISPLAY \"START\".",
+            "    GO TO SKIP.",
+            "MIDDLE.",
+            "    DISPLAY \"MIDDLE\".",
+            "SKIP.",
+            "    DISPLAY \"END\".",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "START\nEND\n");
+    }
+
+    #[test]
+    fn go_to_forms_a_loop_that_terminates() {
+        // A back-edge GO TO drives a counting loop (iterative — no stack growth).
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    MOVE 0 TO I.",
+            "LOOP.",
+            "    ADD 1 TO I.",
+            "    DISPLAY I.",
+            "    IF I LESS 3 GO TO LOOP.",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "1\n2\n3\n");
+    }
+
+    #[test]
+    fn go_to_out_of_a_performed_paragraph_transfers_at_top_level() {
+        // A GO TO inside a performed paragraph transfers control at the top
+        // level, abandoning the PERFORM's return: MAIN's DISPLAY after the
+        // PERFORM never runs.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM SUB.",
+            "    DISPLAY \"AFTER MAIN\".",
+            "    STOP RUN.",
+            "SUB.",
+            "    GO TO ELSEWHERE.",
+            "ELSEWHERE.",
+            "    DISPLAY \"ELSEWHERE\".",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "ELSEWHERE\n");
+    }
+
+    #[test]
+    fn go_to_unknown_paragraph_is_an_error() {
         let err = run_cobol(&program(&[
             "IDENTIFICATION DIVISION.",
             "PROGRAM-ID. P.",
             "PROCEDURE DIVISION.",
             "MAIN.",
-            "    GO TO SUB.",
-            "SUB.",
-            "    STOP RUN.",
+            "    GO TO NOWHERE.",
         ]))
         .unwrap_err();
-        assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
-        assert!(err.to_string().contains("GO"), "message should name the verb: {err}");
+        assert!(matches!(err, RuntimeError::UndefinedName(_)), "got {err:?}");
     }
 
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -81,6 +81,8 @@ pub enum Stmt {
     /// `PERFORM para [n TIMES]` — run a paragraph out of line, optionally a
     /// fixed number of times, then return to the statement after the PERFORM.
     Perform { target: String, times: Option<Operand> },
+    /// `GO TO para` — transfer control unconditionally to a paragraph (no return).
+    GoTo { target: String },
     /// `IF cond then… [ELSE else…]`.
     If { cond: Cond, then_branch: Vec<Stmt>, else_branch: Vec<Stmt> },
     StopRun,
@@ -415,6 +417,12 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 None => None,
             };
             Ok(Stmt::Perform { target, times })
+        }
+        "goto_stmt" => {
+            // GO [TO] target. The DEPENDING ON form is not in the grammar yet.
+            let target = first_token(verb, "NAME")
+                .ok_or_else(|| RuntimeError::Unsupported("GO TO without a target paragraph".into()))?;
+            Ok(Stmt::GoTo { target })
         }
         "if_stmt" => {
             // Children in order: IF, condition, then-statements…, [ELSE,

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -138,13 +138,17 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
    sign through `MOVE`/arithmetic/`COMPUTE`; `DISPLAY` renders it as the default
    trailing "zoned" overpunch on the units digit (`−123` → `12L`). The explicit
    `SIGN` clause and its `SEPARATE`/`LEADING` variants are deferred.
-7. **v0.7 — `PERFORM para [n TIMES]`** (this PR): out-of-line paragraph
+7. **v0.7 — `PERFORM para [n TIMES]`** (merged): out-of-line paragraph
    invocation with return, an integer repeat count (`≤ 0` runs zero times), and a
-   recursion-depth guard against a self-performing paragraph. `PERFORM … THRU`,
-   `… UNTIL`, `… VARYING`, and the inline form are deferred.
-8. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
-9. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
-   `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
+   recursion-depth guard against a self-performing paragraph.
+8. **v0.8 — `GO TO para`** (this PR): unconditional transfer, with the procedure
+   division executed as a **program counter** over paragraphs (so back-edge
+   `GO TO` loops run iteratively, no stack growth). A `GO TO` out of a performed
+   paragraph transfers at the top level. `GO TO … DEPENDING ON` and `ALTER` are
+   deferred.
+9. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+10. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
+    `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
 8. **Conditions** — level-88 condition-names.
 9. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.
 8. **File I/O** — `SELECT`/`FD`, sequential then indexed/relative, `OPEN`/`READ`/


### PR DESCRIPTION
## Summary

Adds `GO TO para` and converts the procedure division to a **program-counter**
execution model. This is the second half of paragraph-level control flow (after
`PERFORM`) and — crucially — makes `GO TO`-driven **loops** work.

### What it does (cobol-runtime 0.8.0)
- **`program.rs`**: `Stmt::GoTo { target }` + `goto_stmt` reader (`GO [TO] NAME`).
- **`interp.rs`**: the statement control signal changes from a stop-`bool` to a
  `Flow` enum — `Normal` / `Stop` / `GoTo(idx)` — threaded through
  `exec_stmt`/`run_stmts`/`exec_perform`/`exec_compute`. `Machine::run` is now a
  program counter over paragraphs: fall through on `Normal`, end on `Stop`, jump
  on `GoTo`.
- **Loops work**: a back-edge `GO TO` (`IF I LESS 3 GO TO LOOP`) is driven
  iteratively by the program counter, so it never grows the native stack.
- A `GO TO` inside a performed paragraph transfers control at the top level
  (abandoning the `PERFORM`'s return) — the honest reading of "GO TO out of a
  range".

### Deferred
`GO TO … DEPENDING ON` and `ALTER`.

## Tests
74 runtime tests + doctest (transfer + skip-fallthrough, a terminating counting
loop, GO-TO-out-of-PERFORM, unknown target → error). Warning-free. Security
review PASSED — verified the loop is iterative (no stack growth), `perform_depth`
stays correct across the `GoTo` unwind, jump indices are always in bounds, and no
`Flow` signal is swallowed. README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)