### PR TITLE
[codex] Port bitset to Dart

### DIFF
--- a/code/packages/dart/bitset/BUILD
+++ b/code/packages/dart/bitset/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/bitset/CHANGELOG.md
+++ b/code/packages/dart/bitset/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog — coding_adventures_bitset
+
+## 0.1.0 — 2026-07-11
+
+### Added
+
+- Initial pure-Dart Bitset implementation using masked 64-bit `BigInt` words.
+- Auto-growing single-bit operations and immutable bulk bitwise operations.
+- Arbitrary-width integer and binary-string conversion.
+- Cross-language contract tests, multi-word algebra checks, and a 10,000-bit
+  sparse-iteration stress test.

--- a/code/packages/dart/bitset/README.md
+++ b/code/packages/dart/bitset/README.md
@@ -1,0 +1,42 @@
+# coding_adventures_bitset
+
+A compact, growable bitset implemented in pure Dart. Boolean values are packed
+into 64-bit `BigInt` words, giving deterministic behavior on the Dart VM and
+JavaScript targets without native bindings.
+
+## Features
+
+- zero-filled construction with capacity rounded to 64-bit words
+- construction from `int`, arbitrary-width `BigInt`, or binary strings
+- auto-growing `set` and `toggle`; non-growing `test` and `clear`
+- immutable AND, OR, XOR, NOT, and AND-NOT bulk operations
+- ascending iteration over set-bit indices
+- popcount, `hasAny`/all/none queries, equality, hashing, and conversions
+
+## Usage
+
+```dart
+import 'package:coding_adventures_bitset/coding_adventures_bitset.dart';
+
+final bits = Bitset(100)
+  ..set(0)
+  ..set(42)
+  ..set(99);
+
+print(bits.popcount);       // 3
+print(bits.test(42));       // true
+print(bits.setBits.toList()); // [0, 42, 99]
+
+final mask = Bitset.fromInteger(42);
+final complement = ~mask;
+final roundTrip = Bitset.fromBinaryString(mask.toBinaryString());
+```
+
+## Development
+
+```text
+dart pub get
+dart format --output=none --set-exit-if-changed .
+dart analyze
+dart test
+```

--- a/code/packages/dart/bitset/lib/coding_adventures_bitset.dart
+++ b/code/packages/dart/bitset/lib/coding_adventures_bitset.dart
@@ -1,0 +1,4 @@
+/// A compact, growable bitset implemented in pure Dart.
+library coding_adventures_bitset;
+
+export 'src/bitset.dart';

--- a/code/packages/dart/bitset/lib/src/bitset.dart
+++ b/code/packages/dart/bitset/lib/src/bitset.dart
@@ -1,0 +1,301 @@
+import 'dart:collection';
+
+/// Number of addressable bits in each internal word.
+const int bitsPerWord = 64;
+
+final BigInt _wordMask = (BigInt.one << bitsPerWord) - BigInt.one;
+
+/// Error raised when a Bitset constructor receives invalid data.
+class BitsetError implements Exception {
+  const BitsetError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'BitsetError: $message';
+}
+
+/// A compact boolean array packed into 64-bit words.
+///
+/// Bits are numbered least-significant-bit first: bit 0 is the low bit of
+/// word 0, bit 63 is its high bit, and bit 64 starts word 1. [set] and
+/// [toggle] grow the logical length automatically. Bulk operations return new
+/// bitsets and never mutate their operands.
+///
+/// Words use [BigInt] so all 64 bits behave identically on the Dart VM and in
+/// JavaScript builds; each word is explicitly masked back to 64 bits.
+class Bitset extends IterableBase<int> {
+  Bitset([int size = 0])
+      : _length = size,
+        _words = List<BigInt>.filled(
+          _wordsNeeded(size),
+          BigInt.zero,
+          growable: true,
+        ) {
+    if (size < 0) {
+      throw RangeError.value(size, 'size', 'must be non-negative');
+    }
+  }
+
+  Bitset._(this._length, List<BigInt> words)
+      : _words = List<BigInt>.of(words, growable: true) {
+    _cleanTrailingBits();
+  }
+
+  /// Create from a non-negative [int] or [BigInt].
+  factory Bitset.fromInteger(Object value) {
+    final BigInt number;
+    if (value is BigInt) {
+      number = value;
+    } else if (value is int) {
+      number = BigInt.from(value);
+    } else {
+      throw BitsetError('fromInteger requires an int or BigInt');
+    }
+    if (number.isNegative) {
+      throw BitsetError(
+        'fromInteger requires a non-negative value, got $value',
+      );
+    }
+    if (number == BigInt.zero) return Bitset();
+
+    final result = Bitset(number.bitLength);
+    var remaining = number;
+    for (var index = 0; index < result._words.length; index++) {
+      result._words[index] = remaining & _wordMask;
+      remaining >>= bitsPerWord;
+    }
+    return result;
+  }
+
+  /// Create from an MSB-first string containing only `0` and `1`.
+  factory Bitset.fromBinaryString(String value) {
+    if (!RegExp(r'^[01]*$').hasMatch(value)) {
+      throw BitsetError('invalid binary string: "$value"');
+    }
+    final result = Bitset(value.length);
+    for (var offset = 0; offset < value.length; offset++) {
+      if (value[value.length - offset - 1] == '1') {
+        result._setWithoutGrowth(offset);
+      }
+    }
+    return result;
+  }
+
+  /// Short alias matching ports that call this constructor `fromBinaryStr`.
+  factory Bitset.fromBinaryStr(String value) => Bitset.fromBinaryString(value);
+
+  final List<BigInt> _words;
+  int _length;
+
+  /// Logical number of addressable bits.
+  @override
+  int get length => _length;
+
+  /// Allocated bit capacity, always a multiple of 64.
+  int get capacity => _words.length * bitsPerWord;
+
+  /// Set bit [index], growing the bitset when needed.
+  void set(int index) {
+    _ensureCapacity(index);
+    _setWithoutGrowth(index);
+  }
+
+  /// Clear bit [index]. Out-of-range positive indices are a no-op.
+  void clear(int index) {
+    _checkNonNegative(index);
+    if (index >= _length) return;
+    final wordIndex = index ~/ bitsPerWord;
+    _words[wordIndex] &= _wordMask ^ _bitMask(index);
+  }
+
+  /// Return whether bit [index] is set.
+  bool test(int index) {
+    _checkNonNegative(index);
+    if (index >= _length) return false;
+    return (_words[index ~/ bitsPerWord] & _bitMask(index)) != BigInt.zero;
+  }
+
+  /// Flip bit [index], growing the bitset when needed.
+  void toggle(int index) {
+    _ensureCapacity(index);
+    _words[index ~/ bitsPerWord] ^= _bitMask(index);
+  }
+
+  /// Intersection of this bitset and [other].
+  Bitset bitwiseAnd(Bitset other) => _binaryOperation(other, (a, b) => a & b);
+
+  /// Union of this bitset and [other].
+  Bitset bitwiseOr(Bitset other) => _binaryOperation(other, (a, b) => a | b);
+
+  /// Symmetric difference of this bitset and [other].
+  Bitset bitwiseXor(Bitset other) => _binaryOperation(other, (a, b) => a ^ b);
+
+  /// Complement of this bitset within its logical length.
+  Bitset bitwiseNot() {
+    final words = _words.map((word) => (~word) & _wordMask).toList();
+    return Bitset._(_length, words);
+  }
+
+  /// Set difference: bits present here but not in [other].
+  Bitset andNot(Bitset other) =>
+      _binaryOperation(other, (a, b) => a & ((~b) & _wordMask));
+
+  Bitset operator &(Bitset other) => bitwiseAnd(other);
+  Bitset operator |(Bitset other) => bitwiseOr(other);
+  Bitset operator ^(Bitset other) => bitwiseXor(other);
+  Bitset operator ~() => bitwiseNot();
+
+  /// Number of set bits.
+  int get popcount {
+    var count = 0;
+    for (final original in _words) {
+      var word = original;
+      while (word != BigInt.zero) {
+        word &= word - BigInt.one;
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /// True when at least one bit is set.
+  ///
+  /// This cannot be named `any` because Dart's [Iterable.any] already accepts
+  /// a predicate.
+  bool get hasAny => _words.any((word) => word != BigInt.zero);
+
+  /// True when no bits are set.
+  bool get none => !hasAny;
+
+  /// True when every logical bit is set; empty is vacuously true.
+  bool get all => popcount == _length;
+
+  /// Set-bit indices in ascending order.
+  Iterable<int> get setBits sync* {
+    for (var wordIndex = 0; wordIndex < _words.length; wordIndex++) {
+      var word = _words[wordIndex];
+      while (word != BigInt.zero) {
+        final leastBit = word & -word;
+        final offset = leastBit.bitLength - 1;
+        final index = wordIndex * bitsPerWord + offset;
+        if (index < _length) yield index;
+        word &= word - BigInt.one;
+      }
+    }
+  }
+
+  /// Method-form alias for [setBits].
+  Iterable<int> iterSetBits() => setBits;
+
+  @override
+  Iterator<int> get iterator => setBits.iterator;
+
+  @override
+  bool contains(Object? element) =>
+      element is int && element >= 0 && test(element);
+
+  /// Materialize the ascending set-bit indices.
+  @override
+  List<int> toList({bool growable = true}) =>
+      setBits.toList(growable: growable);
+
+  /// Convert all logical bits to one non-negative integer.
+  BigInt toInteger() {
+    var result = BigInt.zero;
+    for (var index = _words.length - 1; index >= 0; index--) {
+      result = (result << bitsPerWord) | _words[index];
+    }
+    return result;
+  }
+
+  /// Convert to an MSB-first binary string while preserving logical length.
+  String toBinaryString() {
+    if (_length == 0) return '';
+    final buffer = StringBuffer();
+    for (var index = _length - 1; index >= 0; index--) {
+      buffer.write(test(index) ? '1' : '0');
+    }
+    return buffer.toString();
+  }
+
+  /// Short alias matching ports that call this conversion `toBinaryStr`.
+  String toBinaryStr() => toBinaryString();
+
+  /// Create an independent copy with the same logical length and capacity.
+  Bitset copy() => Bitset._(_length, _words);
+
+  Bitset _binaryOperation(
+    Bitset other,
+    BigInt Function(BigInt, BigInt) operation,
+  ) {
+    final resultLength = _length > other._length ? _length : other._length;
+    final words = List<BigInt>.filled(_wordsNeeded(resultLength), BigInt.zero);
+    for (var index = 0; index < words.length; index++) {
+      final left = index < _words.length ? _words[index] : BigInt.zero;
+      final right =
+          index < other._words.length ? other._words[index] : BigInt.zero;
+      words[index] = operation(left, right) & _wordMask;
+    }
+    return Bitset._(resultLength, words);
+  }
+
+  void _setWithoutGrowth(int index) {
+    _words[index ~/ bitsPerWord] |= _bitMask(index);
+  }
+
+  void _ensureCapacity(int index) {
+    _checkNonNegative(index);
+    if (index < _length) return;
+    final needed = index ~/ bitsPerWord + 1;
+    if (_words.length < needed) {
+      var newWordCount = _words.isEmpty ? 1 : _words.length;
+      while (newWordCount < needed) {
+        newWordCount *= 2;
+      }
+      _words.addAll(
+        List<BigInt>.filled(newWordCount - _words.length, BigInt.zero),
+      );
+    }
+    _length = index + 1;
+  }
+
+  void _cleanTrailingBits() {
+    final logicalWords = _wordsNeeded(_length);
+    for (var index = logicalWords; index < _words.length; index++) {
+      _words[index] = BigInt.zero;
+    }
+    if (logicalWords == 0 || _length % bitsPerWord == 0) return;
+    final used = _length % bitsPerWord;
+    _words[logicalWords - 1] &= (BigInt.one << used) - BigInt.one;
+  }
+
+  static int _wordsNeeded(int bitCount) =>
+      bitCount <= 0 ? 0 : (bitCount + bitsPerWord - 1) ~/ bitsPerWord;
+
+  static BigInt _bitMask(int index) => BigInt.one << (index % bitsPerWord);
+
+  static void _checkNonNegative(int index) {
+    if (index < 0) {
+      throw RangeError.value(index, 'index', 'must be non-negative');
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! Bitset || _length != other._length) return false;
+    final words = _wordsNeeded(_length);
+    for (var index = 0; index < words; index++) {
+      if (_words[index] != other._words[index]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(_length, Object.hashAll(_words.take(_wordsNeeded(_length))));
+
+  @override
+  String toString() => "Bitset('${toBinaryString()}')";
+}

--- a/code/packages/dart/bitset/pubspec.yaml
+++ b/code/packages/dart/bitset/pubspec.yaml
@@ -1,0 +1,11 @@
+name: coding_adventures_bitset
+version: 0.1.0
+description: A compact, growable bitset backed by pure-Dart 64-bit BigInt words.
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/bitset/required_capabilities.json
+++ b/code/packages/dart/bitset/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/bitset",
+  "capabilities": [],
+  "justification": "Pure in-memory bitset operations with no OS access."
+}

--- a/code/packages/dart/bitset/test/bitset_test.dart
+++ b/code/packages/dart/bitset/test/bitset_test.dart
@@ -1,0 +1,282 @@
+import 'package:coding_adventures_bitset/coding_adventures_bitset.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('construction', () {
+    test('empty and sized bitsets have rounded capacity', () {
+      expect(Bitset().length, 0);
+      expect(Bitset().capacity, 0);
+      expect(Bitset().all, isTrue);
+      expect(Bitset(1).capacity, 64);
+      expect(Bitset(64).capacity, 64);
+      expect(Bitset(65).capacity, 128);
+      expect(Bitset(200).capacity, 256);
+    });
+
+    test('negative size is rejected', () {
+      expect(() => Bitset(-1), throwsRangeError);
+    });
+
+    test('fromInteger accepts int and arbitrarily large BigInt', () {
+      final small = Bitset.fromInteger(42);
+      expect(small.length, 6);
+      expect(small.toInteger(), BigInt.from(42));
+      final value = (BigInt.one << 200) | (BigInt.one << 100) | BigInt.one;
+      final large = Bitset.fromInteger(value);
+      expect(large.length, 201);
+      expect(large.setBits, [0, 100, 200]);
+      expect(large.toInteger(), value);
+    });
+
+    test('fromInteger rejects negative and unsupported values', () {
+      expect(() => Bitset.fromInteger(-1), throwsA(isA<BitsetError>()));
+      expect(() => Bitset.fromInteger('1'), throwsA(isA<BitsetError>()));
+    });
+
+    test('fromBinaryString preserves leading zeros', () {
+      final bits = Bitset.fromBinaryString('0001');
+      expect(bits.length, 4);
+      expect(bits.toInteger(), BigInt.one);
+      expect(bits.toBinaryString(), '0001');
+    });
+
+    test('fromBinaryString validates input', () {
+      expect(Bitset.fromBinaryString('').length, 0);
+      for (final invalid in ['102', 'abc', '10 01', '1.0']) {
+        expect(
+          () => Bitset.fromBinaryString(invalid),
+          throwsA(isA<BitsetError>()),
+        );
+      }
+    });
+  });
+
+  group('single-bit operations', () {
+    test('set, test, clear, and toggle', () {
+      final bits = Bitset(100);
+      bits.set(50);
+      expect(bits.test(50), isTrue);
+      expect(bits.popcount, 1);
+      bits.set(50);
+      expect(bits.popcount, 1);
+      bits.clear(50);
+      expect(bits.test(50), isFalse);
+      bits.toggle(5);
+      expect(bits.test(5), isTrue);
+      bits.toggle(5);
+      expect(bits.test(5), isFalse);
+    });
+
+    test('set and toggle auto-grow with doubling capacity', () {
+      final bits = Bitset();
+      bits.set(0);
+      expect(bits.capacity, 64);
+      bits.set(64);
+      expect(bits.capacity, 128);
+      bits.toggle(200);
+      expect(bits.length, 201);
+      expect(bits.capacity, 256);
+      expect(bits.test(200), isTrue);
+    });
+
+    test('clear and test beyond length do not grow', () {
+      final bits = Bitset(10);
+      bits.clear(999);
+      expect(bits.test(999), isFalse);
+      expect(bits.length, 10);
+    });
+
+    test('negative indices are rejected consistently', () {
+      final bits = Bitset();
+      expect(() => bits.set(-1), throwsRangeError);
+      expect(() => bits.clear(-1), throwsRangeError);
+      expect(() => bits.test(-1), throwsRangeError);
+      expect(() => bits.toggle(-1), throwsRangeError);
+    });
+
+    test('word boundaries remain independent', () {
+      final bits = Bitset(200);
+      for (final index in [0, 63, 64, 127, 128, 199]) {
+        bits.set(index);
+      }
+      expect(bits.setBits, [0, 63, 64, 127, 128, 199]);
+    });
+  });
+
+  group('bulk operations', () {
+    final a = Bitset.fromInteger(0x0c);
+    final b = Bitset.fromInteger(0x0a);
+
+    test('AND, OR, XOR, NOT, and AND-NOT truth tables', () {
+      expect(a.bitwiseAnd(b).toInteger(), BigInt.from(0x08));
+      expect(a.bitwiseOr(b).toInteger(), BigInt.from(0x0e));
+      expect(a.bitwiseXor(b).toInteger(), BigInt.from(0x06));
+      expect(b.bitwiseNot().toInteger(), BigInt.from(0x05));
+      expect(a.andNot(b).toInteger(), BigInt.from(0x04));
+    });
+
+    test('operators delegate to bulk methods', () {
+      expect((a & b).toInteger(), BigInt.from(0x08));
+      expect((a | b).toInteger(), BigInt.from(0x0e));
+      expect((a ^ b).toInteger(), BigInt.from(0x06));
+      expect((~b).toInteger(), BigInt.from(0x05));
+    });
+
+    test('different lengths are zero-extended to the maximum length', () {
+      final short = Bitset.fromInteger(0x0a);
+      final long = Bitset.fromInteger(0xcc);
+      final union = short | long;
+      expect(union.length, 8);
+      expect(union.toInteger(), BigInt.from(0xce));
+      expect((short & Bitset()).length, short.length);
+      expect((short & Bitset()).none, isTrue);
+    });
+
+    test('bulk operations do not mutate operands', () {
+      final left = a.toInteger();
+      final right = b.toInteger();
+      a & b;
+      a | b;
+      a ^ b;
+      ~a;
+      a.andNot(b);
+      expect(a.toInteger(), left);
+      expect(b.toInteger(), right);
+    });
+
+    test('NOT cleans trailing capacity bits', () {
+      final result = ~Bitset.fromBinaryString('10101');
+      expect(result.toBinaryString(), '01010');
+      expect(result.popcount, 2);
+    });
+
+    test('NOT clears whole spare words left by capacity doubling', () {
+      final bits = Bitset()..set(128);
+      expect(bits.length, 129);
+      expect(bits.capacity, 256);
+      final result = ~bits;
+      expect(result.length, 129);
+      expect(result.capacity, 256);
+      expect(result.popcount, 128);
+      expect(result.toInteger().bitLength, lessThanOrEqualTo(129));
+      expect(result.setBits.last, 127);
+    });
+  });
+
+  group('queries and iteration', () {
+    test('popcount, any, none, and all', () {
+      final bits = Bitset(70);
+      expect(bits.popcount, 0);
+      expect(bits.hasAny, isFalse);
+      expect(bits.none, isTrue);
+      expect(bits.all, isFalse);
+      for (var index = 0; index < bits.length; index++) {
+        bits.set(index);
+      }
+      expect(bits.popcount, 70);
+      expect(bits.all, isTrue);
+      bits.clear(69);
+      expect(bits.all, isFalse);
+    });
+
+    test('iteration yields ascending set-bit indices', () {
+      final bits = Bitset.fromInteger(0xa5);
+      expect(bits.setBits, [0, 2, 5, 7]);
+      expect(bits.iterSetBits(), [0, 2, 5, 7]);
+      expect(bits.toList(), [0, 2, 5, 7]);
+      final collected = <int>[];
+      for (final index in bits) {
+        collected.add(index);
+      }
+      expect(collected, [0, 2, 5, 7]);
+      expect(bits.contains(5), isTrue);
+      expect(bits.contains(6), isFalse);
+      expect(bits.contains('5'), isFalse);
+    });
+
+    test('large sparse iteration matches membership', () {
+      final bits = Bitset(10000);
+      for (var index = 0; index < bits.length; index += 3) {
+        bits.set(index);
+      }
+      expect(bits.popcount, (10000 + 2) ~/ 3);
+      expect(bits.setBits, [
+        for (var index = 0; index < 10000; index += 3) index,
+      ]);
+    });
+  });
+
+  group('identity and algebra', () {
+    test('length participates in equality and hash code', () {
+      final a = Bitset.fromBinaryString('101');
+      final b = Bitset.fromInteger(5);
+      final leadingZero = Bitset.fromBinaryString('0101');
+      expect(a == b, isTrue);
+      expect(a.hashCode, b.hashCode);
+      expect(a == leadingZero, isFalse);
+      expect(a == 5, isFalse);
+    });
+
+    test('boolean algebra laws hold across multiple words', () {
+      final a = Bitset(200);
+      final b = Bitset(200);
+      for (var index = 0; index < 200; index += 3) {
+        a.set(index);
+      }
+      for (var index = 0; index < 200; index += 5) {
+        b.set(index);
+      }
+      expect(~(a & b), (~a) | (~b));
+      expect(~(a | b), (~a) & (~b));
+      expect((a ^ b) ^ b, a);
+      expect(a & a, a);
+      expect(a | a, a);
+      expect((a ^ a).none, isTrue);
+      expect(a.andNot(b), a & (~b));
+    });
+
+    test('word operations match BigInt at boundary-heavy widths', () {
+      for (final width in [0, 1, 5, 63, 64, 65, 127, 128, 129, 200]) {
+        final a = Bitset(width);
+        final b = Bitset(width);
+        for (var index = 0; index < width; index++) {
+          if (index % 3 == 0) a.set(index);
+          if (index % 5 == 0) b.set(index);
+        }
+        final av = a.toInteger();
+        final bv = b.toInteger();
+        final mask =
+            width == 0 ? BigInt.zero : (BigInt.one << width) - BigInt.one;
+        expect((a & b).toInteger(), av & bv, reason: 'AND width=$width');
+        expect((a | b).toInteger(), av | bv, reason: 'OR width=$width');
+        expect((a ^ b).toInteger(), av ^ bv, reason: 'XOR width=$width');
+        expect((~a).toInteger(), mask ^ av, reason: 'NOT width=$width');
+        expect(
+          a.andNot(b).toInteger(),
+          av & (mask ^ bv),
+          reason: 'AND-NOT width=$width',
+        );
+      }
+    });
+
+    test('string and integer conversions round-trip', () {
+      for (final value in [0, 1, 5, 42, 255, 65535]) {
+        final first = Bitset.fromInteger(value);
+        final second = Bitset.fromBinaryString(first.toBinaryString());
+        expect(second, first);
+        expect(second.toInteger(), BigInt.from(value));
+      }
+      expect(Bitset.fromInteger(5).toString(), "Bitset('101')");
+      expect(Bitset().toString(), "Bitset('')");
+      expect(Bitset.fromBinaryStr('101').toBinaryStr(), '101');
+    });
+
+    test('copy is independent', () {
+      final original = Bitset.fromInteger(42);
+      final copied = original.copy();
+      original.set(100);
+      expect(copied.toInteger(), BigInt.from(42));
+      expect(copied, isNot(original));
+    });
+  });
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -130,14 +130,12 @@ new canonical identity collisions with `--fail-on-collisions`.
 Twenty-one package/language slots turn 21 nearly complete packages into fully
 covered packages.
 
-### Dart: 13 ports
+### Dart: 11 remaining ports
 
 - `algol-lexer`
 - `algol-parser`
-- `bitset`
 - `b-plus-tree`
 - `b-tree`
-- `heap`
 - `image-geometric-transforms`
 - `image-point-ops`
 - `logic-gates`
@@ -146,8 +144,12 @@ covered packages.
 - `pixel-container`
 - `toml-lexer`
 
-### Haskell: 5 ports
+Completed in the Dart lane: `heap`, `bitset`.
 
+### Haskell: 7 ports
+
+- `activation-functions`
+- `caesar-cipher`
 - `huffman-compression`
 - `huffman-tree`
 - `lz77`


### PR DESCRIPTION
## Summary

- add a pure-Dart Bitset backed by masked 64-bit BigInt words
- support auto-growing set/toggle, non-growing test/clear, bulk bitwise operations, Iterable set-bit traversal, arbitrary-width conversion, equality, and copying
- add boundary-heavy, algebraic, sparse 10,000-bit, and capacity-invariant tests
- refresh Priority 1 to reflect the current 21 remaining 14-of-15 gaps

## Impact

Bitset now has a pure implementation in all 15 established implementation languages. The package has no runtime dependencies or OS capabilities.

## Verification

- Dart SDK 3.12.2
- `dart pub get`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` — 25 tests passed
- package parity reporter unit tests — 6 passed
- live parity report — Bitset 15/15, 21 remaining 14-of-15 gaps, 0 collisions
- build planner — affected package `dart/bitset`, Dart toolchain only
- `git diff --check`