### PR TITLE
feat(sir-rust): Array each_slice / each_cons / chunk_while

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.32.0 — Array `each_slice` / `each_cons` / `chunk_while`
+
+Mirrors the Python reference (PR #8031) and the Go backend (PR #8036) into the
+Rust backend's inline `__sir` runtime (`array_method` gains the arms; the
+`Value::Seq` `respond_to?` arm gains the names), adding the Array
+consecutive-grouping family.
+
+- `each_slice(n)` → consecutive sub-arrays of at most `n` elements, the last
+  possibly shorter (`[1,2,3,4,5].each_slice(2)` → `[[1,2],[3,4],[5]]`).
+- `each_cons(n)` → every consecutive `n`-element sliding window
+  (`[1,2,3,4].each_cons(2)` → `[[1,2],[2,3],[3,4]]`); a window larger than the
+  array yields `[]`.
+- Both read `n` via a checked `Value::Int` match (never `as_i64`, which panics on
+  a non-Int arg) and treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; the
+  never-panic floor yields empty).
+- `chunk_while { |prev, cur| pred }` → runs of consecutive elements; the block is
+  called on each ADJACENT pair, a truthy result extends the run and a falsy one
+  starts a new run (`[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` →
+  `[[1,2],[4,5],[7]]`).  Empty → `[]`; single element → `[[x]]`.  The entries are
+  snapshotted before iterating so a reentrant block mutation cannot
+  double-borrow-panic.
+
+Exec-proof: `tests/compile_and_run_array_aggregates.rs` gains
+`array_each_slice_each_cons_chunk_while_compile_and_run`, running each_slice/
+each_cons (incl. `n<=0` and oversized-window → `[]`) and chunk_while (adjacent
+`b-a==1` predicate; empty → `[]`) under real `rustc`, diffed against the
+Python/Go reference semantics.
+
+
 ## 0.31.0 — Hash `to_h` (block + no-block) / `each_with_index` / `each_with_object`
 
 Mirrors the Python reference (PR #8009) and the Go backend (PR #8015) into the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -141,7 +141,8 @@ rather than panicking:
   Python/TS `sir-runtime-oop` reference for parity:
   - **Array** (`Seq`): `length`/`size`, `first`, `last`, `push`/`append`,
     `pop`, `include?`, `reverse`, `sort`, `join`, `map`, `select`/`filter`,
-    `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`.
+    `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`,
+    `each_slice`/`each_cons`, `chunk_while`.
   - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,
     `fetch`, `to_a`, `merge`, `dig` (nested), `invert`, `store`/`[]=`, `delete`,
     `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1470,6 +1470,8 @@ pub const RUNTIME: &str = r##"mod __sir {
                     // more non-block Array methods
                     | "zip" | "rotate" | "to_h" | "tally"
                     | "take" | "drop" | "values_at"
+                    // consecutive-grouping family
+                    | "each_slice" | "each_cons" | "chunk_while"
             ),
             Value::Map(_) => matches!(
                 name,
@@ -2154,6 +2156,82 @@ pub const RUNTIME: &str = r##"mod __sir {
                     .collect();
                 seq_lit(out)
             }
+            // `each_slice(n)` — consecutive sub-arrays of at most `n` elements
+            // (the last may be shorter).  `[1,2,3,4,5].each_slice(2)` →
+            // `[[1,2],[3,4],[5]]`.  Ruby raises `ArgumentError` for `n <= 0`; the
+            // never-panic floor yields `[]`.  `n` is read via a checked `Int`
+            // match (never `as_i64`, which panics on a non-Int arg).
+            "each_slice" => {
+                let n = match pos.first() {
+                    // Validate in the `usize` domain: a huge positive `n` that
+                    // truncates to 0 on a 32-bit target would otherwise loop
+                    // forever, so `try_from` rejects anything past `usize::MAX`.
+                    Some(Value::Int(v)) if *v > 0 => match usize::try_from(*v) {
+                        Ok(n) if n > 0 => n,
+                        _ => return seq_lit(vec![]),
+                    },
+                    _ => return seq_lit(vec![]),
+                };
+                let snapshot = items_rc.borrow().clone();
+                let mut out = Vec::new();
+                let mut i = 0;
+                while i < snapshot.len() {
+                    let end = (i + n).min(snapshot.len());
+                    out.push(seq_lit(snapshot[i..end].to_vec()));
+                    i += n;
+                }
+                seq_lit(out)
+            }
+            // `each_cons(n)` — every consecutive `n`-element sliding window.
+            // `[1,2,3,4].each_cons(2)` → `[[1,2],[2,3],[3,4]]`.  A window larger
+            // than the array (or `n <= 0`) yields `[]`.
+            "each_cons" => {
+                let n = match pos.first() {
+                    // Validate in the `usize` domain: a huge positive `n` that
+                    // truncates to 0 on a 32-bit target would otherwise loop
+                    // forever, so `try_from` rejects anything past `usize::MAX`.
+                    Some(Value::Int(v)) if *v > 0 => match usize::try_from(*v) {
+                        Ok(n) if n > 0 => n,
+                        _ => return seq_lit(vec![]),
+                    },
+                    _ => return seq_lit(vec![]),
+                };
+                let snapshot = items_rc.borrow().clone();
+                let mut out = Vec::new();
+                if snapshot.len() >= n {
+                    for i in 0..=(snapshot.len() - n) {
+                        out.push(seq_lit(snapshot[i..i + n].to_vec()));
+                    }
+                }
+                seq_lit(out)
+            }
+            // `chunk_while { |prev, cur| pred }` — runs of consecutive elements:
+            // the block is called on each ADJACENT pair; while it is truthy the
+            // run continues, and a falsy result starts a new run.
+            // `[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` → `[[1,2],[4,5],[7]]`.
+            // An empty array yields `[]`; a single element yields `[[x]]`.  The
+            // entries are snapshotted first so a block that reentrantly mutates
+            // the receiver cannot double-borrow-panic (the never-panic floor).
+            "chunk_while" => match &block {
+                Some(b) => {
+                    let snapshot = items_rc.borrow().clone();
+                    if snapshot.is_empty() {
+                        return seq_lit(vec![]);
+                    }
+                    let mut chunks: Vec<Vec<Value>> = vec![vec![snapshot[0].clone()]];
+                    for i in 1..snapshot.len() {
+                        let prev = snapshot[i - 1].clone();
+                        let cur = snapshot[i].clone();
+                        if truthy(&apply_closure(b, vec![prev, cur.clone()])) {
+                            chunks.last_mut().unwrap().push(cur);
+                        } else {
+                            chunks.push(vec![cur]);
+                        }
+                    }
+                    seq_lit(chunks.into_iter().map(seq_lit).collect())
+                }
+                None => unknown_method(&recv, name),
+            },
             _ => no_method_error(&recv, name),
         }
     }

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -503,3 +503,103 @@ fn take_drop_values_at_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+// ── Array each_slice / each_cons / chunk_while ─────────────────────────────
+//
+// The consecutive-grouping family, mirroring the Python reference (#8031) and
+// the Go backend (#8036).  `each_slice`/`each_cons` are non-block (take an int
+// `n`); `chunk_while` is a block method (the block is called on each ADJACENT
+// pair).
+fn slice_demo() -> Module {
+    // `{ |a, b| b - a == 1 }` — adjacent-pair predicate (SIR equality builtin is
+    // `=`, subtraction `-`).
+    let adj = block_fn("__b_adj", &["a", "b"], call("=", vec![call("-", vec![param("b"), param("a")]), ilit(1)]));
+    let main_stmts = vec![
+        // [1,2,3,4,5].each_slice(2) → [[1, 2], [3, 4], [5]]
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(3), ilit(4), ilit(5)]),
+            "each_slice",
+            vec![ilit(2)],
+        )),
+        // [1,2,3].each_slice(0) → []  (never-panic floor)
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "each_slice", vec![ilit(0)])),
+        // [1,2,3,4].each_cons(2) → [[1, 2], [2, 3], [3, 4]]
+        print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3), ilit(4)]), "each_cons", vec![ilit(2)])),
+        // [1,2].each_cons(3) → []  (window larger than the array)
+        print_stmt(method(seq(vec![ilit(1), ilit(2)]), "each_cons", vec![ilit(3)])),
+        // [1,2,4,5,7].chunk_while { |a,b| b-a==1 } → [[1, 2], [4, 5], [7]]
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(4), ilit(5), ilit(7)]),
+            "chunk_while",
+            vec![block("__b_adj")],
+        )),
+        // [].chunk_while { … } → []
+        print_stmt(method(seq(vec![]), "chunk_while", vec![block("__b_adj")])),
+    ];
+    demo_module(main_stmts, vec![adj])
+}
+
+#[test]
+fn array_each_slice_each_cons_chunk_while_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&slice_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_arr_slice_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_arr_slice_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "[[1, 2], [3, 4], [5]]",    // each_slice(2)
+            "[]",                       // each_slice(0) → []
+            "[[1, 2], [2, 3], [3, 4]]", // each_cons(2)
+            "[]",                       // each_cons(3) on len-2 → []
+            "[[1, 2], [4, 5], [7]]",    // chunk_while { b-a==1 }
+            "[]",                       // [].chunk_while → []
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8031](https://github.com/adhithyan15/coding-adventures/pull/8031)) and Go backend ([#8036](https://github.com/adhithyan15/coding-adventures/pull/8036)) into the **Rust** backend's inline `__sir` runtime (`array_method` arms + the `Value::Seq` `respond_to?` arm), adding the Array consecutive-grouping family.

## Methods
- `each_slice(n)` → consecutive sub-arrays of at most `n` elements (last shorter).
- `each_cons(n)` → every consecutive `n`-element sliding window; window > len → `[]`.
- Both read `n` via a checked `Value::Int` match (never `as_i64`, which panics on a non-Int arg), validated in the `usize` domain (`usize::try_from` rejects a value past `usize::MAX` so a huge `n` can't truncate to 0 and loop forever on a 32-bit target); `n <= 0` → `[]`.
- `chunk_while { |prev, cur| pred }` → runs of consecutive elements; block called on each adjacent pair, truthy extends the run, falsy starts a new run. Empty → `[]`; single element → `[[x]]`.

## Safety
Every arm snapshots the entries into an owned `Vec` before iterating — no `RefCell` borrow held across `apply_closure` (never-panic floor). Slice ranges are guarded (`end.min(len)`, `len >= n`); the `usize::try_from` guard closes a 32-bit truncation-to-zero infinite-loop (surfaced by the security review and fixed).

## Exec-proof
`tests/compile_and_run_array_aggregates.rs` gains `array_each_slice_each_cons_chunk_while_compile_and_run`, run under real `rustc`:

```
[[1, 2], [3, 4], [5]]      # each_slice(2)
[]                         # each_slice(0) → []
[[1, 2], [2, 3], [3, 4]]   # each_cons(2)
[]                         # each_cons(3) on len-2 → []
[[1, 2], [4, 5], [7]]      # chunk_while { b-a==1 }
[]                         # [].chunk_while → []
```

Lib tests 123 green. Version 0.31.0 → 0.32.0; CHANGELOG + README updated. Security review passed (1 LOW hardened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)