### PR TITLE
feat(sir-to-javascript): Array tally — JS mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.31.0 — Array `tally`
+
+Mirrors the Python reference (PR #8054) into the JS backend's inline
+`arrayMethod` (+ the `ARRAY_METHODS` `respond_to?` set), completing the JS side
+of the `tally` cross-backend catch-up (Go and Rust already shipped it).
+
+- `tally` → a Hash counting how many times each element occurs, keyed in
+  first-seen order (`["a","b","a","c","a"].tally` → `{"a"=>3, "b"=>1, "c"=>1}`;
+  `[].tally` → `{}`).
+- Realised as an insertion-ordered `Map` — the same shape `group_by` returns,
+  printed `{k: v}` by the shared display path (`formatSeen`).  Keys compare by JS
+  SameValueZero, which agrees with Ruby `eql?`/hash on the scalar elements this
+  covers, matching the Go/Rust/Python references.
+- `tests/run_with_node.rs::array_tally` emits three programs (string counts with
+  first-seen ordering, integer counts, empty → `{}`), runs them through `node`,
+  and asserts the printed Hash.
+
 ## 0.30.0 — Array `each_slice` / `each_cons` / `chunk_while`
 
 Mirrors the Python reference (PR #8031), Go (PR #8036), and Rust (PR #8042) into

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -1298,7 +1298,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "take", "drop", "values_at",
     "flatten", "compact", "rotate", "zip",
     "include?", "index",
-    "each_slice", "each_cons", "chunk_while",
+    "each_slice", "each_cons", "chunk_while", "tally",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
@@ -1585,6 +1585,18 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           else { chunks.push([recv[i]]); }
         }
         return chunks;
+      }
+      case "tally": {
+        // `tally` — a Hash counting how many times each element occurs, keyed
+        // in first-seen order.  `["a","b","a","c","a"].tally` →
+        // `{"a"=>3, "b"=>1, "c"=>1}`; an empty array yields `{}`.  Realised as a
+        // `Map` (insertion-ordered), the same shape `group_by` returns and the
+        // display path (`formatSeen`) prints as `{k=>v}`.  Keys compare by JS
+        // SameValueZero, which agrees with Ruby `eql?`/hash on the scalar
+        // elements this covers; matches the Go/Rust/Python references.
+        const counts = new Map();
+        for (const x of recv) { counts.set(x, (counts.get(x) || 0) + 1); }
+        return counts;
       }
     }
     return ARR_MISS;

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -3079,3 +3079,61 @@ fn array_each_slice_each_cons_chunk_while() {
         );
     }
 }
+
+// ── Ruby Array#tally ───────────────────────────────────────────────────────
+// `tally` counts occurrences into a Hash keyed in first-seen order — the JS
+// runtime realises it as an insertion-ordered `Map`, printed `{k: v}` (the same
+// shape `group_by` returns).  Mirrors the Go/Rust/Python references.
+#[test]
+fn array_tally() {
+    let stmts = vec![
+        // ["a","b","a","c","a"].tally → {a: 3, b: 1, c: 1}  (first-seen order)
+        print(method(
+            seq(vec![str_("a"), str_("b"), str_("a"), str_("c"), str_("a")]),
+            "tally",
+            vec![],
+        )),
+        // [1,1,2,3,3,3].tally → {1: 2, 2: 1, 3: 3}
+        print(method(
+            seq(vec![int(1), int(1), int(2), int(3), int(3), int(3)]),
+            "tally",
+            vec![],
+        )),
+        // [].tally → {}  (empty)
+        print(method(seq(vec![]), "tally", vec![])),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let module = Module {
+        name: "arrtally".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "arrtally") {
+        assert_eq!(
+            stdout,
+            "{a: 3, b: 1, c: 1}\n\
+             {1: 2, 2: 1, 3: 3}\n\
+             {}"
+        );
+    }
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8054](https://github.com/adhithyan15/coding-adventures/pull/8054)) into the JS backend's inline `arrayMethod` (+ the `ARRAY_METHODS` `respond_to?` set), completing the **JS side** of the `Array#tally` cross-backend catch-up. Go and Rust already ship `tally`; after this, only the TS reference-runtime mirror remains for full 5-backend parity.

## What

`tally` returns a Hash counting how many times each element occurs, keyed in first-seen order:

- `["a","b","a","c","a"].tally` → `{"a"=>3, "b"=>1, "c"=>1}`
- `[].tally` → `{}`

Realised as an insertion-ordered `Map` — the same shape `group_by` returns, printed `{k: v}` by the shared display path (`formatSeen`). Keys compare by JS SameValueZero, which agrees with Ruby `eql?`/hash on the scalar elements this covers, matching the Go/Rust/Python references.

## Tests

`tests/run_with_node.rs::array_tally` emits three programs (string counts with first-seen ordering, integer counts, empty → `{}`), runs them through `node`, and asserts the printed Hash. Passes locally.

Version 0.30.0 → 0.31.0. Security review passed (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)