### PR TITLE
feat(closure-scope-analyzer): with-soundness gate — disable renaming when a with statement is present (CLOC12.187 PR2a)

### DIFF
--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.12.0] - 2026-07-12
+
+### Added — CLOC12.187 PR2a: decline to rename globals in the presence of `with`
+
+`run` now bails at the top when `program_contains_with_statement`
+(closure-scope-analyzer 0.14.0, added as a new dependency) is `true`, returning
+the program unchanged. Renaming a global is unsound when a `with` is present:
+a bare name in the `with` body may resolve to a property of the injected object
+rather than to the global. `with` is rare (a strict-mode syntax error), so the
+program-wide bail costs little. New `with_statement_disables_global_renaming`
+test.
+
 ## [0.11.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
 coding_adventures_correlation_vector = { path = "../correlation-vector" }
 serde_json = "1"

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -68,6 +68,7 @@ use std::collections::{HashMap, HashSet};
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::program_contains_with_statement;
 use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use serde_json::json;
@@ -136,6 +137,24 @@ impl Pass for RenameGlobalsPass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        // `with` soundness gate (CLOC12.187 PR2a). A `with (obj) …` splices
+        // `obj` onto the scope chain, so a bare name in its body may resolve to
+        // a property of `obj` rather than to the global binding we would rename.
+        // Renaming that global (and its references) could then silently change
+        // which value the name reads, so when the program contains a `with` we
+        // decline to rename and return the input unchanged. `with` is rare (a
+        // strict-mode syntax error), so this program-wide bail costs little.
+        // See [`program_contains_with_statement`].
+        if program_contains_with_statement(ctx.program) {
+            return Ok(PassOutput {
+                program: ctx.program.clone(),
+                contributions: Vec::new(),
+                changed: false,
+                diagnostics: Vec::new(),
+                stats: PassStats { nodes_touched: 1 },
+            });
+        }
+
         let mut program = ctx.program.clone();
         let mut nodes_touched: u32 = 1; // the program root
         let (changed, renames) =
@@ -1692,5 +1711,63 @@ mod tests {
             rename_source("var SHARED = 5; function read() { return SHARED; } read();"),
             "var a=5;function b(){return a};b();"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.187 PR2a — `with` soundness gate. A `with (obj) …` splices
+    // `obj` onto the scope chain, so a bare name may be an `obj` property at
+    // runtime; renaming a global could then change which value the name
+    // reads. RenameGlobalsPass must bail. The bridge does not yet produce
+    // `with` (PR2b), so the AST is hand-built.
+    // -------------------------------------------------------------------
+    #[test]
+    fn with_statement_disables_global_renaming() {
+        use coding_adventures_javascript_ast::{
+            BlockStatement, Declaration, Expression, FunctionDeclaration, Identifier, ProgramItem,
+            Statement, WithStatement,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+
+        // `function longFn() {}` at top level — a global RenameGlobalsPass
+        // would normally shorten to `a`.
+        let f = FunctionDeclaration {
+            cv: None,
+            id: id("longFn"),
+            params: vec![],
+            body: BlockStatement { cv: None, body: vec![] },
+            generator: false,
+            is_async: false,
+        };
+        // `with (o) {}`
+        let with = Statement::with_statement(WithStatement {
+            cv: None,
+            object: Expression::Identifier(id("o")),
+            body: Box::new(Statement::block_statement(BlockStatement { cv: None, body: vec![] })),
+        });
+
+        let mut prog = program();
+        prog.body = vec![
+            ProgramItem::Statement(with),
+            ProgramItem::Declaration(Declaration::FunctionDeclaration(f)),
+        ];
+
+        let pass = RenameGlobalsPass::with_no_externs();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename-globals");
+
+        assert!(!out.changed, "must not rename globals when a `with` is present");
+        assert_eq!(out.program, prog, "program must be returned unchanged");
+        assert!(out.contributions.is_empty());
     }
 }

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.14.0] - 2026-07-12
+
+### Added — CLOC12.187 PR2a: decline to rename properties in the presence of `with`
+
+`run` now bails at the top when `program_contains_with_statement`
+(closure-scope-analyzer 0.14.0, added as a new dependency) is `true`, returning
+the program unchanged. Inside `with (obj) …` a bare `foo` may be the property
+access `obj.foo` in disguise; the pass cannot see that, so renaming the property
+`foo` elsewhere would desynchronize from the hidden access. `with` is rare (a
+strict-mode syntax error), so the program-wide bail costs little. New
+`with_statement_disables_property_renaming` test.
+
 ## [0.13.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 
 [dependencies]
 coding-adventures-closure-pass-pipeline = { path = "../closure-pass-pipeline" }
+coding-adventures-closure-scope-analyzer = { path = "../closure-scope-analyzer" }
 coding-adventures-javascript-ast = { path = "../javascript-ast" }
 coding_adventures_correlation_vector = { path = "../correlation-vector" }
 serde_json = "1"

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -79,6 +79,7 @@ use std::collections::{HashMap, HashSet};
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::program_contains_with_statement;
 use coding_adventures_correlation_vector::Contribution;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
 use serde_json::json;
@@ -774,6 +775,25 @@ impl Pass for RenamePropertiesPass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        // `with` soundness gate (CLOC12.187 PR2a). Inside `with (obj) …` a bare
+        // name like `foo` may be the property access `obj.foo` in disguise.
+        // Property renaming rewrites `.foo` member accesses and object-literal
+        // keys consistently, but it cannot see that a *bare* `foo` in a `with`
+        // body is really a property read — so renaming `foo` elsewhere would
+        // desynchronize from that disguised access. When the program contains a
+        // `with` we therefore decline to rename properties and return the input
+        // unchanged. `with` is rare (a strict-mode syntax error), so this costs
+        // little. See [`program_contains_with_statement`].
+        if program_contains_with_statement(ctx.program) {
+            return Ok(PassOutput {
+                program: ctx.program.clone(),
+                contributions: Vec::new(),
+                changed: false,
+                diagnostics: Vec::new(),
+                stats: PassStats { nodes_touched: 1 },
+            });
+        }
+
         let mut program = ctx.program.clone();
         let mut nodes_touched: u32 = 1;
         let (changed, renames) =
@@ -2153,5 +2173,81 @@ mod tests {
         );
         assert!(out.contains(".innerHTML"));
         assert!(!out.contains("secretField"));
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.187 PR2a — `with` soundness gate. Inside `with (obj) …` a bare
+    // `foo` may be `obj.foo` in disguise, so renaming the property `foo`
+    // elsewhere would desynchronize from that hidden access.
+    // RenamePropertiesPass must bail. The bridge does not yet produce `with`
+    // (PR2b), so the AST is hand-built.
+    // -------------------------------------------------------------------
+    #[test]
+    fn with_statement_disables_property_renaming() {
+        use coding_adventures_javascript_ast::{
+            BindingTarget, BlockStatement, Declaration, Expression, Identifier, NumericLiteral,
+            ObjectExpression, ObjectMember, ProgramItem, Property, PropertyKey, PropertyKind,
+            Statement, VarKind, VariableDeclaration, VariableDeclarator, WithStatement,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+
+        // `var rec = { longProp: 1 };` — `longProp` is an object-literal key
+        // RenamePropertiesPass would normally shorten to `a`.
+        let obj = Expression::ObjectExpression(ObjectExpression {
+            cv: None,
+            properties: vec![ObjectMember::Property(Property {
+                cv: None,
+                kind: PropertyKind::Init,
+                key: PropertyKey::Identifier(id("longProp")),
+                value: Box::new(Expression::NumericLiteral(NumericLiteral {
+                    cv: None,
+                    value: 1.0,
+                    raw: "1".to_string(),
+                })),
+                computed: false,
+                shorthand: false,
+                method: false,
+            })],
+        });
+        let vd = VariableDeclaration {
+            cv: None,
+            kind: VarKind::Var,
+            declarations: vec![VariableDeclarator {
+                cv: None,
+                id: BindingTarget::Identifier(id("rec")),
+                init: Some(obj),
+            }],
+        };
+        // `with (o) {}`
+        let with = Statement::with_statement(WithStatement {
+            cv: None,
+            object: Expression::Identifier(id("o")),
+            body: Box::new(Statement::block_statement(BlockStatement { cv: None, body: vec![] })),
+        });
+
+        let mut prog = program();
+        prog.body = vec![
+            ProgramItem::Statement(with),
+            ProgramItem::Declaration(Declaration::VariableDeclaration(vd)),
+        ];
+
+        let pass = RenamePropertiesPass::new(HashSet::new());
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename-properties");
+
+        assert!(!out.changed, "must not rename properties when a `with` is present");
+        assert_eq!(out.program, prog, "program must be returned unchanged");
+        assert!(out.contributions.is_empty());
     }
 }

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.16.0] - 2026-07-12
+
+### Added — CLOC12.187 PR2a: decline to rename in the presence of `with`
+
+`run` now bails at the top when `program_contains_with_statement` (new in
+closure-scope-analyzer 0.14.0) is `true`, returning the input program unchanged
+with no rename contributions. A `with (obj) …` splices `obj` onto the scope
+chain, so a bare name in its body may resolve to an `obj` property rather than
+the lexical binding the pass sees — renaming would then be unsound (the
+"single declaration ⇒ single binding" safety argument does not hold). `with` is
+a strict-mode syntax error and rare, so this program-wide bail costs little.
+New `with_statement_disables_local_renaming` test. Sets up the `with` bridge
+(PR2b): once the bridge produces the node, this gate keeps renaming sound.
+
 ## [0.15.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -87,6 +87,7 @@ use std::collections::{HashMap, HashSet};
 use coding_adventures_closure_pass_pipeline::{
     IterationPolicy, Pass, PassContext, PassError, PassOutput, PassStats,
 };
+use coding_adventures_closure_scope_analyzer::program_contains_with_statement;
 use coding_adventures_correlation_vector::Contribution;
 use serde_json::json;
 use coding_adventures_javascript_ast::statement::TaggedStatement;
@@ -153,6 +154,26 @@ impl Pass for RenamePass {
     }
 
     fn run(&self, ctx: PassContext<'_>) -> Result<PassOutput, PassError> {
+        // `with` soundness gate (CLOC12.187 PR2a). A `with (obj) …` anywhere
+        // splices `obj` onto the scope chain, so a bare name in its body may
+        // resolve at runtime to a property of `obj` rather than to the lexical
+        // binding we see. Renaming that binding (and its references) could then
+        // silently change which value the name reads — the "single declaration
+        // ⇒ single binding ⇒ every use resolves to it" safety argument below
+        // does not hold in the presence of `with`. So when the program contains
+        // a `with` we decline to rename and return the input unchanged. `with`
+        // is rare (a strict-mode syntax error), so this program-wide bail costs
+        // little in practice. See [`program_contains_with_statement`].
+        if program_contains_with_statement(ctx.program) {
+            return Ok(PassOutput {
+                program: ctx.program.clone(),
+                contributions: Vec::new(),
+                changed: false,
+                diagnostics: Vec::new(),
+                stats: PassStats { nodes_touched: 1 },
+            });
+        }
+
         // Scope: rename the uniquely-bound names of *leaf functions*
         // (function declarations whose body contains no nested function
         // declaration) — their parameters and their body's
@@ -2167,5 +2188,78 @@ mod tests {
         };
         let out = emit(&prog, &Sidecar::new(), &mut cv, &opts).expect("emit").code;
         assert_eq!(out, "function f(){var counter=0;return counter+1};");
+    }
+
+    // -------------------------------------------------------------------
+    // CLOC12.187 PR2a — `with` soundness gate.
+    //
+    // A `with (obj) …` splices `obj` onto the scope chain, so a bare name
+    // in its body can resolve to a property of `obj` at runtime rather than
+    // to the lexical binding the pass sees. Renaming would then be unsound,
+    // so `RenamePass` must bail and return the program unchanged. The bridge
+    // does not yet produce `with` (that is PR2b), so this test hand-builds
+    // the AST to exercise the gate directly.
+    // -------------------------------------------------------------------
+    #[test]
+    fn with_statement_disables_local_renaming() {
+        use coding_adventures_javascript_ast::statement::ReturnStatement;
+        use coding_adventures_javascript_ast::{
+            BlockStatement, Declaration, Expression, FunctionDeclaration, FunctionParam,
+            Identifier, ProgramItem, Statement, WithStatement,
+        };
+
+        let id = |n: &str| Identifier {
+            cv: None,
+            name: n.to_string(),
+        };
+
+        // `function f(longParam) { return longParam; }` — a leaf function
+        // whose param `longParam` RenamePass would normally shorten to `a`.
+        let f = FunctionDeclaration {
+            cv: None,
+            id: id("f"),
+            params: vec![FunctionParam::Identifier(id("longParam"))],
+            body: BlockStatement {
+                cv: None,
+                body: vec![Statement::return_statement(ReturnStatement {
+                    cv: None,
+                    argument: Some(Expression::Identifier(id("longParam"))),
+                })],
+            },
+            generator: false,
+            is_async: false,
+        };
+
+        // `with (o) { <f> }`
+        let with = Statement::with_statement(WithStatement {
+            cv: None,
+            object: Expression::Identifier(id("o")),
+            body: Box::new(Statement::block_statement(BlockStatement {
+                cv: None,
+                body: vec![Statement::Declaration(Declaration::FunctionDeclaration(f))],
+            })),
+        });
+
+        let mut prog = program();
+        prog.body = vec![ProgramItem::Statement(with)];
+
+        let pass = RenamePass::new();
+        let sidecar = Sidecar::new();
+        let mut cv = CVLog::new(false);
+        let out = pass
+            .run(PassContext {
+                program: &prog,
+                sidecar: &sidecar,
+                cv: &mut cv,
+            })
+            .expect("rename");
+
+        // The gate must fire: nothing renamed, program byte-for-byte identical.
+        assert!(!out.changed, "rename must not change a program containing `with`");
+        assert_eq!(out.program, prog, "program must be returned unchanged");
+        assert!(
+            out.contributions.is_empty(),
+            "no rename contributions when bailing on `with`"
+        );
     }
 }

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.14.0] - 2026-07-12
+
+### Added — CLOC12.187 PR2a: `with` soundness gate
+
+New `has_with: bool` field on `ScopeAnalysis` (set by the existing `analyze`
+walk whenever a `with` statement is encountered anywhere) and a public
+`program_contains_with_statement(&Program) -> bool` helper built on it. A `with`
+splices its object onto the scope chain, so a bare name in the body can resolve
+to an object property rather than a lexical binding — which makes renaming
+unsound. The rename / rename-globals / rename-properties passes read this gate
+and decline to rename when it is set. Because it rides the full `analyze` walk,
+it detects a `with` however deeply nested (e.g. inside a function expression).
+Three unit tests pin detection (absent / top-level / nested-in-function).
+
 ## [0.13.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: walk `WithStatement`

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -237,6 +237,17 @@ pub struct ScopeAnalysis {
     pub scopes: Vec<Scope>,
     pub bindings: Vec<Binding>,
     pub references: Vec<Reference>,
+    /// `true` if the program contains at least one `with (obj) …`
+    /// statement anywhere (including nested inside a function/arrow body).
+    ///
+    /// `with` injects `obj` onto the scope chain, so a bare name in the
+    /// `with` body may resolve at runtime to a property of `obj` rather
+    /// than to the lexical binding the analyzer sees. That makes *any*
+    /// renaming of bindings in the program unsound — the renamed reference
+    /// could silently start (or stop) resolving to an `obj` property. The
+    /// rename passes read this flag and decline to rename when it is set.
+    /// See [`program_contains_with_statement`].
+    pub has_with: bool,
 }
 
 impl ScopeAnalysis {
@@ -415,6 +426,7 @@ pub fn analyze(program: &Program) -> ScopeAnalysis {
         }],
         bindings: Vec::new(),
         references: Vec::new(),
+        has_with: false,
     };
 
     let mut pending: Vec<PendingReference> = Vec::new();
@@ -441,6 +453,27 @@ pub fn analyze(program: &Program) -> ScopeAnalysis {
     }
 
     analysis
+}
+
+/// Does `program` contain a `with (obj) …` statement anywhere?
+///
+/// This is the soundness gate for every renaming pass. A `with` splices its
+/// object onto the scope chain, so a bare identifier inside the `with` body
+/// can resolve at runtime to a *property* of that object rather than to the
+/// lexical binding the compiler sees. Renaming that binding (or the reference)
+/// would then silently change which value the name reads. Because a `with`
+/// nested anywhere — even deep inside a function expression — can shadow a
+/// binding declared anywhere else, the only sound response is to disable
+/// renaming for the whole program. The rename / rename-globals /
+/// rename-properties passes call this and return their input unchanged when it
+/// is `true`.
+///
+/// It rides the full [`analyze`] walk, so it is guaranteed to see a `with`
+/// however deeply it is nested (no separate, drift-prone traversal to keep in
+/// sync with the AST shape). A program with no `with` returns `false`; one with
+/// a `with` anywhere returns `true`. See the crate tests for worked examples.
+pub fn program_contains_with_statement(program: &Program) -> bool {
+    analyze(program).has_with
 }
 
 /// Emit a binding into the given scope and update both the
@@ -878,13 +911,14 @@ fn walk_tagged_statement(
         TaggedStatement::DebuggerStatement(_) => {}
         // `with (object) body` (CLOC12.187). The `object` is an ordinary
         // expression evaluated in the current scope; the `body` is a statement.
-        // NOTE: `with` injects `object` onto the scope chain, so a bare name in
-        // the body may resolve to a property of `object` rather than a lexical
-        // binding — which makes renaming inside a `with` body unsound. This node
-        // is not yet reachable (the bridge still declines `with`); the renaming
-        // bailout lands with the bridge that produces it, mirroring the way
-        // `eval` would be handled.
+        // `with` injects `object` onto the scope chain, so a bare name in the
+        // body may resolve to a property of `object` rather than a lexical
+        // binding — which makes renaming *any* binding in the program unsound.
+        // We record that on the analysis (`has_with`) so the rename passes can
+        // decline; see [`program_contains_with_statement`]. We still walk the
+        // object and body so references outside/inside are resolved as usual.
         TaggedStatement::WithStatement(ws) => {
+            analysis.has_with = true;
             walk_expression(&ws.object, ctx, analysis, pending);
             walk_statement(&ws.body, ctx, analysis, pending);
         }
@@ -1178,6 +1212,7 @@ mod tests {
                 declared_at: None,
             }],
             references: Vec::new(),
+            has_with: false,
         };
         let inner = ScopeId(1);
         let resolved = analysis.resolve("x", inner);
@@ -1216,6 +1251,7 @@ mod tests {
                 },
             ],
             references: Vec::new(),
+            has_with: false,
         };
         let inner = ScopeId(1);
         assert_eq!(analysis.resolve("x", inner), Some(BindingId(1)));
@@ -1645,6 +1681,7 @@ mod tests {
                 binding: Some(BindingId(0)),
                 cv: Some("cv.2".to_string()),
             }],
+            has_with: false,
         };
         let json = serde_json::to_string(&analysis).expect("serialize");
         let back: ScopeAnalysis = serde_json::from_str(&json).expect("deserialize");
@@ -1883,5 +1920,53 @@ mod tests {
         assert_eq!(analysis.scopes.len(), 1);
         assert!(analysis.bindings.is_empty());
         assert!(analysis.references.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // CLOC12.187 PR2a — `with` soundness gate.
+    //
+    // `program_contains_with_statement` is the flag the rename passes
+    // read to disable renaming. These tests pin its two contracts: it
+    // is `false` for `with`-free programs (renaming stays on) and
+    // `true` whenever a `with` appears anywhere, including buried in a
+    // function body (which is why one program-wide flag is sound).
+    // ---------------------------------------------------------------
+
+    /// `with (<obj>) ;` as a single top-level program item.
+    fn with_stmt(obj: &str) -> Statement {
+        Statement::with_statement(coding_adventures_javascript_ast::WithStatement {
+            cv: None,
+            object: id_expr(obj),
+            body: Box::new(Statement::empty_statement(
+                coding_adventures_javascript_ast::EmptyStatement { cv: None },
+            )),
+        })
+    }
+
+    #[test]
+    fn program_contains_with_is_false_for_with_free_program() {
+        // `function f(a) {}` — no `with`, so the gate stays open and
+        // renaming remains enabled.
+        let prog = program_with(vec![fn_decl_with_body("f", &["a"], vec![])]);
+        assert!(!program_contains_with_statement(&prog));
+        assert!(!analyze(&prog).has_with);
+    }
+
+    #[test]
+    fn program_contains_with_detects_top_level_with() {
+        // `with (o) ;` — a top-level `with`. The gate must fire.
+        let prog = program_with(vec![ProgramItem::Statement(with_stmt("o"))]);
+        assert!(program_contains_with_statement(&prog));
+        assert!(analyze(&prog).has_with);
+    }
+
+    #[test]
+    fn program_contains_with_detects_with_nested_in_function() {
+        // `function f() { with (o) ; }` — the `with` is buried inside a
+        // function body. Because the gate rides the full `analyze` walk,
+        // it still fires; this is the case that makes a single
+        // program-wide flag (rather than a per-scope one) sound.
+        let prog = program_with(vec![fn_decl_with_body("f", &[], vec![with_stmt("o")])]);
+        assert!(program_contains_with_statement(&prog));
     }
 }


### PR DESCRIPTION
## CLOC12.187 PR2a — `with` renaming-soundness gate

Lands the soundness gate that makes the upcoming `with` bridge (PR2b) safe. A
`with (obj) …` splices `obj` onto the scope chain, so a bare name in the body
can resolve at runtime to a **property of `obj`** rather than to the lexical
binding the compiler sees. Renaming that binding (or a property, or a global)
would then silently change which value the name reads — a miscompile. Shipping
the gate **before** the bridge means `with` is never renamed once it becomes
reachable.

### Changes
- **closure-scope-analyzer 0.14.0** — new `ScopeAnalysis.has_with` flag (set by
  the existing `analyze` walk whenever a `with` is seen) + public
  `program_contains_with_statement(&Program) -> bool`. Because it rides the full
  walk, it detects a `with` however deeply nested (e.g. inside a function
  expression) — no drift-prone separate traversal.
- **closure-pass-rename 0.16.0**, **rename-globals 0.12.0**,
  **rename-properties 0.14.0** — `run` bails at the top when the gate fires,
  returning the input program unchanged with no contributions. rename-globals /
  rename-properties gain a scope-analyzer dependency.

`with` is a strict-mode syntax error and rare, so this program-wide bail costs
little in practice.

### Verification
- scope-analyzer: 3 detection tests (absent / top-level / nested-in-function).
- Each rename pass: a hand-built `with`-program test proving it declines to
  rename (the bridge does not yet produce `with`, so the AST is constructed
  directly).
- All four crate suites green; full closurec suite green.
- `/security-review` PASSED (no vulnerabilities).

Follow-up **PR2b** flips the bridge (`with_statement` → `WithStatement`) and
adds a closurec e2e fixture — now sound because this gate is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)