### PR TITLE
fix(sql-parser): conditionless joins (Cartesian product)

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.18 — Conditionless joins (Cartesian product)
+
+`SELECT … FROM a CROSS JOIN b` and `SELECT … FROM a JOIN b` (no `ON`) now parse
+and run as a Cartesian (cross) product. The generated sql-parser grammar required
+an `ON` after every join; making `ON expr` optional (sql-parser 0.1.2) fixes it,
+and the planner/codegen already produce a cross product for a conditionless join.
+Two new differential-oracle cases (`cross_product_no_on`, `join_no_on_is_cross`)
+diff against real bundled SQLite. (Comma joins `FROM a, b`, `USING`, and `NATURAL
+JOIN` remain unsupported — those need new planner work, not just a grammar tweak.)
+
 ## 0.5.17 — Bare `JOIN` (INNER by default)
 
 `SELECT … FROM a JOIN b ON …` now parses and runs — a bare `JOIN` (no

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -699,6 +699,28 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a.id, b.name FROM a JOIN b ON a.b_id = b.id ORDER BY a.id",
     },
+    // A join with NO `ON` condition is a Cartesian (cross) product — both the
+    // bare `JOIN` and the explicit `CROSS JOIN` forms.
+    Case {
+        id: "cross_product_no_on",
+        setup: &[
+            "CREATE TABLE a (x INTEGER)",
+            "CREATE TABLE b (y INTEGER)",
+            "INSERT INTO a VALUES (1), (2)",
+            "INSERT INTO b VALUES (10), (20)",
+        ],
+        query: "SELECT a.x, b.y FROM a CROSS JOIN b ORDER BY a.x, b.y",
+    },
+    Case {
+        id: "join_no_on_is_cross",
+        setup: &[
+            "CREATE TABLE a (x INTEGER)",
+            "CREATE TABLE b (y INTEGER)",
+            "INSERT INTO a VALUES (1), (2)",
+            "INSERT INTO b VALUES (10), (20)",
+        ],
+        query: "SELECT a.x, b.y FROM a JOIN b ORDER BY a.x, b.y",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - Unreleased
+
+### Fixed
+
+- **A join with no `ON` condition** (a Cartesian product) now parses:
+  `FROM a JOIN b` and `FROM a CROSS JOIN b`. The generated grammar required an
+  `ON expr` after every join; the `ON expr` is now `Optional`. The planner already
+  returns `None` for a missing `ON`, and codegen already emits every pair (no
+  condition check) for a conditionless INNER join, so no downstream change was
+  needed.
+
 ## [0.1.1] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -112,8 +112,14 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"join_type"#.to_string() }) },
                 GrammarElement::Literal { value: r#"JOIN"#.to_string() },
                 GrammarElement::RuleReference { name: r#"table_ref"#.to_string() },
-                GrammarElement::Literal { value: r#"ON"#.to_string() },
-                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                // `ON expr` is OPTIONAL: a join with no condition is a Cartesian
+                // (cross) product — `FROM a JOIN b` and `FROM a CROSS JOIN b`. The
+                // planner returns `None` for a missing ON, and codegen emits every
+                // pair (no condition check) for an INNER join with no condition.
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"ON"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                ] }) },
             ] },
             line_number: 28,
         },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -655,6 +655,25 @@ mod tests {
         );
     }
 
+    /// A join with NO `ON` condition (a Cartesian product) must parse — both the
+    /// bare `JOIN` and the explicit `CROSS JOIN` forms — while the `ON` form
+    /// still works.
+    #[test]
+    fn test_parse_join_without_on() {
+        assert!(
+            parse_sql("SELECT a.x FROM a JOIN b").is_ok(),
+            "JOIN with no ON should parse (cross product)"
+        );
+        assert!(
+            parse_sql("SELECT a.x FROM a CROSS JOIN b").is_ok(),
+            "CROSS JOIN with no ON should parse"
+        );
+        assert!(
+            parse_sql("SELECT a.x FROM a JOIN b ON a.x = b.y").is_ok(),
+            "JOIN ... ON should still parse"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Test 29: Error path — tokenization failure propagates
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`SELECT … FROM a CROSS JOIN b` and `SELECT … FROM a JOIN b` (no `ON`) failed to
parse — the generated grammar required an `ON expr` after every join. Real SQLite
treats a conditionless join as a **Cartesian (cross) product**; this makes mini
match. Continues the stale-generated-grammar hand-fix technique (bare JOIN, `''`
escapes) — another one-liner where the downstream is already ready.

## Fix

Wrap the `ON expr` suffix of `join_clause` in `GrammarElement::Optional`:
`join_clause = [join_type] "JOIN" table_ref [ "ON" expr ]`. **No downstream
change:**
- the planner's `extract_join_condition` already returns `None` when `ON` is absent;
- codegen already emits every pair for a conditionless INNER join
  (`has_condition = condition.is_some() && kind == Inner`).

## Security

Reviewed as a parser grammar change. The parser is a memoized packrat PEG
(linear-time). The mandatory `"JOIN"` literal means a successful `join_clause`
always consumes ≥1 token, so `{ join_clause }` **can't spin on a zero-width
match** even with both `join_type` and `ON` optional. `Optional` is
committed/non-backtracking (no ambiguity); `FROM a JOIN b ON x WHERE y` greedily
consumes `ON x` and leaves `WHERE`; a dangling `ON` is bounds-checked, no panic.
**Review passed, no findings.**

## Verification

- **sql-parser:** 35 tests (new `test_parse_join_without_on` — bare/CROSS JOIN
  with no ON, plus the ON form).
- **mini-sqlite differential oracle:** two new cases (`cross_product_no_on`,
  `join_no_on_is_cross`) diff the Cartesian product vs real bundled SQLite.
- Full affected set green (sql-parser [central], sql-planner, sql-codegen,
  sql-optimizer, sql-vm, storage-sqlite, mini-sqlite) — **no regressions**;
  INNER/LEFT `JOIN … ON` still verified.

**Out of scope** (need new planner work, not a grammar tweak): comma joins
(`FROM a, b`), `USING (cols)`, `NATURAL JOIN`.

sql-parser 0.1.1 → 0.1.2, mini-sqlite 0.5.17 → 0.5.18; CHANGELOGs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
