### PR TITLE
feat(sql-parser): table alias without the AS keyword

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.20 — Table alias without the `AS` keyword
+
+`FROM users u` now aliases the table exactly like `FROM users AS u` — SQLite
+(and standard SQL) accept both spellings. The generated sql-parser grammar
+required `AS`; making it optional (sql-parser 0.1.4) plus teaching the planner's
+`extract_table_ref` to read a bare trailing `NAME` token (sql-planner 0.2.3)
+fixes it, including qualified references through the bare alias (`u.id`) and
+bare aliases on both sides of a `JOIN`. Two new differential-oracle cases
+(`table_alias_without_as`, `join_bare_table_alias`) diff against real bundled
+SQLite. This is the sibling of 0.5.19 (column aliases) — the same idea in the
+`table_ref` grammar slot. (Comma joins `FROM a, b`, `USING`, and `NATURAL JOIN`
+still need new planner work.)
+
 ## 0.5.19 — Column alias without the `AS` keyword
 
 `SELECT a col1` now parses and names the output column `col1`, exactly like

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.19"
+version = "0.5.20"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -744,6 +744,29 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a + b total, a first FROM t ORDER BY total",
     },
+    // A table alias may omit the `AS` keyword: `FROM users u` aliases the table
+    // exactly like `FROM users AS u`. A qualified reference through the bare
+    // alias (`u.id`) must resolve, proving the alias reached the planner.
+    Case {
+        id: "table_alias_without_as",
+        setup: &[
+            "CREATE TABLE users (id INTEGER, name TEXT)",
+            "INSERT INTO users VALUES (1, 'a'), (2, 'b'), (3, 'c')",
+        ],
+        query: "SELECT u.id, u.name FROM users u WHERE u.id > 1 ORDER BY u.id",
+    },
+    // Bare table aliases across a JOIN: both sides aliased without `AS`, joined
+    // on the bare-aliased columns. Must match the explicit-AS join exactly.
+    Case {
+        id: "join_bare_table_alias",
+        setup: &[
+            "CREATE TABLE a (id INTEGER, v INTEGER)",
+            "CREATE TABLE b (id INTEGER, w INTEGER)",
+            "INSERT INTO a VALUES (1, 10), (2, 20)",
+            "INSERT INTO b VALUES (1, 100), (2, 200)",
+        ],
+        query: "SELECT x.v, y.w FROM a x JOIN b y ON x.id = y.id ORDER BY x.v",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - Unreleased
+
+### Fixed
+
+- **A table alias may omit the `AS` keyword.** `FROM users u` now aliases the
+  table exactly like `FROM users AS u` — SQLite and standard SQL accept both.
+  The generated `table_ref` grammar required `AS`; it now matches the
+  `sql.grammar` source (`table_name [ [ "AS" ] NAME ]`) by making `AS`
+  optional. The alias `NAME` cannot swallow a following keyword
+  (`JOIN`/`WHERE`/`ON`/…) — `NAME` only matches `Name`-type tokens — so bare
+  aliases work across joins (`FROM a x JOIN b y ON …`). Mirrors the 0.1.3
+  column-alias fix; paired with a sql-planner 0.2.3 change that reads the
+  implicit table alias.
+
 ## [0.1.3] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -90,8 +90,13 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"table_ref"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::RuleReference { name: r#"table_name"#.to_string() },
+                // `table_ref = table_name [ [ "AS" ] NAME ]` — the AS keyword is
+                // OPTIONAL, so `FROM users u` aliases the table the same as
+                // `FROM users AS u` (SQLite accepts both). The alias NAME cannot
+                // eat a following keyword (JOIN/WHERE/ON/…) because NAME only
+                // matches Name-type tokens, so `FROM a JOIN b` is unaffected.
                 GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"AS"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"AS"#.to_string() }) },
                         GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     ] }) },
             ] },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -327,6 +327,25 @@ mod tests {
         assert!(find_rule(&ast, "select_list"), "Expected select_list");
     }
 
+    /// A table alias may omit `AS`: `FROM users u` parses like
+    /// `FROM users AS u` (SQLite accepts both). Exercises the
+    /// `table_ref = table_name [ [ "AS" ] NAME ]` optional-AS branch.
+    #[test]
+    fn test_parse_table_alias_without_as() {
+        let ast = assert_program_root("SELECT u.id FROM users u WHERE u.id > 1");
+        assert!(find_rule(&ast, "table_ref"), "Expected table_ref");
+        // The bare alias must NOT swallow the WHERE clause.
+        assert!(find_rule(&ast, "where_clause"), "Expected WHERE to still parse");
+    }
+
+    /// Bare table aliases must work across a JOIN and not eat the `JOIN`
+    /// keyword: `FROM a x JOIN b y ON …`.
+    #[test]
+    fn test_parse_join_bare_table_alias() {
+        let ast = assert_program_root("SELECT x.id FROM a x JOIN b y ON x.id = y.id");
+        assert!(find_rule(&ast, "join_clause"), "Expected join_clause");
+    }
+
     // -----------------------------------------------------------------------
     // Test 8: INSERT statement
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.3] - Unreleased
+
+### Fixed
+
+- **Bare table aliases (no `AS`).** `extract_table_ref` keyed the table alias
+  off the `AS` keyword, so `FROM users u` (which sql-parser 0.1.4 now accepts)
+  lost its alias and qualified references like `u.id` failed to resolve. It now
+  also recognises the implicit form: with the table name nested in its own
+  `table_name` node, a bare `Name`-type token directly under `table_ref` is the
+  alias. Guarded on the `table_name` node being present, so the degenerate
+  no-node fallback (where the lone token *is* the table name) is unaffected.
+  Mirrors the 0.2.2 column-alias fix.
+
 ## [0.2.2] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -753,7 +753,9 @@ fn plan_select(
 
 /// Extract the table name and optional alias from a `table_ref` node.
 ///
-/// Grammar: `table_ref = table_name [ "AS" NAME ]`
+/// Grammar: `table_ref = table_name [ [ "AS" ] NAME ]` — the alias may be
+/// written with or without `AS` (`FROM users AS u` and `FROM users u` are
+/// equivalent in SQLite).
 /// Grammar: `table_name = NAME [ "." NAME ]`
 ///
 /// Returns `(table_name, Option<alias>)`.
@@ -762,13 +764,14 @@ fn extract_table_ref(table_ref: &GrammarASTNode) -> (String, Option<String>) {
     // If no name token is found, we return an empty string.  The caller
     // immediately validates the table against the schema, so an empty string
     // will produce `PlanError::UnknownTable("")` — a visible, safe error.
-    let table_name = if let Some(tn) = find_node(table_ref, "table_name") {
+    let table_name_node = find_node(table_ref, "table_name");
+    let table_name = if let Some(tn) = table_name_node {
         first_name_token(tn).unwrap_or_default()
     } else {
         first_name_token(table_ref).unwrap_or_default()
     };
 
-    // Look for an AS alias by scanning the token children.
+    // Explicit `AS name`: scan for the AS keyword, take the following token.
     let mut alias: Option<String> = None;
     let children = &table_ref.children;
     for (i, child) in children.iter().enumerate() {
@@ -776,6 +779,22 @@ fn extract_table_ref(table_ref: &GrammarASTNode) -> (String, Option<String>) {
             // The token after "AS" is the alias name.
             if let Some(next) = children.get(i + 1) {
                 alias = Some(token_text_of(next));
+            }
+        }
+    }
+
+    // Implicit `name` (no AS): the table name lives in its own nested
+    // `table_name` node, so any bare `Name`-type token directly under
+    // `table_ref` is the alias (`FROM users u`). Guard on the `table_name`
+    // node being present — in the degenerate fallback above the lone direct
+    // token IS the table name and must not be doubled up as its own alias.
+    if alias.is_none() && table_name_node.is_some() {
+        for child in children {
+            if let ASTNodeOrToken::Token(tok) = child {
+                if tok.type_ == lexer::token::TokenType::Name {
+                    alias = Some(tok.value.clone());
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Table alias without the `AS` keyword

SQLite (and standard SQL) let a table alias omit `AS`, so `FROM users u`
aliases the table exactly like `FROM users AS u`. The generated `table_ref`
grammar required `AS`, while the `sql.grammar` source already documents it
optional (`table_name [ [ "AS" ] NAME ]`). This is the sibling of the
just-merged column-alias fix (#8075) — same idea, one grammar slot over.

### What changed
- **sql-parser** (`_grammar.rs`): `table_ref`'s optional alias becomes
  `[ [ "AS" ] NAME ]` — `AS` is now optional. The alias `NAME` can't eat a
  following keyword (`JOIN`/`WHERE`/`ON`/…) because `NAME` only matches
  `Name`-type tokens, so bare aliases work across joins
  (`FROM a x JOIN b y ON …`).
- **sql-planner** (`extract_table_ref`): previously keyed the alias off the
  `AS` keyword, so the bare form lost its alias and qualified refs (`u.id`)
  failed to resolve. It now also reads the implicit form — the bare
  `Name`-type token directly under `table_ref`. Guarded on the `table_name`
  node being present, so the degenerate no-node fallback (lone token = table
  name) is unaffected — the table name is never doubled as its own alias.

### Tests (oracle/test-first)
- **Differential oracle** (mini-sqlite): `table_alias_without_as` (qualified
  `u.id` resolved through a bare alias) and `join_bare_table_alias` (both join
  sides bare-aliased), diffed against real bundled SQLite.
- **sql-parser units**: `test_parse_table_alias_without_as` (alias must not
  swallow `WHERE`), `test_parse_join_bare_table_alias` (`a x JOIN b y ON …`).
- Full affected SQL pipeline (parser/planner/codegen/vm/optimizer/mini-sqlite/
  storage-sqlite) green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — no zero-width repetition,
  keywords can't be swallowed across joins, `extract_table_ref` is bounds-safe
  and injection-free, and the `table_name` guard provably prevents the table
  name being echoed as its alias.

### Versions
sql-parser 0.1.3→0.1.4 · sql-planner 0.2.2→0.2.3 · mini-sqlite 0.5.19→0.5.20.

### Follow-up (not in this PR)
Comma joins (`FROM a, b`), `USING (cols)`, and `NATURAL JOIN` remain — those
need new planner logic (computing join/common columns), not a grammar tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
