### PR TITLE
feat(sir-to-rust): Array slice_when — Rust mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.33.0 — Array `slice_when`
+
+Mirrors the Python reference (PR #8070) and the Go backend (PR #8073) into the
+Rust backend's inline `__sir` runtime (`array_method` gains the arm; the
+array-method `responds_to` set gains `slice_when`), continuing the `slice_when`
+cross-backend cascade.
+
+- `slice_when { |prev, cur| pred }` is the INVERSE of `chunk_while`: it splits
+  into runs of consecutive elements, starting a NEW run BETWEEN an adjacent pair
+  exactly WHERE the block is truthy (whereas `chunk_while` starts a new run where
+  the block is FALSY).
+  `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`;
+  an empty array yields `[]`, a single element `[[x]]`.
+- Entries are snapshotted into an owned `Vec` before iterating so a block that
+  reentrantly mutates the receiver cannot double-borrow-panic (never-panic
+  floor), and the closure gets `cur.clone()` so the element can still be pushed.
+- `tests/compile_and_run_array_aggregates.rs::array_slice_when_compile_and_run`
+  emits a program with a `b - a > 1` predicate, compiles it with `rustc`, runs
+  it, and asserts the printed runs.
+
 ## 0.32.0 — Array `each_slice` / `each_cons` / `chunk_while`
 
 Mirrors the Python reference (PR #8031) and the Go backend (PR #8036) into the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -142,7 +142,7 @@ rather than panicking:
   - **Array** (`Seq`): `length`/`size`, `first`, `last`, `push`/`append`,
     `pop`, `include?`, `reverse`, `sort`, `join`, `map`, `select`/`filter`,
     `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`,
-    `each_slice`/`each_cons`, `chunk_while`.
+    `each_slice`/`each_cons`, `chunk_while`/`slice_when`.
   - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,
     `fetch`, `to_a`, `merge`, `dig` (nested), `invert`, `store`/`[]=`, `delete`,
     `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1471,7 +1471,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                     | "zip" | "rotate" | "to_h" | "tally"
                     | "take" | "drop" | "values_at"
                     // consecutive-grouping family
-                    | "each_slice" | "each_cons" | "chunk_while"
+                    | "each_slice" | "each_cons" | "chunk_while" | "slice_when"
             ),
             Value::Map(_) => matches!(
                 name,
@@ -2229,6 +2229,34 @@ pub const RUNTIME: &str = r##"mod __sir {
                         }
                     }
                     seq_lit(chunks.into_iter().map(seq_lit).collect())
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `slice_when { |prev, cur| pred }` — the INVERSE of `chunk_while`:
+            // runs of consecutive elements, starting a NEW run BETWEEN an
+            // adjacent pair exactly WHERE the block is truthy (chunk_while starts
+            // a new run where the block is FALSY).
+            // `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` →
+            // `[[1,2],[4],[9,10,11,12]]`.  An empty array yields `[]`; a single
+            // element yields `[[x]]`.  Entries are snapshotted first so a block
+            // that reentrantly mutates the receiver cannot double-borrow-panic.
+            "slice_when" => match &block {
+                Some(b) => {
+                    let snapshot = items_rc.borrow().clone();
+                    if snapshot.is_empty() {
+                        return seq_lit(vec![]);
+                    }
+                    let mut slices: Vec<Vec<Value>> = vec![vec![snapshot[0].clone()]];
+                    for i in 1..snapshot.len() {
+                        let prev = snapshot[i - 1].clone();
+                        let cur = snapshot[i].clone();
+                        if truthy(&apply_closure(b, vec![prev, cur.clone()])) {
+                            slices.push(vec![cur]);
+                        } else {
+                            slices.last_mut().unwrap().push(cur);
+                        }
+                    }
+                    seq_lit(slices.into_iter().map(seq_lit).collect())
                 }
                 None => unknown_method(&recv, name),
             },

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -603,3 +603,88 @@ fn array_each_slice_each_cons_chunk_while_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+// ── Array slice_when ───────────────────────────────────────────────────────
+//
+// `slice_when { |a, b| pred }` is the INVERSE of `chunk_while`: it starts a NEW
+// run BETWEEN an adjacent pair exactly WHERE the block is truthy.  Mirrors the
+// Python reference (#8070) and the Go backend (#8073).
+fn slice_when_demo() -> Module {
+    // `{ |a, b| b - a > 1 }` — split on an upward gap greater than one.
+    let gap = block_fn("__b_gap", &["a", "b"], call(">", vec![call("-", vec![param("b"), param("a")]), ilit(1)]));
+    let main_stmts = vec![
+        // [1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 } → [[1, 2], [4], [9, 10, 11, 12]]
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(4), ilit(9), ilit(10), ilit(11), ilit(12)]),
+            "slice_when",
+            vec![block("__b_gap")],
+        )),
+        // [9].slice_when { … } → [[9]]  (single element)
+        print_stmt(method(seq(vec![ilit(9)]), "slice_when", vec![block("__b_gap")])),
+        // [].slice_when { … } → []
+        print_stmt(method(seq(vec![]), "slice_when", vec![block("__b_gap")])),
+    ];
+    demo_module(main_stmts, vec![gap])
+}
+
+#[test]
+fn array_slice_when_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&slice_when_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_arr_slicewhen_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_arr_slicewhen_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "[[1, 2], [4], [9, 10, 11, 12]]", // slice_when { b-a>1 }
+            "[[9]]",                          // single element
+            "[]",                             // [].slice_when → []
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
Mirrors the Python reference ([#8070](https://github.com/adhithyan15/coding-adventures/pull/8070)) and the Go backend ([#8073](https://github.com/adhithyan15/coding-adventures/pull/8073)) into the **Rust backend**'s inline `__sir` runtime (`array_method` arm + the array-method `responds_to` set), continuing the `slice_when` cross-backend cascade.

## What

`slice_when { |prev, cur| pred }` is the **inverse of `chunk_while`**: it splits into runs of consecutive elements, starting a **new run BETWEEN an adjacent pair exactly WHERE the block is truthy** (chunk_while starts a new run where the block is *falsy*).

- `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`
- empty → `[]`; single → `[[x]]`

Entries are snapshotted into an owned `Vec` before iterating (never-panic floor: a reentrantly-mutating block can't double-borrow-panic), and the closure gets `cur.clone()` so the element can still be pushed.

## Tests

`tests/compile_and_run_array_aggregates.rs::array_slice_when_compile_and_run` emits a program with a `b - a > 1` predicate, compiles it with `rustc`, runs it, and asserts the printed runs. Passes locally.

Version 0.32.0 → 0.33.0. Security review passed (explicit-match dispatch, no reflection; borrow-safe snapshot; `last_mut().unwrap()` provably Some). JS/TS mirrors follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)