### PR TITLE
feat(sir-go): Array each_slice / each_cons / chunk_while

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.30.0 — Array `each_slice` / `each_cons` / `chunk_while`
+
+Mirrors the Python reference (PR #8031) into the Go backend's inline `__sir`
+runtime, adding the Array consecutive-grouping family (`_sir_array_method` for the
+non-block `each_slice`/`each_cons`, `_sir_array_block_method` for `chunk_while`,
+plus the `_sir_array_responds` `respond_to?` arm).
+
+- `each_slice(n)` → consecutive sub-arrays of at most `n` elements, the last
+  possibly shorter (`[1,2,3,4,5].each_slice(2)` → `[[1,2],[3,4],[5]]`).
+- `each_cons(n)` → every consecutive `n`-element sliding window
+  (`[1,2,3,4].each_cons(2)` → `[[1,2],[2,3],[3,4]]`); a window larger than the
+  array yields `[]`.
+- Both treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; the never-panic floor
+  yields empty instead).
+- `chunk_while { |prev, cur| pred }` → runs of consecutive elements; the block is
+  called on each ADJACENT pair, a truthy result extends the run and a falsy one
+  starts a new run (`[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` →
+  `[[1,2],[4,5],[7]]`).  Empty → `[]`; single element → `[[x]]`.
+
+Exec-proof: `tests/compile_and_run_array_methods.rs` gains
+`array_each_slice_each_cons_chunk_while_compile_and_run`, running each_slice/
+each_cons (incl. `n<=0` and oversized-window → `[]`) and chunk_while (adjacent
+`b-a==1` predicate; empty → `[]`) under real `go run`, diffed against the Python
+reference semantics.
+
 ## 0.29.0 — Hash `to_h` (block + no-block) / `each_with_index` / `each_with_object`
 
 Mirrors the Python reference (PR #8009) into the Go backend's inline `__sir`

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -182,7 +182,8 @@ runtime catalog** and emits every dispatch to it:
 Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `empty?`, `include?`, `index`, `push`/`append`, `<<`, `pop`, `shift`, `reverse`,
 `sort`, `join`, `to_a`, `each`, `map`/`collect`, `select`/`filter`, `reject`,
-`reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`; **Hash** `keys`,
+`reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`,
+`each_slice`/`each_cons`, `chunk_while`; **Hash** `keys`,
 `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `size`/
 `length`, `empty?`, `each`/`each_pair`, `each_key`, `each_value`, `map`,
 `select`/`filter`, `reject`, `transform_values`, `transform_keys`, and the

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1697,13 +1697,14 @@ func _sir_array_responds(name string) bool {
 		"index", "push", "append", "<<", "pop", "shift", "reverse", "sort",
 		"min", "max", "sum", "uniq", "flatten", "compact", "zip", "rotate",
 		"to_h", "tally", "take", "drop", "values_at",
-		"join", "fetch", "to_a":
+		"join", "fetch", "to_a", "each_slice", "each_cons":
 		return true
 	// Block-taking Array/Enumerable methods.
 	case "each", "each_with_index", "map", "collect", "select", "filter",
 		"reject", "reduce", "inject", "find", "detect", "any?", "all?", "none?",
 		"sort_by", "min_by", "max_by", "group_by", "partition", "flat_map",
-		"collect_concat", "take_while", "drop_while", "each_with_object":
+		"collect_concat", "take_while", "drop_while", "each_with_object",
+		"chunk_while":
 		return true
 	}
 	return false
@@ -2050,6 +2051,46 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 		return &Seq{Items: out}, true
 	case "to_a":
 		return recv, true
+	case "each_slice":
+		// `each_slice(n)` -> consecutive sub-arrays of at most n elements (the
+		// last may be shorter).  `[1,2,3,4,5].each_slice(2)` -> [[1,2],[3,4],[5]].
+		// Ruby raises ArgumentError for n <= 0; the never-panic floor yields [].
+		n := int64(0)
+		if len(args) > 0 {
+			n = _sir_as_int_trunc(args[0])
+		}
+		if n <= 0 {
+			return &Seq{Items: []Value{}}, true
+		}
+		out := []Value{}
+		for i := int64(0); i < int64(len(recv.Items)); i += n {
+			end := i + n
+			if end > int64(len(recv.Items)) {
+				end = int64(len(recv.Items))
+			}
+			slice := make([]Value, end-i)
+			copy(slice, recv.Items[i:end])
+			out = append(out, &Seq{Items: slice})
+		}
+		return &Seq{Items: out}, true
+	case "each_cons":
+		// `each_cons(n)` -> every consecutive n-element sliding window.
+		// `[1,2,3,4].each_cons(2)` -> [[1,2],[2,3],[3,4]].  A window larger than
+		// the array (or n <= 0) yields [].
+		n := int64(0)
+		if len(args) > 0 {
+			n = _sir_as_int_trunc(args[0])
+		}
+		out := []Value{}
+		if n <= 0 {
+			return &Seq{Items: out}, true
+		}
+		for i := int64(0); i+n <= int64(len(recv.Items)); i++ {
+			win := make([]Value, n)
+			copy(win, recv.Items[i:i+n])
+			out = append(out, &Seq{Items: win})
+		}
+		return &Seq{Items: out}, true
 	}
 	return nil, false
 }
@@ -2276,6 +2317,28 @@ func _sir_array_block_method(recv *Seq, name string, args []Value, block *Closur
 			_sir_apply(block, []Value{x, obj})
 		}
 		return obj, true
+	case "chunk_while":
+		// `chunk_while { |prev, cur| pred }` -> runs of consecutive elements: the
+		// block is called on each ADJACENT pair; while it is truthy the run
+		// continues, and a falsy result starts a new run.
+		// `[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` -> [[1,2],[4,5],[7]].
+		// An empty array yields []; a single element yields [[x]].
+		if len(recv.Items) == 0 {
+			return &Seq{Items: []Value{}}, true
+		}
+		cur := &Seq{Items: []Value{recv.Items[0]}}
+		chunks := []Value{cur}
+		for i := 1; i < len(recv.Items); i++ {
+			prev := recv.Items[i-1]
+			item := recv.Items[i]
+			if _sir_truthy(_sir_apply(block, []Value{prev, item})) {
+				cur.Items = append(cur.Items, item)
+			} else {
+				cur = &Seq{Items: []Value{item}}
+				chunks = append(chunks, cur)
+			}
+		}
+		return &Seq{Items: chunks}, true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
@@ -275,3 +275,92 @@ fn array_methods_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+// ── Array each_slice / each_cons / chunk_while ─────────────────────────────
+//
+// The consecutive-grouping family, mirroring the Python reference (#8031).
+// `each_slice`/`each_cons` are non-block (take an int `n`); `chunk_while` is a
+// block method (the block is called on each ADJACENT pair).
+fn slice_module() -> Function {
+    Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                // [1,2,3,4,5].each_slice(2) → [[1, 2], [3, 4], [5]]
+                print_stmt(method(
+                    seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]),
+                    "each_slice",
+                    vec![ilit(2)],
+                )),
+                // [1,2,3].each_slice(0) → []  (never-panic floor)
+                print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "each_slice", vec![ilit(0)])),
+                // [1,2,3,4].each_cons(2) → [[1, 2], [2, 3], [3, 4]]
+                print_stmt(method(
+                    seq(vec![ilit(1), ilit(2), ilit(3), ilit(4)]),
+                    "each_cons",
+                    vec![ilit(2)],
+                )),
+                // [1,2].each_cons(3) → []  (window larger than the array)
+                print_stmt(method(seq(vec![ilit(1), ilit(2)]), "each_cons", vec![ilit(3)])),
+                // [1,2,4,5,7].chunk_while { |a,b| b-a==1 } → [[1, 2], [4, 5], [7]]
+                print_stmt(method(
+                    seq(vec![ilit(1), ilit(2), ilit(4), ilit(5), ilit(7)]),
+                    "chunk_while",
+                    vec![closure("__lam_adj")],
+                )),
+                // [].chunk_while { … } → []
+                print_stmt(method(seq(vec![]), "chunk_while", vec![closure("__lam_adj")])),
+            ],
+            value: nil(),
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+#[test]
+fn array_each_slice_each_cons_chunk_while_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    let adj = lambda_fn2(
+        "__lam_adj",
+        "a",
+        "b",
+        Block {
+            stmts: vec![],
+            value: builtin("=", vec![builtin("-", vec![var_p("b"), var_p("a")]), ilit(1)]),
+            span: s(),
+        },
+    );
+    let module = program(vec![slice_module(), adj]);
+    let artifact = compile(&module).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "slice");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "[[1, 2], [3, 4], [5]]",    // each_slice(2)
+            "[]",                       // each_slice(0) → []
+            "[[1, 2], [2, 3], [3, 4]]", // each_cons(2)
+            "[]",                       // each_cons(3) on len-2 → []
+            "[[1, 2], [4, 5], [7]]",    // chunk_while { b-a==1 }
+            "[]",                       // [].chunk_while → []
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8031](https://github.com/adhithyan15/coding-adventures/pull/8031)) into the **Go** backend's inline `__sir` runtime (`_sir_array_method` for the non-block `each_slice`/`each_cons`, `_sir_array_block_method` for `chunk_while`, + the `_sir_array_responds` `respond_to?` arm).

## Methods
- `each_slice(n)` → consecutive sub-arrays of at most `n` elements (last shorter).
- `each_cons(n)` → every consecutive `n`-element sliding window; window > len → `[]`.
- Both treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; never-panic floor → `[]`).
- `chunk_while { |prev, cur| pred }` → runs of consecutive elements; block called on each adjacent pair, truthy extends the run, falsy starts a new run. Empty → `[]`; single element → `[[x]]`.

## Safety
Sub-arrays are `copy()`d into fresh slices (no aliasing of the receiver's backing array); `chunk_while`'s per-run `Seq` starts from a 1-elem literal so `append` reallocates independently. `n<=0`/oversized-window → `[]` keeps the never-panic floor.

## Exec-proof
`tests/compile_and_run_array_methods.rs` gains `array_each_slice_each_cons_chunk_while_compile_and_run`, run under real `go run`:

```
[[1, 2], [3, 4], [5]]      # each_slice(2)
[]                         # each_slice(0) → []
[[1, 2], [2, 3], [3, 4]]   # each_cons(2)
[]                         # each_cons(3) on len-2 → []
[[1, 2], [4, 5], [7]]      # chunk_while { b-a==1 }
[]                         # [].chunk_while → []
```

Lib tests 97 green. Version 0.29.0 → 0.30.0; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)