### PR TITLE
feat(sir-runtime-oop): Array slice_when — TS mirror (final backend)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.24] - 2026-07-11
+
+### Added
+
+- **`Array#slice_when`** — the FINAL backend of the `slice_when` cross-backend
+  cascade (Python reference #8070, Go #8073, Rust #8077, JS #8082), completing it
+  across all five backends.
+  - `slice_when { |prev, cur| pred }` (`arrayBlockMethod` + `ARRAY_BLOCK_METHODS`)
+    is the INVERSE of `chunk_while`: it splits into runs of consecutive elements,
+    starting a NEW run BETWEEN an adjacent pair exactly WHERE the block is truthy
+    (whereas `chunk_while` starts a new run where the block is FALSY).
+    `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`;
+    an empty array yields `[]`, a single element `[[x]]`.
+  - `respond_to?("slice_when")` now reports `true`.
+
 ## [0.1.23] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -70,7 +70,7 @@ deep value equality), plus the **Kernel flow-control** group
 `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self` (item **M6**); and
 (item **M1b**) **block-taking `Array`/`Enumerable`**
 methods `each`, `each_with_index`, `map`/`collect`, `select`/`filter`, `reject`,
-`reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?`, `chunk_while` — a trailing
+`reduce`/`inject`, `find`/`detect`, `flat_map`, `any?`/`all?`/`none?`, `chunk_while`/`slice_when` — a trailing
 `Closure` block is applied via `@coding-adventures/sir-runtime-core`'s `apply`
 (proc-lenient), predicates routed through SIR `truthy`; (item **M1c**) the
 **`Hash`** catalog (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -589,6 +589,7 @@ const ARRAY_BLOCK_METHODS = new Set<string>([
   "count",
   "each_with_object",
   "chunk_while",
+  "slice_when",
 ]);
 
 // Non-block `Hash` methods (M1c). Hash is a JS `Map`.
@@ -1227,6 +1228,21 @@ function arrayBlockMethod(
         else { chunks.push([recv[i]]); }
       }
       return chunks;
+    }
+    case "slice_when": {
+      // `slice_when { |prev, cur| pred }` — the INVERSE of `chunk_while`: runs
+      // of consecutive elements, starting a NEW run BETWEEN an adjacent pair
+      // exactly WHERE the block is truthy (chunk_while starts a new run where
+      // the block is FALSY).
+      // `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → [[1,2],[4],[9,10,11,12]].
+      // An empty array yields []; a single element yields [[x]].
+      if (recv.length === 0) return [];
+      const slices: Val[][] = [[recv[0]]];
+      for (let i = 1; i < recv.length; i++) {
+        if (truthy(apply(block, [recv[i - 1], recv[i]]))) { slices.push([recv[i]]); }
+        else { slices[slices.length - 1].push(recv[i]); }
+      }
+      return slices;
     }
     default:
       return MISS;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -451,6 +451,22 @@ describe("built-in method catalog: block-taking Array/Enumerable (M1b)", () => {
     expect(callMethod([1], "respond_to?", "chunk_while")).toBe(true);
   });
 
+  it("slice_when (inverse of chunk_while — split where the predicate holds)", () => {
+    // `slice_when { |a, b| pred }` starts a NEW run BETWEEN an adjacent pair
+    // exactly WHERE the block is truthy (chunk_while splits where FALSY).
+    expect(
+      callMethod([1, 2, 4, 9, 10, 11, 12], "slice_when", new Closure((a: Val, b: Val) => (b as number) - (a as number) > 1)),
+    ).toEqual([[1, 2], [4], [9, 10, 11, 12]]);
+    // all-truthy → every element its own singleton; all-falsy → one run.
+    expect(callMethod([1, 2, 3], "slice_when", new Closure(() => true))).toEqual([[1], [2], [3]]);
+    expect(callMethod([1, 2, 3], "slice_when", new Closure(() => false))).toEqual([[1, 2, 3]]);
+    // empty → []; single element → [[x]].
+    expect(callMethod([], "slice_when", new Closure(() => true))).toEqual([]);
+    expect(callMethod([9], "slice_when", new Closure(() => true))).toEqual([[9]]);
+    // respond_to? advertises it.
+    expect(callMethod([1], "respond_to?", "slice_when")).toBe(true);
+  });
+
   it("tally (occurrence counts as a first-seen-ordered Hash)", () => {
     // `tally` → a Map counting occurrences, keyed in first-seen order.
     const t = callMethod(["a", "b", "a", "c", "a"], "tally") as Map<Val, Val>;


### PR DESCRIPTION
Completes the `Array#slice_when` cross-backend cascade — now present across **all five backends**. (Python reference [#8070](https://github.com/adhithyan15/coding-adventures/pull/8070), Go [#8073](https://github.com/adhithyan15/coding-adventures/pull/8073), Rust [#8077](https://github.com/adhithyan15/coding-adventures/pull/8077), JS [#8082](https://github.com/adhithyan15/coding-adventures/pull/8082).)

## What

`slice_when { |prev, cur| pred }` is the **inverse of `chunk_while`**: it splits into runs of consecutive elements, starting a **new run BETWEEN an adjacent pair exactly WHERE the block is truthy** (chunk_while starts a new run where the block is *falsy*).

- `[1,2,4,9,10,11,12].slice_when { |a,b| b-a>1 }` → `[[1,2],[4],[9,10,11,12]]`
- empty → `[]`; single → `[[x]]`
- `respond_to?("slice_when")` → `true`

Added to `arrayBlockMethod` (mirroring the `chunk_while` arm) + the `ARRAY_BLOCK_METHODS` set.

## Tests

vitest covers the `b-a>1` example, all-truthy → singletons, all-falsy → one run, empty, single, and `respond_to?`. **Full suite 120 passed.**

Version 0.1.23 → 0.1.24. Security review passed (plain arrays — no prototype pollution; O(n); explicit-switch dispatch, no reflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)