### PR TITLE
fix(cas-simplify): term_count blind to Div/Neg/transcendental-wrapped subtrees (v0.4.1)

### DIFF
--- a/code/packages/rust/cas-simplify/CHANGELOG.md
+++ b/code/packages/rust/cas-simplify/CHANGELOG.md
@@ -28,6 +28,18 @@
   `Div`-wrapped-subtree reproduction (verified to fail without the fix,
   restored to confirm it passes with it) and a correctness check that
   `Neg`/`Sin` wrappers are sized by their contents, not treated as `1`.
+- **Follow-up finding from `/security-review`, fixed in the same PR**: the
+  new fallback's summation used plain `Iterator::sum::<usize>()`, unlike
+  the sibling `Mul` arm's `saturating_mul`. Since a `Mul` subtree can
+  legitimately saturate `term_count` to `usize::MAX` from a modest,
+  ordinary tree, summing that value with any sibling would either panic
+  (overflow-checked debug/test builds — confirmed by reverting the fix
+  and reproducing the exact panic) or silently wrap to a small value
+  (release builds) — reintroducing the guard's exact blindness this PR
+  exists to close, just via arithmetic overflow instead of a missing
+  match arm. Fixed with `saturating_add`, plus a new regression test
+  sized to actually reach the saturation boundary (70 chained two-term
+  factors, 2^70).
 
 ## [0.4.0] — 2026-07-03
 

--- a/code/packages/rust/cas-simplify/CHANGELOG.md
+++ b/code/packages/rust/cas-simplify/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog — cas-simplify (Rust)
 
+## [0.4.1] — 2026-07-12
+
+### Fixed
+
+- **`term_count` was blind to large subtrees hidden under `Div`/`Neg`/every
+  transcendental wrapper** (`Sin`, `Log`, `Exp`, ...) and un-distributed
+  `Pow`. `expand_apply` recursively expands the *children* of these heads
+  but never distributes the wrapper itself, so `Div(huge_expanded_tree, y)`
+  is an entirely ordinary shape a real expansion produces — but
+  `term_count` previously treated any such node as size `1` (the same
+  `_ => 1` catch-all a prior fix already closed for refused `Mul` nodes).
+  If a `Div`/`Neg`/transcendental-wrapped subtree later became an operand
+  under a further `Add`-distribution, `expand_mul` would clone the whole
+  hidden subtree once per term of the other side — real cost proportional
+  to its true size, invisible to the cap check that saw only "1". A
+  9,000-term `Div`-wrapped subtree multiplied by an ordinary 20-term sum
+  reproducibly reached 180,000+ nodes under the old logic (empirically
+  confirmed via the same disable-and-reproduce methodology used for the
+  original `Mul`-blindness fix) despite `EXPAND_MAX_TERMS` (10,000) being
+  configured — the cap check saw `1 * 20 = 20`, nowhere near the limit.
+- Fixed by generalizing `term_count`'s fallback: any `Apply` node whose
+  head is not `Mul` (which multiplies its children's counts) now sums its
+  children's term counts — the same measure `Add`/`Sub` already used,
+  extended to every wrapper shape `expand_apply` can leave in place, not
+  just `Add`/`Sub` specifically. 2 new regression tests: an adversarial
+  `Div`-wrapped-subtree reproduction (verified to fail without the fix,
+  restored to confirm it passes with it) and a correctness check that
+  `Neg`/`Sin` wrappers are sized by their contents, not treated as `1`.
+
 ## [0.4.0] — 2026-07-03
 
 ### Added

--- a/code/packages/rust/cas-simplify/Cargo.toml
+++ b/code/packages/rust/cas-simplify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cas-simplify"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Algebraic simplification of symbolic IR trees: canonical form, constant folding, identity rules"
 license = "MIT"

--- a/code/packages/rust/cas-simplify/src/expand.rs
+++ b/code/packages/rust/cas-simplify/src/expand.rs
@@ -125,16 +125,50 @@ pub const EXPAND_MAX_TERMS: usize = 10_000;
 ///   reports its true (potentially huge) size on every subsequent
 ///   check, so the guard keeps seeing accurate numbers instead of a
 ///   stale "1" and correctly keeps refusing to distribute further.
+///
+/// - **The same blindness recurs for every other head `expand_apply`
+///   leaves in place** — `Div`, `Neg`, `Pow` left un-distributed (a
+///   non-integer or out-of-range exponent), and every transcendental
+///   (`Sin`, `Log`, ...). `expand_apply`'s fallthrough recursively
+///   expands *their children* but never touches the wrapper head
+///   itself (see `expand_recurses_into_div_operands`), so
+///   `Div(huge_expanded_numerator, y)` is a completely ordinary,
+///   frequently-produced shape — not a contrived edge case. Treating it
+///   as size `1` (the pre-fix `_ => 1` catch-all) is safe *mathematically*
+///   (as a polynomial term, `x/y` genuinely is one term, hidden internal
+///   size notwithstanding) but wrong as a *cost estimate*: if this node
+///   later becomes an operand under a further `Add`-distribution (e.g.
+///   `expand_mul` folding it against another sum), [`expand_mul`] clones
+///   it once per term of the other side — real cost proportional to its
+///   *true* size, not `1`. A chain of several such wrapped huge
+///   subtrees, each hidden from the cap check the same way, reproduces
+///   exactly the "cap → go dark → distribute past the cap" cycle the
+///   `Mul` fix above already closed for refused multiplications — just
+///   via `Div`/`Neg`/transcendental wrappers instead of a refused `Mul`.
+///   Any `Apply` node whose head is not itself distributed (i.e.,
+///   anything but `Mul`, which multiplies) now falls through to summing
+///   its children's term counts — the same conservative "total
+///   underlying size" measure `Add`/`Sub` already used, generalized to
+///   every wrapper shape `expand_apply` can leave behind, not just
+///   `Add`/`Sub` specifically.
 fn term_count(node: &IRNode) -> usize {
     match node {
-        IRNode::Apply(app) if is_head(&app.head, ADD) || is_head(&app.head, SUB) => {
-            app.args.iter().map(term_count).sum::<usize>().max(1)
-        }
         IRNode::Apply(app) if is_head(&app.head, MUL) => app
             .args
             .iter()
             .map(term_count)
             .fold(1usize, |acc, c| acc.saturating_mul(c)),
+        // Every other `Apply` head (`Add`/`Sub`, `Div`, `Neg`, `Pow` left
+        // un-distributed, every transcendental, ...) is not itself
+        // distributed by `expand_apply` — only its children are
+        // recursively expanded, the wrapper head stays. Summing the
+        // children's term counts is the right measure for both cases:
+        // for `Add`/`Sub` it *is* the true would-be term count; for
+        // everything else it is a conservative (over-, never under-)
+        // estimate of how much real cloning cost this subtree carries
+        // if it is later multiplied against something else — the
+        // direction a DoS guard must err toward.
+        IRNode::Apply(app) => app.args.iter().map(term_count).sum::<usize>().max(1),
         _ => 1,
     }
 }
@@ -258,7 +292,7 @@ fn expand_apply(node: IRApply) -> IRNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use symbolic_ir::{apply, flt, int, sym, DIV, SIN};
+    use symbolic_ir::{apply, flt, int, sym, DIV, NEG, SIN};
 
     fn add(args: Vec<IRNode>) -> IRNode {
         apply(sym(ADD), args)
@@ -499,5 +533,68 @@ mod tests {
              the way it should",
             total_node_count(&result)
         );
+    }
+
+    #[test]
+    fn term_count_sees_through_a_div_wrapped_subtree_instead_of_going_blind() {
+        // Regression test for the Div/Neg/transcendental generalization
+        // of the fix above. expand_apply never distributes Div itself —
+        // it recurses into the numerator/denominator and leaves the Div
+        // head in place (see expand_recurses_into_div_operands) — so
+        // Div(huge_add_tree, y) is an entirely ordinary shape a real
+        // expansion can leave behind, not a contrived one. Build one
+        // directly (standing in for whatever a prior expand() call
+        // would already have produced) and multiply it by a modest
+        // second Add factor.
+        let huge_numerator = add((0..9000).map(|i| sym(format!("x{i}"))).collect());
+        let big_div = apply(sym(DIV), vec![huge_numerator, sym("y")]);
+        let second_factor = add((0..20).map(|i| sym(format!("z{i}"))).collect());
+
+        let result = expand(mul(vec![big_div, second_factor]));
+
+        // Under the pre-fix logic, term_count(big_div) == 1 (Div is
+        // neither Add/Sub nor Mul), so the cap check saw "1 * 20 = 20"
+        // and happily distributed — cloning the ~9000-node numerator
+        // once per term of the second factor (20 clones, ~180,000+
+        // nodes). With the fix, term_count sees big_div's true size
+        // (~9000), the cap check correctly refuses
+        // (9000 * 20 = 180,000 > EXPAND_MAX_TERMS), and the result
+        // stays a single unexpanded Mul — no cloning at all.
+        assert!(
+            total_node_count(&result) < 20_000,
+            "expand() of a Div-wrapped 9000-term subtree times a 20-term \
+             second factor produced {} nodes -- term_count is not seeing \
+             through the Div wrapper the way it should",
+            total_node_count(&result)
+        );
+    }
+
+    #[test]
+    fn term_count_treats_neg_and_transcendental_wrappers_the_same_way() {
+        // Not adversarial-scale (the Div test above already proves the
+        // guard holds under real pressure) -- this just confirms the
+        // generalized fix actually applies uniformly to every other
+        // non-Mul Apply head, not only Div specifically. Neg(20-term
+        // sum) and Sin(20-term sum) must each report the same term
+        // count as the bare sum (20), not 1.
+        let twenty_terms = add((0..20).map(|i| sym(format!("t{i}"))).collect());
+        let neg_wrapped = apply(sym(NEG), vec![twenty_terms.clone()]);
+        let sin_wrapped = apply(sym(SIN), vec![twenty_terms.clone()]);
+
+        // term_count is private to this module; drive it indirectly the
+        // same way every other test in this file does, by checking that
+        // multiplying each wrapped form against another sizeable sum
+        // gets correctly refused (mirroring the Div test's structure).
+        let other_factor = add((0..600).map(|i| sym(format!("o{i}"))).collect());
+        // 20 * 600 = 12,000 > EXPAND_MAX_TERMS (10,000): must refuse.
+        for wrapped in [neg_wrapped, sin_wrapped] {
+            let result = expand_mul(&wrapped, &other_factor);
+            assert_eq!(
+                result,
+                mul(vec![wrapped, other_factor.clone()]),
+                "a Neg/Sin-wrapped 20-term sum must be sized as 20 terms, \
+                 not 1, when checked against a 600-term second factor"
+            );
+        }
     }
 }

--- a/code/packages/rust/cas-simplify/src/expand.rs
+++ b/code/packages/rust/cas-simplify/src/expand.rs
@@ -168,7 +168,21 @@ fn term_count(node: &IRNode) -> usize {
         // estimate of how much real cloning cost this subtree carries
         // if it is later multiplied against something else — the
         // direction a DoS guard must err toward.
-        IRNode::Apply(app) => app.args.iter().map(term_count).sum::<usize>().max(1),
+        //
+        // `saturating_add`, not plain `Iterator::sum` — a sibling `Mul`
+        // subtree can legitimately saturate to `usize::MAX` on its own
+        // (see the `Mul` arm above), and an un-saturated sum here would
+        // overflow adding anything else to it: panicking under
+        // `overflow-checks` (debug/test builds), or silently wrapping to
+        // a small value in release builds — which would let this exact
+        // guard go blind again, just via arithmetic overflow instead of
+        // a missing match arm.
+        IRNode::Apply(app) => app
+            .args
+            .iter()
+            .map(term_count)
+            .fold(0usize, |acc, c| acc.saturating_add(c))
+            .max(1),
         _ => 1,
     }
 }
@@ -596,5 +610,38 @@ mod tests {
                  not 1, when checked against a 600-term second factor"
             );
         }
+    }
+
+    #[test]
+    fn term_count_saturates_instead_of_overflowing_when_summing() {
+        // A Mul's own term_count can legitimately saturate to usize::MAX
+        // from a modest, entirely ordinary tree -- a flat Mul of 70
+        // two-term Add factors is 2^70, which saturates any real
+        // platform's usize::MAX (2^32-1 or 2^64-1) well before 70
+        // factors. If that saturated value is then summed with a
+        // sibling (the fallback arm's job, used by Add/Sub/Div/Neg/...),
+        // a plain `Iterator::sum` would either panic (overflow-checked
+        // debug/test builds) or silently wrap around to a small value
+        // (release builds) -- either of which would defeat the very cap
+        // check this guard exists to enforce. `saturating_add` must not.
+        let two_term_factors: Vec<IRNode> = (0..70)
+            .map(|i| add(vec![sym(format!("p{i}")), sym(format!("q{i}"))]))
+            .collect();
+        let saturated_mul = mul(two_term_factors);
+        let wrapped = add(vec![saturated_mul, sym("small")]);
+
+        // Drive term_count indirectly via expand_mul, the same way every
+        // other test in this file does: `wrapped`'s true size is
+        // astronomically over EXPAND_MAX_TERMS, so multiplying it by
+        // anything must be refused outright, never distributed.
+        let other = sym("y");
+        let result = expand_mul(&wrapped, &other);
+        assert_eq!(
+            result,
+            mul(vec![wrapped, other]),
+            "a subtree containing a saturated Mul term-count must still \
+             be recognized as astronomically large when summed with a \
+             sibling, not silently wrapped around to something small"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `term_count()` (a resource-exhaustion guard used before `expand_mul` is allowed to distribute) only recursed into `Add`/`Sub` (additively) and `Mul` (multiplicatively) — every other head (`Div`, `Neg`, un-distributed `Pow`, every transcendental) fell into the `_ => 1` catch-all, the same guard-blindness bug class a prior fix already closed for refused `Mul` nodes.
- `expand_apply` recursively expands the *children* of `Div`/`Neg`/transcendental nodes but never distributes the wrapper itself, so `Div(huge_expanded_tree, y)` is an entirely ordinary shape a real expansion produces — not a contrived edge case. If such a wrapped subtree later became an operand under a further `Add`-distribution, `expand_mul` would clone the whole hidden subtree once per term of the other side: real cost proportional to its true size, invisible to a cap check that saw only "1".
- Confirmed empirically (same disable-and-reproduce methodology as the original `Mul`-blindness fix): a 9,000-term `Div`-wrapped subtree multiplied by an ordinary 20-term sum reached 180,101 nodes under the old logic, despite `EXPAND_MAX_TERMS` (10,000) being configured — the cap check saw `1 * 20 = 20`, nowhere near the limit.
- Fixed by generalizing `term_count`'s fallback: any `Apply` node whose head is not `Mul` now sums its children's term counts (the same measure `Add`/`Sub` already used), extended to every wrapper shape `expand_apply` can leave in place.

## Security review (1 round, 1 real finding fixed)
- **HIGH**: the new fallback's summation used plain `Iterator::sum::<usize>()`, unlike the sibling `Mul` arm's `saturating_mul`. Since a `Mul` subtree can legitimately saturate `term_count` to `usize::MAX` from a modest tree, summing that with any sibling would either panic (overflow-checked debug/test builds — confirmed by reverting and reproducing the exact panic) or silently wrap to a small value (release builds), reintroducing this exact PR's blindness via arithmetic overflow instead of a missing match arm. Fixed with `saturating_add`, verified adversarially the same way.
- LOW/INFO (not blocking): a note on recursion depth through deeply-nested wrapper chains, already covered by `expand_recursive`'s existing unconditional recursion and this repo's established depth-guard discipline upstream.

## Test plan
- [x] `cargo test -p cas-simplify -p coding-adventures-macsyma-runtime -p symbolic-vm -p coding-adventures-wolfram-runtime` — 16 + all downstream consumer suites, all green
- [x] `cargo clippy -p cas-simplify --all-targets --no-deps -- -D warnings` — clean
- [x] `/security-review` — 1 round, 1 HIGH finding fixed and adversarially verified, 1 non-blocking LOW/INFO note
- [x] All 3 new regression tests verified adversarially (guard disabled → test fails reproducing the exact bug → restored → passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)