### PR TITLE
feat(sql-parser): LIMIT off, count MySQL shorthand

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.21 — `LIMIT off, count` MySQL shorthand
+
+`SELECT … LIMIT 1, 2` now parses and runs, returning the same rows as
+`LIMIT 2 OFFSET 1` — SQLite accepts this MySQL-compatibility spelling. The
+catch is the flipped argument order: in the comma form the FIRST number is the
+offset and the SECOND is the count. Grammar accepts `, NUMBER` as a `LIMIT`
+tail (sql-parser 0.1.5); the planner detects the comma and swaps
+offset/count (sql-planner 0.2.4). Codegen and the VM already consume the
+`Limit { count, offset }` plan unchanged, so no lower-layer work was needed.
+Two new differential-oracle cases (`limit_comma_offset_count`,
+`limit_comma_matches_offset`) diff the row window against real bundled SQLite.
+
 ## 0.5.20 — Table alias without the `AS` keyword
 
 `FROM users u` now aliases the table exactly like `FROM users AS u` — SQLite

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.20"
+version = "0.5.21"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -767,6 +767,28 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT x.v, y.w FROM a x JOIN b y ON x.id = y.id ORDER BY x.v",
     },
+    // MySQL-compatible `LIMIT off, count` shorthand: `LIMIT 1, 2` skips 1 row
+    // then returns 2, identical to `LIMIT 2 OFFSET 1`. The FIRST number is the
+    // offset and the SECOND is the count — the reverse of the OFFSET form —
+    // which the planner swaps. ORDER BY makes the row window deterministic.
+    Case {
+        id: "limit_comma_offset_count",
+        setup: &[
+            "CREATE TABLE t (n INTEGER)",
+            "INSERT INTO t VALUES (1), (2), (3), (4), (5)",
+        ],
+        query: "SELECT n FROM t ORDER BY n LIMIT 1, 2",
+    },
+    // The comma form and the equivalent `LIMIT count OFFSET off` form must
+    // return the identical window — here both mean "skip 2, take 3".
+    Case {
+        id: "limit_comma_matches_offset",
+        setup: &[
+            "CREATE TABLE t (n INTEGER)",
+            "INSERT INTO t VALUES (10), (20), (30), (40), (50), (60)",
+        ],
+        query: "SELECT n FROM t ORDER BY n LIMIT 2, 3",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - Unreleased
+
+### Added
+
+- **`LIMIT off, count` MySQL shorthand.** The `limit_clause` tail now accepts
+  `, NUMBER` as an alternative to `OFFSET NUMBER`, so `LIMIT 1, 2` parses.
+  SQLite accepts this MySQL-compatibility spelling. Note the argument order
+  flips: in the comma form the FIRST number is the offset and the SECOND is
+  the count (`LIMIT 1, 2` == `LIMIT 2 OFFSET 1`) — the sql-planner 0.2.4 change
+  does the swap.
+
 ## [0.1.4] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -213,9 +213,21 @@ pub fn parser_grammar() -> ParserGrammar {
                 // Allow optional "-" before NUMBER to support LIMIT -1 (all rows).
                 GrammarElement::Optional { element: Box::new(GrammarElement::Literal { value: r#"-"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
-                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
-                        GrammarElement::Literal { value: r#"OFFSET"#.to_string() },
-                        GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                // The tail is either the standard `OFFSET n` or MySQL's
+                // `, n` shorthand. NOTE the argument order flips between them:
+                // `LIMIT count OFFSET off` vs `LIMIT off , count` — in the comma
+                // form the FIRST number is the OFFSET and the SECOND is the
+                // count (plan_limit does the swap). This matches SQLite, which
+                // accepts the comma form purely for MySQL compatibility.
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"OFFSET"#.to_string() },
+                            GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#","#.to_string() },
+                            GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                        ] },
                     ] }) },
             ] },
             line_number: 37,

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -279,6 +279,14 @@ mod tests {
         assert!(find_rule(&ast, "limit_clause"), "Expected limit_clause");
     }
 
+    /// MySQL comma shorthand `LIMIT off, count` parses (SQLite accepts it too).
+    /// The planner does the offset/count swap; here we only assert it parses.
+    #[test]
+    fn test_parse_limit_comma() {
+        let ast = assert_program_root("SELECT id FROM users LIMIT 5, 10");
+        assert!(find_rule(&ast, "limit_clause"), "Expected limit_clause");
+    }
+
     // -----------------------------------------------------------------------
     // Test 6: SELECT with GROUP BY and HAVING
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.4] - Unreleased
+
+### Added
+
+- **`LIMIT off, count` planning (MySQL shorthand).** `plan_limit` now detects
+  the comma form (sql-parser 0.1.5) and swaps the operands: in `LIMIT o, c`
+  the first number is the offset and the second is the count, the reverse of
+  `LIMIT c OFFSET o`. Both spellings now produce the identical `Limit { count,
+  offset }` plan, so `LIMIT 1, 2` and `LIMIT 2 OFFSET 1` return the same rows.
+  The rewrite collects the numeric operands positionally and maps them onto
+  `(count, offset)` per the detected form; the `LIMIT -1` "no limit" sign
+  handling for the `OFFSET` form is preserved.
+
 ## [0.2.3] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -934,42 +934,67 @@ fn plan_order_item(item: &GrammarASTNode) -> Result<SortKey, PlanError> {
 
 /// Parse the `limit_clause` and return `(count, offset)`.
 ///
-/// Grammar: `limit_clause = LIMIT [ "-" ] NUMBER [ OFFSET NUMBER ]`
+/// Grammar: `limit_clause = LIMIT [ "-" ] NUMBER [ OFFSET NUMBER | "," NUMBER ]`
 ///
-/// SQLite semantics: `LIMIT -1` means "no limit" (return all rows).
+/// Two tail forms, with the arguments in the OPPOSITE order:
+///
+/// | Written              | count | offset |
+/// |----------------------|-------|--------|
+/// | `LIMIT c`             | `c`   | —      |
+/// | `LIMIT c OFFSET o`    | `c`   | `o`    |
+/// | `LIMIT o , c`         | `c`   | `o`    |  ← MySQL shorthand, arguments swapped
+///
+/// So `LIMIT 1, 2` returns 2 rows starting after the first — identical to
+/// `LIMIT 2 OFFSET 1`. The comma form is a MySQL-compatibility spelling that
+/// SQLite also accepts; the only wrinkle is that the FIRST number is the
+/// offset, not the count. We detect the comma token and swap accordingly.
+///
+/// SQLite semantics: `LIMIT -1` means "no limit" (return all rows). The `-`
+/// sign only applies to the LIMIT count in the `OFFSET` form (`LIMIT -1
+/// OFFSET n`); the comma form takes two plain non-negative numbers.
 fn plan_limit(limit_clause: &GrammarASTNode) -> Result<(Option<i64>, Option<i64>), PlanError> {
-    // Walk the children in order, tracking whether we just saw a MINUS token
-    // (which only applies to the LIMIT count, not the OFFSET value).
-    let children = &limit_clause.children;
-    let mut past_limit_kw = false;
-    let mut pending_minus = false; // sign for the next NUMBER (only for count)
-    let mut count: Option<i64> = None;
-    let mut offset: Option<i64> = None;
+    // A comma anywhere in the clause selects the MySQL `LIMIT off, count` form.
+    let comma_form = limit_clause
+        .children
+        .iter()
+        .any(|c| matches!(c, ASTNodeOrToken::Token(t) if t.value == ","));
 
-    for child in children {
-        match child {
-            ASTNodeOrToken::Token(tok) => match tok.value.as_str() {
-                "LIMIT" => { past_limit_kw = true; }
-                "OFFSET" => { /* next NUMBER is the offset */ }
-                "-" if past_limit_kw && count.is_none() => {
-                    // Unary minus before the LIMIT count (e.g. LIMIT -1).
-                    pending_minus = true;
-                }
+    // Collect the numeric operands in written order, carrying the optional
+    // leading `-` (only meaningful before the first number, i.e. the count in
+    // the OFFSET form). Keywords (LIMIT/OFFSET) and the comma are structural.
+    let mut nums: Vec<i64> = Vec::new();
+    let mut pending_minus = false;
+    for child in &limit_clause.children {
+        if let ASTNodeOrToken::Token(tok) = child {
+            match tok.value.as_str() {
+                "LIMIT" | "OFFSET" | "," => {}
+                "-" if nums.is_empty() => pending_minus = true,
                 _ => {
                     if let Ok(n) = tok.value.parse::<i64>() {
-                        if count.is_none() {
-                            let sign: i64 = if pending_minus { -1 } else { 1 };
-                            count = Some(n * sign);
-                            pending_minus = false;
-                        } else {
-                            offset = Some(n);
-                        }
+                        let sign = if pending_minus && nums.is_empty() { -1 } else { 1 };
+                        // `saturating_mul` rather than `*`: the current grammar
+                        // never feeds an `i64::MIN`-valued token together with a
+                        // leading `-`, so this can't overflow today — but this
+                        // keeps it panic-free even if a future lexer change let
+                        // NUMBER carry a sign.
+                        nums.push(n.saturating_mul(sign));
+                        pending_minus = false;
                     }
                 }
-            },
-            ASTNodeOrToken::Node(_) => {}
+            }
         }
     }
+
+    // Map the operands onto (count, offset) per the form.
+    let (count, offset) = match (comma_form, nums.as_slice()) {
+        // `LIMIT off, count` — first is offset, second is count.
+        (true, [off, cnt]) => (Some(*cnt), Some(*off)),
+        (true, [off]) => (None, Some(*off)), // degenerate `LIMIT n,` — treat n as offset
+        // `LIMIT count [OFFSET off]`.
+        (false, [cnt, off]) => (Some(*cnt), Some(*off)),
+        (false, [cnt]) => (Some(*cnt), None),
+        _ => (None, None),
+    };
 
     Ok((count, offset))
 }
@@ -2633,6 +2658,24 @@ mod tests {
             if let LogicalPlan::Limit { count, offset, .. } = input.as_ref() {
                 assert_eq!(*count, Some(10));
                 assert_eq!(*offset, Some(5));
+            } else {
+                panic!("Expected Limit below Project, got: {input:?}");
+            }
+        } else {
+            panic!("Expected Project root");
+        }
+    }
+
+    /// MySQL shorthand `LIMIT off, count` swaps the arguments: `LIMIT 5, 10`
+    /// means `LIMIT 10 OFFSET 5` (offset 5, count 10) — the reverse of the
+    /// `OFFSET` form. Both spellings must yield the SAME Limit plan.
+    #[test]
+    fn test_select_limit_comma_form() {
+        let plan = plan_ok("SELECT * FROM t ORDER BY name LIMIT 5, 10");
+        if let LogicalPlan::Project { input, .. } = &plan {
+            if let LogicalPlan::Limit { count, offset, .. } = input.as_ref() {
+                assert_eq!(*count, Some(10), "comma form: second number is the count");
+                assert_eq!(*offset, Some(5), "comma form: first number is the offset");
             } else {
                 panic!("Expected Limit below Project, got: {input:?}");
             }


### PR DESCRIPTION
## `LIMIT off, count` MySQL shorthand

SQLite accepts MySQL's `LIMIT off, count` shorthand alongside
`LIMIT count OFFSET off`, so `LIMIT 1, 2` returns 2 rows after skipping 1 —
identical to `LIMIT 2 OFFSET 1`. The generated grammar only accepted
`OFFSET n`. The planner already reads count/offset from the `Limit` plan and
codegen/VM consume it unchanged, so this is a **grammar + `plan_limit` change
with no lower-layer work**.

The wrinkle: the argument order **flips**. In the comma form the FIRST number
is the offset and the SECOND is the count — the reverse of the `OFFSET` form.

### What changed
- **sql-parser** (`_grammar.rs`): `limit_clause`'s tail becomes an alternation
  `[ OFFSET NUMBER | "," NUMBER ]`.
- **sql-planner** (`plan_limit`): detects the comma token, collects the numeric
  operands positionally, and maps them onto `(count, offset)` per form — the
  comma form swaps them. `LIMIT -1` "no limit" sign handling for the `OFFSET`
  form is preserved. Uses `saturating_mul` for the sign so it stays panic-free
  even if a future lexer change let `NUMBER` carry a sign (defensive hardening
  from the security review).

### Tests (probe-confirmed against real SQLite, then test-first)
- **Differential oracle** (mini-sqlite): `limit_comma_offset_count`
  (`LIMIT 1, 2`) and `limit_comma_matches_offset` (`LIMIT 2, 3`), diffing the
  row window against real bundled SQLite.
- **sql-parser**: `test_parse_limit_comma`. **sql-planner**:
  `test_select_limit_comma_form` asserts the swap (count=10, offset=5 for
  `LIMIT 5, 10`).
- Full affected SQL pipeline green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — grammar alternative is
  DoS-safe (no zero-width match), `plan_limit` can't panic/overflow/OOB
  (`.parse()`-gated, slice-pattern guarded, `saturating_mul`), and huge/negative
  bounds are unchanged from pre-diff behavior.

### Versions
sql-parser 0.1.4→0.1.5 · sql-planner 0.2.3→0.2.4 · mini-sqlite 0.5.20→0.5.21.

### Context
6th mini-sqlite conformance increment. NULLS FIRST/LAST and COLLATE in
ORDER BY were evaluated and deferred — `SortKey` lacks those fields, so they'd
need codegen + a VM comparator change, not a grammar-level fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
