### PR TITLE
feat(cobol): PERFORM … VARYING — counted loop (PL08 v0.10)

### DIFF
--- a/code/grammars/cobol/cobol.grammar
+++ b/code/grammars/cobol/cobol.grammar
@@ -143,7 +143,10 @@ arith_factor  = arith_unary  { POW arith_unary } ;
 arith_unary   = [ PLUS | MINUS ] arith_primary ;
 arith_primary = NUMBER | NAME | LPAREN arith_expr RPAREN ;
 perform_stmt  = "PERFORM" NAME [ "THROUGH" NAME | "THRU" NAME ]
-                        [ operand "TIMES" | "UNTIL" condition ] ;
+                        [ operand "TIMES" | "UNTIL" condition | perform_varying ] ;
+# VARYING id FROM start BY step UNTIL cond — a counted loop over an induction
+# variable (`id := start`; run while `cond` is false, stepping `id` by `step`).
+perform_varying = "VARYING" NAME "FROM" operand "BY" operand "UNTIL" condition ;
 goto_stmt     = "GO" [ "TO" ] NAME ;
 stop_stmt     = "STOP" ( "RUN" | NUMBER | STRING ) ;
 

--- a/code/packages/rust/cobol-parser/CHANGELOG.md
+++ b/code/packages/rust/cobol-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0 — PERFORM … VARYING
+
+- `perform_stmt` gains a third repeat clause, `perform_varying`
+  (`VARYING NAME FROM operand BY operand UNTIL condition`), alongside
+  `operand TIMES` and `UNTIL condition`. `VARYING`/`FROM`/`BY` were already
+  reserved words, so the lexer is unchanged.
+
 ## 0.3.0 — PERFORM … UNTIL
 
 - `perform_stmt` gains the `UNTIL condition` clause as an alternative to

--- a/code/packages/rust/cobol-parser/Cargo.toml
+++ b/code/packages/rust/cobol-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-parser"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Parser for COBOL-60 — parses COBOL source into a generic parse tree using the grammar-driven parser and the cobol.grammar file."
 

--- a/code/packages/rust/cobol-parser/src/_grammar.rs
+++ b/code/packages/rust/cobol-parser/src/_grammar.rs
@@ -475,9 +475,24 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::Literal { value: r#"UNTIL"#.to_string() },
                             GrammarElement::RuleReference { name: r#"condition"#.to_string() },
                         ] },
+                        GrammarElement::RuleReference { name: r#"perform_varying"#.to_string() },
                     ] }) },
             ] },
             line_number: 145,
+        },
+        GrammarRule {
+            name: r#"perform_varying"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"VARYING"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Literal { value: r#"FROM"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Literal { value: r#"BY"#.to_string() },
+                GrammarElement::RuleReference { name: r#"operand"#.to_string() },
+                GrammarElement::Literal { value: r#"UNTIL"#.to_string() },
+                GrammarElement::RuleReference { name: r#"condition"#.to_string() },
+            ] },
+            line_number: 149,
         },
         GrammarRule {
             name: r#"goto_stmt"#.to_string(),
@@ -486,7 +501,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"TO"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 147,
+            line_number: 150,
         },
         GrammarRule {
             name: r#"stop_stmt"#.to_string(),
@@ -498,7 +513,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 148,
+            line_number: 151,
         },
         GrammarRule {
             name: r#"if_stmt"#.to_string(),
@@ -511,7 +526,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                     ] }) },
             ] },
-            line_number: 152,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"condition"#.to_string(),
@@ -520,7 +535,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"operand"#.to_string() },
             ] },
-            line_number: 153,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -542,7 +557,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] },
                     ] }) },
             ] },
-            line_number: 154,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"operand"#.to_string(),
@@ -550,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::RuleReference { name: r#"literal"#.to_string() },
             ] },
-            line_number: 160,
+            line_number: 163,
         },
         GrammarRule {
             name: r#"literal"#.to_string(),
@@ -559,7 +574,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                 GrammarElement::RuleReference { name: r#"figurative"#.to_string() },
             ] },
-            line_number: 161,
+            line_number: 164,
         },
         GrammarRule {
             name: r#"figurative"#.to_string(),
@@ -576,7 +591,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"QUOTE"#.to_string() },
                 GrammarElement::Literal { value: r#"QUOTES"#.to_string() },
             ] },
-            line_number: 162,
+            line_number: 165,
         },
     ],
         version: 1,

--- a/code/packages/rust/cobol-parser/src/lib.rs
+++ b/code/packages/rust/cobol-parser/src/lib.rs
@@ -226,6 +226,24 @@ mod tests {
     }
 
     #[test]
+    fn perform_varying() {
+        // PERFORM … VARYING id FROM start BY step UNTIL cond parses to a
+        // perform_varying node carrying the induction variable and condition.
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM SHOW VARYING I FROM 1 BY 1 UNTIL I GREATER 3.",
+            "    STOP RUN.",
+            "SHOW.",
+            "    DISPLAY I.",
+        ]));
+        assert!(has_rule(&ast, "perform_varying"));
+        assert!(has_rule(&ast, "condition"));
+    }
+
+    #[test]
     fn if_else_statement() {
         let ast = root(&program(&[
             "IDENTIFICATION DIVISION.",

--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.10.0 — PERFORM … VARYING (counted loop)
+
+- **`PERFORM para VARYING id FROM start BY step UNTIL cond`** sets the induction
+  variable `id` to `start`, then runs the paragraph while `cond` is false
+  (test-before), stepping `id` by `step` after each iteration.
+- The `PERFORM` repeat forms are now modelled as a `PerformMode` enum
+  (`Once` / `Times` / `Until` / `Varying`) instead of ad-hoc option fields — a
+  cleaner substrate as the family grows.
+- Iterative like the other loops (a never-satisfied `VARYING` hangs but never
+  overflows the stack); a step overflow is a clean error; `STOP RUN` / `GO TO`
+  in the body propagate.
+- `WITH TEST AFTER`, multiple `AFTER` phrases, and `PERFORM … THRU` remain
+  deferred.
+
 ## 0.9.0 — PERFORM … UNTIL (conditional loop)
 
 - **`PERFORM para UNTIL cond`** repeats a paragraph while the condition is false,

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -27,12 +27,12 @@ decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
 toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
 parentheses), `ROUNDED`, and `ON SIZE ERROR`; `IF … ELSE` with numeric and
-alphanumeric comparison; `PERFORM para [n TIMES | UNTIL cond]` (out-of-line
-paragraph invocation — fixed-count and conditional loops, with a recursion
-guard); and `GO TO para` (unconditional transfer, run as a program counter over
-paragraphs, so back-edge loops work). Anything not yet modelled (the explicit
-`SIGN` clause with `SEPARATE`/`LEADING`, editing pictures, `COMP`,
-`PERFORM … THRU`/`VARYING`, `GO TO … DEPENDING`, `EVALUATE`, tables, files, and
-every other verb) returns a descriptive `RuntimeError` — never wrong output.
-See PL08 for the
+alphanumeric comparison; `PERFORM para [n TIMES | UNTIL cond | VARYING id FROM x
+BY y UNTIL cond]` (out-of-line paragraph invocation — fixed-count, conditional,
+and counted loops, with a recursion guard); and `GO TO para` (unconditional
+transfer, run as a program counter over paragraphs, so back-edge loops work).
+Anything not yet modelled (the explicit `SIGN` clause with `SEPARATE`/`LEADING`,
+editing pictures, `COMP`, `PERFORM … THRU`/`WITH TEST AFTER`,
+`GO TO … DEPENDING`, `EVALUATE`, tables, files, and every other verb) returns a
+descriptive `RuntimeError` — never wrong output. See PL08 for the
 roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -3,7 +3,9 @@
 
 use crate::error::RuntimeError;
 use crate::picture::Picture;
-use crate::program::{ArithOp, Cond, Expr, Fig, Lit, Operand, Paragraph, Program, RelOp, Stmt};
+use crate::program::{
+    ArithOp, Cond, Expr, Fig, Lit, Operand, Paragraph, PerformMode, Program, RelOp, Stmt,
+};
 use crate::value::{add, div, move_into_char, move_into_numeric, mul, pow, round, sub, Decimal};
 use std::collections::HashMap;
 
@@ -261,9 +263,7 @@ impl Machine {
             Stmt::Compute { target, rounded, expr, on_size_error } => {
                 return self.exec_compute(target, *rounded, expr, on_size_error);
             }
-            Stmt::Perform { target, times, until } => {
-                return self.exec_perform(target, times, until)
-            }
+            Stmt::Perform { target, mode } => return self.exec_perform(target, mode),
             Stmt::GoTo { target } => {
                 let idx = *self
                     .para_index
@@ -305,37 +305,11 @@ impl Machine {
     /// so a self-performing paragraph fails cleanly instead of overflowing. A
     /// `STOP RUN` or `GO TO` inside stops the repetition and propagates as its
     /// [`Flow`].
-    fn exec_perform(
-        &mut self,
-        target: &str,
-        times: &Option<Operand>,
-        until: &Option<Cond>,
-    ) -> Result<Flow, RuntimeError> {
+    fn exec_perform(&mut self, target: &str, mode: &PerformMode) -> Result<Flow, RuntimeError> {
         let idx = *self
             .para_index
             .get(target)
             .ok_or_else(|| RuntimeError::UndefinedName(target.into()))?;
-
-        // Resolve the fixed repeat count (only used when there is no UNTIL):
-        // a non-negative integer; ≤ 0 → zero times.
-        let n: usize = match times {
-            None => 1,
-            Some(op) => {
-                let d = self.operand_decimal(op)?;
-                if d.neg {
-                    0
-                } else {
-                    let int = d.int.trim_start_matches('0');
-                    if int.is_empty() {
-                        0
-                    } else {
-                        int.parse::<usize>().map_err(|_| {
-                            RuntimeError::Unsupported("PERFORM … TIMES count is too large".into())
-                        })?
-                    }
-                }
-            }
-        };
 
         self.perform_depth += 1;
         if self.perform_depth > MAX_PERFORM_DEPTH {
@@ -348,38 +322,93 @@ impl Machine {
         // Capture the outcome rather than `?`-ing out of the loop, so the depth
         // counter is restored on every path (including an error). One body
         // iteration returns Some(flow-to-propagate) to stop, or None to continue.
-        let mut outcome = Ok(Flow::Normal);
         let run_body = |m: &mut Self| match m.run_stmts(&stmts) {
             Ok(Flow::Normal) => None,
             other => Some(other), // Stop / GoTo / Err — stop repeating, propagate
         };
-        match until {
-            Some(cond) => loop {
-                // TEST BEFORE: stop as soon as the condition holds.
-                match self.eval_cond(cond) {
-                    Ok(true) => break,
-                    Ok(false) => {}
-                    Err(e) => {
-                        outcome = Err(e);
-                        break;
+
+        let outcome = match mode {
+            PerformMode::Once => run_body(self).unwrap_or(Ok(Flow::Normal)),
+            PerformMode::Times(op) => match self.perform_count(op) {
+                Ok(n) => {
+                    let mut o = Ok(Flow::Normal);
+                    for _ in 0..n {
+                        if let Some(flow) = run_body(self) {
+                            o = flow;
+                            break;
+                        }
                     }
+                    o
                 }
-                if let Some(flow) = run_body(self) {
-                    outcome = flow;
-                    break;
-                }
+                Err(e) => Err(e),
             },
-            None => {
-                for _ in 0..n {
-                    if let Some(flow) = run_body(self) {
-                        outcome = flow;
-                        break;
-                    }
+            PerformMode::Until(cond) => self.perform_until(cond, &run_body),
+            PerformMode::Varying { var, from, by, until } => {
+                // id := from, then the same TEST-BEFORE loop, stepping id by `by`
+                // after each body run.
+                match self
+                    .operand_decimal(from)
+                    .and_then(|start| self.store_number(var, start))
+                {
+                    Err(e) => Err(e),
+                    Ok(()) => self.perform_until(until, &|m: &mut Self| {
+                        // A body Stop/GoTo/Err wins; otherwise step id (a step
+                        // error — e.g. overflow — stops the loop and propagates).
+                        if let Some(f) = run_body(m) {
+                            return Some(f);
+                        }
+                        match m.step_var(var, by) {
+                            Ok(()) => None,
+                            Err(e) => Some(Err(e)),
+                        }
+                    }),
                 }
             }
-        }
+        };
         self.perform_depth -= 1;
         outcome
+    }
+
+    /// Resolve a `PERFORM … TIMES` count: a non-negative integer; `≤ 0` → 0.
+    fn perform_count(&self, op: &Operand) -> Result<usize, RuntimeError> {
+        let d = self.operand_decimal(op)?;
+        if d.neg {
+            return Ok(0);
+        }
+        let int = d.int.trim_start_matches('0');
+        if int.is_empty() {
+            return Ok(0);
+        }
+        int.parse::<usize>()
+            .map_err(|_| RuntimeError::Unsupported("PERFORM … TIMES count is too large".into()))
+    }
+
+    /// The shared TEST-BEFORE loop: while `cond` is false, run `body` (which
+    /// returns `Some(flow)` to stop and propagate, `None` to continue). Iterative,
+    /// so a never-satisfied condition hangs but never grows the stack.
+    fn perform_until(
+        &mut self,
+        cond: &Cond,
+        body: &dyn Fn(&mut Self) -> Option<Result<Flow, RuntimeError>>,
+    ) -> Result<Flow, RuntimeError> {
+        loop {
+            match self.eval_cond(cond) {
+                Ok(true) => return Ok(Flow::Normal),
+                Ok(false) => {}
+                Err(e) => return Err(e),
+            }
+            if let Some(flow) = body(self) {
+                return flow;
+            }
+        }
+    }
+
+    /// Step a `PERFORM VARYING` induction variable: `var := var + by`.
+    fn step_var(&mut self, var: &str, by: &Operand) -> Result<(), RuntimeError> {
+        let cur = self.named_decimal(var)?;
+        let step = self.operand_decimal(by)?;
+        let next = checked(add(&cur, &step))?;
+        self.store_number(var, next)
     }
 
     /// Evaluate a relational condition. Numeric when both sides are numeric;

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -9,10 +9,11 @@
 //! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
 //! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), `IF … ELSE`
-//! (numeric and alphanumeric comparison), `PERFORM para [n TIMES | UNTIL cond]`
-//! (out-of-line paragraph invocation, fixed-count and conditional loops), and
-//! `GO TO para` (unconditional transfer, including back-edge loops) over
-//! numeric-display (`9`/`V`, and
+//! (numeric and alphanumeric comparison),
+//! `PERFORM para [n TIMES | UNTIL cond | VARYING id FROM x BY y UNTIL cond]`
+//! (out-of-line paragraph invocation — fixed-count, conditional, and counted
+//! loops), and `GO TO para` (unconditional transfer, including back-edge loops)
+//! over numeric-display (`9`/`V`, and
 //! signed `S` with trailing-overpunch display) and character pictures — and
 //! returns a descriptive error for anything not yet modelled, rather than
 //! producing wrong output. The roadmap toward full COBOL (the `SIGN` clause and
@@ -868,6 +869,68 @@ mod tests {
         ]))
         .unwrap();
         assert_eq!(out, "ONCE\n");
+    }
+
+    #[test]
+    fn perform_varying_counts_with_an_induction_variable() {
+        // VARYING I FROM 1 BY 1 UNTIL I GREATER 3 runs the body for I = 1, 2, 3.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM SHOW VARYING I FROM 1 BY 1 UNTIL I GREATER 3.",
+            "    DISPLAY \"DONE\".",
+            "    STOP RUN.",
+            "SHOW.",
+            "    DISPLAY I.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "1\n2\n3\nDONE\n");
+    }
+
+    #[test]
+    fn perform_varying_can_step_by_more_than_one() {
+        // FROM 0 BY 2 UNTIL I GREATER 6 → I = 0, 2, 4, 6.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM SHOW VARYING I FROM 0 BY 2 UNTIL I GREATER 6.",
+            "    STOP RUN.",
+            "SHOW.",
+            "    DISPLAY I.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "0\n2\n4\n6\n");
+    }
+
+    #[test]
+    fn perform_varying_tests_before_so_can_run_zero_times() {
+        // The condition is already true at the FROM value, so the body never runs.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  I  PIC 9 VALUE 0.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM SHOW VARYING I FROM 9 BY 1 UNTIL I GREATER 3.",
+            "    DISPLAY \"DONE\".",
+            "    STOP RUN.",
+            "SHOW.",
+            "    DISPLAY I.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "DONE\n");
     }
 
     #[test]

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -78,16 +78,34 @@ pub enum Stmt {
         expr: Expr,
         on_size_error: Vec<Stmt>,
     },
-    /// `PERFORM para [n TIMES | UNTIL cond]` — run a paragraph out of line, then
-    /// return. Bare: once. `n TIMES`: a fixed count. `UNTIL cond`: repeat while
-    /// the condition is false (tested before each iteration). `times` and `until`
-    /// are mutually exclusive; both `None` means once.
-    Perform { target: String, times: Option<Operand>, until: Option<Cond> },
+    /// `PERFORM para <mode>` — run a paragraph out of line, then return. The
+    /// [`PerformMode`] is the repeat form.
+    Perform { target: String, mode: PerformMode },
     /// `GO TO para` — transfer control unconditionally to a paragraph (no return).
     GoTo { target: String },
     /// `IF cond then… [ELSE else…]`.
     If { cond: Cond, then_branch: Vec<Stmt>, else_branch: Vec<Stmt> },
     StopRun,
+}
+
+/// How a [`Stmt::Perform`] repeats its paragraph.
+#[derive(Debug, Clone)]
+pub enum PerformMode {
+    /// Bare `PERFORM para` — run it once.
+    Once,
+    /// `PERFORM para n TIMES` — run it a fixed number of times.
+    Times(Operand),
+    /// `PERFORM para UNTIL cond` — run it while `cond` is false (test before).
+    Until(Cond),
+    /// `PERFORM para VARYING id FROM start BY step UNTIL cond` — set `id` to
+    /// `start`, then run while `cond` is false, stepping `id` by `step` after
+    /// each iteration (test before).
+    Varying {
+        var: String,
+        from: Operand,
+        by: Operand,
+        until: Cond,
+    },
 }
 
 /// An arithmetic expression tree (the operand of `COMPUTE`). Operator precedence
@@ -414,15 +432,18 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             {
                 return Err(RuntimeError::Unsupported("PERFORM … THRU (range form)".into()));
             }
-            let times = match child_node(verb, "operand") {
-                Some(op) => Some(read_operand(op)?),
-                None => None,
+            // The repeat mode: VARYING (its own node), else TIMES (a direct
+            // operand), else UNTIL (a direct condition), else bare/once.
+            let mode = if let Some(v) = child_node(verb, "perform_varying") {
+                read_perform_varying(v)?
+            } else if let Some(op) = child_node(verb, "operand") {
+                PerformMode::Times(read_operand(op)?)
+            } else if let Some(cond) = child_node(verb, "condition") {
+                PerformMode::Until(read_condition(cond)?)
+            } else {
+                PerformMode::Once
             };
-            let until = match child_node(verb, "condition") {
-                Some(cond) => Some(read_condition(cond)?),
-                None => None,
-            };
-            Ok(Stmt::Perform { target, times, until })
+            Ok(Stmt::Perform { target, mode })
         }
         "goto_stmt" => {
             // GO [TO] target. The DEPENDING ON form is not in the grammar yet.
@@ -623,6 +644,25 @@ fn read_binary_chain(
         }
     }
     expr.ok_or_else(|| RuntimeError::Unsupported("empty arithmetic expression".into()))
+}
+
+/// Read a `perform_varying` node
+/// (`VARYING NAME FROM operand BY operand UNTIL condition`).
+fn read_perform_varying(v: &GrammarASTNode) -> Result<PerformMode, RuntimeError> {
+    let var = first_token(v, "NAME")
+        .ok_or_else(|| RuntimeError::Unsupported("PERFORM VARYING without a variable".into()))?;
+    let operands = child_nodes(v, "operand");
+    if operands.len() != 2 {
+        return Err(RuntimeError::Unsupported(
+            "PERFORM VARYING needs FROM and BY operands".into(),
+        ));
+    }
+    let from = read_operand(operands[0])?;
+    let by = read_operand(operands[1])?;
+    let cond = child_node(v, "condition")
+        .ok_or_else(|| RuntimeError::Unsupported("PERFORM VARYING without an UNTIL".into()))?;
+    let until = read_condition(cond)?;
+    Ok(PerformMode::Varying { var, from, by, until })
 }
 
 /// All `operand` child nodes of a verb, read to typed [`Operand`]s.

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -146,13 +146,16 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
    `GO TO` loops run iteratively, no stack growth). A `GO TO` out of a performed
    paragraph transfers at the top level. `GO TO … DEPENDING ON` and `ALTER` are
    deferred.
-9. **v0.9 — `PERFORM … UNTIL`** (this PR): a conditional loop, testing the
+9. **v0.9 — `PERFORM … UNTIL`** (merged): a conditional loop, testing the
    condition **before** each iteration (`WITH TEST BEFORE`), driven iteratively.
-   `PERFORM … VARYING`/`… THRU`/`WITH TEST AFTER` and the inline form remain
-   deferred.
-10. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
-11. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
-    `VARYING`, inline, `TEST AFTER`), `GO TO … DEPENDING ON`, `ALTER`.
+10. **v0.10 — `PERFORM … VARYING`** (this PR): a counted loop over an induction
+    variable (`VARYING id FROM start BY step UNTIL cond`) — `id := start`, run
+    while `cond` is false, step `id` by `step` after each iteration. The repeat
+    forms are modelled as a `PerformMode` enum. `WITH TEST AFTER`, multiple
+    `AFTER` phrases, `PERFORM … THRU`, and the inline form remain deferred.
+11. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+12. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
+    inline, `TEST AFTER`), `GO TO … DEPENDING ON`, `ALTER`.
 8. **Conditions** — level-88 condition-names.
 9. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.
 8. **File I/O** — `SELECT`/`FD`, sequential then indexed/relative, `OPEN`/`READ`/


### PR DESCRIPTION
## Summary

Adds `PERFORM para VARYING id FROM start BY step UNTIL cond` — the counted loop
over an induction variable, completing the common `PERFORM` loop forms. A
frontend + runtime change, and it refactors the repeat forms into a clean
`PerformMode` enum.

### What it does
- **Grammar** (cobol-parser 0.4.0): `perform_stmt` gains a `perform_varying`
  clause (`VARYING NAME FROM operand BY operand UNTIL condition`) as a third
  alternative to `TIMES`/`UNTIL`. `VARYING`/`FROM`/`BY` were already reserved
  words, so the lexer is unchanged.
- **Runtime** (cobol-runtime 0.10.0): the `PERFORM` repeat forms are now a
  `PerformMode` enum (`Once` / `Times` / `Until` / `Varying`) instead of ad-hoc
  option fields. `VARYING` sets `id := start`, then runs the shared TEST-BEFORE
  loop, stepping `id` by `step` after each iteration (re-testing the condition
  against live state each pass).

### Safety
- Iterative like the other loops — a never-satisfied `VARYING` (`BY 0`, or a step
  that never reaches the bound) is an interruptible hang, never a stack overflow.
  A step overflow is a clean error. `perform_depth` is restored on every exit
  path; a self-performing `VARYING` still trips `MAX_PERFORM_DEPTH`. A body
  `STOP RUN`/`GO TO` stops the loop (before stepping) and propagates.

### Deferred
`WITH TEST AFTER`, multiple `AFTER` phrases, `PERFORM … THRU`, and the inline form.

## Tests
16 lexer + 16 parser (incl. a VARYING parse test) + 80 runtime tests (count
1→3, step-by-2, initially-true → zero runs; plus the unchanged TIMES/UNTIL/Once
tests confirming no refactor regression). Warning-free. Security review PASSED.
README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)