### PR TITLE
fix(sql-lexer): parse '' escaped single quotes in string literals

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.16 — Parse `''` escaped single quotes in string literals
+
+A fundamental correctness fix: a doubled single quote (`''`) inside a SQL string
+literal is the escape for one literal quote, so `'it''s'` is the string `it's`
+and `'O''Brien'` is `O'Brien`. mini-sqlite failed to parse these — the generated
+sql-lexer token grammar had a stale backslash-escape regex, so `'it''s'`
+tokenized as two adjacent strings. Fixed in sql-lexer 0.1.1 (SQL `''` regex) and
+sql-planner 0.2.1 (`''` → `'` when building the string value). A new
+differential-oracle case (`escaped_quote_literal`) covers escaped quotes in both
+the SELECT list and INSERT'd row values against real bundled SQLite. This also
+unblocks testing PRINTF's `%q` via ordinary string literals.
+
 ## 0.5.15 — PRINTF / FORMAT (string formatting)
 
 Grows the SQL scalar surface (sql-vm 0.4.11): `PRINTF(format, …)` and its alias

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.15"
+version = "0.5.16"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -676,6 +676,17 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT FORMAT('%d %d', id) AS a, PRINTF('%q', CHAR(39)) AS b FROM t",
     },
+    // A doubled single quote (`''`) inside a string literal is SQL's escape for
+    // one literal quote — `'it''s'` is the 4-character string `it's`. Exercises
+    // string literals in the SELECT list AND in an INSERT'd row value.
+    Case {
+        id: "escaped_quote_literal",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1, 'O''Brien'), (2, 'it''s')",
+        ],
+        query: "SELECT s, LENGTH(s), 'a''b' AS lit FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-lexer/CHANGELOG.md
+++ b/code/packages/rust/sql-lexer/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - Unreleased
+
+### Fixed
+
+- **`''` escaped single quotes** in string literals. The generated token grammar
+  had a stale regex (`'([^'\\]|\\.)*'`, C-style backslash escapes) that didn't
+  match the `sql.tokens` source (`'(''|[^'])*'`), so `'it''s'` tokenized as two
+  adjacent strings and failed to parse. The `STRING_SQ` pattern is corrected to
+  SQL semantics: `''` is a literal quote, a backslash is an ordinary character.
+  (The `''` → `'` unescaping happens in sql-planner when the token becomes a
+  string value.)
+
 ## [0.1.0] - 2026-03-23
 
 ### Added

--- a/code/packages/rust/sql-lexer/Cargo.toml
+++ b/code/packages/rust/sql-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-lexer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "SQL lexer — tokenizes SQL source text using the grammar-driven lexer and the sql.tokens grammar file"
 

--- a/code/packages/rust/sql-lexer/src/_grammar.rs
+++ b/code/packages/rust/sql-lexer/src/_grammar.rs
@@ -28,10 +28,15 @@ pub fn token_grammar() -> TokenGrammar {
                 alias: None,
             },
             TokenDefinition {
+                // SQL string literals use `''` (a doubled single quote) to
+                // represent a literal quote — NOT backslash escapes. This regex
+                // matches `''` or any non-quote character between the delimiters,
+                // matching `sql.tokens`. (The `''` is unescaped to `'` when the
+                // token is turned into a string value, in sql-planner.)
                 name: r#"STRING_SQ"#.to_string(),
-                pattern: r#"'([^'\\]|\\.)*'"#.to_string(),
+                pattern: r#"'(''|[^'])*'"#.to_string(),
                 is_regex: true,
-                line_number: 19,
+                line_number: 32,
                 alias: Some(r#"STRING"#.to_string()),
             },
             TokenDefinition {

--- a/code/packages/rust/sql-lexer/src/lib.rs
+++ b/code/packages/rust/sql-lexer/src/lib.rs
@@ -283,6 +283,23 @@ mod tests {
         assert_eq!(pairs[0].1, "hello world");
     }
 
+    /// A doubled single quote (`''`) is SQL's escape for a literal quote — it
+    /// does NOT terminate the string. `'it''s'` is a single STRING token; the
+    /// raw value keeps the `''` (the parser collapses it to one `'` when it
+    /// builds the string value).
+    #[test]
+    fn test_string_with_escaped_quote() {
+        let pairs = lex("'it''s'");
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, TokenType::String);
+        assert_eq!(pairs[0].1, "it''s");
+        // Four quotes = a string containing one escaped quote.
+        let quad = lex("''''");
+        assert_eq!(quad.len(), 1);
+        assert_eq!(quad[0].0, TokenType::String);
+        assert_eq!(quad[0].1, "''");
+    }
+
     // -----------------------------------------------------------------------
     // Test 7: Operator = (EQUALS)
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.1] - Unreleased
+
+### Fixed
+
+- **`''` unescaping in string literals.** A `String` token's value is the raw
+  inner text (the lexer strips only the surrounding quotes), so a doubled single
+  quote must be collapsed to one when the literal is built:
+  `'it''s'` → the string `it's`. Paired with the sql-lexer 0.1.1 tokenizer fix.
+
 ## [0.2.0] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -2013,10 +2013,12 @@ fn plan_primary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
 /// | `Number`          | Integer or float literal   | `Literal(Int)` or `Float`    |
 /// | `Name`/`Keyword`  | Column name reference      | `Column { name: value }`     |
 fn plan_primary_token(tok: &Token) -> Result<SqlExpr, PlanError> {
-    // STRING literal: the lexer strips quotes and sets type_ = TokenType::String.
-    // The value is already the inner content (no surrounding quotes).
+    // STRING literal: the lexer strips the surrounding quotes and sets
+    // type_ = TokenType::String, but leaves the inner content raw. SQL escapes a
+    // literal single quote by doubling it (`'it''s'` is the four-character string
+    // `it's`), so collapse each `''` back to one `'` here.
     if tok.type_ == TokenType::String {
-        return Ok(SqlExpr::Literal(SqlValue::Text(tok.value.clone())));
+        return Ok(SqlExpr::Literal(SqlValue::Text(tok.value.replace("''", "'"))));
     }
 
     let val = &tok.value;


### PR DESCRIPTION
## Summary

A fundamental SQL correctness fix. A doubled single quote (`''`) inside a string
literal is the SQL-standard escape for one literal quote — `'it''s'` is the
string `it's`, `'O''Brien'` is `O'Brien`. mini-sqlite failed to parse these,
tokenizing `'it''s'` as two adjacent strings (a `"got b"` ParseError). Surfaced
while adding PRINTF's `%q`.

**Root cause:** the *generated* sql-lexer token grammar was **stale** — its
`STRING_SQ` regex was the old C-style `'([^'\\]|\\.)*'` (backslash escapes),
while the `sql.tokens` **source** already had the SQL-correct `'(''|[^'])*'`.
There's no SQL grammar regen tool, so the generated file is the de-facto source;
this aligns it.

## Fix (two lines)

1. **sql-lexer 0.1.1** — `STRING_SQ` pattern → `'(''|[^'])*'`: `''` is an
   escaped quote, and a backslash is now an ordinary character (matching real
   SQLite, which has no backslash escapes).
2. **sql-planner 0.2.1** — collapse `''` → `'` (`tok.value.replace("''","'")`)
   when a `String` token becomes a `SqlValue::Text`; the lexer strips only the
   surrounding quotes and leaves the inner `''` raw.

## Security

Reviewed before push. The `GrammarLexer` uses Rust's `regex` crate (**linear-time
NFA — no ReDoS**); the pattern is unambiguous anyway (`'` only matches via `''`).
`str::replace` is O(n), output ≤ input; quotes always occur in even runs after
validation (no mis-collapse); the value is an in-AST literal (never
re-serialized → no injection). **Review passed, no findings.**

## Verification

- **sql-lexer:** 27 tests (new `test_string_with_escaped_quote` — `'it''s'` and
  `''''`).
- **mini-sqlite differential oracle:** new `escaped_quote_literal` case diffs
  escaped quotes in the SELECT list *and* an INSERT'd row value (`'O''Brien'`,
  `'it''s'`) against real bundled SQLite.
- Full affected set green (sql-lexer, sql-planner [central], sql-codegen,
  sql-optimizer, sql-vm, storage-sqlite, mini-sqlite) — **no regressions**.

sql-lexer 0.1.0 → 0.1.1, sql-planner 0.2.0 → 0.2.1, mini-sqlite 0.5.15 → 0.5.16;
CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
