### PR TITLE
docs: rewrite repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,190 +1,407 @@
 # Coding Adventures
 
-Coding Adventures is a learning-first monorepo for understanding how computers work by building the layers ourselves.
+Coding Adventures is a learning-first monorepo for understanding computers by
+building the layers ourselves: logic gates and processors, parsers and virtual
+machines, compilers and runtimes, storage engines, UI systems, and complete
+applications.
 
-This repo is part computing-stack curriculum, part polyglot package lab, part tooling playground, and part app/program sandbox. The goal is not just to collect implementations, but to make the ideas behind them easier to study, compare, and extend.
+It is part computing-stack curriculum, part polyglot package laboratory, part
+language-platform project, and part application sandbox. The point is not merely
+to collect implementations. The point is to make each idea inspectable,
+testable, comparable across languages, and teachable.
 
-## What Lives Here
+## The Big Picture
 
-- `code/specs/` contains design docs and package specs
-- `code/learning/` contains plain-language teaching material
-- `code/grammars/` contains shared `.grammar` and `.tokens` sources
-- `code/src/` contains shared TypeScript support code and token sources
-- `code/packages/` contains publishable libraries across multiple ecosystems
-- `code/programs/` contains standalone tools, demos, apps, and visualizers
-- `code/fixtures/` contains shared assets and sample inputs
-- `scripts/` contains repo-level helper scripts
-- `.github/workflows/` contains CI, publish, release, and deploy automation
-
-## Current Shape
-
-The repo changes quickly, so this README describes the shape of the project
-rather than trying to keep a live inventory in sync.
-
-- `code/packages/` contains publishable libraries across ecosystems such as
-  C#, Dart, Elixir, F#, Go, Haskell, Java, Kotlin, Lua, Perl, Python, Ruby,
-  Rust, Swift, TypeScript, and WebAssembly.
-- `code/programs/` contains standalone tools, demos, visualizers, apps, and
-  experiments across the same general language families.
-- `code/specs/` contains the package and system design documents.
-- `code/learning/` contains teaching material that explains the concepts behind
-  the packages.
-- `code/grammars/` contains shared grammar and token sources.
-- Starlark is used as a build-time rule/configuration language, not as a
-  package implementation ecosystem.
-
-## Main Themes
-
-### 1. Computer architecture and the computing stack
-
-This is still one of the core stories in the repo:
-
-- logic gates, transistors, clocks, arithmetic, and floating-point arithmetic
-- CPU simulators and ISA simulators
-- ARM, ARM1, RISC-V, WASM, Intel 4004, Intel 8008, JVM, and CLR execution models
-- cache, branch prediction, hazard detection, pipeline, and core design
-- accelerator and GPU-oriented work such as `gpu-core`, `compute-unit`, and `parallel-execution-engine`
-
-### 2. Language tooling and runtimes
-
-The repo has deep coverage of the path from text to execution:
-
-- shared grammars and generated frontends
-- lexers and parsers for multiple languages
-- bytecode compilers, virtual machines, assemblers, and IR tooling
-- LANG-FULL matrix proofs that run frontend features across native, LLVM, WASM, JVM, CLR, VM, and JIT backends
-- grammar tools and build-time code generation
-
-### 3. Data structures, storage, and execution infrastructure
-
-There is broad coverage of classic and systems-oriented data-structure work:
-
-- trees, tries, heaps, skip lists, bloom filters, hyperloglog, and graph packages
-- RESP and in-memory data-store protocol work
-- file-system, process-manager, event-loop, IPC, and network-stack packages
-
-### 4. Cryptography, compression, and encoding
-
-This area is much more prominent than the older README suggested:
-
-- hashes, HMAC, HKDF, PBKDF2, scrypt, AES, ChaCha20-Poly1305, Ed25519, X25519
-- compression families like LZ77, LZ78, LZSS, LZW, Huffman, Deflate, and Brotli
-- barcode and related encoding work such as Code39, Code128, Codabar, EAN-13, ITF, and UPC-A
-
-### 5. Documents, graphics, and rendering
-
-The repo also includes a substantial content/rendering track:
-
-- CommonMark, GFM, AsciiDoc, document ASTs, sanitizers, and HTML rendering
-- draw and paint instruction systems
-- image codecs, font parsing, display work, and visualizer programs
-
-### 6. Tooling, apps, and learning-oriented programs
-
-`code/programs/` is broader than just demos:
-
-- build tools, scaffold generators, grammar tools, and package materializers
-- visualizers such as arithmetic, logic-gates, transistor, ENIAC, and Code39 programs
-- apps and product experiments like checklist, journal, Engram, and browser/extension work
-- small ML/demo programs such as predictors and classifiers
-- multi-language IRC server work via `ircd`
-
-## Repository Map
+The repository has four reinforcing layers:
 
 ```text
-code/
-|-- fixtures/
-|-- grammars/
-|-- learning/
-|-- packages/
-|-- programs/
-|-- specs/
-`-- src/
+specs       define the intended design and contracts
+learning    explains why the ideas work
+packages    implements the reusable pieces
+programs    composes those pieces into tools, demos, and applications
 ```
 
-## Learning Material
+Tests, conformance suites, and the dependency-aware build system connect all
+four. A shared package change is tested not only in isolation but also through
+the downstream packages affected by it.
 
-The learning side of the repo is a first-class part of the structure, not an afterthought.
+The repository changes quickly. This README describes the durable architecture
+and current direction; it deliberately avoids a hand-maintained package
+inventory. Run the [package parity report](./scripts/package_parity_report.py)
+for a live cross-language view.
 
-Start here:
+## What Makes This Repo Different
 
-- [Learning Index](./code/learning/README.md)
-- [Algorithms](./code/learning/algorithms/README.md) — graph algorithms, hashing, Kahn's algorithm
-- [Computer Architecture](./code/learning/computer-architecture/README.md) — logic gates, arithmetic circuits, CPU architecture, floating-point, ISA simulators, bytecode compilation, parsing, lexical analysis, virtual machines, and the computing-stack overview
-- [Language Tooling](./code/learning/language-tooling/README.md)
-- [Programming Languages](./code/learning/programming-languages/) — language-by-language pattern guides for Go, Python, Ruby, Rust, TypeScript, plus the Python ecosystem deep-dive
+### A language platform with two shared hubs
 
-The intended relationship is:
+The north-star is a language platform where a language author supplies grammar
+files and one frontend, then reuses shared tooling, optimizers, runtimes, and
+backends.
 
 ```text
-specs explain what we intend to build
-learning explains why the ideas matter
-packages show the ideas in code
-tests prove the behavior
+source
+  |
+  +--> .tokens + .grammar --> generated lexer/parser --> AST/CST
+                                                        |
+                                      +-----------------+-----------------+
+                                      |                                   |
+                                      v                                   v
+                               IIR: execution hub                  SIR: semantic hub
+                                      |                                   |
+                   +------------------+------------------+       +--------+---------+
+                   |        |        |        |         |       |        |         |
+                 native    LLVM     WASM     JVM/CLR    VM/JIT  Python   Ruby   JS/TS/Go/
+                                                                            Rust/C
 ```
 
-## Tooling
+- **IIR** is the lower, typed execution representation. It feeds native,
+  LLVM, WASM, JVM, CLR, BEAM, VM, JIT, and retro-CPU targets.
+- **SIR** is the higher semantic representation. It preserves source-language
+  concepts and emits runnable Python, Ruby, JavaScript, TypeScript, Go, Rust,
+  and C.
+- The planned IIR/SIR bridges turn compilation and transpilation into routes
+  through one stage graph instead of bespoke language-to-language projects.
 
-The root `mise.toml` currently pins:
+The execution matrix runs real programs across backends and compares results,
+so a backend is not considered supported merely because it accepts the IR.
+See the [LANG-VM platform vision](./code/specs/LANG-PLATFORM-VISION.md),
+[generic language pipeline](./code/specs/LANG00-generic-language-pipeline.md),
+[IIR](./code/specs/LANG01-interpreter-ir.md), and
+[Semantic IR](./code/specs/SIR00-semantic-ir.md).
 
-- Dart `latest`
-- Go `latest`
-- Python `3.12`
-- Ruby `3.4`
-- Rust `stable`
+### The computing stack, bottom to top
 
-The main repo-level grammar helper is:
+Another central thread builds computation from physical and logical primitives:
 
-- [scripts/generate-compiled-grammars.sh](./scripts/generate-compiled-grammars.sh)
+```text
+transistors --> gates --> arithmetic --> CPU/microarchitecture --> ISA
+     --> assembler --> compiler/runtime --> language --> application
+```
 
-## Workflow
+The repo includes transistor and gate models, ALUs, caches, branch prediction,
+pipelines, processor cores, and simulators for architectures including ARM,
+ARM1, RISC-V, WASM, Intel 4004/8008, JVM, and CLR. Several browser visualizers
+make those layers interactive.
 
-The working style for the repo is:
+Start with the [architecture overview](./code/specs/00-architecture.md),
+[deep CPU architecture](./code/specs/D00-deep-cpu-architecture.md), and
+[computing-stack learning guide](./code/learning/computer-architecture/computing-stack.md).
 
-1. Write or refine the spec.
-2. Add or update the matching learning entry.
-3. Add tests.
-4. Implement the package or feature.
-5. Update the package README and changelog.
+### Reference implementations and language mirrors
 
-The long-term goal is that no major concept in the repo exists only as code. It should also exist as a teachable explanation.
+The language directories are not identical snapshots. Rust is the broadest
+implementation surface and often carries systems-facing reference work, native
+backends, and shared engines first. Python, TypeScript, Go, Ruby, and the other
+ecosystems contain a mix of:
 
-## Good Entry Points
+- independent implementations of the same concept;
+- conformance mirrors ported from a reference;
+- native bindings around shared Rust cores;
+- platform-specific implementations and applications;
+- educational ports used to compare language design and tooling.
 
-If you want to explore the repo by theme, start here:
+The parity reporter groups those implementations by concept, highlights
+high-consensus packages, and tracks single-language work without pretending
+every package must exist everywhere.
 
-- [00-architecture.md](./code/specs/00-architecture.md) for the big picture
-- [D00-deep-cpu-architecture.md](./code/specs/D00-deep-cpu-architecture.md) for the architecture track
-- [LANG00-generic-language-pipeline.md](./code/specs/LANG00-generic-language-pipeline.md) for the language pipeline that all of Tetrad, Nib, MACSYMA, Lattice, and others share
-- [VLT00-vault-master.md](./code/specs/VLT00-vault-master.md) for the password-manager-class vault stack
-- [ST00-r-stats-roadmap.md](./code/specs/ST00-r-stats-roadmap.md) for the R-style statistics + language roadmap
-- [DT25-mini-redis.md](./code/specs/DT25-mini-redis.md) for the single-node data-store baseline
-- [Kahn's algorithm](./code/learning/algorithms/kahns-algorithm.md) for the build-planning story
-- [computing-stack.md](./code/learning/computer-architecture/computing-stack.md) for the hardware-to-language story
-- [code/programs/typescript](./code/programs/typescript/) for the current app and visualizer-heavy program surface
+## Major Project Tracks
+
+### Languages, compilers, and runtimes
+
+The repository covers the whole path from source text to execution:
+
+- shared token and grammar formats;
+- generated lexers and parsers;
+- ASTs, type checkers, formatters, LSP and DAP infrastructure;
+- bytecode compilers, VMs, JIT/AOT infrastructure, and native backends;
+- backend-independent IR validation, lowering, optimization, and conformance;
+- historical and experimental languages including BASIC, ALGOL, Nib, Twig,
+  APL, FLOW-MATIC, COBOL-60, MATLAB/Octave, Wolfram, Macsyma/Maxima, and more;
+- JavaScript parsing and Closure Compiler compatibility work.
+
+The FLOW-MATIC and COBOL code-generation track is building toward the intended
+reuse model: frontends target IIR to run across execution backends and SIR to
+transpile across source backends. Math-language work adds array/matrix and
+symbolic domains to the same semantic hub. See
+[PL09 code generation](./code/specs/PL09-codegen.md) and
+[HML01 math languages to Semantic IR](./code/specs/HML01-math-to-semantic-ir.md).
+
+### Dynamic values, exact numerics, and symbolic systems
+
+The runtime stack includes a language-neutral tagged dynamic-value substrate,
+boxing/unboxing, heap values, truthiness, dynamic arithmetic, and a path toward
+garbage-collected dynamic-language execution.
+
+The numeric and symbolic side includes arbitrary-precision integers, rationals,
+decimals and binary floats; computer algebra packages; rewrite systems;
+constraint solving; logic programming; statistics; and the ADJ rule/formula
+language. Exactness and explicit lossy conversions are treated as design
+properties rather than incidental implementation details.
+
+See the [dynamic-value substrate](./code/specs/DVAL01-generic-dynamic-value-substrate.md)
+and [symbolic computation overview](./code/specs/symbolic-computation.md).
+
+### SQL, databases, and storage
+
+The SQL stack is deliberately decomposed:
+
+```text
+SQL text --> lexer --> parser --> planner --> optimizer --> codegen --> SQL VM
+                                                                   |
+                                                                   v
+                                                            Backend trait
+                                                                   |
+                                                   in-memory or SQLite files
+```
+
+This supports both a composable query engine and a path toward a byte-compatible,
+from-scratch SQLite replacement. Work covers SQL semantics, query planning,
+indexes, transactions, SQLite file pages/B-trees, and differential checks
+against real SQLite.
+
+See the [full mini-SQLite conformance roadmap](./code/specs/mini-sqlite-full-conformance.md)
+and [storage-sqlite](./code/specs/storage-sqlite.md).
+
+### Data structures, systems, networking, and security
+
+Package families include trees, tries, graphs, heaps, probabilistic structures,
+filesystems, virtual memory, processes, event loops, reactors, IPC, TCP/HTTP,
+RPC, device protocols, and operating-system abstractions.
+
+Security and encoding work includes hashes, HMAC, HKDF, PBKDF2, scrypt, AES,
+ChaCha20-Poly1305, Ed25519, X25519, compression formats, image/document
+decoders, barcodes, and strict bounds-checked binary parsing.
+
+The C and C++ lanes compile pure-ISO ports under GCC, Clang, Apple Clang, and
+MSVC with strict conformance flags. See the
+[C/C++ multi-compiler lane](./code/specs/CCPP01-c-cpp-iso-multicompiler-lane.md).
+
+### Documents, graphics, and UI compilation
+
+The content/rendering stack includes CommonMark, GFM, AsciiDoc, document ASTs,
+HTML sanitization, Office file formats, font parsing, image codecs, layout,
+draw/paint instruction systems, and native/GPU rendering backends.
+
+Mosaic is the compile-time UI language. A typed UI description can be emitted
+to web components, React, SwiftUI, Jetpack Compose, Flutter, Qt, XAML, HTML,
+and paint-oriented backends. The same pattern lets a headless Rust engine power
+multiple native and web hosts without duplicating product behavior.
+
+See the [Mosaic overview](./code/specs/UI00-mosaic.md) and
+[Mosaic compiler pipeline](./code/specs/UI16-mosaic-compiler-pipeline.md).
+
+### Applications and product experiments
+
+Programs are integration surfaces, not just toy examples:
+
+- **Engram** combines a shared Rust core, native/WASM bridges, Mosaic UI work,
+  Electron/browser hosts, and Anki compatibility.
+- **task-app** is applying the same architecture to a general task/project
+  engine. Its pure `task-core` model and operations/formula API have begun
+  landing; the roadmap projects one model as checklist, todo, kanban, Gantt,
+  flowchart, and table views with scheduling.
+- **VisiCalc** exercises spreadsheet, UI, and multi-host compilation paths.
+- Journal, checklist, browser-extension, language-tooling, IRC, ML, document,
+  and hardware visualizer programs test other package families end to end.
+
+See [Engram](./code/specs/engram-app.md) and the
+[task-app overview](./code/specs/task-app-overview.md).
+
+## Repository Layout
+
+```text
+.
+|-- code/
+|   |-- benchmarks/   reproducible performance experiments
+|   |-- datasets/     shared data used by packages and programs
+|   |-- fixtures/     shared binary/text fixtures and sample inputs
+|   |-- grammars/     canonical .tokens and .grammar sources
+|   |-- learning/     plain-language teaching material
+|   |-- packages/     reusable libraries grouped by ecosystem
+|   |-- programs/     executables, demos, apps, and visualizers
+|   |-- sites/        website source/content
+|   \-- specs/        architecture, package, and roadmap specifications
+|-- scripts/          repository-wide generation, reporting, and safety tools
+|-- .github/workflows CI, CodeQL, safety, publishing, releases, and deployment
+|-- CHANGELOG.md      monorepo-level notable changes
+|-- CLAUDE.md         repository policy and working conventions
+\-- lessons.md        accumulated engineering failures and durable fixes
+```
+
+Package implementations currently span C, C++, C#, Dart, Elixir, F#, Go,
+Haskell, Java, Kotlin, Lua, Perl, Python, Ruby, Rust, Swift, TypeScript, and
+WebAssembly. Mosaic and Twig are domain-language buckets; Starlark is used for
+build configuration rather than as an implementation ecosystem.
+
+## Build System
+
+The primary build tool is the Go program in
+[`code/programs/go/build-tool`](./code/programs/go/build-tool/). It:
+
+1. discovers packages through `BUILD` files;
+2. evaluates Starlark build definitions where used;
+3. reads ecosystem metadata such as Cargo, Go, Python, npm, Gradle, Swift,
+   Ruby, Elixir, Dart, Haskell, and .NET manifests;
+4. constructs the cross-language dependency graph;
+5. maps a Git diff to changed packages and all transitive dependents;
+6. validates declared dependencies and standalone build prerequisites;
+7. schedules independent packages concurrently;
+8. emits reusable and sharded build plans for CI.
+
+`BUILD_windows` files provide legacy/platform-specific Windows commands while
+the repository migrates more rules to OS-aware Starlark definitions.
+`required_capabilities.json` files declare runtime/toolchain requirements for
+packages that need capability-aware execution.
+
+### Toolchains
+
+The root [`mise.toml`](./mise.toml) pins the local toolchain baseline:
+
+- Cabal `3.16.1.0` and GHC `9.14.1`;
+- Dart `latest`;
+- Go `latest`;
+- Gradle `8.14` and Kotlin `2.1.20`;
+- Lua `5.4`;
+- Python `3.12`;
+- Ruby `3.4`;
+- Rust `stable`.
+
+CI installs its own explicit versions and does not depend on mise.
+
+### Build the build tool
+
+On macOS/Linux:
+
+```bash
+cd code/programs/go/build-tool
+go build -o ../../../../build-tool .
+cd ../../../..
+./build-tool -root . -diff-base origin/main -dry-run
+```
+
+On Windows:
+
+```powershell
+cd code\programs\go\build-tool
+go build -o ..\..\..\..\build-tool.exe .
+cd ..\..\..\..
+.\build-tool.exe -root . -diff-base origin/main -dry-run
+```
+
+The diff-based plan compares committed branch history with `origin/main`.
+Commit or otherwise verify the intended diff before treating its affected set
+as authoritative. Use the package's own `BUILD`/test command for fast,
+uncommitted iteration.
+
+Useful repository checks:
+
+```bash
+# Validate and show the affected plan without running it.
+./build-tool -root . -diff-base origin/main -dry-run -validate-build-files
+
+# Show which CI toolchains the branch needs.
+./build-tool -root . -diff-base origin/main -detect-languages
+
+# Inspect cross-language coverage and reject naming collisions.
+python scripts/package_parity_report.py --fail-on-collisions
+
+# Test the build tool itself.
+cd code/programs/go/build-tool && go test ./...
+```
+
+## CI and Quality Gates
+
+The main CI workflow uses the same build planner:
+
+- branch pushes build affected packages;
+- pull requests validate affected work across Linux, macOS, and Windows when
+  the selected languages require those runners;
+- pushes to `main` create a forced five-shard full-build plan;
+- Rust packages run per-package Clippy with warnings denied;
+- CodeQL covers JavaScript/TypeScript, Python, Ruby, Go, and Swift;
+- Miri blocks on unsafe-bearing runtime crates, with deeper integration checks
+  running after merge and nightly;
+- dedicated workflows test Rust-to-Node and Rust-to-Python native matrices;
+- publish, release, and GitHub Pages workflows ship selected artifacts.
+
+Packages are expected to carry tests, a README, a changelog, and publishable
+ecosystem metadata. Libraries target at least 80% coverage, with 95% preferred
+for most package code.
+
+## Working in the Repository
+
+Read [`CLAUDE.md`](./CLAUDE.md) and [`lessons.md`](./lessons.md) before making
+changes. The recurring workflow is:
+
+1. Fetch the latest `origin/main`.
+2. Create a feature branch, preferably in a fresh worktree.
+3. Write or refine the specification.
+4. Add or update the relevant learning material.
+5. Add tests before or alongside implementation.
+6. Implement the smallest coherent change.
+7. Update package README and CHANGELOG files.
+8. Run the package tests and the affected-package plan.
+9. Review the complete branch diff, including generated files and downstream
+   consumers.
+10. Run the required security review before pushing.
+
+Important conventions:
+
+- Do not commit directly to `main`.
+- Shared grammar sources are authoritative; regenerate compiled grammars rather
+  than hand-editing generated files.
+- `BUILD` commands must be standalone and include all transitive local
+  prerequisites in dependency order.
+- New package scaffolding should go through the scaffold generator.
+- Stage explicit files and keep build artifacts out of commits.
+- If implementation and specification diverge, update the spec and document
+  the decision.
+
+## Where to Start
+
+Choose a path based on what you want to understand:
+
+| Interest | Start here |
+|---|---|
+| Whole computing stack | [Architecture overview](./code/specs/00-architecture.md) and [computing-stack guide](./code/learning/computer-architecture/computing-stack.md) |
+| Language platform | [LANG-VM platform vision](./code/specs/LANG-PLATFORM-VISION.md) |
+| Shared execution IR | [Interpreter IR](./code/specs/LANG01-interpreter-ir.md) |
+| Source-level semantic IR | [Semantic IR](./code/specs/SIR00-semantic-ir.md) |
+| Building a new language | [Generic language pipeline](./code/specs/LANG00-generic-language-pipeline.md) |
+| SQL and SQLite | [Mini-SQLite conformance roadmap](./code/specs/mini-sqlite-full-conformance.md) |
+| UI compilation | [Mosaic](./code/specs/UI00-mosaic.md) |
+| Task/project engine | [task-app overview](./code/specs/task-app-overview.md) |
+| Vault/security architecture | [Vault master spec](./code/specs/VLT00-vault-master.md) |
+| Dependency planning | [Kahn's algorithm](./code/learning/algorithms/kahns-algorithm.md) and [build-tool README](./code/programs/go/build-tool/README.md) |
+| Current engineering pitfalls | [Lessons learned](./lessons.md) |
+
+The [learning index](./code/learning/README.md) collects the teaching-oriented
+material by subject.
 
 ## Live Pages
 
-A subset of the repo is deployed to GitHub Pages so you can run things in
-the browser without cloning. The root landing page is at
-[adhithyan15.github.io/coding-adventures](https://adhithyan15.github.io/coding-adventures/);
-individual apps and visualizers live at sibling paths:
+Selected programs are deployed to
+[adhithyan15.github.io/coding-adventures](https://adhithyan15.github.io/coding-adventures/):
 
-- `arithmetic/` — adders, ALU, two's-complement, multiply, CPU step-through
-- `arm1-web/` — ARM1 processor across registers, pipeline, barrel shifter, memory views
-- `busicom/` — Intel 4004-powered Busicom 141-PF calculator with live ALU and gate-level activity
-- `code39/` — full barcode pipeline from text to SVG via draw instructions
-- `commonmark/` — live Markdown-to-HTML renderer built from scratch in TypeScript
-- `electronics-visualizers/` — circuit-level visualizers backing the architecture track
-- `engram/` and `engram-docs/` — product experiment plus its browser-based docs
-- `eniac/` — decimal vacuum-tube computing alongside binary equivalents
-- `journal/` — journaling app
-- `lattice/` — Lattice CSS-superset docs and live transpiler playground
-- `logic-gates/` — NOT/AND/OR/XOR with truth tables and CMOS layouts
-- `ml-learning/` — browser ML demos (predictors, classifiers)
-- `nib-web/` — Nib source → Intel 4004 assembly/binary/HEX, then run in the simulator
-- `transistors/` — vacuum tube → BJT → MOSFET → CMOS device models
+- `arithmetic/` — adders, ALU, two's-complement, multiplication, and CPU steps;
+- `arm1-web/` — ARM1 registers, pipeline, barrel shifter, and memory views;
+- `busicom/` — an Intel 4004-powered Busicom calculator;
+- `code39/` — text-to-barcode rendering through draw instructions;
+- `commonmark/` — a from-scratch Markdown renderer;
+- `electronics-visualizers/` — circuit and architecture visualizers;
+- `engram/` and `engram-docs/` — the Engram app and documentation;
+- `eniac/` — decimal vacuum-tube computation beside binary equivalents;
+- `journal/` — the journaling application;
+- `lattice/` — language documentation and a live transpiler;
+- `logic-gates/` — gates, truth tables, and CMOS layouts;
+- `ml-learning/` — interactive machine-learning demonstrations;
+- `nib-web/` — Nib to Intel 4004 assembly/binary/HEX and simulation;
+- `transistors/` — vacuum tube, BJT, MOSFET, and CMOS models.
+
+The repository also deploys its blog and root landing page through dedicated
+workflows.
 
 ## Copyright
 
-Everything in this repo is copyrighted to Adhithya Rajasekaran. Individual packages may be licensed separately.
+Everything in this repository is copyrighted to Adhithya Rajasekaran.
+Individual packages may be licensed separately.


### PR DESCRIPTION
## Summary

- rewrite the root README around the repository's current architecture instead of a static package-family inventory
- document the IIR/SIR language-platform model, computing stack, reference-versus-mirror ecosystem, and active project tracks
- add current build-tool, toolchain, CI, CodeQL, Clippy, Miri, and contributor workflow guidance
- replace stale paths and add curated entry points for language, SQL/SQLite, Mosaic, task-app, security, and build-planning work

## Why

The previous README no longer reflected the scale or center of gravity of the repository. It omitted the LANG-VM platform vision, understated the custom build and validation system, listed an incomplete toolchain set, referenced a removed directory, and did not distinguish shipped capabilities from roadmap work clearly enough.

## Impact

This is documentation-only. New contributors get a current architectural map, working setup commands, and clearer routes into the major subsystems without changing package or runtime behavior.

## Validation

- `git diff --check`
- verified all 37 repository-relative README links resolve
- verified Markdown code fences are balanced
- `python scripts/package_parity_report.py --format json --fail-on-collisions`
- reviewed the final diff for executable content, secrets, embedded scripts, and unsafe copy-paste commands