### PR TITLE
feat(sir-runtime-oop): Array tally — TS mirror (final backend)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.23] - 2026-07-11
+
+### Added
+
+- **`Array#tally`** — the FINAL backend of the `tally` cross-backend catch-up
+  (Python reference #8054, JS #8058; Go and Rust already shipped it), completing
+  it across all five backends.
+  - `tally` (`arrayMethod` + `ARRAY_METHODS`) → a Hash counting how many times
+    each element occurs, keyed in first-seen order
+    (`["a","b","a","c","a"].tally` → `{"a"=>3, "b"=>1, "c"=>1}`; `[].tally` →
+    `{}`).
+  - Realised as an insertion-ordered `Map` — the same shape `group_by` returns,
+    printed `{k=>v}` by `rubyInspect` (no display change needed). Keys compare by
+    JS SameValueZero, which agrees with Ruby `eql?`/hash on the scalar elements
+    this covers, matching the Go/Rust/Python/JS references.
+  - `respond_to?("tally")` now reports `true`.
+
 ## [0.1.22] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -63,7 +63,7 @@ The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
 `min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
-`take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons` — and the
+`take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons`, `tally` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a` (`include?`/`index`/`==` use
 deep value equality), plus the **Kernel flow-control** group

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -557,6 +557,7 @@ const ARRAY_METHODS = new Set<string>([
   "zip",
   "each_slice",
   "each_cons",
+  "tally",
 ]);
 
 // Block-taking `Array`/`Enumerable` methods (M1b); each invokes a trailing
@@ -1059,6 +1060,18 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
       const out: Val[] = [];
       for (let i = 0; i + n <= recv.length; i++) out.push(recv.slice(i, i + n));
       return out;
+    }
+    case "tally": {
+      // `tally` — a Hash counting how many times each element occurs, keyed in
+      // first-seen order.  `["a","b","a","c","a"].tally` →
+      // `{"a"=>3, "b"=>1, "c"=>1}`; an empty array yields `{}`.  A Hash is a JS
+      // `Map` (insertion-ordered), the same shape `group_by` returns, printed
+      // `{k=>v}` by `rubyInspect`.  Keys compare by JS SameValueZero, which
+      // agrees with Ruby `eql?`/hash on the scalar elements this covers;
+      // mirrors the Go/Rust/Python/JS references.
+      const counts = new Map<Val, Val>();
+      for (const x of recv) counts.set(x, ((counts.get(x) as number) ?? 0) + 1);
+      return counts;
     }
     default:
       return MISS;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -451,6 +451,26 @@ describe("built-in method catalog: block-taking Array/Enumerable (M1b)", () => {
     expect(callMethod([1], "respond_to?", "chunk_while")).toBe(true);
   });
 
+  it("tally (occurrence counts as a first-seen-ordered Hash)", () => {
+    // `tally` → a Map counting occurrences, keyed in first-seen order.
+    const t = callMethod(["a", "b", "a", "c", "a"], "tally") as Map<Val, Val>;
+    expect(t).toBeInstanceOf(Map);
+    expect(t.get("a")).toBe(3);
+    expect(t.get("b")).toBe(1);
+    expect(t.get("c")).toBe(1);
+    expect(t.size).toBe(3);
+    // First-seen key order is preserved (a, b, c).
+    expect([...t.keys()]).toEqual(["a", "b", "c"]);
+    // Integer elements count too.
+    const ti = callMethod([1, 1, 2, 3, 3, 3], "tally") as Map<Val, Val>;
+    expect([...ti.entries()]).toEqual([[1, 2], [2, 1], [3, 3]]);
+    // Empty array → empty Hash.
+    const te = callMethod([], "tally") as Map<Val, Val>;
+    expect(te.size).toBe(0);
+    // respond_to? advertises it.
+    expect(callMethod([1], "respond_to?", "tally")).toBe(true);
+  });
+
   it("find/detect and flat_map", () => {
     expect(callMethod([1, 2, 3, 4], "find", new Closure((x: Val) => x > 2))).toBe(3);
     expect(callMethod([1, 2], "detect", new Closure((x: Val) => x > 9))).toBeNull();


### PR DESCRIPTION
Completes the `Array#tally` cross-backend catch-up — now present across **all five backends**. (Python reference [#8054](https://github.com/adhithyan15/coding-adventures/pull/8054), JS [#8058](https://github.com/adhithyan15/coding-adventures/pull/8058); Go and Rust already shipped it.)

## What

`tally` returns a Hash counting how many times each element occurs, keyed in first-seen order:

- `["a","b","a","c","a"].tally` → `{"a"=>3, "b"=>1, "c"=>1}`
- `[].tally` → `{}`

Realised as an insertion-ordered `Map` — the same shape `group_by` returns, printed `{k=>v}` by `rubyInspect` (no display change). Keys compare by JS SameValueZero, which agrees with Ruby `eql?`/hash on the scalar elements this covers, matching the Go/Rust/Python/JS references. `respond_to?("tally")` now reports `true`.

## Tests

Adds a vitest case (string counts + first-seen ordering, integer counts, empty → `{}`, `respond_to?`). Full suite **119 passed**.

Version 0.1.22 → 0.1.23. Security review passed (Map keys inert against prototype pollution; O(n); explicit-switch dispatch, no reflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)