### PR TITLE
feat(sir-runtime-oop): Array each_slice / each_cons / chunk_while — final backend

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.22] - 2026-07-11
+
+### Added
+
+- **`Array#each_slice`, `Array#each_cons`, `Array#chunk_while`** — the FINAL
+  backend of this cross-backend batch (Python reference #8031, then Go #8036 /
+  Rust #8042 / JS #8048), the consecutive-grouping family.
+  - `each_slice(n)` (`arrayMethod` + `ARRAY_METHODS`) → consecutive sub-arrays of
+    at most `n` elements, the last possibly shorter.
+  - `each_cons(n)` (non-block) → every consecutive `n`-element sliding window; a
+    window larger than the array → `[]`.
+  - Both read `n` via `Number.isInteger` and treat `n <= 0` as `[]` (Ruby raises
+    `ArgumentError`; the never-raise floor yields empty).
+  - `chunk_while { |prev, cur| pred }` (`arrayBlockMethod` + `ARRAY_BLOCK_METHODS`)
+    → runs of consecutive elements; the block is called on each ADJACENT pair, a
+    truthy result extends the run and a falsy one starts a new run.  Empty →
+    `[]`; single element → `[[x]]`.
+
 ## [0.1.21] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -63,14 +63,14 @@ The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
-`take`/`drop`/`values_at`, `rotate`/`zip` — and the
+`take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a` (`include?`/`index`/`==` use
 deep value equality), plus the **Kernel flow-control** group
 `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self` (item **M6**); and
 (item **M1b**) **block-taking `Array`/`Enumerable`**
 methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
-`reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?` — a trailing
+`reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?`, `chunk_while` — a trailing
 `Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
 (proc-lenient), predicates routed through SIR `truthy`; (item **M1c**) the
 **`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -555,6 +555,8 @@ const ARRAY_METHODS = new Set<string>([
   "values_at",
   "rotate",
   "zip",
+  "each_slice",
+  "each_cons",
 ]);
 
 // Block-taking `Array`/`Enumerable` methods (M1b); each invokes a trailing
@@ -585,6 +587,7 @@ const ARRAY_BLOCK_METHODS = new Set<string>([
   "drop_while",
   "count",
   "each_with_object",
+  "chunk_while",
 ]);
 
 // Non-block `Hash` methods (M1c). Hash is a JS `Map`.
@@ -1037,6 +1040,26 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
       }
       return zipped;
     }
+    case "each_slice": {
+      // `each_slice(n)` — consecutive sub-arrays of at most `n` elements (the
+      // last may be shorter).  `[1,2,3,4,5].each_slice(2)` → [[1,2],[3,4],[5]].
+      // Ruby raises ArgumentError for n <= 0; the never-raise floor yields [].
+      const n = args.length > 0 && Number.isInteger(args[0]) ? (args[0] as number) : 0;
+      if (n <= 0) return [];
+      const out: Val[] = [];
+      for (let i = 0; i < recv.length; i += n) out.push(recv.slice(i, i + n));
+      return out;
+    }
+    case "each_cons": {
+      // `each_cons(n)` — every consecutive n-element sliding window.
+      // `[1,2,3,4].each_cons(2)` → [[1,2],[2,3],[3,4]].  A window larger than
+      // the array (or n <= 0) yields [].
+      const n = args.length > 0 && Number.isInteger(args[0]) ? (args[0] as number) : 0;
+      if (n <= 0) return [];
+      const out: Val[] = [];
+      for (let i = 0; i + n <= recv.length; i++) out.push(recv.slice(i, i + n));
+      return out;
+    }
     default:
       return MISS;
   }
@@ -1177,6 +1200,20 @@ function arrayBlockMethod(
       const memo = args[0];
       for (const item of recv) apply(block, [item, memo]);
       return memo;
+    }
+    case "chunk_while": {
+      // `chunk_while { |prev, cur| pred }` — runs of consecutive elements: the
+      // block is called on each ADJACENT pair; while it is truthy the run
+      // continues, and a falsy result starts a new run.
+      // `[1,2,4,5,7].chunk_while { |a,b| b-a==1 }` → [[1,2],[4,5],[7]].
+      // An empty array yields []; a single element yields [[x]].
+      if (recv.length === 0) return [];
+      const chunks: Val[][] = [[recv[0]]];
+      for (let i = 1; i < recv.length; i++) {
+        if (truthy(apply(block, [recv[i - 1], recv[i]]))) { chunks[chunks.length - 1].push(recv[i]); }
+        else { chunks.push([recv[i]]); }
+      }
+      return chunks;
     }
     default:
       return MISS;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -330,7 +330,7 @@ describe("respond_to? honesty + nil floor (M1a)", () => {
     expect(callMethod([1], "respond_to?", "nil?")).toBe(true);
     expect(callMethod([1], "respond_to?", "is_a?")).toBe(true);
     expect(callMethod([1], "respond_to?", "map")).toBe(true); // block method (M1b)
-    expect(callMethod([1], "respond_to?", "each_slice")).toBe(false);
+    expect(callMethod([1], "respond_to?", "chunk")).toBe(false); // uncatalogued (non-`_while` variant)
   });
 
   it("known block method WITHOUT a block bottoms out at nil (no over-raise, T2)", () => {
@@ -419,6 +419,36 @@ describe("built-in method catalog: block-taking Array/Enumerable (M1b)", () => {
     expect(
       callMethod([1, 2, 3], "each_with_object", [], new Closure((x: Val, o: Val) => o.push(x * 10))),
     ).toEqual([10, 20, 30]);
+  });
+
+  it("each_slice / each_cons / chunk_while (consecutive-grouping family)", () => {
+    // `each_slice(n)` → consecutive <=n-size chunks (last may be shorter).
+    expect(callMethod([1, 2, 3, 4, 5], "each_slice", 2)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(callMethod([1, 2, 3, 4], "each_slice", 2)).toEqual([[1, 2], [3, 4]]);
+    expect(callMethod([1, 2, 3], "each_slice", 5)).toEqual([[1, 2, 3]]);
+    expect(callMethod([], "each_slice", 2)).toEqual([]);
+    // n <= 0 → [] (Ruby raises ArgumentError; never-raise floor yields empty).
+    expect(callMethod([1, 2], "each_slice", 0)).toEqual([]);
+    // `each_cons(n)` → every consecutive n-element sliding window.
+    expect(callMethod([1, 2, 3, 4], "each_cons", 2)).toEqual([[1, 2], [2, 3], [3, 4]]);
+    expect(callMethod([1, 2, 3], "each_cons", 3)).toEqual([[1, 2, 3]]);
+    // window larger than the array (or n <= 0) → [].
+    expect(callMethod([1, 2], "each_cons", 3)).toEqual([]);
+    expect(callMethod([1, 2], "each_cons", 0)).toEqual([]);
+    // `chunk_while { |a, b| pred }` → runs while the adjacent-pair predicate holds.
+    expect(
+      callMethod([1, 2, 4, 5, 7], "chunk_while", new Closure((a: Val, b: Val) => (b as number) - (a as number) === 1)),
+    ).toEqual([[1, 2], [4, 5], [7]]);
+    // all-truthy → one run; all-falsy → singletons.
+    expect(callMethod([1, 2, 3], "chunk_while", new Closure(() => true))).toEqual([[1, 2, 3]]);
+    expect(callMethod([1, 2, 3], "chunk_while", new Closure(() => false))).toEqual([[1], [2], [3]]);
+    // empty → []; single element → [[x]].
+    expect(callMethod([], "chunk_while", new Closure(() => true))).toEqual([]);
+    expect(callMethod([9], "chunk_while", new Closure(() => true))).toEqual([[9]]);
+    // respond_to? advertises the new methods.
+    expect(callMethod([1], "respond_to?", "each_slice")).toBe(true);
+    expect(callMethod([1], "respond_to?", "each_cons")).toBe(true);
+    expect(callMethod([1], "respond_to?", "chunk_while")).toBe(true);
   });
 
   it("find/detect and flat_map", () => {


### PR DESCRIPTION
Mirrors the Python reference ([#8031](https://github.com/adhithyan15/coding-adventures/pull/8031)), Go ([#8036](https://github.com/adhithyan15/coding-adventures/pull/8036)), Rust ([#8042](https://github.com/adhithyan15/coding-adventures/pull/8042)), and JS ([#8048](https://github.com/adhithyan15/coding-adventures/pull/8048)) into the **TS reference library** (`@coding-adventures/sir-runtime-oop`) — **completing the Array consecutive-grouping cascade across all five backends**.

## Methods
- `each_slice(n)` (`arrayMethod`, non-block) → consecutive sub-arrays of at most `n` elements (last shorter).
- `each_cons(n)` (non-block) → every consecutive `n`-element sliding window; window > len → `[]`.
- Both read `n` via `Number.isInteger` and treat `n <= 0` as `[]` (Ruby raises `ArgumentError`; never-raise floor → `[]`).
- `chunk_while { |prev, cur| pred }` (`arrayBlockMethod`) → runs of consecutive elements; block called on each adjacent pair, truthy extends the run, falsy starts a new run. Empty → `[]`; single element → `[[x]]`.

## Tests
New vitest `each_slice / each_cons / chunk_while` case covers slice/cons sizes, `n<=0` → `[]`, oversized window → `[]`, chunk_while runs (all-truthy / all-falsy / empty / single), `respond_to?`. Also moved the catalog-membership test's "uncatalogued" example from `each_slice` (now catalogued) to `chunk`. **Full suite green (118 tests).** Version 0.1.21 → 0.1.22; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)