### PR TITLE
feat(javascript-parser): bridge private generator methods *#m(){} (CLOC12.182)

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.46.0] - 2026-07-11
+
+### Added — CLOC12.182: bridge private generator methods (`*#m(){}`)
+
+`convert_private_method_definition` detected the leading `*` token but bundled it
+into a blanket `"*" | "async" => decline` arm, dropping the file to
+WHITESPACE_ONLY. The `*` is now split out into its own `saw_star` flag and set on
+the method value's `FunctionExpression.generator`, exactly like a public
+generator method (CLOC12.181) — `yield` is a modelled `YieldExpression`, and the
+emitter's `emit_class_member` already reprints the `*` before the private-name
+key. Covers `*#g(){}` and `static *#g(){}`.
+
+Only the private **async** form (`async #m(){}`) still DECLINES — `await` is not
+yet modelled (grammar-blocked, gap-165). A private name can never be the
+`constructor`, so the generator's kind stays [`MethodKind::Method`]; private
+get/set accessors (CLOC12.179) are unaffected.
+
+The former `class_private_generator_still_declines` test flipped to
+`class_private_generator` (asserting the generator flag); added
+`class_static_private_generator` and `class_private_async_method_declines` to
+lock in the static form and the remaining async decline.
+
 ## [0.45.0] - 2026-07-11
 
 ### Added — CLOC12.181: bridge generator methods (`*m(){}`)

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -1530,11 +1530,13 @@ fn convert_method_definition(
 /// | [ "static" ] STAR   PRIVATE_NAME ...          // private generator
 /// ```
 ///
-/// This slice models the **plain** method and the **get / set accessor** forms
-/// (each optionally `static`) — `#m(){}`, `get #x(){}`, `set #x(v){}`. The
-/// private *generator* (`*#m(){}`) and *async* forms carry evaluation semantics
-/// not yet represented, so — like a public generator method — they DECLINE via
-/// `UnsupportedSyntax` (safe WHITESPACE_ONLY fallback), never a mis-emit.
+/// This slice models the **plain** method, the **get / set accessor**, and the
+/// **generator** (`*#m(){}`) forms (each optionally `static`) — `#m(){}`,
+/// `get #x(){}`, `set #x(v){}`, `*#g(){}`. The private *generator* bridges
+/// exactly like a public one (CLOC12.182): `saw_star` sets the value's
+/// `generator` flag and the emitter reprints the `*`. Only the private *async*
+/// form (`async #m(){}`) still DECLINES via `UnsupportedSyntax` (safe
+/// WHITESPACE_ONLY fallback), never a mis-emit — `await` is not yet modelled.
 ///
 /// Two shape differences from a public `method_definition`:
 /// - the key is a bare `PRIVATE_NAME` token (`#m`), lowered by
@@ -1549,14 +1551,16 @@ fn convert_method_definition(
 /// shared [`convert_formal_parameters`] / [`convert_formal_parameter`] /
 /// [`convert_function_body`], mirroring [`convert_method_definition`].
 fn convert_private_method_definition(node: &GrammarASTNode) -> Result<MethodDefinition, BridgeError> {
-    // Read `static` and the `get` / `set` accessor keyword (inside this node);
-    // decline the generator / async forms this slice does not model. All of
-    // `static` / `get` / `set` / `*` / `async` precede the PRIVATE_NAME as direct
-    // token children (params live under `formal_parameter(s)` *nodes*, so a
-    // parameter literally named `get` cannot be confused for the modifier).
+    // Read `static`, the `get` / `set` accessor keyword, and the `*` generator
+    // marker (inside this node); decline only the `async` form this slice does
+    // not model. All of `static` / `get` / `set` / `*` / `async` precede the
+    // PRIVATE_NAME as direct token children (params live under
+    // `formal_parameter(s)` *nodes*, so a parameter literally named `get` cannot
+    // be confused for the modifier).
     let mut is_static = false;
     let mut saw_get = false;
     let mut saw_set = false;
+    let mut saw_star = false;
     let mut decline = false;
     for c in &node.children {
         if let ASTNodeOrToken::Token(t) = c {
@@ -1564,7 +1568,8 @@ fn convert_private_method_definition(node: &GrammarASTNode) -> Result<MethodDefi
                 "static" => is_static = true,
                 "get" => saw_get = true,
                 "set" => saw_set = true,
-                "*" | "async" => decline = true,
+                "*" => saw_star = true,
+                "async" => decline = true,
                 _ => {}
             }
         }
@@ -1612,7 +1617,8 @@ fn convert_private_method_definition(node: &GrammarASTNode) -> Result<MethodDefi
             id: None,
             params,
             body,
-            generator: false,
+            // `*#g(){}` → a private generator method; the emitter reprints the `*`.
+            generator: saw_star,
             is_async: false,
         },
         computed: false,
@@ -4150,12 +4156,35 @@ mod tests {
     }
 
     #[test]
-    fn class_private_generator_still_declines() {
-        // `*#m(){}` — a private *generator* carries evaluation semantics this
-        // slice does not model; it still DECLINES (safe WHITESPACE_ONLY), never a
-        // mis-emit. (A later slice.)
+    fn class_private_generator() {
+        // `*#m(){}` — a private *generator* bridges (CLOC12.182): a plain
+        // `MethodKind::Method` with a private-name key whose value's `generator`
+        // flag is set so the emitter reprints the `*`. `yield` in the body is a
+        // modelled `YieldExpression`.
+        let m = method_of("w = class { *#m(){ yield 1 } };");
+        assert!(matches!(m.kind, MethodKind::Method));
+        assert!(m.value.generator);
+        assert!(!m.value.is_async);
+        assert!(matches!(&m.key, PropertyKey::PrivateName(p) if p.name == "m"));
+    }
+
+    #[test]
+    fn class_static_private_generator() {
+        // `static *#m(){}` — the `static` and `*` markers both precede the
+        // private key inside the node; the generator flag is still set.
+        let m = method_of("w = class { static *#m(){} };");
+        assert!(m.is_static);
+        assert!(m.value.generator);
+        assert!(matches!(m.kind, MethodKind::Method));
+    }
+
+    #[test]
+    fn class_private_async_method_declines() {
+        // `async #m(){}` — a private *async* method carries `await` semantics not
+        // yet modelled (grammar-blocked); it still DECLINES (safe WHITESPACE_ONLY),
+        // never a mis-emit.
         assert!(matches!(
-            bridge("w = class { *#m(){} };"),
+            bridge("w = class { async #m(){} };"),
             Err(BridgeError::UnsupportedSyntax { .. })
         ));
     }

--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.21] - 2026-07-11
+
+### Added — CLOC12.182: private generator methods end-to-end
+
+Picks up javascript-parser 0.46.0, whose bridge now sets the `generator` flag on
+a `*#g(){}` private method's `FunctionExpression` value instead of declining. A
+private generator method — `class C { *#g(){} }`, optionally `static` — now
+survives the full closurec pipeline instead of dropping to WHITESPACE_ONLY.
+New e2e diff fixture `tests/diff/simple-private-generator-method/`:
+`class C { *#g(){ return 1 + 2 } }` → `class C{*#g(){return 3}}` at SIMPLE.
+
+The fixture proves two things at once: the `*#g` head round-trips (the emitter
+reprinted the `*` before the private-name key from the propagated `generator`
+flag), and the SIMPLE pipeline descends INTO the private generator's body
+(`return 1 + 2` folds to `return 3`). Before this bridge change the private
+generator declined, dropping the file to WHITESPACE_ONLY
+(`class C{*#g(){return 1+2}};`).
+Version-synced cli.spec.json + tests/diff/help-markdown/expected.stdout. PATCH.
+
 ## [0.234.20] - 2026-07-11
 
 ### Added — CLOC12.181: generator methods end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.20"
+version = "0.234.21"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.20",
+  "version": "0.234.21",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.20
+Version: 0.234.21
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-private-generator-method/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-private-generator-method/expected.stdout
@@ -1,0 +1,1 @@
+class C{*#g(){return 3}}

--- a/code/programs/rust/closurec/tests/diff/simple-private-generator-method/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-private-generator-method/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-private-generator-method/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-private-generator-method/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-private-generator-method/input/a.js
@@ -1,0 +1,1 @@
+class C { *#g(){ return 1 + 2 } }

--- a/code/programs/rust/closurec/tests/diff_simple_private_generator_method.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_private_generator_method.rs
@@ -1,0 +1,85 @@
+//! Integration test for the `tests/diff/simple-private-generator-method/` fixture.
+//!
+//! Exercises a **private generator method** (`*#g(){…}`, a `MethodDefinition`
+//! with a `PropertyKey::PrivateName` key whose `value` [`FunctionExpression`] has
+//! `generator: true`) end-to-end at SIMPLE — the CLOC12.182 bridge of the `*`
+//! generator marker in `convert_private_method_definition`. Private accessors
+//! (`get #x()`/`set #x()`, CLOC12.179) and public generator methods (`*gen()`,
+//! CLOC12.181) already bridged; the private *generator* form still declined until
+//! now. Only the private *async* form (`async #m()`) still declines.
+//!
+//! The fixture is `class C { *#g(){ return 1 + 2 } }` compiled at SIMPLE.
+//! Two facts prove the whole pipeline ran through the private generator method:
+//!   1. the class round-trips with a `*#g` head — proving the bridge set the
+//!      `generator` flag (and the emitter reprinted the `*` before the private
+//!      key), not a WHITESPACE_ONLY fallback; and
+//!   2. the body folds — `return 1 + 2` → `return 3` — proving the SIMPLE
+//!      pipeline descended INTO the private generator's body. A WHITESPACE_ONLY
+//!      fallback would leave `1+2` intact.
+//! Before this bridge change a private generator method DECLINED, dropping the
+//! file to WHITESPACE_ONLY (`class C{*#g(){return 1+2}};`) and assertion (2)
+//! failed.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/simple-private-generator-method/flags.txt")
+        .expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_private_generator_method_folds_body() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected =
+        std::fs::read_to_string("tests/diff/simple-private-generator-method/expected.stdout")
+            .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    let a = actual.replace(' ', "");
+    // (1) the class round-tripped with a `*#g` private-generator head.
+    assert!(
+        (a.contains("classC{") || a.contains("class C{")) && a.contains("*#g("),
+        "private generator method did not round-trip with a `*#g` head: {actual}"
+    );
+    // (2) the body folded — proving the pipeline descended INTO the method body
+    //     (`return 1+2`→`return 3`). A WHITESPACE_ONLY fallback would leave the
+    //     arithmetic intact.
+    assert!(
+        a.contains("return3"),
+        "private generator method body did not fold to `return 3`: {actual}"
+    );
+    assert!(
+        !a.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+    // (3) a class *declaration* emits bare — NO wrapping paren (a WHITESPACE_ONLY
+    //     fallback for a class *expression* would wrap; a declaration must not).
+    let t = actual.trim_end_matches('\n');
+    assert!(
+        t.ends_with('}') && !t.starts_with('('),
+        "class declaration must emit bare (no wrap): {actual}"
+    );
+}


### PR DESCRIPTION
## CLOC12.182 — bridge private generator methods `*#m(){}`

`convert_private_method_definition` detected the leading `*` but bundled it into a blanket `"*" | "async" => decline` arm, dropping the whole file to `WHITESPACE_ONLY`. The `*` is now split into its own `saw_star` flag and set on the method value's `FunctionExpression.generator` — exactly like the public generator method bridged in CLOC12.181. `yield` is a modelled `YieldExpression`, and the emitter's `emit_class_member` already reprints the `*` before the private-name key.

### Scope
- `class C { *#g(){} }` and `static *#g(){}`.
- Only the private **async** form (`async #m(){}`) still DECLINES — `await` is not yet modelled (grammar-blocked, gap-165).
- A private name is never `constructor`, so the generator's kind stays `MethodKind::Method`; private get/set accessors (CLOC12.179) are unaffected.

### Changes
- **javascript-parser 0.45.0 → 0.46.0** (new capability): split the decline arm; `*` → `saw_star` → `generator: saw_star`; `async` keeps declining.
- **closurec 0.234.20 → 0.234.21** (patch) + trio-synced `cli.spec.json` + `tests/diff/help-markdown/expected.stdout`.
- Former `class_private_generator_still_declines` test flipped to `class_private_generator`; added `class_static_private_generator` + `class_private_async_method_declines`.
- e2e fixture `tests/diff/simple-private-generator-method/`: `class C { *#g(){ return 1 + 2 } }` → `class C{*#g(){return 3}}` at SIMPLE. Proves the `*#g` head round-trips **and** the pipeline descends into the body (`return 1 + 2` → `return 3`).

### Verification
- 219 javascript-parser tests green.
- closurec diff suite green (incl. new `diff_simple_private_generator_method`).
- security-review PASSED (single bool-flag propagation, no new I/O/recursion; async still safely declines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)