### PR TITLE
feat(sql-vm): OCTET_LENGTH — byte count (vs LENGTH's character count)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.12 — OCTET_LENGTH (byte length)
+
+Grows the SQL scalar surface (sql-vm 0.4.8): `OCTET_LENGTH(x)` returns the byte
+count of a value, where `LENGTH` returns the character count — `OCTET_LENGTH('héllo')`
+is 6 but `LENGTH('héllo')` is 5. Text is measured as UTF-8 bytes, a blob by its
+raw bytes, an integer by its decimal digits; NULL → NULL; floats declined. A new
+differential-oracle case (`octet_length`) diffs `OCTET_LENGTH(s)` and `LENGTH(s)`
+across multibyte, empty, and NULL rows against real bundled SQLite.
+
 ## 0.5.11 — Fix HEX(NULL) to return an empty string
 
 Stream A correctness fix (sql-vm 0.4.7): `HEX(NULL)` returned SQL NULL but real

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.11"
+version = "0.5.12"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -626,6 +626,16 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT HEX(s) AS h, TYPEOF(HEX(s)) AS t FROM t ORDER BY id",
     },
+    // OCTET_LENGTH counts BYTES (UTF-8), where LENGTH counts characters:
+    // 'héllo' is 5 characters but 6 bytes.
+    Case {
+        id: "octet_length",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1, 'héllo'), (2, '日本'), (3, ''), (4, NULL)",
+        ],
+        query: "SELECT OCTET_LENGTH(s) AS o, LENGTH(s) AS l FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.8] - Unreleased
+
+### Added
+
+- **`OCTET_LENGTH(x)`** — the number of *bytes*, in contrast to `LENGTH`'s count
+  of characters: `OCTET_LENGTH('héllo')` = 6 where `LENGTH('héllo')` = 5. Text is
+  measured as its UTF-8 bytes, a blob as its raw byte count, and an
+  integer/boolean as its decimal-text bytes (`OCTET_LENGTH(123)` = 3); NULL →
+  NULL. Floats are declined (their byte length depends on SQLite's subtle float
+  text form — same convention as HEX/QUOTE). Arity is checked before indexing.
+  (The `LENGTH` doc is corrected: it counts characters, not bytes.)
+
 ## [0.4.7] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1037,7 +1037,8 @@ fn pop(stack: &mut Vec<SqlValue>) -> Result<SqlValue, VmError> {
 ///
 /// | Name     | Args | Semantics                                             |
 /// |----------|------|-------------------------------------------------------|
-/// | LENGTH   |  1   | Byte-length of a string (returns Integer or NULL)     |
+/// | LENGTH   |  1   | Character count of a string (returns Integer or NULL) |
+/// | OCTET_LENGTH | 1 | Byte count of text/blob/integer (Integer or NULL)    |
 /// | UPPER    |  1   | ASCII-uppercase the string                            |
 /// | LOWER    |  1   | ASCII-lowercase the string                            |
 /// | TRIM     | 1–2  | Strip whitespace, or a given character set, from both ends |
@@ -1149,6 +1150,27 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
                 SqlValue::Null => Ok(SqlValue::Null),
                 SqlValue::Text(s) => Ok(SqlValue::Int(s.chars().count() as i64)),
                 other => Err(VmError::TypeMismatch(format!("LENGTH expects TEXT, got {:?}", other))),
+            }
+        }
+
+        "OCTET_LENGTH" => {
+            // OCTET_LENGTH(x): the number of *bytes*, in contrast to LENGTH's
+            // count of characters. Text is measured as its UTF-8 bytes
+            // (`octet_length('héllo')` = 6, five characters but `é` is two
+            // bytes); a blob as its raw byte count; an integer/boolean as its
+            // decimal-text bytes (`octet_length(123)` = 3). NULL → NULL. Floats
+            // are declined — their byte length depends on SQLite's exact float
+            // text form, which is subtle (see HEX/QUOTE).
+            if args.len() != 1 {
+                return Err(VmError::TypeMismatch(format!("OCTET_LENGTH expects 1 arg, got {}", args.len())));
+            }
+            match &args[0] {
+                SqlValue::Null => Ok(SqlValue::Null),
+                SqlValue::Text(s) => Ok(SqlValue::Int(s.len() as i64)),
+                SqlValue::Blob(b) => Ok(SqlValue::Int(b.len() as i64)),
+                SqlValue::Int(i) => Ok(SqlValue::Int(i.to_string().len() as i64)),
+                SqlValue::Bool(b) => Ok(SqlValue::Int((*b as i64).to_string().len() as i64)),
+                other => Err(VmError::TypeMismatch(format!("OCTET_LENGTH expects TEXT/BLOB/INTEGER, got {:?}", other))),
             }
         }
 
@@ -4053,6 +4075,26 @@ mod tests {
                 call_builtin("SUBSTR", args).unwrap(),
             );
         }
+    }
+
+    #[test]
+    fn builtin_octet_length_counts_bytes() {
+        let ol = |v: SqlValue| call_builtin("OCTET_LENGTH", vec![v]).unwrap();
+        // Text is measured in UTF-8 bytes, not characters (contrast LENGTH).
+        assert_eq!(ol(SqlValue::Text("héllo".into())), SqlValue::Int(6)); // 5 chars, 6 bytes
+        assert_eq!(
+            call_builtin("LENGTH", vec![SqlValue::Text("héllo".into())]).unwrap(),
+            SqlValue::Int(5)
+        );
+        assert_eq!(ol(SqlValue::Text("abc".into())), SqlValue::Int(3));
+        assert_eq!(ol(SqlValue::Text("".into())), SqlValue::Int(0));
+        assert_eq!(ol(SqlValue::Text("日本".into())), SqlValue::Int(6)); // 2 chars × 3 bytes
+        // Blobs measure raw bytes; integers their decimal digits.
+        assert_eq!(ol(SqlValue::Blob(vec![0x00, 0xff])), SqlValue::Int(2));
+        assert_eq!(ol(SqlValue::Int(123)), SqlValue::Int(3));
+        // NULL propagates; wrong arity errors, not panics.
+        assert_eq!(ol(SqlValue::Null), SqlValue::Null);
+        assert!(call_builtin("OCTET_LENGTH", vec![]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Stream B** — grows the mini-sqlite SQL scalar surface. `OCTET_LENGTH(x)`
returns the number of **bytes** in a value, in contrast to `LENGTH`, which counts
characters. Probed real bundled SQLite for the exact semantics:

```
octet_length('héllo') -> 6   (LENGTH('héllo') = 5; é is two UTF-8 bytes)
octet_length('日本')  -> 6   (two CJK chars × 3 bytes)
octet_length('')      -> 0
octet_length(x'00ff') -> 2   (raw blob bytes)
octet_length(123)     -> 3   (decimal-text bytes)
octet_length(NULL)    -> NULL
```

Text → UTF-8 bytes, blob → raw byte count, integer/boolean → decimal-text bytes.
Floats are declined (byte length depends on SQLite's subtle float text form —
same convention as HEX/QUOTE). No grammar/planner/codegen work. The `LENGTH` doc
comment is corrected to say "character count" (it never counted bytes).

## Security

Reviewed before push. Arity is checked (`args.len() != 1`) **before** indexing
(the panic-before-arity class from the earlier `TRIM()` bug is avoided); no
allocation grows with input (only already-materialized lengths + a bounded i64
`to_string`); the `len() as i64` casts can't overflow on a 64-bit target; no
unsafe. **Review passed, no findings.**

## Verification

- `sql-vm`: **95 lib tests** (new case: multibyte text vs LENGTH, empty, CJK,
  blob, integer, NULL, zero-arg arity).
- **mini-sqlite differential oracle:** new `octet_length` case diffs
  `OCTET_LENGTH(s)` and `LENGTH(s)` across multibyte/empty/NULL rows against real
  bundled SQLite. Full mini-sqlite suite green.

`sql-vm` 0.4.7 → 0.4.8, `mini-sqlite` 0.5.11 → 0.5.12; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
