### PR TITLE
feat(wolfram-to-semantic-ir): Wolfram → Semantic IR frontend, first SIR23 target (HML01 Stream B, v0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -238,6 +238,7 @@ members = [
     "wolfram-parser",
     "wolfram-runtime",
     "wolfram-repl",
+    "wolfram-to-semantic-ir",
     "apl-lexer",
     "apl-parser",
     "logic-gates",

--- a/code/packages/rust/wolfram-to-semantic-ir/BUILD
+++ b/code/packages/rust/wolfram-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p wolfram-to-semantic-ir -- --nocapture

--- a/code/packages/rust/wolfram-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/wolfram-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p wolfram-to-semantic-ir -- --nocapture

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -198,6 +198,24 @@
   ever runs, and so was never masked by this bug). Fixed by converting both
   failure paths into a `WolframLowerError` instead of `.expect()`-ing.
 
+### Fixed (CI)
+
+- **`PARSE_STACK_SIZE` reduced from 512 MiB to 64 MiB.** The initial value
+  copied `wolfram-runtime`'s own `EVAL_STACK_SIZE` verbatim, but that crate
+  spawns its enlarged-stack thread rarely (a long-running REPL/eval
+  process), while `compile_source` may spawn one per call — many
+  concurrent test threads each reserving 512 MiB of address space at once
+  caused real CI resource pressure (the "Build and test affected packages"
+  job was externally terminated, exit code 143, while building this
+  crate). `wolfram-parser`'s own measured bare-stack crash floor (~276
+  frames on ~2 MiB, ~7.4 KiB/frame) means supporting its full default
+  `MAX_RULE_DEPTH` (2000 frames) with a comfortable ~4x margin needs only
+  ~64 MiB, a fraction of 512 MiB's reservation with the same safety
+  guarantee. Verified directly (not just reasoned about): a 90-level
+  legitimate `(...)` nesting — comfortably inside `wolfram-parser`'s own
+  measured ~98-level safe ceiling — still parses and lowers successfully
+  through `compile_source` at the reduced stack size.
+
 ### Known limitation (disclosed, not a bug)
 
 No module this crate produces currently executes end-to-end through any

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -156,6 +156,37 @@
   because `wolfram-parser`'s own O(n) packrat-memo lookup — tracked
   separately as a performance follow-up, not a correctness issue — makes
   parsing it alone take minutes.)
+- **HIGH — the round-3 fix's own rejection path recursively dropped the
+  tree it had just detected as too deep, found in round 4 (final) of
+  security review.** `measure_depth_iterative` correctly *detects* a
+  pathologically deep tree and returns `None`, but detecting the problem
+  doesn't dispose of it: the code then did `return Err(...)`, letting
+  `lhs`/`rhs`/`expr` fall out of scope normally — since `semantic_ir::Expr`
+  has no custom `Drop` impl, that invokes the compiler-derived *recursive*
+  drop glue on the very tree just found to be too deep, exactly the same
+  native-stack-overflow risk this whole fix history exists to eliminate,
+  just relocated from "walking the tree forward" (validator/backend/the
+  caller's own eventual `Drop` of an accepted `Module`) to "walking it
+  backward" (this crate's own `Drop` of the value it's about to reject).
+  This directly falsified `compile()`'s own documented safety claim ("safe
+  to call directly on an ordinary thread"). Confirmed empirically via an
+  isolated subprocess (not just reasoned about): calling `compile()`
+  directly on a bare default-stack thread with a rejected, composed
+  ~23,040-level-deep tree (90 levels of `(...)` wrapping around a 256-group
+  bracket chain — well within `wolfram-parser`'s own real-nesting ceiling)
+  produced a genuine `SIGABRT` stack overflow; the same construction at
+  9,000 and 4,500 levels survived, bracketing the actual crash floor for
+  ordinary recursive `Drop` somewhere in between. Fixed by adding
+  `drop_iterative`, which takes ownership of a rejected tree and tears it
+  down using an explicit heap-allocated work stack — moving each nested
+  `Expr` field out via the match instead of leaving it to be dropped
+  recursively as part of the outer value, the same technique a
+  hand-written `impl Drop for List` uses to avoid overflowing on a long
+  linked list, generalised from a list to a tree — called at both
+  rejection sites (`lower_rule`, `lower_file`) before returning the error.
+  Verified adversarially: re-ran the exact isolated-subprocess repro that
+  crashed at ~23,040 levels with the fix in place and confirmed it now
+  survives cleanly.
 - **MEDIUM — `compile_source`'s panic handling defeated its own "fails
   cleanly" hardening guarantee.** `compile_source` is documented as the
   hardened entry point specifically so pathological input fails with a

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -44,11 +44,12 @@
   native stack overflow without the guard, then restored it and confirmed
   the same test passes cleanly. Mirrors `matlab-to-semantic-ir`'s own
   post-hoc discovery of this exact bug class, applied here proactively.
-- 59 tests: 49 unit tests over exact `Expr` shapes for every grammar
+- 61 tests: 51 unit tests over exact `Expr` shapes for every grammar
   production plus DoS-guard regressions (a 60,000-term flat chain, a
-  60,000-deep chained bracket/part/pure-function-apply/`&`-run, deeply
-  nested parens, and exact-boundary pairs at `MAX_EXPR_DEPTH`/
-  `MAX_EXPR_DEPTH + 1`), 9 validator/capability-rejection tests, 1 doctest.
+  60,000-deep chained bracket/part/pure-function-apply/`&`-run, a
+  256×256-multiplicative bracket/index combination, deeply nested parens,
+  and exact-boundary pairs), 9 validator/capability-rejection tests, 1
+  doctest.
 - Marks `wolfram-to-semantic-ir` done in `HML01-math-to-semantic-ir.md`'s
   Stream B rollout.
 
@@ -79,6 +80,27 @@
   the two new checks, reproduced the same `SIGABRT` on the exact same input
   that had crashed pre-fix, then restored them and confirmed the dedicated
   regression tests pass.
+- **HIGH — the fix above's own two new guards were independently
+  bypassable, found in round 2 of security review.** `check_postfix_chain_length`
+  capped the number of bracket/part *groups* to `MAX_EXPR_DEPTH`;
+  `check_apply_arg_count` separately capped the number of indices/args
+  *within* one group to `MAX_EXPR_DEPTH`. Those two axes multiply, not add —
+  an `LDBRACKET` group folds one `Part` per index, so N chained groups each
+  carrying M indices builds N×M levels of real nesting. Both per-axis caps
+  individually passing (N ≤ 256 and M ≤ 256) still permitted up to
+  256×256 = 65,536 levels, confirmed via security review to reproduce the
+  same `SIGABRT` stack overflow at that scale. Fixed by replacing both
+  per-production guards (`check_postfix_chain_length`/
+  `check_amp_chain_length`) with a single cumulative `add_chain_depth`
+  budget threaded through the whole `postfix`/`amp`/`amp_apply` chain,
+  charging each group's own contribution (`args.len()`/`indices.len()`,
+  floored at 1 — a safe conservative upper bound, since a plain
+  non-associative call only adds one real level regardless of its
+  argument count) against a single running total capped at
+  `MAX_EXPR_DEPTH` for the *entire* chain, not per group. Verified
+  adversarially: reproduced the 256×256 crash with the new guard disabled,
+  then confirmed the fix rejects it cleanly and the dedicated regression
+  test passes.
 - **MEDIUM — `compile_source`'s panic handling defeated its own "fails
   cleanly" hardening guarantee.** `compile_source` is documented as the
   hardened entry point specifically so pathological input fails with a

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -45,12 +45,12 @@
   the same test passes cleanly. Mirrors `matlab-to-semantic-ir`'s own
   post-hoc discovery of this exact bug class, applied here proactively.
 - 62 tests: 52 unit tests over exact `Expr` shapes for every grammar
-  production plus DoS-guard regressions (a 60,000-term flat chain, a
-  60,000-deep chained bracket/part/pure-function-apply/`&`-run, a
-  256×256-multiplicative bracket/index combination, a chain composed
-  across nested `(...)` boundaries, deeply nested parens, and
-  exact-boundary pairs), 9 validator/capability-rejection tests, 1
-  doctest.
+  production plus DoS-guard regressions (flat-chain, chained
+  bracket/part/pure-function-apply/`&`-run, multiplicative bracket/index
+  combination, cross-`(...)`-boundary composition, deeply nested parens,
+  and exact-boundary cases — see the "Fixed (CI)" entry below for why
+  these run at a smaller scale than the incidents that originally
+  motivated them), 9 validator/capability-rejection tests, 1 doctest.
 - Marks `wolfram-to-semantic-ir` done in `HML01-math-to-semantic-ir.md`'s
   Stream B rollout.
 
@@ -215,6 +215,31 @@
   legitimate `(...)` nesting — comfortably inside `wolfram-parser`'s own
   measured ~98-level safe ceiling — still parses and lowers successfully
   through `compile_source` at the reduced stack size.
+
+- **Real root cause of the CI exit-143 failures: several DoS-regression
+  tests were slow to *parse*, not just slow to lower.** The stack-size
+  reduction above was a reasonable, low-risk change but did not fix the
+  failure — a fresh CI run at that commit failed identically (same exit
+  code, same package, near-identical elapsed time on it). Confirmed by
+  simulating a resource-constrained runner locally (`cargo test --
+  --test-threads=2`): the whole suite took 47.85s (vs ~25s at full local
+  parallelism), and four individual tests each took 15-16 seconds alone —
+  the ones building a 60,000-element chained bracket/part/pure-function-
+  apply construct, and the multiplicative 256×256 combination test.
+  `wolfram-parser` must fully tokenize and parse a flat chain of that size
+  *before* this crate's own lowering guards ever get a chance to reject
+  it, and that parser's own packrat-memo lookup is a known, separately
+  tracked O(n) performance concern (not a correctness issue) that scales
+  badly at this size. Fixed by reducing these tests' scale (60,000 → 3,000
+  for flat/chained constructs; 256×256 → 30×30 for the multiplicative
+  combination) — comfortably past `MAX_EXPR_DEPTH` (256) still proves the
+  guard rejects the input equally well, at a fraction of the parse cost;
+  confirmed the reduced suite now completes in ~4s under the same
+  `--test-threads=2` simulation. The original larger scales remain
+  confirmed (via throwaway, not-checked-in adversarial repros during
+  security review, per the entries above) to reproduce real crashes with
+  each guard disabled — only the *permanent, always-run* regression tests
+  were rescaled, not the adversarial-verification methodology itself.
 
 ### Known limitation (disclosed, not a bug)
 

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -44,13 +44,51 @@
   native stack overflow without the guard, then restored it and confirmed
   the same test passes cleanly. Mirrors `matlab-to-semantic-ir`'s own
   post-hoc discovery of this exact bug class, applied here proactively.
-- 55 tests: 44 unit tests over exact `Expr` shapes for every grammar
-  production plus DoS-guard regressions (a 60,000-term flat chain, deeply
-  nested parens, and an exact-boundary pair at `MAX_EXPR_DEPTH`/
-  `MAX_EXPR_DEPTH + 1` operands), 9 validator/capability-rejection tests,
-  1 doctest.
+- 59 tests: 49 unit tests over exact `Expr` shapes for every grammar
+  production plus DoS-guard regressions (a 60,000-term flat chain, a
+  60,000-deep chained bracket/part/pure-function-apply/`&`-run, deeply
+  nested parens, and exact-boundary pairs at `MAX_EXPR_DEPTH`/
+  `MAX_EXPR_DEPTH + 1`), 9 validator/capability-rejection tests, 1 doctest.
 - Marks `wolfram-to-semantic-ir` done in `HML01-math-to-semantic-ir.md`'s
   Stream B rollout.
+
+### Fixed (security review, before first push)
+
+- **HIGH — DoS: chained postfix application/part/pure-function-apply
+  groups bypassed the chain-length guard entirely.** The initial
+  `check_chain_length` audit covered every flat operator-chain production
+  the module doc comment enumerates (`additive`/`multiplicative`/
+  `logical_or`/`logical_and`/`alternatives`/`mapapply`/`patterntest`/
+  `replaceall`) but missed that `postfix` (`f[…][…][…]…`, `x[[…]][[…]]…`)
+  and `amp`'s `&`-run/trailing-application suffixes (`expr & & &…`,
+  `f&[…][…]…`) have the *identical* flat-repetition grammar shape — a long
+  chain collapses into one CST node with many bracket-group/`&` children
+  rather than nesting through parens, so it never recurses through the
+  depth-capped `lower_node` at all. `lower_postfix`'s `while` loop and
+  `lower_amp`'s wrapping loops iteratively rebuild `result` as the head (or
+  `Part` target, or `Function` wrapper) of a brand-new node every
+  iteration, producing an unboundedly deep tree with **no check ever
+  firing** — confirmed via security review to crash (`SIGABRT`, real stack
+  overflow) on a symbol followed by 60,000 chained `[0]` groups. Fixed by
+  adding two new guards mirroring `check_chain_length`'s shape but counting
+  tokens/child-node-kinds specific to each production
+  (`check_postfix_chain_length` counts `LBRACKET`/`LDBRACKET` tokens;
+  `check_amp_chain_length` counts both the `&`-run length and the trailing
+  `amp_apply` suffix count), called before their respective loops run.
+  Verified adversarially the same way the flat-chain guards were: disabled
+  the two new checks, reproduced the same `SIGABRT` on the exact same input
+  that had crashed pre-fix, then restored them and confirmed the dedicated
+  regression tests pass.
+- **MEDIUM — `compile_source`'s panic handling defeated its own "fails
+  cleanly" hardening guarantee.** `compile_source` is documented as the
+  hardened entry point specifically so pathological input fails with a
+  `Result::Err` instead of crashing the caller. But `.spawn(...).expect(...)`
+  panicked the calling thread on OS thread-creation failure, and
+  `.join().expect(...)` re-panicked the calling thread on *any* worker
+  panic — silently defeating the guarantee for every failure mode short of
+  an actual stack overflow (which aborts the whole process before `.join()`
+  ever runs, and so was never masked by this bug). Fixed by converting both
+  failure paths into a `WolframLowerError` instead of `.expect()`-ing.
 
 ### Known limitation (disclosed, not a bug)
 

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -44,11 +44,12 @@
   native stack overflow without the guard, then restored it and confirmed
   the same test passes cleanly. Mirrors `matlab-to-semantic-ir`'s own
   post-hoc discovery of this exact bug class, applied here proactively.
-- 61 tests: 51 unit tests over exact `Expr` shapes for every grammar
+- 62 tests: 52 unit tests over exact `Expr` shapes for every grammar
   production plus DoS-guard regressions (a 60,000-term flat chain, a
   60,000-deep chained bracket/part/pure-function-apply/`&`-run, a
-  256×256-multiplicative bracket/index combination, deeply nested parens,
-  and exact-boundary pairs), 9 validator/capability-rejection tests, 1
+  256×256-multiplicative bracket/index combination, a chain composed
+  across nested `(...)` boundaries, deeply nested parens, and
+  exact-boundary pairs), 9 validator/capability-rejection tests, 1
   doctest.
 - Marks `wolfram-to-semantic-ir` done in `HML01-math-to-semantic-ir.md`'s
   Stream B rollout.
@@ -101,6 +102,60 @@
   adversarially: reproduced the 256×256 crash with the new guard disabled,
   then confirmed the fix rejects it cleanly and the dedicated regression
   test passes.
+- **HIGH — the round-2 fix's cumulative budget was scoped per grammar
+  node, not globally, found in round 3 (final) of security review.**
+  `add_chain_depth`'s running total correctly bounds nesting *within one*
+  `postfix`/`amp` node, but resets fresh (`= 0`) on every call — it has no
+  awareness that the node's own *base* (the "atom" the chain applies to)
+  might already be an arbitrarily deep tree, built either by ordinary
+  legitimate `(...)` nesting or by a *different* instance of the same
+  chain-fold pattern one level up. Wrapping an already-at-cap chain in
+  parentheses and appending another full chain — repeated across as many
+  `(...)` boundaries as `wolfram-parser`'s own real-nesting limit allows
+  (see that crate's `MAX_RULE_DEPTH` doc comment — around 98 levels on
+  `compile_source`'s enlarged-stack thread) — composes each individually
+  in-bounds chain multiplicatively, reaching tens of thousands of true
+  nesting levels overall; confirmed via security review that this
+  structurally bypasses every existing per-node guard (`add_chain_depth`,
+  `check_chain_length`, and the ordinary CST-recursion `depth` parameter,
+  which only costs ~2 units per `(...)` wrap — nowhere near enough to
+  itself trip `MAX_EXPR_DEPTH`). The same composition gap applies in
+  principle to every other flat-chain production (`additive`/
+  `multiplicative`/`logical_or`/`logical_and`/`alternatives`/`mapapply`/
+  `patterntest`/`replaceall`), not just `postfix`/`amp` — none of them
+  account for their base operand's pre-existing depth either. Fixed with a
+  different, more fundamental mechanism rather than another per-construct
+  patch: constructing a deeply-nested `Box`-based tree costs only heap,
+  not stack (each construction step is O(1) regardless of how the tree
+  eventually gets used), so the risk is entirely in *walking* it
+  recursively afterward — not in building it. Added
+  `measure_depth_iterative`, an authoritative depth check that walks an
+  already-built `Expr` using an explicit heap-allocated work stack (never
+  native recursion, so it can never itself crash regardless of how deep
+  the input already is, and bails out the moment depth is certain to
+  exceed the cap rather than doing unbounded work). Called on `lhs`/`rhs`
+  in `lower_rule` before either is handed to `collect_pattern_names`/
+  `bind_pattern_refs` (the two functions in this crate that already
+  recursed without their own cap, on the — now corrected — assumption that
+  `MAX_EXPR_DEPTH` alone already bounded their input), and once per
+  top-level statement in `lower_file` before it can reach the returned
+  `Module` (protecting `semantic_ir::validate`, any backend, and — since
+  `semantic_ir::Expr` has no custom `Drop` impl — the unconditional,
+  unguarded recursive `Drop` glue that runs whenever a caller lets a
+  `Module` go out of scope). This closes the gap regardless of how the
+  oversized tree was composed, rather than requiring a bespoke guard for
+  every new way constructs might chain together. Verified adversarially:
+  temporarily disabled both new call sites, confirmed a composed chain
+  that individually stays under every per-node cap (20 levels of
+  `(...)`-wrapping around a 20-group bracket chain, 400 true nesting
+  levels) is wrongly *accepted* — proving the structural bypass — then
+  restored the fix and confirmed it is correctly rejected. (A larger,
+  ~97-level/256-groups-per-level construction, matching the crate's other
+  60,000-scale regressions, was also confirmed to be correctly rejected
+  with the fix in place; it was not kept as a checked-in regression test
+  because `wolfram-parser`'s own O(n) packrat-memo lookup — tracked
+  separately as a performance follow-up, not a correctness issue — makes
+  parsing it alone take minutes.)
 - **MEDIUM — `compile_source`'s panic handling defeated its own "fails
   cleanly" hardening guarantee.** `compile_source` is documented as the
   hardened entry point specifically so pathological input fails with a

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+## [0.1.0] - 2026-07-11
+
+### Added
+
+- Initial `wolfram-to-semantic-ir` frontend crate (HML01 Stream B), the
+  first to target SIR23 (symbolic-expression/pattern domain):
+  `compile`/`compile_source` lowering `coding-adventures-wolfram-parser`'s
+  `GrammarASTNode` CST into a `semantic_ir::Module`.
+- Design decision ("everything is data", see `src/lower.rs`'s module doc
+  comment): every Wolfram construct — arithmetic, comparisons, lists,
+  function application, `=`/`:=` assignment — lowers to the SIR23 symbolic
+  vocabulary (`SymSymbol`/`SymApply`/pattern/rule nodes), never to a
+  host-language variable/binding. No environment, no evaluation happens at
+  lowering time; that is deliberately left to a future backend runtime
+  library (`sir-runtime-symbolic`, not yet built).
+- Because every construct reduces to the same small vocabulary, this crate
+  covers the full grammar surface `wolfram-parser` accepts: literals,
+  arithmetic (`+ - * / ^`, unary, and explicit `Plus[…]`/`Times[…]`/…
+  head-application forms with the same associative n-ary left-fold the
+  native `wolfram-runtime` uses), comparisons, logic, lists, arbitrary
+  function application (including a computed head, `f[x][y]`), `Set`/
+  `SetDelayed`, pattern blanks (`_`/`_h`) and named patterns (`x_`/`x_h`),
+  rules (`->`/`:>`) with the same pattern-name-to-reference RHS rewriting
+  the native lowering performs, replacement (`/.`/`//.`) with rule-list
+  flattening, and the W-6 (`/@`/`@@`/`[[ ]]`), W-11 (`#`/`#n`/`##`/`&`/
+  `Function`), and W-21 (`|`/`/;`/`?`) operator sugar.
+- Recursion-depth hardening applied from day one, not retrofitted: every
+  flat operator-chain fold (`additive`/`multiplicative`/`logical_or`/
+  `logical_and`/`alternatives`/`mapapply`/`patterntest`/`replaceall`) is
+  capped at `MAX_EXPR_DEPTH` (256) operands before any tree is built
+  (`check_chain_length`), and every `f[…]`/`{…}`/`[[…]]` argument list is
+  capped at the same bound (`check_apply_arg_count`) as a modest
+  allocation-size backstop. `compile_source` parses on an enlarged-stack
+  (512 MiB) worker thread, reusing `wolfram-runtime`'s own validated-safe
+  `EVAL_STACK_SIZE` deployment rather than inventing an unproven new
+  configuration — see `wolfram-parser`'s own `MAX_RULE_DEPTH` doc comment
+  for why no single cap can be both bare-stack-safe and support realistic
+  nesting for this grammar.
+- Verified the chain-length guard adversarially before shipping (not just
+  asserted as correct): temporarily removed `check_chain_length`'s calls
+  and re-ran the 60,000-term regression test, confirming a real `SIGABRT`
+  native stack overflow without the guard, then restored it and confirmed
+  the same test passes cleanly. Mirrors `matlab-to-semantic-ir`'s own
+  post-hoc discovery of this exact bug class, applied here proactively.
+- 55 tests: 44 unit tests over exact `Expr` shapes for every grammar
+  production plus DoS-guard regressions (a 60,000-term flat chain, deeply
+  nested parens, and an exact-boundary pair at `MAX_EXPR_DEPTH`/
+  `MAX_EXPR_DEPTH + 1` operands), 9 validator/capability-rejection tests,
+  1 doctest.
+- Marks `wolfram-to-semantic-ir` done in `HML01-math-to-semantic-ir.md`'s
+  Stream B rollout.
+
+### Known limitation (disclosed, not a bug)
+
+No module this crate produces currently executes end-to-end through any
+backend: under the "everything is data" design, even bare literal
+arithmetic emits at least one SIR23 node, and `semantic-ir-to-javascript`
+does not implement SIR23 codegen yet (it depends on `sir-runtime-symbolic`,
+a separate, not-yet-shipped runtime library — HML01 Stream B rollout item
+6). This crate's tests therefore verify structural correctness and the
+capability-rejection path only; there is no e2e `node`-execution test,
+unlike `matlab-to-semantic-ir`'s purely-literal case.

--- a/code/packages/rust/wolfram-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/wolfram-to-semantic-ir/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "wolfram-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Wolfram CST → narrow-waist Semantic IR (SIR23 symbolic/pattern domain, Stream B). Fifth frontend for the SIR10 narrow-waist IR, first to target SIR23."
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-wolfram-parser = { path = "../wolfram-parser" }
+# The reusable canonical head-name constants (`ADD`/`SUB`/`MUL`/…) so the
+# surface→canonical bridging table stays typo-proof and in lockstep with
+# the native `wolfram-runtime`'s own identical table.
+symbolic-ir = { path = "../symbolic-ir" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode`
+# whose leaf tokens are `lexer::token::Token`; we walk both directly.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# Used only by the capability-rejection tests: every module this frontend
+# produces uses SIR23 nodes, and this backend does not implement SIR23
+# codegen yet, so these tests confirm the *gate* rejects every module (see
+# tests/test_validator.rs's module doc comment — there is no e2e
+# `node`-execution test in this crate, unlike `matlab-to-semantic-ir`).
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/wolfram-to-semantic-ir/README.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/README.md
@@ -62,17 +62,20 @@ token).
 
 ### Recursion-depth hardening
 
-Applied from day one, not retrofitted after a security-review finding
-(unlike `matlab-to-semantic-ir`'s own history): every flat, same-precedence
-operator chain (`+`, `*`, `&&`, `||`, `|`, `/@`/`@@`, `/.`/`//.`, `?`) is
-capped at `MAX_EXPR_DEPTH` operands *before* any tree is built, because the
-Wolfram grammar — like MATLAB's — collapses a long unparenthesized chain
-into one CST node with many children rather than nesting through parens, so
-it never trips the ordinary grammar-nesting depth guard. Verified
-adversarially during development (not just asserted): temporarily removing
-the guard and re-running the 60,000-term regression test reproduces a real
-`SIGABRT` native stack overflow, confirming the guard is load-bearing, not
-decorative.
+Every flat, same-precedence operator chain (`+`, `*`, `&&`, `||`, `|`,
+`/@`/`@@`, `/.`/`//.`, `?`) — and, after a security-review finding fixed
+before first push, every chained postfix application/part group
+(`f[…][…]…`) and `&`-run/pure-function-apply suffix run — is capped at
+`MAX_EXPR_DEPTH` operands *before* any tree is built, because the Wolfram
+grammar — like MATLAB's — collapses a long unparenthesized chain into one
+CST node with many children rather than nesting through parens, so it
+never trips the ordinary grammar-nesting depth guard. The first eight
+productions were covered from day one; the postfix/amp chains were an
+initial gap the security review caught (see `CHANGELOG.md`'s "Fixed"
+entry) — both classes are now verified adversarially: temporarily removing
+each guard and re-running its 60,000-term regression test reproduces a
+real `SIGABRT` native stack overflow, confirming the guards are
+load-bearing, not decorative.
 
 `compile_source` additionally parses on an enlarged-stack worker thread
 (see "Usage" above), reusing `wolfram-runtime`'s own validated-safe
@@ -86,8 +89,10 @@ nesting for this particular grammar.
 - `tests/test_lower.rs` — unit tests asserting exact `Expr` shapes for
   every grammar production, plus DoS-guard regression tests at the same
   60,000-term scale `matlab-to-semantic-ir`'s own security review
-  established, and an exact-boundary test (`MAX_EXPR_DEPTH` operands parse,
-  one more is rejected).
+  established (covering both the flat operator chains and the
+  postfix/amp chained-application gap the review found here), and
+  exact-boundary tests (`MAX_EXPR_DEPTH` operands/groups parse, one more is
+  rejected).
 - `tests/test_validator.rs` — every lowered module passes
   `semantic_ir::validate` (manifest declares exactly the SIR23 features
   used) and is correctly *rejected* by `semantic-ir-to-javascript`'s

--- a/code/packages/rust/wolfram-to-semantic-ir/README.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/README.md
@@ -111,12 +111,17 @@ nesting for this particular grammar.
 ### Testing
 
 - `tests/test_lower.rs` — unit tests asserting exact `Expr` shapes for
-  every grammar production, plus DoS-guard regression tests at the same
-  60,000-term scale `matlab-to-semantic-ir`'s own security review
-  established (covering both the flat operator chains and the
-  postfix/amp chained-application gap the review found here), and
+  every grammar production, plus DoS-guard regression tests proving each
+  guard rejects a chain comfortably past `MAX_EXPR_DEPTH` (covering the
+  flat operator chains, the postfix/amp chained-application gap, and the
+  cross-`(...)`-boundary composition gap the review found), and
   exact-boundary tests (`MAX_EXPR_DEPTH` operands/groups parse, one more is
-  rejected).
+  rejected). These run at a scale well past the cap but much smaller than
+  the incidents that originally motivated them, since `wolfram-parser`
+  must parse the input before this crate's guards ever run, and parsing
+  a very large flat chain is itself slow — see `CHANGELOG.md`'s "Fixed
+  (CI)" entries for the full story (this was the real cause of an early
+  CI failure, not a stack-size issue).
 - `tests/test_validator.rs` — every lowered module passes
   `semantic_ir::validate` (manifest declares exactly the SIR23 features
   used) and is correctly *rejected* by `semantic-ir-to-javascript`'s

--- a/code/packages/rust/wolfram-to-semantic-ir/README.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/README.md
@@ -82,12 +82,24 @@ not stack; only *walking* it recursively is dangerous. It runs before this
 crate's own unguarded recursive helpers (`collect_pattern_names`/
 `bind_pattern_refs`) touch a tree, and once per top-level statement before
 anything reaches the returned `Module`, closing the gap regardless of how
-the tree was composed. See `CHANGELOG.md`'s "Fixed" entries for the full
-three-round history — every class of guard here (per-construct caps and
-the final authoritative check) was verified adversarially by temporarily
-disabling it and confirming a real `SIGABRT` native stack overflow (or, for
-the composition gap, a silent wrongful *acceptance* of oversized input)
-reproduces, then restoring it and confirming the regression test passes.
+the tree was composed.
+
+Detecting an oversized tree isn't the same as safely disposing of it,
+either — a fourth review round found that simply letting a rejected tree
+fall out of scope invoked `Expr`'s ordinary *recursive* `Drop` glue on the
+very tree just found to be too deep, relocating the same crash from
+"walking forward" to "walking backward" through it. [`drop_iterative`](src/lower.rs)
+tears a rejected tree down the same way `measure_depth_iterative` measures
+it — an explicit work stack, no native recursion — before either rejection
+site returns its error.
+
+See `CHANGELOG.md`'s "Fixed" entries for the full four-round history —
+every guard here (per-construct caps, the authoritative depth check, and
+the teardown fix) was verified adversarially: temporarily disabling it and
+confirming a real `SIGABRT` native stack overflow (or, for the composition
+gap, a silent wrongful *acceptance* of oversized input) reproduces, then
+restoring it and confirming the regression test — or, for the `Drop` fix,
+an isolated-subprocess repro — passes cleanly.
 
 `compile_source` additionally parses on an enlarged-stack worker thread
 (see "Usage" above), reusing `wolfram-runtime`'s own validated-safe

--- a/code/packages/rust/wolfram-to-semantic-ir/README.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/README.md
@@ -1,0 +1,101 @@
+# wolfram-to-semantic-ir
+
+Wolfram CST → narrow-waist Semantic IR. The first frontend to target
+[SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+symbolic-expression/pattern-matching domain extension of the SIR10
+narrow-waist IR (Stream B of
+[HML01](../../../specs/HML01-math-to-semantic-ir.md)).
+
+## Where this fits
+
+```
+Wolfram source
+   │
+   ▼  coding_adventures_wolfram_parser::try_parse_wolfram(src)
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  wolfram_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR23)
+```
+
+## Usage
+
+```rust
+use wolfram_to_semantic_ir::compile_source;
+
+let module = compile_source("1 + 2\n", "demo")?;
+```
+
+`compile_source` is the hardened entry point: it parses and lowers on a
+worker thread with an enlarged stack, so pathologically deep (but
+syntactically valid) input fails cleanly instead of overflowing the native
+stack — see `src/lib.rs`'s `PARSE_STACK_SIZE` doc comment for why. `compile`
+(taking an already-parsed `GrammarASTNode`) is pure lowering with no
+thread-spawning of its own, mirroring `matlab-to-semantic-ir::compile`'s
+identical division of responsibility.
+
+## Design: "everything is data"
+
+Wolfram's defining idea (MA04 §1) is that *every* fragment is one expression
+tree `head[arg, …]`, manipulable as data even before being evaluated. This
+frontend lowers **every** construct — arithmetic, comparisons, lists,
+function application, even `=`/`:=` assignment — into the SIR23 symbolic
+vocabulary (`SymSymbol`/`SymApply`/pattern/rule nodes), never into a
+host-language `Expr::VarRef`/`Stmt::Assign`. There is no environment, no
+binding, no evaluation at lowering time — see `src/lower.rs`'s module doc
+comment for the full reasoning and why this is the only choice that lets an
+*uncomputed* Wolfram function body (`f[x_] := x + 1`) compile at all.
+
+## Scope (v0.1.0)
+
+Because everything reduces to the same small SIR23 vocabulary, this crate
+covers the **full** grammar `wolfram-parser` accepts (arithmetic,
+comparisons, logic, lists, application, patterns, rules, replacement, the
+W-6/W-11/W-21 operator sugar) — unlike `matlab-to-semantic-ir`, there is no
+scalar/array-style ambiguity here forcing a narrower cut. See
+`src/lower.rs`'s module doc comment for the exact node-by-node mapping and
+the small, disclosed set of things left out (sequence patterns and other
+constructs still open even in the native `wolfram-runtime`'s own W-20
+deferred list; `SymRational`, part of the SIR23 vocabulary but unreachable
+from this grammar's surface syntax since there is no rational literal
+token).
+
+### Recursion-depth hardening
+
+Applied from day one, not retrofitted after a security-review finding
+(unlike `matlab-to-semantic-ir`'s own history): every flat, same-precedence
+operator chain (`+`, `*`, `&&`, `||`, `|`, `/@`/`@@`, `/.`/`//.`, `?`) is
+capped at `MAX_EXPR_DEPTH` operands *before* any tree is built, because the
+Wolfram grammar — like MATLAB's — collapses a long unparenthesized chain
+into one CST node with many children rather than nesting through parens, so
+it never trips the ordinary grammar-nesting depth guard. Verified
+adversarially during development (not just asserted): temporarily removing
+the guard and re-running the 60,000-term regression test reproduces a real
+`SIGABRT` native stack overflow, confirming the guard is load-bearing, not
+decorative.
+
+`compile_source` additionally parses on an enlarged-stack worker thread
+(see "Usage" above), reusing `wolfram-runtime`'s own validated-safe
+deployment pattern rather than inventing a new one — see that function's
+doc comment and `wolfram-parser`'s own `MAX_RULE_DEPTH` doc comment for why
+no single depth cap can be both bare-stack-safe and support realistic
+nesting for this particular grammar.
+
+### Testing
+
+- `tests/test_lower.rs` — unit tests asserting exact `Expr` shapes for
+  every grammar production, plus DoS-guard regression tests at the same
+  60,000-term scale `matlab-to-semantic-ir`'s own security review
+  established, and an exact-boundary test (`MAX_EXPR_DEPTH` operands parse,
+  one more is rejected).
+- `tests/test_validator.rs` — every lowered module passes
+  `semantic_ir::validate` (manifest declares exactly the SIR23 features
+  used) and is correctly *rejected* by `semantic-ir-to-javascript`'s
+  capability check.
+
+There is **no** e2e `node`-execution test in this crate, unlike
+`matlab-to-semantic-ir`'s purely-literal case: under the "everything is
+data" design, even bare literal arithmetic (`1 + 2`) emits at least one
+SIR23 node, and no backend implements SIR23 codegen yet
+(`sir-runtime-symbolic`, the JS/TS runtime library it would depend on, is
+separate, not-yet-shipped follow-on work — HML01 Stream B rollout item 6).

--- a/code/packages/rust/wolfram-to-semantic-ir/README.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/README.md
@@ -63,19 +63,31 @@ token).
 ### Recursion-depth hardening
 
 Every flat, same-precedence operator chain (`+`, `*`, `&&`, `||`, `|`,
-`/@`/`@@`, `/.`/`//.`, `?`) — and, after a security-review finding fixed
-before first push, every chained postfix application/part group
-(`f[…][…]…`) and `&`-run/pure-function-apply suffix run — is capped at
-`MAX_EXPR_DEPTH` operands *before* any tree is built, because the Wolfram
-grammar — like MATLAB's — collapses a long unparenthesized chain into one
-CST node with many children rather than nesting through parens, so it
-never trips the ordinary grammar-nesting depth guard. The first eight
-productions were covered from day one; the postfix/amp chains were an
-initial gap the security review caught (see `CHANGELOG.md`'s "Fixed"
-entry) — both classes are now verified adversarially: temporarily removing
-each guard and re-running its 60,000-term regression test reproduces a
-real `SIGABRT` native stack overflow, confirming the guards are
-load-bearing, not decorative.
+`/@`/`@@`, `/.`/`//.`, `?`, and — after a security-review finding — chained
+postfix application/part groups and `&`-run/pure-function-apply suffixes)
+is capped at `MAX_EXPR_DEPTH` operands before any tree is built, because
+the Wolfram grammar — like MATLAB's — collapses a long unparenthesized
+chain into one CST node with many children rather than nesting through
+parens, so it never trips the ordinary grammar-nesting depth guard.
+
+That per-construct capping is necessary but, on its own, not sufficient: a
+second security-review finding showed that per-node-scoped guards don't
+compose across nested `(...)` boundaries — chaining several
+independently-in-bounds constructs through parentheses can still build a
+tree far deeper than any single guard's own limit. The authoritative fix
+is [`measure_depth_iterative`](src/lower.rs) — an iterative (never
+recursive) post-construction depth check, safe to call on a tree of any
+size because building a deeply-nested `Box`-based tree only costs heap,
+not stack; only *walking* it recursively is dangerous. It runs before this
+crate's own unguarded recursive helpers (`collect_pattern_names`/
+`bind_pattern_refs`) touch a tree, and once per top-level statement before
+anything reaches the returned `Module`, closing the gap regardless of how
+the tree was composed. See `CHANGELOG.md`'s "Fixed" entries for the full
+three-round history — every class of guard here (per-construct caps and
+the final authoritative check) was verified adversarially by temporarily
+disabling it and confirming a real `SIGABRT` native stack overflow (or, for
+the composition gap, a silent wrongful *acceptance* of oversized input)
+reproduces, then restoring it and confirming the regression test passes.
 
 `compile_source` additionally parses on an enlarged-stack worker thread
 (see "Usage" above), reusing `wolfram-runtime`'s own validated-safe

--- a/code/packages/rust/wolfram-to-semantic-ir/required_capabilities.json
+++ b/code/packages/rust/wolfram-to-semantic-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/wolfram-to-semantic-ir",
+  "capabilities": [],
+  "justification": "Pure computation over an in-memory GrammarASTNode and semantic_ir::Module. No filesystem, network, process, DOM, or environment access needed beyond spawning a worker thread for stack-size control."
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lib.rs
@@ -68,19 +68,57 @@ const PARSE_STACK_SIZE: usize = 512 * 1024 * 1024;
 /// [`WolframLowerError`] instead of a native, uncatchable stack overflow on
 /// an ordinary caller thread. Prefer this over `compile` for any input that
 /// was not already parsed under an equivalent guard.
+///
+/// Both thread-spawn failure (OS resource exhaustion, e.g. hitting a
+/// per-process thread-count or address-space limit under many concurrent
+/// calls) and a worker-thread panic (from anywhere in the parse/lower
+/// pipeline, not just a stack overflow — which is unrecoverable regardless
+/// and aborts the whole process before `join` ever runs) are converted into
+/// a [`WolframLowerError`] rather than propagated as a panic on the calling
+/// thread — a bare `.expect()` on either would otherwise silently defeat
+/// this function's own "fails cleanly" guarantee, caught during security
+/// review.
 pub fn compile_source(
     source: &str,
     module_name: &str,
 ) -> Result<semantic_ir::Module, WolframLowerError> {
     let source = source.to_string();
     let module_name = module_name.to_string();
-    std::thread::Builder::new()
+    let handle = std::thread::Builder::new()
         .name("wolfram-to-semantic-ir-compile".to_string())
         .stack_size(PARSE_STACK_SIZE)
         .spawn(move || compile_on_this_thread(&source, &module_name))
-        .expect("failed to spawn wolfram-to-semantic-ir compile worker thread")
-        .join()
-        .expect("wolfram-to-semantic-ir compile worker thread panicked")
+        .map_err(|e| WolframLowerError {
+            message: format!("failed to spawn wolfram-to-semantic-ir compile worker thread: {e}"),
+            line: 1,
+            column: 1,
+        })?;
+    match handle.join() {
+        Ok(result) => result,
+        Err(panic_payload) => Err(WolframLowerError {
+            message: format!(
+                "wolfram-to-semantic-ir compile worker thread panicked: {}",
+                panic_message(&panic_payload)
+            ),
+            line: 1,
+            column: 1,
+        }),
+    }
+}
+
+/// Extract a human-readable message from a `std::thread::Result::Err`
+/// panic payload, which is `Box<dyn Any + Send>` and in practice almost
+/// always a `&'static str` (a string-literal panic) or a `String` (a
+/// formatted panic, e.g. via `panic!("{}", ...)`) — falls back to a fixed
+/// placeholder for the rare payload that is neither.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
 }
 
 fn compile_on_this_thread(

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lib.rs
@@ -1,0 +1,98 @@
+//! # wolfram-to-semantic-ir
+//!
+//! Wolfram CST → narrow-waist Semantic IR, **v0.1.0**.
+//!
+//! This is the first frontend to target
+//! [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+//! symbolic-expression/pattern-matching domain extension of the SIR10
+//! narrow-waist IR (Stream B of
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)). It consumes the
+//! generic `GrammarASTNode` CST produced by the
+//! `coding-adventures-wolfram-parser` crate and emits a
+//! [`semantic_ir::Module`]. See `lower.rs`'s module doc comment for the
+//! full scope and the "everything is data" design decision this frontend
+//! makes throughout.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Wolfram source
+//!    │
+//!    ▼  coding_adventures_wolfram_parser::try_parse_wolfram(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  wolfram_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR23)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use wolfram_to_semantic_ir::compile_source;
+//! let module = compile_source("1 + 2\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+
+mod lower;
+pub use lower::{compile, WolframLowerError};
+
+/// Recursion-depth cap `compile_source` parses under, and the enlarged
+/// worker-thread stack size it parses *on*.
+///
+/// `wolfram-parser`'s own `MAX_RULE_DEPTH` doc comment explains why no
+/// single cap value can simultaneously be safe on a bare default (~2 MiB)
+/// stack *and* support realistic nesting: Wolfram's 20-rule-per-level
+/// precedence cascade means even 40 levels of ordinary `(...)` nesting
+/// needs ~840 `parse_rule` frames, already past that crate's own measured
+/// bare-stack crash floor (~276) regardless of any cap. That doc comment
+/// explicitly recommends one of two fixes for a caller in this position:
+/// reuse `wolfram-runtime`'s own pattern (parse on an enlarged-stack worker
+/// thread) or tighten the cap and accept a much lower nesting ceiling on a
+/// bare thread. This crate takes the first option, reusing
+/// `wolfram-runtime`'s own validated-safe deployment exactly (its
+/// `EVAL_STACK_SIZE`) rather than inventing an unproven new stack size, so
+/// `wolfram-parser`'s *default* `MAX_RULE_DEPTH` (2000, ~98 real nesting
+/// levels) stays in force — comfortable headroom for realistic compiled
+/// programs — while remaining provably safe.
+const PARSE_STACK_SIZE: usize = 512 * 1024 * 1024;
+
+/// Parse `source` as Wolfram and lower it into a [`semantic_ir::Module`] in
+/// one step, mirroring every other `-to-semantic-ir` frontend's
+/// `compile_source` convenience wrapper.
+///
+/// Unlike a plain call to [`compile`] (which trusts its caller already
+/// parsed `source` safely), this function is the hardened entry point: it
+/// spawns the parse-then-lower pipeline onto a worker thread with an
+/// enlarged stack (see [`PARSE_STACK_SIZE`]'s doc comment), so pathologically
+/// deep — but syntactically valid — Wolfram source fails with a clean
+/// [`WolframLowerError`] instead of a native, uncatchable stack overflow on
+/// an ordinary caller thread. Prefer this over `compile` for any input that
+/// was not already parsed under an equivalent guard.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, WolframLowerError> {
+    let source = source.to_string();
+    let module_name = module_name.to_string();
+    std::thread::Builder::new()
+        .name("wolfram-to-semantic-ir-compile".to_string())
+        .stack_size(PARSE_STACK_SIZE)
+        .spawn(move || compile_on_this_thread(&source, &module_name))
+        .expect("failed to spawn wolfram-to-semantic-ir compile worker thread")
+        .join()
+        .expect("wolfram-to-semantic-ir compile worker thread panicked")
+}
+
+fn compile_on_this_thread(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, WolframLowerError> {
+    let tree = coding_adventures_wolfram_parser::try_parse_wolfram(source).map_err(|msg| {
+        WolframLowerError {
+            message: format!("parse error: {msg}"),
+            line: 1,
+            column: 1,
+        }
+    })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lib.rs
@@ -48,13 +48,24 @@ pub use lower::{compile, WolframLowerError};
 /// explicitly recommends one of two fixes for a caller in this position:
 /// reuse `wolfram-runtime`'s own pattern (parse on an enlarged-stack worker
 /// thread) or tighten the cap and accept a much lower nesting ceiling on a
-/// bare thread. This crate takes the first option, reusing
-/// `wolfram-runtime`'s own validated-safe deployment exactly (its
-/// `EVAL_STACK_SIZE`) rather than inventing an unproven new stack size, so
-/// `wolfram-parser`'s *default* `MAX_RULE_DEPTH` (2000, ~98 real nesting
-/// levels) stays in force — comfortable headroom for realistic compiled
-/// programs — while remaining provably safe.
-const PARSE_STACK_SIZE: usize = 512 * 1024 * 1024;
+/// bare thread. This crate takes the first option.
+///
+/// Unlike `wolfram-runtime` (a long-running REPL/eval process that spawns
+/// this worker thread rarely), `compile_source` may be called once per
+/// test or per request — reusing `wolfram-runtime`'s own 512 MiB
+/// `EVAL_STACK_SIZE` verbatim caused real CI resource pressure (many
+/// concurrent test threads each reserving 512 MiB of address space at
+/// once), so this crate derives its own, smaller budget instead of
+/// copying that constant unquestioned. `wolfram-parser`'s own measured
+/// bare-stack crash floor is ~276 `parse_rule` frames on a ~2 MiB stack —
+/// roughly 7.4 KiB/frame. Supporting the *default* `MAX_RULE_DEPTH` (2000
+/// frames) with a comfortable ~4x margin over that per-frame cost needs
+/// only ~64 MiB (2000 × 7.4 KiB × 4 ≈ 59 MiB, rounded up), a fraction of
+/// 512 MiB's reservation while still keeping the full 2000-frame
+/// (~98-real-nesting-level) ceiling in force — comfortable headroom for
+/// realistic compiled programs, while remaining provably safe and far
+/// less memory-hungry per call.
+const PARSE_STACK_SIZE: usize = 64 * 1024 * 1024;
 
 /// Parse `source` as Wolfram and lower it into a [`semantic_ir::Module`] in
 /// one step, mirroring every other `-to-semantic-ir` frontend's

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -121,10 +121,18 @@
 //!
 //! # Recursion-depth hardening
 //!
-//! Applied from day one (not retrofitted after a security-review finding,
-//! unlike `matlab-to-semantic-ir`'s own history — see
-//! [`MAX_EXPR_DEPTH`] and [`Lowerer::check_chain_length`]'s doc comments
-//! for the two distinct guards this needs and why both are necessary).
+//! Per-construct chain-length checks (see [`MAX_EXPR_DEPTH`] and
+//! [`Lowerer::check_chain_length`]/[`Lowerer::add_chain_depth`]) were
+//! applied from day one rather than retrofitted, but two rounds of
+//! security review still found real gaps in them: `postfix`/`amp` share
+//! the same flat-repetition grammar shape without being on the "obviously
+//! chain-shaped" list, and — even once every construct had its own
+//! guard — those guards are each scoped to one grammar node, so chaining
+//! several independently-in-bounds constructs across `(...)` boundaries
+//! still composes past the cap (see [`measure_depth_iterative`], the
+//! authoritative, construction-composition-independent check this crate
+//! ultimately relies on; `CHANGELOG.md` has the full history of what each
+//! round found).
 
 use std::collections::HashSet;
 
@@ -279,6 +287,12 @@ impl Lowerer {
                 continue;
             };
             let expr = self.lower_node(stmt, 0)?;
+            if measure_depth_iterative(&expr).is_none() {
+                return Err(self.err_at(
+                    stmt,
+                    format!("expression tree too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+                ));
+            }
             let span = expr.span().clone();
             stmts.push(Stmt::ExprStmt { expr, span });
         }
@@ -491,6 +505,29 @@ impl Lowerer {
         let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
         let delayed = token_type(as_token(&node.children[op_index]).unwrap()) == "RULEDELAYED";
         let span = self.span_of(node);
+
+        // `collect_pattern_names`/`bind_pattern_refs` below recurse over
+        // `lhs`/`rhs` with no depth cap of their own (see their doc
+        // comments -- they assume whatever tree they're handed is already
+        // bounded). That assumption does not hold in general: `depth`
+        // alone only bounds *this crate's own* CST-walking recursion, not
+        // the true depth of a tree a flat-chain fold (postfix/amp/etc, see
+        // `add_chain_depth`) may have built -- and per-construct chain
+        // budgets don't compose across nested grammar boundaries (a
+        // security review found chaining several independently-capped
+        // constructs, e.g. through `(...)` boundaries, can still build a
+        // tree far deeper than any single guard's own limit). Measure the
+        // TRUE depth authoritatively and iteratively (never recursively,
+        // so this check itself can never crash regardless of how deep the
+        // tree already is -- building a deep `Box`-based tree costs heap,
+        // not stack, so it's always safe to measure after the fact) before
+        // handing `lhs`/`rhs` to either unguarded recursive helper.
+        if measure_depth_iterative(&lhs).is_none() || measure_depth_iterative(&rhs).is_none() {
+            return Err(self.err_at(
+                node,
+                format!("expression tree too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
 
         // Wolfram binds a pattern name on the LHS (`t_`) and refers to it as
         // a *bare* symbol on the RHS (`-> t`); a later matcher only fills in
@@ -1366,16 +1403,79 @@ fn is_list_apply(expr: &Expr) -> bool {
     matches!(expr, Expr::SymApply { head, .. } if matches!(head.as_ref(), Expr::SymSymbol { name, .. } if name == LIST))
 }
 
+/// Measure `expr`'s true tree depth **iteratively**, using an explicit
+/// heap-allocated work stack rather than native recursion, so calling this
+/// can never itself overflow the stack no matter how deep `expr` already
+/// is -- unlike a naive recursive depth check, which would have exactly
+/// the same crash risk as the thing it's trying to detect. Building a
+/// deeply-nested `Box`-based tree only costs heap space (each construction
+/// step is O(1) stack), so it is always safe to measure a tree's depth
+/// *after* it has been fully built; the risk this guards against is only
+/// in *walking* it recursively afterward.
+///
+/// Returns `None` (bailing out early, without doing more than
+/// `O(MAX_EXPR_DEPTH * branching factor)` work) as soon as the depth is
+/// certain to exceed `MAX_EXPR_DEPTH`, `Some(depth)` otherwise.
+///
+/// This is the authoritative depth check every other guard in this file
+/// (`MAX_EXPR_DEPTH`'s recursion-depth parameter, [`Lowerer::add_chain_depth`])
+/// is only an early, cheap approximation of. A security review found that
+/// per-construct chain budgets do not compose across nested grammar
+/// boundaries -- chaining several independently-capped constructs (e.g.
+/// through `(...)` boundaries) can still build a tree far deeper than any
+/// single guard's own limit, since each guard only sees its own local
+/// slice of the construction. This function is called on the fully-built
+/// result before anything recurses over it without its own cap (see
+/// [`Lowerer::lower_rule`]'s use before `collect_pattern_names`/
+/// `bind_pattern_refs`) and once per top-level statement in
+/// [`Lowerer::lower_file`], so no tree this crate hands to a caller (or
+/// recurses over internally) can ever actually exceed `MAX_EXPR_DEPTH`,
+/// regardless of how its construction was composed.
+fn measure_depth_iterative(expr: &Expr) -> Option<usize> {
+    // The root itself starts at 0 wraps deep (matching the counting
+    // convention `Lowerer::add_chain_depth`/`check_apply_arg_count` already
+    // use elsewhere -- a chain of exactly `MAX_EXPR_DEPTH` nested wraps
+    // atop a leaf is "at the cap", not one past it).
+    let mut stack: Vec<(&Expr, usize)> = vec![(expr, 0)];
+    let mut max_depth = 0;
+    while let Some((node, d)) = stack.pop() {
+        if d > MAX_EXPR_DEPTH {
+            return None;
+        }
+        max_depth = max_depth.max(d);
+        match node {
+            Expr::SymApply { head, args, .. } => {
+                stack.push((head, d + 1));
+                for a in args {
+                    stack.push((a, d + 1));
+                }
+            }
+            Expr::SymPatternBlank { head: Some(h), .. } => stack.push((h, d + 1)),
+            Expr::SymPatternNamed { pattern, .. } => stack.push((pattern, d + 1)),
+            Expr::SymRule { lhs, rhs, .. } => {
+                stack.push((lhs, d + 1));
+                stack.push((rhs, d + 1));
+            }
+            Expr::SymReplaceAll { expr, rules, .. } => {
+                stack.push((expr, d + 1));
+                for r in rules {
+                    stack.push((r, d + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+    Some(max_depth)
+}
+
 /// Gather the names captured by every [`Expr::SymPatternNamed`] anywhere in
 /// `expr` -- used by `lower_rule` to know which RHS bare-symbol references
-/// need rewriting into pattern-reference form. Safe to recurse unguarded:
-/// `expr` was built by [`Lowerer::lower_node`], whose own `MAX_EXPR_DEPTH`
-/// cap already bounds its depth, so walking it again can never exceed that
-/// same bound (this is the "structure is already bounded, so a second walk
-/// of it is safe" half of the lesson `matlab-to-semantic-ir`'s
-/// `expr_is_known_scalar_d` doc comment discusses -- unlike that function,
-/// this one is never called on anything *other* than an already-built,
-/// already-capped tree, so it needs no depth parameter of its own).
+/// need rewriting into pattern-reference form. Recurses without its own
+/// depth cap: safe because its only caller ([`Lowerer::lower_rule`])
+/// verifies `expr`'s true depth via [`measure_depth_iterative`] first,
+/// which is the authoritative bound -- see that function's doc comment for
+/// why a purely construction-time cap (`MAX_EXPR_DEPTH`/`add_chain_depth`)
+/// is not sufficient on its own.
 fn collect_pattern_names(expr: &Expr, names: &mut HashSet<String>) {
     match expr {
         Expr::SymPatternNamed { name, pattern, .. } => {
@@ -1408,6 +1508,8 @@ fn collect_pattern_names(expr: &Expr, names: &mut HashSet<String>) {
 /// reference nodes -- the same shape a fresh `x_` occurrence lowers to (see
 /// the SIR23 spec) -- so a later matcher's substitution step fills them in.
 /// Symbols not in `bound`, and all literals, pass through unchanged.
+/// Recurses without its own depth cap for the same reason
+/// [`collect_pattern_names`] does -- see that function's doc comment.
 fn bind_pattern_refs(expr: Expr, bound: &HashSet<String>) -> Expr {
     match expr {
         Expr::SymSymbol { name, span } if bound.contains(&name) => Expr::SymPatternNamed {

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -737,6 +737,7 @@ impl Lowerer {
     /// RBRACKET RBRACKET }` -- function application and the `[[ … ]]` part
     /// sugar, both postfix, left-associative and chainable.
     fn lower_postfix(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        self.check_postfix_chain_length(node)?;
         let mut result = self.lower_child(
             node.children
                 .first()
@@ -910,6 +911,13 @@ impl Lowerer {
 
     /// `amp = power AMP { AMP } { amp_apply } | power` -- the `&`
     /// pure-function postfix and any immediate trailing application.
+    ///
+    /// Both repetitions here (`{ AMP }` and `{ amp_apply }`) are flat,
+    /// token-or-node runs the grammar folds into ONE `amp` node's children
+    /// rather than nesting -- exactly the same shape `check_chain_length`
+    /// guards for `additive`/`multiplicative`/etc, so both are capped
+    /// before their respective wrapping loops run (see
+    /// [`Self::check_amp_chain_length`]).
     fn lower_amp(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
         let amp_count = node
             .children
@@ -919,6 +927,7 @@ impl Lowerer {
         if amp_count == 0 {
             return self.lower_first_node(node, depth);
         }
+        self.check_amp_chain_length(node, amp_count)?;
         let body = self.lower_first_node(node, depth + 1)?;
         let mut result = body;
         for _ in 0..amp_count {
@@ -1108,6 +1117,72 @@ impl Lowerer {
             return Err(self.err_at(
                 node,
                 format!("too many arguments ({count}, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reject a chain of postfix application/part groups
+    /// (`f[…][…][…]…`/`x[[…]][[…]][[…]]…`, in any mix) longer than
+    /// `MAX_EXPR_DEPTH`.
+    ///
+    /// `lower_postfix`'s `while` loop is iterative, not recursive through
+    /// `lower_node` -- each `LBRACKET`/`LDBRACKET` group wraps the running
+    /// `result` as the head (or `Part` target) of a brand-new `SymApply`,
+    /// so this chain never engages `MAX_EXPR_DEPTH`'s own recursion check
+    /// no matter how many groups there are. This is the exact same bug
+    /// class [`Self::check_chain_length`] guards against, on a grammar
+    /// shape [`Self::check_chain_length`] itself does not cover (the chain
+    /// here is expressed as a run of TOKENS with an optional trailing
+    /// `arglist` node each, not a run of `Node` operands) -- found during
+    /// security review after the initial per-production audit missed it,
+    /// since `postfix` was not in the list of "obviously chain-shaped"
+    /// rules the additive/multiplicative/logical/alternatives/mapapply/
+    /// patterntest/replaceall productions made explicit.
+    fn check_postfix_chain_length(&self, node: &GrammarASTNode) -> Result<(), WolframLowerError> {
+        let group_count = node
+            .children
+            .iter()
+            .filter(|c| as_token(c).is_some_and(|t| matches!(token_type(t), "LBRACKET" | "LDBRACKET")))
+            .count();
+        if group_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "too many chained application/part groups ({group_count}, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reject an `amp` node (`expr & & & …`, and/or `expr & […] […] …`)
+    /// whose `&` run or trailing `amp_apply` suffix run exceeds
+    /// `MAX_EXPR_DEPTH`.
+    ///
+    /// Both `lower_amp`'s `&`-wrapping loop (`for _ in 0..amp_count`) and
+    /// its `amp_apply` suffix loop are the same iterative-wrap-in-a-loop
+    /// shape [`Self::check_postfix_chain_length`] guards for ordinary
+    /// postfix application -- same bug class, same fix.
+    fn check_amp_chain_length(&self, node: &GrammarASTNode, amp_count: usize) -> Result<(), WolframLowerError> {
+        if amp_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("too many chained `&` (amp_count {amp_count}, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        let suffix_count = child_nodes(node)
+            .into_iter()
+            .filter(|n| n.rule_name == "amp_apply")
+            .count();
+        if suffix_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "too many chained pure-function applications ({suffix_count}, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
             ));
         }
         Ok(())

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -288,10 +288,12 @@ impl Lowerer {
             };
             let expr = self.lower_node(stmt, 0)?;
             if measure_depth_iterative(&expr).is_none() {
-                return Err(self.err_at(
+                let err = self.err_at(
                     stmt,
                     format!("expression tree too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
-                ));
+                );
+                drop_iterative(expr);
+                return Err(err);
             }
             let span = expr.span().clone();
             stmts.push(Stmt::ExprStmt { expr, span });
@@ -523,10 +525,18 @@ impl Lowerer {
         // not stack, so it's always safe to measure after the fact) before
         // handing `lhs`/`rhs` to either unguarded recursive helper.
         if measure_depth_iterative(&lhs).is_none() || measure_depth_iterative(&rhs).is_none() {
-            return Err(self.err_at(
+            let err = self.err_at(
                 node,
                 format!("expression tree too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
-            ));
+            );
+            // Tear both down iteratively before returning -- letting either
+            // fall out of scope normally here would recurse through the
+            // ordinary derived `Drop` glue on exactly the pathologically
+            // deep tree we just detected (see `drop_iterative`'s doc
+            // comment).
+            drop_iterative(lhs);
+            drop_iterative(rhs);
+            return Err(err);
         }
 
         // Wolfram binds a pattern name on the LHS (`t_`) and refers to it as
@@ -1466,6 +1476,55 @@ fn measure_depth_iterative(expr: &Expr) -> Option<usize> {
         }
     }
     Some(max_depth)
+}
+
+/// Tear down a rejected, pathologically-deep `Expr` tree **iteratively**,
+/// so freeing it can never itself overflow the stack -- unlike simply
+/// letting `expr` fall out of scope, which invokes `Expr`/`Box<Expr>`'s
+/// ordinary *recursive* compiler-derived `Drop` glue (`semantic_ir::Expr`
+/// has no custom `Drop` impl of its own). A security review confirmed
+/// (empirically, via an isolated subprocess: `compile()` called directly
+/// on a bare default-stack thread with a rejected ~23,000-level-deep tree)
+/// that this ordinary drop is a real, exploitable crash -- moving a
+/// pathologically deep tree past [`measure_depth_iterative`]'s detection
+/// only to then let it drop normally just relocates the same native stack
+/// overflow from "walking the tree forward" to "walking it backward",
+/// which none of the prior fixes in this file's history examined.
+///
+/// The technique: take ownership of `expr`, and for every node with a
+/// nested `Expr` field, *move* that field out via the match (not borrow
+/// it), pushing it onto our own explicit heap-allocated work stack instead
+/// of leaving it in place to be dropped as part of the outer match's
+/// scrutinee. Each loop iteration therefore drops only one node's own
+/// non-recursive fields (strings, spans, flags) -- moving a child out via
+/// `*head` / `Vec` iteration prevents the *outer* value's default drop
+/// glue from ever recursing into it. This mirrors the standard
+/// iterative-drop pattern for a boxed recursive structure (the same
+/// technique a hand-written `impl Drop for List` uses to avoid overflowing
+/// on a long linked list), generalised from a list to a tree.
+fn drop_iterative(expr: Expr) {
+    let mut stack: Vec<Expr> = vec![expr];
+    while let Some(node) = stack.pop() {
+        match node {
+            Expr::SymApply { head, args, .. } => {
+                stack.push(*head);
+                stack.extend(args);
+            }
+            Expr::SymPatternBlank { head: Some(h), .. } => stack.push(*h),
+            Expr::SymPatternNamed { pattern, .. } => stack.push(*pattern),
+            Expr::SymRule { lhs, rhs, .. } => {
+                stack.push(*lhs);
+                stack.push(*rhs);
+            }
+            Expr::SymReplaceAll { expr, rules, .. } => {
+                stack.push(*expr);
+                stack.extend(rules);
+            }
+            _ => {}
+        }
+        // `node`'s own shell drops here -- shallowly, since every nested
+        // `Expr` field it had was already moved out onto `stack` above.
+    }
 }
 
 /// Gather the names captured by every [`Expr::SymPatternNamed`] anywhere in

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -1,0 +1,1378 @@
+//! The lowering pass from `coding_adventures_wolfram_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0**.
+//!
+//! This is the first frontend to target
+//! [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md), the
+//! symbolic-expression/pattern-matching domain extension of the SIR10
+//! narrow-waist IR (Stream B of
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)).
+//!
+//! # "Everything is data" — this frontend's one design decision
+//!
+//! Wolfram's defining idea (MA04 §1) is that *every* fragment is one
+//! expression tree `head[arg, …]`, manipulable as **data** even before (or
+//! instead of) being evaluated — `2 + 3` is `Add(2, 3)`, `{1, 2}` is
+//! `List(1, 2)`, `x = 5` is `Set(x, 5)`. The existing native
+//! `wolfram-runtime` crate lowers to `symbolic_ir::IRNode` with exactly this
+//! shape and then *evaluates* it against a live environment (variable
+//! bindings, held heads, a pattern-matching VM). This crate lowers to the
+//! same shape in `semantic_ir::Expr`'s SIR23 vocabulary
+//! (`SymSymbol`/`SymApply`/pattern/rule nodes) but stops there: **every**
+//! Wolfram construct — arithmetic, comparisons, lists, function
+//! application, even `=`/`:=` assignment — becomes symbolic *data*, never a
+//! host-language `Expr::VarRef`/`Stmt::Assign`. There is no environment, no
+//! binding, no evaluation at lowering time.
+//!
+//! This is not a simplification of convenience; it is the only choice that
+//! matches the SIR23 spec's stated fidelity goal: representing an
+//! **uncomputed** Wolfram function body (`f[x_] := x + 1`, which
+//! pattern-matches at call time, not at definition time) requires `x + 1`
+//! to already be data *before* `x` has any value. Lowering ordinary
+//! arithmetic straight to a host addition would make that impossible; by
+//! lowering everything uniformly to `SymApply`, the same code path handles
+//! both "this expression happens to be computable now" and "this
+//! expression is a pattern-matched template" without special-casing.
+//! Evaluating that data (binding `Set`/`SetDelayed`, running the matcher
+//! for `SymReplaceAll`) is deliberately left to a **backend runtime**
+//! library (`sir-runtime-symbolic`, not yet built — SIR23 spec, "Backend
+//! impact"; Stream B rollout item 6) — mirroring the SIR23 spec's own
+//! explicit "session state isn't SIR" boundary (the same boundary that lets
+//! Macsyma's `assume`/`kill` stay out of the IR entirely).
+//!
+//! # Scope (v0.1.0)
+//!
+//! Because everything reduces to the same small SIR23 vocabulary, this
+//! crate covers the **full** grammar `wolfram-parser` accepts — there is no
+//! scalar/array-style ambiguity here forcing a narrower cut the way there
+//! was for MATLAB. Concretely:
+//!
+//! - Literals: `NUMBER` (int- or float-shaped by lexeme, exactly as the
+//!   native `wolfram-runtime` lowering decides), `STRING` → `IntLit`/
+//!   `FloatLit`/`StrLit` (SIR10 nodes, reused directly per the SIR23 spec —
+//!   no new literal node needed for these three).
+//! - Bare symbols (`NAME`) → [`Expr::SymSymbol`] — always data, never a
+//!   variable lookup (see above).
+//! - Arithmetic (`+ - * / ^`, unary `-`/`+`) and their explicit-head forms
+//!   (`Plus[…]`/`Times[…]`/`Power[…]`/`Subtract[…]`/`Divide[…]`/`Minus[…]`)
+//!   → [`Expr::SymApply`] with the canonical head (`Add`/`Sub`/`Mul`/`Div`/
+//!   `Pow`/`Neg`), bridged through the exact same surface→canonical table
+//!   the native `wolfram-runtime::lower` uses, including the same
+//!   associative n-ary left-fold for a 3-or-more-argument explicit head
+//!   application (`Plus[1, 2, 3]` → `Add(Add(1, 2), 3)`, byte-identical to
+//!   the infix `1 + 2 + 3`).
+//! - Comparisons (`== != < > <= >=` and `Equal`/`Unequal`/`Less`/`Greater`/
+//!   `LessEqual`/`GreaterEqual`), logic (`&& || !` and `And`/`Or`/`Not`),
+//!   lists (`{…}` and `List[…]`) → `SymApply`.
+//! - Function application `head[args]`, including a *computed* head
+//!   (`f[x][y]`) and any unrecognised head (a user-defined function name
+//!   passes through unchanged, exactly like the native runtime) →
+//!   `SymApply`.
+//! - `x = e` (`Set`) and `f[params] := body` (`SetDelayed`) → `SymApply`
+//!   with head `Assign`/`Define` — pure data (see "Everything is data"
+//!   above); no host-language binding is created or assumed.
+//! - The W-6 sugar `/@` (`Map`), `@@` (`Apply`), `x[[i]]` (`Part`, folding
+//!   a multi-index `x[[i, j]]` into nested `Part`s exactly as the native
+//!   lowering does) → `SymApply` with those well-known heads.
+//! - The W-11 pure-function forms `#`/`#n` (`Slot[n]`), `##`
+//!   (`SlotSequence[1]`), `expr &` (`Function[expr]`), and the named
+//!   long form `Function[params, body]` (params normalised to a `List`,
+//!   mirroring the native lowering) → `SymApply`.
+//! - The W-21 sugar `a | b` (`Alternatives`), `patt /; test` (`Condition`),
+//!   `patt ? fn` (`PatternTest`) → `SymApply`.
+//! - Pattern blanks `_`/`_h` → [`Expr::SymPatternBlank`]; named `x_`/`x_h`
+//!   → [`Expr::SymPatternNamed`].
+//! - Rules `a -> b` (eager) / `a :> b` (delayed) → [`Expr::SymRule`],
+//!   including the same pattern-name-to-reference rewriting on the RHS the
+//!   native lowering performs (see [`bind_pattern_refs`]) so a later
+//!   `sir-runtime-symbolic` matcher can substitute bindings the same way
+//!   `cas-pattern-matching::substitute` does today.
+//! - Replacement `expr /. rules` (one pass) / `expr //. rules` (fixed
+//!   point) → [`Expr::SymReplaceAll`], flattening a `{…}` list of rules on
+//!   the right-hand side into the node's `rules: Vec<Expr>` (a bare single
+//!   rule, or any other computed expression, becomes a one-element `Vec`
+//!   — the spec explicitly allows a non-`SymRule` element there as "a
+//!   backend concern, not an IR shape").
+//!
+//! **Deliberately out of scope, disclosed rather than silently
+//! mis-lowered:**
+//! - Sequence patterns (`__`/`___`), `Repeated`/`Except`/`Longest`/
+//!   `Shortest`, `Replace` level-specs — SIR23 tracks the native
+//!   `wolfram-runtime`'s own still-open W-20 deferred-feature list exactly,
+//!   and this grammar subset has no surface syntax for them regardless.
+//! - `SymRational` is part of the SIR23 vocabulary but **unreachable**
+//!   from this grammar's surface syntax: there is no dedicated rational
+//!   *literal* token (`1/3` parses as `Div[1, 3]`, an ordinary `SymApply`,
+//!   exactly as the native lowering treats it) — a future constant-folding
+//!   pass could collapse that into a `SymRational` at lowering time, but
+//!   this crate does not attempt constant folding.
+//! - Evaluating anything: no environment, no binding, no pattern matching
+//!   happens in this crate — see "Everything is data" above. This means
+//!   **no** module this crate produces currently executes end-to-end
+//!   through any backend (`sir-runtime-symbolic`, the JS/TS runtime
+//!   library SIR23 codegen needs, does not exist yet — Stream B rollout
+//!   item 6, after this frontend). This crate's tests verify structural
+//!   correctness (exact `Expr` shapes) and the capability-rejection path
+//!   (the validator confirms the manifest declares exactly the features
+//!   used; every JS-backend check is expected to *reject*, not accept, a
+//!   module using SIR23 nodes) — there is no e2e `node`-execution test,
+//!   unlike `matlab-to-semantic-ir`'s purely-literal case, because no
+//!   Wolfram program (not even bare literal arithmetic) can avoid emitting
+//!   at least one SIR23 node under the "everything is data" design.
+//!
+//! # Recursion-depth hardening
+//!
+//! Applied from day one (not retrofitted after a security-review finding,
+//! unlike `matlab-to-semantic-ir`'s own history — see
+//! [`MAX_EXPR_DEPTH`] and [`Lowerer::check_chain_length`]'s doc comments
+//! for the two distinct guards this needs and why both are necessary).
+
+use std::collections::HashSet;
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use symbolic_ir::{
+    ADD, AND, ASSIGN, DEFINE, DIV, EQUAL, GREATER, GREATER_EQUAL, LESS, LESS_EQUAL, LIST, MUL,
+    NEG, NOT, NOT_EQUAL, OR, POW, SUB,
+};
+
+/// Maximum expression-nesting depth for *this crate's own* lowering
+/// recursion — distinct from (and independent of) `wolfram-parser`'s own
+/// `MAX_RULE_DEPTH` grammar-nesting guard, which bounds the CST this crate
+/// walks. Mirrors every other SIR frontend's identically-named,
+/// identically-justified guard: turns pathologically deep (but parseable)
+/// input into a clean [`WolframLowerError`] instead of a native
+/// (uncatchable) stack overflow.
+///
+/// This value (256) is comfortably above the ~98 real nesting levels
+/// `wolfram-parser`'s own default `MAX_RULE_DEPTH` (2000) permits on the
+/// enlarged-stack worker thread [`compile_source`] parses on (see that
+/// function's doc comment) — so in practice this guard is a defense-in-depth
+/// backstop against genuine bracket/`f[…]` nesting, which the parser's own
+/// cap already bounds first. It is *not* a backstop against a flat,
+/// unparenthesized operator chain — that risk is real and structurally
+/// different (a long `1 + 1 + ... + 1` run never nests at the CST level at
+/// all), and is handled separately by [`Lowerer::check_chain_length`].
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<wolfram>";
+
+// ---------------------------------------------------------------------------
+// Surface-only head names (not exported by `symbolic_ir`, since these are
+// synthetic heads a Wolfram-family frontend introduces, not part of the
+// shared symbolic-IR vocabulary itself — mirrors the native
+// `wolfram-runtime::lower`'s own identically-named local constants).
+// ---------------------------------------------------------------------------
+
+const ALTERNATIVES_HEAD: &str = "Alternatives";
+const CONDITION_HEAD: &str = "Condition";
+const PATTERN_TEST_HEAD: &str = "PatternTest";
+const MAP_HEAD: &str = "Map";
+const APPLY_HEAD: &str = "Apply";
+const PART_HEAD: &str = "Part";
+const SLOT_HEAD: &str = "Slot";
+const SLOT_SEQUENCE_HEAD: &str = "SlotSequence";
+const FUNCTION_HEAD: &str = "Function";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during Wolfram → SIR lowering.
+///
+/// Mirrors `MatlabLowerError`/`PythonLowerError`'s shape exactly
+/// (`message` + 1-based `line`/`column`) so tooling can treat every SIR
+/// frontend uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WolframLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for WolframLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "WolframLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for WolframLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed Wolfram CST (rooted at the `program` rule) into a SIR
+/// module.
+///
+/// This function does **not** itself guard against native stack overflow
+/// on deeply-nested input beyond its own [`MAX_EXPR_DEPTH`] cap — it trusts
+/// `tree` was already parsed under a suitable guard (see
+/// [`compile_source`]'s doc comment for the hardened, recommended entry
+/// point). This mirrors `matlab-to-semantic-ir::compile`'s identical
+/// division of responsibility: `compile` is pure lowering over an
+/// already-parsed tree, safe to call directly on an ordinary thread because
+/// `MAX_EXPR_DEPTH` (256) alone is a modest, bare-stack-safe recursion
+/// budget; `compile_source` is the guarded, parse-and-lower convenience
+/// wrapper untrusted-input callers should prefer.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, WolframLowerError> {
+    Lowerer::new(module_name).lower_file(tree)
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// The lowering pass's only mutable state: the module name (fixed at
+/// construction) and the set of SIR features observed while lowering (used
+/// to build the manifest so it declares *exactly* what the module emits —
+/// see `semantic-ir/src/validator.rs`'s `check_expr` for the ground truth
+/// this must match node-kind-for-node-kind).
+///
+/// Unlike `matlab-to-semantic-ir`'s `Lowerer`, there is no per-function
+/// name-resolution context (`FunctionCtx`, a `locals`/`params` set) here at
+/// all — under the "everything is data" design (see the module doc
+/// comment) there are no host variables to resolve, so this lowerer is a
+/// near-stateless recursive descent over the CST.
+struct Lowerer {
+    module_name: String,
+    observed: FeatureManifest,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program = { statement_line }`
+    // -------------------------------------------------------------------
+
+    fn lower_file(&mut self, program: &GrammarASTNode) -> Result<Module, WolframLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        let mut stmts: Vec<Stmt> = Vec::new();
+        for line in child_nodes(program) {
+            if line.rule_name != "statement_line" {
+                continue;
+            }
+            // A statement_line is `statement (NEWLINE|SEMI) | statement |
+            // NEWLINE | SEMI`; only the first two carry an inner `statement`
+            // node -- a bare terminator (blank line) contributes nothing.
+            let Some(stmt) = first_child_named(line, "statement") else {
+                continue;
+            };
+            let expr = self.lower_node(stmt, 0)?;
+            let span = expr.span().clone();
+            stmts.push(Stmt::ExprStmt { expr, span });
+        }
+
+        let span = Span::point(FILE, 1, 1);
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        let metadata = Metadata::new()
+            .with_source_language("wolfram")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![main],
+            globals: vec![],
+            metadata,
+            span,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Dispatch
+    // -------------------------------------------------------------------
+
+    /// Lower a single arbitrary node, one level deeper than `depth`.
+    ///
+    /// Most grammar rules are "transparent wrappers" — a precedence level
+    /// that did not apply its own operator still emits its own node with a
+    /// single child. [`unwrap_single`] peels those away so we dispatch on
+    /// the first rule that genuinely shapes the tree.
+    fn lower_node(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        match unwrap_single(node) {
+            Unwrapped::Token(token) => self.lower_token(token),
+            Unwrapped::Node(node) => match node.rule_name.as_str() {
+                "program" => Err(self.err_at(node, "nested program node is not an expression".to_string())),
+                "statement_line" | "statement" | "expr" => self.lower_first_node(node, depth),
+                "assignment" => self.lower_assignment(node, depth),
+                "replaceall" => self.lower_replaceall(node, depth),
+                "rule" => self.lower_rule(node, depth),
+                "condition" => self.lower_condition(node, depth),
+                "alternatives" => self.lower_alternatives(node, depth),
+                "patterntest" => self.lower_patterntest(node, depth),
+                "logical_or" => self.lower_logical_chain(node, depth, OR),
+                "logical_and" => self.lower_logical_chain(node, depth, AND),
+                "logical_not" => self.lower_logical_not(node, depth),
+                "comparison" => self.lower_comparison(node, depth),
+                "additive" | "multiplicative" => self.lower_binary_chain(node, depth),
+                "unary" => self.lower_unary(node, depth),
+                "power" => self.lower_power(node, depth),
+                "amp" => self.lower_amp(node, depth),
+                "mapapply" => self.lower_mapapply(node, depth),
+                "postfix" => self.lower_postfix(node, depth),
+                "atom" => self.lower_atom(node, depth),
+                "slot" => self.lower_slot(node),
+                "list" => self.lower_list(node, depth),
+                "group" => self.lower_group(node, depth),
+                "arglist" => Err(self.err_at(
+                    node,
+                    "an arglist cannot be lowered as a scalar expression".to_string(),
+                )),
+                other => Err(self.err_at(node, format!("no lowering for rule `{other}`"))),
+            },
+        }
+    }
+
+    /// Lower a raw token (a literal or a bare symbol).
+    fn lower_token(&mut self, token: &Token) -> Result<Expr, WolframLowerError> {
+        let span = self.token_span(token);
+        match token_type(token) {
+            "NUMBER" => Ok(number_literal_expr(&token.value, span)),
+            "NAME" => Ok(self.sym_symbol(token.value.clone(), span)),
+            "STRING" => Ok(Expr::StrLit {
+                value: strip_quotes(&token.value).to_string(),
+                span,
+            }),
+            // A lone `_` is `Blank()` -- see `lower_atom`'s doc comment for
+            // why the token-level arm is the right place to interpret it.
+            "BLANK" => Ok(self.pattern_blank(None, span)),
+            "HASH" => Ok(self.slot_apply(1, span)),
+            "SLOTSEQ" => Ok(self.slot_sequence_apply(span)),
+            other => Err(WolframLowerError {
+                message: format!("unexpected token `{other}` = {:?}", token.value),
+                line: token.line,
+                column: token.column,
+            }),
+        }
+    }
+
+    /// `assignment = replaceall [ ( SET | SETDELAYED ) assignment ]`.
+    ///
+    /// `x = e` lowers to `SymApply{head: Assign, args: [x, e]}`; `f[x_] :=
+    /// e` to `SymApply{head: Define, args: [f[x_], e]}` -- both pure data
+    /// (see the module doc comment's "Everything is data"); no host
+    /// binding is created.
+    fn lower_assignment(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| matches!(token_type(t), "SET" | "SETDELAYED")))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed assignment node".to_string()));
+        }
+        let lhs = self.lower_child(&node.children[op_index - 1], depth + 1)?;
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        let op = token_type(as_token(&node.children[op_index]).unwrap());
+        let span = self.span_of(node);
+        let head = if op == "SETDELAYED" { DEFINE } else { ASSIGN };
+        Ok(self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![lhs, rhs], span))
+    }
+
+    /// `replaceall = rule { ( REPLACEALL | REPLACEREPEATED ) rule }` --
+    /// left-associative `/.` and `//.`.
+    ///
+    /// `e /. r1 /. r2` folds left into nested `SymReplaceAll`s, exactly as
+    /// the native lowering folds nested `ReplaceAll` applies. The RHS of
+    /// each step is flattened into `rules: Vec<Expr>` -- a `{…}` list
+    /// literal's elements become the vec directly; anything else becomes a
+    /// single-element vec (the spec explicitly allows a non-`SymRule`
+    /// element there as a runtime concern).
+    fn lower_replaceall(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        self.check_chain_length(node)?;
+        if node.children.len() == 1 {
+            return self.lower_child(&node.children[0], depth + 1);
+        }
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty replaceall node".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let repeated = match as_token(op_child).map(token_type) {
+                Some("REPLACEALL") => false,
+                Some("REPLACEREPEATED") => true,
+                _ => return Err(self.err_at(node, "expected a `/.` or `//.` operator".to_string())),
+            };
+            let rhs_child = children
+                .next()
+                .ok_or_else(|| self.err_at(node, "`/.`/`//.` with no right operand".to_string()))?;
+            let rules = self.lower_rules_operand(rhs_child, depth + 1)?;
+            let span = self.span_of(node);
+            self.observed.add(Feature::PatternMatching);
+            result = Expr::SymReplaceAll {
+                expr: Box::new(result),
+                rules,
+                repeated,
+                span,
+            };
+        }
+        Ok(result)
+    }
+
+    /// Flatten the right-hand operand of `/.`/`//.` into a `Vec<Expr>` of
+    /// rules: a `{…}` list literal's elements unpack directly; anything
+    /// else (a single rule, a variable, a computed expression) becomes a
+    /// one-element vec.
+    fn lower_rules_operand(
+        &mut self,
+        child: &ASTNodeOrToken,
+        depth: usize,
+    ) -> Result<Vec<Expr>, WolframLowerError> {
+        if let ASTNodeOrToken::Node(node) = child {
+            if unwrap_single(node).is_list() {
+                if let Unwrapped::Node(list_node) = unwrap_single(node) {
+                    return self.lower_list_elements(list_node, depth);
+                }
+            }
+        }
+        Ok(vec![self.lower_child(child, depth)?])
+    }
+
+    /// `rule = logical_or [ ( RULE | RULEDELAYED ) rule ]` --
+    /// right-associative.
+    fn lower_rule(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| matches!(token_type(t), "RULE" | "RULEDELAYED")))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed rule node".to_string()));
+        }
+        let lhs = self.lower_child(&node.children[op_index - 1], depth + 1)?;
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        let delayed = token_type(as_token(&node.children[op_index]).unwrap()) == "RULEDELAYED";
+        let span = self.span_of(node);
+
+        // Wolfram binds a pattern name on the LHS (`t_`) and refers to it as
+        // a *bare* symbol on the RHS (`-> t`); a later matcher only fills in
+        // `SymPatternNamed` reference nodes, so we rewrite every RHS
+        // occurrence of a name bound on the LHS into that reference shape --
+        // see `bind_pattern_refs`'s doc comment.
+        let mut bound = HashSet::new();
+        collect_pattern_names(&lhs, &mut bound);
+        let rhs = bind_pattern_refs(rhs, &bound);
+
+        self.observed.add(Feature::PatternMatching);
+        Ok(Expr::SymRule {
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+            delayed,
+            span,
+        })
+    }
+
+    /// `condition = alternatives [ CONDITION condition ]` -- the `/;`
+    /// operator, right-associative. Lowers to an ordinary `SymApply` with
+    /// head `Condition` (no dedicated SIR23 node; see the module doc
+    /// comment). Unlike `lower_rule`, the test keeps its bare
+    /// named-symbol references -- we do NOT run `bind_pattern_refs` here,
+    /// matching the native lowering's identical reasoning (a future
+    /// `sir-runtime-symbolic` `Condition` evaluator substitutes bindings
+    /// into the test at match time, not at lowering time).
+    fn lower_condition(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| token_type(t) == "CONDITION"))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed condition node".to_string()));
+        }
+        let patt = self.lower_child(&node.children[op_index - 1], depth + 1)?;
+        let test = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(CONDITION_HEAD, span.clone()), vec![patt, test], span))
+    }
+
+    /// `alternatives = logical_or { ALTERNATIVES logical_or }` -- the `|`
+    /// operator. Folds into one n-ary `SymApply{head: Alternatives, …}`.
+    fn lower_alternatives(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        self.check_chain_length(node)?;
+        let operands = self.lower_child_nodes(node, depth + 1)?;
+        match operands.len() {
+            0 => Err(self.err_at(node, "empty alternatives node".to_string())),
+            1 => Ok(operands.into_iter().next().unwrap()),
+            _ => {
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(ALTERNATIVES_HEAD, span.clone()), operands, span))
+            }
+        }
+    }
+
+    /// `patterntest = postfix { PATTERNTEST postfix }` -- the `?` operator,
+    /// left-associative.
+    fn lower_patterntest(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        self.check_chain_length(node)?;
+        if node.children.len() == 1 {
+            return self.lower_child(&node.children[0], depth + 1);
+        }
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty patterntest node".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            if as_token(op_child).map(token_type) != Some("PATTERNTEST") {
+                return Err(self.err_at(node, "expected a `?` operator".to_string()));
+            }
+            let rhs = children
+                .next()
+                .ok_or_else(|| self.err_at(node, "`?` with no right operand".to_string()))?;
+            let rhs_expr = self.lower_child(rhs, depth + 1)?;
+            let span = self.span_of(node);
+            result = self.sym_apply(
+                self.sym_symbol_bare(PATTERN_TEST_HEAD, span.clone()),
+                vec![result, rhs_expr],
+                span,
+            );
+        }
+        Ok(result)
+    }
+
+    /// `logical_or`/`logical_and` -- fold operands into an n-ary
+    /// `And`/`Or` `SymApply`.
+    fn lower_logical_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+        head: &str,
+    ) -> Result<Expr, WolframLowerError> {
+        self.check_chain_length(node)?;
+        let operands = self.lower_child_nodes(node, depth + 1)?;
+        match operands.len() {
+            0 => Err(self.err_at(node, "empty logical chain".to_string())),
+            1 => Ok(operands.into_iter().next().unwrap()),
+            _ => {
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(head, span.clone()), operands, span))
+            }
+        }
+    }
+
+    /// `logical_not = NOT logical_not | comparison`.
+    fn lower_logical_not(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let has_not = node
+            .children
+            .iter()
+            .any(|c| as_token(c).is_some_and(|t| token_type(t) == "NOT"));
+        if !has_not {
+            return self.lower_first_node(node, depth);
+        }
+        let inner = child_nodes(node)
+            .into_iter()
+            .next()
+            .ok_or_else(|| self.err_at(node, "`!` with no operand".to_string()))?;
+        let operand = self.lower_node(inner, depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(NOT, span.clone()), vec![operand], span))
+    }
+
+    /// `comparison = additive [ op additive ]` -- a single, non-chained
+    /// comparison (the grammar does not flatten a chain here, so no
+    /// `check_chain_length` call is needed).
+    fn lower_comparison(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let Some(op_index) = node
+            .children
+            .iter()
+            .position(|c| as_token(c).is_some_and(|t| comparison_head(token_type(t)).is_some()))
+        else {
+            return self.lower_first_node(node, depth);
+        };
+        if op_index == 0 || op_index + 1 >= node.children.len() {
+            return Err(self.err_at(node, "malformed comparison node".to_string()));
+        }
+        let head = comparison_head(token_type(as_token(&node.children[op_index]).unwrap())).unwrap();
+        let lhs = self.lower_child(&node.children[op_index - 1], depth + 1)?;
+        let rhs = self.lower_child(&node.children[op_index + 1], depth + 1)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![lhs, rhs], span))
+    }
+
+    /// `additive`/`multiplicative` -- a left-associative chain of
+    /// `+`/`-`/`*`/`/`.
+    ///
+    /// The Wolfram grammar, like MATLAB's, collapses a flat run of
+    /// same-precedence operators into ONE CST node with many children
+    /// rather than nesting through parens -- see [`Self::check_chain_length`]
+    /// for why this specifically needs its own cap independent of
+    /// `MAX_EXPR_DEPTH`.
+    fn lower_binary_chain(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        self.check_chain_length(node)?;
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty binary chain".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = as_token(op_child)
+                .and_then(|t| binary_head(token_type(t)))
+                .ok_or_else(|| self.err_at(node, "expected a binary operator".to_string()))?;
+            let rhs = children
+                .next()
+                .ok_or_else(|| self.err_at(node, "binary operator with no right operand".to_string()))?;
+            let rhs_expr = self.lower_child(rhs, depth + 1)?;
+            let span = self.span_of(node);
+            result = self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![result, rhs_expr], span);
+        }
+        Ok(result)
+    }
+
+    /// `unary = ( MINUS | PLUS ) unary | power`.
+    fn lower_unary(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        if node.children.len() == 1 {
+            return self.lower_child(&node.children[0], depth + 1);
+        }
+        let op = token_type(
+            as_token(&node.children[0])
+                .ok_or_else(|| self.err_at(node, "unary op must be a token".to_string()))?,
+        );
+        let operand = self.lower_child(
+            node.children
+                .get(1)
+                .ok_or_else(|| self.err_at(node, "unary op with no operand".to_string()))?,
+            depth + 1,
+        )?;
+        if op == "MINUS" {
+            let span = self.span_of(node);
+            Ok(self.sym_apply(self.sym_symbol_bare(NEG, span.clone()), vec![operand], span))
+        } else {
+            Ok(operand) // unary plus is a no-op
+        }
+    }
+
+    /// `power = postfix [ POWER unary ]` -- right-associative `^`.
+    fn lower_power(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        match node.children.len() {
+            1 => self.lower_child(&node.children[0], depth + 1),
+            3 => {
+                let lhs = self.lower_child(&node.children[0], depth + 1)?;
+                let rhs = self.lower_child(&node.children[2], depth + 1)?;
+                let span = self.span_of(node);
+                Ok(self.sym_apply(self.sym_symbol_bare(POW, span.clone()), vec![lhs, rhs], span))
+            }
+            _ => Err(self.err_at(node, "malformed power node".to_string())),
+        }
+    }
+
+    /// `mapapply = postfix { ( MAP | APPLY ) postfix }` -- the `/@`/`@@`
+    /// operator sugar, infix and left-associative.
+    fn lower_mapapply(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        self.check_chain_length(node)?;
+        if node.children.len() == 1 {
+            return self.lower_child(&node.children[0], depth + 1);
+        }
+        let mut children = node.children.iter();
+        let first = children
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty mapapply node".to_string()))?;
+        let mut result = self.lower_child(first, depth + 1)?;
+        while let Some(op_child) = children.next() {
+            let head = match as_token(op_child).map(token_type) {
+                Some("MAP") => MAP_HEAD,
+                Some("APPLY") => APPLY_HEAD,
+                _ => return Err(self.err_at(node, "expected a `/@` or `@@` operator".to_string())),
+            };
+            let rhs = children
+                .next()
+                .ok_or_else(|| self.err_at(node, "`/@`/`@@` with no right operand".to_string()))?;
+            let rhs_expr = self.lower_child(rhs, depth + 1)?;
+            let span = self.span_of(node);
+            result = self.sym_apply(self.sym_symbol_bare(head, span.clone()), vec![result, rhs_expr], span);
+        }
+        Ok(result)
+    }
+
+    /// `postfix = atom { LBRACKET [ arglist ] RBRACKET | LDBRACKET arglist
+    /// RBRACKET RBRACKET }` -- function application and the `[[ … ]]` part
+    /// sugar, both postfix, left-associative and chainable.
+    fn lower_postfix(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let mut result = self.lower_child(
+            node.children
+                .first()
+                .ok_or_else(|| self.err_at(node, "postfix has no base".to_string()))?,
+            depth + 1,
+        )?;
+
+        let mut i = 1;
+        while i < node.children.len() {
+            let Some(token) = as_token(&node.children[i]) else {
+                i += 1;
+                continue;
+            };
+            match token_type(token) {
+                "LBRACKET" => {
+                    let args = node
+                        .children
+                        .get(i + 1)
+                        .and_then(as_node)
+                        .filter(|n| n.rule_name == "arglist")
+                        .map(|n| self.lower_arglist(n, depth + 1))
+                        .transpose()?
+                        .unwrap_or_default();
+                    self.check_apply_arg_count(node, args.len())?;
+                    result = self.build_application(result, args, node);
+                }
+                "LDBRACKET" => {
+                    let indices = node
+                        .children
+                        .get(i + 1)
+                        .and_then(as_node)
+                        .filter(|n| n.rule_name == "arglist")
+                        .map(|n| self.lower_arglist(n, depth + 1))
+                        .transpose()?
+                        .unwrap_or_default();
+                    self.check_apply_arg_count(node, indices.len())?;
+                    for index in indices {
+                        let span = self.span_of(node);
+                        result = self.sym_apply(
+                            self.sym_symbol_bare(PART_HEAD, span.clone()),
+                            vec![result, index],
+                            span,
+                        );
+                    }
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        Ok(result)
+    }
+
+    /// Apply `head` to `args`, bridging built-in surface heads to their
+    /// canonical IR head, and left-folding a 3-or-more-argument
+    /// associative application (`Plus`/`Times`/`And`/`Or`) into a binary
+    /// chain -- mirrors the native `wolfram-runtime::lower::build_application`
+    /// exactly, so `Plus[1, 2, 3]` and `1 + 2 + 3` produce byte-identical
+    /// IR.
+    fn build_application(&mut self, head: Expr, args: Vec<Expr>, node: &GrammarASTNode) -> Expr {
+        let span = self.span_of(node);
+        let canonical_head = match &head {
+            Expr::SymSymbol { name, span } => surface_head_to_ir(name)
+                .map(|c| self.sym_symbol_bare(c, span.clone()))
+                .unwrap_or_else(|| head.clone()),
+            _ => head,
+        };
+        if let Expr::SymSymbol { name, .. } = &canonical_head {
+            if name == FUNCTION_HEAD && args.len() == 2 && !is_list_apply(&args[0]) {
+                let mut it = args.into_iter();
+                let param = it.next().unwrap();
+                let body = it.next().unwrap();
+                let list_span = self.span_of(node);
+                let params = self.sym_apply(
+                    self.sym_symbol_bare(LIST, list_span.clone()),
+                    vec![param],
+                    list_span,
+                );
+                return self.sym_apply(canonical_head, vec![params, body], span);
+            }
+            if matches!(name.as_str(), ADD | MUL | AND | OR) && args.len() > 2 {
+                let mut iter = args.into_iter();
+                let mut acc = iter.next().unwrap();
+                for next in iter {
+                    let step_span = self.span_of(node);
+                    acc = self.sym_apply(
+                        self.sym_symbol_bare(name, step_span.clone()),
+                        vec![acc, next],
+                        step_span,
+                    );
+                }
+                return acc;
+            }
+        }
+        self.sym_apply(canonical_head, args, span)
+    }
+
+    /// `arglist = expr { COMMA expr }` -- lower each comma-separated
+    /// argument. An arglist is a flat `Vec`, not a folded tree, so it has
+    /// no stack-recursion risk analogous to the binary-chain rules --
+    /// [`Self::check_apply_arg_count`] still bounds its raw length as a
+    /// modest defense-in-depth cap on allocation size.
+    fn lower_arglist(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Vec<Expr>, WolframLowerError> {
+        self.lower_child_nodes(node, depth)
+    }
+
+    /// `atom = NUMBER | STRING | NAME [ BLANK [ NAME ] ] | BLANK [ NAME ] |
+    /// list | group | slot`.
+    fn lower_atom(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        if let Some(child) = child_nodes(node).into_iter().next() {
+            if matches!(child.rule_name.as_str(), "list" | "group" | "slot") {
+                return self.lower_node(child, depth + 1);
+            }
+        }
+        let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+        let span = self.span_of(node);
+        match tokens.as_slice() {
+            [b, rest @ ..] if token_type(b) == "BLANK" => Ok(self.blank_from_tokens(rest, span)),
+            [name, b, rest @ ..] if token_type(name) == "NAME" && token_type(b) == "BLANK" => {
+                let inner = self.blank_from_tokens(rest, span.clone());
+                self.observed.add(Feature::PatternMatching);
+                Ok(Expr::SymPatternNamed {
+                    name: name.value.clone(),
+                    pattern: Box::new(inner),
+                    span,
+                })
+            }
+            [single] => self.lower_token(single),
+            _ => Err(WolframLowerError {
+                message: format!(
+                    "unrecognised atom token shape: {:?}",
+                    tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+                ),
+                line: span.start_line,
+                column: span.start_col,
+            }),
+        }
+    }
+
+    /// `slot = HASH [ NUMBER ] | SLOTSEQ`.
+    fn lower_slot(&mut self, node: &GrammarASTNode) -> Result<Expr, WolframLowerError> {
+        let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+        let span = self.span_of(node);
+        match tokens.as_slice() {
+            [s] if token_type(s) == "SLOTSEQ" => Ok(self.slot_sequence_apply(span)),
+            [h] if token_type(h) == "HASH" => Ok(self.slot_apply(1, span)),
+            [h, n] if token_type(h) == "HASH" && token_type(n) == "NUMBER" => {
+                let idx = n.value.parse::<i64>().map_err(|e| WolframLowerError {
+                    message: format!("invalid slot number {:?}: {e}", n.value),
+                    line: n.line,
+                    column: n.column,
+                })?;
+                if idx < 1 {
+                    return Err(WolframLowerError {
+                        message: format!("slot number must be >= 1, got {idx}"),
+                        line: n.line,
+                        column: n.column,
+                    });
+                }
+                Ok(self.slot_apply(idx, span))
+            }
+            _ => Err(WolframLowerError {
+                message: format!(
+                    "unrecognised slot token shape: {:?}",
+                    tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+                ),
+                line: span.start_line,
+                column: span.start_col,
+            }),
+        }
+    }
+
+    /// `amp = power AMP { AMP } { amp_apply } | power` -- the `&`
+    /// pure-function postfix and any immediate trailing application.
+    fn lower_amp(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let amp_count = node
+            .children
+            .iter()
+            .filter(|c| as_token(c).is_some_and(|t| token_type(t) == "AMP"))
+            .count();
+        if amp_count == 0 {
+            return self.lower_first_node(node, depth);
+        }
+        let body = self.lower_first_node(node, depth + 1)?;
+        let mut result = body;
+        for _ in 0..amp_count {
+            let span = self.span_of(node);
+            result = self.sym_apply(self.sym_symbol_bare(FUNCTION_HEAD, span.clone()), vec![result], span);
+        }
+        for suffix in child_nodes(node) {
+            if suffix.rule_name == "amp_apply" {
+                result = self.lower_amp_apply(result, suffix, depth + 1)?;
+            }
+        }
+        Ok(result)
+    }
+
+    /// Apply one `amp_apply` suffix (`[args]` or `[[i]]`) to an
+    /// already-built pure function.
+    fn lower_amp_apply(
+        &mut self,
+        func: Expr,
+        suffix: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Expr, WolframLowerError> {
+        let is_part = suffix
+            .children
+            .iter()
+            .any(|c| as_token(c).is_some_and(|t| token_type(t) == "LDBRACKET"));
+        let args = match child_nodes(suffix).into_iter().find(|n| n.rule_name == "arglist") {
+            Some(n) => self.lower_arglist(n, depth)?,
+            None => vec![],
+        };
+        self.check_apply_arg_count(suffix, args.len())?;
+        if is_part {
+            let mut result = func;
+            for index in args {
+                let span = self.span_of(suffix);
+                result = self.sym_apply(self.sym_symbol_bare(PART_HEAD, span.clone()), vec![result, index], span);
+            }
+            Ok(result)
+        } else {
+            Ok(self.build_application(func, args, suffix))
+        }
+    }
+
+    /// `list = LBRACE [ arglist ] RBRACE` → `SymApply{head: List, …}`.
+    fn lower_list(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let args = self.lower_list_elements(node, depth)?;
+        let span = self.span_of(node);
+        Ok(self.sym_apply(self.sym_symbol_bare(LIST, span.clone()), args, span))
+    }
+
+    /// The raw element list of a `list` node, without wrapping in `List`
+    /// (used both by `lower_list` and by `lower_rules_operand`, which needs
+    /// the bare elements rather than a `List` `SymApply`).
+    fn lower_list_elements(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Vec<Expr>, WolframLowerError> {
+        let mut args = Vec::new();
+        for child in child_nodes(node) {
+            if child.rule_name == "arglist" {
+                args.extend(self.lower_arglist(child, depth + 1)?);
+            }
+        }
+        self.check_apply_arg_count(node, args.len())?;
+        Ok(args)
+    }
+
+    /// `group = LPAREN expr RPAREN` -- grouping only.
+    fn lower_group(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let inner = child_nodes(node)
+            .into_iter()
+            .next()
+            .ok_or_else(|| self.err_at(node, "empty group `( )`".to_string()))?;
+        self.lower_node(inner, depth + 1)
+    }
+
+    // -------------------------------------------------------------------
+    // Small constructors (each observes the feature the validator's own
+    // `check_expr` requires for that node kind -- see `semantic-ir/src/
+    // validator.rs`, the ground truth this must match exactly).
+    // -------------------------------------------------------------------
+
+    fn sym_symbol(&mut self, name: String, span: Span) -> Expr {
+        self.observed.add(Feature::SymbolicExpr);
+        Expr::SymSymbol { name, span }
+    }
+
+    /// Build a `SymSymbol` for a *head* name (identical shape to
+    /// [`Self::sym_symbol`] -- named separately only so call sites that
+    /// build a head make their intent legible).
+    fn sym_symbol_bare(&self, name: impl Into<String>, span: Span) -> Expr {
+        Expr::SymSymbol {
+            name: name.into(),
+            span,
+        }
+    }
+
+    fn sym_apply(&mut self, head: Expr, args: Vec<Expr>, span: Span) -> Expr {
+        self.observed.add(Feature::SymbolicExpr);
+        Expr::SymApply {
+            head: Box::new(head),
+            args,
+            span,
+        }
+    }
+
+    fn pattern_blank(&mut self, head: Option<Box<Expr>>, span: Span) -> Expr {
+        self.observed.add(Feature::PatternMatching);
+        Expr::SymPatternBlank { head, span }
+    }
+
+    fn blank_from_tokens(&mut self, rest: &[&Token], span: Span) -> Expr {
+        match rest.first() {
+            Some(head) if token_type(head) == "NAME" => {
+                let head_span = self.token_span(head);
+                self.pattern_blank(Some(Box::new(self.sym_symbol_bare(head.value.clone(), head_span))), span)
+            }
+            _ => self.pattern_blank(None, span),
+        }
+    }
+
+    fn slot_apply(&mut self, n: i64, span: Span) -> Expr {
+        let int_span = span.clone();
+        self.sym_apply(
+            self.sym_symbol_bare(SLOT_HEAD, span.clone()),
+            vec![Expr::IntLit { value: n, span: int_span }],
+            span,
+        )
+    }
+
+    fn slot_sequence_apply(&mut self, span: Span) -> Expr {
+        let int_span = span.clone();
+        self.sym_apply(
+            self.sym_symbol_bare(SLOT_SEQUENCE_HEAD, span.clone()),
+            vec![Expr::IntLit { value: 1, span: int_span }],
+            span,
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // Guards
+    // -------------------------------------------------------------------
+
+    /// Reject a same-precedence operator chain (`additive`/
+    /// `multiplicative`/`logical_or`/`logical_and`/`alternatives`/
+    /// `mapapply`/`patterntest`/`replaceall`) with more than
+    /// `MAX_EXPR_DEPTH` operands.
+    ///
+    /// The Wolfram grammar collapses a flat run of same-precedence
+    /// operators into ONE CST node with many children rather than nesting
+    /// through parens, so a long unparenthesized chain (`1 + 1 + ... + 1`,
+    /// tens of thousands of terms) never trips the ordinary grammar-nesting
+    /// depth guard (`wolfram-parser`'s `MAX_RULE_DEPTH`, which counts
+    /// *nesting*, not the length of one flat repetition). But folding N
+    /// operands left-associatively still builds an N-deep *binary* `Expr`
+    /// tree, and that tree's own depth is what every later recursive pass
+    /// over it pays for (the validator, any backend's emit pass, even plain
+    /// `Drop`) regardless of how cheaply each fold step was. This is the
+    /// exact bug class `matlab-to-semantic-ir` discovered the hard way
+    /// during its own security review (a 60,000-term chain overflowed the
+    /// native stack even after fixing that crate's O(1)-per-step
+    /// construction cost, because the *structure* was still 60,000 levels
+    /// deep) -- applied here from day one instead of being retrofitted.
+    fn check_chain_length(&self, node: &GrammarASTNode) -> Result<(), WolframLowerError> {
+        let operand_count = node
+            .children
+            .iter()
+            .filter(|c| matches!(c, ASTNodeOrToken::Node(_)))
+            .count();
+        if operand_count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!(
+                    "expression chain too long ({operand_count} operands, exceeds \
+                     {MAX_EXPR_DEPTH})"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Cap the argument count of a single `f[…]`/`{…}`/`x[[…]]` application
+    /// or list literal. Unlike [`Self::check_chain_length`], an arglist does
+    /// not fold into a nested tree (it stays a flat `Vec<Expr>`), so this is
+    /// not a stack-recursion guard -- it is a modest defense-in-depth cap on
+    /// a single allocation's size, using the same `MAX_EXPR_DEPTH` bound for
+    /// consistency rather than inventing a second unrelated constant.
+    fn check_apply_arg_count(&self, node: &GrammarASTNode, count: usize) -> Result<(), WolframLowerError> {
+        if count > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("too many arguments ({count}, exceeds {MAX_EXPR_DEPTH})"),
+            ));
+        }
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Small helpers
+    // -------------------------------------------------------------------
+
+    fn lower_first_node(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
+        let child = child_nodes(node)
+            .into_iter()
+            .next()
+            .ok_or_else(|| self.err_at(node, format!("`{}` has no expression child", node.rule_name)))?;
+        self.lower_node(child, depth + 1)
+    }
+
+    fn lower_child(&mut self, child: &ASTNodeOrToken, depth: usize) -> Result<Expr, WolframLowerError> {
+        match child {
+            ASTNodeOrToken::Node(node) => self.lower_node(node, depth),
+            ASTNodeOrToken::Token(token) => self.lower_token(token),
+        }
+    }
+
+    fn lower_child_nodes(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Vec<Expr>, WolframLowerError> {
+        child_nodes(node)
+            .into_iter()
+            .map(|n| self.lower_node(n, depth))
+            .collect()
+    }
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::new(
+            FILE,
+            node.start_line.unwrap_or(1),
+            node.start_column.unwrap_or(1),
+            node.end_line.unwrap_or(node.start_line.unwrap_or(1)),
+            node.end_column.unwrap_or(node.start_column.unwrap_or(1)),
+        )
+    }
+
+    fn token_span(&self, token: &Token) -> Span {
+        Span::point(FILE, token.line, token.column)
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> WolframLowerError {
+        WolframLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (no `&mut self` needed)
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// The first *node* child of `node` whose `rule_name == name`.
+fn first_child_named<'a>(node: &'a GrammarASTNode, name: &str) -> Option<&'a GrammarASTNode> {
+    child_nodes(node).into_iter().find(|n| n.rule_name == name)
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+/// Parse a `NUMBER` lexeme into an `IntLit` or `FloatLit`, matching the
+/// native `wolfram-runtime::lower::lower_number`'s identical rule (a `.`,
+/// `e`, or `E` means a real; otherwise an integer). An integer lexeme too
+/// large for `i64` falls back to a float rather than silently truncating.
+fn number_literal_expr(text: &str, span: Span) -> Expr {
+    if text.contains('.') || text.contains('e') || text.contains('E') {
+        Expr::FloatLit {
+            value: text.parse::<f64>().unwrap_or(0.0),
+            span,
+        }
+    } else {
+        match text.parse::<i64>() {
+            Ok(v) => Expr::IntLit { value: v, span },
+            Err(_) => Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span,
+            },
+        }
+    }
+}
+
+/// Strip the surrounding double-quotes from a `STRING` lexeme (mirrors the
+/// native lowering's identical helper).
+fn strip_quotes(text: &str) -> &str {
+    text.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(text)
+}
+
+/// Map an arithmetic/separator token type to its canonical IR head.
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a comparison token type to its canonical IR head.
+fn comparison_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "EQUAL" => Some(EQUAL),
+        "UNEQUAL" => Some(NOT_EQUAL),
+        "LESS" => Some(LESS),
+        "GREATER" => Some(GREATER),
+        "LE" => Some(LESS_EQUAL),
+        "GE" => Some(GREATER_EQUAL),
+        _ => None,
+    }
+}
+
+/// Bridge a Wolfram *surface* head to the canonical IR head for built-ins
+/// (`Plus`→`Add`, …). Returns `None` for anything else (already-canonical
+/// heads like `Sin`, and any user-defined head, pass through unchanged) --
+/// mirrors the native `wolfram-runtime::lower::surface_head_to_ir` table
+/// exactly.
+fn surface_head_to_ir(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "Plus" => ADD,
+        "Subtract" => SUB,
+        "Times" => MUL,
+        "Divide" => DIV,
+        "Power" => POW,
+        "Minus" => NEG,
+        "Equal" => EQUAL,
+        "Unequal" => NOT_EQUAL,
+        "Less" => LESS,
+        "Greater" => GREATER,
+        "LessEqual" => LESS_EQUAL,
+        "GreaterEqual" => GREATER_EQUAL,
+        "And" => AND,
+        "Or" => OR,
+        "Not" => NOT,
+        "List" => LIST,
+        "Set" => ASSIGN,
+        "SetDelayed" => DEFINE,
+        _ => return None,
+    })
+}
+
+/// True if `expr` is a `SymApply{head: List, ..}` -- used to detect an
+/// already-list `Function` parameter list (`Function[{x, y}, body]`) vs. a
+/// single-symbol one (`Function[x, body]`).
+fn is_list_apply(expr: &Expr) -> bool {
+    matches!(expr, Expr::SymApply { head, .. } if matches!(head.as_ref(), Expr::SymSymbol { name, .. } if name == LIST))
+}
+
+/// Gather the names captured by every [`Expr::SymPatternNamed`] anywhere in
+/// `expr` -- used by `lower_rule` to know which RHS bare-symbol references
+/// need rewriting into pattern-reference form. Safe to recurse unguarded:
+/// `expr` was built by [`Lowerer::lower_node`], whose own `MAX_EXPR_DEPTH`
+/// cap already bounds its depth, so walking it again can never exceed that
+/// same bound (this is the "structure is already bounded, so a second walk
+/// of it is safe" half of the lesson `matlab-to-semantic-ir`'s
+/// `expr_is_known_scalar_d` doc comment discusses -- unlike that function,
+/// this one is never called on anything *other* than an already-built,
+/// already-capped tree, so it needs no depth parameter of its own).
+fn collect_pattern_names(expr: &Expr, names: &mut HashSet<String>) {
+    match expr {
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            names.insert(name.clone());
+            collect_pattern_names(pattern, names);
+        }
+        Expr::SymPatternBlank { head: Some(h), .. } => collect_pattern_names(h, names),
+        Expr::SymApply { head, args, .. } => {
+            collect_pattern_names(head, names);
+            for a in args {
+                collect_pattern_names(a, names);
+            }
+        }
+        Expr::SymRule { lhs, rhs, .. } => {
+            collect_pattern_names(lhs, names);
+            collect_pattern_names(rhs, names);
+        }
+        Expr::SymReplaceAll { expr, rules, .. } => {
+            collect_pattern_names(expr, names);
+            for r in rules {
+                collect_pattern_names(r, names);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Rewrite bare `SymSymbol(name)` references that are bound LHS pattern
+/// names into `SymPatternNamed{name, pattern: SymPatternBlank{None}}`
+/// reference nodes -- the same shape a fresh `x_` occurrence lowers to (see
+/// the SIR23 spec) -- so a later matcher's substitution step fills them in.
+/// Symbols not in `bound`, and all literals, pass through unchanged.
+fn bind_pattern_refs(expr: Expr, bound: &HashSet<String>) -> Expr {
+    match expr {
+        Expr::SymSymbol { name, span } if bound.contains(&name) => Expr::SymPatternNamed {
+            name: name.clone(),
+            pattern: Box::new(Expr::SymPatternBlank {
+                head: None,
+                span: span.clone(),
+            }),
+            span,
+        },
+        Expr::SymApply { head, args, span } => Expr::SymApply {
+            head: Box::new(bind_pattern_refs(*head, bound)),
+            args: args.into_iter().map(|a| bind_pattern_refs(a, bound)).collect(),
+            span,
+        },
+        other => other,
+    }
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+impl<'a> Unwrapped<'a> {
+    fn is_list(&self) -> bool {
+        matches!(self, Unwrapped::Node(n) if n.rule_name == "list")
+    }
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with
+/// structure (or a leaf token). A precedence-cascade rule that did not
+/// apply its operator still emits its own node with exactly one child --
+/// this skips straight to the rule that actually matters.
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -736,8 +736,21 @@ impl Lowerer {
     /// `postfix = atom { LBRACKET [ arglist ] RBRACKET | LDBRACKET arglist
     /// RBRACKET RBRACKET }` -- function application and the `[[ … ]]` part
     /// sugar, both postfix, left-associative and chainable.
+    ///
+    /// Tracks a *cumulative* nesting-depth budget (`chain_depth`) across the
+    /// whole chain rather than separately capping "how many bracket groups"
+    /// and "how many indices/args per group": those two axes multiply, not
+    /// add -- an `LDBRACKET` group folds one `Part` per index, so N chained
+    /// groups each carrying M indices builds N×M levels of nesting, not N.
+    /// A prior version of this guard counted groups only (bounding N to
+    /// `MAX_EXPR_DEPTH`) and relied on `check_apply_arg_count` to separately
+    /// bound M per group to `MAX_EXPR_DEPTH` -- a security review found this
+    /// still permits up to `MAX_EXPR_DEPTH`² levels of real nesting (256×256
+    /// far exceeds the intended cap), confirmed to reproduce the same class
+    /// of native stack overflow `check_chain_length`'s own doc comment
+    /// describes. See [`Self::add_chain_depth`] for the shared budget this
+    /// function and [`Self::lower_amp_apply`] both draw from.
     fn lower_postfix(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
-        self.check_postfix_chain_length(node)?;
         let mut result = self.lower_child(
             node.children
                 .first()
@@ -745,6 +758,7 @@ impl Lowerer {
             depth + 1,
         )?;
 
+        let mut chain_depth: usize = 0;
         let mut i = 1;
         while i < node.children.len() {
             let Some(token) = as_token(&node.children[i]) else {
@@ -762,6 +776,7 @@ impl Lowerer {
                         .transpose()?
                         .unwrap_or_default();
                     self.check_apply_arg_count(node, args.len())?;
+                    chain_depth = self.add_chain_depth(node, chain_depth, args.len().max(1))?;
                     result = self.build_application(result, args, node);
                 }
                 "LDBRACKET" => {
@@ -774,6 +789,7 @@ impl Lowerer {
                         .transpose()?
                         .unwrap_or_default();
                     self.check_apply_arg_count(node, indices.len())?;
+                    chain_depth = self.add_chain_depth(node, chain_depth, indices.len().max(1))?;
                     for index in indices {
                         let span = self.span_of(node);
                         result = self.sym_apply(
@@ -914,10 +930,14 @@ impl Lowerer {
     ///
     /// Both repetitions here (`{ AMP }` and `{ amp_apply }`) are flat,
     /// token-or-node runs the grammar folds into ONE `amp` node's children
-    /// rather than nesting -- exactly the same shape `check_chain_length`
-    /// guards for `additive`/`multiplicative`/etc, so both are capped
-    /// before their respective wrapping loops run (see
-    /// [`Self::check_amp_chain_length`]).
+    /// rather than nesting. `amp_count` levels of `Function`-wrapping is
+    /// exact (each `&` adds exactly one level, no multiplication risk), but
+    /// each trailing `amp_apply` suffix can itself carry a multi-index
+    /// `[[…]]` Part-fold or a multi-arg associative-head call -- see
+    /// [`Self::lower_postfix`]'s doc comment for why a per-suffix-count cap
+    /// alone is insufficient (the same multiplicative gap applies here), so
+    /// the `&`-run and every suffix share one cumulative
+    /// [`Self::add_chain_depth`] budget.
     fn lower_amp(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, WolframLowerError> {
         let amp_count = node
             .children
@@ -927,7 +947,7 @@ impl Lowerer {
         if amp_count == 0 {
             return self.lower_first_node(node, depth);
         }
-        self.check_amp_chain_length(node, amp_count)?;
+        let mut chain_depth = self.add_chain_depth(node, 0, amp_count)?;
         let body = self.lower_first_node(node, depth + 1)?;
         let mut result = body;
         for _ in 0..amp_count {
@@ -936,20 +956,26 @@ impl Lowerer {
         }
         for suffix in child_nodes(node) {
             if suffix.rule_name == "amp_apply" {
-                result = self.lower_amp_apply(result, suffix, depth + 1)?;
+                let (new_result, new_depth) =
+                    self.lower_amp_apply(result, suffix, depth + 1, chain_depth)?;
+                result = new_result;
+                chain_depth = new_depth;
             }
         }
         Ok(result)
     }
 
     /// Apply one `amp_apply` suffix (`[args]` or `[[i]]`) to an
-    /// already-built pure function.
+    /// already-built pure function, threading and returning the updated
+    /// cumulative chain-depth budget (see [`Self::lower_amp`]'s doc
+    /// comment).
     fn lower_amp_apply(
         &mut self,
         func: Expr,
         suffix: &GrammarASTNode,
         depth: usize,
-    ) -> Result<Expr, WolframLowerError> {
+        chain_depth: usize,
+    ) -> Result<(Expr, usize), WolframLowerError> {
         let is_part = suffix
             .children
             .iter()
@@ -959,15 +985,16 @@ impl Lowerer {
             None => vec![],
         };
         self.check_apply_arg_count(suffix, args.len())?;
+        let chain_depth = self.add_chain_depth(suffix, chain_depth, args.len().max(1))?;
         if is_part {
             let mut result = func;
             for index in args {
                 let span = self.span_of(suffix);
                 result = self.sym_apply(self.sym_symbol_bare(PART_HEAD, span.clone()), vec![result, index], span);
             }
-            Ok(result)
+            Ok((result, chain_depth))
         } else {
-            Ok(self.build_application(func, args, suffix))
+            Ok((self.build_application(func, args, suffix), chain_depth))
         }
     }
 
@@ -1122,70 +1149,45 @@ impl Lowerer {
         Ok(())
     }
 
-    /// Reject a chain of postfix application/part groups
-    /// (`f[…][…][…]…`/`x[[…]][[…]][[…]]…`, in any mix) longer than
-    /// `MAX_EXPR_DEPTH`.
+    /// Add `delta` to a running cumulative nesting-depth budget shared
+    /// across an entire postfix/amp-apply chain, rejecting once the total
+    /// exceeds `MAX_EXPR_DEPTH`.
     ///
-    /// `lower_postfix`'s `while` loop is iterative, not recursive through
-    /// `lower_node` -- each `LBRACKET`/`LDBRACKET` group wraps the running
-    /// `result` as the head (or `Part` target) of a brand-new `SymApply`,
-    /// so this chain never engages `MAX_EXPR_DEPTH`'s own recursion check
-    /// no matter how many groups there are. This is the exact same bug
-    /// class [`Self::check_chain_length`] guards against, on a grammar
-    /// shape [`Self::check_chain_length`] itself does not cover (the chain
-    /// here is expressed as a run of TOKENS with an optional trailing
-    /// `arglist` node each, not a run of `Node` operands) -- found during
-    /// security review after the initial per-production audit missed it,
-    /// since `postfix` was not in the list of "obviously chain-shaped"
-    /// rules the additive/multiplicative/logical/alternatives/mapapply/
-    /// patterntest/replaceall productions made explicit.
-    fn check_postfix_chain_length(&self, node: &GrammarASTNode) -> Result<(), WolframLowerError> {
-        let group_count = node
-            .children
-            .iter()
-            .filter(|c| as_token(c).is_some_and(|t| matches!(token_type(t), "LBRACKET" | "LDBRACKET")))
-            .count();
-        if group_count > MAX_EXPR_DEPTH {
+    /// Used by [`Self::lower_postfix`] and [`Self::lower_amp`]/
+    /// [`Self::lower_amp_apply`], whose bracket/part/pure-function-apply
+    /// chains are iterative loops that rebuild a result across many
+    /// grammar-flattened repetitions -- never recursing through the
+    /// depth-capped `lower_node` -- so nothing else bounds how deep the
+    /// resulting tree gets.
+    ///
+    /// This must be a single *cumulative* budget, not independent per-axis
+    /// counts: a security review found that separately capping "how many
+    /// bracket groups" (to `MAX_EXPR_DEPTH`) and "how many indices/args per
+    /// group" (also to `MAX_EXPR_DEPTH`, via [`Self::check_apply_arg_count`])
+    /// still permits up to `MAX_EXPR_DEPTH`² levels of real nesting, since
+    /// an `LDBRACKET` group folds one `Part` per index and those two axes
+    /// multiply rather than add. Every call site therefore threads the same
+    /// running total through the whole chain and charges each group's own
+    /// contribution (`args.len()`/`indices.len()`, floored at 1) against
+    /// it, so the *cumulative* depth the entire chain can add is bounded to
+    /// `MAX_EXPR_DEPTH` regardless of how it's distributed across groups.
+    fn add_chain_depth(
+        &self,
+        node: &GrammarASTNode,
+        current: usize,
+        delta: usize,
+    ) -> Result<usize, WolframLowerError> {
+        let next = current.saturating_add(delta);
+        if next > MAX_EXPR_DEPTH {
             return Err(self.err_at(
                 node,
                 format!(
-                    "too many chained application/part groups ({group_count}, exceeds \
+                    "chained application/part/pure-function nesting too deep ({next}, exceeds \
                      {MAX_EXPR_DEPTH})"
                 ),
             ));
         }
-        Ok(())
-    }
-
-    /// Reject an `amp` node (`expr & & & …`, and/or `expr & […] […] …`)
-    /// whose `&` run or trailing `amp_apply` suffix run exceeds
-    /// `MAX_EXPR_DEPTH`.
-    ///
-    /// Both `lower_amp`'s `&`-wrapping loop (`for _ in 0..amp_count`) and
-    /// its `amp_apply` suffix loop are the same iterative-wrap-in-a-loop
-    /// shape [`Self::check_postfix_chain_length`] guards for ordinary
-    /// postfix application -- same bug class, same fix.
-    fn check_amp_chain_length(&self, node: &GrammarASTNode, amp_count: usize) -> Result<(), WolframLowerError> {
-        if amp_count > MAX_EXPR_DEPTH {
-            return Err(self.err_at(
-                node,
-                format!("too many chained `&` (amp_count {amp_count}, exceeds {MAX_EXPR_DEPTH})"),
-            ));
-        }
-        let suffix_count = child_nodes(node)
-            .into_iter()
-            .filter(|n| n.rule_name == "amp_apply")
-            .count();
-        if suffix_count > MAX_EXPR_DEPTH {
-            return Err(self.err_at(
-                node,
-                format!(
-                    "too many chained pure-function applications ({suffix_count}, exceeds \
-                     {MAX_EXPR_DEPTH})"
-                ),
-            ));
-        }
-        Ok(())
+        Ok(next)
     }
 
     // -------------------------------------------------------------------

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
@@ -545,8 +545,7 @@ fn a_chain_at_exactly_the_cap_still_compiles() {
 // operator chains above (a run of TOKENS with an optional trailing
 // `arglist` node each, not a run of `Node` operands). Found during
 // security review, after the initial per-production chain-length audit
-// above missed it — see `check_postfix_chain_length`/`check_amp_chain_length`
-// in `src/lower.rs`.
+// above missed it — see `add_chain_depth` in `src/lower.rs`.
 
 #[test]
 fn a_huge_chained_bracket_application_is_rejected_cleanly_not_crashed() {
@@ -584,5 +583,36 @@ fn a_bracket_chain_at_exactly_the_cap_still_compiles() {
 
     let bad_chains = 257;
     let bad_src = format!("x{}\n", "[0]".repeat(bad_chains));
+    assert!(compile_source(&bad_src, "test").is_err());
+}
+
+// A prior version of the chained-application guard capped "how many
+// bracket groups" and "how many indices per group" as two INDEPENDENT
+// counts, each bounded to MAX_EXPR_DEPTH. That looks safe per-axis but the
+// two axes multiply: an LDBRACKET group folds one Part per index, so N
+// chained groups each carrying M indices builds N*M levels of nesting, not
+// N. Found during round 2 of security review — see `add_chain_depth`'s
+// doc comment in src/lower.rs.
+
+#[test]
+fn a_multiplicative_bracket_times_index_combination_is_rejected_cleanly() {
+    // 256 chained [[..]] groups, each with 256 indices: the old per-axis
+    // caps (group_count <= 256 AND indices_per_group <= 256) both
+    // individually passed, but the real nesting depth was 256*256 = 65536.
+    let indices = (0..256).map(|_| "1").collect::<Vec<_>>().join(",");
+    let group = format!("[[{indices}]]");
+    let src = format!("x{}\n", group.repeat(256));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_cumulative_chain_depth_at_exactly_the_cap_still_compiles() {
+    // A single group with exactly MAX_EXPR_DEPTH (256) indices should still
+    // compile (256 <= 256); one more group of any size should not.
+    let indices = (0..256).map(|_| "1").collect::<Vec<_>>().join(",");
+    let ok_src = format!("x[[{indices}]]\n");
+    assert!(compile_source(&ok_src, "test").is_ok());
+
+    let bad_src = format!("x[[{indices}]][0]\n");
     assert!(compile_source(&bad_src, "test").is_err());
 }

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
@@ -537,3 +537,52 @@ fn a_chain_at_exactly_the_cap_still_compiles() {
     let bad_src = format!("{}\n", (0..bad_terms).map(|_| "1").collect::<Vec<_>>().join(" + "));
     assert!(compile_source(&bad_src, "test").is_err());
 }
+
+// A chained application/part/pure-function-apply run is iterative in
+// `lower_postfix`/`lower_amp`, not recursive through `lower_node` -- it
+// never engages `MAX_EXPR_DEPTH`'s own recursion check no matter how many
+// groups there are, which is a different grammar shape from the flat
+// operator chains above (a run of TOKENS with an optional trailing
+// `arglist` node each, not a run of `Node` operands). Found during
+// security review, after the initial per-production chain-length audit
+// above missed it — see `check_postfix_chain_length`/`check_amp_chain_length`
+// in `src/lower.rs`.
+
+#[test]
+fn a_huge_chained_bracket_application_is_rejected_cleanly_not_crashed() {
+    let chains = 60_000;
+    let src = format!("x{}\n", "[0]".repeat(chains));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_huge_chained_double_bracket_part_is_rejected_cleanly_not_crashed() {
+    let chains = 60_000;
+    let src = format!("x{}\n", "[[0]]".repeat(chains));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_huge_chained_pure_function_amp_apply_is_rejected_cleanly_not_crashed() {
+    let chains = 60_000;
+    let src = format!("(#&){}\n", "[0]".repeat(chains));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_huge_chained_ampersand_run_is_rejected_cleanly_not_crashed() {
+    let count = 60_000;
+    let src = format!("x{}\n", " &".repeat(count));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_bracket_chain_at_exactly_the_cap_still_compiles() {
+    let ok_chains = 256;
+    let ok_src = format!("x{}\n", "[0]".repeat(ok_chains));
+    assert!(compile_source(&ok_src, "test").is_ok());
+
+    let bad_chains = 257;
+    let bad_src = format!("x{}\n", "[0]".repeat(bad_chains));
+    assert!(compile_source(&bad_src, "test").is_err());
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
@@ -496,9 +496,24 @@ fn multiple_top_level_statements_each_become_an_expr_stmt() {
 
 // --- recursion-depth / chain-length guards (DoS hardening) -----------------
 //
-// These mirror the exact regression scale `matlab-to-semantic-ir`'s own
-// security review established (60,000 flat operands) rather than a smaller,
-// less convincing number.
+// These prove `compile_source` cleanly rejects (not crashes on) a chain far
+// past `MAX_EXPR_DEPTH` (256). An earlier version of this suite matched
+// `matlab-to-semantic-ir`'s own historical crash scale (60,000 flat
+// operands) for narrative consistency with that incident, but that scale
+// makes `wolfram-parser` itself (whose packrat-memo lookup is a known,
+// separately-tracked O(n) performance concern) slow enough to parse that,
+// under a resource-constrained CI runner running many tests concurrently,
+// the combined wall-clock pushed this package's CI step past an external
+// time budget and got it killed mid-run (confirmed: these tests took
+// 15-16s *each* individually; `--test-threads=2`, simulating a 2-core
+// runner, nearly doubled the whole suite's wall-clock). What actually
+// matters for a regression test is just "comfortably past the cap", not
+// matching a specific historical incident's scale -- the guard rejecting
+// 3,000 operands proves it rejects 60,000 equally well, at a small
+// fraction of the parse cost. The much larger scales were still confirmed
+// (via throwaway, not-checked-in adversarial repros during security
+// review) to reproduce real crashes with each guard disabled; see
+// CHANGELOG.md's "Fixed" entries for that history.
 
 #[test]
 fn a_deeply_parenthesised_expression_is_rejected_cleanly() {
@@ -513,14 +528,14 @@ fn a_deeply_parenthesised_expression_is_rejected_cleanly() {
 
 #[test]
 fn a_huge_flat_additive_chain_is_rejected_cleanly_not_crashed() {
-    let terms = 60_000;
+    let terms = 3_000;
     let src = format!("{}\n", (0..terms).map(|_| "1").collect::<Vec<_>>().join(" + "));
     assert!(compile_source(&src, "test").is_err());
 }
 
 #[test]
 fn a_huge_flat_alternatives_chain_is_rejected_cleanly() {
-    let terms = 60_000;
+    let terms = 3_000;
     let src = format!("{}\n", (0..terms).map(|_| "a").collect::<Vec<_>>().join(" | "));
     assert!(compile_source(&src, "test").is_err());
 }
@@ -549,28 +564,28 @@ fn a_chain_at_exactly_the_cap_still_compiles() {
 
 #[test]
 fn a_huge_chained_bracket_application_is_rejected_cleanly_not_crashed() {
-    let chains = 60_000;
+    let chains = 3_000;
     let src = format!("x{}\n", "[0]".repeat(chains));
     assert!(compile_source(&src, "test").is_err());
 }
 
 #[test]
 fn a_huge_chained_double_bracket_part_is_rejected_cleanly_not_crashed() {
-    let chains = 60_000;
+    let chains = 3_000;
     let src = format!("x{}\n", "[[0]]".repeat(chains));
     assert!(compile_source(&src, "test").is_err());
 }
 
 #[test]
 fn a_huge_chained_pure_function_amp_apply_is_rejected_cleanly_not_crashed() {
-    let chains = 60_000;
+    let chains = 3_000;
     let src = format!("(#&){}\n", "[0]".repeat(chains));
     assert!(compile_source(&src, "test").is_err());
 }
 
 #[test]
 fn a_huge_chained_ampersand_run_is_rejected_cleanly_not_crashed() {
-    let count = 60_000;
+    let count = 3_000;
     let src = format!("x{}\n", " &".repeat(count));
     assert!(compile_source(&src, "test").is_err());
 }
@@ -596,12 +611,20 @@ fn a_bracket_chain_at_exactly_the_cap_still_compiles() {
 
 #[test]
 fn a_multiplicative_bracket_times_index_combination_is_rejected_cleanly() {
-    // 256 chained [[..]] groups, each with 256 indices: the old per-axis
-    // caps (group_count <= 256 AND indices_per_group <= 256) both
-    // individually passed, but the real nesting depth was 256*256 = 65536.
-    let indices = (0..256).map(|_| "1").collect::<Vec<_>>().join(",");
+    // 30 chained [[..]] groups, each with 30 indices: both counts
+    // individually stay well under MAX_EXPR_DEPTH (256) -- so an old-style
+    // per-axis cap on "how many groups" and "how many indices per group"
+    // would pass this input -- but the real nesting depth is their
+    // *product*, 30*30 = 900, already past the cap. (The original finding
+    // used 256*256 = 65,536 to mirror the confirmed crash scale, but
+    // proving the guard catches a smaller over-cap product demonstrates
+    // the same multiplicative-bypass fix at a fraction of the parse cost;
+    // the 256*256 scale was independently confirmed, via a throwaway
+    // adversarial repro during security review, to reproduce a real
+    // SIGABRT with the guard disabled.)
+    let indices = (0..30).map(|_| "1").collect::<Vec<_>>().join(",");
     let group = format!("[[{indices}]]");
-    let src = format!("x{}\n", group.repeat(256));
+    let src = format!("x{}\n", group.repeat(30));
     assert!(compile_source(&src, "test").is_err());
 }
 

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
@@ -616,3 +616,35 @@ fn a_cumulative_chain_depth_at_exactly_the_cap_still_compiles() {
     let bad_src = format!("x[[{indices}]][0]\n");
     assert!(compile_source(&bad_src, "test").is_err());
 }
+
+// Per-construct chain budgets (`add_chain_depth`, `check_chain_length`) are
+// each scoped to ONE grammar node and don't compose across a nested
+// boundary -- chaining several independently-capped bracket chains through
+// `(...)` grouping (each individually at or under MAX_EXPR_DEPTH) can still
+// build a tree far deeper than any single guard's own limit, since each
+// guard only sees its own local slice of the construction. Found during
+// round 3 of security review -- see `measure_depth_iterative`'s doc
+// comment in src/lower.rs, the authoritative post-construction check that
+// closes this regardless of how the tree was composed.
+
+#[test]
+fn chained_bracket_groups_composed_across_paren_boundaries_are_rejected_cleanly() {
+    // 20 levels of "(...) [20 groups]" wrapping -- each level's own 20
+    // bracket groups is comfortably UNDER MAX_EXPR_DEPTH (256) on its own
+    // (so a per-node-local check alone would pass every single level), but
+    // the levels compose to 20*20 = 400 real nesting levels, already past
+    // the cap. (A much larger, ~97-level/256-groups-per-level version of
+    // this same construction was independently confirmed, during security
+    // review, to take `wolfram-parser` itself minutes to even parse --
+    // `wolfram-parser`'s own O(n) packrat-memo lookup, tracked separately
+    // as a performance follow-up, not a correctness issue -- so this test
+    // uses the smallest scale that still demonstrably exceeds the cap via
+    // composition, to stay fast.)
+    let group = "[0]".repeat(20);
+    let mut src = format!("x{group}");
+    for _ in 0..20 {
+        src = format!("({src}){group}");
+    }
+    src.push('\n');
+    assert!(compile_source(&src, "test").is_err());
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,539 @@
+//! Unit tests asserting exact `Expr` shapes produced by
+//! `wolfram_to_semantic_ir::compile_source` — one per grammar production,
+//! mirroring `matlab-to-semantic-ir`'s own `tests/test_lower.rs` structure.
+
+use semantic_ir::{Expr, Feature, Module, Stmt};
+use wolfram_to_semantic_ir::compile_source;
+
+/// Lower a single-statement source to its one top-level `Expr`.
+fn lower_one(src: &str) -> Expr {
+    let module = compile_source(src, "test").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let main = module
+        .functions
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("no main function");
+    assert_eq!(
+        main.body.stmts.len(),
+        1,
+        "expected exactly one statement for {src:?}, got {}",
+        main.body.stmts.len()
+    );
+    match &main.body.stmts[0] {
+        Stmt::ExprStmt { expr, .. } => expr.clone(),
+        other => panic!("expected an ExprStmt, got {other:?}"),
+    }
+}
+
+fn manifest_has(module: &Module, feature: Feature) -> bool {
+    module.manifest.iter().any(|f| f == feature)
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol {
+        name: name.to_string(),
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn int(v: i64) -> Expr {
+    Expr::IntLit {
+        value: v,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+fn apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply {
+        head: Box::new(head),
+        args,
+        span: semantic_ir::Span::synthetic(),
+    }
+}
+
+/// Equality that ignores spans (every helper above uses a synthetic span;
+/// real lowered spans point at real source positions) — recursively zero
+/// out spans on both sides before comparing.
+fn assert_shape_eq(actual: Expr, expected: Expr) {
+    assert_eq!(strip_spans(actual), strip_spans(expected));
+}
+
+fn strip_spans(expr: Expr) -> Expr {
+    let z = semantic_ir::Span::synthetic();
+    match expr {
+        Expr::IntLit { value, .. } => Expr::IntLit { value, span: z },
+        Expr::FloatLit { value, .. } => Expr::FloatLit { value, span: z },
+        Expr::StrLit { value, .. } => Expr::StrLit { value, span: z },
+        Expr::SymSymbol { name, .. } => Expr::SymSymbol { name, span: z },
+        Expr::SymRational { numer, denom, .. } => Expr::SymRational { numer, denom, span: z },
+        Expr::SymApply { head, args, .. } => Expr::SymApply {
+            head: Box::new(strip_spans(*head)),
+            args: args.into_iter().map(strip_spans).collect(),
+            span: z,
+        },
+        Expr::SymPatternBlank { head, .. } => Expr::SymPatternBlank {
+            head: head.map(|h| Box::new(strip_spans(*h))),
+            span: z,
+        },
+        Expr::SymPatternNamed { name, pattern, .. } => Expr::SymPatternNamed {
+            name,
+            pattern: Box::new(strip_spans(*pattern)),
+            span: z,
+        },
+        Expr::SymRule { lhs, rhs, delayed, .. } => Expr::SymRule {
+            lhs: Box::new(strip_spans(*lhs)),
+            rhs: Box::new(strip_spans(*rhs)),
+            delayed,
+            span: z,
+        },
+        Expr::SymReplaceAll { expr, rules, repeated, .. } => Expr::SymReplaceAll {
+            expr: Box::new(strip_spans(*expr)),
+            rules: rules.into_iter().map(strip_spans).collect(),
+            repeated,
+            span: z,
+        },
+        other => other,
+    }
+}
+
+// --- literals ---------------------------------------------------------
+
+#[test]
+fn integer_and_real_literals() {
+    assert_shape_eq(lower_one("42\n"), int(42));
+    assert_shape_eq(
+        lower_one("1.5\n"),
+        Expr::FloatLit {
+            value: 1.5,
+            span: semantic_ir::Span::synthetic(),
+        },
+    );
+}
+
+#[test]
+fn string_literal_loses_its_quotes() {
+    assert_shape_eq(
+        lower_one("\"hello\"\n"),
+        Expr::StrLit {
+            value: "hello".to_string(),
+            span: semantic_ir::Span::synthetic(),
+        },
+    );
+}
+
+#[test]
+fn bare_symbol_is_symbolic_data() {
+    let module = compile_source("foo\n", "test").unwrap();
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+    assert_shape_eq(lower_one("foo\n"), sym("foo"));
+}
+
+// --- arithmetic ---------------------------------------------------------
+
+#[test]
+fn additive_lowers_to_add_apply() {
+    assert_shape_eq(lower_one("1 + 2\n"), apply(sym("Add"), vec![int(1), int(2)]));
+}
+
+#[test]
+fn subtraction_is_left_associative() {
+    assert_shape_eq(
+        lower_one("a - b - c\n"),
+        apply(sym("Sub"), vec![apply(sym("Sub"), vec![sym("a"), sym("b")]), sym("c")]),
+    );
+}
+
+#[test]
+fn multiplication_and_division() {
+    assert_shape_eq(lower_one("a * b\n"), apply(sym("Mul"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("a / b\n"), apply(sym("Div"), vec![sym("a"), sym("b")]));
+}
+
+#[test]
+fn power_is_right_associative() {
+    assert_shape_eq(
+        lower_one("a ^ b ^ c\n"),
+        apply(sym("Pow"), vec![sym("a"), apply(sym("Pow"), vec![sym("b"), sym("c")])]),
+    );
+}
+
+#[test]
+fn unary_minus_is_neg_and_plus_is_noop() {
+    assert_shape_eq(lower_one("-x\n"), apply(sym("Neg"), vec![sym("x")]));
+    assert_shape_eq(lower_one("+x\n"), sym("x"));
+}
+
+#[test]
+fn explicit_head_application_is_bridged_and_left_folded() {
+    // Plus[1, 2, 3] -> Add(Add(1, 2), 3), byte-identical to 1 + 2 + 3.
+    assert_shape_eq(
+        lower_one("Plus[1, 2, 3]\n"),
+        apply(sym("Add"), vec![apply(sym("Add"), vec![int(1), int(2)]), int(3)]),
+    );
+    assert_shape_eq(lower_one("Times[a, b]\n"), apply(sym("Mul"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(lower_one("Power[2, 10]\n"), apply(sym("Pow"), vec![int(2), int(10)]));
+}
+
+#[test]
+fn sin_is_already_canonical_and_unknown_heads_pass_through() {
+    assert_shape_eq(lower_one("Sin[x]\n"), apply(sym("Sin"), vec![sym("x")]));
+    assert_shape_eq(
+        lower_one("f[x, y]\n"),
+        apply(sym("f"), vec![sym("x"), sym("y")]),
+    );
+    assert_shape_eq(lower_one("f[]\n"), apply(sym("f"), vec![]));
+}
+
+#[test]
+fn nested_application_is_left_associative() {
+    assert_shape_eq(
+        lower_one("f[x][y]\n"),
+        apply(apply(sym("f"), vec![sym("x")]), vec![sym("y")]),
+    );
+}
+
+// --- comparisons / logic -------------------------------------------------
+
+#[test]
+fn comparisons_lower_to_their_canonical_heads() {
+    assert_shape_eq(lower_one("a == b\n"), apply(sym("Equal"), vec![sym("a"), sym("b")]));
+    assert_shape_eq(
+        lower_one("a <= b\n"),
+        apply(sym("LessEqual"), vec![sym("a"), sym("b")]),
+    );
+}
+
+#[test]
+fn logic_chains_and_not() {
+    assert_shape_eq(
+        lower_one("a && b || c\n"),
+        apply(sym("Or"), vec![apply(sym("And"), vec![sym("a"), sym("b")]), sym("c")]),
+    );
+    assert_shape_eq(lower_one("!x\n"), apply(sym("Not"), vec![sym("x")]));
+}
+
+// --- lists / grouping -----------------------------------------------------
+
+#[test]
+fn list_literal_lowers_to_list_head() {
+    assert_shape_eq(lower_one("{1, 2, 3}\n"), apply(sym("List"), vec![int(1), int(2), int(3)]));
+    assert_shape_eq(lower_one("{}\n"), apply(sym("List"), vec![]));
+}
+
+#[test]
+fn grouping_parens_are_transparent() {
+    assert_shape_eq(
+        lower_one("(a + b) * c\n"),
+        apply(sym("Mul"), vec![apply(sym("Add"), vec![sym("a"), sym("b")]), sym("c")]),
+    );
+}
+
+// --- assignment: pure data, no host binding -----------------------------
+
+#[test]
+fn set_lowers_to_assign_apply() {
+    assert_shape_eq(lower_one("x = 5\n"), apply(sym("Assign"), vec![sym("x"), int(5)]));
+    let module = compile_source("x = 5\n", "test").unwrap();
+    assert!(manifest_has(&module, Feature::SymbolicExpr));
+}
+
+#[test]
+fn setdelayed_lowers_to_define_apply() {
+    assert_shape_eq(
+        lower_one("f[x] := x\n"),
+        apply(sym("Define"), vec![apply(sym("f"), vec![sym("x")]), sym("x")]),
+    );
+}
+
+// --- patterns -------------------------------------------------------------
+
+#[test]
+fn bare_blank_lowers_to_pattern_blank() {
+    let module = compile_source("_\n", "test").unwrap();
+    assert!(manifest_has(&module, Feature::PatternMatching));
+    let expr = lower_one("_\n");
+    assert!(matches!(expr, Expr::SymPatternBlank { head: None, .. }));
+}
+
+#[test]
+fn head_constrained_blank_lowers_with_head() {
+    let expr = lower_one("_Integer\n");
+    match expr {
+        Expr::SymPatternBlank { head: Some(h), .. } => {
+            assert_eq!(strip_spans(*h), sym("Integer"));
+        }
+        other => panic!("expected SymPatternBlank with a head, got {other:?}"),
+    }
+}
+
+#[test]
+fn named_pattern_lowers_to_pattern_named() {
+    let expr = lower_one("x_\n");
+    match expr {
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            assert_eq!(name, "x");
+            assert!(matches!(*pattern, Expr::SymPatternBlank { head: None, .. }));
+        }
+        other => panic!("expected SymPatternNamed, got {other:?}"),
+    }
+}
+
+#[test]
+fn named_head_constrained_pattern() {
+    let expr = lower_one("x_Integer\n");
+    match expr {
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            assert_eq!(name, "x");
+            match *pattern {
+                Expr::SymPatternBlank { head: Some(h), .. } => {
+                    assert_eq!(strip_spans(*h), sym("Integer"));
+                }
+                other => panic!("expected a head-constrained blank, got {other:?}"),
+            }
+        }
+        other => panic!("expected SymPatternNamed, got {other:?}"),
+    }
+}
+
+// --- rules and replacement ------------------------------------------------
+
+#[test]
+fn rule_lowers_to_sym_rule() {
+    let expr = lower_one("a -> b\n");
+    match expr {
+        Expr::SymRule { lhs, rhs, delayed, .. } => {
+            assert_eq!(strip_spans(*lhs), sym("a"));
+            assert_eq!(strip_spans(*rhs), sym("b"));
+            assert!(!delayed);
+        }
+        other => panic!("expected SymRule, got {other:?}"),
+    }
+    let module = compile_source("a -> b\n", "test").unwrap();
+    assert!(manifest_has(&module, Feature::PatternMatching));
+}
+
+#[test]
+fn ruledelayed_sets_the_delayed_flag() {
+    let expr = lower_one("a :> b\n");
+    match expr {
+        Expr::SymRule { delayed, .. } => assert!(delayed),
+        other => panic!("expected SymRule, got {other:?}"),
+    }
+}
+
+#[test]
+fn rule_rewrites_bound_pattern_names_on_the_rhs() {
+    // x_ -> x + 1: the bare `x` reference on the RHS must be rewritten into
+    // the same SymPatternNamed reference shape a fresh `x_` produces, so a
+    // later matcher's substitution step fills it in.
+    let expr = lower_one("x_ -> x + 1\n");
+    let Expr::SymRule { rhs, .. } = expr else {
+        panic!("expected SymRule");
+    };
+    let Expr::SymApply { args, .. } = *rhs else {
+        panic!("expected the rhs to be Add(x, 1)");
+    };
+    assert!(matches!(&args[0], Expr::SymPatternNamed { name, .. } if name == "x"));
+}
+
+#[test]
+fn replaceall_lowers_to_sym_replaceall_one_pass() {
+    let expr = lower_one("x /. a -> b\n");
+    match expr {
+        Expr::SymReplaceAll { repeated, rules, .. } => {
+            assert!(!repeated);
+            assert_eq!(rules.len(), 1);
+        }
+        other => panic!("expected SymReplaceAll, got {other:?}"),
+    }
+}
+
+#[test]
+fn replacerepeated_sets_the_repeated_flag() {
+    let expr = lower_one("x //. a -> b\n");
+    match expr {
+        Expr::SymReplaceAll { repeated, .. } => assert!(repeated),
+        other => panic!("expected SymReplaceAll, got {other:?}"),
+    }
+}
+
+#[test]
+fn replaceall_flattens_a_list_of_rules() {
+    let expr = lower_one("x /. {a -> b, c -> d}\n");
+    match expr {
+        Expr::SymReplaceAll { rules, .. } => assert_eq!(rules.len(), 2),
+        other => panic!("expected SymReplaceAll, got {other:?}"),
+    }
+}
+
+#[test]
+fn condition_test_keeps_bare_symbol_references() {
+    // Unlike a Rule's rhs, Condition's test must NOT have its bare `x`
+    // rewritten into pattern-reference form.
+    let expr = lower_one("x_ /; x > 2\n");
+    let Expr::SymApply { head, args, .. } = expr else {
+        panic!("expected a Condition SymApply");
+    };
+    assert_eq!(strip_spans(*head), sym("Condition"));
+    let Expr::SymApply { args: test_args, .. } = &args[1] else {
+        panic!("expected the test to be Greater(x, 2)");
+    };
+    assert_eq!(strip_spans(test_args[0].clone()), sym("x"));
+}
+
+// --- W-6 sugar: /@ @@ [[ ]] ------------------------------------------------
+
+#[test]
+fn map_and_apply_sugar_lower_to_their_long_form_heads() {
+    assert_shape_eq(lower_one("f /@ x\n"), apply(sym("Map"), vec![sym("f"), sym("x")]));
+    assert_shape_eq(lower_one("f @@ x\n"), apply(sym("Apply"), vec![sym("f"), sym("x")]));
+}
+
+#[test]
+fn double_bracket_lowers_to_part() {
+    assert_shape_eq(lower_one("x[[2]]\n"), apply(sym("Part"), vec![sym("x"), int(2)]));
+}
+
+#[test]
+fn multi_index_double_bracket_folds_into_nested_part() {
+    assert_shape_eq(
+        lower_one("m[[1, 2]]\n"),
+        apply(sym("Part"), vec![apply(sym("Part"), vec![sym("m"), int(1)]), int(2)]),
+    );
+}
+
+// --- W-11 pure functions ----------------------------------------------------
+
+#[test]
+fn slot_forms_lower_to_slot_apply() {
+    assert_shape_eq(lower_one("#\n"), apply(sym("Slot"), vec![int(1)]));
+    assert_shape_eq(lower_one("#2\n"), apply(sym("Slot"), vec![int(2)]));
+    assert_shape_eq(lower_one("##\n"), apply(sym("SlotSequence"), vec![int(1)]));
+}
+
+#[test]
+fn ampersand_wraps_the_body_in_function() {
+    assert_shape_eq(
+        lower_one("#^2 &\n"),
+        apply(
+            sym("Function"),
+            vec![apply(sym("Pow"), vec![apply(sym("Slot"), vec![int(1)]), int(2)])],
+        ),
+    );
+}
+
+#[test]
+fn pure_function_applied_immediately() {
+    assert_shape_eq(
+        lower_one("#&[9]\n"),
+        apply(apply(sym("Function"), vec![apply(sym("Slot"), vec![int(1)])]), vec![int(9)]),
+    );
+}
+
+#[test]
+fn named_function_long_form_normalises_a_single_param_to_a_list() {
+    assert_shape_eq(
+        lower_one("Function[x, x^2]\n"),
+        apply(
+            sym("Function"),
+            vec![
+                apply(sym("List"), vec![sym("x")]),
+                apply(sym("Pow"), vec![sym("x"), int(2)]),
+            ],
+        ),
+    );
+}
+
+// --- W-21 sugar: | /; ? --------------------------------------------------
+
+#[test]
+fn alternatives_folds_into_one_n_ary_apply() {
+    assert_shape_eq(
+        lower_one("a | b | c\n"),
+        apply(sym("Alternatives"), vec![sym("a"), sym("b"), sym("c")]),
+    );
+}
+
+#[test]
+fn patterntest_lowers_and_chains_left_associatively() {
+    assert_shape_eq(
+        lower_one("_?IntegerQ?Positive\n"),
+        apply(
+            sym("PatternTest"),
+            vec![
+                apply(sym("PatternTest"), vec![Expr::SymPatternBlank { head: None, span: semantic_ir::Span::synthetic() }, sym("IntegerQ")]),
+                sym("Positive"),
+            ],
+        ),
+    );
+}
+
+// --- error cases ------------------------------------------------------------
+
+#[test]
+fn a_syntax_error_is_reported_as_a_lower_error() {
+    assert!(compile_source("1 +\n", "test").is_err());
+}
+
+#[test]
+fn a_small_wolfram_program_compiles() {
+    let module = compile_source(
+        "f[x_] := x^2\nf[3] + Sin[0]\n{1, 2, 3} /. a_ -> a + 1\n",
+        "test",
+    )
+    .unwrap();
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 3);
+}
+
+#[test]
+fn multiple_top_level_statements_each_become_an_expr_stmt() {
+    let module = compile_source("1\n2\n3\n", "test").unwrap();
+    let main = module.functions.iter().find(|f| f.name == "main").unwrap();
+    assert_eq!(main.body.stmts.len(), 3);
+    assert!(matches!(main.body.value, Expr::NilLit { .. }));
+}
+
+// --- recursion-depth / chain-length guards (DoS hardening) -----------------
+//
+// These mirror the exact regression scale `matlab-to-semantic-ir`'s own
+// security review established (60,000 flat operands) rather than a smaller,
+// less convincing number.
+
+#[test]
+fn a_deeply_parenthesised_expression_is_rejected_cleanly() {
+    let nesting = 5_000;
+    let src = format!("{}0{}\n", "(".repeat(nesting), ")".repeat(nesting));
+    // The parser's own MAX_RULE_DEPTH trips first on input this deep; either
+    // way this must be a clean Err, never a crash (the surrounding test
+    // process itself is the proof: if this overflowed the stack, the whole
+    // test binary would abort, not fail one assertion).
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_huge_flat_additive_chain_is_rejected_cleanly_not_crashed() {
+    let terms = 60_000;
+    let src = format!("{}\n", (0..terms).map(|_| "1").collect::<Vec<_>>().join(" + "));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_huge_flat_alternatives_chain_is_rejected_cleanly() {
+    let terms = 60_000;
+    let src = format!("{}\n", (0..terms).map(|_| "a").collect::<Vec<_>>().join(" | "));
+    assert!(compile_source(&src, "test").is_err());
+}
+
+#[test]
+fn a_chain_at_exactly_the_cap_still_compiles() {
+    // MAX_EXPR_DEPTH is 256; 256 operands is exactly at the cap (255
+    // operators), one more trips it.
+    let ok_terms = 256;
+    let ok_src = format!("{}\n", (0..ok_terms).map(|_| "1").collect::<Vec<_>>().join(" + "));
+    assert!(compile_source(&ok_src, "test").is_ok());
+
+    let bad_terms = 257;
+    let bad_src = format!("{}\n", (0..bad_terms).map(|_| "1").collect::<Vec<_>>().join(" + "));
+    assert!(compile_source(&bad_src, "test").is_err());
+}

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,112 @@
+//! Structural verification of lowered modules: every module this frontend
+//! produces must pass the shared SIR validator (confirming the manifest
+//! declares exactly the SIR23 features the module actually uses — the same
+//! ground truth `semantic-ir/src/validator.rs`'s `check_expr` enforces node
+//! kind for node kind), and every module must currently be *rejected* by
+//! the JS backend — mirroring the capability-rejection verification
+//! pattern used to land SIR22/SIR23 themselves and `matlab-to-semantic-ir`.
+//!
+//! Unlike `matlab-to-semantic-ir` (which has one purely-literal subset that
+//! *is* accepted, since scalar-only MATLAB arithmetic never touches SIR22
+//! at all), **every** test below is expected to be rejected: under this
+//! frontend's "everything is data" design (see `lower.rs`'s module doc
+//! comment), even the most trivial literal arithmetic (`1 + 2`) emits at
+//! least one `SymApply` node, and `semantic-ir-to-javascript` does not
+//! implement SIR23 codegen at all yet (`sir-runtime-symbolic`, the runtime
+//! library it would depend on, is future work — Stream B rollout item 6).
+//! There is therefore no e2e `node`-execution test in this crate at all;
+//! see `lower.rs`'s module doc comment for the full disclosure.
+
+use semantic_ir::backend::Backend;
+use semantic_ir::Feature;
+use semantic_ir_to_javascript::JavaScriptBackend;
+use wolfram_to_semantic_ir::compile_source;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for `{src}`: {:?}",
+        report.issues
+    );
+    module
+}
+
+fn assert_js_backend_rejects(module: &semantic_ir::Module) {
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(module);
+    assert!(
+        !errors.is_empty(),
+        "expected the JS backend to reject a module using SIR23 features \
+         (codegen for them isn't implemented there yet)"
+    );
+}
+
+#[test]
+fn bare_arithmetic_validates_and_declares_symbolic_expr() {
+    let module = assert_valid("1 + 2\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(!module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_bare_symbol_alone_validates_and_declares_symbolic_expr() {
+    let module = assert_valid("x\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_pattern_program_validates_and_declares_pattern_matching() {
+    let module = assert_valid("f[x_] := x^2\nf[3]\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_replaceall_program_validates_and_declares_pattern_matching() {
+    let module = assert_valid("{1, 2, 3} /. a_ -> a + 1\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_replacerepeated_program_validates() {
+    let module = assert_valid("x //. a -> b\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_condition_alternatives_patterntest_program_validates() {
+    let module = assert_valid("x_ /; x > 2\n_?IntegerQ\na | b\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_pure_function_program_validates() {
+    let module = assert_valid("Map[#^2 &, {1, 2, 3}]\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn assignment_is_pure_data_and_still_validates() {
+    let module = assert_valid("x = 5\ny = x + 1\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
+fn a_complex_multi_statement_program_validates_end_to_end() {
+    let module = assert_valid(
+        "f[x_] := x^2\ng[x_] := f[x] + 1\nresult = g[3] /. Null -> 0\n{result, f[2]}\n",
+    );
+    assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));
+    assert!(module.manifest.iter().any(|f| f == Feature::PatternMatching));
+    assert_js_backend_rejects(&module);
+}

--- a/code/specs/HML01-math-to-semantic-ir.md
+++ b/code/specs/HML01-math-to-semantic-ir.md
@@ -112,11 +112,24 @@ pub fn compile_source(source: &str, module_name: &str)
   existing `octavify` source-rewrite shim, then delegate to
   `matlab-to-semantic-ir::compile_source`. Mirrors how `octave-runtime`
   itself reuses `matlab-runtime` wholesale today (no new grammar).
-- **`wolfram-to-semantic-ir`** — walks the `wolfram-parser` CST, emits SIR23
-  (symbolic/pattern domain) nodes. Reuses the existing surface-to-head
-  desugaring table already in `wolfram-runtime/src/lower.rs` (`+`→`Add`,
-  `*`→`Mul`, `/.`→ReplaceAll, etc.) but targets `semantic_ir::Expr` instead
-  of `symbolic_ir::IRNode`.
+- **`wolfram-to-semantic-ir`** (✅ v0.1.0 shipped) — walks the `wolfram-parser`
+  CST, emits SIR23 (symbolic/pattern domain) nodes. Reuses the existing
+  surface-to-head desugaring table already in `wolfram-runtime/src/lower.rs`
+  (`+`→`Add`, `*`→`Mul`, etc.) but targets `semantic_ir::Expr` instead of
+  `symbolic_ir::IRNode`. Adopts one design decision beyond what this section
+  originally sketched: **every** Wolfram construct — not just patterns and
+  rules — lowers to symbolic *data* (`SymApply`/`SymSymbol`), including
+  ordinary arithmetic and `=`/`:=` assignment; there is no host-language
+  variable binding at all in this frontend's output (see `src/lower.rs`'s
+  module doc comment for why this is necessary, not just convenient, to
+  compile an *uncomputed* function body like `f[x_] := x + 1`). One
+  consequence: because every Wolfram program, even bare literal arithmetic,
+  therefore emits at least one SIR23 node, no lowered module currently
+  executes end-to-end through any backend (`sir-runtime-symbolic` does not
+  exist yet) — unlike `matlab-to-semantic-ir`'s purely-literal subset, which
+  can. Covers the full grammar `wolfram-parser` accepts (the W-6/W-11/W-21
+  operator sugar included), since nothing here forces a MATLAB-style
+  narrower cut.
 - **`macsyma-to-semantic-ir`** — walks the `macsyma-parser` CST using the
   same rule-name dispatch already proven in `macsyma-compiler` (`"assign"`,
   `"additive"`, `"postfix"`, …), emits SIR23 nodes.


### PR DESCRIPTION
## Summary
- First frontend to target SIR23 (symbolic-expression/pattern domain): `compile`/`compile_source` lowering `coding-adventures-wolfram-parser`'s `GrammarASTNode` CST into a `semantic_ir::Module`.
- Design decision ("everything is data"): every Wolfram construct — arithmetic, comparisons, lists, function application, even `=`/`:=` assignment — lowers to SIR23 symbolic data (`SymSymbol`/`SymApply`/pattern/rule nodes), never a host-language variable binding, since an uncomputed function body (`f[x_] := x + 1`) must already be data before it can be pattern-matched at call time. Because everything reduces to the same small vocabulary, this covers the **full** `wolfram-parser` grammar surface (arithmetic, comparisons, logic, lists, patterns/rules/replacement, and the W-6/W-11/W-21 operator sugar), unlike `matlab-to-semantic-ir`'s narrower, scalar/array-ambiguity-driven cut.
- **Known, disclosed limitation**: no lowered module executes end-to-end yet, since `sir-runtime-symbolic` (the JS/TS runtime library SIR23 codegen depends on) doesn't exist yet — HML01 Stream B rollout item 6. Tests verify structural correctness and capability-rejection only.

## Security review — four rounds, each found and fixed a real bug
This crate's DoS-hardening had an unusually deep review history; summarizing since the CHANGELOG has the full detail:
1. **Round 1 (HIGH)**: `postfix`/`amp` chained application/part/pure-function-apply groups shared the same flat-repetition grammar shape as the eight explicitly-guarded chain productions but weren't covered — confirmed to crash (`SIGABRT`) at 60,000 chained groups. Fixed with two new per-node guards.
2. **Round 2 (HIGH)**: those two new guards independently bounded "number of groups" and "args/indices per group" to 256 each — but those axes multiply (an `LDBRACKET` group folds one `Part` per index), permitting up to 256×256 = 65,536 levels. Fixed by replacing both with one cumulative `add_chain_depth` budget.
3. **Round 3 (HIGH)**: that cumulative budget is scoped to one grammar node and resets on every new node — composing several individually-in-bounds chains across `(...)` boundaries still reached tens of thousands of levels. Fixed with a fundamentally different mechanism: `measure_depth_iterative`, an authoritative post-construction depth check using an explicit work stack (never native recursion, since building a `Box`-based tree only costs heap — only *walking* it recursively is dangerous), called before this crate's own unguarded recursive helpers touch a tree and before anything reaches the returned `Module`.
4. **Round 4 (HIGH)**: the round-3 fix's own rejection path (`return Err(...)`) let the just-detected oversized tree fall out of scope normally — since `semantic_ir::Expr` has no custom `Drop`, that recurses through the compiler-derived drop glue on the very tree just found too deep, falsifying `compile()`'s own "safe on a bare thread" claim. **Confirmed empirically via an isolated subprocess** (not just reasoned about): `compile()` on a bare thread with a rejected ~23,040-level tree produced a genuine `SIGABRT`; 9,000 and 4,500 levels survived. Fixed with `drop_iterative` — iterative teardown using the same explicit-work-stack technique, called at both rejection sites.

Every fix in this chain was verified adversarially (disable → reproduce the crash → restore → confirm the regression test passes), not just asserted correct.

## Test plan
- [x] `cargo test -p wolfram-to-semantic-ir` — 62/62 pass (52 unit tests over exact `Expr` shapes + DoS regressions, 9 validator/capability-rejection tests, 1 doctest)
- [x] `cargo clippy -p wolfram-to-semantic-ir --all-targets` — zero warnings on this crate
- [x] Four rounds of `/security-review`, converging after round 4 with all HIGH/MEDIUM findings fixed and adversarially verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)