### PR TITLE
feat(sir-js): Array each_slice / each_cons / chunk_while

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.30.0 — Array `each_slice` / `each_cons` / `chunk_while`
+
+Mirrors the Python reference (PR #8031), Go (PR #8036), and Rust (PR #8042) into
+the JS backend's inline `arrayMethod` (+ the `ARRAY_METHODS` `respond_to?` set),
+adding the Array consecutive-grouping family.
+
+- `each_slice(n)` → consecutive sub-arrays of at most `n` elements, the last
+  possibly shorter (`[1,2,3,4,5].each_slice(2)` → `[[1,2],[3,4],[5]]`).
+- `each_cons(n)` → every consecutive `n`-element sliding window
+  (`[1,2,3,4].each_cons(2)` → `[[1,2],[2,3],[3,4]]`); a window larger than the
+  array yields `[]`.
+- Both read `n` via `Number.isInteger` and treat `n <= 0` as `[]` (Ruby raises
+  `ArgumentError`; the never-throw floor yields empty).
+- `chunk_while { |prev, cur| pred }` → runs of consecutive elements; the block is
+  called on each ADJACENT pair, a truthy result extends the run and a falsy one
+  starts a new run (`[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` →
+  `[[1,2],[4,5],[7]]`).  Empty → `[]`; single element → `[[x]]`.
+
+Exec-proof: `tests/run_with_node.rs` gains `array_each_slice_each_cons_chunk_while`,
+running each_slice/each_cons (incl. `n<=0` and oversized-window → `[]`) and
+chunk_while (adjacent `b-a==1` predicate; empty → `[]`) under real `node`, diffed
+against the Python/Go/Rust reference.
+
 ## 0.29.0 — Hash `to_h` (block + no-block) / `each_with_index` / `each_with_object`
 
 Mirrors the Python reference (PR #8009), Go (PR #8015), and Rust (PR #8020)

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -1298,6 +1298,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "take", "drop", "values_at",
     "flatten", "compact", "rotate", "zip",
     "include?", "index",
+    "each_slice", "each_cons", "chunk_while",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
@@ -1550,6 +1551,41 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         return null;
       }
       case "to_a": return recv;
+      case "each_slice": {
+        // `each_slice(n)` — consecutive sub-arrays of at most `n` elements (the
+        // last may be shorter).  `[1,2,3,4,5].each_slice(2)` → [[1,2],[3,4],[5]].
+        // Ruby raises ArgumentError for n <= 0; the never-throw floor yields [].
+        const n = args.length > 0 && Number.isInteger(args[0]) ? args[0] : 0;
+        if (n <= 0) { return []; }
+        const out = [];
+        for (let i = 0; i < recv.length; i += n) { out.push(recv.slice(i, i + n)); }
+        return out;
+      }
+      case "each_cons": {
+        // `each_cons(n)` — every consecutive n-element sliding window.
+        // `[1,2,3,4].each_cons(2)` → [[1,2],[2,3],[3,4]].  A window larger than
+        // the array (or n <= 0) yields [].
+        const n = args.length > 0 && Number.isInteger(args[0]) ? args[0] : 0;
+        if (n <= 0) { return []; }
+        const out = [];
+        for (let i = 0; i + n <= recv.length; i++) { out.push(recv.slice(i, i + n)); }
+        return out;
+      }
+      case "chunk_while": {
+        // `chunk_while { |prev, cur| pred }` — runs of consecutive elements: the
+        // block is called on each ADJACENT pair; while it is truthy the run
+        // continues, and a falsy result starts a new run.
+        // `[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` → [[1,2],[4,5],[7]].
+        // An empty array yields []; a single element yields [[x]].
+        if (typeof blk !== "function") { return ARR_MISS; }
+        if (recv.length === 0) { return []; }
+        const chunks = [[recv[0]]];
+        for (let i = 1; i < recv.length; i++) {
+          if (truthy(blk(recv[i - 1], recv[i]))) { chunks[chunks.length - 1].push(recv[i]); }
+          else { chunks.push([recv[i]]); }
+        }
+        return chunks;
+      }
     }
     return ARR_MISS;
   }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -3006,3 +3006,76 @@ fn hash_to_h_and_indexed_iteration() {
         );
     }
 }
+
+// ── Array each_slice / each_cons / chunk_while ─────────────────────────────
+//
+// The consecutive-grouping family, mirroring the Python (#8031), Go (#8036),
+// and Rust (#8042) references.  `each_slice`/`each_cons` are non-block (take an
+// int `n`); `chunk_while` is a block method (the block is called on each
+// ADJACENT pair).  All route through the explicit `arrayMethod` switch.
+#[test]
+fn array_each_slice_each_cons_chunk_while() {
+    // `{ |a, b| b - a == 1 }` — adjacent-pair predicate (JS equality builtin `=`).
+    let adj = func(
+        "__t_adj",
+        vec![param("a"), param("b")],
+        vec![],
+        bc("=", vec![bc("-", vec![param_ref("b"), param_ref("a")]), int(1)]),
+    );
+    let stmts = vec![
+        // [1,2,3,4,5].each_slice(2) → [[1, 2], [3, 4], [5]]
+        print(method(seq(vec![int(1), int(2), int(3), int(4), int(5)]), "each_slice", vec![int(2)])),
+        // [1,2,3].each_slice(0) → []  (never-throw floor)
+        print(method(seq(vec![int(1), int(2), int(3)]), "each_slice", vec![int(0)])),
+        // [1,2,3,4].each_cons(2) → [[1, 2], [2, 3], [3, 4]]
+        print(method(seq(vec![int(1), int(2), int(3), int(4)]), "each_cons", vec![int(2)])),
+        // [1,2].each_cons(3) → []  (window larger than the array)
+        print(method(seq(vec![int(1), int(2)]), "each_cons", vec![int(3)])),
+        // [1,2,4,5,7].chunk_while { |a,b| b-a==1 } → [[1, 2], [4, 5], [7]]
+        print(method(
+            seq(vec![int(1), int(2), int(4), int(5), int(7)]),
+            "chunk_while",
+            vec![method_closure("__t_adj")],
+        )),
+        // [].chunk_while { … } → []
+        print(method(seq(vec![]), "chunk_while", vec![method_closure("__t_adj")])),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let module = Module {
+        name: "arrslice".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main, adj],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "arrslice") {
+        assert_eq!(
+            stdout,
+            "[[1, 2], [3, 4], [5]]\n\
+             []\n\
+             [[1, 2], [2, 3], [3, 4]]\n\
+             []\n\
+             [[1, 2], [4, 5], [7]]\n\
+             []"
+        );
+    }
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8031](https://github.com/adhithyan15/coding-adventures/pull/8031)), Go ([#8036](https://github.com/adhithyan15/coding-adventures/pull/8036)), and Rust ([#8042](https://github.com/adhithyan15/coding-adventures/pull/8042)) into the **JS** backend's inline `arrayMethod` (+ the `ARRAY_METHODS` `respond_to?` set), adding the Array consecutive-grouping family.

## Methods
- `each_slice(n)` → consecutive sub-arrays of at most `n` elements (last shorter).
- `each_cons(n)` → every consecutive `n`-element sliding window; window > len → `[]`.
- Both read `n` via `Number.isInteger` and treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; never-throw floor → `[]`).
- `chunk_while { |prev, cur| pred }` → runs of consecutive elements; block called on each adjacent pair, truthy extends the run, falsy starts a new run. Empty → `[]`; single element → `[[x]]`.

## Exec-proof
`tests/run_with_node.rs` gains `array_each_slice_each_cons_chunk_while`, run under real `node`:

```
[[1, 2], [3, 4], [5]]      # each_slice(2)
[]                         # each_slice(0) → []
[[1, 2], [2, 3], [3, 4]]   # each_cons(2)
[]                         # each_cons(3) on len-2 → []
[[1, 2], [4, 5], [7]]      # chunk_while { b-a==1 }
[]                         # [].chunk_while → []
```

Full JS suite green (109 lib + 76 node). Version 0.29.0 → 0.30.0; CHANGELOG updated. Security review passed. Remaining mirror: **TS** (final backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)