### PR TITLE
feat(sir-runtime-oop): Array minmax (Python reference)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.25] - 2026-07-11
+
+### Added
+
+- **`Array#minmax`** — the non-block Array method returning the two-element
+  array `[min, max]` in one call (`[3,1,2].minmax` → `[1, 3]`;
+  `["b","a","c"].minmax` → `["a", "c"]`). Ruby returns `[nil, nil]` for an empty
+  array (there is no smallest/largest element), which the runtime mirrors with
+  `[None, None]`. This is the Python **reference** for the new cross-backend
+  cascade (Go/Rust/JS/TS mirrors to follow). `respond_to?("minmax")` reports
+  `true`.
+
 ## [0.1.24] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -64,7 +64,7 @@ native Python subscripts and still return `nil` (Ruby does not raise for `[]`).
 The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md`)
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
-`min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
+`min`/`max`/`minmax`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
 `take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons`, `tally` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a`, plus the **Kernel

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.24"
+version = "0.1.25"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -563,6 +563,7 @@ _ARRAY_METHODS = frozenset(
         "sort",
         "min",
         "max",
+        "minmax",
         "sum",
         "uniq",
         "flatten",
@@ -965,6 +966,11 @@ def _array_method(recv: list[Val], name: str, args: list[Val]) -> Val:
         return min(recv) if recv else None
     if name == "max":
         return max(recv) if recv else None
+    if name == "minmax":
+        # ``minmax`` — the two-element array ``[min, max]`` in one pass.
+        # ``[3,1,2].minmax`` → ``[1, 3]``.  Ruby returns ``[nil, nil]`` for an
+        # empty array (there is no smallest/largest element).
+        return [min(recv), max(recv)] if recv else [None, None]
     if name == "sum":
         total: Val = args[0] if args else 0
         for item in recv:

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -329,6 +329,11 @@ def test_array_reverse_sort_minmax_sum() -> None:
     assert oop.call_method([1, 2, 3], "sum") == 6
     assert oop.call_method([1, 2, 3], "sum", 10) == 16
     assert oop.call_method([], "min") is None
+    # `minmax` → [min, max] in one call; empty → [nil, nil].
+    assert oop.call_method([3, 1, 2], "minmax") == [1, 3]
+    assert oop.call_method(["b", "a", "c"], "minmax") == ["a", "c"]
+    assert oop.call_method([], "minmax") == [None, None]
+    assert oop.call_method([1], "respond_to?", "minmax") is True
 
 
 def test_array_reverse_is_nonmutating() -> None:


### PR DESCRIPTION
Starts a new cross-backend cascade — the **Python reference** for `Array#minmax`.

## What

`minmax` is the non-block Array method returning the two-element array `[min, max]` in one call:

- `[3,1,2].minmax` → `[1, 3]`
- `["b","a","c"].minmax` → `["a", "c"]`
- `[].minmax` → `[nil, nil]` (Ruby: no smallest/largest element for an empty array)
- `respond_to?("minmax")` → `true`

Added to `_array_method` beside the existing `min`/`max` arms + the `_ARRAY_METHODS` set.

## Tests

pytest covers int + string ordering, empty → `[nil, nil]`, and `respond_to?`. **130 passed, 97% coverage, ruff clean.**

Version 0.1.24 → 0.1.25. Security review passed. Go/Rust/JS/TS mirrors follow, one per tick-cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)