### PR TITLE
feat(cobol): PERFORM … UNTIL — conditional loop (PL08 v0.9)

### DIFF
--- a/code/grammars/cobol/cobol.grammar
+++ b/code/grammars/cobol/cobol.grammar
@@ -143,7 +143,7 @@ arith_factor  = arith_unary  { POW arith_unary } ;
 arith_unary   = [ PLUS | MINUS ] arith_primary ;
 arith_primary = NUMBER | NAME | LPAREN arith_expr RPAREN ;
 perform_stmt  = "PERFORM" NAME [ "THROUGH" NAME | "THRU" NAME ]
-                        [ operand "TIMES" ] ;
+                        [ operand "TIMES" | "UNTIL" condition ] ;
 goto_stmt     = "GO" [ "TO" ] NAME ;
 stop_stmt     = "STOP" ( "RUN" | NUMBER | STRING ) ;
 

--- a/code/packages/rust/cobol-parser/CHANGELOG.md
+++ b/code/packages/rust/cobol-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0 — PERFORM … UNTIL
+
+- `perform_stmt` gains the `UNTIL condition` clause as an alternative to
+  `operand TIMES`: `PERFORM para [THRU …] [ operand TIMES | UNTIL condition ]`.
+  Reuses the existing `condition` rule. `UNTIL` was already a reserved word, so
+  the lexer is unchanged.
+
 ## 0.2.0 — COMPUTE and arithmetic expressions
 
 - `compute_stmt = "COMPUTE" NAME [ "ROUNDED" ] EQ arith_expr [ size_error ]` —

--- a/code/packages/rust/cobol-parser/Cargo.toml
+++ b/code/packages/rust/cobol-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-parser"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Parser for COBOL-60 — parses COBOL source into a generic parse tree using the grammar-driven parser and the cobol.grammar file."
 

--- a/code/packages/rust/cobol-parser/src/_grammar.rs
+++ b/code/packages/rust/cobol-parser/src/_grammar.rs
@@ -466,9 +466,15 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                         ] },
                     ] }) },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::RuleReference { name: r#"operand"#.to_string() },
-                        GrammarElement::Literal { value: r#"TIMES"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                            GrammarElement::Literal { value: r#"TIMES"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"UNTIL"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"condition"#.to_string() },
+                        ] },
                     ] }) },
             ] },
             line_number: 145,

--- a/code/packages/rust/cobol-parser/src/lib.rs
+++ b/code/packages/rust/cobol-parser/src/lib.rs
@@ -206,6 +206,26 @@ mod tests {
     }
 
     #[test]
+    fn perform_until_and_times() {
+        // PERFORM … UNTIL <condition> carries a condition node; PERFORM … TIMES
+        // carries an operand. Both are the optional trailing clause.
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM STEP UNTIL I GREATER 9.",
+            "    PERFORM STEP 3 TIMES.",
+            "    STOP RUN.",
+            "STEP.",
+            "    DISPLAY I.",
+        ]));
+        assert_eq!(count_rule(&ast, "perform_stmt"), 2);
+        // The UNTIL clause introduces a condition inside a perform_stmt.
+        assert!(has_rule(&ast, "condition"));
+    }
+
+    #[test]
     fn if_else_statement() {
         let ast = root(&program(&[
             "IDENTIFICATION DIVISION.",

--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.0 — PERFORM … UNTIL (conditional loop)
+
+- **`PERFORM para UNTIL cond`** repeats a paragraph while the condition is false,
+  testing it **before** each iteration (so an initially-true condition runs the
+  paragraph zero times) — COBOL's default `WITH TEST BEFORE`.
+- The repeat loop is iterative, so even a never-satisfied `UNTIL` (an infinite
+  loop — the programmer's bug, valid COBOL) does not grow the native stack. A
+  `STOP RUN` / `GO TO` inside the body propagates out as its `Flow`.
+- `PERFORM … VARYING` / `… THRU` / `WITH TEST AFTER` and the inline form remain
+  deferred.
+
 ## 0.8.0 — GO TO (unconditional transfer) + program-counter execution
 
 - **`GO TO para`** transfers control unconditionally to a paragraph. The

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -27,11 +27,12 @@ decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
 toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
 parentheses), `ROUNDED`, and `ON SIZE ERROR`; `IF … ELSE` with numeric and
-alphanumeric comparison; `PERFORM para [n TIMES]` (out-of-line paragraph
-invocation, with a recursion guard); and `GO TO para` (unconditional transfer,
-run as a program counter over paragraphs, so back-edge loops work). Anything not
-yet modelled (the explicit `SIGN` clause with `SEPARATE`/`LEADING`, editing
-pictures, `COMP`, `PERFORM … THRU`/`UNTIL`/`VARYING`, `GO TO … DEPENDING`,
-`EVALUATE`, tables, files, and every other verb) returns a descriptive
-`RuntimeError` — never wrong output. See PL08 for the
+alphanumeric comparison; `PERFORM para [n TIMES | UNTIL cond]` (out-of-line
+paragraph invocation — fixed-count and conditional loops, with a recursion
+guard); and `GO TO para` (unconditional transfer, run as a program counter over
+paragraphs, so back-edge loops work). Anything not yet modelled (the explicit
+`SIGN` clause with `SEPARATE`/`LEADING`, editing pictures, `COMP`,
+`PERFORM … THRU`/`VARYING`, `GO TO … DEPENDING`, `EVALUATE`, tables, files, and
+every other verb) returns a descriptive `RuntimeError` — never wrong output.
+See PL08 for the
 roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -261,7 +261,9 @@ impl Machine {
             Stmt::Compute { target, rounded, expr, on_size_error } => {
                 return self.exec_compute(target, *rounded, expr, on_size_error);
             }
-            Stmt::Perform { target, times } => return self.exec_perform(target, times),
+            Stmt::Perform { target, times, until } => {
+                return self.exec_perform(target, times, until)
+            }
             Stmt::GoTo { target } => {
                 let idx = *self
                     .para_index
@@ -291,19 +293,31 @@ impl Machine {
         Ok(Flow::Normal)
     }
 
-    /// `PERFORM target [n TIMES]` — run one paragraph out of line, `n` times
-    /// (default 1), then return. A `TIMES` count that is zero or negative runs
-    /// the paragraph zero times (COBOL's rule); a fractional count truncates.
-    /// Nesting is bounded by [`MAX_PERFORM_DEPTH`] so a self-performing paragraph
-    /// fails with a clean error instead of overflowing the stack. A `STOP RUN`
-    /// or `GO TO` inside stops the repetition and propagates as its [`Flow`].
-    fn exec_perform(&mut self, target: &str, times: &Option<Operand>) -> Result<Flow, RuntimeError> {
+    /// `PERFORM target [n TIMES | UNTIL cond]` — run one paragraph out of line,
+    /// then return. Bare form: once. `n TIMES`: a fixed count (`≤ 0` runs zero
+    /// times, a fractional count truncates). `UNTIL cond`: repeat while the
+    /// condition is false, testing it **before** each iteration (so a
+    /// initially-true condition runs zero times).
+    ///
+    /// The repeat loop is iterative, so even a never-satisfied `UNTIL` (an
+    /// infinite loop — the programmer's bug, valid COBOL) does not grow the
+    /// stack. Nesting of *distinct* performs is bounded by [`MAX_PERFORM_DEPTH`]
+    /// so a self-performing paragraph fails cleanly instead of overflowing. A
+    /// `STOP RUN` or `GO TO` inside stops the repetition and propagates as its
+    /// [`Flow`].
+    fn exec_perform(
+        &mut self,
+        target: &str,
+        times: &Option<Operand>,
+        until: &Option<Cond>,
+    ) -> Result<Flow, RuntimeError> {
         let idx = *self
             .para_index
             .get(target)
             .ok_or_else(|| RuntimeError::UndefinedName(target.into()))?;
 
-        // Resolve the repeat count: a non-negative integer; ≤ 0 → zero times.
+        // Resolve the fixed repeat count (only used when there is no UNTIL):
+        // a non-negative integer; ≤ 0 → zero times.
         let n: usize = match times {
             None => 1,
             Some(op) => {
@@ -332,19 +346,35 @@ impl Machine {
         }
         let stmts = self.paragraphs[idx].stmts.clone();
         // Capture the outcome rather than `?`-ing out of the loop, so the depth
-        // counter is restored on every path (including an error).
+        // counter is restored on every path (including an error). One body
+        // iteration returns Some(flow-to-propagate) to stop, or None to continue.
         let mut outcome = Ok(Flow::Normal);
-        for _ in 0..n {
-            match self.run_stmts(&stmts) {
-                Ok(Flow::Normal) => {}
-                // STOP RUN or GO TO — stop repeating and propagate it upward.
-                Ok(other) => {
-                    outcome = Ok(other);
+        let run_body = |m: &mut Self| match m.run_stmts(&stmts) {
+            Ok(Flow::Normal) => None,
+            other => Some(other), // Stop / GoTo / Err — stop repeating, propagate
+        };
+        match until {
+            Some(cond) => loop {
+                // TEST BEFORE: stop as soon as the condition holds.
+                match self.eval_cond(cond) {
+                    Ok(true) => break,
+                    Ok(false) => {}
+                    Err(e) => {
+                        outcome = Err(e);
+                        break;
+                    }
+                }
+                if let Some(flow) = run_body(self) {
+                    outcome = flow;
                     break;
                 }
-                Err(e) => {
-                    outcome = Err(e);
-                    break;
+            },
+            None => {
+                for _ in 0..n {
+                    if let Some(flow) = run_body(self) {
+                        outcome = flow;
+                        break;
+                    }
                 }
             }
         }

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -9,9 +9,10 @@
 //! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
 //! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), `IF … ELSE`
-//! (numeric and alphanumeric comparison), `PERFORM para [n TIMES]`
-//! (out-of-line paragraph invocation), and `GO TO para` (unconditional transfer,
-//! including back-edge loops) over numeric-display (`9`/`V`, and
+//! (numeric and alphanumeric comparison), `PERFORM para [n TIMES | UNTIL cond]`
+//! (out-of-line paragraph invocation, fixed-count and conditional loops), and
+//! `GO TO para` (unconditional transfer, including back-edge loops) over
+//! numeric-display (`9`/`V`, and
 //! signed `S` with trailing-overpunch display) and character pictures — and
 //! returns a descriptive error for anything not yet modelled, rather than
 //! producing wrong output. The roadmap toward full COBOL (the `SIGN` clause and
@@ -799,6 +800,74 @@ mod tests {
         ]))
         .unwrap();
         assert_eq!(out, "IN\n");
+    }
+
+    #[test]
+    fn perform_until_loops_while_condition_is_false() {
+        // Count I from 1 to 3: PERFORM STEP UNTIL I GREATER 2 runs STEP while
+        // I is not > 2. STEP adds 1 and displays, so I goes 1, 2, 3 and stops
+        // once I = 3 (which is > 2, tested before the would-be 4th run).
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM STEP UNTIL I GREATER 2.",
+            "    DISPLAY \"DONE\".",
+            "    STOP RUN.",
+            "STEP.",
+            "    ADD 1 TO I.",
+            "    DISPLAY I.",
+        ]))
+        .unwrap();
+        // STEP runs at I=0→1, I=1→2, I=2→3; next test I=3>2 true → stop.
+        assert_eq!(out, "1\n2\n3\nDONE\n");
+    }
+
+    #[test]
+    fn perform_until_tests_before_so_can_run_zero_times() {
+        // The condition is already true, so the paragraph never runs.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 5.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM NOISE UNTIL I GREATER 2.",
+            "    DISPLAY \"DONE\".",
+            "    STOP RUN.",
+            "NOISE.",
+            "    DISPLAY \"X\".",
+        ]))
+        .unwrap();
+        assert_eq!(out, "DONE\n");
+    }
+
+    #[test]
+    fn perform_until_propagates_stop_run() {
+        // A STOP RUN inside the UNTIL body ends the program immediately.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM STEP UNTIL I GREATER 9.",
+            "    DISPLAY \"NEVER\".",
+            "    STOP RUN.",
+            "STEP.",
+            "    DISPLAY \"ONCE\".",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "ONCE\n");
     }
 
     #[test]

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -78,9 +78,11 @@ pub enum Stmt {
         expr: Expr,
         on_size_error: Vec<Stmt>,
     },
-    /// `PERFORM para [n TIMES]` — run a paragraph out of line, optionally a
-    /// fixed number of times, then return to the statement after the PERFORM.
-    Perform { target: String, times: Option<Operand> },
+    /// `PERFORM para [n TIMES | UNTIL cond]` — run a paragraph out of line, then
+    /// return. Bare: once. `n TIMES`: a fixed count. `UNTIL cond`: repeat while
+    /// the condition is false (tested before each iteration). `times` and `until`
+    /// are mutually exclusive; both `None` means once.
+    Perform { target: String, times: Option<Operand>, until: Option<Cond> },
     /// `GO TO para` — transfer control unconditionally to a paragraph (no return).
     GoTo { target: String },
     /// `IF cond then… [ELSE else…]`.
@@ -416,7 +418,11 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 Some(op) => Some(read_operand(op)?),
                 None => None,
             };
-            Ok(Stmt::Perform { target, times })
+            let until = match child_node(verb, "condition") {
+                Some(cond) => Some(read_condition(cond)?),
+                None => None,
+            };
+            Ok(Stmt::Perform { target, times, until })
         }
         "goto_stmt" => {
             // GO [TO] target. The DEPENDING ON form is not in the grammar yet.

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -141,14 +141,18 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
 7. **v0.7 — `PERFORM para [n TIMES]`** (merged): out-of-line paragraph
    invocation with return, an integer repeat count (`≤ 0` runs zero times), and a
    recursion-depth guard against a self-performing paragraph.
-8. **v0.8 — `GO TO para`** (this PR): unconditional transfer, with the procedure
+8. **v0.8 — `GO TO para`** (merged): unconditional transfer, with the procedure
    division executed as a **program counter** over paragraphs (so back-edge
    `GO TO` loops run iteratively, no stack growth). A `GO TO` out of a performed
    paragraph transfers at the top level. `GO TO … DEPENDING ON` and `ALTER` are
    deferred.
-9. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
-10. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
-    `UNTIL`, `VARYING`, inline), `GO TO … DEPENDING ON`, `ALTER`.
+9. **v0.9 — `PERFORM … UNTIL`** (this PR): a conditional loop, testing the
+   condition **before** each iteration (`WITH TEST BEFORE`), driven iteratively.
+   `PERFORM … VARYING`/`… THRU`/`WITH TEST AFTER` and the inline form remain
+   deferred.
+10. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+11. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
+    `VARYING`, inline, `TEST AFTER`), `GO TO … DEPENDING ON`, `ALTER`.
 8. **Conditions** — level-88 condition-names.
 9. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.
 8. **File I/O** — `SELECT`/`FD`, sequential then indexed/relative, `OPEN`/`READ`/


### PR DESCRIPTION
## Summary

Adds `PERFORM para UNTIL condition` — the conditional (`while`-style) loop form,
building on the `PERFORM` and program-counter work already on `main`. A
frontend + runtime change.

### What it does
- **Grammar** (cobol-parser 0.3.0): `perform_stmt` gains `UNTIL condition` as an
  alternative to `operand TIMES` — `PERFORM para [THRU …] [ operand TIMES | UNTIL condition ]`,
  reusing the existing `condition` rule. `UNTIL` was already a reserved word, so
  the lexer is unchanged.
- **Runtime** (cobol-runtime 0.9.0): `Stmt::Perform` gains `until: Option<Cond>`;
  `exec_perform` runs a **TEST-BEFORE** loop — repeat the paragraph while the
  condition evaluates false, checking it before each iteration (so an
  initially-true condition runs the body zero times), re-evaluated against live
  state each pass.

### Safety
- The repeat loop is **iterative**, so a never-satisfied `UNTIL` (an infinite
  loop — the programmer's bug, valid COBOL) is an interruptible hang, never a
  stack overflow. `perform_depth` is incremented once per PERFORM (not per
  iteration) and restored on every exit path, so a self-performing `UNTIL` still
  trips `MAX_PERFORM_DEPTH` cleanly. `STOP RUN` / `GO TO` in the body propagate.

### Deferred
`PERFORM … VARYING` / `… THRU` / `WITH TEST AFTER` and the inline form.

## Tests
16 lexer + 15 parser (incl. an UNTIL-vs-TIMES parse test) + 77 runtime tests
(loop-while-false, initially-true → zero runs, `STOP RUN` propagation).
Warning-free. Security review PASSED. README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)