### PR TITLE
feat(task-core): pure engine — formula fields + operations API (no Reactism)

### DIFF
--- a/code/packages/rust/task-core/CHANGELOG.md
+++ b/code/packages/rust/task-core/CHANGELOG.md
@@ -63,10 +63,26 @@ All notable changes to `task-core` are documented here.
     `AsSoonAsPossible`; negative lag (lead) is applied in elapsed time; resource
     leveling is not yet applied.
 
+- **Computed fields** (`formula` module) — formula and rollup fields, reusing the
+  repo's named-variable expression stack:
+  - A `[field]` bracket-syntax `parse` (our surface syntax, matching MS Project's
+    `[Field]` convention) → `symbolic-ir` expression tree; supports `+ - * /`, unary
+    minus, comparisons, and parentheses with correct precedence.
+  - `referenced_fields` — extracts a formula's dependencies (the field names it reads)
+    by walking the AST.
+  - `eval_number` — evaluates a formula against name→value bindings via `symbolic-vm`'s
+    `StrictBackend`. **Panic-safe on untrusted input**: unbound references and runtime
+    errors (division by zero — which `StrictBackend` panics on) yield `None`, caught
+    via `catch_unwind`, never a crash.
+  - `rollup` — folds child values (Sum/Min/Max/Average/Count) directly in Rust.
+  - `field_eval_order` — topological order of the computed-field dependency graph via
+    `directed-graph`, rejecting self-referential and transitively cyclic formulas
+    (self-loops are detected explicitly, since `directed-graph` drops them).
+
 ### Notes
 
-- Design principle: everything a scheduler derives is computed, never stored — this
-  release is the *input* model, the working-time engine, and the CPM scheduler; the
-  `TaskCommand` reducer and formula fields land next.
-- Reuses `directed-graph` (dependency graph) and `datetime-core` (date arithmetic)
-  rather than reimplementing them.
+- Design principle: everything a scheduler derives is computed, never stored — the
+  input model, the working-time engine, the CPM scheduler, and computed fields are in.
+- Reuses `directed-graph` (dependency/recalc graph), `datetime-core` (date arithmetic),
+  and `symbolic-ir`/`symbolic-vm` (named-variable formula evaluation) rather than
+  reimplementing them.

--- a/code/packages/rust/task-core/CHANGELOG.md
+++ b/code/packages/rust/task-core/CHANGELOG.md
@@ -79,10 +79,26 @@ All notable changes to `task-core` are documented here.
     `directed-graph`, rejecting self-referential and transitively cyclic formulas
     (self-loops are detected explicitly, since `directed-graph` drops them).
 
+- **The pure operations API** (`ops` module) — every mutation as a validated method on
+  `ProjectState` (`create_task`, `reparent`, `link_dependency`, `assign`,
+  `add_calendar_exception`, `set_field_value`, …), returning `Result<(), OpError>`.
+  There is **no command enum and no dispatch** (those are Flux/React idioms this engine
+  deliberately avoids — see the architecture note below). Methods are pure (mutate the
+  value in place; no I/O, no clock, no globals) and are the single trust boundary that
+  enforces invariants: `percent_complete` clamped to 0..=100; calendar intervals
+  validated (`start < end <= 1440`) and length-capped; reparent-cycle, self-, duplicate-,
+  and cycle-forming dependency links rejected (cycle checks reuse `directed-graph`).
+  `OpError` carries a stable `code()` for the C ABI.
+
 ### Notes
 
+- **Architecture correction:** the earlier "TaskCommand reducer" (a Flux/React command
+  bus) was dropped in favour of this native pure-operations API. The engine is *pure
+  computation only*; each backend will manage state in its own native conventions (no
+  universal `dispatch`/`getProps`/`handleEvent` facade). See `task-app-architecture.md`.
 - Design principle: everything a scheduler derives is computed, never stored — the
-  input model, the working-time engine, the CPM scheduler, and computed fields are in.
+  input model, the working-time engine, the CPM scheduler, computed fields, and the
+  operations API are in.
 - Reuses `directed-graph` (dependency/recalc graph), `datetime-core` (date arithmetic),
   and `symbolic-ir`/`symbolic-vm` (named-variable formula evaluation) rather than
   reimplementing them.

--- a/code/packages/rust/task-core/Cargo.toml
+++ b/code/packages/rust/task-core/Cargo.toml
@@ -16,6 +16,11 @@ serde = ["dep:serde"]
 # provides civil-date arithmetic (weekday/add-days) for the working-time model.
 directed-graph = { path = "../directed-graph" }
 datetime-core = { path = "../datetime-core" }
+# Named-variable formula evaluation for computed/rollup fields — a field reference
+# `[rate]` is an `IRNode::Symbol("rate")`, evaluated by symbolic-vm's StrictBackend.
+# This is the win over spreadsheet-core (A1-only). See task-app-formula-fields.md.
+symbolic-ir = { path = "../symbolic-ir" }
+symbolic-vm = { path = "../symbolic-vm" }
 serde = { version = "1", features = ["derive"], optional = true }
 
 # `serde_json` is a dev-only oracle: the JSON round-trip tests (gated on the

--- a/code/packages/rust/task-core/README.md
+++ b/code/packages/rust/task-core/README.md
@@ -17,19 +17,24 @@ series overview in [`task-app-overview.md`](../../../specs/task-app-overview.md)
 
 ## Where this sits in the stack
 
-`task-core` is the bottom of the task-app layer cake, mirroring Engram:
+`task-core` is the **pure engine** at the bottom of the task-app stack:
 
 ```
-task-core            ← you are here: pure model + (soon) CPM scheduler
-  └ task-core-wasm   facade: JSON in / JSON out, props + events
-        ├ task-capi  C ABI for native shells
-        └ task-wasm  WASM ABI for web / Electron
+task-core            ← you are here: the PURE ENGINE — model + operations API + queries
+                       + scheduler + calendar + formula. No I/O, no clock, no state runtime.
+  ├ task-capi        C ABI exposing the engine's functions to native shells
+  └ task-wasm        WASM ABI exposing the same to web / Electron
+
+  …consumed by per-backend NATIVE host bindings: React state on web, @Observable on
+  SwiftUI, Compose State, Qt models — each idiomatic. There is deliberately NO universal
+  "facade" / dispatch / props-events contract (that would import React-isms into
+  platforms that don't have them). See `code/specs/task-app-architecture.md`.
 ```
 
 It is **pure and headless**: no I/O, no system clock (the current time is passed in
-as `now: u64`), and no id generation (ids are minted by the facade and passed in).
-`serde` is behind a feature flag, so the model has zero external dependencies by
-default. This matches the house style of `engram-core` and `spreadsheet-core`.
+as `now: u64`), no id generation (ids are minted by the host and passed in), and **no
+state-management runtime** — it is a library of pure functions over a value. `serde` is
+behind a feature flag, so the model has zero external dependencies by default.
 
 Everything a scheduler *derives* — early/late dates, slack, the critical flag,
 rollups, formula values — is **computed, never stored as source of truth**.
@@ -63,10 +68,14 @@ rollups, formula values — is **computed, never stored as source of truth**.
   panic-safe `symbolic-vm` evaluation of formula fields, direct-Rust rollups, and a
   `directed-graph` field-dependency order that rejects cyclic formulas. The
   named-variable win over A1-only spreadsheet formulas.
+- **The operations API** (`ops`): every mutation as a validated `ProjectState` method
+  (`create_task`, `reparent`, `link_dependency`, `assign`, `add_calendar_exception`, …)
+  returning `Result<(), OpError>` — no command/dispatch. Pure, and the single trust
+  boundary enforcing invariants (percent clamp, interval bounds, cycle rejection).
 
-Landing next (per the specs): the `TaskCommand` reducer (in review) and resource
-leveling, then Track B (the `task-core-wasm` facade → `task-capi`/`task-wasm` →
-Mosaic web app).
+Landing next (per the specs): pure view **projections** (checklist / todo / kanban /
+gantt / flowchart / table), then the `task-capi` / `task-wasm` ABIs, then the Mosaic UI
+wired natively per backend.
 
 ```rust
 use task_core::{scheduler, Date};

--- a/code/packages/rust/task-core/README.md
+++ b/code/packages/rust/task-core/README.md
@@ -59,9 +59,14 @@ rollups, formula values — is **computed, never stored as source of truth**.
   backward passes over `directed-graph`, honouring FS/SS/FF/SF links with lag,
   working-time calendars, the common date constraints, and summary rollups. Rejects
   cyclic networks; surfaces constraint conflicts.
+- **Computed fields** (`formula`): a `[field]` bracket-syntax parser → `symbolic-ir`,
+  panic-safe `symbolic-vm` evaluation of formula fields, direct-Rust rollups, and a
+  `directed-graph` field-dependency order that rejects cyclic formulas. The
+  named-variable win over A1-only spreadsheet formulas.
 
-Landing next (per the specs): the `TaskCommand` reducer (with input range validation),
-formula/rollup fields (via `symbolic-vm`), and resource leveling.
+Landing next (per the specs): the `TaskCommand` reducer (in review) and resource
+leveling, then Track B (the `task-core-wasm` facade → `task-capi`/`task-wasm` →
+Mosaic web app).
 
 ```rust
 use task_core::{scheduler, Date};

--- a/code/packages/rust/task-core/src/formula.rs
+++ b/code/packages/rust/task-core/src/formula.rs
@@ -1,0 +1,531 @@
+//! Computed fields: **formulas** and **rollups**.
+//!
+//! A custom field can be a *formula* — an expression over other fields, written in a
+//! small `[field]` bracket syntax (`[work] / [duration] * 100`) — or a *rollup* — an
+//! aggregate of a field across a task's children. Both are **computed, never stored**:
+//! recomputed from their inputs on demand.
+//!
+//! ## Why `symbolic-vm`
+//!
+//! Formula fields need **named-variable** expressions, not cell coordinates. In this
+//! repo's `symbolic-ir`, a variable *is* a named atom — `IRNode::Symbol("rate")` — and
+//! `symbolic-vm`'s `StrictBackend` evaluates it once every name is bound. That is the
+//! reuse win over the A1-only `spreadsheet-core`. We add only a thin bracket parser
+//! (our own surface syntax, matching Microsoft Project's `[Field]` convention) and a
+//! dependency walker; the evaluator is reused wholesale.
+//!
+//! Rollups are simple aggregations, so we fold them directly in Rust rather than
+//! routing them through the VM — the VM is for arbitrary formula expressions.
+
+use crate::ids::FieldId;
+use crate::model::{FieldKind, ProjectState, RollupAgg};
+use std::collections::{HashMap, HashSet};
+use symbolic_ir::{apply, flt, int, sym, IRNode};
+use symbolic_vm::{StrictBackend, VM};
+
+/// What can go wrong turning a formula into a value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FormulaError {
+    /// The source could not be parsed (with a human-readable reason).
+    Parse(String),
+    /// The computed-field dependency graph has a cycle (a formula that reads itself,
+    /// directly or transitively).
+    Cycle(Vec<FieldId>),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parser: `[field]` bracket syntax → symbolic-ir
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parse a formula source into a `symbolic-ir` expression tree.
+///
+/// Grammar (lowest precedence first): one optional comparison over additive terms,
+/// additive over multiplicative, multiplicative over unary, unary over a primary
+/// (`[field]`, a number literal, or a parenthesised expression). Operators lower to
+/// the canonical `symbolic-ir` heads (`Add`/`Sub`/`Mul`/`Div`/`Neg`, comparisons).
+pub fn parse(src: &str) -> Result<IRNode, FormulaError> {
+    let toks = tokenize(src)?;
+    let mut p = Parser { toks, pos: 0 };
+    let node = p.expr()?;
+    if p.pos != p.toks.len() {
+        return Err(FormulaError::Parse(format!(
+            "unexpected trailing input at token {}",
+            p.pos
+        )));
+    }
+    Ok(node)
+}
+
+/// The set of field names a parsed formula reads — its dependencies. Fields appear
+/// only as leaf `Symbol`s in argument position (operator heads sit in `Apply.head`),
+/// so we recurse into arguments and collect leaf symbols.
+pub fn referenced_fields(node: &IRNode) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    collect(node, &mut out, &mut seen);
+    return out;
+
+    fn collect(node: &IRNode, out: &mut Vec<String>, seen: &mut HashSet<String>) {
+        match node {
+            IRNode::Symbol(name) => {
+                if seen.insert(name.clone()) {
+                    out.push(name.clone());
+                }
+            }
+            IRNode::Apply(app) => {
+                // Skip the head; recurse into arguments only.
+                for arg in &app.args {
+                    collect(arg, out, seen);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Evaluate a parsed numeric formula given `bindings` (field name → value).
+///
+/// Returns `None` — never panics — when a referenced field is unbound (which would
+/// otherwise trip `StrictBackend`'s strictness) or when the result is not a finite
+/// number (e.g. division by zero, or a boolean comparison result). This is the
+/// panic-safe boundary for untrusted formula strings.
+pub fn eval_number(node: &IRNode, bindings: &HashMap<String, f64>) -> Option<f64> {
+    // Gate: every referenced field must be bound, or StrictBackend would panic.
+    for name in referenced_fields(node) {
+        if !bindings.contains_key(&name) {
+            return None;
+        }
+    }
+    let mut vm = VM::new(Box::new(StrictBackend::new()));
+    for (name, value) in bindings {
+        vm.backend.bind(name, number_to_ir(*value));
+    }
+    // `StrictBackend` *panics* on some runtime errors (e.g. division by zero). Since
+    // formula strings are untrusted, catch the unwind so a bad formula yields `None`
+    // rather than crashing the caller.
+    let node = node.clone();
+    let evaluated = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || vm.eval(node)));
+    evaluated.ok().as_ref().and_then(ir_to_f64)
+}
+
+/// Fold a rollup aggregation over child values.
+pub fn rollup(values: &[f64], agg: RollupAgg) -> f64 {
+    match agg {
+        RollupAgg::Sum => values.iter().sum(),
+        RollupAgg::Min => values.iter().copied().fold(f64::INFINITY, f64::min),
+        RollupAgg::Max => values.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        RollupAgg::Average => {
+            if values.is_empty() {
+                0.0
+            } else {
+                values.iter().sum::<f64>() / values.len() as f64
+            }
+        }
+        RollupAgg::Count => values.len() as f64,
+    }
+}
+
+/// The order in which computed fields must be evaluated so every formula sees fresh
+/// inputs — a topological sort of the field-dependency graph. Returns a `Cycle` error
+/// if a formula references itself (directly or transitively). Reuses `directed-graph`.
+pub fn field_eval_order(project: &ProjectState) -> Result<Vec<FieldId>, FormulaError> {
+    // Map field name → id so a formula's `[name]` references resolve to field ids.
+    let name_to_id: HashMap<&str, &FieldId> = project
+        .fields
+        .values()
+        .map(|f| (f.name.as_str(), &f.id))
+        .collect();
+
+    let mut graph = directed_graph::Graph::new();
+    let mut computed: Vec<FieldId> = Vec::new();
+    for f in project.fields.values() {
+        graph.add_node(f.id.as_str());
+    }
+    for f in project.fields.values() {
+        match &f.kind {
+            FieldKind::Formula { source } => {
+                computed.push(f.id.clone());
+                if let Ok(ast) = parse(source) {
+                    for dep_name in referenced_fields(&ast) {
+                        if let Some(dep_id) = name_to_id.get(dep_name.as_str()) {
+                            // A field referencing itself is a cycle. `directed-graph`
+                            // silently drops self-loops, so detect it explicitly.
+                            if **dep_id == f.id {
+                                return Err(FormulaError::Cycle(vec![f.id.clone()]));
+                            }
+                            let _ = graph.add_edge(dep_id.as_str(), f.id.as_str());
+                        }
+                    }
+                }
+            }
+            FieldKind::Rollup { field, .. } => {
+                computed.push(f.id.clone());
+                if field == &f.id {
+                    return Err(FormulaError::Cycle(vec![f.id.clone()]));
+                }
+                let _ = graph.add_edge(field.as_str(), f.id.as_str());
+            }
+            _ => {}
+        }
+    }
+
+    if graph.has_cycle() {
+        return Err(FormulaError::Cycle(computed));
+    }
+    let order = graph
+        .topological_sort()
+        .map_err(|_| FormulaError::Cycle(computed.clone()))?;
+    // Keep only computed fields, in dependency order.
+    let computed_set: HashSet<&str> = computed.iter().map(|f| f.as_str()).collect();
+    Ok(order
+        .into_iter()
+        .filter(|id| computed_set.contains(id.as_str()))
+        .map(FieldId::from_raw)
+        .collect())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A number binds as an exact integer when it is integral (so `symbolic-vm` keeps
+/// exact arithmetic), otherwise as a float.
+fn number_to_ir(v: f64) -> IRNode {
+    if v.fract() == 0.0 && v.abs() < 9.0e18 {
+        int(v as i64)
+    } else {
+        flt(v)
+    }
+}
+
+/// Extract a finite `f64` from an evaluated node, or `None` for non-numeric / infinite
+/// results (unevaluated symbols, booleans, division by zero).
+fn ir_to_f64(node: &IRNode) -> Option<f64> {
+    let v = match node {
+        IRNode::Integer(n) => *n as f64,
+        IRNode::Rational(n, d) if *d != 0 => *n as f64 / *d as f64,
+        IRNode::Float(f) => *f,
+        _ => return None,
+    };
+    v.is_finite().then_some(v)
+}
+
+// ── tokenizer + recursive-descent parser ─────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+enum Tok {
+    Num(f64, bool), // value, is_integer
+    Field(String),
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    LParen,
+    RParen,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+    Eq,
+    Ne,
+}
+
+fn tokenize(src: &str) -> Result<Vec<Tok>, FormulaError> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut toks = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            c if c.is_whitespace() => i += 1,
+            '[' => {
+                let mut name = String::new();
+                i += 1;
+                while i < chars.len() && chars[i] != ']' {
+                    name.push(chars[i]);
+                    i += 1;
+                }
+                if i >= chars.len() {
+                    return Err(FormulaError::Parse(
+                        "unclosed '[' in field reference".into(),
+                    ));
+                }
+                i += 1; // consume ']'
+                toks.push(Tok::Field(name.trim().to_string()));
+            }
+            '0'..='9' | '.' => {
+                let start = i;
+                let mut is_int = true;
+                while i < chars.len() && (chars[i].is_ascii_digit() || chars[i] == '.') {
+                    if chars[i] == '.' {
+                        is_int = false;
+                    }
+                    i += 1;
+                }
+                let s: String = chars[start..i].iter().collect();
+                let v: f64 = s
+                    .parse()
+                    .map_err(|_| FormulaError::Parse(format!("bad number '{s}'")))?;
+                toks.push(Tok::Num(v, is_int));
+            }
+            '+' => {
+                toks.push(Tok::Plus);
+                i += 1;
+            }
+            '-' => {
+                toks.push(Tok::Minus);
+                i += 1;
+            }
+            '*' => {
+                toks.push(Tok::Star);
+                i += 1;
+            }
+            '/' => {
+                toks.push(Tok::Slash);
+                i += 1;
+            }
+            '(' => {
+                toks.push(Tok::LParen);
+                i += 1;
+            }
+            ')' => {
+                toks.push(Tok::RParen);
+                i += 1;
+            }
+            '=' => {
+                toks.push(Tok::Eq);
+                i += 1;
+            }
+            '<' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    toks.push(Tok::Le);
+                    i += 2;
+                } else if i + 1 < chars.len() && chars[i + 1] == '>' {
+                    toks.push(Tok::Ne);
+                    i += 2;
+                } else {
+                    toks.push(Tok::Lt);
+                    i += 1;
+                }
+            }
+            '>' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    toks.push(Tok::Ge);
+                    i += 2;
+                } else {
+                    toks.push(Tok::Gt);
+                    i += 1;
+                }
+            }
+            other => {
+                return Err(FormulaError::Parse(format!(
+                    "unexpected character '{other}'"
+                )))
+            }
+        }
+    }
+    Ok(toks)
+}
+
+struct Parser {
+    toks: Vec<Tok>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&Tok> {
+        self.toks.get(self.pos)
+    }
+    fn bump(&mut self) -> Option<Tok> {
+        let t = self.toks.get(self.pos).cloned();
+        if t.is_some() {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn expr(&mut self) -> Result<IRNode, FormulaError> {
+        let left = self.additive()?;
+        let head = match self.peek() {
+            Some(Tok::Eq) => symbolic_ir::EQUAL,
+            Some(Tok::Ne) => symbolic_ir::NOT_EQUAL,
+            Some(Tok::Lt) => symbolic_ir::LESS,
+            Some(Tok::Gt) => symbolic_ir::GREATER,
+            Some(Tok::Le) => symbolic_ir::LESS_EQUAL,
+            Some(Tok::Ge) => symbolic_ir::GREATER_EQUAL,
+            _ => return Ok(left),
+        };
+        self.bump();
+        let right = self.additive()?;
+        Ok(apply(sym(head), vec![left, right]))
+    }
+
+    fn additive(&mut self) -> Result<IRNode, FormulaError> {
+        let mut node = self.multiplicative()?;
+        loop {
+            let head = match self.peek() {
+                Some(Tok::Plus) => symbolic_ir::ADD,
+                Some(Tok::Minus) => symbolic_ir::SUB,
+                _ => break,
+            };
+            self.bump();
+            let rhs = self.multiplicative()?;
+            node = apply(sym(head), vec![node, rhs]);
+        }
+        Ok(node)
+    }
+
+    fn multiplicative(&mut self) -> Result<IRNode, FormulaError> {
+        let mut node = self.unary()?;
+        loop {
+            let head = match self.peek() {
+                Some(Tok::Star) => symbolic_ir::MUL,
+                Some(Tok::Slash) => symbolic_ir::DIV,
+                _ => break,
+            };
+            self.bump();
+            let rhs = self.unary()?;
+            node = apply(sym(head), vec![node, rhs]);
+        }
+        Ok(node)
+    }
+
+    fn unary(&mut self) -> Result<IRNode, FormulaError> {
+        if matches!(self.peek(), Some(Tok::Minus)) {
+            self.bump();
+            let inner = self.unary()?;
+            return Ok(apply(sym(symbolic_ir::NEG), vec![inner]));
+        }
+        self.primary()
+    }
+
+    fn primary(&mut self) -> Result<IRNode, FormulaError> {
+        match self.bump() {
+            Some(Tok::Num(v, is_int)) => Ok(if is_int { int(v as i64) } else { flt(v) }),
+            Some(Tok::Field(name)) => Ok(sym(name)),
+            Some(Tok::LParen) => {
+                let inner = self.expr()?;
+                match self.bump() {
+                    Some(Tok::RParen) => Ok(inner),
+                    _ => Err(FormulaError::Parse("expected ')'".into())),
+                }
+            }
+            other => Err(FormulaError::Parse(format!(
+                "expected a field, number, or '(', found {other:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::{FieldId, ProjectId};
+    use crate::model::{FieldDef, FieldKind};
+
+    fn binds(pairs: &[(&str, f64)]) -> HashMap<String, f64> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    #[test]
+    fn parses_and_evaluates_arithmetic() {
+        let ast = parse("[a] * [b] + 2").unwrap();
+        let v = eval_number(&ast, &binds(&[("a", 3.0), ("b", 4.0)])).unwrap();
+        assert_eq!(v, 14.0);
+    }
+
+    #[test]
+    fn respects_precedence_and_parens() {
+        assert_eq!(
+            eval_number(&parse("2 + 3 * 4").unwrap(), &binds(&[])).unwrap(),
+            14.0
+        );
+        assert_eq!(
+            eval_number(&parse("(2 + 3) * 4").unwrap(), &binds(&[])).unwrap(),
+            20.0
+        );
+        assert_eq!(
+            eval_number(&parse("-[a] + 10").unwrap(), &binds(&[("a", 3.0)])).unwrap(),
+            7.0
+        );
+    }
+
+    #[test]
+    fn extracts_referenced_fields() {
+        let ast = parse("[work] / [duration] * 100").unwrap();
+        let mut fields = referenced_fields(&ast);
+        fields.sort();
+        assert_eq!(fields, vec!["duration".to_string(), "work".to_string()]);
+    }
+
+    #[test]
+    fn unbound_field_is_none_not_panic() {
+        let ast = parse("[a] + [missing]").unwrap();
+        assert_eq!(eval_number(&ast, &binds(&[("a", 1.0)])), None);
+    }
+
+    #[test]
+    fn division_by_zero_is_none_not_panic() {
+        let ast = parse("[a] / [b]").unwrap();
+        assert_eq!(
+            eval_number(&ast, &binds(&[("a", 6.0), ("b", 2.0)])),
+            Some(3.0)
+        );
+        assert_eq!(eval_number(&ast, &binds(&[("a", 6.0), ("b", 0.0)])), None);
+    }
+
+    #[test]
+    fn rollups_fold_correctly() {
+        let v = [1.0, 5.0, 3.0];
+        assert_eq!(rollup(&v, RollupAgg::Sum), 9.0);
+        assert_eq!(rollup(&v, RollupAgg::Min), 1.0);
+        assert_eq!(rollup(&v, RollupAgg::Max), 5.0);
+        assert_eq!(rollup(&v, RollupAgg::Average), 3.0);
+        assert_eq!(rollup(&v, RollupAgg::Count), 3.0);
+        assert_eq!(rollup(&[], RollupAgg::Average), 0.0);
+    }
+
+    #[test]
+    fn malformed_formula_is_a_parse_error() {
+        assert!(matches!(parse("[a] +"), Err(FormulaError::Parse(_))));
+        assert!(matches!(parse("[a"), Err(FormulaError::Parse(_))));
+        assert!(matches!(parse("2 @ 3"), Err(FormulaError::Parse(_))));
+    }
+
+    fn formula_field(id: &str, name: &str, source: &str) -> FieldDef {
+        FieldDef {
+            id: FieldId::from_raw(id),
+            name: name.to_string(),
+            kind: FieldKind::Formula {
+                source: source.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn field_eval_order_is_topological() {
+        // total = [subtotal] + 1; subtotal = [base] * 2. Order: subtotal before total.
+        let mut p = ProjectState::empty(ProjectId::from_raw("p1"));
+        p.fields.insert(
+            FieldId::from_raw("f_total"),
+            formula_field("f_total", "total", "[subtotal] + 1"),
+        );
+        p.fields.insert(
+            FieldId::from_raw("f_sub"),
+            formula_field("f_sub", "subtotal", "[base] * 2"),
+        );
+        let order = field_eval_order(&p).unwrap();
+        let pos = |id: &str| order.iter().position(|f| f.as_str() == id).unwrap();
+        assert!(pos("f_sub") < pos("f_total"));
+    }
+
+    #[test]
+    fn self_referential_formula_is_a_cycle() {
+        let mut p = ProjectState::empty(ProjectId::from_raw("p1"));
+        p.fields.insert(
+            FieldId::from_raw("f_a"),
+            formula_field("f_a", "a", "[a] + 1"),
+        );
+        assert!(matches!(field_eval_order(&p), Err(FormulaError::Cycle(_))));
+    }
+}

--- a/code/packages/rust/task-core/src/formula.rs
+++ b/code/packages/rust/task-core/src/formula.rs
@@ -44,9 +44,15 @@ pub enum FormulaError {
 /// (`[field]`, a number literal, or a parenthesised expression). Operators lower to
 /// the canonical `symbolic-ir` heads (`Add`/`Sub`/`Mul`/`Div`/`Neg`, comparisons).
 pub fn parse(src: &str) -> Result<IRNode, FormulaError> {
+    // Bound the input and the parser's recursion depth. Without this, a crafted
+    // formula (a long run of `-` or `(` from untrusted project JSON) would overflow
+    // the stack — an *uncatchable* abort, not a recoverable panic.
+    if src.len() > MAX_FORMULA_LEN {
+        return Err(FormulaError::Parse("formula too long".into()));
+    }
     let toks = tokenize(src)?;
     let mut p = Parser { toks, pos: 0 };
-    let node = p.expr()?;
+    let node = p.expr(0)?;
     if p.pos != p.toks.len() {
         return Err(FormulaError::Parse(format!(
             "unexpected trailing input at token {}",
@@ -55,6 +61,11 @@ pub fn parse(src: &str) -> Result<IRNode, FormulaError> {
     }
     Ok(node)
 }
+
+/// Maximum formula source length.
+const MAX_FORMULA_LEN: usize = 4096;
+/// Maximum parser nesting depth (parentheses / unary chains).
+const MAX_DEPTH: usize = 128;
 
 /// The set of field names a parsed formula reads — its dependencies. Fields appear
 /// only as leaf `Symbol`s in argument position (operator heads sit in `Apply.head`),
@@ -85,10 +96,16 @@ pub fn referenced_fields(node: &IRNode) -> Vec<String> {
 
 /// Evaluate a parsed numeric formula given `bindings` (field name → value).
 ///
-/// Returns `None` — never panics — when a referenced field is unbound (which would
-/// otherwise trip `StrictBackend`'s strictness) or when the result is not a finite
-/// number (e.g. division by zero, or a boolean comparison result). This is the
-/// panic-safe boundary for untrusted formula strings.
+/// Returns `None` when a referenced field is unbound (which would otherwise trip
+/// `StrictBackend`'s strictness) or when the result is not a finite number (a boolean
+/// comparison result, or division by zero — which `StrictBackend` *panics* on, caught
+/// here via `catch_unwind`).
+///
+/// **Caveat:** the div-by-zero guard relies on unwinding. Under a `panic = "abort"`
+/// profile (as some wasm builds use) `catch_unwind` cannot intercept it — so a crate
+/// that evaluates untrusted formulas must be built with `panic = "unwind"` (or the
+/// facade must pre-validate divisors). Parse-time limits (length + depth) are
+/// unconditional and do not depend on unwinding.
 pub fn eval_number(node: &IRNode, bindings: &HashMap<String, f64>) -> Option<f64> {
     // Gate: every referenced field must be bound, or StrictBackend would panic.
     for name in referenced_fields(node) {
@@ -344,8 +361,11 @@ impl Parser {
         t
     }
 
-    fn expr(&mut self) -> Result<IRNode, FormulaError> {
-        let left = self.additive()?;
+    fn expr(&mut self, depth: usize) -> Result<IRNode, FormulaError> {
+        if depth > MAX_DEPTH {
+            return Err(FormulaError::Parse("expression too deeply nested".into()));
+        }
+        let left = self.additive(depth)?;
         let head = match self.peek() {
             Some(Tok::Eq) => symbolic_ir::EQUAL,
             Some(Tok::Ne) => symbolic_ir::NOT_EQUAL,
@@ -356,12 +376,12 @@ impl Parser {
             _ => return Ok(left),
         };
         self.bump();
-        let right = self.additive()?;
+        let right = self.additive(depth)?;
         Ok(apply(sym(head), vec![left, right]))
     }
 
-    fn additive(&mut self) -> Result<IRNode, FormulaError> {
-        let mut node = self.multiplicative()?;
+    fn additive(&mut self, depth: usize) -> Result<IRNode, FormulaError> {
+        let mut node = self.multiplicative(depth)?;
         loop {
             let head = match self.peek() {
                 Some(Tok::Plus) => symbolic_ir::ADD,
@@ -369,14 +389,14 @@ impl Parser {
                 _ => break,
             };
             self.bump();
-            let rhs = self.multiplicative()?;
+            let rhs = self.multiplicative(depth)?;
             node = apply(sym(head), vec![node, rhs]);
         }
         Ok(node)
     }
 
-    fn multiplicative(&mut self) -> Result<IRNode, FormulaError> {
-        let mut node = self.unary()?;
+    fn multiplicative(&mut self, depth: usize) -> Result<IRNode, FormulaError> {
+        let mut node = self.unary(depth)?;
         loop {
             let head = match self.peek() {
                 Some(Tok::Star) => symbolic_ir::MUL,
@@ -384,27 +404,30 @@ impl Parser {
                 _ => break,
             };
             self.bump();
-            let rhs = self.unary()?;
+            let rhs = self.unary(depth)?;
             node = apply(sym(head), vec![node, rhs]);
         }
         Ok(node)
     }
 
-    fn unary(&mut self) -> Result<IRNode, FormulaError> {
+    fn unary(&mut self, depth: usize) -> Result<IRNode, FormulaError> {
+        if depth > MAX_DEPTH {
+            return Err(FormulaError::Parse("expression too deeply nested".into()));
+        }
         if matches!(self.peek(), Some(Tok::Minus)) {
             self.bump();
-            let inner = self.unary()?;
+            let inner = self.unary(depth + 1)?;
             return Ok(apply(sym(symbolic_ir::NEG), vec![inner]));
         }
-        self.primary()
+        self.primary(depth)
     }
 
-    fn primary(&mut self) -> Result<IRNode, FormulaError> {
+    fn primary(&mut self, depth: usize) -> Result<IRNode, FormulaError> {
         match self.bump() {
             Some(Tok::Num(v, is_int)) => Ok(if is_int { int(v as i64) } else { flt(v) }),
             Some(Tok::Field(name)) => Ok(sym(name)),
             Some(Tok::LParen) => {
-                let inner = self.expr()?;
+                let inner = self.expr(depth + 1)?;
                 match self.bump() {
                     Some(Tok::RParen) => Ok(inner),
                     _ => Err(FormulaError::Parse("expected ')'".into())),
@@ -490,6 +513,24 @@ mod tests {
         assert!(matches!(parse("[a] +"), Err(FormulaError::Parse(_))));
         assert!(matches!(parse("[a"), Err(FormulaError::Parse(_))));
         assert!(matches!(parse("2 @ 3"), Err(FormulaError::Parse(_))));
+    }
+
+    #[test]
+    fn pathological_input_is_rejected_not_a_stack_overflow() {
+        // A crafted formula from untrusted JSON must be bounded at parse time — a deep
+        // paren/unary nest or an over-long source is an error, never a stack overflow.
+        assert!(matches!(
+            parse(&"(".repeat(1000)),
+            Err(FormulaError::Parse(_))
+        ));
+        assert!(matches!(
+            parse(&"-".repeat(1000)),
+            Err(FormulaError::Parse(_))
+        ));
+        assert!(matches!(
+            parse(&"1".repeat(5000)),
+            Err(FormulaError::Parse(_))
+        ));
     }
 
     fn formula_field(id: &str, name: &str, source: &str) -> FieldDef {

--- a/code/packages/rust/task-core/src/lib.rs
+++ b/code/packages/rust/task-core/src/lib.rs
@@ -36,6 +36,7 @@
 //! types here define the *shape* of the world they operate on.
 
 pub mod calendar;
+pub mod formula;
 mod ids;
 mod model;
 mod primitives;

--- a/code/packages/rust/task-core/src/lib.rs
+++ b/code/packages/rust/task-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod calendar;
 pub mod formula;
 mod ids;
 mod model;
+pub mod ops;
 mod primitives;
 pub mod scheduler;
 

--- a/code/packages/rust/task-core/src/ops.rs
+++ b/code/packages/rust/task-core/src/ops.rs
@@ -1,0 +1,639 @@
+//! The pure operations API — every mutation as a validated method on `ProjectState`.
+//!
+//! There is **no command enum and no dispatch loop** (those are Flux/React idioms we
+//! deliberately avoid — see `task-app-architecture.md`). A mutation is an ordinary
+//! method that mutates the value in place and returns `Result<(), OpError>`. Methods
+//! are *pure*: deterministic, no I/O, no globals, no clock. A backend that wants value
+//! semantics simply `clone()`s first.
+//!
+//! This is the **single trust boundary** for the model's invariants — the validation
+//! (percent clamping, calendar interval bounds, reparent- and dependency-cycle
+//! rejection) lives here, so every platform gets it for free by calling the engine.
+
+use crate::ids::*;
+use crate::model::*;
+use crate::primitives::{Date, Duration};
+use std::collections::BTreeMap;
+
+/// The largest number of working intervals accepted on a single day — a real day has
+/// a handful; capping defends the working-time walk against a crafted calendar.
+const MAX_INTERVALS_PER_DAY: usize = 48;
+
+/// Why an operation was rejected. Operations never panic and never do I/O; an invalid
+/// request is a typed error, not a crash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub enum OpError {
+    /// A referenced entity (task, resource, calendar, field) does not exist.
+    NotFound,
+    /// The entity already exists (e.g. a duplicate id or dependency).
+    Duplicate,
+    /// The operation would create a cycle (task hierarchy or dependency network).
+    WouldCycle,
+    /// The input violated a constraint, with a short reason.
+    Invalid(&'static str),
+}
+
+impl OpError {
+    /// A stable integer code for the C ABI (0 = success is returned by the ABI, not here).
+    pub fn code(&self) -> i32 {
+        match self {
+            OpError::NotFound => 1,
+            OpError::Duplicate => 2,
+            OpError::WouldCycle => 3,
+            OpError::Invalid(_) => 4,
+        }
+    }
+}
+
+impl ProjectState {
+    // ── project ──────────────────────────────────────────────────────────────────
+
+    /// Rename the whole project.
+    pub fn set_project_name(&mut self, name: impl Into<String>) {
+        self.name = name.into();
+    }
+
+    // ── tasks ────────────────────────────────────────────────────────────────────
+
+    /// Create a leaf task. Rejects a duplicate id or a non-existent parent.
+    pub fn create_task(
+        &mut self,
+        id: TaskId,
+        name: impl Into<String>,
+        parent: Option<TaskId>,
+    ) -> Result<(), OpError> {
+        if self.tasks.contains_key(&id) {
+            return Err(OpError::Duplicate);
+        }
+        if let Some(p) = &parent {
+            if !self.tasks.contains_key(p) {
+                return Err(OpError::NotFound);
+            }
+        }
+        let mut t = Task::new(id.clone(), name);
+        t.parent = parent;
+        self.tasks.insert(id, t);
+        Ok(())
+    }
+
+    /// Rename a task.
+    pub fn rename_task(&mut self, id: &TaskId, name: impl Into<String>) -> Result<(), OpError> {
+        self.task_mut(id)?.name = name.into();
+        Ok(())
+    }
+
+    /// Set a task's notes.
+    pub fn set_notes(&mut self, id: &TaskId, notes: impl Into<String>) -> Result<(), OpError> {
+        self.task_mut(id)?.notes = notes.into();
+        Ok(())
+    }
+
+    /// Delete a task; its children are reparented to its parent, and links,
+    /// dependencies, and assignments referencing it are removed.
+    pub fn delete_task(&mut self, id: &TaskId) -> Result<(), OpError> {
+        let removed = self.tasks.remove(id).ok_or(OpError::NotFound)?;
+        for t in self.tasks.values_mut() {
+            if t.parent.as_ref() == Some(id) {
+                t.parent = removed.parent.clone();
+            }
+        }
+        self.dependencies
+            .retain(|d| &d.predecessor != id && &d.successor != id);
+        self.links.retain(|l| &l.from != id && &l.to != id);
+        self.assignments.retain(|a| &a.task != id);
+        Ok(())
+    }
+
+    /// Move a task under a new parent. Rejects a missing target or a cycle.
+    pub fn reparent(&mut self, id: &TaskId, new_parent: Option<TaskId>) -> Result<(), OpError> {
+        if !self.tasks.contains_key(id) {
+            return Err(OpError::NotFound);
+        }
+        if let Some(p) = &new_parent {
+            if !self.tasks.contains_key(p) {
+                return Err(OpError::NotFound);
+            }
+            if p == id || is_ancestor(self, id, p) {
+                return Err(OpError::WouldCycle);
+            }
+        }
+        self.tasks.get_mut(id).unwrap().parent = new_parent;
+        Ok(())
+    }
+
+    /// Set a task's sibling ordering key.
+    pub fn set_order(&mut self, id: &TaskId, order: i64) -> Result<(), OpError> {
+        self.task_mut(id)?.order = order;
+        Ok(())
+    }
+
+    /// Set a task's kind (leaf/summary/milestone).
+    pub fn set_kind(&mut self, id: &TaskId, kind: TaskKind) -> Result<(), OpError> {
+        self.task_mut(id)?.kind = kind;
+        Ok(())
+    }
+
+    /// Toggle a summary's collapsed state.
+    pub fn toggle_collapsed(&mut self, id: &TaskId) -> Result<(), OpError> {
+        let t = self.task_mut(id)?;
+        t.collapsed = !t.collapsed;
+        Ok(())
+    }
+
+    // ── progress / workflow ──────────────────────────────────────────────────────
+
+    /// Set a task's workflow status.
+    pub fn set_status(&mut self, id: &TaskId, status: Option<StatusId>) -> Result<(), OpError> {
+        self.task_mut(id)?.status = status;
+        Ok(())
+    }
+
+    /// Set a task's completion flag.
+    pub fn set_completed(&mut self, id: &TaskId, completed: bool) -> Result<(), OpError> {
+        self.task_mut(id)?.completed = completed;
+        Ok(())
+    }
+
+    /// Set percent complete, **clamped to 0..=100**.
+    pub fn set_percent_complete(&mut self, id: &TaskId, pct: u8) -> Result<(), OpError> {
+        self.task_mut(id)?.percent_complete = pct.min(100);
+        Ok(())
+    }
+
+    // ── scheduling ───────────────────────────────────────────────────────────────
+
+    /// Set or clear a task's whole scheduling block.
+    pub fn set_schedule(
+        &mut self,
+        id: &TaskId,
+        schedule: Option<TaskSchedule>,
+    ) -> Result<(), OpError> {
+        self.task_mut(id)?.schedule = schedule;
+        Ok(())
+    }
+
+    /// Set a task's duration (creating a default schedule block if absent).
+    pub fn set_duration(&mut self, id: &TaskId, duration: Duration) -> Result<(), OpError> {
+        self.task_mut(id)?
+            .schedule
+            .get_or_insert_with(TaskSchedule::default)
+            .duration = duration;
+        Ok(())
+    }
+
+    /// Set a task's date constraint (creating a schedule block if absent).
+    pub fn set_constraint(&mut self, id: &TaskId, constraint: Constraint) -> Result<(), OpError> {
+        self.task_mut(id)?
+            .schedule
+            .get_or_insert_with(TaskSchedule::default)
+            .constraint = constraint;
+        Ok(())
+    }
+
+    /// Set or clear a task's deadline (creating a schedule block if absent).
+    pub fn set_deadline(&mut self, id: &TaskId, deadline: Option<Date>) -> Result<(), OpError> {
+        self.task_mut(id)?
+            .schedule
+            .get_or_insert_with(TaskSchedule::default)
+            .deadline = deadline;
+        Ok(())
+    }
+
+    // ── relations ────────────────────────────────────────────────────────────────
+
+    /// Add a dependency. Rejects a self-link, a duplicate, unknown endpoints, or a
+    /// link that would make the dependency network cyclic.
+    pub fn link_dependency(&mut self, link: DependencyLink) -> Result<(), OpError> {
+        if link.predecessor == link.successor {
+            return Err(OpError::Invalid("self-dependency"));
+        }
+        if !self.tasks.contains_key(&link.predecessor) || !self.tasks.contains_key(&link.successor)
+        {
+            return Err(OpError::NotFound);
+        }
+        if self
+            .dependencies
+            .iter()
+            .any(|d| d.predecessor == link.predecessor && d.successor == link.successor)
+        {
+            return Err(OpError::Duplicate);
+        }
+        if would_cycle(self, &link) {
+            return Err(OpError::WouldCycle);
+        }
+        self.dependencies.push(link);
+        Ok(())
+    }
+
+    /// Remove a dependency by id.
+    pub fn unlink_dependency(&mut self, id: &LinkId) {
+        self.dependencies.retain(|d| &d.id != id);
+    }
+
+    /// Add a non-scheduling link. Rejects unknown endpoints.
+    pub fn add_link(&mut self, link: GenericLink) -> Result<(), OpError> {
+        if !self.tasks.contains_key(&link.from) || !self.tasks.contains_key(&link.to) {
+            return Err(OpError::NotFound);
+        }
+        self.links.push(link);
+        Ok(())
+    }
+
+    /// Remove a non-scheduling link by id.
+    pub fn remove_link(&mut self, id: &LinkId) {
+        self.links.retain(|l| &l.id != id);
+    }
+
+    // ── resources / assignments ──────────────────────────────────────────────────
+
+    /// Create or replace a resource.
+    pub fn upsert_resource(&mut self, resource: Resource) {
+        self.resources.insert(resource.id.clone(), resource);
+    }
+
+    /// Delete a resource and its assignments.
+    pub fn delete_resource(&mut self, id: &ResourceId) {
+        self.resources.remove(id);
+        self.assignments.retain(|a| &a.resource != id);
+    }
+
+    /// Assign a resource to a task (replacing an existing assignment of the same pair).
+    /// Rejects unknown task or resource.
+    pub fn assign(&mut self, assignment: Assignment) -> Result<(), OpError> {
+        if !self.tasks.contains_key(&assignment.task)
+            || !self.resources.contains_key(&assignment.resource)
+        {
+            return Err(OpError::NotFound);
+        }
+        self.assignments
+            .retain(|a| !(a.task == assignment.task && a.resource == assignment.resource));
+        self.assignments.push(assignment);
+        Ok(())
+    }
+
+    /// Remove an assignment.
+    pub fn unassign(&mut self, task: &TaskId, resource: &ResourceId) {
+        self.assignments
+            .retain(|a| !(&a.task == task && &a.resource == resource));
+    }
+
+    // ── calendars ────────────────────────────────────────────────────────────────
+
+    /// Create or replace a calendar. Rejects invalid day schedules.
+    pub fn upsert_calendar(&mut self, calendar: Calendar) -> Result<(), OpError> {
+        if !calendar.work_week.iter().all(valid_day_schedule)
+            || !calendar
+                .exceptions
+                .iter()
+                .all(|e| valid_day_schedule(&e.schedule))
+        {
+            return Err(OpError::Invalid("invalid calendar interval"));
+        }
+        self.calendars.insert(calendar.id.clone(), calendar);
+        Ok(())
+    }
+
+    /// Set the project's default calendar (must exist).
+    pub fn set_project_calendar(&mut self, id: CalendarId) -> Result<(), OpError> {
+        if !self.calendars.contains_key(&id) {
+            return Err(OpError::NotFound);
+        }
+        self.project_calendar = id;
+        Ok(())
+    }
+
+    /// Add a dated exception to a calendar. Rejects invalid intervals or unknown calendar.
+    pub fn add_calendar_exception(
+        &mut self,
+        cal: &CalendarId,
+        exception: CalendarException,
+    ) -> Result<(), OpError> {
+        if !valid_day_schedule(&exception.schedule) {
+            return Err(OpError::Invalid("invalid calendar interval"));
+        }
+        let c = self.calendars.get_mut(cal).ok_or(OpError::NotFound)?;
+        c.exceptions.retain(|e| e.date != exception.date);
+        c.exceptions.push(exception);
+        Ok(())
+    }
+
+    // ── fields ───────────────────────────────────────────────────────────────────
+
+    /// Create or replace a custom field definition.
+    pub fn upsert_field(&mut self, field: FieldDef) {
+        self.fields.insert(field.id.clone(), field);
+    }
+
+    /// Delete a custom field and its stored values.
+    pub fn delete_field(&mut self, id: &FieldId) {
+        self.fields.remove(id);
+        for t in self.tasks.values_mut() {
+            t.fields.remove(id);
+        }
+    }
+
+    /// Set or clear a task's value for a field. Rejects unknown field or task.
+    pub fn set_field_value(
+        &mut self,
+        task: &TaskId,
+        field: &FieldId,
+        value: Option<FieldValue>,
+    ) -> Result<(), OpError> {
+        if !self.fields.contains_key(field) {
+            return Err(OpError::NotFound);
+        }
+        let t = self.task_mut(task)?;
+        match value {
+            Some(v) => {
+                t.fields.insert(field.clone(), v);
+            }
+            None => {
+                t.fields.remove(field);
+            }
+        }
+        Ok(())
+    }
+
+    // ── decisions ────────────────────────────────────────────────────────────────
+
+    /// Set or clear a task's decision (branch point).
+    pub fn set_decision(&mut self, id: &TaskId, decision: Option<Decision>) -> Result<(), OpError> {
+        self.task_mut(id)?.decision = decision;
+        Ok(())
+    }
+
+    /// Answer a task's decision. Rejects a task with no decision.
+    pub fn answer_decision(&mut self, id: &TaskId, answer: bool) -> Result<(), OpError> {
+        let d = self
+            .task_mut(id)?
+            .decision
+            .as_mut()
+            .ok_or(OpError::Invalid("task has no decision"))?;
+        d.answer = Some(answer);
+        Ok(())
+    }
+
+    // ── baselines / views ────────────────────────────────────────────────────────
+
+    /// Capture a baseline of the current task durations and work.
+    pub fn capture_baseline(&mut self, id: BaselineId, name: String, now: u64) {
+        let tasks: BTreeMap<TaskId, BaselineTask> = self
+            .tasks
+            .iter()
+            .filter_map(|(tid, t)| {
+                t.schedule.as_ref().map(|sc| {
+                    (
+                        tid.clone(),
+                        BaselineTask {
+                            start: sc.actual_start,
+                            finish: sc.actual_finish,
+                            duration: sc.duration,
+                            work: sc.work,
+                        },
+                    )
+                })
+            })
+            .collect();
+        self.baselines.insert(
+            id.clone(),
+            Baseline {
+                id,
+                name,
+                captured_at: now,
+                tasks,
+            },
+        );
+    }
+
+    /// Delete a baseline.
+    pub fn delete_baseline(&mut self, id: &BaselineId) {
+        self.baselines.remove(id);
+    }
+
+    /// Create or replace a saved view.
+    pub fn upsert_view(&mut self, view: View) {
+        self.views.insert(view.id.clone(), view);
+    }
+
+    /// Delete a saved view.
+    pub fn delete_view(&mut self, id: &ViewId) {
+        self.views.remove(id);
+    }
+
+    // ── internal ─────────────────────────────────────────────────────────────────
+
+    fn task_mut(&mut self, id: &TaskId) -> Result<&mut Task, OpError> {
+        self.tasks.get_mut(id).ok_or(OpError::NotFound)
+    }
+}
+
+// ── validation helpers ───────────────────────────────────────────────────────────
+
+/// A day schedule is valid when every interval is well-formed (`start < end <= 1440`)
+/// and there are not pathologically many of them.
+fn valid_day_schedule(sched: &DaySchedule) -> bool {
+    sched.intervals.len() <= MAX_INTERVALS_PER_DAY
+        && sched
+            .intervals
+            .iter()
+            .all(|iv| iv.start_min < iv.end_min && iv.end_min <= 1440)
+}
+
+/// Whether `ancestor` appears on the parent chain of `task` (so making `task` the
+/// parent of `ancestor` would create a cycle). Bounded by the task count.
+fn is_ancestor(state: &ProjectState, ancestor: &TaskId, task: &TaskId) -> bool {
+    let mut cur = state.tasks.get(task).and_then(|t| t.parent.clone());
+    let mut guard = 0;
+    while let Some(p) = cur {
+        if &p == ancestor {
+            return true;
+        }
+        cur = state.tasks.get(&p).and_then(|t| t.parent.clone());
+        guard += 1;
+        if guard > state.tasks.len() {
+            break;
+        }
+    }
+    false
+}
+
+/// Whether adding `link` would introduce a cycle in the dependency network. Reuses
+/// `directed-graph`'s cycle detector over the existing edges plus the candidate.
+fn would_cycle(state: &ProjectState, link: &DependencyLink) -> bool {
+    let mut g = directed_graph::Graph::new();
+    for t in state.tasks.keys() {
+        g.add_node(t.as_str());
+    }
+    for d in &state.dependencies {
+        let _ = g.add_edge(d.predecessor.as_str(), d.successor.as_str());
+    }
+    let _ = g.add_edge(link.predecessor.as_str(), link.successor.as_str());
+    g.has_cycle()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> ProjectState {
+        ProjectState::empty(ProjectId::from_raw("p1"))
+    }
+    fn tid(s: &str) -> TaskId {
+        TaskId::from_raw(s)
+    }
+
+    #[test]
+    fn create_reject_duplicate_and_bad_parent() {
+        let mut s = base();
+        assert!(s.create_task(tid("a"), "A", None).is_ok());
+        assert_eq!(s.create_task(tid("a"), "A2", None), Err(OpError::Duplicate));
+        assert_eq!(
+            s.create_task(tid("b"), "B", Some(tid("missing"))),
+            Err(OpError::NotFound)
+        );
+        assert!(s.create_task(tid("b"), "B", Some(tid("a"))).is_ok());
+    }
+
+    #[test]
+    fn rename_missing_is_not_found() {
+        let mut s = base();
+        assert_eq!(s.rename_task(&tid("x"), "X"), Err(OpError::NotFound));
+    }
+
+    #[test]
+    fn percent_complete_is_clamped() {
+        let mut s = base();
+        s.create_task(tid("a"), "A", None).unwrap();
+        s.set_percent_complete(&tid("a"), 250).unwrap();
+        assert_eq!(s.tasks[&tid("a")].percent_complete, 100);
+    }
+
+    #[test]
+    fn reparent_rejects_cycles() {
+        let mut s = base();
+        s.create_task(tid("a"), "A", None).unwrap();
+        s.create_task(tid("b"), "B", Some(tid("a"))).unwrap(); // b under a
+        assert_eq!(
+            s.reparent(&tid("a"), Some(tid("b"))),
+            Err(OpError::WouldCycle)
+        );
+        assert_eq!(
+            s.reparent(&tid("a"), Some(tid("a"))),
+            Err(OpError::WouldCycle)
+        );
+    }
+
+    #[test]
+    fn delete_reparents_children_and_prunes_links() {
+        let mut s = base();
+        s.create_task(tid("a"), "A", None).unwrap();
+        s.create_task(tid("b"), "B", Some(tid("a"))).unwrap();
+        s.create_task(tid("c"), "C", None).unwrap();
+        s.link_dependency(DependencyLink {
+            id: LinkId::from_raw("l1"),
+            predecessor: tid("a"),
+            successor: tid("c"),
+            kind: DependencyKind::FinishToStart,
+            lag: Duration::zero(),
+        })
+        .unwrap();
+        s.delete_task(&tid("a")).unwrap();
+        assert!(!s.tasks.contains_key(&tid("a")));
+        assert_eq!(
+            s.tasks[&tid("b")].parent,
+            None,
+            "child reparented to grandparent"
+        );
+        assert!(s.dependencies.is_empty(), "dangling dependency pruned");
+    }
+
+    #[test]
+    fn dependency_rejects_self_dup_and_cycle() {
+        let mut s = base();
+        s.create_task(tid("a"), "A", None).unwrap();
+        s.create_task(tid("b"), "B", None).unwrap();
+        let mk = |id: &str, p: &str, q: &str| DependencyLink {
+            id: LinkId::from_raw(id),
+            predecessor: tid(p),
+            successor: tid(q),
+            kind: DependencyKind::FinishToStart,
+            lag: Duration::zero(),
+        };
+        assert_eq!(
+            s.link_dependency(mk("l0", "a", "a")),
+            Err(OpError::Invalid("self-dependency"))
+        );
+        assert!(s.link_dependency(mk("l1", "a", "b")).is_ok());
+        assert_eq!(
+            s.link_dependency(mk("l2", "a", "b")),
+            Err(OpError::Duplicate)
+        );
+        assert_eq!(
+            s.link_dependency(mk("l3", "b", "a")),
+            Err(OpError::WouldCycle)
+        );
+    }
+
+    #[test]
+    fn calendar_exception_with_bad_interval_is_rejected() {
+        let mut s = base();
+        let cal = s.project_calendar.clone();
+        let bad = CalendarException {
+            date: Date::from_ymd(2026, 7, 10).unwrap(),
+            schedule: DaySchedule {
+                working: true,
+                intervals: vec![MinuteInterval {
+                    start_min: 600,
+                    end_min: 500,
+                }],
+            },
+        };
+        assert_eq!(
+            s.add_calendar_exception(&cal, bad),
+            Err(OpError::Invalid("invalid calendar interval"))
+        );
+    }
+
+    #[test]
+    fn assign_replaces_by_pair_and_needs_known_entities() {
+        let mut s = base();
+        s.create_task(tid("a"), "A", None).unwrap();
+        let asn = |units: f64| Assignment {
+            task: tid("a"),
+            resource: ResourceId::from_raw("r1"),
+            units,
+            work: crate::primitives::Work::minutes(480),
+            contour: WorkContour::Flat,
+        };
+        assert_eq!(
+            s.assign(asn(1.0)),
+            Err(OpError::NotFound),
+            "unknown resource"
+        );
+        s.upsert_resource(Resource {
+            id: ResourceId::from_raw("r1"),
+            name: "Dev".into(),
+            kind: ResourceKind::Work,
+            calendar: None,
+            max_units: 1.0,
+            std_rate: crate::primitives::Money::zero("USD"),
+            cost_per_use: crate::primitives::Money::zero("USD"),
+        });
+        s.assign(asn(1.0)).unwrap();
+        s.assign(asn(0.5)).unwrap();
+        assert_eq!(s.assignments.len(), 1);
+        assert_eq!(s.assignments[0].units, 0.5);
+    }
+
+    #[test]
+    fn methods_are_pure_no_hidden_state() {
+        // Two independent projects don't interfere — the "engine" holds no globals.
+        let mut a = base();
+        let b = base();
+        a.create_task(tid("x"), "X", None).unwrap();
+        assert_eq!(a.tasks.len(), 1);
+        assert_eq!(b.tasks.len(), 0);
+    }
+}

--- a/code/specs/task-app-architecture.md
+++ b/code/specs/task-app-architecture.md
@@ -1,210 +1,174 @@
 # task-app — Application Architecture
 
-> Part of the [task-app spec series](task-app-overview.md). Defines the crate layering, the
-> props/event contract, and the FFI/UI seams. This replicates the **Engram** architecture
-> (`engram-core` → `engram-core-wasm` → `engram-capi`+`engram-wasm` → Mosaic host adapters) exactly;
-> where a decision has a proven Engram precedent, we cite it.
+> Part of the [task-app spec series](task-app-overview.md). Defines the crate layering and the
+> engine ↔ UI seam.
+>
+> **This spec was rewritten (2026-07-11) to remove imported "Reactism".** The original draft copied
+> Engram's Flux command/dispatch reducer and a single `dispatch`/`getProps`/`handleEvent` JSON facade
+> and imposed that React-shaped contract on all nine platforms. That is wrong: SwiftUI, Compose, Qt,
+> Flutter, and WinUI do not work like React, and forcing a props/events dispatch model onto them
+> produces awkward, non-idiomatic code. The corrected architecture is below.
+
+## Two principles
+
+1. **The engine is pure computation only.** `task-core` is the data model plus pure functions —
+   validated operations, queries/projections, the CPM scheduler, calendar math, and formula
+   evaluation. It has no I/O, no clock (`now: u64` is passed in), and **no state-management runtime**
+   (no store, no command bus, no dispatch loop). It is a library of pure functions over a value.
+
+2. **Each backend adopts its own native conventions.** There is **no universal facade**. Every host
+   holds the engine's state in *its platform's* native container and calls the engine's functions
+   directly, observing changes the platform's own way. React-isms live only in the React (web)
+   backend — never leaked into the others.
 
 ## The layer cake
 
 ```
-task-core            pure domain: ProjectState + reduce() + CPM scheduler + formula/calendar modules
-  │                  no I/O, no clock (now: u64 injected), serde behind a feature, forbid(unsafe)
-  └ task-core-wasm   THE FACADE (platform-free, forbid(unsafe)): TaskSession = ProjectState +
-        │            view-model state; &str-in / JSON-String-out (panic-caught); dispatch() command
-        │            bus; get_props(ctx) → flat kebab slot map; handle_event() → combined envelope
-        ├ task-capi  extern "C" over TaskSession — native shells; + task-host-cli sidecar
-        └ task-wasm  linear-memory WASM ABI over TaskSession — browser / Electron; + JS loader
+task-core            THE PURE ENGINE (no I/O, no clock, no state runtime, forbid(unsafe)):
+                       • model types (ProjectState and its entities)
+                       • pure operations API — validated &mut methods (the trust boundary)
+                       • pure queries / projections — checklist, todo, kanban, gantt,
+                         flowchart, table, computed fields
+                       • scheduler (CPM), calendar (working time), formula (symbolic-vm)
+  ├ task-capi        C ABI exposing the engine's functions to native shells (opaque handle)
+  └ task-wasm        linear-memory WASM ABI exposing the same to browser / Electron (+ JS accessor)
+
+per-backend NATIVE host bindings (each idiomatic — NOT a shared facade):
+  web / React        engine (via task-wasm) held in React state / hooks   — React-isms belong here
+  SwiftUI            @Observable model wraps the engine (via task-capi)
+  Jetpack Compose    State / ViewModel wraps the engine (via task-capi + JNA)
+  Qt                 QAbstractItemModel + signals/slots over the engine (via task-capi)
+  Flutter            ChangeNotifier / Riverpod over the engine (via task-capi + Dart FFI)
+  WinUI / XAML       observable dependency properties over the engine (via task-capi)
 ```
 
-`task-capi` and `task-wasm` are **siblings**, each depending only on `task-core-wasm` and adding an
-ABI + marshalling. All behavior — every prop, every event — lives once in the facade. Porting to a
-platform is a new thin ABI/adapter, never a change to core logic. (Engram precedent:
-`engram-capi`/`engram-wasm` both wrap `engram-core-wasm`, not `engram-core`.)
+`task-capi` and `task-wasm` are thin ABIs over the **same pure engine functions** — they add
+marshalling only, never behavior or state. Only they contain `unsafe`; everything in `task-core` is
+`forbid(unsafe_code)`.
 
-Only the two ABI crates contain `unsafe`; everything below `forbid(unsafe_code)`.
+## `task-core` — the pure engine API
 
-## `task-core` — the domain core
+### Operations (validated mutations)
 
-Public surface (engram-core `reducer.rs` pattern):
-
-```rust
-pub struct ProjectState { /* see data-model spec */ }
-
-pub enum TaskCommand { /* the full mutation catalog, below */ }
-
-/// Pure reducer: immutable in, new state out. Never mutates in place.
-pub fn reduce(state: &ProjectState, cmd: TaskCommand) -> ProjectState;
-
-/// Pure read-models (not commands) — the scheduler & projections:
-pub fn schedule(state: &ProjectState) -> ScheduleResult;        // CPM: dates, slack, critical, conflicts
-pub fn level_resources(state: &ProjectState, opts: LevelOpts) -> ScheduleResult;
-pub fn recompute_fields(state: &ProjectState) -> FieldValues;   // formula/rollup via symbolic-vm
-pub fn checklist_view(state, view) -> ChecklistProjection;      // flattenVisibleItems analogue
-pub fn kanban_view(state, view) -> KanbanProjection;
-pub fn gantt_view(state, view) -> GanttProjection;
-// … one per ViewShape …
-```
-
-### Command catalog (`TaskCommand`)
-
-Grouped; each variant carries typed ids/values (not strings):
-
-- **Task**: `CreateTask`, `RenameTask`, `SetNotes`, `DeleteTask`, `Reparent{task,new_parent,index}`,
-  `Reorder`, `SetKind`, `ToggleCollapsed`.
-- **Progress/workflow**: `SetStatus`, `ToggleCompleted`, `SetPercentComplete`.
-- **Schedule**: `SetDuration`, `SetWork`, `SetTaskType`, `SetConstraint`, `SetDeadline`,
-  `SetTaskCalendar`, `SetActuals`.
-- **Dependencies**: `LinkDependency{pred,succ,kind,lag}`, `UnlinkDependency`, `SetDependencyKind`,
-  `SetLag`.
-- **Generic links**: `AddLink`, `RemoveLink`.
-- **Resources/assignments**: `CreateResource`, `EditResource`, `DeleteResource`, `Assign`,
-  `SetAssignmentUnits`, `SetContour`, `Unassign`.
-- **Calendars**: `CreateCalendar`, `SetWorkWeek`, `AddException`, `RemoveException`, `SetProjectCalendar`.
-- **Fields**: `AddFieldDef`, `EditFieldDef`, `DeleteFieldDef`, `SetFieldValue`.
-- **Decision (checklist)**: `SetDecisionQuestion`, `AnswerDecision{task,answer}`, `ClearDecision`.
-- **Baselines**: `CaptureBaseline`, `DeleteBaseline`.
-- **Views**: `CreateView`, `EditView`, `DeleteView`.
-- **Bulk/state**: `LoadState`, `ImportProject`, `Undo`, `Redo` (history via snapshot stack).
-
-### Recompute triggers
-
-Each command declares what it invalidates, so the facade recomputes minimally:
-
-| Invalidates | Commands (examples) |
-|---|---|
-| **Schedule cache** (→ re-run CPM) | duration/work/type/constraint/calendar edits, link CRUD, reparent, assignment edits |
-| **Formula cache** (→ recompute affected fields) | `SetFieldValue`, any schedule change formulas read (`[finish]` etc.) |
-| **Neither** | rename, notes, view CRUD, collapse toggle |
-
-`directed-graph.affected_nodes` bounds both recomputations to the transitive impact set.
-
-## `task-core-wasm` — the facade (the contract layer)
-
-The keystone: the single place the UI contract is defined. (Engram precedent:
-`engram-core-wasm/src/lib.rs`.)
+Mutations are ordinary methods on `ProjectState`, returning `Result<_, OpError>`. They mutate the
+value in place (pure: deterministic, no I/O, no globals) and are the **single trust boundary** that
+enforces the model's invariants — the validation formerly attributed to a "reducer" lives here, with
+no command enum and no dispatch:
 
 ```rust
-pub struct TaskSession {
-    state: ProjectState,
-    // view-model state the core doesn't track:
-    active_view: ViewId,
-    selection: Vec<TaskId>,
-    editor: Option<TaskEditorState>,
-    filters: FilterState,
-}
-impl TaskSession {
-    pub fn new() -> Self; pub fn new_demo() -> Self;
-    pub fn snapshot(&self) -> String;                 // JSON of ProjectState
-    pub fn load_snapshot(&mut self, json: &str) -> String;
-    pub fn dispatch(&mut self, command_json: &str) -> String;      // {"ok":true,"state":…}
-    pub fn get_props(&self, ctx_json: &str) -> String;             // flat kebab-case slot map
-    pub fn handle_event(&mut self, event_json: &str, now: u64) -> String; // combined envelope
-    pub fn export_backup(&self, now: u64) -> String;
-    pub fn import_backup(&mut self, json: &str) -> String;
+pub enum OpError { NotFound, Duplicate, WouldCycle, Invalid(&'static str) }
+
+impl ProjectState {
+    pub fn create_task(&mut self, id: TaskId, name: impl Into<String>, parent: Option<TaskId>) -> Result<(), OpError>;
+    pub fn rename_task(&mut self, id: &TaskId, name: impl Into<String>) -> Result<(), OpError>;
+    pub fn delete_task(&mut self, id: &TaskId) -> Result<(), OpError>;   // reparents children, prunes links
+    pub fn reparent(&mut self, id: &TaskId, new_parent: Option<TaskId>) -> Result<(), OpError>; // cycle-checked
+    pub fn set_percent_complete(&mut self, id: &TaskId, pct: u8) -> Result<(), OpError>;        // clamped 0..=100
+    pub fn set_schedule(&mut self, id: &TaskId, schedule: Option<TaskSchedule>) -> Result<(), OpError>;
+    pub fn link_dependency(&mut self, link: DependencyLink) -> Result<(), OpError>; // self/dup/cycle-checked
+    pub fn upsert_resource(&mut self, r: Resource) -> Result<(), OpError>;
+    pub fn assign(&mut self, a: Assignment) -> Result<(), OpError>;
+    pub fn add_calendar_exception(&mut self, cal: &CalendarId, ex: CalendarException) -> Result<(), OpError>; // interval-validated
+    pub fn set_field_value(&mut self, task: &TaskId, field: &FieldId, value: Option<FieldValue>) -> Result<(), OpError>;
+    pub fn answer_decision(&mut self, id: &TaskId, answer: bool) -> Result<(), OpError>;
+    pub fn capture_baseline(&mut self, id: BaselineId, name: String, now: u64) -> Result<(), OpError>;
+    // … one method per operation; each returns Ok or a typed rejection.
 }
 ```
 
-- **Method shape**: `&str` in, JSON `String` out, every call wrapped in a panic-catcher so a bug
-  becomes `{"ok":false,"error":…}` instead of trapping the FFI boundary. Standard success envelope
-  `{"ok":true,"<key>":<payload>}`. (Engram's `catch_json`/`ok_with`.)
-- **`dispatch`** deserializes a `FacadeCommand`, lowers it into a core `TaskCommand`, and `reduce`s.
-- **`get_props(ctx)`** builds a flat object of **kebab-case slot keys** from the current state +
-  active view + selection — e.g. `"app-title"`, `"view-shape"`, `"task-count"`,
-  `"gantt-bars"` (list), `"selected-task-name"`, `"schedule-conflicts"` (list),
-  `"kanban-columns"`. Names line up 1:1 with the Mosaic `.mil` slots.
-- **`handle_event(event, now)`** parses an event envelope into a typed `TaskAppEvent`
-  (`SelectTask`, `Toggle`, `AnswerDecision`, `MoveCard{task,to_status}`, `EditDuration`,
-  `RequestOpenFile`, `RequestSave`, …), mutates via `dispatch`/view-model, and returns **one combined
-  envelope**: `{ ok, event, hostIntent?, state, props }` — the freshly recomputed props *and* an
-  optional out-of-band host intent.
-- **`hostIntent`** is the escape hatch for things the sandbox can't do — file open/save,
-  OS dialogs. `host_intent_for_event` emits e.g. `{"type":"openProject","accept":[".taskproj",".json"]}`
-  or `{"type":"saveProject","extension":".taskproj"}`. The host performs the side effect and feeds
-  bytes back through a dedicated method. (Engram precedent: Anki import/export intents.)
+A backend that prefers value semantics simply `clone()`s first — the methods do not impose
+immutability, and they do not impose a command/dispatch shape.
 
-The facade also owns **snapshot persistence policy** (what to persist after each non-error event),
-which host adapters wrap with `storage-core` / localStorage.
+### Queries / projections (read-only)
+
+Every view primitive is a pure function over the state — this is the "one model, many views" thesis
+made concrete, and the "rock-solid API across all the primitives" the app is built on:
+
+```rust
+impl ProjectState {
+    pub fn schedule(&self, project_start: Date) -> Result<ScheduleResult, SchedulingError>; // CPM
+    pub fn checklist(&self, view: &View) -> Vec<ChecklistRow>;   // flatten decision-visible items
+    pub fn todos(&self, view: &View) -> Vec<TodoRow>;
+    pub fn kanban(&self, view: &View) -> Vec<KanbanColumn>;
+    pub fn gantt(&self, project_start: Date) -> GanttView;       // bars from schedule()
+    pub fn flowchart(&self) -> FlowGraph;                        // tasks as nodes, links as edges
+    pub fn table(&self, view: &View) -> TableData;
+    pub fn computed_fields(&self) -> BTreeMap<TaskId, BTreeMap<FieldId, FieldValue>>; // formula/rollup
+}
+```
+
+### Serialization
+
+`serde` (behind the feature) gives `to_json` / `from_json` for `ProjectState`. Persistence is
+**host-owned**: the host serialises the value and writes it wherever is native (localStorage, a file,
+a keychain) and hands bytes back to `from_json`. The engine performs no I/O.
 
 ## `task-capi` — C ABI (native shells)
 
-(Engram precedent: `engram-capi`.) `crate-type = ["cdylib","staticlib","rlib"]`, plus a
-`[[bin]] task-host-cli`.
+An opaque handle over a `ProjectState`, with functions that mirror the engine API 1:1. No
+"session", no "dispatch", no props/events:
 
 ```c
-TaskSession* task_session_new(void);
-void         task_session_free(TaskSession*);
-char*        task_dispatch(TaskSession*, const char* command_json);
-char*        task_get_props(TaskSession*, const char* ctx_json);
-char*        task_handle_event(TaskSession*, const char* event_json, uint64_t now);
-char*        task_snapshot(TaskSession*);
-char*        task_load_snapshot(TaskSession*, const char* json);
-char*        task_import_project(TaskSession*, const uint8_t* data, size_t len); // binary payloads
-void         task_string_free(char*);   // caller frees every returned string
+ProjectState* ts_new(void);
+void          ts_free(ProjectState*);
+// operations: typed args or a small JSON arg; return 0 or an OpError code
+int32_t       ts_create_task(ProjectState*, const char* id, const char* name, const char* parent_or_null);
+int32_t       ts_link_dependency(ProjectState*, const char* link_json);
+// queries: return owned JSON strings (freed by ts_string_free)
+char*         ts_schedule(ProjectState*, int32_t project_start_days);
+char*         ts_checklist(ProjectState*, const char* view_json);
+char*         ts_gantt(ProjectState*, int32_t project_start_days);
+char*         ts_snapshot(ProjectState*);
+int32_t       ts_load(ProjectState*, const char* json);
+void          ts_string_free(char*);
 ```
 
-Opaque handle + NUL-terminated UTF-8 strings; a `with_session` helper null-checks and maps 1:1 onto
-the facade. Binary payloads (project file import) use `(ptr,len)` byte pairs. Events flow back the
-same way any call returns — request/response, no callbacks; `hostIntent` rides inside the
-`handle_event` JSON. Ships a generated `include/task.h` for the SwiftUI module map.
+FFI input enums are primitive ints validated via `TryFrom` (never `repr(C)` Rust enums). Binary
+import/export uses `(ptr, len)` byte pairs. A native host calls these from *its* model layer.
 
 ## `task-wasm` — WASM ABI (browser / Electron)
 
-(Engram precedent: `engram-wasm`, mirroring the repo's `spreadsheet-wasm` convention.) Hand-rolled
-`extern "C"` over `wasm32-unknown-unknown` linear memory — not wasm-bindgen:
+The same engine functions over a hand-rolled linear-memory ABI (`alloc`/`dealloc`, `(ptr,len)` in,
+length-prefixed out), plus a small JS accessor:
 
-- exports `alloc(len)` / `dealloc(ptr,len)`; inputs are `(ptr,len)` byte pairs; outputs are
-  **length-prefixed** (`[u32 LE len][UTF-8 JSON]`).
-- one `thread_local! { static SESSION: RefCell<TaskSession> }`, with `reset()`/`reset_demo()`.
-- exports mirror the facade: `dispatch`, `snapshot`, `load_snapshot`, `get_props`, `handle_event`,
-  `import_project`, `export_backup`.
-- a hand-written JS loader `task-mosaic-host-wasm.mjs` (typed `.d.ts`) exposes
-  `createTaskEngine(wasmBytes, opts) → TaskEngine` with camelCase methods and, crucially,
-  `engine.createMosaicHost({now, onHostIntent}) → { platform, getProps, handleEvent }` — where the
-  Rust kebab-case slot keys are surfaced to the Mosaic host contract.
+```ts
+const engine = await createTaskEngine(wasmBytes);   // holds one ProjectState
+engine.createTask(id, name, parent);                // → throws on OpError
+engine.schedule(projectStart);                       // → ScheduleResult
+engine.checklist(view); engine.gantt(projectStart);  // → view data
+engine.snapshot(); engine.load(json);
+```
 
-## Mosaic UI package (`code/programs/mosaic/task-app`)
+The web/React host keeps this engine in React state and re-renders on change — idiomatic React, not
+a `getProps`/`handleEvent` bus.
 
-A **UI** package — no product logic. (Engram precedent: `engram-app` package.)
+## Mosaic UI + native wiring
 
-- `TaskApp.mil` — interface: `slot`s (props, typed) and `emit`s (events, some with typed args like
-  `onMoveCard(task:text, toStatus:text)`), names aligned to the facade's kebab-case prop keys.
-- `TaskApp.mll` + `TaskApp.touch.mll` — desktop and touch layout variants.
-- `TaskApp.light.msl` + `TaskApp.dark.msl` — theme stylesheets (`--theme` at build).
-- `mosaic-package.toml` — `exports = ["TaskApp"]`; depends on reusable
-  `code/packages/mosaic/mosaic-pkg-*` components; declares `[host_assets]` (the adapter files).
-- `scripts/build-all.ps1` — the assembly line: build `task-wasm` (→ wasm + JS loader) and
-  `cargo build -p task-capi` (→ dll/dylib/so + static lib + `task-host-cli`); then per backend run
-  `mosaic-compile pkg … --backend X --emit-project`; then install the right artifact — wasm+loader
-  for web/react/electron, `task_capi.{dll,dylib,so}` for qt/xaml/flutter/compose, static lib +
-  `task.h` + module.modulemap for swiftui.
+The UI is authored **once in Mosaic** (`.mil`/`.mll`/`.msl`) and emitted per backend. But the *data
+in* and *actions out* are wired **natively**, not through a universal contract:
 
-### Reusable components (`code/packages/mosaic/mosaic-pkg-*`)
+- **Web/React**: the Mosaic-emitted React components receive data as **props from React state**
+  (backed by the wasm engine) and raise callbacks that call engine methods.
+- **SwiftUI**: the Mosaic-emitted views bind to an **`@Observable`** model that wraps `task-capi`.
+- **Compose**: bind to Compose **`State`** exposed by a ViewModel over `task-capi`.
+- **Qt**: back the Mosaic views with a **`QAbstractItemModel`**; actions are slots calling `task-capi`.
 
-`checklist-runner`, `todo-list`, `task-board` (kanban), `gantt-view`, `flowchart-view`,
-`task-detail`, `field-editor`, `calendar-view`. Each is an independently-adoptable Mosaic component,
-authored once, emitted to every backend.
+Reusable `code/packages/mosaic/mosaic-pkg-*` components cover the primitives (checklist-runner,
+todo-list, task-board, gantt-view, flowchart-view, task-detail, field-editor). Mosaic is the view
+layer; each backend owns its state and reactivity.
 
-### Host adapters (`host/{web,electron,qt,swiftui,compose,flutter,xaml}`)
+## What this deliberately does NOT have
 
-Thin per-backend glue. The **getProps/handleEvent contract** is the seam: Mosaic-generated UI calls
-`window.mosaicHost.getProps({component})` to fill slots and `window.mosaicHost.handleEvent(...)` on
-`emit`. The web adapter builds that host object from `engine.createMosaicHost(...)`:
-`getProps → task_get_props → {props}`; `handleEvent → task_handle_event → {props, hostIntent}`;
-re-render from `props`, and route any `hostIntent` through `onHostIntent` (file open/save), then
-persist `snapshot()` via `withSnapshotPersistence` (localStorage / `~/.task-app/snapshot.v1.json`).
-Native shells (Qt/XAML/SwiftUI/Compose/Flutter) link `task-capi` and marshal identically.
+- No `reduce(state, command)` / `TaskCommand` enum / command bus (a Flux/React idiom).
+- No `task-core-wasm` "session" facade, no `dispatch` / `getProps` / `handleEvent` universal contract.
+- No kebab-case slot map treated as the cross-platform wire format.
 
-## Contract-parity testing
+The engine is functions over a value; the platforms are native. That is the whole design.
 
-Following Engram's smoke tests: assert that every generated host shell (web/react/electron and the
-native project shells) exposes the **same** slot keys and event envelope as the `TaskSession` facade
-— i.e. the `.mil` interface stays in lockstep with `get_props`/`handle_event`. This catches drift
-between the Rust contract and the Mosaic UI at build time, on every platform.
+## Testing
 
-## Phase-1 seam (how the two tracks meet)
-
-Track B (facade + wasm + Mosaic + web/electron) can start against a **minimal** `task-core` (tasks +
-checklist/todo projections, no scheduling) so the pipeline is proven end-to-end early; as Track A
-lands the real CPM scheduler + resources, the facade's read-models (`schedule`, `gantt_view`, …)
-light up without changing the ABI or the UI contract. The contract-parity tests guard the seam.
+- **Engine**: exhaustive pure unit tests (operations incl. validation/rejection; every projection;
+  scheduler correctness; formula eval) — no mocks needed, since there is no I/O.
+- **ABIs**: round-trip tests that the C/WASM boundary faithfully forwards to the engine.
+- **Host bindings**: tested in each backend's native idiom (SwiftUI previews, Compose tests, etc.).
+- The "contract" is the engine's typed Rust API, not a JSON props schema.


### PR DESCRIPTION
## What

Finishes the mutation + formula surface of the **pure `task-core` engine**, and
**corrects the architecture** away from imported React-isms.

Per user direction: *"Do not import Reactism into platforms that do not have them. For
each backend adopt the native conventions. The engine should be pure computations only."*

## Architecture correction

- **Dropped** the Flux command/dispatch reducer (`TaskCommand` + `reduce`) — a React/
  Redux idiom (its PR #8081 is closed).
- **`task-app-architecture.md` rewritten**: the engine is **pure computation** exposed
  over C ABI + WASM; each backend adopts **native conventions** (React state on web,
  SwiftUI `@Observable`, Compose `State`, Qt models). **No** universal `dispatch` /
  `getProps` / `handleEvent` facade.

## The pure operations API (`ops` module)

Every mutation is a validated method on `ProjectState` — `create_task`, `reparent`,
`link_dependency`, `assign`, `add_calendar_exception`, `set_field_value`, … — returning
`Result<(), OpError>`. No command enum, no dispatch. Pure (mutate in place; no I/O,
clock, or globals) and the **single trust boundary** enforcing invariants: `percent`
clamped 0..=100; calendar intervals validated (`start < end <= 1440`) + length-capped;
reparent-cycle and self/duplicate/cycle dependency links rejected (via `directed-graph`).
`OpError` carries a stable `code()` for the C ABI.

## Computed fields (`formula` module, also in this branch)

`[field]` bracket parser → `symbolic-ir`; panic-safe `symbolic-vm` evaluation (parse-time
length + depth caps against crafted input; div-by-zero → `None`); direct-Rust rollups;
`directed-graph` field-eval order rejecting cyclic formulas.

## Quality

- 44 tests pass (ops validation/rejection + formula + scheduler + calendar + model);
  **clippy-clean** (`-D warnings`); `#![forbid(unsafe_code)]`; both feature configs.

## Next

Pure view **projections** (checklist/todo/kanban/gantt/flowchart/table), then the
`task-capi`/`task-wasm` ABIs, then the Mosaic UI wired natively per backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)