### PR TITLE
feat(sql-vm): UNHEX — decode hex digit pairs into a blob

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.10 — UNHEX (decode hex to blob)
+
+Grows the SQL scalar surface (sql-vm 0.4.6): `UNHEX(x)` / `UNHEX(x, ignore)`
+decodes hexadecimal digit pairs into a blob — the inverse of `HEX`. Odd length
+or non-hex characters → NULL; the optional ignore-set is honoured only at byte
+boundaries (`unhex('41.42','.')` → `x'4142'`, `unhex('4-1-4-2','-')` → NULL).
+Two new differential-oracle cases (`unhex`, `unhex_ignore_set`) diff against real
+bundled SQLite.
+
+Note: adding UNHEX surfaced a separate, pre-existing divergence — `HEX(NULL)`
+returns NULL here but real SQLite returns an empty string. That is left for its
+own fix; the UNHEX oracle cases compare blobs directly to avoid it.
+
 ## 0.5.9 — Fix ROUND with a negative digit count
 
 Stream A correctness fix (sql-vm 0.4.5): `ROUND(x, n)` with a negative `n` now

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.9"
+version = "0.5.10"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -595,6 +595,27 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT ROUND(x, -1) AS a, ROUND(x, -5) AS b, ROUND(x, 1) AS c FROM t ORDER BY id",
     },
+    // UNHEX decodes hex digit pairs into a blob (inverse of HEX). Even-length hex
+    // → blob; odd length or a non-hex char → NULL. Compared as blobs directly
+    // (wrapping in HEX would trip a separate, pre-existing HEX(NULL) divergence).
+    Case {
+        id: "unhex",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1, '414243'), (2, 'abc'), (3, 'DEADbeef')",
+        ],
+        query: "SELECT UNHEX(s) AS r FROM t ORDER BY id",
+    },
+    // The 2-argument form ignores a set of characters, but only at byte
+    // boundaries: '41.42' with '.' → x'4142', '4-1-4-2' with '-' → NULL.
+    Case {
+        id: "unhex_ignore_set",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT, ig TEXT)",
+            "INSERT INTO t VALUES (1, '41.42', '.'), (2, '4-1-4-2', '-')",
+        ],
+        query: "SELECT UNHEX(s, ig) AS r FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.6] - Unreleased
+
+### Added
+
+- **`UNHEX(x)` / `UNHEX(x, ignore)`** — the inverse of `HEX`: decode a string of
+  hexadecimal digit pairs into a blob (case-insensitive). `unhex('414243')` →
+  `x'414243'`, `unhex('')` → empty blob; an odd number of digits or a non-hex
+  character yields NULL. The optional second argument is a set of ignorable
+  characters, which SQLite permits only at a byte boundary — never splitting a
+  pair: `unhex('41.42', '.')` → `x'4142'` but `unhex('4-1-4-2', '-')` → NULL.
+  Integer/boolean arguments coerce to their decimal text; NULL in either argument
+  → NULL. Output is bounded by the input length (no unbounded allocation), and
+  arity is checked before indexing.
+
 ## [0.4.5] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1046,6 +1046,7 @@ fn pop(stack: &mut Vec<SqlValue>) -> Result<SqlValue, VmError> {
 /// | SUBSTR   | 2–3  | 1-indexed substring extraction (alias: SUBSTRING)     |
 /// | CONCAT   | ≥1   | Concatenate all arguments (NULL → empty string)       |
 /// | CONCAT_WS| ≥2   | Join value arguments with a separator (NULLs skipped) |
+/// | UNHEX    | 1–2  | Decode hex digit pairs into a blob (inverse of HEX)   |
 /// | REPLACE  |  3   | Replace all occurrences of a pattern with another str |
 /// | ABS      |  1   | Absolute value (Integer or Float)                     |
 /// | COALESCE | ≥1   | Return the first non-NULL argument                    |
@@ -1433,6 +1434,70 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
                 out.push_str(&format!("{byte:02X}"));
             }
             Ok(SqlValue::Text(out))
+        }
+
+        "UNHEX" => {
+            // UNHEX(x) / UNHEX(x, ignore): the inverse of HEX — decode a string of
+            // hexadecimal digit pairs into a blob. Case-insensitive.
+            //
+            //   unhex('414243')  -> x'414243'  ("ABC")
+            //   unhex('')        -> x''          (empty blob)
+            //   unhex('abc')     -> NULL         (odd number of digits)
+            //   unhex('4g')      -> NULL         (non-hex character)
+            //   unhex(12)        -> x'12'        (integer coerces to its digits)
+            //
+            // The optional second argument is a *set of ignorable characters*.
+            // An ignorable character may appear only at a byte boundary — never
+            // splitting a hex pair — matching SQLite exactly:
+            //
+            //   unhex('41.42', '.')   -> x'4142'   ('.' sits between pairs)
+            //   unhex('4-1-4-2', '-') -> NULL      ('-' splits the pair '4'…'1')
+            //
+            // NULL in either argument yields NULL. Integer/boolean `x` coerces to
+            // its decimal text (via `trim_coerce`); Float/Blob are declined, as
+            // with HEX/QUOTE.
+            if args.is_empty() || args.len() > 2 {
+                return Err(VmError::TypeMismatch(format!("UNHEX expects 1 or 2 args, got {}", args.len())));
+            }
+            let x = match trim_coerce("UNHEX", &args[0])? {
+                None => return Ok(SqlValue::Null),
+                Some(s) => s,
+            };
+            let ignore: std::collections::HashSet<char> = if args.len() == 2 {
+                match trim_coerce("UNHEX", &args[1])? {
+                    None => return Ok(SqlValue::Null),
+                    Some(s) => s.chars().collect(),
+                }
+            } else {
+                std::collections::HashSet::new()
+            };
+            // Output is at most half the input length — bounded by the argument,
+            // so no unbounded allocation.
+            let mut out: Vec<u8> = Vec::with_capacity(x.len() / 2);
+            let mut high: Option<u8> = None;
+            for c in x.chars() {
+                if let Some(v) = c.to_digit(16) {
+                    match high {
+                        None => high = Some(v as u8),
+                        Some(h) => {
+                            out.push(h * 16 + v as u8);
+                            high = None;
+                        }
+                    }
+                } else if ignore.contains(&c) {
+                    // Only allowed at a byte boundary, never mid-pair.
+                    if high.is_some() {
+                        return Ok(SqlValue::Null);
+                    }
+                } else {
+                    // Any other character invalidates the whole string.
+                    return Ok(SqlValue::Null);
+                }
+            }
+            if high.is_some() {
+                return Ok(SqlValue::Null); // a trailing, unpaired hex digit
+            }
+            Ok(SqlValue::Blob(out))
         }
 
         "SIGN" => {
@@ -3985,6 +4050,47 @@ mod tests {
                 call_builtin("SUBSTR", args).unwrap(),
             );
         }
+    }
+
+    #[test]
+    fn builtin_unhex_decodes_hex_pairs() {
+        let u1 = |s: &str| call_builtin("UNHEX", vec![SqlValue::Text(s.into())]).unwrap();
+        // Even-length hex → blob; case-insensitive.
+        assert_eq!(u1("414243"), SqlValue::Blob(vec![0x41, 0x42, 0x43]));
+        assert_eq!(u1("abcdef"), SqlValue::Blob(vec![0xab, 0xcd, 0xef]));
+        assert_eq!(u1("ABCDEF"), SqlValue::Blob(vec![0xab, 0xcd, 0xef]));
+        assert_eq!(u1(""), SqlValue::Blob(vec![])); // empty → empty blob
+        // Odd length or a non-hex character → NULL.
+        assert_eq!(u1("abc"), SqlValue::Null);
+        assert_eq!(u1("4g"), SqlValue::Null);
+        assert_eq!(u1("41 42"), SqlValue::Null);
+        // NULL propagates; an integer coerces to its decimal digits.
+        assert_eq!(call_builtin("UNHEX", vec![SqlValue::Null]).unwrap(), SqlValue::Null);
+        assert_eq!(
+            call_builtin("UNHEX", vec![SqlValue::Int(12)]).unwrap(),
+            SqlValue::Blob(vec![0x12])
+        );
+        // Result is a blob.
+        assert!(matches!(u1("41"), SqlValue::Blob(_)));
+    }
+
+    #[test]
+    fn builtin_unhex_ignore_set_only_at_byte_boundaries() {
+        let u2 = |s: &str, ig: &str| {
+            call_builtin("UNHEX", vec![SqlValue::Text(s.into()), SqlValue::Text(ig.into())]).unwrap()
+        };
+        // An ignorable char between pairs is fine.
+        assert_eq!(u2("41.42", "."), SqlValue::Blob(vec![0x41, 0x42]));
+        assert_eq!(u2("41", "x"), SqlValue::Blob(vec![0x41])); // ignore char absent
+        // An ignorable char that splits a pair invalidates the string.
+        assert_eq!(u2("4-1-4-2", "-"), SqlValue::Null);
+        // A NULL ignore set yields NULL.
+        assert_eq!(
+            call_builtin("UNHEX", vec![SqlValue::Text("41".into()), SqlValue::Null]).unwrap(),
+            SqlValue::Null
+        );
+        // Zero args is an arity error, not a panic.
+        assert!(call_builtin("UNHEX", vec![]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Stream B** — grows the mini-sqlite SQL scalar surface. `UNHEX(x)` and
`UNHEX(x, ignore)` decode a string of hex digit pairs into a blob — the inverse
of `HEX`. Probed real bundled SQLite for the exact semantics:

```
unhex('414243')      -> x'414243'   ("ABC")
unhex('')            -> x''         (empty blob)
unhex('abc')         -> NULL        (odd number of digits)
unhex('4g')          -> NULL        (non-hex character)
unhex(12)            -> x'12'       (integer coerces to its digits)
unhex('41.42','.')   -> x'4142'     (ignore char at a byte boundary)
unhex('4-1-4-2','-') -> NULL        (ignore char SPLITS a pair)
```

The one subtlety is the 2-argument ignore set: SQLite permits an ignorable
character only at a **byte boundary**, never mid-pair. A single unified loop
(1-arg = empty ignore set) reproduces every probed case. Integer/boolean `x`
coerces to decimal text; NULL in either argument → NULL; Float/Blob declined
(HEX/QUOTE convention). No grammar/planner/codegen work.

## Security

Reviewed before push. Arity is checked (`is_empty() || len() > 2`) **before** any
indexing (the panic-before-arity class from the earlier `TRIM()` bug is avoided);
output is bounded by the input length (no unbounded allocation); the nibble
combine `h*16+v` cannot overflow `u8` (max 255); char-based iteration is
UTF-8-safe. **Review passed, no findings.**

## A latent bug, kept separate

Adding UNHEX surfaced a pre-existing divergence: **`HEX(NULL)` returns NULL here
but real SQLite returns an empty string `''`.** That's left for its own fix (to
avoid scope creep); the UNHEX oracle cases compare blobs **directly** (not
`HEX(UNHEX(...))`) so they don't trip it.

## Verification

- `sql-vm`: **94 lib tests** (two new: decode / odd / non-hex→NULL / integer
  coercion, the ignore-set byte-boundary rule, NULL, and zero-arg arity).
- **mini-sqlite differential oracle:** two new cases (`unhex`, `unhex_ignore_set`)
  diff against real bundled SQLite and match. Full mini-sqlite suite green.

`sql-vm` 0.4.5 → 0.4.6, `mini-sqlite` 0.5.9 → 0.5.10; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
