### PR TITLE
feat(sql-parser): column alias without the AS keyword

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.19 — Column alias without the `AS` keyword
+
+`SELECT a col1` now parses and names the output column `col1`, exactly like
+`SELECT a AS col1` — SQLite (and standard SQL) accept both spellings. The
+generated sql-parser grammar required `AS`; making it optional (sql-parser
+0.1.3) plus teaching the planner's alias extractor to read a bare trailing
+`NAME` token (sql-planner 0.2.2) fixes it. Two new differential-oracle cases
+(`column_alias_without_as`, `bare_alias_matches_as`) diff the resulting
+**column names** against real bundled SQLite. (Table aliases without `AS`,
+`FROM t u`, are the same idea in a different grammar slot and remain a
+follow-up.)
+
 ## 0.5.18 — Conditionless joins (Cartesian product)
 
 `SELECT … FROM a CROSS JOIN b` and `SELECT … FROM a JOIN b` (no `ON`) now parse

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.18"
+version = "0.5.19"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -721,6 +721,29 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a.x, b.y FROM a JOIN b ORDER BY a.x, b.y",
     },
+    // A column alias may omit the `AS` keyword: `SELECT id n` names the output
+    // column `n`, exactly like `SELECT id AS n`. SQLite (and standard SQL)
+    // accept both spellings. The output *column name* is what this case checks,
+    // so it directly exercises alias plumbing, not just row values.
+    Case {
+        id: "column_alias_without_as",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1, 'a'), (2, 'b')",
+        ],
+        query: "SELECT id n, name label FROM t ORDER BY id",
+    },
+    // A bare alias must behave identically to the explicit-AS form and must not
+    // swallow the trailing FROM/ORDER BY. Pairing an expression alias with a
+    // plain column alias covers both the computed and the passthrough path.
+    Case {
+        id: "bare_alias_matches_as",
+        setup: &[
+            "CREATE TABLE t (a INTEGER, b INTEGER)",
+            "INSERT INTO t VALUES (2, 3), (5, 7)",
+        ],
+        query: "SELECT a + b total, a first FROM t ORDER BY total",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - Unreleased
+
+### Fixed
+
+- **A column alias may omit the `AS` keyword.** `SELECT a col1` now parses and
+  names the output column `col1`, exactly like `SELECT a AS col1` — SQLite and
+  standard SQL accept both spellings. The generated `select_item` grammar
+  required `AS`; it now matches the `sql.grammar` source
+  (`expr [ [ "AS" ] NAME ]`) by making `AS` optional. The alias `NAME` cannot
+  swallow a following keyword (`FROM`/`WHERE`/…) — `NAME` only matches
+  `Name`-type tokens — nor a comma, so `SELECT a, b` and `SELECT a FROM t` are
+  unaffected. Paired with a sql-planner 0.2.2 change that reads a bare trailing
+  alias token (no `AS` keyword to key off).
+
 ## [0.1.2] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -74,8 +74,13 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"select_item"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                // `select_item = expr [ [ "AS" ] NAME ]` — the AS keyword is
+                // OPTIONAL, so `SELECT a col1` (bare alias) parses the same as
+                // `SELECT a AS col1`. The alias NAME can never eat a following
+                // keyword (FROM/WHERE/…) because NAME only matches Name-type
+                // tokens, and it can't eat a comma, so `SELECT a, b` is safe.
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"AS"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"AS"#.to_string() }) },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -308,6 +308,25 @@ mod tests {
         assert!(find_rule(&ast, "select_item"), "Expected select_item");
     }
 
+    /// The `AS` keyword is optional in a column alias: `SELECT age years`
+    /// parses the same as `SELECT age AS years` (SQLite accepts both). This
+    /// exercises the `[ [ "AS" ] NAME ]` optional-AS branch of `select_item`.
+    #[test]
+    fn test_parse_select_alias_without_as() {
+        let ast = assert_program_root("SELECT age years FROM users");
+        assert!(find_rule(&ast, "select_item"), "Expected select_item");
+        // The bare alias must NOT swallow the FROM clause.
+        assert!(find_rule(&ast, "table_ref"), "Expected FROM table_ref to still parse");
+    }
+
+    /// A bare alias in a multi-item list must not consume the comma or the
+    /// following item: `SELECT a x, b y` yields two aliased items.
+    #[test]
+    fn test_parse_bare_alias_in_list() {
+        let ast = assert_program_root("SELECT a x, b y FROM t");
+        assert!(find_rule(&ast, "select_list"), "Expected select_list");
+    }
+
     // -----------------------------------------------------------------------
     // Test 8: INSERT statement
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.2] - Unreleased
+
+### Fixed
+
+- **Bare column aliases (no `AS`).** `extract_as_alias` keyed the output-column
+  alias off the `AS` keyword, so `SELECT a col1` (which sql-parser 0.1.3 now
+  accepts) lost its alias. It now also recognises the implicit form: when there
+  is no `AS`, the lone `Name`-type token directly under `select_item` is the
+  alias. The expression is always a nested node, so a bare identifier token can
+  only be the alias — no ambiguity. `SELECT a` (no alias) still yields `None`.
+
 ## [0.2.1] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1003,14 +1003,38 @@ fn plan_select_item(item: &GrammarASTNode) -> Result<OutputColumn, PlanError> {
     Ok(OutputColumn { expr, alias })
 }
 
-/// Extract an AS alias from a node: scan for "AS" keyword then take the
-/// following token's text.
+/// Extract a `select_item` alias.
+///
+/// Grammar: `select_item = expr [ [ "AS" ] NAME ]` — the alias may be written
+/// with or without the `AS` keyword (`SELECT a AS x` and `SELECT a x` are
+/// equivalent in SQLite). Two AST shapes result:
+///
+/// * **Explicit** `expr AS name` → children `[Node(expr), Token("AS"),
+///   Token(name)]`. We scan for the `AS` keyword and take the token after it.
+/// * **Implicit** `expr name` → children `[Node(expr), Token(name)]` — no `AS`.
+///   The expression is *always* a nested Node (never a bare token) and the only
+///   bare tokens the grammar can place directly under `select_item` are the
+///   optional `AS` and the alias, so a lone `Name`-type token that isn't a
+///   keyword is unambiguously the implicit alias.
+///
+/// A bare `expr` with no alias (`SELECT a`) has no token children → `None`.
 fn extract_as_alias(node: &GrammarASTNode) -> Option<String> {
     let children = &node.children;
+    // Explicit `AS name`.
     for (i, child) in children.iter().enumerate() {
         if is_keyword_token(child, "AS") {
             if let Some(next) = children.get(i + 1) {
                 return Some(token_text_of(next));
+            }
+        }
+    }
+    // Implicit `name` (no AS): the first bare identifier token directly under
+    // the item. Restricting to Name-type tokens keeps us from mistaking any
+    // stray keyword/punctuation for an alias.
+    for child in children {
+        if let ASTNodeOrToken::Token(tok) = child {
+            if tok.type_ == lexer::token::TokenType::Name {
+                return Some(tok.value.clone());
             }
         }
     }


### PR DESCRIPTION
## Column alias without the `AS` keyword

SQLite (and standard SQL) let a column alias omit the `AS` keyword, so
`SELECT a col1` names the output column `col1` exactly like `SELECT a AS col1`.
The generated `select_item` grammar required `AS`, while the `sql.grammar`
source already documents it optional (`expr [ [ "AS" ] NAME ]`). This closes
that gap — one more mismatch where the generated grammar lagged the source and
the planner was already ready.

### What changed
- **sql-parser** (`_grammar.rs`): `select_item`'s optional alias becomes
  `[ [ "AS" ] NAME ]` — `AS` is now optional. The alias `NAME` can't eat a
  following keyword (`FROM`/`WHERE`/…) because `NAME` only matches `Name`-type
  tokens, and it can't eat a comma, so `SELECT a, b` and `SELECT a FROM t` are
  unchanged.
- **sql-planner** (`extract_as_alias`): previously keyed the alias off the `AS`
  keyword, so the bare form lost its alias. It now also reads the implicit
  form — the lone `Name`-type token directly under `select_item`. The
  expression is always a nested node, so a bare identifier token can only be
  the alias (verified against the actual AST shape). `SELECT a` (no alias)
  still yields `None`.

### Tests (oracle/test-first)
- **Differential oracle** (mini-sqlite): `column_alias_without_as` and
  `bare_alias_matches_as` — both diff the resulting **column names** against
  real bundled SQLite, not just row values.
- **sql-parser units**: `test_parse_select_alias_without_as` (bare alias must
  not swallow `FROM`), `test_parse_bare_alias_in_list` (`a x, b y` → two items).
- Full affected SQL pipeline (parser/planner/codegen/vm/optimizer/mini-sqlite/
  storage-sqlite) green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — no zero-width repetition /
  infinite-parse risk (NAME can't match empty), `extract_as_alias` fallback is
  bounds-safe and injection-free, no clause swallowing.

### Versions
sql-parser 0.1.2→0.1.3 · sql-planner 0.2.1→0.2.2 · mini-sqlite 0.5.18→0.5.19.

### Follow-up (not in this PR)
Table aliases without `AS` (`FROM t u`) are the same idea in a different grammar
slot (`table_ref` + `extract_table_ref`) and are the natural next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
