### PR TITLE
feat(sir-runtime-oop): Array each_slice / each_cons / chunk_while — Python reference

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.22] - 2026-07-11
+
+### Added
+
+- **`Array#each_slice`, `Array#each_cons`, `Array#chunk_while`** — the
+  consecutive-grouping family.  Reference implementation for the next
+  cross-backend cascade (Go/Rust/JS/TS mirrors to follow).
+  - `each_slice(n)` (`_array_method` + `_ARRAY_METHODS`) → consecutive
+    sub-arrays of at most `n` elements, the last possibly shorter
+    (`[1,2,3,4,5].each_slice(2)` → `[[1,2],[3,4],[5]]`).
+  - `each_cons(n)` (non-block) → every consecutive `n`-element sliding window
+    (`[1,2,3,4].each_cons(2)` → `[[1,2],[2,3],[3,4]]`); a window larger than the
+    array yields `[]`.
+  - Both treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; the never-raise
+    floor yields empty instead).
+  - `chunk_while { |prev, cur| pred }` (`_array_block_method` +
+    `_ARRAY_BLOCK_METHODS`) → runs of consecutive elements; the block is called
+    on each ADJACENT pair, a truthy result extends the current run and a falsy
+    one starts a new run (`[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` →
+    `[[1,2],[4,5],[7]]`).  Empty → `[]`; single element → `[[x]]`.
+
+
+
 ## [0.1.21] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -65,14 +65,14 @@ The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
-`take`/`drop`/`values_at`, `rotate`/`zip` — and the
+`take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`, plus the **Kernel
 flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 (item **M6**); and (item **M1b**)
 **block-taking `Array`/`Enumerable`** methods `each`, `each_with_index`,
 `map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`, `find`/`detect`,
-`flat_map`, `any?`/`all?`/`none?` — a trailing `Closure` block is applied via
+`flat_map`, `any?`/`all?`/`none?`, `chunk_while` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
 (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/`to_h`/`each_with_index`/`each_with_object`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/`group_by`/`partition`/`flat_map`/`reduce`/`sum`/…);

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.21"
+version = "0.1.22"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -576,6 +576,8 @@ _ARRAY_METHODS = frozenset(
         "values_at",
         "rotate",
         "zip",
+        "each_slice",
+        "each_cons",
     }
 )
 
@@ -609,6 +611,7 @@ _ARRAY_BLOCK_METHODS = frozenset(
         "drop_while",
         "count",
         "each_with_object",
+        "chunk_while",
     }
 )
 
@@ -1046,6 +1049,24 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
                 row.append(o[i] if i < len(o) else None)
             zipped.append(row)
         return zipped
+    if name == "each_slice":
+        # ``each_slice(n)`` — split into consecutive sub-arrays of at most ``n``
+        # elements (the last slice may be shorter).  ``[1,2,3,4,5].each_slice(2)``
+        # → ``[[1,2],[3,4],[5]]``.  Ruby raises ``ArgumentError`` for ``n <= 0``;
+        # the never-raise floor yields ``[]`` (no valid slice size) instead.
+        n = args[0] if args and isinstance(args[0], int) else 0
+        if n <= 0:
+            return []
+        return [recv[i : i + n] for i in range(0, len(recv), n)]
+    if name == "each_cons":
+        # ``each_cons(n)`` — every consecutive ``n``-element window (sliding by
+        # one).  ``[1,2,3,4].each_cons(2)`` → ``[[1,2],[2,3],[3,4]]``.  A window
+        # size larger than the array (or ``n <= 0``) yields ``[]``; Ruby raises
+        # for ``n <= 0`` but the never-raise floor returns empty.
+        n = args[0] if args and isinstance(args[0], int) else 0
+        if n <= 0:
+            return []
+        return [recv[i : i + n] for i in range(0, len(recv) - n + 1)]
     return _MISS
 
 
@@ -1153,6 +1174,21 @@ def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Clos
         for item in recv:
             apply(block, [item, memo])
         return memo
+    if name == "chunk_while":
+        # ``chunk_while { |prev, cur| pred }`` — split into runs of consecutive
+        # elements: the block is called on each ADJACENT pair; while it is truthy
+        # the run continues, and a falsy result starts a new run.
+        # ``[1,2,4,5,7].chunk_while { |a,b| b - a == 1 }`` → ``[[1,2],[4,5],[7]]``.
+        # An empty array yields ``[]``; a single element yields ``[[x]]``.
+        if not recv:
+            return []
+        chunks: list[Val] = [[recv[0]]]
+        for prev, cur in zip(recv, recv[1:], strict=False):
+            if truthy(apply(block, [prev, cur])):
+                chunks[-1].append(cur)
+            else:
+                chunks.append([cur])
+        return chunks
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -244,6 +244,37 @@ def test_array_zip_pads_and_truncates_to_receiver_length() -> None:
     assert oop.call_method([1, 2], "zip") == [[1], [2]]
 
 
+def test_array_each_slice_each_cons_chunk_while() -> None:
+    # `each_slice(n)` splits into consecutive <=n-size chunks (last may be short).
+    assert oop.call_method([1, 2, 3, 4, 5], "each_slice", 2) == [[1, 2], [3, 4], [5]]
+    assert oop.call_method([1, 2, 3, 4], "each_slice", 2) == [[1, 2], [3, 4]]
+    assert oop.call_method([1, 2, 3], "each_slice", 5) == [[1, 2, 3]]
+    assert oop.call_method([], "each_slice", 2) == []
+    # n <= 0 → [] (Ruby raises ArgumentError; never-raise floor yields empty).
+    assert oop.call_method([1, 2], "each_slice", 0) == []
+    # `each_cons(n)` yields every consecutive n-element sliding window.
+    assert oop.call_method([1, 2, 3, 4], "each_cons", 2) == [[1, 2], [2, 3], [3, 4]]
+    assert oop.call_method([1, 2, 3], "each_cons", 3) == [[1, 2, 3]]
+    # window larger than the array (or n <= 0) → [].
+    assert oop.call_method([1, 2], "each_cons", 3) == []
+    assert oop.call_method([1, 2], "each_cons", 0) == []
+    # `chunk_while { |a, b| pred }` splits into runs while the adjacent-pair
+    # predicate holds; a falsy result starts a new run.
+    assert oop.call_method(
+        [1, 2, 4, 5, 7], "chunk_while", Closure(lambda a, b: b - a == 1)
+    ) == [[1, 2], [4, 5], [7]]
+    # all-truthy → one run; all-falsy → singletons.
+    assert oop.call_method([1, 2, 3], "chunk_while", Closure(lambda a, b: True)) == [[1, 2, 3]]
+    assert oop.call_method([1, 2, 3], "chunk_while", Closure(lambda a, b: False)) == [[1], [2], [3]]
+    # empty → []; single element → [[x]].
+    assert oop.call_method([], "chunk_while", Closure(lambda a, b: True)) == []
+    assert oop.call_method([9], "chunk_while", Closure(lambda a, b: True)) == [[9]]
+    # respond_to? advertises the new methods.
+    assert oop.call_method([1], "respond_to?", "each_slice") is True
+    assert oop.call_method([1], "respond_to?", "each_cons") is True
+    assert oop.call_method([1], "respond_to?", "chunk_while") is True
+
+
 def test_array_mutating_push_pop_shift_unshift() -> None:
     a = [1, 2]
     assert oop.call_method(a, "push", 3) == [1, 2, 3]
@@ -319,8 +350,8 @@ def test_respond_to_reports_catalog_membership() -> None:
     assert oop.call_method([1], "respond_to?", "nil?") is True
     assert oop.call_method([1], "respond_to?", "is_a?") is True
     assert oop.call_method([1], "respond_to?", "map") is True  # block method (M1b)
-    # An out-of-catalog method:
-    assert oop.call_method([1], "respond_to?", "each_slice") is False
+    # An out-of-catalog method (`chunk` is the non-`_while` variant, uncatalogued):
+    assert oop.call_method([1], "respond_to?", "chunk") is False
 
 
 def test_known_block_method_without_block_still_returns_nil() -> None:


### PR DESCRIPTION
The Array **consecutive-grouping family**. **Python reference** for the next cross-backend cascade (Go → Rust → JS → TS mirrors to follow).

## Methods
- `each_slice(n)` (non-block) → consecutive sub-arrays of at most `n` elements, the last possibly shorter (`[1,2,3,4,5].each_slice(2)` → `[[1,2],[3,4],[5]]`).
- `each_cons(n)` (non-block) → every consecutive `n`-element sliding window (`[1,2,3,4].each_cons(2)` → `[[1,2],[2,3],[3,4]]`); a window larger than the array → `[]`.
- Both treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; the never-raise floor yields empty).
- `chunk_while { |prev, cur| pred }` (block) → runs of consecutive elements; the block is called on each adjacent pair — a truthy result extends the run, a falsy one starts a new run (`[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` → `[[1,2],[4,5],[7]]`). Empty → `[]`; single element → `[[x]]`.

## Tests
`test_array_each_slice_each_cons_chunk_while` covers slice/cons sizes, `n<=0` → `[]`, oversized window → `[]`, chunk_while runs (all-truthy / all-falsy / empty / single), `respond_to?`. Also moved the catalog-membership test's "uncatalogued" example from `each_slice` (now catalogued) to `chunk`. **128 tests pass, 97% coverage; ruff clean.** Version 0.1.21 → 0.1.22; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)