### PR TITLE
feat(cobol): ROUNDED / ON SIZE ERROR on ADD/SUBTRACT/MULTIPLY/DIVIDE (PL08 v0.12)

### DIFF
--- a/code/grammars/cobol/cobol.grammar
+++ b/code/grammars/cobol/cobol.grammar
@@ -110,10 +110,16 @@ statement = move_stmt | display_stmt | accept_stmt
 move_stmt     = "MOVE" operand "TO" NAME { NAME } ;
 display_stmt  = "DISPLAY" operand { operand } ;
 accept_stmt   = "ACCEPT" NAME ;
-add_stmt      = "ADD" operand { operand } "TO" NAME [ "GIVING" NAME ] ;
-subtract_stmt = "SUBTRACT" operand { operand } "FROM" NAME [ "GIVING" NAME ] ;
-multiply_stmt = "MULTIPLY" operand "BY" operand [ "GIVING" NAME ] ;
-divide_stmt   = "DIVIDE" operand "INTO" operand [ "GIVING" NAME ] ;
+# The four arithmetic verbs share two optional trailing clauses with COMPUTE:
+# ROUNDED (round instead of truncate into the receiver) and ON SIZE ERROR.
+add_stmt      = "ADD" operand { operand } "TO" NAME [ "GIVING" NAME ]
+                        [ "ROUNDED" ] [ size_error ] ;
+subtract_stmt = "SUBTRACT" operand { operand } "FROM" NAME [ "GIVING" NAME ]
+                        [ "ROUNDED" ] [ size_error ] ;
+multiply_stmt = "MULTIPLY" operand "BY" operand [ "GIVING" NAME ]
+                        [ "ROUNDED" ] [ size_error ] ;
+divide_stmt   = "DIVIDE" operand "INTO" operand [ "GIVING" NAME ]
+                        [ "ROUNDED" ] [ size_error ] ;
 
 # COMPUTE evaluates a full arithmetic EXPRESSION and MOVEs the result into the
 # receiver — the one COBOL verb that takes operator symbols instead of

--- a/code/packages/rust/cobol-parser/CHANGELOG.md
+++ b/code/packages/rust/cobol-parser/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.0 — ROUNDED / ON SIZE ERROR on the arithmetic verbs
+
+- `add_stmt` / `subtract_stmt` / `multiply_stmt` / `divide_stmt` gain the trailing
+  `[ ROUNDED ] [ size_error ]` clauses, sharing the `size_error` rule already used
+  by `COMPUTE`. `ROUNDED`/`ON`/`SIZE`/`ERROR` were already reserved words, so the
+  lexer is unchanged.
+
 ## 0.4.0 — PERFORM … VARYING
 
 - `perform_stmt` gains a third repeat clause, `perform_varying`

--- a/code/packages/rust/cobol-parser/Cargo.toml
+++ b/code/packages/rust/cobol-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-parser"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Parser for COBOL-60 — parses COBOL source into a generic parse tree using the grammar-driven parser and the cobol.grammar file."
 

--- a/code/packages/rust/cobol-parser/src/_grammar.rs
+++ b/code/packages/rust/cobol-parser/src/_grammar.rs
@@ -320,8 +320,10 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"GIVING"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"ROUNDED"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"size_error"#.to_string() }) },
             ] },
-            line_number: 113,
+            line_number: 115,
         },
         GrammarRule {
             name: r#"subtract_stmt"#.to_string(),
@@ -335,8 +337,10 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"GIVING"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"ROUNDED"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"size_error"#.to_string() }) },
             ] },
-            line_number: 114,
+            line_number: 117,
         },
         GrammarRule {
             name: r#"multiply_stmt"#.to_string(),
@@ -349,8 +353,10 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"GIVING"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"ROUNDED"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"size_error"#.to_string() }) },
             ] },
-            line_number: 115,
+            line_number: 119,
         },
         GrammarRule {
             name: r#"divide_stmt"#.to_string(),
@@ -363,8 +369,10 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"GIVING"#.to_string() },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"ROUNDED"#.to_string() }) },
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"size_error"#.to_string() }) },
             ] },
-            line_number: 116,
+            line_number: 121,
         },
         GrammarRule {
             name: r#"compute_stmt"#.to_string(),
@@ -376,7 +384,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"arith_expr"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"size_error"#.to_string() }) },
             ] },
-            line_number: 123,
+            line_number: 129,
         },
         GrammarRule {
             name: r#"size_error"#.to_string(),
@@ -386,7 +394,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"ERROR"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
             ] },
-            line_number: 124,
+            line_number: 130,
         },
         GrammarRule {
             name: r#"arith_expr"#.to_string(),
@@ -400,7 +408,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"arith_term"#.to_string() },
                     ] }) },
             ] },
-            line_number: 140,
+            line_number: 146,
         },
         GrammarRule {
             name: r#"arith_term"#.to_string(),
@@ -414,7 +422,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"arith_factor"#.to_string() },
                     ] }) },
             ] },
-            line_number: 141,
+            line_number: 147,
         },
         GrammarRule {
             name: r#"arith_factor"#.to_string(),
@@ -425,7 +433,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"arith_unary"#.to_string() },
                     ] }) },
             ] },
-            line_number: 142,
+            line_number: 148,
         },
         GrammarRule {
             name: r#"arith_unary"#.to_string(),
@@ -436,7 +444,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     ] }) },
                 GrammarElement::RuleReference { name: r#"arith_primary"#.to_string() },
             ] },
-            line_number: 143,
+            line_number: 149,
         },
         GrammarRule {
             name: r#"arith_primary"#.to_string(),
@@ -449,7 +457,7 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                 ] },
             ] },
-            line_number: 144,
+            line_number: 150,
         },
         GrammarRule {
             name: r#"perform_stmt"#.to_string(),
@@ -478,7 +486,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::RuleReference { name: r#"perform_varying"#.to_string() },
                     ] }) },
             ] },
-            line_number: 145,
+            line_number: 151,
         },
         GrammarRule {
             name: r#"perform_varying"#.to_string(),
@@ -492,7 +500,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"UNTIL"#.to_string() },
                 GrammarElement::RuleReference { name: r#"condition"#.to_string() },
             ] },
-            line_number: 149,
+            line_number: 155,
         },
         GrammarRule {
             name: r#"goto_stmt"#.to_string(),
@@ -501,7 +509,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"TO"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
             ] },
-            line_number: 150,
+            line_number: 156,
         },
         GrammarRule {
             name: r#"stop_stmt"#.to_string(),
@@ -513,7 +521,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                     ] }) },
             ] },
-            line_number: 151,
+            line_number: 157,
         },
         GrammarRule {
             name: r#"if_stmt"#.to_string(),
@@ -526,7 +534,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement"#.to_string() }) },
                     ] }) },
             ] },
-            line_number: 155,
+            line_number: 161,
         },
         GrammarRule {
             name: r#"condition"#.to_string(),
@@ -535,7 +543,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"relop"#.to_string() },
                 GrammarElement::RuleReference { name: r#"operand"#.to_string() },
             ] },
-            line_number: 156,
+            line_number: 162,
         },
         GrammarRule {
             name: r#"relop"#.to_string(),
@@ -557,7 +565,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] },
                     ] }) },
             ] },
-            line_number: 157,
+            line_number: 163,
         },
         GrammarRule {
             name: r#"operand"#.to_string(),
@@ -565,7 +573,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                 GrammarElement::RuleReference { name: r#"literal"#.to_string() },
             ] },
-            line_number: 163,
+            line_number: 169,
         },
         GrammarRule {
             name: r#"literal"#.to_string(),
@@ -574,7 +582,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
                 GrammarElement::RuleReference { name: r#"figurative"#.to_string() },
             ] },
-            line_number: 164,
+            line_number: 170,
         },
         GrammarRule {
             name: r#"figurative"#.to_string(),
@@ -591,7 +599,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"QUOTE"#.to_string() },
                 GrammarElement::Literal { value: r#"QUOTES"#.to_string() },
             ] },
-            line_number: 165,
+            line_number: 171,
         },
     ],
         version: 1,

--- a/code/packages/rust/cobol-parser/src/lib.rs
+++ b/code/packages/rust/cobol-parser/src/lib.rs
@@ -226,6 +226,26 @@ mod tests {
     }
 
     #[test]
+    fn arithmetic_rounded_and_on_size_error() {
+        // ADD/SUBTRACT/MULTIPLY/DIVIDE take the trailing ROUNDED and ON SIZE
+        // ERROR clauses, sharing the `size_error` rule with COMPUTE.
+        let ast = root(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    ADD 1 TO R ROUNDED.",
+            "    DIVIDE 3 INTO X GIVING Y ROUNDED",
+            "        ON SIZE ERROR DISPLAY \"OVR\".",
+            "    STOP RUN.",
+        ]));
+        assert!(has_rule(&ast, "add_stmt"));
+        assert!(has_rule(&ast, "divide_stmt"));
+        // The DIVIDE's ON SIZE ERROR introduces a size_error node.
+        assert!(has_rule(&ast, "size_error"));
+    }
+
+    #[test]
     fn perform_varying() {
         // PERFORM … VARYING id FROM start BY step UNTIL cond parses to a
         // perform_varying node carrying the induction variable and condition.

--- a/code/packages/rust/cobol-runtime/CHANGELOG.md
+++ b/code/packages/rust/cobol-runtime/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.12.0 — ROUNDED / ON SIZE ERROR on the arithmetic verbs
+
+- **`ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` now take `ROUNDED` and `ON SIZE ERROR`**,
+  matching `COMPUTE`. `ROUNDED` rounds half away from zero into the receiver
+  (else truncate); `ON SIZE ERROR` runs its statements (receiver unchanged) when
+  the result's integer part overflows — or, for `DIVIDE`, when the divisor is
+  zero. Without a handler, overflow truncates silently and a zero divisor stays a
+  hard `DivideByZero`.
+- The store path (round → size-error → store) is now a shared `store_result`
+  helper used by all five arithmetic verbs, so their rounding/overflow behaviour
+  is identical. `DIVIDE` now computes at the same intermediate precision as
+  `COMPUTE` before rounding into the receiver.
+
 ## 0.11.0 — PERFORM … THRU (paragraph range)
 
 - **`PERFORM para-1 THRU para-2`** runs the whole range of paragraphs from

--- a/code/packages/rust/cobol-runtime/Cargo.toml
+++ b/code/packages/rust/cobol-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-cobol-runtime"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Runtime (tree-walking interpreter) for COBOL-60 — a faithful PICTURE-typed data model and statement execution, built on the cobol-parser CST."
 

--- a/code/packages/rust/cobol-runtime/README.md
+++ b/code/packages/rust/cobol-runtime/README.md
@@ -23,8 +23,9 @@ A small but **fully correct** slice, growing one quirk at a time: numeric-displa
 (`X`/`A`) pictures; the item tree from
 level numbers; `VALUE` initialisation; figurative `ZERO`/`SPACE`; `MOVE` with
 the exact justify/pad/truncate rules; `DISPLAY`; `STOP RUN`; fixed-point
-decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned, truncating
-toward zero into the receiver; divide-by-zero is a clean error); `COMPUTE` with
+decimal `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` (decimal-point aligned; `ROUNDED`
+and `ON SIZE ERROR`; divide-by-zero is a clean error or a size-error condition);
+`COMPUTE` with
 precedence-correct arithmetic expressions (`+ - * / **`, unary sign,
 parentheses), `ROUNDED`, and `ON SIZE ERROR`; `IF … ELSE` with numeric and
 alphanumeric comparison; `PERFORM para [THRU para2] [n TIMES | UNTIL cond |

--- a/code/packages/rust/cobol-runtime/src/interp.rs
+++ b/code/packages/rust/cobol-runtime/src/interp.rs
@@ -254,11 +254,17 @@ impl Machine {
             Stmt::StopRun => return Ok(Flow::Stop),
             Stmt::Display(ops) => self.exec_display(ops)?,
             Stmt::Move { src, dsts } => self.exec_move(src, dsts)?,
-            Stmt::Add { operands, to, giving } => self.exec_add(operands, to, giving)?,
-            Stmt::Subtract { operands, from, giving } => self.exec_subtract(operands, from, giving)?,
-            Stmt::Multiply { a, by, giving } => self.exec_multiply(a, by, giving)?,
-            Stmt::Divide { divisor, dividend, giving } => {
-                self.exec_divide(divisor, dividend, giving)?
+            Stmt::Add { operands, to, giving, rounded, on_size_error } => {
+                return self.exec_add(operands, to, giving, *rounded, on_size_error)
+            }
+            Stmt::Subtract { operands, from, giving, rounded, on_size_error } => {
+                return self.exec_subtract(operands, from, giving, *rounded, on_size_error)
+            }
+            Stmt::Multiply { a, by, giving, rounded, on_size_error } => {
+                return self.exec_multiply(a, by, giving, *rounded, on_size_error)
+            }
+            Stmt::Divide { divisor, dividend, giving, rounded, on_size_error } => {
+                return self.exec_divide(divisor, dividend, giving, *rounded, on_size_error)
             }
             Stmt::Compute { target, rounded, expr, on_size_error } => {
                 return self.exec_compute(target, *rounded, expr, on_size_error);
@@ -505,41 +511,47 @@ impl Machine {
     // Arithmetic (fixed-point decimal, truncating; unsigned receivers)
     // ----------------------------------------------------------------------
 
-    /// `ADD op… TO name [GIVING g]` → (name + op1 + … + opN) into g or name.
+    /// `ADD op… TO name [GIVING g] [ROUNDED] [ON SIZE ERROR …]`.
     fn exec_add(
         &mut self,
         operands: &[Operand],
         to: &str,
         giving: &Option<String>,
-    ) -> Result<(), RuntimeError> {
+        rounded: bool,
+        on_size_error: &[Stmt],
+    ) -> Result<Flow, RuntimeError> {
         let mut acc = self.named_decimal(to)?;
         for op in operands {
             acc = checked(add(&acc, &self.operand_decimal(op)?))?;
         }
-        self.store_number(giving.as_deref().unwrap_or(to), acc)
+        self.store_result(giving.as_deref().unwrap_or(to), acc, rounded, on_size_error)
     }
 
-    /// `SUBTRACT op… FROM name [GIVING g]` → (name − op1 − … − opN) into g or name.
+    /// `SUBTRACT op… FROM name [GIVING g] [ROUNDED] [ON SIZE ERROR …]`.
     fn exec_subtract(
         &mut self,
         operands: &[Operand],
         from: &str,
         giving: &Option<String>,
-    ) -> Result<(), RuntimeError> {
+        rounded: bool,
+        on_size_error: &[Stmt],
+    ) -> Result<Flow, RuntimeError> {
         let mut acc = self.named_decimal(from)?;
         for op in operands {
             acc = checked(sub(&acc, &self.operand_decimal(op)?))?;
         }
-        self.store_number(giving.as_deref().unwrap_or(from), acc)
+        self.store_result(giving.as_deref().unwrap_or(from), acc, rounded, on_size_error)
     }
 
-    /// `MULTIPLY a BY b [GIVING g]` → (a × b) into g, or into b when no GIVING.
+    /// `MULTIPLY a BY b [GIVING g] [ROUNDED] [ON SIZE ERROR …]`.
     fn exec_multiply(
         &mut self,
         a: &Operand,
         by: &Operand,
         giving: &Option<String>,
-    ) -> Result<(), RuntimeError> {
+        rounded: bool,
+        on_size_error: &[Stmt],
+    ) -> Result<Flow, RuntimeError> {
         let product = checked(mul(&self.operand_decimal(a)?, &self.operand_decimal(by)?))?;
         let target = match (giving, by) {
             (Some(g), _) => g.clone(),
@@ -550,20 +562,26 @@ impl Machine {
                 ))
             }
         };
-        self.store_number(&target, product)
+        self.store_result(&target, product, rounded, on_size_error)
     }
 
-    /// `DIVIDE a INTO b [GIVING g]` → (b ÷ a), truncated to the receiver's
-    /// decimal places, stored in g, or in b (the dividend) when no GIVING.
+    /// `DIVIDE a INTO b [GIVING g] [ROUNDED] [ON SIZE ERROR …]` → b ÷ a.
     fn exec_divide(
         &mut self,
         divisor: &Operand,
         dividend: &Operand,
         giving: &Option<String>,
-    ) -> Result<(), RuntimeError> {
+        rounded: bool,
+        on_size_error: &[Stmt],
+    ) -> Result<Flow, RuntimeError> {
         let d = self.operand_decimal(divisor)?;
         if d.is_zero() {
-            return Err(RuntimeError::DivideByZero);
+            // Division by zero is a size-error condition (as in COMPUTE): the
+            // handler catches it; without one it is a hard error.
+            if on_size_error.is_empty() {
+                return Err(RuntimeError::DivideByZero);
+            }
+            return self.run_stmts(on_size_error);
         }
         let n = self.operand_decimal(dividend)?;
         let target = match (giving, dividend) {
@@ -575,16 +593,42 @@ impl Machine {
                 ))
             }
         };
-        // Compute to the receiver's fractional precision (COBOL truncates there
-        // absent ROUNDED); store_number then aligns the integer part.
-        let scale = self.numeric_dec_digits(&target)?;
-        let quotient = checked(div(&n, &d, scale))?;
-        self.store_number(&target, quotient)
+        // Compute at the shared intermediate precision; store_result then
+        // rounds or truncates into the receiver's decimal places.
+        let quotient = checked(div(&n, &d, COMPUTE_DIV_SCALE))?;
+        self.store_result(&target, quotient, rounded, on_size_error)
     }
 
-    /// The number of fractional digit positions of a named numeric receiver.
-    fn numeric_dec_digits(&self, name: &str) -> Result<usize, RuntimeError> {
-        Ok(self.numeric_dims(name)?.1)
+    /// Store a computed value into a numeric receiver, applying `ROUNDED`
+    /// (half away from zero, else truncate toward zero at the receiver's decimal
+    /// places) and `ON SIZE ERROR` (when the result's integer part overflows the
+    /// receiver, run the handler and leave the receiver unchanged; without a
+    /// handler, COBOL truncates the high-order digits silently, as `MOVE` does).
+    /// Shared by the arithmetic verbs and `COMPUTE`.
+    fn store_result(
+        &mut self,
+        target: &str,
+        value: Decimal,
+        rounded: bool,
+        on_size_error: &[Stmt],
+    ) -> Result<Flow, RuntimeError> {
+        let (int_digits, dec_digits) = self.numeric_dims(target)?;
+        let final_value = if rounded {
+            checked(round(&value, dec_digits))?
+        } else {
+            value
+        };
+        // Size error = the integer part does not fit (fractional truncation is
+        // never a size error).
+        if final_value.int.trim_start_matches('0').len() > int_digits {
+            if on_size_error.is_empty() {
+                self.store_number(target, final_value)?;
+                return Ok(Flow::Normal);
+            }
+            return self.run_stmts(on_size_error);
+        }
+        self.store_number(target, final_value)?;
+        Ok(Flow::Normal)
     }
 
     /// The `(int_digits, dec_digits)` of a named numeric receiver.
@@ -615,8 +659,6 @@ impl Machine {
         expr: &Expr,
         on_size_error: &[Stmt],
     ) -> Result<Flow, RuntimeError> {
-        let (int_digits, dec_digits) = self.numeric_dims(target)?;
-
         let value = match self.eval_expr(expr) {
             Ok(v) => v,
             // Division by zero is a size-error condition: the handler catches it;
@@ -626,29 +668,7 @@ impl Machine {
             }
             Err(e) => return Err(e),
         };
-
-        // Round (half away from zero) or leave full precision for the store to
-        // truncate at the receiver's decimal places.
-        let final_value = if rounded {
-            checked(round(&value, dec_digits))?
-        } else {
-            value
-        };
-
-        // Size error = the integer part does not fit. (Fractional truncation is
-        // never a size error.)
-        if final_value.int.trim_start_matches('0').len() > int_digits {
-            if on_size_error.is_empty() {
-                // No handler: COBOL truncates the high-order digits silently,
-                // exactly as move_into_numeric already does.
-                self.store_number(target, final_value)?;
-                return Ok(Flow::Normal);
-            }
-            return self.run_stmts(on_size_error);
-        }
-
-        self.store_number(target, final_value)?;
-        Ok(Flow::Normal)
+        self.store_result(target, value, rounded, on_size_error)
     }
 
     /// Evaluate an arithmetic expression to an exact [`Decimal`]. Division is

--- a/code/packages/rust/cobol-runtime/src/lib.rs
+++ b/code/packages/rust/cobol-runtime/src/lib.rs
@@ -6,7 +6,8 @@
 //! [PL08](../../../specs/PL08-cobol-runtime.md).
 //!
 //! It implements a *small but fully correct* slice — `MOVE` / `DISPLAY` /
-//! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`,
+//! `STOP RUN`, fixed-point decimal `ADD` / `SUBTRACT` / `MULTIPLY` / `DIVIDE`
+//! (with `ROUNDED` and `ON SIZE ERROR`),
 //! `COMPUTE` (precedence-correct arithmetic expressions with `+ - * / **`, unary
 //! sign and parentheses, `ROUNDED`, and `ON SIZE ERROR`), `IF … ELSE`
 //! (numeric and alphanumeric comparison),
@@ -330,6 +331,97 @@ mod tests {
         ]))
         .unwrap_err();
         assert!(matches!(err, RuntimeError::DivideByZero), "got {err:?}");
+    }
+
+    // ----------------------------------------------------------------------
+    // ROUNDED / ON SIZE ERROR on the arithmetic verbs
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn divide_giving_rounded_rounds_the_receiver() {
+        // 10 / 3 = 3.333… → into V99. Truncated: 3.33; ROUNDED: still 3.33 (3rd
+        // place < 5). Use 20 / 3 = 6.666… → truncated 6.66, ROUNDED 6.67.
+        let prog = |rounded: &str| {
+            run_cobol(&program(&[
+                "IDENTIFICATION DIVISION.",
+                "PROGRAM-ID. P.",
+                "DATA DIVISION.",
+                "WORKING-STORAGE SECTION.",
+                "01  R  PIC 9(2)V99 VALUE 0.",
+                "PROCEDURE DIVISION.",
+                "MAIN.",
+                &format!("    DIVIDE 3 INTO 20 GIVING R{rounded}."),
+                "    DISPLAY R.",
+                "    STOP RUN.",
+            ]))
+            .unwrap()
+        };
+        assert_eq!(prog(""), "0666\n"); // truncated 6.66
+        assert_eq!(prog(" ROUNDED"), "0667\n"); // rounded 6.67
+    }
+
+    #[test]
+    fn multiply_giving_rounded() {
+        // 2.5 * 2.5 = 6.25 into 9(2)V9: truncated 6.2, ROUNDED 6.3 (2nd place 5).
+        let prog = |rounded: &str| {
+            run_cobol(&program(&[
+                "IDENTIFICATION DIVISION.",
+                "PROGRAM-ID. P.",
+                "DATA DIVISION.",
+                "WORKING-STORAGE SECTION.",
+                "01  R  PIC 9(2)V9 VALUE 0.",
+                "PROCEDURE DIVISION.",
+                "MAIN.",
+                &format!("    MULTIPLY 2.5 BY 2.5 GIVING R{rounded}."),
+                "    DISPLAY R.",
+                "    STOP RUN.",
+            ]))
+            .unwrap()
+        };
+        assert_eq!(prog(""), "062\n");
+        assert_eq!(prog(" ROUNDED"), "063\n");
+    }
+
+    #[test]
+    fn add_on_size_error_fires_on_overflow() {
+        // R is 9(2) (max 99). ADD 50 TO R twice → 100 overflows on the second;
+        // the handler runs and R is left unchanged (still 50).
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  R  PIC 9(2) VALUE 50.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    ADD 60 TO R",
+            "        ON SIZE ERROR DISPLAY \"OVER\".",
+            "    DISPLAY R.",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        // 50 + 60 = 110 overflows 9(2) → handler runs, R unchanged at 50.
+        assert_eq!(out, "OVER\n50\n");
+    }
+
+    #[test]
+    fn divide_by_zero_with_on_size_error_runs_the_handler() {
+        // A zero divisor is a size-error condition; with a handler it is caught.
+        let out = run_cobol(&program(&[
+            "IDENTIFICATION DIVISION.",
+            "PROGRAM-ID. P.",
+            "DATA DIVISION.",
+            "WORKING-STORAGE SECTION.",
+            "01  R  PIC 9(3) VALUE 7.",
+            "PROCEDURE DIVISION.",
+            "MAIN.",
+            "    DIVIDE 0 INTO 10 GIVING R",
+            "        ON SIZE ERROR DISPLAY \"DIVZERO\".",
+            "    DISPLAY R.",
+            "    STOP RUN.",
+        ]))
+        .unwrap();
+        assert_eq!(out, "DIVZERO\n007\n");
     }
 
     // ----------------------------------------------------------------------

--- a/code/packages/rust/cobol-runtime/src/program.rs
+++ b/code/packages/rust/cobol-runtime/src/program.rs
@@ -60,14 +60,38 @@ pub struct Paragraph {
 pub enum Stmt {
     Display(Vec<Operand>),
     Move { src: Operand, dsts: Vec<String> },
-    /// `ADD op… TO name [GIVING g]` — result = op1+…+name, stored in g or name.
-    Add { operands: Vec<Operand>, to: String, giving: Option<String> },
-    /// `SUBTRACT op… FROM name [GIVING g]` — result = name-(op1+…), in g or name.
-    Subtract { operands: Vec<Operand>, from: String, giving: Option<String> },
-    /// `MULTIPLY a BY b [GIVING g]` — result = a*b, stored in g or b.
-    Multiply { a: Operand, by: Operand, giving: Option<String> },
-    /// `DIVIDE a INTO b [GIVING g]` — result = b/a, stored in g or b.
-    Divide { divisor: Operand, dividend: Operand, giving: Option<String> },
+    /// `ADD op… TO name [GIVING g] [ROUNDED] [ON SIZE ERROR …]` — op1+…+name.
+    Add {
+        operands: Vec<Operand>,
+        to: String,
+        giving: Option<String>,
+        rounded: bool,
+        on_size_error: Vec<Stmt>,
+    },
+    /// `SUBTRACT op… FROM name [GIVING g] [ROUNDED] [ON SIZE ERROR …]`.
+    Subtract {
+        operands: Vec<Operand>,
+        from: String,
+        giving: Option<String>,
+        rounded: bool,
+        on_size_error: Vec<Stmt>,
+    },
+    /// `MULTIPLY a BY b [GIVING g] [ROUNDED] [ON SIZE ERROR …]` — a*b.
+    Multiply {
+        a: Operand,
+        by: Operand,
+        giving: Option<String>,
+        rounded: bool,
+        on_size_error: Vec<Stmt>,
+    },
+    /// `DIVIDE a INTO b [GIVING g] [ROUNDED] [ON SIZE ERROR …]` — b/a.
+    Divide {
+        divisor: Operand,
+        dividend: Operand,
+        giving: Option<String>,
+        rounded: bool,
+        on_size_error: Vec<Stmt>,
+    },
     /// `COMPUTE target [ROUNDED] = expr [ON SIZE ERROR stmts…]` — evaluate an
     /// arithmetic expression and store it in `target`, rounding instead of
     /// truncating when `rounded`, running `on_size_error` when the result
@@ -359,12 +383,14 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             // direct NAME tokens are [to] or [to, giving].
             let operands = read_operands(verb)?;
             let (to, giving) = read_target_and_giving(verb)?;
-            Ok(Stmt::Add { operands, to, giving })
+            let (rounded, on_size_error) = read_rounded_and_size_error(verb)?;
+            Ok(Stmt::Add { operands, to, giving, rounded, on_size_error })
         }
         "subtract_stmt" => {
             let operands = read_operands(verb)?;
             let (from, giving) = read_target_and_giving(verb)?;
-            Ok(Stmt::Subtract { operands, from, giving })
+            let (rounded, on_size_error) = read_rounded_and_size_error(verb)?;
+            Ok(Stmt::Subtract { operands, from, giving, rounded, on_size_error })
         }
         "multiply_stmt" => {
             // MULTIPLY a BY b [GIVING g]: two operand nodes; a direct NAME token
@@ -380,8 +406,15 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 .map(|(_, v)| v)
                 .collect();
             let giving = if has_giving { names.into_iter().next() } else { None };
+            let (rounded, on_size_error) = read_rounded_and_size_error(verb)?;
             let mut it = ops.into_iter();
-            Ok(Stmt::Multiply { a: it.next().unwrap(), by: it.next().unwrap(), giving })
+            Ok(Stmt::Multiply {
+                a: it.next().unwrap(),
+                by: it.next().unwrap(),
+                giving,
+                rounded,
+                on_size_error,
+            })
         }
         "divide_stmt" => {
             // DIVIDE a INTO b [GIVING g]: first operand is the divisor, second
@@ -397,8 +430,15 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
                 .map(|(_, v)| v)
                 .collect();
             let giving = if has_giving { names.into_iter().next() } else { None };
+            let (rounded, on_size_error) = read_rounded_and_size_error(verb)?;
             let mut it = ops.into_iter();
-            Ok(Stmt::Divide { divisor: it.next().unwrap(), dividend: it.next().unwrap(), giving })
+            Ok(Stmt::Divide {
+                divisor: it.next().unwrap(),
+                dividend: it.next().unwrap(),
+                giving,
+                rounded,
+                on_size_error,
+            })
         }
         "compute_stmt" => {
             // COMPUTE target [ROUNDED] = <expr> [ON SIZE ERROR stmts…].
@@ -406,19 +446,10 @@ fn read_statement(stmt: &GrammarASTNode) -> Result<Stmt, RuntimeError> {
             // deeper, inside the arith_* nodes.
             let target = first_token(verb, "NAME")
                 .ok_or_else(|| RuntimeError::Unsupported("COMPUTE without a receiver".into()))?;
-            let rounded = child_tokens(verb)
-                .iter()
-                .any(|(k, v)| k == "KEYWORD" && v == "ROUNDED");
             let expr_node = child_node(verb, "arith_expr")
                 .ok_or_else(|| RuntimeError::Unsupported("COMPUTE without an expression".into()))?;
             let expr = read_arith_expr_bounded(expr_node)?;
-            let on_size_error = match child_node(verb, "size_error") {
-                Some(se) => child_nodes(se, "statement")
-                    .into_iter()
-                    .map(read_statement)
-                    .collect::<Result<Vec<_>, _>>()?,
-                None => Vec::new(),
-            };
+            let (rounded, on_size_error) = read_rounded_and_size_error(verb)?;
             Ok(Stmt::Compute { target, rounded, expr, on_size_error })
         }
         "perform_stmt" => {
@@ -670,6 +701,24 @@ fn read_perform_varying(v: &GrammarASTNode) -> Result<PerformMode, RuntimeError>
         .ok_or_else(|| RuntimeError::Unsupported("PERFORM VARYING without an UNTIL".into()))?;
     let until = read_condition(cond)?;
     Ok(PerformMode::Varying { var, from, by, until })
+}
+
+/// Read the trailing `[ROUNDED] [ON SIZE ERROR statements…]` clauses shared by
+/// the arithmetic verbs (`ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE`) and `COMPUTE`.
+fn read_rounded_and_size_error(
+    verb: &GrammarASTNode,
+) -> Result<(bool, Vec<Stmt>), RuntimeError> {
+    let rounded = child_tokens(verb)
+        .iter()
+        .any(|(k, v)| k == "KEYWORD" && v == "ROUNDED");
+    let on_size_error = match child_node(verb, "size_error") {
+        Some(se) => child_nodes(se, "statement")
+            .into_iter()
+            .map(read_statement)
+            .collect::<Result<Vec<_>, _>>()?,
+        None => Vec::new(),
+    };
+    Ok((rounded, on_size_error))
 }
 
 /// All `operand` child nodes of a verb, read to typed [`Operand`]s.

--- a/code/specs/PL08-cobol-runtime.md
+++ b/code/specs/PL08-cobol-runtime.md
@@ -152,10 +152,14 @@ Each item is a run-verified PR; the runtime grows one quirk at a time.
     variable (`VARYING id FROM start BY step UNTIL cond`) — `id := start`, run
     while `cond` is false, step `id` by `step` after each iteration. The repeat
     forms are modelled as a `PerformMode` enum.
-11. **v0.11 — `PERFORM … THRU`** (this PR): run a range of paragraphs
+11. **v0.11 — `PERFORM … THRU`** (merged): run a range of paragraphs
     (`para-1 THRU para-2`, source order, fall-through between) as the perform
     body; composes with every repeat mode. Backwards ranges are a clean error.
     `WITH TEST AFTER` and the inline form remain deferred.
+12. **v0.12 — `ROUNDED`/`ON SIZE ERROR` on the arithmetic verbs** (this PR):
+    `ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE` now accept both clauses, matching
+    `COMPUTE`, via a shared `store_result` path (round → size-error → store). A
+    zero `DIVIDE` divisor is a size-error condition when a handler is present.
 12. **Editing pictures** on `MOVE`/`DISPLAY` (`Z`/`*`/`$`/`,`/`.`/`+`/`-`/`CR`/`DB`).
 13. **Rest of control flow** — `END-IF`, `EVALUATE`, inline `PERFORM`,
     `PERFORM … WITH TEST AFTER`, `GO TO … DEPENDING ON`, `ALTER`.


### PR DESCRIPTION
## Summary

Brings the four arithmetic verbs (`ADD`/`SUBTRACT`/`MULTIPLY`/`DIVIDE`) to parity
with `COMPUTE` by adding `ROUNDED` and `ON SIZE ERROR`. A frontend + runtime
change that reuses the existing rounding/size-error machinery.

### What it does
- **Grammar** (cobol-parser 0.5.0): the four arithmetic rules gain trailing
  `[ ROUNDED ] [ size_error ]`, reusing `COMPUTE`'s `size_error` rule.
  `ROUNDED`/`ON`/`SIZE`/`ERROR` were already reserved words, so the lexer is
  unchanged.
- **Runtime** (cobol-runtime 0.12.0): the store path (round → size-error → store)
  is extracted into a shared `store_result` helper used by all five arithmetic
  verbs, so their rounding/overflow behaviour is identical. `ROUNDED` rounds half
  away from zero into the receiver (else truncate); `ON SIZE ERROR` runs its
  statements (receiver unchanged) on integer overflow — or, for `DIVIDE`, on a
  zero divisor. Without a handler, overflow truncates silently and a zero divisor
  stays a hard `DivideByZero`. The verbs now return `Flow`, so a `STOP RUN`/`GO TO`
  inside a handler propagates.

### Notes
- `DIVIDE` now computes at the same intermediate precision as `COMPUTE` before
  rounding into the receiver; the un-`ROUNDED` result is identical to before
  (nested truncation toward zero).

## Tests
16 lexer + 17 parser + 87 runtime tests (DIVIDE/MULTIPLY … GIVING ROUNDED,
ADD ON SIZE ERROR overflow, DIVIDE-by-zero ON SIZE ERROR; plus the unchanged
plain-arithmetic tests confirming no regression). Warning-free. Security review
PASSED (refactor preserves prior behavior, Flow propagation correct, no new
panics). README + PL08 synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)