### PR TITLE
feat(sir-runtime-oop): Array slice_when (Python reference)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.24] - 2026-07-11
+
+### Added
+
+- **`Array#slice_when`** — the block-taking Array method that is the INVERSE of
+  `chunk_while`: it splits into runs of consecutive elements, starting a NEW run
+  BETWEEN an adjacent pair exactly WHERE the block is truthy (whereas
+  `chunk_while` starts a new run where the block is FALSY).
+  `[1,2,4,9,10,11,12].slice_when { |a,b| b - a > 1 }` →
+  `[[1,2],[4],[9,10,11,12]]`; an empty array yields `[]`, a single element
+  `[[x]]`. This is the Python **reference** for the new cross-backend cascade
+  (Go/Rust/JS/TS mirrors to follow). `respond_to?("slice_when")` reports `true`.
+
 ## [0.1.23] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -72,7 +72,7 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 (item **M6**); and (item **M1b**)
 **block-taking `Array`/`Enumerable`** methods `each`, `each_with_index`,
 `map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`, `find`/`detect`,
-`flat_map`, `any?`/`all?`/`none?`, `chunk_while` — a trailing `Closure` block is applied via
+`flat_map`, `any?`/`all?`/`none?`, `chunk_while`/`slice_when` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
 (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/`to_h`/`each_with_index`/`each_with_object`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/`group_by`/`partition`/`flat_map`/`reduce`/`sum`/…);

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.23"
+version = "0.1.24"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -613,6 +613,7 @@ _ARRAY_BLOCK_METHODS = frozenset(
         "count",
         "each_with_object",
         "chunk_while",
+        "slice_when",
     }
 )
 
@@ -1201,6 +1202,23 @@ def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Clos
             else:
                 chunks.append([cur])
         return chunks
+    if name == "slice_when":
+        # ``slice_when { |prev, cur| pred }`` — the INVERSE of ``chunk_while``:
+        # split into runs of consecutive elements, starting a NEW run BETWEEN an
+        # adjacent pair exactly WHERE the block is truthy (chunk_while starts a
+        # new run where the block is FALSY).
+        # ``[1,2,4,9,10,11,12].slice_when { |a,b| b - a > 1 }``
+        #   → ``[[1,2],[4],[9,10,11,12]]`` (splits on each upward gap > 1).
+        # An empty array yields ``[]``; a single element yields ``[[x]]``.
+        if not recv:
+            return []
+        slices: list[Val] = [[recv[0]]]
+        for prev, cur in zip(recv, recv[1:], strict=False):
+            if truthy(apply(block, [prev, cur])):
+                slices.append([cur])
+            else:
+                slices[-1].append(cur)
+        return slices
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -287,6 +287,28 @@ def test_array_tally() -> None:
     assert oop.call_method([1], "respond_to?", "tally") is True
 
 
+def test_array_slice_when() -> None:
+    # `slice_when { |a, b| pred }` is the INVERSE of `chunk_while`: it starts a
+    # NEW run BETWEEN an adjacent pair exactly WHERE the block is truthy.
+    # `b - a > 1` splits only on an UPWARD gap; (12, 0) has b - a == -12, so 0
+    # stays in the preceding run.
+    assert oop.call_method(
+        [1, 2, 4, 9, 10, 11, 12, 0], "slice_when", Closure(lambda a, b: b - a > 1)
+    ) == [[1, 2], [4], [9, 10, 11, 12, 0]]
+    # A non-monotonic split predicate (`b < a`) breaks each descent.
+    assert oop.call_method(
+        [1, 4, 2, 3, 1], "slice_when", Closure(lambda a, b: b < a)
+    ) == [[1, 4], [2, 3], [1]]
+    # all-truthy → every element its own singleton run; all-falsy → one run.
+    assert oop.call_method([1, 2, 3], "slice_when", Closure(lambda a, b: True)) == [[1], [2], [3]]
+    assert oop.call_method([1, 2, 3], "slice_when", Closure(lambda a, b: False)) == [[1, 2, 3]]
+    # empty → []; single element → [[x]].
+    assert oop.call_method([], "slice_when", Closure(lambda a, b: True)) == []
+    assert oop.call_method([9], "slice_when", Closure(lambda a, b: True)) == [[9]]
+    # respond_to? advertises it.
+    assert oop.call_method([1], "respond_to?", "slice_when") is True
+
+
 def test_array_mutating_push_pop_shift_unshift() -> None:
     a = [1, 2]
     assert oop.call_method(a, "push", 3) == [1, 2, 3]


### PR DESCRIPTION
Starts a new cross-backend cascade — the **Python reference** for `Array#slice_when`.

## What

`slice_when { |prev, cur| pred }` is the **inverse of `chunk_while`**: it splits into runs of consecutive elements, starting a **new run BETWEEN an adjacent pair exactly WHERE the block is truthy** (whereas `chunk_while` starts a new run where the block is *falsy*).

- `[1,2,4,9,10,11,12].slice_when { |a,b| b - a > 1 }` → `[[1,2],[4],[9,10,11,12]]`
- empty → `[]`; single → `[[x]]`
- `respond_to?("slice_when")` → `true`

Added to `_array_block_method` (mirroring the `chunk_while` arm) + the `_ARRAY_BLOCK_METHODS` set.

## Tests

pytest covers the upward-gap example (note `(12,0)` does **not** split since `b-a < 0`), a descending-split predicate, all-truthy → singletons, all-falsy → one run, empty, single, and `respond_to?`. **130 passed, 97% coverage, ruff clean.**

Version 0.1.23 → 0.1.24. Security review passed. Go/Rust/JS/TS mirrors follow, one per tick-cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)