### PR TITLE
feat(wolfram-runtime): Factor[...] wiring, third W-22 cas-* head (v0.19.2)

### DIFF
--- a/code/packages/rust/symbolic-vm/CHANGELOG.md
+++ b/code/packages/rust/symbolic-vm/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — symbolic-vm (Rust)
 
+## [0.20.1] — 2026-07-12
+
+### Changed
+
+- `handlers::factor_handler` is now `pub` (was module-private). No
+  behavior change — this only widens visibility so other language
+  runtimes sharing this crate's `VM`/`IRApply` types can call the exact
+  same `Factor` evaluation pipeline Macsyma's own runtime already uses,
+  rather than reimplementing or duplicating it. First consumer:
+  `wolfram-runtime`'s `Factor[...]` wiring (W-22, see that crate's own
+  changelog).
+
 ## [0.20.0] — 2026-05-29
 
 **Track K2 — n-variate Hensel factor bridge (Rust port).**

--- a/code/packages/rust/symbolic-vm/Cargo.toml
+++ b/code/packages/rust/symbolic-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "symbolic-vm"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 description = "Generic symbolic expression evaluator over the symbolic-ir tree representation"
 license = "MIT"

--- a/code/packages/rust/symbolic-vm/src/handlers.rs
+++ b/code/packages/rust/symbolic-vm/src/handlers.rs
@@ -5351,7 +5351,18 @@ fn apply_node(head: &str, args: Vec<IRNode>) -> IRNode {
 // Factor
 // ---------------------------------------------------------------------------
 
-fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+/// `Factor(expr)` — factor a univariate integer polynomial (via
+/// [`cas_factor::factor_integer_polynomial`]) or recognise a handful of
+/// common multivariate patterns (perfect square/cube, difference of
+/// squares, cubic identities, a common symbolic/integer term to pull out,
+/// bivariate and n-variate Hensel lifting) — falling back to the
+/// unevaluated form when nothing applies. This is `pub` (unlike its
+/// sibling handlers in this module) so other language runtimes sharing
+/// this crate's `VM`/`IRApply` types (e.g. `wolfram-runtime`'s `Factor`
+/// wiring) can call the exact same factoring pipeline Macsyma's own
+/// `factor` surface function uses, rather than reimplementing or
+/// duplicating it.
+pub fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
     let fallback = IRNode::Apply(Box::new(expr.clone()));
     if expr.args.len() != 1 {
         return fallback;

--- a/code/packages/rust/wolfram-runtime/CHANGELOG.md
+++ b/code/packages/rust/wolfram-runtime/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to `wolfram-runtime` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and this project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.19.2] — 2026-07-12
+
+### Added (W-22 — `Factor`, third `cas-*` head)
+
+- `Factor[expr]` — factors a univariate integer polynomial, or recognises
+  one of a handful of common multivariate patterns (perfect square/cube,
+  difference of squares, cubic identities, a common symbolic/integer term
+  to pull out, bivariate/n-variate Hensel lifting) — unevaluated if none
+  apply. Unlike `Simplify`/`Expand` (thin calls into the standalone
+  `cas-simplify` crate), `Factor`'s implementation lives directly in
+  `symbolic-vm` itself: this wiring calls
+  `symbolic_vm::handlers::factor_handler` directly — the exact function
+  Macsyma's own `factor` surface function already calls — made `pub`
+  specifically for this reuse (see `symbolic-vm`'s own changelog). No
+  algorithm is reimplemented or duplicated; a parity test pins both
+  languages' call sites to agree on the same input, exactly like
+  `Simplify`/`Expand`'s own parity tests.
+- Like every W-5+ built-in, `Factor` is an ordinary eager `Head[args]` form
+  requiring exactly one argument; any other arity leaves the form
+  unevaluated. That arity check lives inside `factor_handler` itself
+  (unlike `simplify_handler`/`expand_handler`, which must unwrap a single
+  expression argument themselves before calling a function that only takes
+  one bare expression), so this wiring needs no arity check of its own.
+- 5 new tests: basic univariate factoring, an unrecognised multivariate
+  form staying unevaluated, the Wolfram/Macsyma parity check, wrong-arity
+  fail-soft, and full parser→lower→backend dispatch.
+- Marks `Factor` delivered in `MA04-wolfram-language.md` §24.
+
 ## [0.19.1] — 2026-07-11
 
 ### Fixed (W-13 — quadratic set-op DoS)

--- a/code/packages/rust/wolfram-runtime/Cargo.toml
+++ b/code/packages/rust/wolfram-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-wolfram-runtime"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 description = "Wolfram Language runtime — lowers M-expressions to symbolic-ir and evaluates via symbolic-vm"
 license = "MIT"

--- a/code/packages/rust/wolfram-runtime/README.md
+++ b/code/packages/rust/wolfram-runtime/README.md
@@ -626,14 +626,18 @@ the existing shared `cas-*` crate, not a reimplementation:
 | `Simplify` | `Simplify[x + 0]` | `x` |
 | `Simplify` | `Simplify[2 + 3]` | `5` |
 | `Expand` | `Expand[(x + 1)^2]` | `1 + x + x + x*x` |
+| `Factor` | `Factor[x^2 - 1]` | `(1 + x) * (-1 + x)` |
 
 `Simplify` calls `cas-simplify`'s existing `simplify()`; `Expand` calls its
 existing `expand()` (distributes `Mul` over `Add`/`Sub`, expands bounded
 non-negative integer `Pow`, does **not** collect like terms — see
-`cas-simplify`'s own docs). Both are the exact functions Macsyma's own
-`simplify()`/`expand()` surface functions call — so Wolfram and Macsyma
-agree on every result this crate can produce. Further heads (`Factor`,
-`Solve`, `D`, `Integrate`, …) land one at a time, each its own item.
+`cas-simplify`'s own docs). `Factor` calls `symbolic-vm`'s own
+`handlers::factor_handler` directly (made `pub` for this reuse) rather than
+a separate `cas-*` crate, since factoring lives in the shared VM crate
+itself. All three are the exact functions Macsyma's own
+`simplify()`/`expand()`/`factor()` surface functions call — so Wolfram and
+Macsyma agree on every result this crate can produce. Further heads
+(`Solve`, `D`, `Integrate`, …) land one at a time, each its own item.
 
 ## Robustness
 
@@ -711,7 +715,7 @@ session-rebuild so a panic becomes a clean `Err` rather than a crash.
   conditions / `PatternTest` / sequences / `Repeated` / `Replace` level specs /
   `ReplaceRepeated` (`//.`) deferred to W-20. No grammar change.
 - **Future** — the rest of the `cas-*` function surface under Wolfram names
-  (`Factor`, `Solve`, `D`, `Integrate`, …) — `Simplify` and `Expand` are
+  (`Solve`, `D`, `Integrate`, …) — `Simplify`, `Expand`, and `Factor` are
   delivered, see the W-22 section above.
 
 ## Testing

--- a/code/packages/rust/wolfram-runtime/src/builtins.rs
+++ b/code/packages/rust/wolfram-runtime/src/builtins.rs
@@ -249,13 +249,17 @@ pub fn build_wolfram_builtins() -> HashMap<String, Handler> {
     m.insert("Sqrt".to_string(), handler_fn(sqrt_handler));
 
     // W-22 cas-* algorithm surface under Wolfram names (MA04 §2 "Future" item,
-    // now in progress). `Simplify` was the first entry; `Expand` is the
-    // second — both ordinary eager `Head[args]` forms reusing `cas-simplify`
-    // verbatim. Further heads (`Factor`, `Solve`, `D`, `Integrate`, ...) are
-    // added one at a time, each its own PR, per HML00's one-item-per-PR
-    // discipline.
+    // now in progress). `Simplify` was the first entry, `Expand` the second —
+    // both ordinary eager `Head[args]` forms reusing `cas-simplify` verbatim.
+    // `Factor` is the third, reusing `symbolic-vm`'s own `factor_handler`
+    // (the exact function Macsyma's `factor` surface function already calls)
+    // rather than `cas-simplify`, since factoring lives directly in the
+    // shared VM crate, not a separate `cas-*` crate. Further heads (`Solve`,
+    // `D`, `Integrate`, ...) are added one at a time, each its own PR, per
+    // HML00's one-item-per-PR discipline.
     m.insert("Simplify".to_string(), handler_fn(simplify_handler));
     m.insert("Expand".to_string(), handler_fn(expand_handler));
+    m.insert("Factor".to_string(), handler_fn(factor_handler));
 
     // W-18 pattern-matching predicates (MA04 §19). HELD (see `PATTERN_HEADS`):
     // each handler evaluates ONLY its subject and matches against the *literal*
@@ -3353,6 +3357,26 @@ fn expand_handler(_vm: &mut VM, expr: IRApply) -> IRNode {
     expand(expr.args[0].clone())
 }
 
+/// `Factor[expr]` → factor a univariate integer polynomial, or recognise one
+/// of a handful of common multivariate patterns (perfect square/cube,
+/// difference of squares, cubic identities, a common symbolic/integer term to
+/// pull out, bivariate/n-variate Hensel lifting) — unevaluated if none apply.
+///
+/// Unlike `Simplify`/`Expand` (thin calls into the standalone `cas-simplify`
+/// crate), `Factor`'s implementation lives directly in `symbolic-vm` itself
+/// (`symbolic_vm::handlers::factor_handler`, made `pub` specifically so this
+/// wiring can reuse it) — so this is a direct call into the exact same
+/// function Macsyma's own `factor` surface function already calls, no
+/// algorithm reimplemented or duplicated. That function already performs its
+/// own arity check (any arity other than one leaves the form unevaluated, the
+/// same fail-soft contract every other W-22/W-15 built-in follows), so this
+/// wrapper needs no arity check of its own — unlike `simplify_handler`/
+/// `expand_handler`, which must unwrap `expr.args[0]` themselves before
+/// calling a single-expression-argument function.
+fn factor_handler(vm: &mut VM, expr: IRApply) -> IRNode {
+    symbolic_vm::handlers::factor_handler(vm, expr)
+}
+
 // ---------------------------------------------------------------------------
 // W-12 string builtins
 // ---------------------------------------------------------------------------
@@ -6221,6 +6245,96 @@ mod tests {
         assert_eq!(
             eval_full(apply(sym("Expand"), vec![product.clone()])),
             cas_simplify::expand(product)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // W-22 cas-* algorithm surface — Factor
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn factor_factors_a_univariate_integer_polynomial() {
+        // Factor[x^2 - 1] -> (1 + x) * (-1 + x), the exact same difference-of-
+        // squares factorisation `factor(x^2 - 1)` produces in Macsyma (see
+        // `factors_univariate_integer_polynomials_through_runtime` in
+        // `macsyma-runtime/tests/test_runtime.rs`).
+        let x_squared_minus_one = apply(
+            sym(symbolic_ir::SUB),
+            vec![apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]), int(1)],
+        );
+        assert_eq!(
+            run("Factor", vec![x_squared_minus_one]),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(ADD), vec![int(1), sym("x")]),
+                    apply(sym(ADD), vec![int(-1), sym("x")]),
+                ],
+            )
+        );
+    }
+
+    #[test]
+    fn factor_leaves_an_unrecognised_multivariate_form_unevaluated() {
+        // Factor[x + y] has no common factor and matches none of the
+        // recognised multivariate patterns, so it echoes back unevaluated —
+        // mirrors `keeps_multivariate_factor_calls_unevaluated` in
+        // `macsyma-runtime/tests/test_runtime.rs`.
+        let x_plus_y = apply(sym(ADD), vec![sym("x"), sym("y")]);
+        assert_eq!(
+            run("Factor", vec![x_plus_y.clone()]),
+            apply(sym("Factor"), vec![x_plus_y])
+        );
+    }
+
+    #[test]
+    fn factor_agrees_with_macsyma_on_the_same_underlying_call() {
+        // Both Wolfram's Factor and Macsyma's factor() dispatch to the exact
+        // same symbolic_vm::handlers::factor_handler -- this pins that the
+        // Wolfram wiring doesn't diverge from the reference call. Needs a
+        // fresh VM on each side since factor_handler takes `&mut VM` (unlike
+        // Simplify/Expand's parity tests, which call a plain free function).
+        let expr = apply(
+            sym(symbolic_ir::SUB),
+            vec![apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]), int(1)],
+        );
+        let via_wolfram = run("Factor", vec![expr.clone()]);
+        let ir_apply = IRApply {
+            head: sym("Factor"),
+            args: vec![expr],
+        };
+        let mut vm = VM::new(Box::new(SymbolicBackend::new()));
+        let via_macsyma_path = symbolic_vm::handlers::factor_handler(&mut vm, ir_apply);
+        assert_eq!(via_wolfram, via_macsyma_path);
+    }
+
+    #[test]
+    fn factor_with_wrong_arity_stays_unevaluated() {
+        assert_eq!(run("Factor", vec![]), apply(sym("Factor"), vec![]));
+        assert_eq!(
+            run("Factor", vec![int(1), int(2)]),
+            apply(sym("Factor"), vec![int(1), int(2)])
+        );
+    }
+
+    #[test]
+    fn factor_dispatches_end_to_end_through_the_wolfram_backend() {
+        // x^2 - 1 fully factors through the full parser -> lower -> backend
+        // path, exactly mirroring `expand_dispatches_end_to_end_through_the_
+        // wolfram_backend` above.
+        let x_squared_minus_one = apply(
+            sym(symbolic_ir::SUB),
+            vec![apply(sym(symbolic_ir::POW), vec![sym("x"), int(2)]), int(1)],
+        );
+        assert_eq!(
+            eval_full(apply(sym("Factor"), vec![x_squared_minus_one])),
+            apply(
+                sym(MUL),
+                vec![
+                    apply(sym(ADD), vec![int(1), sym("x")]),
+                    apply(sym(ADD), vec![int(-1), sym("x")]),
+                ],
+            )
         );
     }
 

--- a/code/specs/MA04-wolfram-language.md
+++ b/code/specs/MA04-wolfram-language.md
@@ -2098,7 +2098,7 @@ it). `ReplaceRepeated` retains its §22.4 hard iteration cap
 (`REPLACE_GROWTH_NODE_CAP`) — the `//.` operator lowers to the very same head, so
 the DoS bounds apply identically whether written as operator or `Head[args]`.
 
-## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify`, `Expand` (in progress)
+## §24 W-22 the `cas-*` function surface under Wolfram names — `Simplify`, `Expand`, `Factor` (in progress)
 
 W-22 starts closing §2's previously unnumbered "Future" item: wiring the
 existing `cas-*` algorithm crates under Wolfram's own head names. Unlike
@@ -2154,11 +2154,44 @@ gap):** `expand` does not collect like terms — e.g. `Expand[(x+1)^2]`
 produces `1 + x + x + x*x`, not the fully-collected `1 + 2*x + x^2` —
 tracked as a separate follow-up (see `cas-simplify`'s own module docs).
 
-### §24.3 Remaining (not yet delivered)
+### §24.3 `Factor` (delivered)
 
-`Factor`, `Solve`, `D`, `Integrate`, and the rest of §2's original list —
-each is a separate future item, no grammar change required for any of them
-(all are ordinary `Head[args]` forms the existing grammar already parses).
+`Factor[expr]` is a direct call into `symbolic_vm::handlers::factor_handler`
+— **the exact function** Macsyma's own `factor()` surface function calls
+(`macsyma-runtime`'s `factor_handler`). Unlike `Simplify`/`Expand` (thin
+calls into the standalone `cas-simplify` crate), `Factor`'s implementation
+lives directly inside `symbolic-vm` itself, so this wiring reuses that
+function directly rather than going through a separate `cas-*` crate;
+`factor_handler` was made `pub` in `symbolic-vm` specifically for this
+cross-language reuse (see that crate's own changelog). No algorithm is
+reimplemented; a test pins both languages' call sites to agree on the same
+input, exactly like `Simplify`/`Expand`'s own parity tests.
+
+`factor_handler` itself factors a univariate integer polynomial (via
+`cas_factor::factor_integer_polynomial`), or recognises one of a handful of
+common multivariate patterns (perfect square/cube, difference of squares,
+cubic identities, a common symbolic/integer term to pull out, bivariate and
+n-variate Hensel lifting), falling back to the unevaluated form when none
+apply — see `symbolic-vm`'s own module docs for the full algorithm
+inventory (shared, not reimplemented, with Macsyma).
+
+Like `Simplify` and `Expand`, `Factor` is an ordinary eager `Head[args]`
+form requiring exactly one argument; any other arity leaves the form
+unevaluated. That arity check lives inside `factor_handler` itself, so
+(unlike `simplify_handler`/`expand_handler`, which must unwrap a single
+expression argument themselves before calling a function that only takes
+one bare expression) the Wolfram wiring needs no arity check of its own.
+
+```
+Factor[x^2 - 1]     (* (1 + x) * (-1 + x) *)
+Factor[x + y]       (* x + y — unevaluated, no recognised pattern *)
+```
+
+### §24.4 Remaining (not yet delivered)
+
+`Solve`, `D`, `Integrate`, and the rest of §2's original list — each is a
+separate future item, no grammar change required for any of them (all are
+ordinary `Head[args]` forms the existing grammar already parses).
 
 ### §6 References
 


### PR DESCRIPTION
## Summary
- `Factor[expr]` — factors a univariate integer polynomial, or recognises one of a handful of common multivariate patterns (perfect square/cube, difference of squares, cubic identities, a common symbolic/integer term to pull out, bivariate/n-variate Hensel lifting) — unevaluated if none apply.
- Unlike `Simplify`/`Expand` (thin calls into the standalone `cas-simplify` crate), `Factor`'s implementation lives directly in `symbolic-vm` itself. Made `symbolic_vm::handlers::factor_handler` `pub` (bump 0.20.0 → 0.20.1, no behavior change) so this wiring can call the exact same factoring pipeline Macsyma's own `factor` surface function already uses, rather than reimplementing or duplicating it.
- Marks `Factor` delivered in `MA04-wolfram-language.md`'s W-22 section (§24.3).

## Test plan
- [x] `cargo test -p coding-adventures-wolfram-runtime -p symbolic-vm` — all pass, including 5 new tests (basic univariate factoring, an unrecognised multivariate form staying unevaluated, a Wolfram/Macsyma parity check pinning both call sites to the same result, wrong-arity fail-soft, and full parser→lower→backend dispatch)
- [x] Verified downstream `symbolic-vm` consumers (`macsyma-runtime`, `cas-summation`) still pass unaffected by the visibility change
- [x] `/security-review` passed clean — confirmed the pre-existing DoS bounds (`cas-factor`'s internal degree/prime/combination caps, `ir_to_integer_poly`'s exponent cap, `wolfram-runtime`'s own input-size/token-count/bounded-stack guards) apply identically to the new `Factor` entry point, no weaker regime introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)