### PR TITLE
feat(sir-to-javascript): Array slice_when — JS mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.32.0 — Array `slice_when`
+
+Mirrors the Python reference (PR #8070), Go (PR #8073), and Rust (PR #8077) into
+the JS backend's inline `arrayMethod` (+ the `ARRAY_METHODS` `respond_to?` set),
+continuing the `slice_when` cross-backend cascade.
+
+- `slice_when { |prev, cur| pred }` is the INVERSE of `chunk_while`: it splits
+  into runs of consecutive elements, starting a NEW run BETWEEN an adjacent pair
+  exactly WHERE the block is truthy (whereas `chunk_while` starts a new run where
+  the block is FALSY).
+  `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`;
+  an empty array yields `[]`, a single element `[[x]]`.
+- `tests/run_with_node.rs::array_slice_when` emits a program with a `b - a > 1`
+  predicate, runs it through `node`, and asserts the printed runs.
+
 ## 0.31.0 — Array `tally`
 
 Mirrors the Python reference (PR #8054) into the JS backend's inline

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -1298,7 +1298,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "take", "drop", "values_at",
     "flatten", "compact", "rotate", "zip",
     "include?", "index",
-    "each_slice", "each_cons", "chunk_while", "tally",
+    "each_slice", "each_cons", "chunk_while", "slice_when", "tally",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
@@ -1585,6 +1585,22 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
           else { chunks.push([recv[i]]); }
         }
         return chunks;
+      }
+      case "slice_when": {
+        // `slice_when { |prev, cur| pred }` — the INVERSE of `chunk_while`: runs
+        // of consecutive elements, starting a NEW run BETWEEN an adjacent pair
+        // exactly WHERE the block is truthy (chunk_while starts a new run where
+        // the block is FALSY).
+        // `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → [[1,2],[4],[9,10,11,12]].
+        // An empty array yields []; a single element yields [[x]].
+        if (typeof blk !== "function") { return ARR_MISS; }
+        if (recv.length === 0) { return []; }
+        const slices = [[recv[0]]];
+        for (let i = 1; i < recv.length; i++) {
+          if (truthy(blk(recv[i - 1], recv[i]))) { slices.push([recv[i]]); }
+          else { slices[slices.length - 1].push(recv[i]); }
+        }
+        return slices;
       }
       case "tally": {
         // `tally` — a Hash counting how many times each element occurs, keyed

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -3083,6 +3083,68 @@ fn array_each_slice_each_cons_chunk_while() {
     }
 }
 
+// ── Ruby Array#slice_when ──────────────────────────────────────────────────
+// `slice_when { |a, b| pred }` is the INVERSE of `chunk_while`: it starts a NEW
+// run BETWEEN an adjacent pair exactly WHERE the block is truthy.  Mirrors the
+// Python reference (#8070), Go (#8073), Rust (#8077).
+#[test]
+fn array_slice_when() {
+    // `{ |a, b| b - a > 1 }` — split on an upward gap greater than one.
+    let gap = func(
+        "__t_gap",
+        vec![param("a"), param("b")],
+        vec![],
+        bc(">", vec![bc("-", vec![param_ref("b"), param_ref("a")]), int(1)]),
+    );
+    let stmts = vec![
+        // [1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 } → [[1, 2], [4], [9, 10, 11, 12]]
+        print(method(
+            seq(vec![int(1), int(2), int(4), int(9), int(10), int(11), int(12)]),
+            "slice_when",
+            vec![method_closure("__t_gap")],
+        )),
+        // [9].slice_when { … } → [[9]]  (single element)
+        print(method(seq(vec![int(9)]), "slice_when", vec![method_closure("__t_gap")])),
+        // [].slice_when { … } → []
+        print(method(seq(vec![]), "slice_when", vec![method_closure("__t_gap")])),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let module = Module {
+        name: "arrslicewhen".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main, gap],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "arrslicewhen") {
+        assert_eq!(
+            stdout,
+            "[[1, 2], [4], [9, 10, 11, 12]]\n\
+             [[9]]\n\
+             []"
+        );
+    }
+}
+
 // ── Ruby Array#tally ───────────────────────────────────────────────────────
 // `tally` counts occurrences into a Hash keyed in first-seen order — the JS
 // runtime realises it as an insertion-ordered `Map`, printed `{k: v}` (the same


### PR DESCRIPTION
Mirrors the Python reference ([#8070](https://github.com/adhithyan15/coding-adventures/pull/8070)), Go ([#8073](https://github.com/adhithyan15/coding-adventures/pull/8073)), and Rust ([#8077](https://github.com/adhithyan15/coding-adventures/pull/8077)) into the **JS backend**'s inline `arrayMethod` (+ the `ARRAY_METHODS` `respond_to?` set), continuing the `slice_when` cross-backend cascade. Only the TS mirror remains after this.

## What

`slice_when { |prev, cur| pred }` is the **inverse of `chunk_while`**: it splits into runs of consecutive elements, starting a **new run BETWEEN an adjacent pair exactly WHERE the block is truthy** (chunk_while starts a new run where the block is *falsy*).

- `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`
- empty → `[]`; single → `[[x]]`

## Tests

`tests/run_with_node.rs::array_slice_when` emits a program with a `b - a > 1` predicate, runs it through `node`, and asserts the printed runs. Passes locally.

Version 0.31.0 → 0.32.0. Security review passed (static runtime string, explicit-switch dispatch, plain arrays — no prototype pollution, O(n)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)