### PR TITLE
feat(javascript-ast): ImportDeclaration node + emitter + pass arms (CLOC12.188 PR1)

### DIFF
--- a/code/packages/rust/closure-emitter/CHANGELOG.md
+++ b/code/packages/rust/closure-emitter/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-emitter` crate will be documented in this file.
 
+## [0.44.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: emit `import` declarations
+
+`emit_import` renders `Declaration::ImportDeclaration` in minified form:
+side-effect `import"y";`, default `import x from"y";`, namespace
+`import*as ns from"y";` (the `*` punctuator abuts `import` with no space), named
+`import{a,b as c}from"y";`, and the default-plus-named combination
+`import x,{a}from"y";`. Five emit tests cover each shape.
+
 ## [0.43.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: emit `with (obj) stmt`

--- a/code/packages/rust/closure-emitter/Cargo.toml
+++ b/code/packages/rust/closure-emitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-emitter"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 description = "JavaScript code emitter for the Closure Compiler clone. Per CLOC07's emit contract. Takes a finalized Program + sidecar and produces output JavaScript text + companion source map. Runs after every pass in the pipeline."
 

--- a/code/packages/rust/closure-emitter/src/lib.rs
+++ b/code/packages/rust/closure-emitter/src/lib.rs
@@ -74,7 +74,8 @@ use coding_adventures_javascript_ast::{
     EmptyStatement, Expression, ExpressionStatement, ForInStatement, ForInit, ForOfStatement,
     ForStatement,
     ClassDeclaration, FunctionDeclaration, FunctionExpression,
-    FunctionParam, Identifier, IfStatement, LabeledStatement, LogicalExpression, LogicalOperator,
+    FunctionParam, Identifier, IfStatement, ImportDeclaration, ImportSpecifier, LabeledStatement,
+    LogicalExpression, LogicalOperator,
     MemberExpression, NewExpression, NullLiteral, NumericLiteral, ObjectExpression, Program, ProgramItem, SequenceExpression,
     ObjectMember, Property, PropertyKey, PropertyKind, ReturnStatement, Statement, StringLiteral,
     SwitchCase, SwitchStatement, ThrowStatement, TryStatement, UnaryExpression, UnaryOperator, UpdateExpression, UpdateOperator,
@@ -799,7 +800,104 @@ impl<'a> Emitter<'a> {
             }
             Declaration::FunctionDeclaration(f) => self.emit_function_declaration(f),
             Declaration::ClassDeclaration(c) => self.emit_class_declaration(c),
+            Declaration::ImportDeclaration(i) => self.emit_import(i),
         }
+    }
+
+    /// Emit an ES-module import declaration (CLOC12.188).
+    ///
+    /// Minified forms (no optional whitespace; the only spaces are the ones
+    /// the tokenizer *requires* between two identifier-like tokens):
+    ///
+    /// | source                          | emitted                 |
+    /// |---------------------------------|-------------------------|
+    /// | `import "y";`                   | `import"y";`            |
+    /// | `import x from "y";`            | `import x from"y";`    |
+    /// | `import * as ns from "y";`      | `import*as ns from"y";`|
+    /// | `import {a, b as c} from "y";`  | `import{a,b as c}from"y";`|
+    /// | `import x, {a} from "y";`       | `import x,{a}from"y";` |
+    ///
+    /// A bare keyword abuts punctuation with no space (`import{`, `}from`,
+    /// `import"`); an identifier next to a keyword/identifier needs one
+    /// (`x from`, `as ns`).
+    fn emit_import(&mut self, imp: &ImportDeclaration) {
+        self.maybe_map(&imp.cv);
+        self.write_str("import");
+
+        // Partition specifiers by kind. ESTree order is
+        // `[ default?, (namespace | named)? ]`; we honour it and, when the AST
+        // holds an unusual mix, emit default → namespace → named so commas land
+        // in a valid place.
+        let mut default_id: Option<&Identifier> = None;
+        let mut namespace_id: Option<&Identifier> = None;
+        let mut named: Vec<(&Identifier, &Identifier)> = Vec::new();
+        for s in &imp.specifiers {
+            match s {
+                ImportSpecifier::Default(id) => default_id = Some(id),
+                ImportSpecifier::Namespace(id) => namespace_id = Some(id),
+                ImportSpecifier::Named { imported, local } => named.push((imported, local)),
+            }
+        }
+
+        // `wrote` tracks whether an earlier clause element was emitted (so the
+        // next one needs a `,` separator). `ends_with_brace` records whether the
+        // clause ended with a named group's `}` — which abuts `from` with no
+        // space, unlike a trailing identifier.
+        let has_clause = default_id.is_some() || namespace_id.is_some() || !named.is_empty();
+        let mut wrote = false;
+        let mut ends_with_brace = false;
+
+        if let Some(id) = default_id {
+            self.required_ws();
+            self.emit_identifier(id);
+            wrote = true;
+        }
+        if let Some(id) = namespace_id {
+            // `*` is a punctuator, so it abuts `import` with no space
+            // (`import*as ns`). Only a preceding default clause needs a `,`.
+            if wrote {
+                self.write_str(",");
+            }
+            self.write_str("*as");
+            self.required_ws();
+            self.emit_identifier(id);
+            wrote = true;
+        }
+        if !named.is_empty() {
+            if wrote {
+                self.write_str(",");
+            }
+            self.write_str("{");
+            for (i, (imported, local)) in named.iter().enumerate() {
+                if i > 0 {
+                    self.write_str(",");
+                }
+                self.emit_identifier(imported);
+                // `{a}` when imported == local; `{a as c}` when they differ.
+                if imported.name != local.name {
+                    self.required_ws();
+                    self.write_str("as");
+                    self.required_ws();
+                    self.emit_identifier(local);
+                }
+            }
+            self.write_str("}");
+            ends_with_brace = true;
+        }
+
+        // The `from` clause is present iff there was an import clause. A
+        // side-effect import (`import "y"`) has no clause and jumps straight to
+        // the source string.
+        if has_clause {
+            if !ends_with_brace {
+                // Previous token was an identifier (`x` / `ns`) — separate it
+                // from `from`.
+                self.required_ws();
+            }
+            self.write_str("from");
+        }
+        self.emit_string(&imp.source);
+        self.write_str(";");
     }
 
     fn emit_variable_declaration(&mut self, v: &VariableDeclaration, with_semi: bool) {
@@ -6329,5 +6427,93 @@ mod tests {
     fn import_expression_as_member_object_is_bare() {
         let e = call(member(import_expr(ident("x")), "then", false), vec![ident("f")]);
         assert_eq!(emit_expr(e), "import(x).then(f);");
+    }
+
+    // ---- ES-module import declarations (CLOC12.188) -----------
+    //
+    // Minified forms: the only spaces are the tokenizer-required ones between
+    // two identifier-like tokens (`x from`, `as ns`). Keyword↔punctuation
+    // abuts (`import{`, `}from`, `import"`).
+
+    fn id_(name: &str) -> Identifier {
+        Identifier {
+            cv: None,
+            name: name.to_string(),
+        }
+    }
+
+    fn src_(v: &str) -> StringLiteral {
+        StringLiteral {
+            cv: None,
+            value: v.to_string(),
+            raw: format!("\"{v}\""),
+        }
+    }
+
+    fn emit_import_decl(specifiers: Vec<ImportSpecifier>, source: &str) -> String {
+        let item = ProgramItem::Declaration(Declaration::import_declaration(ImportDeclaration {
+            cv: None,
+            specifiers,
+            source: src_(source),
+        }));
+        emit_default(program().with_body(vec![item])).code
+    }
+
+    #[test]
+    fn import_side_effect() {
+        assert_eq!(emit_import_decl(vec![], "y"), "import\"y\";");
+    }
+
+    #[test]
+    fn import_default() {
+        assert_eq!(
+            emit_import_decl(vec![ImportSpecifier::Default(id_("x"))], "y"),
+            "import x from\"y\";"
+        );
+    }
+
+    #[test]
+    fn import_namespace() {
+        assert_eq!(
+            emit_import_decl(vec![ImportSpecifier::Namespace(id_("ns"))], "y"),
+            "import*as ns from\"y\";"
+        );
+    }
+
+    #[test]
+    fn import_named_plain_and_aliased() {
+        assert_eq!(
+            emit_import_decl(
+                vec![
+                    ImportSpecifier::Named {
+                        imported: id_("a"),
+                        local: id_("a"),
+                    },
+                    ImportSpecifier::Named {
+                        imported: id_("b"),
+                        local: id_("c"),
+                    },
+                ],
+                "y"
+            ),
+            "import{a,b as c}from\"y\";"
+        );
+    }
+
+    #[test]
+    fn import_default_plus_named() {
+        assert_eq!(
+            emit_import_decl(
+                vec![
+                    ImportSpecifier::Default(id_("x")),
+                    ImportSpecifier::Named {
+                        imported: id_("a"),
+                        local: id_("a"),
+                    },
+                ],
+                "y"
+            ),
+            "import x,{a}from\"y\";"
+        );
     }
 }

--- a/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-constant-fold/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-constant-fold` crate will be documented in this file.
 
+## [0.87.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` rebuild arm
+
+Exhaustive-match arm for the new `Declaration::ImportDeclaration` variant — an
+import binds foreign-linked names and has no foldable body, so the rebuild clones
+it unchanged.
+
 ## [0.86.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: fold through `WithStatement`

--- a/code/packages/rust/closure-pass-constant-fold/Cargo.toml
+++ b/code/packages/rust/closure-pass-constant-fold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-constant-fold"
-version = "0.86.0"
+version = "0.87.0"
 edition = "2021"
 description = "Constant-folding optimization pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Folds compile-time-evaluable expressions like `2 + 3 → 5`."
 

--- a/code/packages/rust/closure-pass-constant-fold/src/lib.rs
+++ b/code/packages/rust/closure-pass-constant-fold/src/lib.rs
@@ -478,6 +478,9 @@ fn fold_declaration(decl: &Declaration, st: &mut FoldState) -> Declaration {
         // type and the required `id` differ. Both route through the shared
         // `fold_class_body` helper.
         Declaration::ClassDeclaration(c) => fold_class_declaration(c, st),
+        // An import declaration has no foldable body — its only payload is the
+        // bound names and the module specifier string. Preserve it verbatim.
+        Declaration::ImportDeclaration(i) => Declaration::ImportDeclaration(i.clone()),
     }
 }
 

--- a/code/packages/rust/closure-pass-dce/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-dce/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-dce` crate will be documented in this file.
 
+## [0.22.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arms
+
+Exhaustive-match arms for the new `Declaration::ImportDeclaration` variant: the
+rebuild clones the import unchanged, and the "is this statement removable"
+predicate treats an import as a live, side-effecting binding (never dead).
+
 ## [0.21.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-dce/Cargo.toml
+++ b/code/packages/rust/closure-pass-dce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-dce"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Dead-code elimination pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Drops code after definite-terminator statements and removes EmptyStatement noise."
 

--- a/code/packages/rust/closure-pass-dce/src/lib.rs
+++ b/code/packages/rust/closure-pass-dce/src/lib.rs
@@ -873,6 +873,9 @@ fn tail_is_safe_to_truncate(stmts: &[Statement]) -> bool {
         // function declaration (conservative: preserving it is never a
         // miscompile, and a genuinely-unused one is removed downstream).
         Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
+        // An import declaration is module-top-level only; it never legally
+        // appears inside a block, so flattening/truncating it away is unsafe.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => false,
     })
 }
 
@@ -1029,6 +1032,9 @@ fn block_is_scope_safe_to_flatten(b: &BlockStatement) -> bool {
         // it out of an inner block would leak the binding, so it is never safe
         // to flatten, exactly like a nested function declaration.
         Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
+        // An import declaration is module-top-level only; it never legally
+        // appears inside a block, so flattening/truncating it away is unsafe.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => false,
         // Tagged statements never introduce a new lexical binding
         // by themselves. `ExpressionStatement`, control flow,
         // `EmptyStatement`, etc. are all safe.
@@ -1148,6 +1154,7 @@ fn dce_declaration(decl: &Declaration, st: &mut DceState) -> Declaration {
         // A class *declaration* runs DCE inside its heritage operand and each
         // method body, exactly as `dce_class` does for a class *expression* —
         // only the outer node type and the required `id` differ.
+        Declaration::ImportDeclaration(i) => Declaration::ImportDeclaration(i.clone()),
         Declaration::ClassDeclaration(c) => {
             Declaration::ClassDeclaration(dce_class_declaration(c, st))
         }

--- a/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-fold-control-flow/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-fold-control-flow` crate will be documented in this file.
 
+## [0.22.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arms
+
+Exhaustive-match arms for the new `Declaration::ImportDeclaration` variant: the
+control-flow predicate reports an import has no foldable control flow, and the
+rebuild clones it unchanged.
+
 ## [0.21.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
+++ b/code/packages/rust/closure-pass-fold-control-flow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-fold-control-flow"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Control-flow folding pass for the Closure Compiler clone. Slots between constant-fold and DCE per CLOC06's canonical pass set. Eliminates dead branches (`if (false) A else B → B`), removes unreachable code after `return`/`throw`, and collapses degenerate switch arms."
 

--- a/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
+++ b/code/packages/rust/closure-pass-fold-control-flow/src/lib.rs
@@ -655,6 +655,9 @@ fn block_is_scope_safe_to_hoist(b: &BlockStatement) -> bool {
         // `else` block would leak or collide its binding — unsafe, like a
         // nested function declaration.
         Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
+        // An import declaration is module-top-level only; never legally inside
+        // the block being hoisted, so treat it as unsafe to hoist.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => false,
         // Tagged statements introduce no lexical binding of their own.
         Statement::Tagged(_) => true,
     })
@@ -1086,6 +1089,8 @@ fn fold_declaration(decl: &Declaration, st: &mut FoldState) -> Declaration {
         // `fold_class` for the expression form. Unlike a function declaration
         // it hoists no `var`s of its own — a class body is not a `var` scope in
         // the hoisting sense — so no `hoist_function_body_vars` step applies.
+        // An import has no foldable control flow — preserve it verbatim.
+        Declaration::ImportDeclaration(i) => Declaration::ImportDeclaration(i.clone()),
         Declaration::ClassDeclaration(c) => {
             let (super_class, body) = fold_class_body(&c.super_class, &c.body, st);
             Declaration::ClassDeclaration(ClassDeclaration {

--- a/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline-variables/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline-variables` crate will be documented in this file.
 
+## [0.13.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arms
+
+Exhaustive-match arms for the new `Declaration::ImportDeclaration` variant: the
+inertness predicate reports an import is not inert (it has runtime effect), and
+the count/propagate walks skip it as a no-op.
+
 ## [0.12.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-inline-variables/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline-variables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline-variables"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Constant-propagation pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces references to a top-level `const` bound to a literal with the literal itself, so the binding becomes unused and remove-unused-vars deletes it."
 

--- a/code/packages/rust/closure-pass-inline-variables/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline-variables/src/lib.rs
@@ -385,6 +385,9 @@ fn decl_is_inert(decl: &Declaration) -> bool {
         // declaration site — unlike a function declaration, which only hoists.
         // Conservatively (and correctly) treat it as running code.
         Declaration::ClassDeclaration(_) => false,
+        // An import declaration runs the target module for its side effects, so
+        // it is NOT inert — it can observe/mutate state before a later `const`.
+        Declaration::ImportDeclaration(_) => false,
         Declaration::VariableDeclaration(vd) => vd.declarations.iter().all(|d| match &d.init {
             None => true,
             Some(init) => is_literal(init),
@@ -468,6 +471,9 @@ fn count_decl_names_decl(
         // declare their own locals — count both, mirroring the function
         // declaration arm (name + body-declared names). Counting more names is
         // conservative: it only ever prevents an unsafe inline, never causes one.
+        // An import declaration binds names but holds no expressions to
+        // count/propagate through — nothing to do.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             *out.entry(cd.id.name.clone()).or_insert(0) += 1;
             for member in &cd.body {
@@ -634,6 +640,9 @@ fn count_uses_decl(decl: &Declaration, name: &str, count: &mut usize) {
         // count every such use — missing one would let the pass inline/remove
         // `name` while the class still references it (a miscompile). Mirrors the
         // `Expression::ClassExpression` arm of `count_uses_expr`.
+        // An import declaration binds names but holds no expressions to
+        // count/propagate through — nothing to do.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             if let Some(sup) = &cd.super_class {
                 count_uses_expr(sup, name, count);
@@ -1022,6 +1031,9 @@ fn propagate_in_decl(decl: &mut Declaration, cand: &ConstCandidate) -> bool {
         // inspects — the `extends` operand and each method body — so the count
         // and the rewrite stay in lockstep. Mirrors the
         // `Expression::ClassExpression` arm of `propagate_in_expr`.
+        // An import declaration binds names but holds no expressions to
+        // count/propagate through — nothing to do.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             if let Some(sup) = &mut cd.super_class {
                 changed |= propagate_in_expr(sup, cand);

--- a/code/packages/rust/closure-pass-inline/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-inline/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-inline` crate will be documented in this file.
 
+## [0.27.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arms
+
+Exhaustive-match arms for the new `Declaration::ImportDeclaration` variant across
+the walk and splice paths: an import has no inlinable body, so the walk arms are
+no-ops and the void/valued-call splice predicates report nothing spliced.
+
 ## [0.26.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: traverse `WithStatement`

--- a/code/packages/rust/closure-pass-inline/Cargo.toml
+++ b/code/packages/rust/closure-pass-inline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-inline"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 description = "Function-inlining pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Substitutes small or single-use function bodies at their call sites to enable downstream folding and shrink call overhead."
 

--- a/code/packages/rust/closure-pass-inline/src/lib.rs
+++ b/code/packages/rust/closure-pass-inline/src/lib.rs
@@ -681,6 +681,9 @@ fn count_decl_names_decl(
         // A class declaration binds its name, and each method's params + locals
         // are declared names — count all, mirroring the function arm. Counting
         // method params keeps inline-collision detection conservative.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             *out.entry(cd.id.name.clone()).or_insert(0) += 1;
             for member in &cd.body {
@@ -1074,6 +1077,9 @@ fn tally_decl(decl: &Declaration, cand: &InlineCandidate, t: &mut Tally) {
         // and method bodies — missing one would let the pass inline a callee
         // that is still called from inside the class (a miscompile). Mirrors the
         // `Expression::ClassExpression` arm of `tally_expr`.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             if let Some(sup) = &cd.super_class {
                 tally_expr(sup, cand, t);
@@ -1495,6 +1501,9 @@ fn inline_in_decl(decl: &mut Declaration, cand: &InlineCandidate) -> bool {
         // Perform the inline substitution inside a class declaration's heritage
         // operand and method bodies, kept in lockstep with `tally_decl` above.
         // Mirrors the `Expression::ClassExpression` arm of `inline_in_expr`.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             if let Some(sup) = &mut cd.super_class {
                 changed |= inline_in_expr(sup, cand);
@@ -2308,6 +2317,9 @@ fn collect_top_level_decl_names(program: &Program) -> HashSet<String> {
         }
         // A top-level `class C {}` binds `C` in the program scope, exactly like
         // a top-level function name.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             out.insert(cd.id.name.clone());
         }
@@ -3054,6 +3066,9 @@ fn splice_void_in_decl(
         }
         // Each class method body is a `Vec<Statement>` a void call may live in
         // — splice into every method, mirroring the function-body arm.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => false,
         Declaration::ClassDeclaration(cd) => {
             let mut changed = false;
             for member in &mut cd.body {
@@ -3910,6 +3925,9 @@ fn splice_valued_in_decl(
         }
         // Each class method body is a `Vec<Statement>` a valued call may live
         // in — splice into every method, mirroring the function-body arm.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => false,
         Declaration::ClassDeclaration(cd) => {
             let mut changed = false;
             for member in &mut cd.body {
@@ -4286,6 +4304,9 @@ fn collect_used_idents_decl(decl: &Declaration, out: &mut HashSet<String>) {
         // Collect identifiers used in a class declaration's heritage operand and
         // method bodies, so an inline never mints a fresh name that collides
         // with one referenced inside the class.
+        // An import declaration has no inlinable body and binds foreign-linked
+        // names — leave it untouched.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             if let Some(sup) = &cd.super_class {
                 collect_binding_idents_expr(sup, out);

--- a/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-globals/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-globals` crate will be documented in this file.
 
+## [0.13.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arm
+
+Exhaustive-match no-op arm for the new `Declaration::ImportDeclaration` variant —
+the global-renaming walk does not descend into imports (import bindings link to
+foreign exports and must not be renamed; the gate lands with the bridge PR).
+
 ## [0.12.0] - 2026-07-12
 
 ### Added — CLOC12.187 PR2a: decline to rename globals in the presence of `with`

--- a/code/packages/rust/closure-pass-rename-globals/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-globals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-globals"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Aggressive top-level (global) renaming pass for the Closure Compiler clone — the ADVANCED-level complement to closure-pass-rename. Shortens program-private top-level names, gated by an externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-globals/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-globals/src/lib.rs
@@ -376,6 +376,9 @@ fn count_decl_names_decl(
         // `rename_apply_decl`: a method param that shares a global name pushes
         // that name's count past 1, disqualifying it from renaming — so a
         // later body walk with the full map can never rewrite a shadowed use.
+        // An import declaration's bound names reference a foreign module's
+        // exports — renaming them is unsound, so we skip it entirely.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             *out.entry(cd.id.name.clone()).or_insert(0) += 1;
             for member in &cd.body {
@@ -528,6 +531,9 @@ fn collect_all_idents_decl(decl: &Declaration, out: &mut HashSet<String>) {
                 }
             }
         }
+        // An import declaration's bound names reference a foreign module's
+        // exports — renaming them is unsound, so we skip it entirely.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             // Mirror the `Expression::ClassExpression` arm of
             // `collect_all_idents_expr`: the class name, the heritage operand's
@@ -1002,6 +1008,9 @@ fn rename_apply_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
                 rename_apply_stmt(s, map);
             }
         }
+        // An import declaration's bound names reference a foreign module's
+        // exports — renaming them is unsound, so we skip it entirely.
+        Declaration::ImportDeclaration(_) => {}
         Declaration::ClassDeclaration(cd) => {
             // Rename the class's own name (a top-level binding, a rename
             // target) and the `extends` operand (a use position). Then recurse

--- a/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename-properties/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename-properties` crate will be documented in this file.
 
+## [0.15.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arms
+
+Exhaustive-match no-op arms for the new `Declaration::ImportDeclaration` variant
+in the class-member classify and rewrite walks — an import has no properties to
+classify or rename.
+
 ## [0.14.0] - 2026-07-12
 
 ### Added — CLOC12.187 PR2a: decline to rename properties in the presence of `with`

--- a/code/packages/rust/closure-pass-rename-properties/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename-properties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename-properties"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Aggressive property renaming pass for the Closure Compiler clone (ADVANCED-only). Consistently shortens program-private object property names that are never quoted/computed and not in the built-in or externs do-not-rename boundary."
 

--- a/code/packages/rust/closure-pass-rename-properties/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename-properties/src/lib.rs
@@ -1039,6 +1039,8 @@ fn classify_decl(decl: &Declaration, cls: &mut Classify, nodes_touched: &mut u32
         // *expression* — the class name is a variable binding, not a property,
         // so only the member keys + bodies matter.
         Declaration::ClassDeclaration(cd) => classify_class_members(&cd.super_class, &cd.body, cls),
+        // An import declaration has no property accesses/keys to classify.
+        Declaration::ImportDeclaration(_) => {}
     }
 }
 
@@ -1464,6 +1466,8 @@ fn rewrite_decl(decl: &mut Declaration, map: &HashMap<String, String>) {
         Declaration::ClassDeclaration(cd) => {
             rewrite_class_members(&mut cd.super_class, &mut cd.body, map)
         }
+        // An import declaration has no property accesses/keys to rewrite.
+        Declaration::ImportDeclaration(_) => {}
     }
 }
 

--- a/code/packages/rust/closure-pass-rename/CHANGELOG.md
+++ b/code/packages/rust/closure-pass-rename/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `coding-adventures-closure-pass-rename` crate will be documented in this file.
 
+## [0.17.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arms
+
+Exhaustive-match arms for the new `Declaration::ImportDeclaration` variant: the
+process/`has_function` predicates report no function payload, and the local-name
+walks skip the import (no descent). Renaming an import-introduced binding is
+unsound — an imported local references a foreign export — so the full soundness
+gate lands with the bridge PR; PR1 simply does not descend into imports.
+
 ## [0.16.0] - 2026-07-12
 
 ### Added — CLOC12.187 PR2a: decline to rename in the presence of `with`

--- a/code/packages/rust/closure-pass-rename/Cargo.toml
+++ b/code/packages/rust/closure-pass-rename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-pass-rename"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Variable renaming pass for the Closure Compiler clone. Per CLOC06's canonical pass set. Replaces non-exported binding names with shorter identifiers to reduce output size while preserving externally-visible names and semantics."
 

--- a/code/packages/rust/closure-pass-rename/src/lib.rs
+++ b/code/packages/rust/closure-pass-rename/src/lib.rs
@@ -327,6 +327,8 @@ fn process_stmt(
         // here). Its method bodies are separate scopes; leaving them unrenamed
         // is safe (a missed optimisation, never unsound).
         Statement::Declaration(Declaration::ClassDeclaration(_)) => false,
+        // An import declaration binds no leaf-function params to rename here.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => false,
         Statement::Tagged(t) => process_tagged(t, nodes_touched, renames),
     }
 }
@@ -461,6 +463,9 @@ fn stmt_has_function(stmt: &Statement) -> bool {
         // method could capture/re-scope a name, which would make the leaf
         // rename unsound (see this function's doc comment).
         Statement::Declaration(Declaration::ClassDeclaration(_)) => true,
+        // An import declaration contains no functions and cannot re-scope a
+        // leaf binding, so it does not disable the leaf rename.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => false,
         Statement::Tagged(t) => match t {
             TaggedStatement::BlockStatement(b) => b.body.iter().any(stmt_has_function),
             TaggedStatement::IfStatement(is) => {
@@ -685,6 +690,10 @@ fn collect_decl_occurrences_stmt(stmt: &Statement, out: &mut Vec<(String, bool)>
             out.push((fd.id.name.clone(), false));
             // Do NOT recurse into fd.body — separate scope.
         }
+        // An import declaration's bound names link to a foreign module's
+        // exports — renaming them would break the cross-module contract, so we
+        // never descend into it.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => {}
         Statement::Declaration(Declaration::ClassDeclaration(cd)) => {
             // A class declaration binds a name — mark it ineligible for local
             // renaming, like a nested function name (renaming a class name
@@ -821,6 +830,10 @@ fn collect_all_idents_stmt(stmt: &Statement, out: &mut HashSet<String>) {
             }
             collect_all_idents_block(&fd.body, out);
         }
+        // An import declaration's bound names link to a foreign module's
+        // exports — renaming them would break the cross-module contract, so we
+        // never descend into it.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => {}
         Statement::Declaration(Declaration::ClassDeclaration(cd)) => {
             // Soundness-critical: collect EVERY identifier the class introduces
             // or references — its name, the heritage operand, and each method's
@@ -1262,6 +1275,10 @@ fn rewrite_uses_stmt(stmt: &mut Statement, map: &HashMap<String, String>) {
         // A leaf function has no nested function declarations, so this arm
         // is unreachable in practice; leave nested functions untouched.
         Statement::Declaration(Declaration::FunctionDeclaration(_)) => {}
+        // An import declaration's bound names link to a foreign module's
+        // exports — renaming them would break the cross-module contract, so we
+        // never descend into it.
+        Statement::Declaration(Declaration::ImportDeclaration(_)) => {}
         Statement::Declaration(Declaration::ClassDeclaration(cd)) => {
             // Rewrite renamed outer locals used in the heritage operand and
             // inside each method body. The class's own name is marked

--- a/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
+++ b/code/packages/rust/closure-scope-analyzer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `coding-adventures-closure-scope-analyzer` crate will be documented in this file.
 
+## [0.15.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: `ImportDeclaration` arm
+
+Exhaustive-match no-op arm for the new `Declaration::ImportDeclaration` variant in
+`walk_declaration`. Full import-binding scope handling (the specifier idents are
+module-scoped bindings that must not be renamed) lands with the bridge PR.
+
 ## [0.14.0] - 2026-07-12
 
 ### Added — CLOC12.187 PR2a: `with` soundness gate

--- a/code/packages/rust/closure-scope-analyzer/Cargo.toml
+++ b/code/packages/rust/closure-scope-analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closure-scope-analyzer"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Lexical scope + symbol-table analyzer for the Closure Compiler clone. Per CLOC13 — produces a `ScopeAnalysis` consumed by the rename, inline, treeshake, collapse-properties, and remove-unused-vars passes."
 

--- a/code/packages/rust/closure-scope-analyzer/src/lib.rs
+++ b/code/packages/rust/closure-scope-analyzer/src/lib.rs
@@ -529,6 +529,12 @@ fn walk_declaration(
         Declaration::VariableDeclaration(vd) => walk_variable_declaration(vd, ctx, analysis, pending),
         Declaration::FunctionDeclaration(fd) => walk_function_declaration(fd, ctx, analysis, pending),
         Declaration::ClassDeclaration(cd) => walk_class_declaration(cd, ctx, analysis, pending),
+        // An import declaration binds module-local names, but those names link
+        // to a *foreign module's* exports — renaming them would break the
+        // cross-module contract. PR1 keeps the node unreachable; we register no
+        // scope binding for it, so references stay conservatively un-renameable.
+        // (The full soundness treatment lands with the bridge PR.)
+        Declaration::ImportDeclaration(_) => {}
     }
 }
 

--- a/code/packages/rust/javascript-ast/CHANGELOG.md
+++ b/code/packages/rust/javascript-ast/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to the `coding-adventures-javascript-ast` crate will be documented in this file.
 
+## [0.39.0] - 2026-07-11
+
+### Added — CLOC12.188 PR1: ES-module `import` declarations
+
+New `ImportDeclaration { cv, specifiers, source }` struct and a
+`Declaration::ImportDeclaration(ImportDeclaration)` variant (ESTree
+`ImportDeclaration`), plus the `Declaration::import_declaration` convenience
+constructor. A companion `ImportSpecifier` enum models the three binding shapes:
+`Default(Identifier)` (`import x from …`), `Namespace(Identifier)`
+(`import * as ns from …`), and `Named { imported, local }` (`import { a } from …`
+/ `import { a as c } from …`). A side-effect `import "y"` carries an empty
+`specifiers` vector. The node is **not** yet produced by the parser bridge (a
+follow-up PR wires `convert_import_declaration` together with the
+renaming-soundness gate that imports demand — an imported local name references a
+foreign module's export and must not be renamed); this PR only adds the type so
+the whole pass pipeline can traverse it exhaustively. New
+`import_declaration_all_specifier_kinds_roundtrip` and
+`side_effect_import_has_empty_specifiers` tests.
+
 ## [0.38.0] - 2026-07-11
 
 ### Added — CLOC12.187 PR1: `with (obj) { … }` statement

--- a/code/packages/rust/javascript-ast/Cargo.toml
+++ b/code/packages/rust/javascript-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-ast"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 description = "Backend-agnostic JavaScript AST — full ESTree-compatible node taxonomy with optional per-node CV id. Reusable by the Closure-Compiler-clone and the future V8-in-Rust clone. Per CLOC02 / CLOC09."
 

--- a/code/packages/rust/javascript-ast/src/declaration.rs
+++ b/code/packages/rust/javascript-ast/src/declaration.rs
@@ -16,7 +16,7 @@
 //! in [`crate::statement`] lets a declaration appear anywhere a
 //! statement does — matching ESTree's flatter shape on the JSON wire.
 
-use crate::expression::{ClassMember, Expression, Identifier};
+use crate::expression::{ClassMember, Expression, Identifier, StringLiteral};
 use crate::statement::BlockStatement;
 use crate::CvId;
 use serde::{Deserialize, Serialize};
@@ -29,6 +29,11 @@ pub enum Declaration {
     VariableDeclaration(VariableDeclaration),
     FunctionDeclaration(FunctionDeclaration),
     ClassDeclaration(ClassDeclaration),
+    /// `import x from "y"` — an ES-module import declaration (CLOC12.188).
+    /// A *module-level* declaration: legal only at the top of a module, but
+    /// modelled here as a `Declaration` variant (the codebase's Phase-4 plan)
+    /// so it flows through the existing `ProgramItem::Declaration` plumbing.
+    ImportDeclaration(ImportDeclaration),
 }
 
 /// `var x = 1, y = 2;`, `let i = 0;`, `const PI = 3.14;`. The `kind`
@@ -142,6 +147,72 @@ pub struct ClassDeclaration {
     /// The class body — the ordered member list between the braces. May be
     /// empty (`class C {}`). Reuses [`ClassMember`] from the expression form.
     pub body: Vec<ClassMember>,
+}
+
+/// `import x from "y"` / `import {a, b as c} from "y"` / `import * as ns from
+/// "y"` / `import "y"` — an ES-module **import declaration** (CLOC12.188).
+///
+/// # Anatomy
+///
+/// ```text
+///   import  x, { a, b as c }  from  "y" ;
+///   └────┘  └──────────────┘  └──┘  └─┘
+///   keyword     specifiers     from  source
+/// ```
+///
+/// - `specifiers` — the bound names the import introduces, in source order.
+///   A **side-effect** import (`import "y";`) has an EMPTY `specifiers` list —
+///   it runs the module for effects and binds nothing.
+/// - `source` — the module specifier string literal (`"y"`). Preserved as a
+///   [`StringLiteral`] so the emitter re-quotes it faithfully.
+///
+/// # Renaming note
+///
+/// The *local* names an import introduces are ordinary module-scoped bindings.
+/// But the `imported` half of a named specifier (and a `default`/`namespace`
+/// binding's link to the foreign module) references an **export of another
+/// module** — renaming it would break the cross-module contract. The renaming
+/// passes therefore treat import-introduced names conservatively; that gate
+/// lands with the bridge PR that makes this node reachable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportDeclaration {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cv: Option<CvId>,
+    /// The imported bindings, in source order. Empty for a side-effect import.
+    pub specifiers: Vec<ImportSpecifier>,
+    /// The module specifier — `"y"` in `import … from "y"`.
+    pub source: StringLiteral,
+}
+
+/// One binding introduced by an [`ImportDeclaration`]. ESTree splits these into
+/// three node types; we model them as one `#[serde(tag = "type")]` enum so the
+/// JSON wire stays ESTree-shaped (`ImportDefaultSpecifier` /
+/// `ImportNamespaceSpecifier` / `ImportSpecifier`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ImportSpecifier {
+    /// `import x from "y"` — the default export bound to local `x`.
+    #[serde(rename = "ImportDefaultSpecifier")]
+    Default(Identifier),
+    /// `import * as ns from "y"` — the whole module namespace bound to `ns`.
+    #[serde(rename = "ImportNamespaceSpecifier")]
+    Namespace(Identifier),
+    /// `import { a } from "y"` (→ `imported = local = a`) or
+    /// `import { a as c } from "y"` (→ `imported = a`, `local = c`). `imported`
+    /// is the foreign export's name; `local` is the name bound in this module.
+    #[serde(rename = "ImportSpecifier")]
+    Named {
+        imported: Identifier,
+        local: Identifier,
+    },
+}
+
+impl Declaration {
+    /// Convenience constructor for an [`ImportDeclaration`].
+    pub fn import_declaration(d: ImportDeclaration) -> Self {
+        Declaration::ImportDeclaration(d)
+    }
 }
 
 #[cfg(test)]
@@ -399,5 +470,74 @@ mod tests {
         });
         let json = serde_json::to_string(&without).expect("serialize");
         assert!(!json.contains("superClass"), "heritage omitted; got {}", json);
+    }
+
+    // ---------------------------------------------------------------
+    // CLOC12.188 — ImportDeclaration.
+    // ---------------------------------------------------------------
+
+    fn id(name: &str) -> Identifier {
+        Identifier {
+            cv: None,
+            name: name.to_string(),
+        }
+    }
+
+    fn src(v: &str) -> StringLiteral {
+        StringLiteral {
+            cv: None,
+            value: v.to_string(),
+            raw: format!("\"{v}\""),
+        }
+    }
+
+    #[test]
+    fn import_declaration_all_specifier_kinds_roundtrip() {
+        // `import def, * as ns, { a, b as c } from "y"` — one of every
+        // specifier kind in a single declaration exercises all serde arms.
+        // (Real JS can't combine namespace + named, but the AST models each
+        // independently, so a mixed list is the strongest round-trip probe.)
+        let d = Declaration::import_declaration(ImportDeclaration {
+            cv: None,
+            specifiers: vec![
+                ImportSpecifier::Default(id("def")),
+                ImportSpecifier::Namespace(id("ns")),
+                ImportSpecifier::Named {
+                    imported: id("a"),
+                    local: id("a"),
+                },
+                ImportSpecifier::Named {
+                    imported: id("b"),
+                    local: id("c"),
+                },
+            ],
+            source: src("y"),
+        });
+        assert_eq!(roundtrip(d.clone()), d);
+        assert_eq!(type_tag(&d), "ImportDeclaration");
+
+        // ESTree-shaped specifier type tags.
+        let json = serde_json::to_string(&d).expect("serialize");
+        assert!(json.contains("\"ImportDefaultSpecifier\""), "got {json}");
+        assert!(json.contains("\"ImportNamespaceSpecifier\""), "got {json}");
+        assert!(json.contains("\"ImportSpecifier\""), "got {json}");
+    }
+
+    #[test]
+    fn side_effect_import_has_empty_specifiers() {
+        // `import "y";` binds nothing — an empty specifier list round-trips.
+        let d = Declaration::import_declaration(ImportDeclaration {
+            cv: None,
+            specifiers: vec![],
+            source: src("y"),
+        });
+        assert_eq!(roundtrip(d.clone()), d);
+        match &d {
+            Declaration::ImportDeclaration(i) => {
+                assert!(i.specifiers.is_empty());
+                assert_eq!(i.source.value, "y");
+            }
+            other => panic!("expected ImportDeclaration, got {other:?}"),
+        }
     }
 }

--- a/code/packages/rust/javascript-ast/src/lib.rs
+++ b/code/packages/rust/javascript-ast/src/lib.rs
@@ -128,8 +128,8 @@ mod es_version_serde {
 // `use coding_adventures_javascript_ast::{Program, IfStatement,
 // BinaryOperator}` without learning the module layout.
 pub use declaration::{
-    BindingTarget, ClassDeclaration, Declaration, FunctionDeclaration, FunctionParam, VarKind,
-    VariableDeclaration, VariableDeclarator,
+    BindingTarget, ClassDeclaration, Declaration, FunctionDeclaration, FunctionParam,
+    ImportDeclaration, ImportSpecifier, VarKind, VariableDeclaration, VariableDeclarator,
 };
 pub use expression::{
     ArrayExpression, ArrowBody, ArrowFunctionExpression, AssignmentExpression,


### PR DESCRIPTION
## CLOC12.188 PR1 — ES-module `import` declarations (greenfield atomic node)

Adds `ImportDeclaration` — the last unmodelled **module-level** declaration the `javascript-ast` doc-comment planned for "Phase 4". This PR adds the type and threads it through every pass so the pipeline traverses it exhaustively. It is **not** yet produced by the parser bridge — a follow-up PR wires `convert_import_declaration` together with the renaming-soundness gate imports demand (an imported local name references a foreign module's export and must not be renamed).

### javascript-ast (0.39.0)
- `Declaration::ImportDeclaration(ImportDeclaration)` variant + struct `ImportDeclaration { cv, specifiers, source: StringLiteral }`.
- `ImportSpecifier` enum — `Default(Identifier)` (`import x from …`), `Namespace(Identifier)` (`import * as ns from …`), `Named { imported, local }` (`import { a } from …` / `{ a as c }`). A side-effect `import "y"` carries an empty `specifiers` vector.
- `Declaration::import_declaration` constructor; re-exported from `lib.rs`; two roundtrip tests.

### closure-emitter (0.44.0)
- `emit_import` renders minified `import"y";` / `import x from"y";` / `import*as ns from"y";` (the `*` punctuator abuts `import`) / `import{a,b as c}from"y";` / `import x,{a}from"y";`. Five emit tests.

### Pass-crate exhaustive-match arms (all no-op / conservative)
An import has no foldable, inlinable, or renameable body; renaming an import-introduced local is unsound (deferred to the bridge PR):
constant-fold 0.87.0 · dce 0.22.0 · fold-control-flow 0.22.0 · inline 0.27.0 · inline-variables 0.13.0 · rename 0.17.0 · rename-globals 0.13.0 · rename-properties 0.15.0 · scope-analyzer 0.15.0.

### Notes
- **No closurec change** — the node is unreachable until the bridge PR. Full closurec suite stays green (emitter is a shared dep).
- Follow-ups: **PR2** bridge + renaming-soundness gate; **PR3** closurec e2e fixture (an `import` file survives instead of falling back to WHITESPACE_ONLY).

### Testing
- `javascript-ast` 107 tests green (incl. 2 new roundtrip tests).
- `closure-emitter` 237 lib tests green (incl. 5 new emit tests).
- All 9 touched pass crates + scope-analyzer build & test green.
- Full closurec suite green.
- Security review: PASSED (no vulnerabilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)