### PR TITLE
feat(sql-vm): LIKELY / UNLIKELY / LIKELIHOOD planner-hint functions

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.13 — LIKELY / UNLIKELY / LIKELIHOOD (planner hints)
+
+Grows the SQL scalar surface (sql-vm 0.4.9) with SQLite's query-planner hint
+functions: `LIKELY(x)`, `UNLIKELY(x)`, and `LIKELIHOOD(x, p)`. They're the
+identity function on their first argument (any type, including NULL) — the hint
+only nudges the optimizer. `LIKELIHOOD`'s probability `p` must be a number in
+`[0,1]`. A new differential-oracle case (`likely_family`) diffs against real
+bundled SQLite.
+
 ## 0.5.12 — OCTET_LENGTH (byte length)
 
 Grows the SQL scalar surface (sql-vm 0.4.8): `OCTET_LENGTH(x)` returns the byte

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.12"
+version = "0.5.13"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -636,6 +636,16 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT OCTET_LENGTH(s) AS o, LENGTH(s) AS l FROM t ORDER BY id",
     },
+    // LIKELY / UNLIKELY / LIKELIHOOD are planner hints — semantically the
+    // identity function on their first argument.
+    Case {
+        id: "likely_family",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, n INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1, 5, 'a'), (2, NULL, 'b')",
+        ],
+        query: "SELECT LIKELY(n) AS a, UNLIKELY(s) AS b, LIKELIHOOD(id, 0.5) AS c FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.9] - Unreleased
+
+### Added
+
+- **`LIKELY(x)` / `UNLIKELY(x)` / `LIKELIHOOD(x, p)`** — SQLite's query-planner
+  hint functions. They bias the optimizer's row-count estimates but have no
+  effect on the result: each returns its first argument unchanged (any type,
+  including NULL). `LIKELIHOOD`'s second argument `p` is a probability the planner
+  uses as a hint and must be a number in `[0.0, 1.0]` (validated; out-of-range or
+  non-numeric is an error). Arity is checked before indexing.
+
 ## [0.4.8] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1048,6 +1048,8 @@ fn pop(stack: &mut Vec<SqlValue>) -> Result<SqlValue, VmError> {
 /// | CONCAT   | ≥1   | Concatenate all arguments (NULL → empty string)       |
 /// | CONCAT_WS| ≥2   | Join value arguments with a separator (NULLs skipped) |
 /// | UNHEX    | 1–2  | Decode hex digit pairs into a blob (inverse of HEX)   |
+/// | LIKELY / UNLIKELY | 1 | Planner hint; returns the argument unchanged     |
+/// | LIKELIHOOD | 2  | Planner hint with a probability; returns arg 1        |
 /// | REPLACE  |  3   | Replace all occurrences of a pattern with another str |
 /// | ABS      |  1   | Absolute value (Integer or Float)                     |
 /// | COALESCE | ≥1   | Return the first non-NULL argument                    |
@@ -1172,6 +1174,44 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
                 SqlValue::Bool(b) => Ok(SqlValue::Int((*b as i64).to_string().len() as i64)),
                 other => Err(VmError::TypeMismatch(format!("OCTET_LENGTH expects TEXT/BLOB/INTEGER, got {:?}", other))),
             }
+        }
+
+        "LIKELY" | "UNLIKELY" => {
+            // Query-planner hints: `likely(x)` / `unlikely(x)` tell SQLite's
+            // optimizer that `x` is probably true / probably false, biasing its
+            // row-count estimates. They have no effect on the result — they are
+            // the *identity* function, returning the argument unchanged (any
+            // type, including NULL).
+            if args.len() != 1 {
+                return Err(VmError::TypeMismatch(format!("{name} expects 1 arg, got {}", args.len())));
+            }
+            Ok(args.into_iter().next().unwrap())
+        }
+
+        "LIKELIHOOD" => {
+            // `likelihood(x, p)` is `likely`/`unlikely` with an explicit
+            // probability `p` (the fraction of rows for which `x` is expected to
+            // be true). It returns `x` unchanged; `p` only hints the planner.
+            // SQLite requires `p` to be a constant number in [0.0, 1.0] — we
+            // validate the value's range and reject anything else.
+            if args.len() != 2 {
+                return Err(VmError::TypeMismatch(format!("LIKELIHOOD expects 2 args, got {}", args.len())));
+            }
+            let p = match &args[1] {
+                SqlValue::Float(f) => *f,
+                SqlValue::Int(i) => *i as f64,
+                other => {
+                    return Err(VmError::TypeMismatch(format!(
+                        "LIKELIHOOD probability must be a number in [0,1], got {other:?}"
+                    )))
+                }
+            };
+            if !(0.0..=1.0).contains(&p) {
+                return Err(VmError::TypeMismatch(format!(
+                    "LIKELIHOOD probability {p} is out of range [0,1]"
+                )));
+            }
+            Ok(args.into_iter().next().unwrap())
         }
 
         "UPPER" => {
@@ -4075,6 +4115,37 @@ mod tests {
                 call_builtin("SUBSTR", args).unwrap(),
             );
         }
+    }
+
+    #[test]
+    fn builtin_likely_family_is_identity() {
+        // likely / unlikely return their single argument unchanged, any type.
+        for name in ["LIKELY", "UNLIKELY"] {
+            assert_eq!(call_builtin(name, vec![SqlValue::Int(5)]).unwrap(), SqlValue::Int(5));
+            assert_eq!(
+                call_builtin(name, vec![SqlValue::Text("abc".into())]).unwrap(),
+                SqlValue::Text("abc".into())
+            );
+            assert_eq!(call_builtin(name, vec![SqlValue::Null]).unwrap(), SqlValue::Null);
+            assert_eq!(call_builtin(name, vec![SqlValue::Float(2.5)]).unwrap(), SqlValue::Float(2.5));
+            // Wrong arity is an error, not a panic.
+            assert!(call_builtin(name, vec![]).is_err());
+            assert!(call_builtin(name, vec![SqlValue::Int(1), SqlValue::Int(2)]).is_err());
+        }
+        // likelihood(x, p) returns x when p is a probability in [0, 1].
+        assert_eq!(
+            call_builtin("LIKELIHOOD", vec![SqlValue::Int(7), SqlValue::Float(0.0625)]).unwrap(),
+            SqlValue::Int(7)
+        );
+        assert_eq!(
+            call_builtin("LIKELIHOOD", vec![SqlValue::Null, SqlValue::Float(0.5)]).unwrap(),
+            SqlValue::Null
+        );
+        // A probability outside [0, 1], a non-numeric probability, or wrong arity
+        // are all errors.
+        assert!(call_builtin("LIKELIHOOD", vec![SqlValue::Int(1), SqlValue::Float(1.5)]).is_err());
+        assert!(call_builtin("LIKELIHOOD", vec![SqlValue::Int(1), SqlValue::Text("x".into())]).is_err());
+        assert!(call_builtin("LIKELIHOOD", vec![SqlValue::Int(1)]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Stream B** — grows the mini-sqlite SQL scalar surface with SQLite's
query-planner hint functions. `LIKELY(x)` / `UNLIKELY(x)` tell the optimizer that
`x` is probably true / false, and `LIKELIHOOD(x, p)` gives an explicit
probability. They bias the planner's row-count estimates but have **no effect on
the result** — each is the identity function on its first argument. Probed real
SQLite:

```
likely(5)             -> 5
unlikely('abc')       -> 'abc'
likelihood(7, 0.0625) -> 7
unlikely(NULL)        -> NULL
```

`LIKELY`/`UNLIKELY` take exactly one argument (any type, including NULL) and
return it unchanged. `LIKELIHOOD` takes two: it returns the first, and its second
argument `p` must be a number in `[0.0, 1.0]` (out-of-range, NaN, or non-numeric
all error). No grammar/planner/codegen work.

## Security

Reviewed before push. Each arm checks arity (`len == 1` / `== 2`) **before**
indexing or consuming args (the panic-before-arity class from the earlier
`TRIM()` bug is avoided; the `next().unwrap()` is safe under the guard); the
`[0,1]` check via `(0.0..=1.0).contains(&p)` correctly rejects NaN; no
allocation, overflow, or unsafe. **Review passed, no findings.**

## Verification

- `sql-vm`: **96 lib tests** (new case: identity on int/text/float/NULL, arity
  errors for all three, out-of-range / non-numeric probability).
- **mini-sqlite differential oracle:** new `likely_family` case diffs
  LIKELY/UNLIKELY/LIKELIHOOD (including a NULL row) against real bundled SQLite.
  Full mini-sqlite suite green.

`sql-vm` 0.4.8 → 0.4.9, `mini-sqlite` 0.5.12 → 0.5.13; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
