### PR TITLE
fix(sql-parser): parse a bare JOIN (INNER by default)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.17 — Bare `JOIN` (INNER by default)
+
+`SELECT … FROM a JOIN b ON …` now parses and runs — a bare `JOIN` (no
+`INNER`/`LEFT`/… keyword) is an INNER join. The generated sql-parser grammar
+required an explicit `join_type` before `JOIN`; making it optional (sql-parser
+0.1.1) fixes it, and the planner already defaulted a missing type to INNER. A new
+differential-oracle case (`bare_join`) confirms it produces the same rows as
+`INNER JOIN` against real bundled SQLite.
+
 ## 0.5.16 — Parse `''` escaped single quotes in string literals
 
 A fundamental correctness fix: a doubled single quote (`''`) inside a SQL string

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.16"
+version = "0.5.17"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -687,6 +687,18 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT s, LENGTH(s), 'a''b' AS lit FROM t ORDER BY id",
     },
+    // A bare `JOIN` (no INNER/LEFT/… keyword) is an INNER join, and must produce
+    // the same rows as an explicit `INNER JOIN`.
+    Case {
+        id: "bare_join",
+        setup: &[
+            "CREATE TABLE a (id INTEGER, b_id INTEGER)",
+            "CREATE TABLE b (id INTEGER, name TEXT)",
+            "INSERT INTO a VALUES (1, 10), (2, 20), (3, 99)",
+            "INSERT INTO b VALUES (10, 'x'), (20, 'y')",
+        ],
+        query: "SELECT a.id, b.name FROM a JOIN b ON a.b_id = b.id ORDER BY a.id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - Unreleased
+
+### Fixed
+
+- **Bare `JOIN`** (without an `INNER`/`LEFT`/… keyword) now parses. The generated
+  grammar's `join_clause` required a `join_type` before `JOIN`, so `FROM a JOIN b`
+  failed while `FROM a INNER JOIN b` worked. `join_type` is now `Optional`,
+  matching the `sql.grammar` source (`[ join_type ]`); the planner already
+  defaults a missing `join_type` to INNER, so no downstream change was needed.
+
 ## [0.1.0] - 2026-03-23
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -106,7 +106,10 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"join_clause"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"join_type"#.to_string() },
+                // `join_type` is OPTIONAL: a bare `JOIN` (no INNER/LEFT/… prefix)
+                // is an INNER join, which the planner already defaults to when the
+                // `join_type` node is absent. Matches `sql.grammar` (`[ join_type ]`).
+                GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"join_type"#.to_string() }) },
                 GrammarElement::Literal { value: r#"JOIN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"table_ref"#.to_string() },
                 GrammarElement::Literal { value: r#"ON"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -640,6 +640,21 @@ mod tests {
         );
     }
 
+    /// A bare `JOIN` (no INNER/LEFT/… keyword) must parse — `join_type` is
+    /// optional and defaults to INNER downstream. Both the bare and the explicit
+    /// `INNER JOIN` forms should parse.
+    #[test]
+    fn test_parse_bare_join() {
+        assert!(
+            parse_sql("SELECT a.id FROM a JOIN b ON a.x = b.y").is_ok(),
+            "bare JOIN should parse"
+        );
+        assert!(
+            parse_sql("SELECT a.id FROM a INNER JOIN b ON a.x = b.y").is_ok(),
+            "INNER JOIN should still parse"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Test 29: Error path — tokenization failure propagates
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`SELECT … FROM a JOIN b ON …` — a **bare `JOIN`** (no `INNER`/`LEFT`/… keyword,
which is an INNER join) — failed to parse, while `FROM a INNER JOIN b` worked.
Real SQLite treats a bare `JOIN` as an INNER join; this makes mini match.

**Root cause:** the same stale-generated-grammar pattern as the recent `''`
lexer fix. The generated sql-parser `_grammar.rs` `join_clause` required a
`join_type` before `JOIN`, but the `sql.grammar` **source** already has it
optional (`[ join_type ]`). No SQL grammar regen tool exists, so the generated
file is the de-facto source; this aligns it.

## Fix (one grammar element)

Wrap the `join_type` `RuleReference` in `GrammarElement::Optional`. **No
downstream change needed** — the planner's `plan_join_clause` already defaults a
missing `join_type` node to `JoinKind::Inner`. INNER/LEFT/RIGHT/FULL/CROSS joins
are unaffected.

## Security

Reviewed as a parser grammar change. The parser is a **memoized packrat PEG**
(linear-time, no exponential backtracking); `Optional` is non-backtracking; a
successful `join_clause` always consumes the mandatory `JOIN` token (never
zero-width), so `{ join_clause }` can't loop; `join_type`'s alternatives don't
collide with `JOIN`/`ON` (no ambiguity); malformed joins still yield a clean
parse error, not a panic. Data-only change, no `unsafe`. **Review passed, no
findings.**

## Verification

- **sql-parser:** 34 tests (new `test_parse_bare_join` — bare + explicit INNER).
- **mini-sqlite differential oracle:** new `bare_join` case confirms
  `FROM a JOIN b ON …` yields the same rows as `INNER JOIN` vs real bundled
  SQLite.
- Full affected set green (sql-parser [central], sql-planner, sql-codegen,
  sql-optimizer, sql-vm, storage-sqlite, mini-sqlite) — **no regressions**;
  INNER/LEFT JOIN still verified.

sql-parser 0.1.0 → 0.1.1, mini-sqlite 0.5.16 → 0.5.17; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
