### PR TITLE
feat(sir-to-go): Array slice_when — Go mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.31.0 — Array `slice_when`
+
+Mirrors the Python reference (PR #8070) into the Go backend's inline `__sir`
+runtime (`_sir_array_block_method` + the `_sir_array_responds` `respond_to?`
+arm), continuing the `slice_when` cross-backend cascade.
+
+- `slice_when { |prev, cur| pred }` is the INVERSE of `chunk_while`: it splits
+  into runs of consecutive elements, starting a NEW run BETWEEN an adjacent pair
+  exactly WHERE the block is truthy (whereas `chunk_while` starts a new run where
+  the block is FALSY).
+  `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`;
+  an empty array yields `[]`, a single element `[[x]]`.
+- `tests/compile_and_run_array_methods.rs::array_slice_when_compile_and_run`
+  emits a program with a `b - a > 1` predicate, compiles + runs it with the Go
+  toolchain, and asserts the printed runs.
+
 ## 0.30.0 — Array `each_slice` / `each_cons` / `chunk_while`
 
 Mirrors the Python reference (PR #8031) into the Go backend's inline `__sir`

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -183,7 +183,7 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `empty?`, `include?`, `index`, `push`/`append`, `<<`, `pop`, `shift`, `reverse`,
 `sort`, `join`, `to_a`, `each`, `map`/`collect`, `select`/`filter`, `reject`,
 `reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`,
-`each_slice`/`each_cons`, `chunk_while`; **Hash** `keys`,
+`each_slice`/`each_cons`, `chunk_while`/`slice_when`; **Hash** `keys`,
 `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `size`/
 `length`, `empty?`, `each`/`each_pair`, `each_key`, `each_value`, `map`,
 `select`/`filter`, `reject`, `transform_values`, `transform_keys`, and the

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1704,7 +1704,7 @@ func _sir_array_responds(name string) bool {
 		"reject", "reduce", "inject", "find", "detect", "any?", "all?", "none?",
 		"sort_by", "min_by", "max_by", "group_by", "partition", "flat_map",
 		"collect_concat", "take_while", "drop_while", "each_with_object",
-		"chunk_while":
+		"chunk_while", "slice_when":
 		return true
 	}
 	return false
@@ -2339,6 +2339,29 @@ func _sir_array_block_method(recv *Seq, name string, args []Value, block *Closur
 			}
 		}
 		return &Seq{Items: chunks}, true
+	case "slice_when":
+		// `slice_when { |prev, cur| pred }` -> the INVERSE of chunk_while: runs of
+		// consecutive elements, starting a NEW run BETWEEN an adjacent pair
+		// exactly WHERE the block is truthy (chunk_while starts a new run where
+		// the block is FALSY).
+		// `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` -> [[1,2],[4],[9,10,11,12]].
+		// An empty array yields []; a single element yields [[x]].
+		if len(recv.Items) == 0 {
+			return &Seq{Items: []Value{}}, true
+		}
+		cur := &Seq{Items: []Value{recv.Items[0]}}
+		slices := []Value{cur}
+		for i := 1; i < len(recv.Items); i++ {
+			prev := recv.Items[i-1]
+			item := recv.Items[i]
+			if _sir_truthy(_sir_apply(block, []Value{prev, item})) {
+				cur = &Seq{Items: []Value{item}}
+				slices = append(slices, cur)
+			} else {
+				cur.Items = append(cur.Items, item)
+			}
+		}
+		return &Seq{Items: slices}, true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
@@ -364,3 +364,76 @@ fn array_each_slice_each_cons_chunk_while_compile_and_run() {
         "unexpected stdout:\n{stdout}"
     );
 }
+
+// ── Array slice_when ───────────────────────────────────────────────────────
+//
+// `slice_when { |a, b| pred }` is the INVERSE of chunk_while: it starts a NEW
+// run BETWEEN an adjacent pair exactly WHERE the block is truthy.  Mirrors the
+// Python reference (#8070).
+fn slice_when_module() -> Function {
+    Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                // [1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 } → [[1,2],[4],[9,10,11,12]]
+                print_stmt(method(
+                    seq(vec![ilit(1), ilit(2), ilit(4), ilit(9), ilit(10), ilit(11), ilit(12)]),
+                    "slice_when",
+                    vec![closure("__lam_gap")],
+                )),
+                // [9].slice_when { … } → [[9]]  (single element)
+                print_stmt(method(seq(vec![ilit(9)]), "slice_when", vec![closure("__lam_gap")])),
+                // [].slice_when { … } → []
+                print_stmt(method(seq(vec![]), "slice_when", vec![closure("__lam_gap")])),
+            ],
+            value: nil(),
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+#[test]
+fn array_slice_when_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // { |a, b| b - a > 1 } — split on an upward gap greater than one.
+    let gap = lambda_fn2(
+        "__lam_gap",
+        "a",
+        "b",
+        Block {
+            stmts: vec![],
+            value: builtin(">", vec![builtin("-", vec![var_p("b"), var_p("a")]), ilit(1)]),
+            span: s(),
+        },
+    );
+    let module = program(vec![slice_when_module(), gap]);
+    let artifact = compile(&module).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "slicewhen");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "[[1, 2], [4], [9, 10, 11, 12]]", // slice_when { b-a>1 }
+            "[[9]]",                          // single element
+            "[]",                             // [].slice_when → []
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8070](https://github.com/adhithyan15/coding-adventures/pull/8070)) into the **Go backend**'s inline `__sir` runtime (`_sir_array_block_method` + the `_sir_array_responds` `respond_to?` arm), continuing the `slice_when` cross-backend cascade.

## What

`slice_when { |prev, cur| pred }` is the **inverse of `chunk_while`**: it splits into runs of consecutive elements, starting a **new run BETWEEN an adjacent pair exactly WHERE the block is truthy** (chunk_while starts a new run where the block is *falsy*).

- `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`
- empty → `[]`; single → `[[x]]`

## Tests

`tests/compile_and_run_array_methods.rs::array_slice_when_compile_and_run` emits a program with a `b - a > 1` predicate, compiles + runs it with the Go toolchain, and asserts the printed runs. Passes locally.

Version 0.30.0 → 0.31.0. Security review passed (explicit-switch dispatch, no reflection; O(n); bounds-guarded). Rust/JS/TS mirrors follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)