### PR TITLE
feat(cobol): PERFORM … THRU — paragraph-range perform (PL08 v0.11)

### DIFF
--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.11.0 — PERFORM … THRU (paragraph range)
+
+- **`PERFORM para-1 THRU para-2`** runs the whole range of paragraphs from
+  `para-1` through `para-2` in source order (falling through between them), then
+  returns. It composes with every repeat mode — `PERFORM A THRU B 3 TIMES`,
+  `… UNTIL …`, `… VARYING …` all repeat the whole range.
+- The grammar already parsed `THRU`/`THROUGH`; this wires up the runtime (the
+  reader previously rejected it). A backwards range (`para-2` before `para-1`) is
+  a clean error.
+- The inline form and non-consecutive/`EXIT`-terminated ranges remain deferred.
+
 ## 0.10.0 — PERFORM … VARYING (counted loop)
 
 - **`PERFORM para VARYING id FROM start BY step UNTIL cond`** sets the induction

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -27,12 +27,13 @@ decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
 toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
 parentheses), `ROUNDED`, and `ON SIZE ERROR`; `IF … ELSE` with numeric and
-alphanumeric comparison; `PERFORM para [n TIMES | UNTIL cond | VARYING id FROM x
-BY y UNTIL cond]` (out-of-line paragraph invocation — fixed-count, conditional,
-and counted loops, with a recursion guard); and `GO TO para` (unconditional
-transfer, run as a program counter over paragraphs, so back-edge loops work).
-Anything not yet modelled (the explicit `SIGN` clause with `SEPARATE`/`LEADING`,
-editing pictures, `COMP`, `PERFORM … THRU`/`WITH TEST AFTER`,
-`GO TO … DEPENDING`, `EVALUATE`, tables, files, and every other verb) returns a
-descriptive `RuntimeError` — never wrong output. See PL08 for the
+alphanumeric comparison; `PERFORM para [THRU para2] [n TIMES | UNTIL cond |
+VARYING id FROM x BY y UNTIL cond]` (out-of-line paragraph or paragraph-range
+invocation — fixed-count, conditional, and counted loops, with a recursion
+guard); and `GO TO para` (unconditional transfer, run as a program counter over
+paragraphs, so back-edge loops work). Anything not yet modelled (the explicit
+`SIGN` clause with `SEPARATE`/`LEADING`, editing pictures, `COMP`,
+`PERFORM … WITH TEST AFTER`/inline, `GO TO … DEPENDING`, `EVALUATE`, tables,
+files, and every other verb) returns a descriptive `RuntimeError` — never wrong
+output. See PL08 for the
 roadmap toward full COBOL and later standards.

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -263,7 +263,9 @@ impl Machine {
             Stmt::Compute { target, rounded, expr, on_size_error } => {
                 return self.exec_compute(target, *rounded, expr, on_size_error);
             }
-            Stmt::Perform { target, mode } => return self.exec_perform(target, mode),
+            Stmt::Perform { target, thru, mode } => {
+                return self.exec_perform(target, thru, mode)
+            }
             Stmt::GoTo { target } => {
                 let idx = *self
                     .para_index
@@ -305,11 +307,33 @@ impl Machine {
     /// so a self-performing paragraph fails cleanly instead of overflowing. A
     /// `STOP RUN` or `GO TO` inside stops the repetition and propagates as its
     /// [`Flow`].
-    fn exec_perform(&mut self, target: &str, mode: &PerformMode) -> Result<Flow, RuntimeError> {
-        let idx = *self
+    fn exec_perform(
+        &mut self,
+        target: &str,
+        thru: &Option<String>,
+        mode: &PerformMode,
+    ) -> Result<Flow, RuntimeError> {
+        let start = *self
             .para_index
             .get(target)
             .ok_or_else(|| RuntimeError::UndefinedName(target.into()))?;
+        // The range end: `target` itself without THRU, else the THRU paragraph
+        // (which must not precede `target` in source order).
+        let end = match thru {
+            None => start,
+            Some(t) => {
+                let e = *self
+                    .para_index
+                    .get(t)
+                    .ok_or_else(|| RuntimeError::UndefinedName(t.clone()))?;
+                if e < start {
+                    return Err(RuntimeError::Unsupported(
+                        "PERFORM … THRU range runs backwards".into(),
+                    ));
+                }
+                e
+            }
+        };
 
         self.perform_depth += 1;
         if self.perform_depth > MAX_PERFORM_DEPTH {
@@ -318,13 +342,20 @@ impl Machine {
                 "PERFORM nesting too deep (a paragraph performing itself?)".into(),
             ));
         }
-        let stmts = self.paragraphs[idx].stmts.clone();
-        // Capture the outcome rather than `?`-ing out of the loop, so the depth
-        // counter is restored on every path (including an error). One body
-        // iteration returns Some(flow-to-propagate) to stop, or None to continue.
-        let run_body = |m: &mut Self| match m.run_stmts(&stmts) {
-            Ok(Flow::Normal) => None,
-            other => Some(other), // Stop / GoTo / Err — stop repeating, propagate
+        // One body iteration runs the whole paragraph range `start..=end` in
+        // source order (falling through between them); it returns
+        // Some(flow-to-propagate) to stop repeating, or None to continue.
+        // Outcomes are captured (never `?`-ed out) so the depth counter is
+        // restored on every path.
+        let run_body = |m: &mut Self| {
+            for i in start..=end {
+                let stmts = m.paragraphs[i].stmts.clone();
+                match m.run_stmts(&stmts) {
+                    Ok(Flow::Normal) => {}          // fall through to the next
+                    other => return Some(other),    // Stop / GoTo / Err propagates
+                }
+            }
+            None
         };
 
         let outcome = match mode {

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -10,10 +10,10 @@
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
 //! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), `IF … ELSE`
 //! (numeric and alphanumeric comparison),
-//! `PERFORM para [n TIMES | UNTIL cond | VARYING id FROM x BY y UNTIL cond]`
-//! (out-of-line paragraph invocation — fixed-count, conditional, and counted
-//! loops), and `GO TO para` (unconditional transfer, including back-edge loops)
-//! over numeric-display (`9`/`V`, and
+//! `PERFORM para [THRU para2] [n TIMES | UNTIL cond | VARYING id FROM x BY y UNTIL cond]`
+//! (out-of-line paragraph or paragraph-range invocation — fixed-count,
+//! conditional, and counted loops), and `GO TO para` (unconditional transfer,
+//! including back-edge loops) over numeric-display (`9`/`V`, and
 //! signed `S` with trailing-overpunch display) and character pictures — and
 //! returns a descriptive error for anything not yet modelled, rather than
 //! producing wrong output. The roadmap toward full COBOL (the `SIGN` clause and
@@ -869,6 +869,69 @@ mod tests {
         ]))
         .unwrap();
         assert_eq!(out, "ONCE\n");
+    }
+
+    #[test]
+    fn perform_thru_runs_a_paragraph_range() {
+        // PERFORM A THRU C runs A, B, C in order, then returns; MAIN's own
+        // DISPLAY runs after. The paragraphs do NOT run again by fall-through
+        // because MAIN stops.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM A THRU C.",
+            "    DISPLAY \"BACK\".",
+            "    STOP RUN.",
+            "A.",
+            "    DISPLAY \"A\".",
+            "B.",
+            "    DISPLAY \"B\".",
+            "C.",
+            "    DISPLAY \"C\".",
+        ]))
+        .unwrap();
+        assert_eq!(out, "A\nB\nC\nBACK\n");
+    }
+
+    #[test]
+    fn perform_thru_with_times_repeats_the_whole_range() {
+        // PERFORM A THRU B 2 TIMES runs (A, B) twice → A B A B.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM A THRU B 2 TIMES.",
+            "    STOP RUN.",
+            "A.",
+            "    DISPLAY \"A\".",
+            "B.",
+            "    DISPLAY \"B\".",
+        ]))
+        .unwrap();
+        assert_eq!(out, "A\nB\nA\nB\n");
+    }
+
+    #[test]
+    fn perform_thru_backwards_range_is_an_error() {
+        // THRU target must not precede the start paragraph.
+        let err = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    PERFORM C THRU A.",
+            "    STOP RUN.",
+            "A.",
+            "    DISPLAY \"A\".",
+            "C.",
+            "    DISPLAY \"C\".",
+        ]))
+        .unwrap_err();
+        assert!(matches!(err, RuntimeError::Unsupported(_)), "got {err:?}");
+        assert!(err.to_string().contains("backwards"), "message should explain: {err}");
     }
 
     #[test]

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -78,9 +78,10 @@ pub enum Stmt {
         expr: Expr,
         on_size_error: Vec<Stmt>,
     },
-    /// `PERFORM para <mode>` — run a paragraph out of line, then return. The
+    /// `PERFORM para [THRU para2] <mode>` — run a paragraph (or the range
+    /// `para`…`para2` in source order) out of line, then return. The
     /// [`PerformMode`] is the repeat form.
-    Perform { target: String, mode: PerformMode },
+    Perform { target: String, thru: Option<String>, mode: PerformMode },
     /// `GO TO para` — transfer control unconditionally to a paragraph (no return).
     GoTo { target: String },
     /// `IF cond then… [ELSE else…]`.
@@ -421,17 +422,23 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             Ok(Stmt::Compute { target, rounded, expr, on_size_error })
         }
         "perform_stmt" => {
-            // PERFORM target [THROUGH/THRU target2] [operand TIMES]. The target
-            // is the first direct NAME token; the optional `TIMES` count is an
-            // `operand` node. The THRU range form is deferred.
-            let target = first_token(verb, "NAME")
+            // PERFORM target [THROUGH/THRU target2] [ operand TIMES | UNTIL … |
+            // VARYING … ]. The direct NAME tokens are [target] or, with THRU,
+            // [target, target2]; the induction/TIMES/UNTIL operands live inside
+            // their own child nodes.
+            let names: Vec<String> = child_tokens(verb)
+                .into_iter()
+                .filter(|(k, _)| k == "NAME")
+                .map(|(_, v)| v)
+                .collect();
+            let target = names
+                .first()
+                .cloned()
                 .ok_or_else(|| RuntimeError::Unsupported("PERFORM without a target paragraph".into()))?;
-            if child_tokens(verb)
+            let has_thru = child_tokens(verb)
                 .iter()
-                .any(|(k, v)| k == "KEYWORD" && (v == "THRU" || v == "THROUGH"))
-            {
-                return Err(RuntimeError::Unsupported("PERFORM … THRU (range form)".into()));
-            }
+                .any(|(k, v)| k == "KEYWORD" && (v == "THRU" || v == "THROUGH"));
+            let thru = if has_thru { names.get(1).cloned() } else { None };
             // The repeat mode: VARYING (its own node), else TIMES (a direct
             // operand), else UNTIL (a direct condition), else bare/once.
             let mode = if let Some(v) = child_node(verb, "perform_varying") {
@@ -443,7 +450,7 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             } else {
                 PerformMode::Once
             };
-            Ok(Stmt::Perform { target, mode })
+            Ok(Stmt::Perform { target, thru, mode })
         }
         "goto_stmt" => {
             // GO [TO] target. The DEPENDING ON form is not in the grammar yet.

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -148,14 +148,17 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
    deferred.
 9. **v0.9 — `PERFORM … UNTIL`** (merged): a conditional loop, testing the
    condition **before** each iteration (`WITH TEST BEFORE`), driven iteratively.
-10. **v0.10 — `PERFORM … VARYING`** (this PR): a counted loop over an induction
+10. **v0.10 — `PERFORM … VARYING`** (merged): a counted loop over an induction
     variable (`VARYING id FROM start BY step UNTIL cond`) — `id := start`, run
     while `cond` is false, step `id` by `step` after each iteration. The repeat
-    forms are modelled as a `PerformMode` enum. `WITH TEST AFTER`, multiple
-    `AFTER` phrases, `PERFORM … THRU`, and the inline form remain deferred.
-11. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
-12. **Rest of control flow** — `END-IF`, `EVALUATE`, `PERFORM` (`THRU`,
-    inline, `TEST AFTER`), `GO TO … DEPENDING ON`, `ALTER`.
+    forms are modelled as a `PerformMode` enum.
+11. **v0.11 — `PERFORM … THRU`** (this PR): run a range of paragraphs
+    (`para-1 THRU para-2`, source order, fall-through between) as the perform
+    body; composes with every repeat mode. Backwards ranges are a clean error.
+    `WITH TEST AFTER` and the inline form remain deferred.
+12. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
+13. **Rest of control flow** — `END-IF`, `EVALUATE`, inline `PERFORM`,
+    `PERFORM … WITH TEST AFTER`, `GO TO … DEPENDING ON`, `ALTER`.
 8. **Conditions** — level-88 condition-names.
 9. **Tables** — `OCCURS`, subscripts, `REDEFINES`, `USAGE`.
 8. **File I/O** — `SELECT`/`FD`, sequential then indexed/relative, `OPEN`/`READ`/


### PR DESCRIPTION
## Summary

Adds `PERFORM para-1 THRU para-2` — running a **range** of paragraphs as the
perform body. This completes the `PERFORM` family. Runtime-only: the grammar
already parsed `THRU`/`THROUGH`; the reader previously rejected it.

### What it does (cobol-runtime 0.11.0)
- **`program.rs`**: `Stmt::Perform` gains `thru: Option<String>`; the reader
  takes the second direct NAME token as the range end (the VARYING induction
  variable and TIMES/UNTIL operands live in child nodes, so they don't interfere).
- **`interp.rs`**: `exec_perform` resolves the range `[start..=end]` and its
  `run_body` runs every paragraph in the range in source order (falling through
  between them). It composes with every repeat mode — `PERFORM A THRU B 3 TIMES`,
  `… UNTIL …`, `… VARYING …` all repeat the **whole range**.
- A backwards range (`para-2` before `para-1`) is a clean error.

### Deferred
The inline `PERFORM` form and `WITH TEST AFTER`.

## Tests
83 runtime tests + doctest (range `A B C`, range×`TIMES` → `A B A B`,
backwards-range error; plus the unchanged single-paragraph/mode tests confirming
no regression). Warning-free. Security review PASSED (range indices always valid,
recursion bounded by `MAX_PERFORM_DEPTH`, Flow propagation correct). README +
PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)