### PR TITLE
feat(sir-to-go): Array minmax — Go mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.32.0 — Array `minmax`
+
+Mirrors the Python reference (PR #8092) into the Go backend's inline `__sir`
+runtime (`_sir_array_method` beside the existing `min`/`max` arm + the
+`_sir_array_responds` `respond_to?` arm), continuing the `minmax` cross-backend
+cascade.
+
+- `minmax` (non-block) → the two-element array `[min, max]` in one pass, via `<`
+  (`_sir_value_lt`). `[3,1,2].minmax` → `[1, 3]`; `["b","a","c"].minmax` →
+  `["a", "c"]`. An empty array yields `[nil, nil]` (no smallest/largest element),
+  matching the Python reference's `[None, None]`.
+- The `array_methods_compile_and_run` exec-proof test gains `minmax` (non-empty
+  and empty) — the emitted Go compiles + runs with the toolchain and asserts
+  `[1, 3]` / `[nil, nil]`.
+
 ## 0.31.0 — Array `slice_when`
 
 Mirrors the Python reference (PR #8070) into the Go backend's inline `__sir`

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -181,7 +181,7 @@ runtime catalog** and emits every dispatch to it:
 
 Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `empty?`, `include?`, `index`, `push`/`append`, `<<`, `pop`, `shift`, `reverse`,
-`sort`, `join`, `to_a`, `each`, `map`/`collect`, `select`/`filter`, `reject`,
+`sort`, `min`/`max`/`minmax`/`sum`, `join`, `to_a`, `each`, `map`/`collect`, `select`/`filter`, `reject`,
 `reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`,
 `each_slice`/`each_cons`, `chunk_while`/`slice_when`; **Hash** `keys`,
 `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `size`/

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1695,7 +1695,7 @@ func _sir_array_responds(name string) bool {
 	// Non-block Array methods.
 	case "length", "size", "count", "first", "last", "empty?", "include?",
 		"index", "push", "append", "<<", "pop", "shift", "reverse", "sort",
-		"min", "max", "sum", "uniq", "flatten", "compact", "zip", "rotate",
+		"min", "max", "minmax", "sum", "uniq", "flatten", "compact", "zip", "rotate",
 		"to_h", "tally", "take", "drop", "values_at",
 		"join", "fetch", "to_a", "each_slice", "each_cons":
 		return true
@@ -1878,6 +1878,25 @@ func _sir_array_method(recv *Seq, name string, args []Value) (Value, bool) {
 			}
 		}
 		return best, true
+	case "minmax":
+		// Ruby `Array#minmax` (no block): the two-element array `[min, max]` in
+		// one pass, via `<` (modelled by `_sir_value_lt`).  An empty array ⇒
+		// `[nil, nil]` (no smallest/largest element), matching the Python
+		// reference's `[None, None]`.
+		if len(recv.Items) == 0 {
+			return &Seq{Items: []Value{nil, nil}}, true
+		}
+		lo := recv.Items[0]
+		hi := recv.Items[0]
+		for _, x := range recv.Items[1:] {
+			if _sir_value_lt(x, lo) {
+				lo = x
+			}
+			if _sir_value_lt(hi, x) {
+				hi = x
+			}
+		}
+		return &Seq{Items: []Value{lo, hi}}, true
 	case "sum":
 		// Ruby `Array#sum`: fold with polymorphic `+` over an initial value
 		// (default 0, or the supplied `sum(init)` argument), preserving

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
@@ -171,6 +171,10 @@ fn catalog_module() -> Module {
         print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "max", vec![])),
         // [].max → nil
         print_stmt(method(seq(vec![]), "max", vec![])),
+        // [3,1,2].minmax → [1, 3]
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "minmax", vec![])),
+        // [].minmax → [nil, nil]
+        print_stmt(method(seq(vec![]), "minmax", vec![])),
         // [1,2,3].sum → 6
         print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "sum", vec![])),
         // [].sum → 0
@@ -262,6 +266,8 @@ fn array_methods_compile_and_run() {
             "1",         // [3,1,2].min
             "3",         // [3,1,2].max
             "nil",       // [].max  (print of nil is "nil")
+            "[1, 3]",    // [3,1,2].minmax
+            "[nil, nil]", // [].minmax → [nil, nil]
             "6",         // [1,2,3].sum
             "0",         // [].sum
             "[1, 2, 3]", // [1,2,2,3,1].uniq


### PR DESCRIPTION
Mirrors the Python reference ([#8092](https://github.com/adhithyan15/coding-adventures/pull/8092)) into the **Go backend**'s inline `__sir` runtime (`_sir_array_method` beside the existing `min`/`max` arm + the `_sir_array_responds` `respond_to?` arm), continuing the `minmax` cross-backend cascade.

## What

`minmax` (non-block) returns the two-element array `[min, max]` in one pass via `<` (`_sir_value_lt`):

- `[3,1,2].minmax` → `[1, 3]`
- `["b","a","c"].minmax` → `["a", "c"]`
- `[].minmax` → `[nil, nil]` (Ruby: no smallest/largest element)

## Tests

The `array_methods_compile_and_run` exec-proof test gains `minmax` (non-empty and empty) — the emitted Go compiles + runs with the toolchain and asserts `[1, 3]` / `[nil, nil]`. Passes locally.

Version 0.31.0 → 0.32.0. Security review passed (static runtime string, explicit-switch dispatch, O(n), bounds-guarded). Rust/JS/TS mirrors follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)