### PR TITLE
fix(sql-vm): HEX(NULL) returns an empty string, not NULL

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.11 — Fix HEX(NULL) to return an empty string
+
+Stream A correctness fix (sql-vm 0.4.7): `HEX(NULL)` returned SQL NULL but real
+SQLite returns the empty string `''` — it casts the argument to a blob first, so
+NULL → empty blob → `''` (a text value). This was the latent divergence flagged
+by the UNHEX work (0.5.10). A new differential-oracle case (`hex_of_null`) diffs
+`HEX(s)` and `TYPEOF(HEX(s))` for both a text and a NULL row against real bundled
+SQLite.
+
 ## 0.5.10 — UNHEX (decode hex to blob)
 
 Grows the SQL scalar surface (sql-vm 0.4.6): `UNHEX(x)` / `UNHEX(x, ignore)`

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.10"
+version = "0.5.11"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -616,6 +616,16 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT UNHEX(s, ig) AS r FROM t ORDER BY id",
     },
+    // HEX(NULL) is the EMPTY STRING, not NULL — SQLite casts the argument to a
+    // blob first, and NULL → empty blob → ''. The non-NULL cases are unchanged.
+    Case {
+        id: "hex_of_null",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1, 'abc'), (2, NULL)",
+        ],
+        query: "SELECT HEX(s) AS h, TYPEOF(HEX(s)) AS t FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.7] - Unreleased
+
+### Fixed
+
+- **`HEX(NULL)`** now returns the empty string `''` (a text value), matching
+  SQLite, instead of NULL. SQLite casts HEX's argument to a blob first, so
+  `NULL` becomes an empty blob and hexing it yields `''` (`typeof` is `text`).
+  Surfaced while adding UNHEX (`HEX(UNHEX('abc'))` should be `''`, not NULL).
+
 ## [0.4.6] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1416,13 +1416,15 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
             // HEX(x): uppercase hexadecimal of the argument's bytes. SQLite reads
             // the argument as a blob — text uses its UTF-8 bytes, a blob its raw
             // bytes, and an integer its decimal-text bytes (`hex(255)` → "323535").
-            // NULL maps to NULL. Floats are declined: their SQLite text form
-            // (`2.0`, not Rust's `2`) is subtle enough that we don't guess here.
+            // NULL casts to an *empty blob*, so `hex(NULL)` is the empty string
+            // `''` (a text value), NOT NULL. Floats are declined: their SQLite
+            // text form (`2.0`, not Rust's `2`) is subtle enough that we don't
+            // guess here.
             if args.len() != 1 {
                 return Err(VmError::TypeMismatch(format!("HEX expects 1 arg, got {}", args.len())));
             }
             let bytes: Vec<u8> = match &args[0] {
-                SqlValue::Null => return Ok(SqlValue::Null),
+                SqlValue::Null => return Ok(SqlValue::Text(String::new())),
                 SqlValue::Text(s) => s.as_bytes().to_vec(),
                 SqlValue::Blob(b) => b.clone(),
                 SqlValue::Int(i) => i.to_string().into_bytes(),
@@ -3824,7 +3826,8 @@ mod tests {
         assert_eq!(h(SqlValue::Text("abc".into())), "616263");
         assert_eq!(h(SqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])), "DEADBEEF");
         assert_eq!(h(SqlValue::Int(255)), "323535"); // hex of the text "255"
-        assert_eq!(call_builtin("HEX", vec![SqlValue::Null]).unwrap(), SqlValue::Null);
+        // NULL casts to an empty blob, so HEX(NULL) is the empty string, NOT NULL.
+        assert_eq!(call_builtin("HEX", vec![SqlValue::Null]).unwrap(), SqlValue::Text(String::new()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Stream A** correctness fix. `HEX(NULL)` returned SQL NULL, but real SQLite
returns the empty string `''` (a text value): HEX casts its argument to a blob
first, so NULL becomes an empty blob and hexing it yields `''`.

```
hex(NULL)          -> ''       (was NULL)
typeof(hex(NULL))  -> 'text'
```

This is the latent divergence surfaced by the [UNHEX PR](https://github.com/adhithyan15/coding-adventures/pull/8030):
`HEX(UNHEX('abc'))` should be `''` (since `UNHEX('abc')` is NULL), not NULL. It
was kept separate from that PR to avoid scope creep.

## Security

Reviewed before push. Returning `Text(String::new())` allocates nothing and does
no indexing; the arity check and byte-encoding paths are unchanged; an
empty-text result was already reachable (`HEX('')`), so no downstream invariant
is broken. **Review passed, no findings.**

## Verification

- `sql-vm`: **94 lib tests** (the HEX unit test now asserts `HEX(NULL) == Text("")`).
- **mini-sqlite differential oracle:** new `hex_of_null` case diffs `HEX(s)` and
  `TYPEOF(HEX(s))` for a text row and a NULL row against real bundled SQLite.
  Full mini-sqlite suite green.

`sql-vm` 0.4.6 → 0.4.7, `mini-sqlite` 0.5.10 → 0.5.11; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
