### PR TITLE
feat(sir-runtime-oop): Array tally — Python catch-up (Go/Rust already ship it)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.23] - 2026-07-11
+
+### Added
+
+- **`Array#tally`** — a Hash mapping each element to its occurrence count, in
+  first-seen key order (`["a","b","a","c","a"].tally` → `{a: 3, b: 1, c: 1}`; a
+  `dict` preserves insertion order, matching Ruby).  Brings the Python reference
+  level with the Go/Rust runtimes, which already ship `tally` (JS/TS mirrors to
+  follow).  As with the rest of the Python `Hash` surface (a `dict`), elements
+  are counted by hash/equality — hashable elements only.
+
+
+
 ## [0.1.22] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -65,7 +65,7 @@ The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
-`take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons` — and the
+`take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons`, `tally` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`, plus the **Kernel
 flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.22"
+version = "0.1.23"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -578,6 +578,7 @@ _ARRAY_METHODS = frozenset(
         "zip",
         "each_slice",
         "each_cons",
+        "tally",
     }
 )
 
@@ -1067,6 +1068,17 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
         if n <= 0:
             return []
         return [recv[i : i + n] for i in range(0, len(recv) - n + 1)]
+    if name == "tally":
+        # ``tally`` — a Hash mapping each element to its occurrence count, in
+        # first-seen key order.  ``[a, b, a, c, a].tally`` → ``{a: 3, b: 1, c: 1}``
+        # (a ``dict`` preserves insertion order, matching Ruby).  Brings the
+        # Python reference level with the Go/Rust runtimes, which already ship
+        # ``tally``.  As with the rest of the Python ``Hash`` surface (a ``dict``),
+        # elements are counted by hash/equality, so hashable elements only.
+        counts: dict[Val, Val] = {}
+        for item in recv:
+            counts[item] = counts.get(item, 0) + 1
+        return counts
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -275,6 +275,18 @@ def test_array_each_slice_each_cons_chunk_while() -> None:
     assert oop.call_method([1], "respond_to?", "chunk_while") is True
 
 
+def test_array_tally() -> None:
+    # `tally` → a Hash of element → occurrence count, in first-seen key order
+    # (a dict preserves insertion order, matching Ruby).  Brings Python level
+    # with the Go/Rust runtimes, which already ship `tally`.
+    assert oop.call_method(["a", "b", "a", "c", "a"], "tally") == {"a": 3, "b": 1, "c": 1}
+    assert oop.call_method([1, 1, 2, 3, 3, 3], "tally") == {1: 2, 2: 1, 3: 3}
+    # empty array → empty hash.
+    assert oop.call_method([], "tally") == {}
+    # respond_to? advertises it.
+    assert oop.call_method([1], "respond_to?", "tally") is True
+
+
 def test_array_mutating_push_pop_shift_unshift() -> None:
     a = [1, 2]
     assert oop.call_method(a, "push", 3) == [1, 2, 3]


### PR DESCRIPTION
Adds `Array#tally` to the **Python reference** — a Hash of element → occurrence count, in first-seen key order (`["a","b","a","c","a"].tally` → `{a: 3, b: 1, c: 1}`; a `dict` preserves insertion order, matching Ruby).

`tally` is already shipped by the **Go and Rust** runtimes but was missing in **Python, JS, and TS**. This is the Python reference; **JS and TS mirrors follow** (Go/Rust already complete).

As with the rest of the Python `Hash` surface (a `dict`), elements are counted by hash/equality — hashable elements only.

## Tests
`test_array_tally` covers string/int counts (first-seen order), empty → `{}`, `respond_to?`. **129 tests pass, 97% coverage; ruff clean.** Version 0.1.22 → 0.1.23; CHANGELOG + README updated. Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)