### PR TITLE
feat(sir-to-rust): Array minmax — Rust mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.34.0 — Array `minmax`
+
+Mirrors the Python reference (PR #8092) and the Go backend (PR #8098) into the
+Rust backend's inline `__sir` runtime (`array_method` beside the existing
+`min`/`max` arms; the array-method `responds_to` set gains `minmax`), continuing
+the `minmax` cross-backend cascade.
+
+- `minmax` (non-block) → the two-element array `[min, max]` computed in one pass
+  via `num_lt`. `[3,1,2].minmax` → `[1, 3]`; `["b","a","c"].minmax` →
+  `["a", "c"]`. An empty array yields `[nil, nil]` (no smallest/largest element),
+  matching the Python reference's `[None, None]`.
+- The entries are snapshotted into an owned `Vec` before the scan so a block-free
+  reentrant call cannot double-borrow-panic (never-panic floor), consistent with
+  the `min`/`max` arms.
+- The `array_aggregates_compile_and_run` exec-proof test gains `minmax` (non-empty
+  and empty) — the emitted Rust compiles with `rustc`, runs, and asserts
+  `[1, 3]` / `[nil, nil]`.
+
 ## 0.33.0 — Array `slice_when`
 
 Mirrors the Python reference (PR #8070) and the Go backend (PR #8073) into the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -140,7 +140,7 @@ rather than panicking:
   **explicitly** on `(receiver type, method name)`, ported from the
   Python/TS `sir-runtime-oop` reference for parity:
   - **Array** (`Seq`): `length`/`size`, `first`, `last`, `push`/`append`,
-    `pop`, `include?`, `reverse`, `sort`, `join`, `map`, `select`/`filter`,
+    `pop`, `include?`, `reverse`, `sort`, `min`/`max`/`minmax`/`sum`, `join`, `map`, `select`/`filter`,
     `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`,
     `each_slice`/`each_cons`, `chunk_while`/`slice_when`.
   - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1466,7 +1466,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                     | "drop_while" | "count" | "each_with_object" | "each_with_index"
                     // aggregate / reshape non-block methods (all dispatch in
                     // `array_method` above; previously under-reported here)
-                    | "min" | "max" | "sum" | "uniq" | "flatten" | "compact" | "to_a"
+                    | "min" | "max" | "minmax" | "sum" | "uniq" | "flatten" | "compact" | "to_a"
                     // more non-block Array methods
                     | "zip" | "rotate" | "to_h" | "tally"
                     | "take" | "drop" | "values_at"
@@ -1945,6 +1945,31 @@ pub const RUNTIME: &str = r##"mod __sir {
                         best
                     }
                     None => Value::Nil,
+                }
+            }
+            // `minmax` (no block): the two-element array `[min, max]` computed
+            // in one pass via `num_lt`.  An empty array yields `[nil, nil]` (no
+            // smallest/largest element), matching the Python reference's
+            // `[None, None]`.  Snapshot first so no borrow is held across the
+            // scan (never-panic floor).
+            "minmax" => {
+                let snapshot = items_rc.borrow().clone();
+                let mut iter = snapshot.into_iter();
+                match iter.next() {
+                    Some(first) => {
+                        let mut lo = first.clone();
+                        let mut hi = first;
+                        for item in iter {
+                            if num_lt(&item, &lo) {
+                                lo = item.clone();
+                            }
+                            if num_lt(&hi, &item) {
+                                hi = item;
+                            }
+                        }
+                        seq_lit(vec![lo, hi])
+                    }
+                    None => seq_lit(vec![Value::Nil, Value::Nil]),
                 }
             }
             // `sum`: numeric fold seeded at `0` (or the explicit seed arg,

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -155,6 +155,10 @@ fn full_demo() -> Module {
         print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "max", vec![])),
         // 2. [3, 1, 2].min  → 1
         print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "min", vec![])),
+        // 2b. [3, 1, 2].minmax  → [1, 3]
+        print_stmt(method(seq(vec![ilit(3), ilit(1), ilit(2)]), "minmax", vec![])),
+        // 2c. [].minmax  → [nil, nil]
+        print_stmt(method(seq(vec![]), "minmax", vec![])),
         // 3. [1, 2, 3].sum  → 6
         print_stmt(method(seq(vec![ilit(1), ilit(2), ilit(3)]), "sum", vec![])),
         // 4. [1, 2, 2, 3].uniq  → [1, 2, 3]
@@ -250,6 +254,8 @@ fn array_aggregates_compile_and_run() {
         vec![
             "3",         // [3,1,2].max
             "1",         // [3,1,2].min
+            "[1, 3]",    // [3,1,2].minmax
+            "[nil, nil]", // [].minmax → [nil, nil]
             "6",         // [1,2,3].sum
             "[1, 2, 3]", // [1,2,2,3].uniq
             "[1, 2, 3]", // [[1,[2]],3].flatten


### PR DESCRIPTION
Mirrors the Python reference ([#8092](https://github.com/adhithyan15/coding-adventures/pull/8092)) and the Go backend ([#8098](https://github.com/adhithyan15/coding-adventures/pull/8098)) into the **Rust backend**'s inline `__sir` runtime (`array_method` beside the existing `min`/`max` arms + the array-method `responds_to` set), continuing the `minmax` cross-backend cascade.

## What

`minmax` (non-block) returns the two-element array `[min, max]` computed in one pass via `num_lt`:

- `[3,1,2].minmax` → `[1, 3]`
- `["b","a","c"].minmax` → `["a", "c"]`
- `[].minmax` → `[nil, nil]` (Ruby: no smallest/largest element)

Entries are snapshotted into an owned `Vec` before the scan so a reentrant call can't double-borrow-panic (never-panic floor), consistent with the `min`/`max` arms.

## Tests

The `array_aggregates_compile_and_run` exec-proof test gains `minmax` (non-empty and empty) — the emitted Rust compiles with `rustc`, runs, and asserts `[1, 3]` / `[nil, nil]`. Passes locally.

Version 0.33.0 → 0.34.0. Security review passed (borrow-safe snapshot, `num_lt` total/never-panics, explicit-match dispatch). JS/TS mirrors follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)