### PR TITLE
feat(sql-vm): GLOB(pattern, subject) function

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.14 — GLOB() function
+
+Grows the SQL scalar surface (sql-vm 0.4.10): `GLOB(pattern, subject)` — the
+function form of the `GLOB` operator — does a case-sensitive wildcard match
+(`*`, `?`, `[...]` classes) returning 1/0, NULL if either argument is NULL. The
+matcher is `O(text × pattern)` (no ReDoS-style blow-up). A new differential-oracle
+case (`glob_function`) diffs against real bundled SQLite. (The infix `x GLOB y`
+operator is grammar-blocked and remains unsupported — see
+project_minisqlite_conformance_probe_map.)
+
 ## 0.5.13 — LIKELY / UNLIKELY / LIKELIHOOD (planner hints)
 
 Grows the SQL scalar surface (sql-vm 0.4.9) with SQLite's query-planner hint

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.13"
+version = "0.5.14"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -646,6 +646,16 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT LIKELY(n) AS a, UNLIKELY(s) AS b, LIKELIHOOD(id, 0.5) AS c FROM t ORDER BY id",
     },
+    // GLOB(pattern, subject) — the function form of the GLOB operator: a
+    // case-sensitive wildcard match (`*`, `?`, `[...]`).
+    Case {
+        id: "glob_function",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1, 'hello'), (2, 'HELLO'), (3, 'help'), (4, NULL)",
+        ],
+        query: "SELECT GLOB('h*o', s) AS a, GLOB('hel[lp]*', s) AS b FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.10] - Unreleased
+
+### Added
+
+- **`GLOB(pattern, subject)`** — the function form of SQLite's `GLOB` operator: a
+  case-sensitive wildcard match returning `1` / `0` (`*` = any run, `?` = any
+  single character, `[...]` = character class with `[^...]` negation and `a-c`
+  ranges; a backslash is a literal, GLOB has no escape). NULL in either argument
+  → NULL; arguments are matched by Unicode character. The matcher (`glob_match`)
+  uses the same iterative two-pointer backtracking as `like_match`, so it is
+  `O(text × pattern)` — no exponential blow-up on adversarial `*`-heavy patterns.
+  (The infix `GLOB` operator remains a separate grammar-level feature; this is
+  the callable function.)
+
 ## [0.4.9] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1050,6 +1050,7 @@ fn pop(stack: &mut Vec<SqlValue>) -> Result<SqlValue, VmError> {
 /// | UNHEX    | 1–2  | Decode hex digit pairs into a blob (inverse of HEX)   |
 /// | LIKELY / UNLIKELY | 1 | Planner hint; returns the argument unchanged     |
 /// | LIKELIHOOD | 2  | Planner hint with a probability; returns arg 1        |
+/// | GLOB     |  2   | Case-sensitive wildcard match: GLOB(pattern, subject) |
 /// | REPLACE  |  3   | Replace all occurrences of a pattern with another str |
 /// | ABS      |  1   | Absolute value (Integer or Float)                     |
 /// | COALESCE | ≥1   | Return the first non-NULL argument                    |
@@ -1212,6 +1213,22 @@ fn call_builtin(name: &str, args: Vec<SqlValue>) -> Result<SqlValue, VmError> {
                 )));
             }
             Ok(args.into_iter().next().unwrap())
+        }
+
+        "GLOB" => {
+            // GLOB(pattern, subject) is the function form of `subject GLOB
+            // pattern`: a case-sensitive wildcard match returning 1 or 0. NULL in
+            // either argument yields NULL. (The infix `GLOB` operator is a
+            // separate, grammar-level feature; this is the callable function.)
+            if args.len() != 2 {
+                return Err(VmError::TypeMismatch(format!("GLOB expects 2 args, got {}", args.len())));
+            }
+            if matches!(args[0], SqlValue::Null) || matches!(args[1], SqlValue::Null) {
+                return Ok(SqlValue::Null);
+            }
+            let pattern = sql_to_str(&args[0]);
+            let subject = sql_to_str(&args[1]);
+            Ok(SqlValue::Int(glob_match(&subject, &pattern) as i64))
         }
 
         "UPPER" => {
@@ -2059,6 +2076,96 @@ fn like_match(text: &str, pattern: &str) -> bool {
         pi += 1;
     }
 
+    pi == p.len()
+}
+
+/// Try to match a GLOB character class `[...]` in `p` starting at `p[start]`
+/// (which must be `'['`) against `ch`. Returns `Some((matched, after))` where
+/// `after` is the pattern index just past the closing `']'`; or `None` if there
+/// is no closing `']'`, in which case the caller treats `'['` as a literal.
+///
+/// A leading `^` negates the class. A `]` immediately after `[` (or `[^`) is a
+/// literal member, not the closer. `a-c` is an inclusive range.
+fn glob_class_match(p: &[char], start: usize, ch: char) -> Option<(bool, usize)> {
+    let mut i = start + 1;
+    let negate = i < p.len() && p[i] == '^';
+    if negate {
+        i += 1;
+    }
+    let first = i; // a `]` here is a literal member, not the class close
+    let mut matched = false;
+    while i < p.len() {
+        if p[i] == ']' && i != first {
+            let result = if negate { !matched } else { matched };
+            return Some((result, i + 1));
+        }
+        // `x-y` range (but not when `-` is the class's closing-adjacent char).
+        if i + 2 < p.len() && p[i + 1] == '-' && p[i + 2] != ']' {
+            if p[i] <= ch && ch <= p[i + 2] {
+                matched = true;
+            }
+            i += 3;
+        } else {
+            if p[i] == ch {
+                matched = true;
+            }
+            i += 1;
+        }
+    }
+    None // unterminated class
+}
+
+/// Whether the single GLOB pattern element at `p[pi]` (a literal, `?`, or a
+/// `[...]` class) matches `ch`. Returns the pattern index after the element on a
+/// match, or `None` on no match. Does not handle `*` (the caller does).
+fn glob_single(p: &[char], pi: usize, ch: char) -> Option<usize> {
+    match p[pi] {
+        '?' => Some(pi + 1),
+        '[' => match glob_class_match(p, pi, ch) {
+            Some((true, after)) => Some(after),
+            Some((false, _)) => None,
+            None => (ch == '[').then_some(pi + 1), // literal '['
+        },
+        c => (c == ch).then_some(pi + 1),
+    }
+}
+
+/// GLOB pattern match: case-sensitive, `*` = any run, `?` = any single char,
+/// `[...]` = character class (`[^...]` negated, `a-c` ranges). Unlike LIKE, a
+/// backslash is a literal character (GLOB has no escape). Uses the same
+/// iterative two-pointer backtracking as [`like_match`], so it is `O(text ×
+/// pattern)` — no exponential blow-up on adversarial `*`-heavy patterns.
+fn glob_match(text: &str, pattern: &str) -> bool {
+    let t: Vec<char> = text.chars().collect();
+    let p: Vec<char> = pattern.chars().collect();
+
+    let (mut ti, mut pi) = (0usize, 0usize);
+    // Backtrack point: pattern index just after the last `*`, and the text index
+    // it started matching from.
+    let (mut star_pi, mut star_ti): (Option<usize>, usize) = (None, 0);
+
+    while ti < t.len() {
+        if pi < p.len() && p[pi] == '*' {
+            star_pi = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if let Some(next_pi) = p.get(pi).and_then(|_| glob_single(&p, pi, t[ti])) {
+            pi = next_pi;
+            ti += 1;
+        } else if let Some(sp) = star_pi {
+            // The last `*` consumes one more text character.
+            star_ti += 1;
+            ti = star_ti;
+            pi = sp + 1;
+        } else {
+            return false;
+        }
+    }
+
+    // Any trailing `*` wildcards match the empty suffix.
+    while pi < p.len() && p[pi] == '*' {
+        pi += 1;
+    }
     pi == p.len()
 }
 
@@ -4115,6 +4222,40 @@ mod tests {
                 call_builtin("SUBSTR", args).unwrap(),
             );
         }
+    }
+
+    #[test]
+    fn builtin_glob_matches_case_sensitively() {
+        let g = |pat: &str, subj: &str| {
+            call_builtin("GLOB", vec![SqlValue::Text(pat.into()), SqlValue::Text(subj.into())]).unwrap()
+        };
+        let t = SqlValue::Int(1);
+        let f = SqlValue::Int(0);
+        // `*` and `?` wildcards; GLOB is case-sensitive.
+        assert_eq!(g("a*", "abc"), t);
+        assert_eq!(g("A*", "abc"), f); // case-sensitive
+        assert_eq!(g("*c", "abc"), t);
+        assert_eq!(g("a?c", "abc"), t);
+        assert_eq!(g("a?c", "ac"), f);
+        assert_eq!(g("h*o", "hello"), t);
+        // Character classes, ranges, and negation.
+        assert_eq!(g("[a-c]x", "bx"), t);
+        assert_eq!(g("[a-c]x", "dx"), f);
+        assert_eq!(g("[^a]", "b"), t);
+        assert_eq!(g("[0-9]*", "7up"), t);
+        // Empty pattern / subject; `*` matches empty.
+        assert_eq!(g("", ""), t);
+        assert_eq!(g("*", ""), t);
+        // Backslash is a LITERAL in GLOB (no escape).
+        assert_eq!(g("a\\*b", "a*b"), f);
+        // Unicode is matched by character.
+        assert_eq!(g("日*", "日本"), t);
+        // NULL in either argument → NULL; wrong arity errors, not panics.
+        assert_eq!(
+            call_builtin("GLOB", vec![SqlValue::Text("a*".into()), SqlValue::Null]).unwrap(),
+            SqlValue::Null
+        );
+        assert!(call_builtin("GLOB", vec![SqlValue::Text("a".into())]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Grows the mini-sqlite SQL scalar surface with **`GLOB(pattern, subject)`** — the
function form of SQLite's `GLOB` operator: a case-sensitive wildcard match
returning `1` / `0`.

A broad conformance probe (over both in-memory and real file-backed tables)
confirmed the remaining *easy* scalar/storage gaps are now **grammar-blocked**
(bare `JOIN`, `NULLS FIRST/LAST`, `CAST`, the infix `GLOB`/`LIKE` operators) — but
the GLOB **function** parses as an ordinary `function_call`, so it needs only a
`call_builtin` arm, no grammar work. Probed real SQLite for semantics:

```
glob('a*','abc')    -> 1     glob('A*','abc')  -> 0   (case-sensitive)
glob('a?c','abc')   -> 1     glob('a?c','ac')  -> 0
glob('[a-c]x','bx') -> 1     glob('[^a]','b')  -> 1
glob('a\*b','a*b')  -> 0     (backslash is LITERAL — GLOB has no escape)
glob('a*',NULL)     -> NULL  glob('日*','日本') -> 1  (per-character)
```

`*` = any run, `?` = any single character, `[...]` = character class with
`[^...]` negation and `a-c` ranges. NULL in either argument → NULL; result is an
integer. No grammar/planner/codegen work. *(The infix `x GLOB y` operator remains
grammar-blocked and unsupported.)*

## Security

Reviewed before push as a **pattern matcher**. `glob_match` uses the same
iterative two-pointer backtracking as the existing `like_match`: only the last
`*` is a backtrack point and `star_ti` advances monotonically, so total work is
**O(text × pattern)** — no exponential ReDoS blow-up on `*`-heavy / `*?*?` /
class-heavy adversarial patterns. Every index is bounds-guarded, arity (`len == 2`)
and NULL are checked before matching, no `unsafe`, char-vector indexing is
UTF-8-safe. **Review passed, no findings.**

## Verification

- `sql-vm`: **97 lib tests** (new case: `*`/`?`, case sensitivity, ranges,
  negation, empty pattern/subject, literal backslash, Unicode, NULL, wrong arity).
- **mini-sqlite differential oracle:** new `glob_function` case diffs against
  real bundled SQLite. Full mini-sqlite suite green.

`sql-vm` 0.4.9 → 0.4.10, `mini-sqlite` 0.5.13 → 0.5.14; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
