### PR TITLE
feat(semantic-ir): SIR22 addendum — APL primitive Expr variants (v0.23.0)

### DIFF
--- a/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/javascript-to-semantic-ir/src/lower.rs
@@ -3532,6 +3532,27 @@ fn expr_may_have_effects(expr: &Expr) -> bool {
                 })
         }
 
+        // SIR22 addendum: APL primitive operators — same "Pure" treatment
+        // as the base SIR22 nodes above (the spec's "Effects" section marks
+        // every one of these `Pure` too).
+        Expr::Reduce { target, .. } => expr_may_have_effects(target),
+        Expr::Scan { target, .. } => expr_may_have_effects(target),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            expr_may_have_effects(lhs) || expr_may_have_effects(rhs)
+        }
+        Expr::Shape { target, .. } => expr_may_have_effects(target),
+        Expr::Reshape { shape, target, .. } => {
+            expr_may_have_effects(shape) || expr_may_have_effects(target)
+        }
+        Expr::IndexGenerator { count, .. } => expr_may_have_effects(count),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => expr_may_have_effects(haystack) || expr_may_have_effects(needle),
+        Expr::Ravel { target, .. } => expr_may_have_effects(target),
+        Expr::Catenate { lhs, rhs, .. } => {
+            expr_may_have_effects(lhs) || expr_may_have_effects(rhs)
+        }
+
         // Calls, closures, and intrinsics may do anything → keep.
         Expr::DirectCall { .. }
         | Expr::IndirectCall { .. }

--- a/code/packages/rust/python-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/python-to-semantic-ir/src/lower.rs
@@ -3742,6 +3742,32 @@ fn collect_callees_expr(expr: &Expr, out: &mut HashSet<String>) {
                 }
             }
         }
+        // SIR22 addendum: APL primitive operators — the Python frontend
+        // never emits these either, but recurse into every child `Expr`
+        // slot for the same reason as the base SIR22 nodes above.
+        Expr::Reduce { target, .. } => collect_callees_expr(target, out),
+        Expr::Scan { target, .. } => collect_callees_expr(target, out),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            collect_callees_expr(lhs, out);
+            collect_callees_expr(rhs, out);
+        }
+        Expr::Shape { target, .. } => collect_callees_expr(target, out),
+        Expr::Reshape { shape, target, .. } => {
+            collect_callees_expr(shape, out);
+            collect_callees_expr(target, out);
+        }
+        Expr::IndexGenerator { count, .. } => collect_callees_expr(count, out),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            collect_callees_expr(haystack, out);
+            collect_callees_expr(needle, out);
+        }
+        Expr::Ravel { target, .. } => collect_callees_expr(target, out),
+        Expr::Catenate { lhs, rhs, .. } => {
+            collect_callees_expr(lhs, out);
+            collect_callees_expr(rhs, out);
+        }
         // SIR23 symbolic-expression/pattern nodes: the Python frontend never
         // emits these either, but recurse into every child `Expr` slot for
         // the same reason as the SIR22 nodes above.

--- a/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/ruby-to-semantic-ir/src/lower.rs
@@ -320,6 +320,29 @@ fn expr_references_any_name(expr: &Expr, names: &HashSet<String>) -> bool {
                     .any(|idx| index_arg_references_any_name(idx, names))
         }
 
+        // SIR22 addendum compile-compat stubs: same rationale as the base
+        // SIR22 stubs above — never produced by this frontend today, but
+        // walked structurally regardless.
+        Expr::Reduce { target, .. } => expr_references_any_name(target, names),
+        Expr::Scan { target, .. } => expr_references_any_name(target, names),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+        Expr::Shape { target, .. } => expr_references_any_name(target, names),
+        Expr::Reshape { shape, target, .. } => {
+            expr_references_any_name(shape, names) || expr_references_any_name(target, names)
+        }
+        Expr::IndexGenerator { count, .. } => expr_references_any_name(count, names),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            expr_references_any_name(haystack, names) || expr_references_any_name(needle, names)
+        }
+        Expr::Ravel { target, .. } => expr_references_any_name(target, names),
+        Expr::Catenate { lhs, rhs, .. } => {
+            expr_references_any_name(lhs, names) || expr_references_any_name(rhs, names)
+        }
+
         // SIR23 compile-compat stubs: same rationale as the SIR22 stubs
         // above — the Ruby frontend never produces any symbolic-expression
         // or pattern/rewrite node today, but every arm still recurses
@@ -4173,6 +4196,36 @@ impl Lowerer {
                 found
             }
 
+            // SIR22 addendum compile-compat stubs: same rationale as the
+            // base SIR22 stubs above.
+            Expr::Reduce { target, .. } => Self::rewrite_yields_in_expr(target, block_scope),
+            Expr::Scan { target, .. } => Self::rewrite_yields_in_expr(target, block_scope),
+            Expr::OuterProduct { lhs, rhs, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(lhs, block_scope);
+                found |= Self::rewrite_yields_in_expr(rhs, block_scope);
+                found
+            }
+            Expr::Shape { target, .. } => Self::rewrite_yields_in_expr(target, block_scope),
+            Expr::Reshape { shape, target, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(shape, block_scope);
+                found |= Self::rewrite_yields_in_expr(target, block_scope);
+                found
+            }
+            Expr::IndexGenerator { count, .. } => Self::rewrite_yields_in_expr(count, block_scope),
+            Expr::IndexOf {
+                haystack, needle, ..
+            } => {
+                let mut found = Self::rewrite_yields_in_expr(haystack, block_scope);
+                found |= Self::rewrite_yields_in_expr(needle, block_scope);
+                found
+            }
+            Expr::Ravel { target, .. } => Self::rewrite_yields_in_expr(target, block_scope),
+            Expr::Catenate { lhs, rhs, .. } => {
+                let mut found = Self::rewrite_yields_in_expr(lhs, block_scope);
+                found |= Self::rewrite_yields_in_expr(rhs, block_scope);
+                found
+            }
+
             // SIR23 compile-compat stubs: same rationale as the SIR22 stubs
             // above — this frontend never emits any symbolic-expression or
             // pattern/rewrite node today, but every arm still recurses into
@@ -4877,6 +4930,32 @@ impl Lowerer {
                     Self::normalize_calls_in_index_arg(idx, ctx);
                 }
             }
+            // SIR22 addendum compile-compat stubs (never emitted by this
+            // frontend): recurse into every child `Expr`, matching the base
+            // SIR22 stubs above.
+            Expr::Reduce { target, .. } => Self::normalize_calls_in_expr(target, ctx),
+            Expr::Scan { target, .. } => Self::normalize_calls_in_expr(target, ctx),
+            Expr::OuterProduct { lhs, rhs, .. } => {
+                Self::normalize_calls_in_expr(lhs, ctx);
+                Self::normalize_calls_in_expr(rhs, ctx);
+            }
+            Expr::Shape { target, .. } => Self::normalize_calls_in_expr(target, ctx),
+            Expr::Reshape { shape, target, .. } => {
+                Self::normalize_calls_in_expr(shape, ctx);
+                Self::normalize_calls_in_expr(target, ctx);
+            }
+            Expr::IndexGenerator { count, .. } => Self::normalize_calls_in_expr(count, ctx),
+            Expr::IndexOf {
+                haystack, needle, ..
+            } => {
+                Self::normalize_calls_in_expr(haystack, ctx);
+                Self::normalize_calls_in_expr(needle, ctx);
+            }
+            Expr::Ravel { target, .. } => Self::normalize_calls_in_expr(target, ctx),
+            Expr::Catenate { lhs, rhs, .. } => {
+                Self::normalize_calls_in_expr(lhs, ctx);
+                Self::normalize_calls_in_expr(rhs, ctx);
+            }
             // SIR23 compile-compat stubs (never emitted by this frontend):
             // recurse into every child `Expr`, matching the SIR22 stubs
             // above, so a parenless block-method call nested inside one of
@@ -5139,6 +5218,32 @@ impl Lowerer {
                 for idx in indices {
                     Self::collect_bound_names_expr_in_index_arg(idx, out);
                 }
+            }
+            // SIR22 addendum compile-compat stubs (never emitted by this
+            // frontend): recurse into every child `Expr`, matching the base
+            // SIR22 stubs above.
+            Expr::Reduce { target, .. } => Self::collect_bound_names_expr(target, out),
+            Expr::Scan { target, .. } => Self::collect_bound_names_expr(target, out),
+            Expr::OuterProduct { lhs, rhs, .. } => {
+                Self::collect_bound_names_expr(lhs, out);
+                Self::collect_bound_names_expr(rhs, out);
+            }
+            Expr::Shape { target, .. } => Self::collect_bound_names_expr(target, out),
+            Expr::Reshape { shape, target, .. } => {
+                Self::collect_bound_names_expr(shape, out);
+                Self::collect_bound_names_expr(target, out);
+            }
+            Expr::IndexGenerator { count, .. } => Self::collect_bound_names_expr(count, out),
+            Expr::IndexOf {
+                haystack, needle, ..
+            } => {
+                Self::collect_bound_names_expr(haystack, out);
+                Self::collect_bound_names_expr(needle, out);
+            }
+            Expr::Ravel { target, .. } => Self::collect_bound_names_expr(target, out),
+            Expr::Catenate { lhs, rhs, .. } => {
+                Self::collect_bound_names_expr(lhs, out);
+                Self::collect_bound_names_expr(rhs, out);
             }
             // SIR23 compile-compat stubs (never emitted by this frontend):
             // recurse into every child `Expr`, matching the SIR22 stubs

--- a/code/packages/rust/semantic-ir-to-go/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/emit.rs
@@ -851,6 +851,18 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
         | Expr::IndexGet { .. }
+        // SIR22 addendum: APL primitive operators — same deferral rationale
+        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
+        // features, which `ACCEPTED_FEATURES` still doesn't declare).
+        | Expr::Reduce { .. }
+        | Expr::Scan { .. }
+        | Expr::OuterProduct { .. }
+        | Expr::Shape { .. }
+        | Expr::Reshape { .. }
+        | Expr::IndexGenerator { .. }
+        | Expr::IndexOf { .. }
+        | Expr::Ravel { .. }
+        | Expr::Catenate { .. }
         // SIR26 `Convert` — this backend does not accept `Conversions`, so a
         // validated module never reaches here (capability check rejects it).
         | Expr::Convert { .. } => {

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -838,6 +838,19 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::ElementwiseOp { span, .. }
         | Expr::Transpose { span, .. }
         | Expr::IndexGet { span, .. }
+        // SIR22 addendum: APL primitive operators — same deferral as the
+        // base SIR22 nodes above; `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
+        // are still the gating features, so none of these nine reach this
+        // emitter in a validated module either.
+        | Expr::Reduce { span, .. }
+        | Expr::Scan { span, .. }
+        | Expr::OuterProduct { span, .. }
+        | Expr::Shape { span, .. }
+        | Expr::Reshape { span, .. }
+        | Expr::IndexGenerator { span, .. }
+        | Expr::IndexOf { span, .. }
+        | Expr::Ravel { span, .. }
+        | Expr::Catenate { span, .. }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module (capability check rejects it).
         | Expr::Convert { span, .. } => {

--- a/code/packages/rust/semantic-ir-to-python/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-python/src/emit.rs
@@ -415,6 +415,26 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
             expr_uses_builtin(target, name)
                 || indices.iter().any(|ix| index_arg_uses_builtin(ix, name))
         }
+        // SIR22 addendum: APL primitive operators — not accepted by this
+        // backend either (same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
+        // gating), but recurse faithfully regardless.
+        Expr::Reduce { target, .. } => expr_uses_builtin(target, name),
+        Expr::Scan { target, .. } => expr_uses_builtin(target, name),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::Shape { target, .. } => expr_uses_builtin(target, name),
+        Expr::Reshape { shape, target, .. } => {
+            expr_uses_builtin(shape, name) || expr_uses_builtin(target, name)
+        }
+        Expr::IndexGenerator { count, .. } => expr_uses_builtin(count, name),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => expr_uses_builtin(haystack, name) || expr_uses_builtin(needle, name),
+        Expr::Ravel { target, .. } => expr_uses_builtin(target, name),
+        Expr::Catenate { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
         Expr::Convert { value, .. } => expr_uses_builtin(value, name),
         // SIR23 symbolic-expression/pattern nodes are not accepted by this
         // backend yet (see `ACCEPTED_FEATURES` in `lib.rs`), so a validated
@@ -1258,6 +1278,18 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
         | Expr::IndexGet { .. }
+        // SIR22 addendum: APL primitive operators — same deferral rationale
+        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
+        // features, not in `ACCEPTED_FEATURES` either).
+        | Expr::Reduce { .. }
+        | Expr::Scan { .. }
+        | Expr::OuterProduct { .. }
+        | Expr::Shape { .. }
+        | Expr::Reshape { .. }
+        | Expr::IndexGenerator { .. }
+        | Expr::IndexOf { .. }
+        | Expr::Ravel { .. }
+        | Expr::Catenate { .. }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module.
         | Expr::Convert { .. } => {

--- a/code/packages/rust/semantic-ir-to-rust/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/emit.rs
@@ -520,6 +520,17 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
         | Expr::IndexGet { .. }
+        // SIR22 addendum: APL primitive operators — same rationale as the
+        // base SIR22 nodes above.
+        | Expr::Reduce { .. }
+        | Expr::Scan { .. }
+        | Expr::OuterProduct { .. }
+        | Expr::Shape { .. }
+        | Expr::Reshape { .. }
+        | Expr::IndexGenerator { .. }
+        | Expr::IndexOf { .. }
+        | Expr::Ravel { .. }
+        | Expr::Catenate { .. }
         | Expr::Convert { .. } => {}
         // SIR23 symbolic-expression/pattern nodes: same rationale as the
         // SIR22 nodes above — rejected before emit, so none of these carry
@@ -1114,6 +1125,18 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::ElementwiseOp { span, .. }
         | Expr::Transpose { span, .. }
         | Expr::IndexGet { span, .. }
+        // SIR22 addendum: APL primitive operators — same deferral rationale
+        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
+        // features, not in this backend's accepted-features list either).
+        | Expr::Reduce { span, .. }
+        | Expr::Scan { span, .. }
+        | Expr::OuterProduct { span, .. }
+        | Expr::Shape { span, .. }
+        | Expr::Reshape { span, .. }
+        | Expr::IndexGenerator { span, .. }
+        | Expr::IndexOf { span, .. }
+        | Expr::Ravel { span, .. }
+        | Expr::Catenate { span, .. }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module.
         | Expr::Convert { span, .. } => {

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -421,6 +421,27 @@ fn expr_uses_builtin(e: &Expr, name: &str) -> bool {
             expr_uses_builtin(target, name)
                 || indices.iter().any(|idx| index_arg_uses_builtin(idx, name))
         }
+        // SIR22 addendum compile-compat stubs: same rationale as the base
+        // SIR22 stubs above — this backend doesn't accept `MatrixOps`/
+        // `NDArrays`/`ArrayColumnMajor` either, so these never reach
+        // emission, but the scan still recurses faithfully.
+        Expr::Reduce { target, .. } => expr_uses_builtin(target, name),
+        Expr::Scan { target, .. } => expr_uses_builtin(target, name),
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
+        Expr::Shape { target, .. } => expr_uses_builtin(target, name),
+        Expr::Reshape { shape, target, .. } => {
+            expr_uses_builtin(shape, name) || expr_uses_builtin(target, name)
+        }
+        Expr::IndexGenerator { count, .. } => expr_uses_builtin(count, name),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => expr_uses_builtin(haystack, name) || expr_uses_builtin(needle, name),
+        Expr::Ravel { target, .. } => expr_uses_builtin(target, name),
+        Expr::Catenate { lhs, rhs, .. } => {
+            expr_uses_builtin(lhs, name) || expr_uses_builtin(rhs, name)
+        }
         Expr::Convert { value, .. } => expr_uses_builtin(value, name),
         // SIR23 compile-compat stubs: this backend does not accept
         // `Feature::SymbolicExpr`/`Feature::PatternMatching` (see
@@ -940,6 +961,27 @@ fn collect_expr_assigned(e: &Expr, out: &mut HashSet<String>) {
             for idx in indices {
                 collect_index_arg_assigned(idx, out);
             }
+        }
+        // SIR22 addendum compile-compat stubs: same rationale as the base
+        // SIR22 stubs above.
+        Expr::Reduce { target, .. }
+        | Expr::Scan { target, .. }
+        | Expr::Shape { target, .. }
+        | Expr::Ravel { target, .. } => collect_expr_assigned(target, out),
+        Expr::OuterProduct { lhs, rhs, .. } | Expr::Catenate { lhs, rhs, .. } => {
+            collect_expr_assigned(lhs, out);
+            collect_expr_assigned(rhs, out);
+        }
+        Expr::Reshape { shape, target, .. } => {
+            collect_expr_assigned(shape, out);
+            collect_expr_assigned(target, out);
+        }
+        Expr::IndexGenerator { count, .. } => collect_expr_assigned(count, out),
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            collect_expr_assigned(haystack, out);
+            collect_expr_assigned(needle, out);
         }
         Expr::Convert { value, .. } => collect_expr_assigned(value, out),
         // SIR23 compile-compat stubs: rejected by `check_module` before this
@@ -1510,6 +1552,18 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
         | Expr::ElementwiseOp { .. }
         | Expr::Transpose { .. }
         | Expr::IndexGet { .. }
+        // SIR22 addendum: APL primitive operators — same deferral rationale
+        // (gated by the same `MatrixOps`/`NDArrays`/`ArrayColumnMajor`
+        // features, which this backend still doesn't declare).
+        | Expr::Reduce { .. }
+        | Expr::Scan { .. }
+        | Expr::OuterProduct { .. }
+        | Expr::Shape { .. }
+        | Expr::Reshape { .. }
+        | Expr::IndexGenerator { .. }
+        | Expr::IndexOf { .. }
+        | Expr::Ravel { .. }
+        | Expr::Catenate { .. }
         // SIR26 `Convert` — `Conversions` not accepted; unreachable in a
         // validated module.
         | Expr::Convert { .. } => {

--- a/code/packages/rust/semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir/CHANGELOG.md
@@ -2,6 +2,128 @@
 
 All notable changes to the `semantic-ir` crate are documented here.
 
+## 0.23.0 — SIR22 addendum: APL primitive Expr variants
+
+Extends [SIR22](../../../specs/SIR22-array-matrix-semantic-ir.md) with the
+array-family primitive *operators* the base spec's first cut didn't cover.
+SIR22's own Motivation section always claimed to be "the substrate for ...
+every future array-family frontend (APL, J, K/Q, Scilab, IDL)," but the
+first cut only populated the `Expr` variants MATLAB's own frontend needed
+(`ArrayLit`/`Range`/`MatMul`/`ElementwiseOp`/`Transpose`/`IndexGet`/
+`IndexSet`) — MATLAB has no first-class *operator* syntax for reduce/scan/
+outer-product/reshape/iota/ravel/catenate (it would call `sum(x)`/
+`reshape(x, ...)` etc. as ordinary function calls, which this repo's MATLAB
+frontend subset doesn't yet support at all). APL (`apl-runtime`/
+`apl-parser`, already shipped) exposes all of these as first-class bare
+glyphs, so this is a genuine substrate gap — the exact same kind of
+prerequisite gap `array-runtime`'s own AR-2 task was for `apl-runtime`
+before that runtime crate could be built. This PR closes the gap at the IR
+level; it does **not** add the `apl-to-semantic-ir` frontend that will
+consume it — that is a follow-up task. Additive only, following the exact
+discipline SIR23 used for its own extension: every existing SIR10/SIR16/
+SIR17/SIR18/SIR21/SIR22/SIR23/SIR26 module remains valid; no existing
+`Expr`/`Stmt`/`SirType`/`Feature` variant, validator rule, or backend
+behaviour changed.
+
+**New `ElementwiseOpKind` variants** (`nodes.rs`): `Max, Min, Eq, Ne, Lt,
+Le, Ge, Gt` added alongside the five SIR22 shipped (`Add, Sub, Mul, Div,
+Pow`), mirroring `array_runtime::BinOp`'s own identical extension (added
+for `apl-runtime`'s `⌈`/`⌊` max/min glyphs and its six comparison glyphs
+`= ≠ < ≤ ≥ >` in PR #8072). Kebab-case `.name()`/`.from_name()` round-trip
+extended to all thirteen variants.
+
+**New `Expr` variants** (`nodes.rs`), each mapped 1:1 onto an existing
+`array_runtime::ops`/`apl-runtime::builtins` op shape (the same "map 1:1
+onto an existing op shape" discipline the SIR22 spec itself states as its
+design principle, extended here to a second source op-shape since APL's
+`⍴`/`⍳`/`,` don't fit the `BinOp` shape any more than they did for
+`apl-runtime` itself):
+- `Reduce { op: ElementwiseOpKind, target: Box<Expr>, span }` — `+/A`,
+  maps 1:1 onto `array_runtime::ops::reduce(op, a)`.
+- `Scan { op: ElementwiseOpKind, target: Box<Expr>, span }` — `+\A`, maps
+  1:1 onto `array_runtime::ops::scan(op, a)`.
+- `OuterProduct { op: ElementwiseOpKind, lhs: Box<Expr>, rhs: Box<Expr>,
+  span }` — `A∘.×B`, maps 1:1 onto `array_runtime::ops::outer(op, a, b)`.
+- `Shape { target: Box<Expr>, span }` — monadic `⍴A`, mirrors
+  `apl-runtime::builtins::shape`.
+- `Reshape { shape: Box<Expr>, target: Box<Expr>, span }` — dyadic `A⍴B`,
+  mirrors `apl-runtime::builtins::reshape(a, b)`; field names spell out
+  the shape-vector-vs-data role instead of reusing `lhs`/`rhs`, since
+  (unlike `MatMul`/`ElementwiseOp`) the two operands aren't interchangeable
+  in kind.
+- `IndexGenerator { count: Box<Expr>, span }` — monadic `⍳N` (iota), mirrors
+  `apl-runtime::builtins::index_generator`.
+- `IndexOf { haystack: Box<Expr>, needle: Box<Expr>, span }` — dyadic `A⍳B`
+  (index-of/search), mirrors `apl-runtime::builtins::index_of(a, b)`.
+- `Ravel { target: Box<Expr>, span }` — monadic `,A` (flatten), mirrors
+  `apl-runtime::builtins::ravel`.
+- `Catenate { lhs: Box<Expr>, rhs: Box<Expr>, span }` — dyadic `A,B`
+  (concatenate), mirrors `apl-runtime::builtins::catenate`.
+
+**No new `Stmt` or `SirType` variant** — every new node is `Expr`-shaped and
+`Pure`, same as the rest of SIR22.
+
+**No new `Feature` flag** — every new node reuses SIR22's existing
+`MatrixOps`/`NDArrays`/`ArrayColumnMajor` flags rather than adding new ones
+(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`Ravel`/`Catenate` observe
+both `MatrixOps` and `ArrayColumnMajor` — same class of operation as
+`MatMul`/`Transpose`; `IndexGenerator`/`IndexOf` observe only `NDArrays` —
+they construct/query arrays without inherently being a "matrix op" any more
+than `Range`/`IndexGet` are).
+
+**Validator** (`validator.rs`): one match arm per new variant following the
+exact feature-observation split above, each recursing into every child
+`Expr`. Extensive new tests (one "rejected undeclared" + one "accepted
+declared" pair per variant) mirror the existing SIR22 validator tests.
+
+**Walker** (`walker.rs`) and **printer** (`text/printer.rs`): one arm per
+new variant — the walker recurses into every child `Expr` with no `Feature`
+bookkeeping (purely structural traversal); the printer renders each as a
+parenthesized s-expression (`(reduce <op> <target>)`, `(scan <op>
+<target>)`, `(outer-product <op> <lhs> <rhs>)`, `(shape <target>)`,
+`(reshape <shape> <target>)`, `(index-generator <count>)`, `(index-of
+<haystack> <needle>)`, `(ravel <target>)`, `(catenate <lhs> <rhs>)`),
+reusing `op.name()` for the op-kind token exactly like the existing
+`ElementwiseOp` arm does. New tests mirror the existing SIR22 walker/
+printer tests one-for-one.
+
+**Compile-compat ripple**: adding `Expr` variants to a shared narrow-waist
+IR is not confined to `semantic-ir` itself — every crate with an exhaustive
+`match` over `Expr` needs a new arm to keep compiling, independent of
+whether it does anything semantically interesting with the new node. Eight
+downstream crates had such exhaustive matches (carried over from SIR23's
+own rollout): the five backends `semantic-ir-to-{javascript,typescript,
+rust,go,python}` (panic-guard "deferred, not accepted" stubs in their
+codegen `match`, gated the same way as the existing SIR22/SIR23 stubs —
+`MatrixOps`/`NDArrays`/`ArrayColumnMajor` aren't in any of their
+`ACCEPTED_FEATURES`, so a validated module can never reach these arms) and
+the three frontends `{javascript,ruby,python}-to-semantic-ir` (faithful
+structural recursion in internal analysis passes — effect inference,
+call-graph collection, yield-rewriting, swap-safety checks — since none of
+these frontends emit the new nodes today). `semantic-ir`'s own
+`backend.rs::walk_intrinsics_in_expr` needed the same treatment. No actual
+codegen was added anywhere — per this task's scope, real JS/TS backend
+support for these ops (or any SIR22 node) remains a separate, not-yet-
+started rollout item. `wolfram-to-semantic-ir`, `matlab-to-semantic-ir`,
+`octave-to-semantic-ir`, `c-to-semantic-ir`, `twig-to-semantic-ir`,
+`semantic-ir-to-c`, `semantic-ir-to-ruby`, and `sir-conformance` required no
+changes (no exhaustive `Expr` match in any of them — their internal helpers
+already use a wildcard `_ => ...` arm).
+
+**Versioning** (`metadata.rs`): `CURRENT_SIR_VERSION` bumped `"3"` → `"4"`,
+following the same "adding a feature is a v.bump" policy that moved `"2"`
+→ `"3"` in SIR23 and `"1"` → `"2"` in SIR22 — this addendum introduces new
+SIR text tokens (new printer forms, new op-kind names) even though it
+isn't a new numbered spec. The `v3`-asserting golden tests (`lib.rs`,
+`metadata.rs`, `text/printer.rs`) were updated to `v4`. No frontend crate
+sets `metadata.sir_version` to `"4"` yet — `apl-to-semantic-ir` will, once
+it exists.
+
+No frontend crate consumes any of these nine variants yet — this addendum
+is IR-substrate-only, mirroring how `array-runtime`'s AR-2 task preceded
+`apl-runtime` as its own separate step. `apl-to-semantic-ir` is the
+follow-up task that will actually emit these nodes from parsed APL source.
+
 ## 0.22.0 — SIR23: symbolic expression + pattern/rewrite IR extension
 
 Implements [SIR23](../../../specs/SIR23-symbolic-pattern-semantic-ir.md) —

--- a/code/packages/rust/semantic-ir/Cargo.toml
+++ b/code/packages/rust/semantic-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Narrow-waist Semantic IR (SIR10): a language-neutral intermediate representation between frontends and backends."
 

--- a/code/packages/rust/semantic-ir/src/backend.rs
+++ b/code/packages/rust/semantic-ir/src/backend.rs
@@ -443,6 +443,42 @@ where
             walk_intrinsics_in_expr(target, f, depth + 1);
             walk_intrinsics_in_index_args(indices, f, depth + 1);
         }
+
+        // ── SIR22 addendum: APL primitive operators ─────────────────
+        Expr::Reduce { target, .. } => {
+            walk_intrinsics_in_expr(target, f, depth + 1);
+        }
+        Expr::Scan { target, .. } => {
+            walk_intrinsics_in_expr(target, f, depth + 1);
+        }
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            walk_intrinsics_in_expr(lhs, f, depth + 1);
+            walk_intrinsics_in_expr(rhs, f, depth + 1);
+        }
+        Expr::Shape { target, .. } => {
+            walk_intrinsics_in_expr(target, f, depth + 1);
+        }
+        Expr::Reshape { shape, target, .. } => {
+            walk_intrinsics_in_expr(shape, f, depth + 1);
+            walk_intrinsics_in_expr(target, f, depth + 1);
+        }
+        Expr::IndexGenerator { count, .. } => {
+            walk_intrinsics_in_expr(count, f, depth + 1);
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            walk_intrinsics_in_expr(haystack, f, depth + 1);
+            walk_intrinsics_in_expr(needle, f, depth + 1);
+        }
+        Expr::Ravel { target, .. } => {
+            walk_intrinsics_in_expr(target, f, depth + 1);
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            walk_intrinsics_in_expr(lhs, f, depth + 1);
+            walk_intrinsics_in_expr(rhs, f, depth + 1);
+        }
+
         // ── SIR26 ──────────────────────────────────────────────────
         Expr::Convert { value, .. } => {
             walk_intrinsics_in_expr(value, f, depth + 1);

--- a/code/packages/rust/semantic-ir/src/lib.rs
+++ b/code/packages/rust/semantic-ir/src/lib.rs
@@ -100,7 +100,7 @@ mod smoke {
         let r = validate(&m);
         assert!(r.is_ok());
         let t = print_module(&m);
-        assert!(t.contains("(sir-module empty v3"));
+        assert!(t.contains("(sir-module empty v4"));
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/metadata.rs
+++ b/code/packages/rust/semantic-ir/src/metadata.rs
@@ -9,7 +9,8 @@
 //!
 //! - `source_language` — frontend identifier (`"twig"`, `"python"`, …)
 //! - `source_version`  — version string of the source language
-//! - `sir_version`     — IR spec version (`"2"` in this build)
+//! - `sir_version`     — IR spec version (see [`CURRENT_SIR_VERSION`] for
+//!   the value this build implements)
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -42,7 +43,20 @@ use std::fmt;
 ///   lowering a Wolfram/Macsyma/Maxima-family CAS language sets
 ///   `metadata.sir_version` to this value when its module uses any
 ///   SIR23 node.
-pub const CURRENT_SIR_VERSION: &str = "3";
+/// - `"4"` — SIR22 addendum: nine new APL-primitive `Expr` variants
+///   (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+///   `IndexOf`/`Ravel`/`Catenate`) plus eight new `ElementwiseOpKind`
+///   variants (`Max`/`Min`/`Eq`/`Ne`/`Lt`/`Le`/`Ge`/`Gt`), closing the
+///   gap between what the base SIR22 spec always claimed to cover
+///   ("every future array-family frontend (APL, J, K/Q, Scilab, IDL)")
+///   and what it actually modeled (MATLAB/Octave's own vocabulary
+///   only).  No new `SirType` or `Feature` flag — every new node reuses
+///   `NDArrays`/`MatrixOps`/`ArrayColumnMajor`.  Still additive, still
+///   new SIR text tokens (new printer forms, new op-kind names), so the
+///   same "adding a feature is a v.bump" policy bumps `"3"` → `"4"`.  No
+///   frontend crate consumes these yet — `apl-to-semantic-ir` is a
+///   follow-up task that will set `metadata.sir_version` to this value.
+pub const CURRENT_SIR_VERSION: &str = "4";
 
 /// Advisory metadata.  All fields are optional.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -133,7 +147,7 @@ mod tests {
             .with_sir_version(CURRENT_SIR_VERSION);
         assert_eq!(m.source_language.as_deref(), Some("twig"));
         assert_eq!(m.source_version.as_deref(), Some("0.7"));
-        assert_eq!(m.sir_version.as_deref(), Some("3"));
+        assert_eq!(m.sir_version.as_deref(), Some("4"));
         assert!(!m.is_empty());
     }
 
@@ -158,11 +172,11 @@ mod tests {
     }
 
     #[test]
-    fn current_sir_version_is_three() {
-        // Bumped 2 → 3 in SIR23 (symbolic expression + pattern/rewrite IR
-        // extension: new SirType/Expr/Feature text tokens), following the
-        // same "adding a feature is a v.bump" policy that moved 1 → 2 in
-        // SIR22.
-        assert_eq!(CURRENT_SIR_VERSION, "3");
+    fn current_sir_version_is_four() {
+        // Bumped 3 → 4 in the SIR22 addendum (nine new APL-primitive
+        // `Expr` variants + eight new `ElementwiseOpKind` variants: new
+        // SIR text tokens), following the same "adding a feature is a
+        // v.bump" policy that moved 2 → 3 in SIR23 and 1 → 2 in SIR22.
+        assert_eq!(CURRENT_SIR_VERSION, "4");
     }
 }

--- a/code/packages/rust/semantic-ir/src/nodes.rs
+++ b/code/packages/rust/semantic-ir/src/nodes.rs
@@ -900,6 +900,108 @@ pub enum Expr {
         span: Span,
     },
 
+    // ── SIR22 addendum: APL primitive operators ─────────────────────
+    //
+    // The six node kinds below extend SIR22 to cover the array-family
+    // primitive *operators* that MATLAB has no first-class syntax for
+    // (it would call `sum(x)`/`reshape(x, ...)` etc. as ordinary function
+    // calls, which this repo's MATLAB frontend subset doesn't yet support
+    // at all) but that APL (`apl-runtime`/`apl-parser`, already shipped)
+    // exposes as bare glyphs: `+/A` (reduce), `+\A` (scan), `A∘.×B` (outer
+    // product), `⍴`/`⍳`/`,` (shape-reshape / index-generator-index-of /
+    // ravel-catenate). Each is mapped 1:1 onto an existing op shape —
+    // `array_runtime::ops::{reduce,scan,outer}` for the three that take an
+    // `ElementwiseOpKind`, and `apl-runtime::builtins`'s own bespoke
+    // (non-`BinOp`-shaped) logic for the rest — mirroring the discipline
+    // the base SIR22 spec states for its own MATLAB-oriented cut. All are
+    // `Pure`, same as every other SIR22 node. No frontend crate consumes
+    // these yet; `apl-to-semantic-ir` is a follow-up task.
+    /// `+/A` (APL reduce) — folds `target` with `op` along its one axis.
+    /// Maps 1:1 onto `array_runtime::ops::reduce(op, a)`. `op` reuses
+    /// `ElementwiseOpKind` even though not every variant is meaningful here
+    /// (e.g. `Pow` has no APL reduce-adverb precedent) — the IR does not
+    /// restrict which `op` a frontend may pick, mirroring how `ElementwiseOp`
+    /// itself places no restriction on which arithmetic op appears there.
+    Reduce {
+        op: ElementwiseOpKind,
+        target: Box<Expr>,
+        span: Span,
+    },
+
+    /// `+\A` (APL scan) — a running fold of `target` with `op`, emitting one
+    /// result per prefix. Maps 1:1 onto `array_runtime::ops::scan(op, a)`.
+    Scan {
+        op: ElementwiseOpKind,
+        target: Box<Expr>,
+        span: Span,
+    },
+
+    /// `A∘.×B` (APL outer product) — every pairwise `op` application between
+    /// `lhs`'s and `rhs`'s elements, producing a result of combined rank.
+    /// Maps 1:1 onto `array_runtime::ops::outer(op, a, b)`.
+    OuterProduct {
+        op: ElementwiseOpKind,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+        span: Span,
+    },
+
+    /// Monadic `⍴A` (APL shape) — the dimensions of `target` as a vector.
+    /// Mirrors `apl-runtime::builtins::shape`, which is not itself an
+    /// `array_runtime::ops`/`execute()` primitive (it reads `Array::shape()`
+    /// directly) — the same "bespoke, not `BinOp`-shaped" situation
+    /// `apl-runtime`'s own `NonScalarAtom::Rho` already documents.
+    Shape {
+        target: Box<Expr>,
+        span: Span,
+    },
+
+    /// Dyadic `A⍴B` (APL reshape) — reinterpret `target`'s data under the new
+    /// dimensions given by `shape`. Mirrors `apl-runtime::builtins::reshape(a,
+    /// b)`, where `a` is the shape vector and `b` is the data being reshaped
+    /// — field names here spell out that role instead of reusing `lhs`/`rhs`,
+    /// since (unlike `MatMul`/`ElementwiseOp`) the two operands are not
+    /// interchangeable in kind.
+    Reshape {
+        shape: Box<Expr>,
+        target: Box<Expr>,
+        span: Span,
+    },
+
+    /// Monadic `⍳N` (APL iota / index generator) — the vector `0, 1, ..., N-1`
+    /// (this repo's APL implementation; note this is 0-based at the `Array`
+    /// level even though APL's own surface syntax is 1-indexed — see
+    /// `apl-runtime::builtins::index_generator`, which this mirrors 1:1).
+    IndexGenerator {
+        count: Box<Expr>,
+        span: Span,
+    },
+
+    /// Dyadic `A⍳B` (APL index-of / search) — for each element of `needle`,
+    /// its position in `haystack` (or `haystack`'s length if not found).
+    /// Mirrors `apl-runtime::builtins::index_of(a, b)`, where `a` is the
+    /// haystack and `b` is the needle.
+    IndexOf {
+        haystack: Box<Expr>,
+        needle: Box<Expr>,
+        span: Span,
+    },
+
+    /// Monadic `,A` (APL ravel) — flatten `target` to a rank-1 vector.
+    /// Mirrors `apl-runtime::builtins::ravel`.
+    Ravel {
+        target: Box<Expr>,
+        span: Span,
+    },
+
+    /// Dyadic `A,B` (APL catenate) — concatenate `lhs` and `rhs` along their
+    /// ravel order. Mirrors `apl-runtime::builtins::catenate`.
+    Catenate {
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+        span: Span,
+    },
+
     // ── SIR26 (integer conversions) ──────────────────────────────────
     /// Convert an integer `value` to the target integer type `to` by
     /// two's-complement reinterpretation: reduce modulo `2^width` (mask to
@@ -1043,6 +1145,13 @@ pub enum Expr {
 /// so a backend's `match` has one arm to open and a `match op` inside
 /// it, mirroring how `Scope`/`ParamKind` are small closed enums rather
 /// than a variant explosion on their parent node.
+/// SIR22 shipped `Add, Sub, Mul, Div, Pow` (MATLAB's five dotted
+/// operators). This addendum adds `Max, Min, Eq, Ne, Lt, Le, Ge, Gt`,
+/// mirroring `array_runtime::BinOp`'s own identical extension (added
+/// alongside `apl-runtime` for APL's `⌈`/`⌊` max/min glyphs and its six
+/// comparison glyphs `= ≠ < ≤ ≥ >`, none of which MATLAB's frontend uses
+/// today but which every `ElementwiseOp`/`Reduce`/`Scan`/`OuterProduct`
+/// consumer can already carry without any shape change).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ElementwiseOpKind {
     Add,
@@ -1050,6 +1159,14 @@ pub enum ElementwiseOpKind {
     Mul,
     Div,
     Pow,
+    Max,
+    Min,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Ge,
+    Gt,
 }
 
 impl ElementwiseOpKind {
@@ -1062,6 +1179,14 @@ impl ElementwiseOpKind {
             ElementwiseOpKind::Mul => "mul",
             ElementwiseOpKind::Div => "div",
             ElementwiseOpKind::Pow => "pow",
+            ElementwiseOpKind::Max => "max",
+            ElementwiseOpKind::Min => "min",
+            ElementwiseOpKind::Eq => "eq",
+            ElementwiseOpKind::Ne => "ne",
+            ElementwiseOpKind::Lt => "lt",
+            ElementwiseOpKind::Le => "le",
+            ElementwiseOpKind::Ge => "ge",
+            ElementwiseOpKind::Gt => "gt",
         }
     }
 
@@ -1073,6 +1198,14 @@ impl ElementwiseOpKind {
             "mul" => ElementwiseOpKind::Mul,
             "div" => ElementwiseOpKind::Div,
             "pow" => ElementwiseOpKind::Pow,
+            "max" => ElementwiseOpKind::Max,
+            "min" => ElementwiseOpKind::Min,
+            "eq" => ElementwiseOpKind::Eq,
+            "ne" => ElementwiseOpKind::Ne,
+            "lt" => ElementwiseOpKind::Lt,
+            "le" => ElementwiseOpKind::Le,
+            "ge" => ElementwiseOpKind::Ge,
+            "gt" => ElementwiseOpKind::Gt,
             _ => return None,
         })
     }
@@ -1151,6 +1284,15 @@ impl Expr {
             Expr::ElementwiseOp { span, .. } => span,
             Expr::Transpose { span, .. } => span,
             Expr::IndexGet { span, .. } => span,
+            Expr::Reduce { span, .. } => span,
+            Expr::Scan { span, .. } => span,
+            Expr::OuterProduct { span, .. } => span,
+            Expr::Shape { span, .. } => span,
+            Expr::Reshape { span, .. } => span,
+            Expr::IndexGenerator { span, .. } => span,
+            Expr::IndexOf { span, .. } => span,
+            Expr::Ravel { span, .. } => span,
+            Expr::Catenate { span, .. } => span,
             Expr::Convert { span, .. } => span,
             Expr::SymSymbol { span, .. } => span,
             Expr::SymRational { span, .. } => span,
@@ -1195,6 +1337,15 @@ impl Expr {
             Expr::ElementwiseOp { .. } => "elementwise-op",
             Expr::Transpose { .. } => "transpose",
             Expr::IndexGet { .. } => "index-get",
+            Expr::Reduce { .. } => "reduce",
+            Expr::Scan { .. } => "scan",
+            Expr::OuterProduct { .. } => "outer-product",
+            Expr::Shape { .. } => "shape",
+            Expr::Reshape { .. } => "reshape",
+            Expr::IndexGenerator { .. } => "index-generator",
+            Expr::IndexOf { .. } => "index-of",
+            Expr::Ravel { .. } => "ravel",
+            Expr::Catenate { .. } => "catenate",
             Expr::Convert { .. } => "convert",
             Expr::SymSymbol { .. } => "sym-symbol",
             Expr::SymRational { .. } => "sym-rational",
@@ -1775,6 +1926,94 @@ mod tests {
     }
 
     #[test]
+    fn sir22_addendum_apl_primitive_expr_kind_names_and_spans() {
+        // One case per new APL-primitive Expr variant, mirroring
+        // `sir22_expr_kind_names_and_spans` above: confirm `.span()` and
+        // `.kind_name()` are correct for every one of the nine additions.
+        let span = s();
+        let leaf = |v: i64| Expr::IntLit {
+            value: v,
+            span: span.clone(),
+        };
+        let cases: Vec<(Expr, &'static str)> = vec![
+            (
+                Expr::Reduce {
+                    op: ElementwiseOpKind::Add,
+                    target: Box::new(leaf(1)),
+                    span: span.clone(),
+                },
+                "reduce",
+            ),
+            (
+                Expr::Scan {
+                    op: ElementwiseOpKind::Add,
+                    target: Box::new(leaf(1)),
+                    span: span.clone(),
+                },
+                "scan",
+            ),
+            (
+                Expr::OuterProduct {
+                    op: ElementwiseOpKind::Mul,
+                    lhs: Box::new(leaf(1)),
+                    rhs: Box::new(leaf(2)),
+                    span: span.clone(),
+                },
+                "outer-product",
+            ),
+            (
+                Expr::Shape {
+                    target: Box::new(leaf(1)),
+                    span: span.clone(),
+                },
+                "shape",
+            ),
+            (
+                Expr::Reshape {
+                    shape: Box::new(leaf(1)),
+                    target: Box::new(leaf(2)),
+                    span: span.clone(),
+                },
+                "reshape",
+            ),
+            (
+                Expr::IndexGenerator {
+                    count: Box::new(leaf(5)),
+                    span: span.clone(),
+                },
+                "index-generator",
+            ),
+            (
+                Expr::IndexOf {
+                    haystack: Box::new(leaf(1)),
+                    needle: Box::new(leaf(2)),
+                    span: span.clone(),
+                },
+                "index-of",
+            ),
+            (
+                Expr::Ravel {
+                    target: Box::new(leaf(1)),
+                    span: span.clone(),
+                },
+                "ravel",
+            ),
+            (
+                Expr::Catenate {
+                    lhs: Box::new(leaf(1)),
+                    rhs: Box::new(leaf(2)),
+                    span: span.clone(),
+                },
+                "catenate",
+            ),
+        ];
+        for (e, expected) in &cases {
+            assert_eq!(e.kind_name(), *expected);
+            assert_eq!(e.span(), &span);
+        }
+    }
+
+    #[test]
     fn range_with_explicit_step() {
         // 0:2:10 — step is `Some`, distinct from the default-step form.
         let r = Expr::Range {
@@ -1842,6 +2081,14 @@ mod tests {
             ElementwiseOpKind::Mul,
             ElementwiseOpKind::Div,
             ElementwiseOpKind::Pow,
+            ElementwiseOpKind::Max,
+            ElementwiseOpKind::Min,
+            ElementwiseOpKind::Eq,
+            ElementwiseOpKind::Ne,
+            ElementwiseOpKind::Lt,
+            ElementwiseOpKind::Le,
+            ElementwiseOpKind::Ge,
+            ElementwiseOpKind::Gt,
         ] {
             assert_eq!(ElementwiseOpKind::from_name(op.name()), Some(op));
         }

--- a/code/packages/rust/semantic-ir/src/text/printer.rs
+++ b/code/packages/rust/semantic-ir/src/text/printer.rs
@@ -644,6 +644,64 @@ fn print_expr_inline_depth(out: &mut String, e: &Expr, depth: usize) {
             print_index_args(out, indices, depth);
             out.push(')');
         }
+
+        // ── SIR22 addendum: APL primitive operators ────────────────────
+        Expr::Reduce { op, target, .. } => {
+            let _ = write!(out, "(reduce {} ", op.name());
+            print_expr_inline_depth(out, target, depth + 1);
+            out.push(')');
+        }
+        Expr::Scan { op, target, .. } => {
+            let _ = write!(out, "(scan {} ", op.name());
+            print_expr_inline_depth(out, target, depth + 1);
+            out.push(')');
+        }
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            let _ = write!(out, "(outer-product {} ", op.name());
+            print_expr_inline_depth(out, lhs, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, rhs, depth + 1);
+            out.push(')');
+        }
+        Expr::Shape { target, .. } => {
+            let _ = write!(out, "(shape ");
+            print_expr_inline_depth(out, target, depth + 1);
+            out.push(')');
+        }
+        Expr::Reshape { shape, target, .. } => {
+            let _ = write!(out, "(reshape ");
+            print_expr_inline_depth(out, shape, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, target, depth + 1);
+            out.push(')');
+        }
+        Expr::IndexGenerator { count, .. } => {
+            let _ = write!(out, "(index-generator ");
+            print_expr_inline_depth(out, count, depth + 1);
+            out.push(')');
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            let _ = write!(out, "(index-of ");
+            print_expr_inline_depth(out, haystack, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, needle, depth + 1);
+            out.push(')');
+        }
+        Expr::Ravel { target, .. } => {
+            let _ = write!(out, "(ravel ");
+            print_expr_inline_depth(out, target, depth + 1);
+            out.push(')');
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            let _ = write!(out, "(catenate ");
+            print_expr_inline_depth(out, lhs, depth + 1);
+            out.push(' ');
+            print_expr_inline_depth(out, rhs, depth + 1);
+            out.push(')');
+        }
+
         // ── SIR26: integer conversion ──────────────────────────────────
         Expr::Convert { value, to, .. } => {
             // `(convert <to> <value>)`, where <to> is the IntSpec text form
@@ -830,7 +888,7 @@ mod tests {
     fn print_empty_module() {
         let m = module_with(vec![], FeatureManifest::new());
         let t = print_module(&m);
-        assert!(t.starts_with("(sir-module demo v3"));
+        assert!(t.starts_with("(sir-module demo v4"));
         assert!(t.contains("(metadata"));
         assert!(t.ends_with(")\n"));
     }
@@ -1770,6 +1828,168 @@ mod tests {
             span: s(),
         };
         assert_eq!(print_expr(&e), "(index-get (var-ref a local))");
+    }
+
+    // ── SIR22 addendum: APL primitive operator printer tests ─────────
+
+    #[test]
+    fn print_reduce() {
+        // +/A
+        let e = Expr::Reduce {
+            op: ElementwiseOpKind::Add,
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(reduce add (var-ref a local))");
+    }
+
+    #[test]
+    fn print_scan() {
+        // +\A
+        let e = Expr::Scan {
+            op: ElementwiseOpKind::Add,
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(scan add (var-ref a local))");
+    }
+
+    #[test]
+    fn print_outer_product() {
+        // A∘.×B
+        let e = Expr::OuterProduct {
+            op: ElementwiseOpKind::Mul,
+            lhs: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::VarRef {
+                name: "b".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(outer-product mul (var-ref a local) (var-ref b local))"
+        );
+    }
+
+    #[test]
+    fn print_shape() {
+        // ⍴A
+        let e = Expr::Shape {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(shape (var-ref a local))");
+    }
+
+    #[test]
+    fn print_reshape() {
+        // A⍴B — `shape` first, `target` second, matching field order.
+        let e = Expr::Reshape {
+            shape: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            target: Box::new(Expr::VarRef {
+                name: "b".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(reshape (var-ref a local) (var-ref b local))"
+        );
+    }
+
+    #[test]
+    fn print_index_generator() {
+        // ⍳N
+        let e = Expr::IndexGenerator {
+            count: Box::new(Expr::IntLit {
+                value: 5,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(index-generator (int 5))");
+    }
+
+    #[test]
+    fn print_index_of() {
+        // A⍳B
+        let e = Expr::IndexOf {
+            haystack: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            needle: Box::new(Expr::VarRef {
+                name: "b".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(index-of (var-ref a local) (var-ref b local))"
+        );
+    }
+
+    #[test]
+    fn print_ravel() {
+        // ,A
+        let e = Expr::Ravel {
+            target: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(print_expr(&e), "(ravel (var-ref a local))");
+    }
+
+    #[test]
+    fn print_catenate() {
+        // A,B
+        let e = Expr::Catenate {
+            lhs: Box::new(Expr::VarRef {
+                name: "a".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::VarRef {
+                name: "b".into(),
+                scope: Scope::Local,
+                span: s(),
+            }),
+            span: s(),
+        };
+        assert_eq!(
+            print_expr(&e),
+            "(catenate (var-ref a local) (var-ref b local))"
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir/src/validator.rs
+++ b/code/packages/rust/semantic-ir/src/validator.rs
@@ -1025,6 +1025,65 @@ impl<'m> ValidatorState<'m> {
                 self.check_index_args(indices, env, depth + 1);
             }
 
+            // ── SIR22 addendum: APL primitive operators ─────────────
+            // `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`Ravel`/
+            // `Catenate` are genuine array/matrix operations on the
+            // column-major representation, same class as `MatMul`/
+            // `Transpose` above, so they observe both `MatrixOps` and
+            // `ArrayColumnMajor`. `IndexGenerator`/`IndexOf` only
+            // construct/query arrays, without inherently being a "matrix
+            // op" any more than `Range`/`IndexGet` are, so they observe
+            // only `NDArrays`.
+            Expr::Reduce { target, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(target, env, depth + 1);
+            }
+            Expr::Scan { target, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(target, env, depth + 1);
+            }
+            Expr::OuterProduct { lhs, rhs, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(lhs, env, depth + 1);
+                self.check_expr(rhs, env, depth + 1);
+            }
+            Expr::Shape { target, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(target, env, depth + 1);
+            }
+            Expr::Reshape { shape, target, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(shape, env, depth + 1);
+                self.check_expr(target, env, depth + 1);
+            }
+            Expr::IndexGenerator { count, .. } => {
+                self.observed.add(Feature::NDArrays);
+                self.check_expr(count, env, depth + 1);
+            }
+            Expr::IndexOf {
+                haystack, needle, ..
+            } => {
+                self.observed.add(Feature::NDArrays);
+                self.check_expr(haystack, env, depth + 1);
+                self.check_expr(needle, env, depth + 1);
+            }
+            Expr::Ravel { target, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(target, env, depth + 1);
+            }
+            Expr::Catenate { lhs, rhs, .. } => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                self.check_expr(lhs, env, depth + 1);
+                self.check_expr(rhs, env, depth + 1);
+            }
+
             // ── SIR26: integer conversion ──────────────────────────────
             Expr::Convert { value, to, .. } => {
                 // Observe the conversion feature plus the SIR21 type-implied
@@ -4168,6 +4227,354 @@ mod tests {
             default: None,
             span: s(),
         });
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    // ── SIR22 addendum: APL primitive operator validator tests ───────
+
+    #[test]
+    fn reduce_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Reduce {
+                op: ElementwiseOpKind::Add,
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn reduce_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::Reduce {
+                op: ElementwiseOpKind::Add,
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn scan_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Scan {
+                op: ElementwiseOpKind::Add,
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn scan_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::Scan {
+                op: ElementwiseOpKind::Add,
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn outer_product_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::OuterProduct {
+                op: ElementwiseOpKind::Mul,
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn outer_product_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::OuterProduct {
+                op: ElementwiseOpKind::Mul,
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn shape_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Shape {
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn shape_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::Shape {
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn reshape_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Reshape {
+                shape: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn reshape_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::Reshape {
+                shape: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn index_generator_observes_nd_arrays_feature_only() {
+        // ⍳N — construction/query only, not a "matrix op" any more than
+        // Range/IndexGet are, so only NDArrays should be observed.
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::IndexGenerator {
+                count: Box::new(Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("nd-arrays")));
+        assert!(!r.errors().any(|i| i.message.contains("matrix-ops")));
+    }
+
+    #[test]
+    fn index_generator_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::NDArrays]),
+            Expr::IndexGenerator {
+                count: Box::new(Expr::IntLit {
+                    value: 5,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn index_of_observes_nd_arrays_feature_only() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::IndexOf {
+                haystack: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                needle: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("nd-arrays")));
+        assert!(!r.errors().any(|i| i.message.contains("matrix-ops")));
+    }
+
+    #[test]
+    fn index_of_with_declared_feature_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::NDArrays]),
+            Expr::IndexOf {
+                haystack: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                needle: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn ravel_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Ravel {
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn ravel_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::Ravel {
+                target: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
+    }
+
+    #[test]
+    fn catenate_observes_matrix_ops_and_column_major_features() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::new(),
+            Expr::Catenate {
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
+        let r = validate(&m);
+        assert!(!r.is_ok());
+        assert!(r.errors().any(|i| i.message.contains("matrix-ops")));
+        assert!(r.errors().any(|i| i.message.contains("array-column-major")));
+    }
+
+    #[test]
+    fn catenate_with_declared_features_is_valid() {
+        let m = module_with_fn_body_value(
+            FeatureManifest::from_features(&[Feature::MatrixOps, Feature::ArrayColumnMajor]),
+            Expr::Catenate {
+                lhs: Box::new(Expr::IntLit {
+                    value: 1,
+                    span: s(),
+                }),
+                rhs: Box::new(Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                }),
+                span: s(),
+            },
+        );
         let r = validate(&m);
         assert!(r.is_ok(), "expected ok, got {:?}", r.issues);
     }

--- a/code/packages/rust/semantic-ir/src/walker.rs
+++ b/code/packages/rust/semantic-ir/src/walker.rs
@@ -352,6 +352,41 @@ pub fn walk_expr_default<V: Visitor>(v: &mut V, e: &Expr) {
             walk_index_args(v, indices);
         }
 
+        // ── SIR22 addendum: APL primitive operators ─────────────────
+        Expr::Reduce { target, .. } => {
+            v.visit_expr(target);
+        }
+        Expr::Scan { target, .. } => {
+            v.visit_expr(target);
+        }
+        Expr::OuterProduct { lhs, rhs, .. } => {
+            v.visit_expr(lhs);
+            v.visit_expr(rhs);
+        }
+        Expr::Shape { target, .. } => {
+            v.visit_expr(target);
+        }
+        Expr::Reshape { shape, target, .. } => {
+            v.visit_expr(shape);
+            v.visit_expr(target);
+        }
+        Expr::IndexGenerator { count, .. } => {
+            v.visit_expr(count);
+        }
+        Expr::IndexOf {
+            haystack, needle, ..
+        } => {
+            v.visit_expr(haystack);
+            v.visit_expr(needle);
+        }
+        Expr::Ravel { target, .. } => {
+            v.visit_expr(target);
+        }
+        Expr::Catenate { lhs, rhs, .. } => {
+            v.visit_expr(lhs);
+            v.visit_expr(rhs);
+        }
+
         // ── SIR26 ──────────────────────────────────────────────────
         Expr::Convert { value, .. } => {
             v.visit_expr(value);
@@ -881,6 +916,180 @@ mod tests {
         };
         c.visit_module(&m);
         assert_eq!(c.ints, 3);
+    }
+
+    // ── SIR22 addendum: APL primitive operator walker tests ──────────
+
+    #[test]
+    fn visitor_walks_reduce_target() {
+        let m = module_with_body_value(Expr::Reduce {
+            op: ElementwiseOpKind::Add,
+            target: Box::new(Expr::IntLit {
+                value: 7,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_scan_target() {
+        let m = module_with_body_value(Expr::Scan {
+            op: ElementwiseOpKind::Add,
+            target: Box::new(Expr::IntLit {
+                value: 7,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_outer_product_lhs_and_rhs() {
+        let m = module_with_body_value(Expr::OuterProduct {
+            op: ElementwiseOpKind::Mul,
+            lhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_shape_target() {
+        let m = module_with_body_value(Expr::Shape {
+            target: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_reshape_shape_and_target() {
+        let m = module_with_body_value(Expr::Reshape {
+            shape: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            target: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_index_generator_count() {
+        let m = module_with_body_value(Expr::IndexGenerator {
+            count: Box::new(Expr::IntLit {
+                value: 5,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_index_of_haystack_and_needle() {
+        let m = module_with_body_value(Expr::IndexOf {
+            haystack: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            needle: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
+    }
+
+    #[test]
+    fn visitor_walks_ravel_target() {
+        let m = module_with_body_value(Expr::Ravel {
+            target: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 1);
+    }
+
+    #[test]
+    fn visitor_walks_catenate_lhs_and_rhs() {
+        let m = module_with_body_value(Expr::Catenate {
+            lhs: Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            }),
+            rhs: Box::new(Expr::IntLit {
+                value: 2,
+                span: s(),
+            }),
+            span: s(),
+        });
+        let mut c = Counter {
+            builtins: 0,
+            ints: 0,
+        };
+        c.visit_module(&m);
+        assert_eq!(c.ints, 2);
     }
 
     #[test]

--- a/code/specs/SIR22-array-matrix-semantic-ir.md
+++ b/code/specs/SIR22-array-matrix-semantic-ir.md
@@ -78,7 +78,10 @@ Range {
 MatMul { lhs: Box<Expr>, rhs: Box<Expr>, span }
 
 ElementwiseOp {
-    op:   ElementwiseOpKind,   -- Add | Sub | Mul | Div | Pow
+    op:   ElementwiseOpKind,   -- Add | Sub | Mul | Div | Pow (original cut)
+                                  | Max | Min | Eq | Ne | Lt | Le | Ge | Gt
+                                  (APL addendum — see "New Expr variants
+                                  (APL primitives)" below)
     lhs:  Box<Expr>,
     rhs:  Box<Expr>,
     span,
@@ -117,6 +120,103 @@ IR concept — the frontend resolves `end` to a concrete expression (a call to
 a `size`/`length`-equivalent builtin minus an offset) before emitting
 `IndexArg::Scalar`. The IR never sees `end`; per SIR10 discipline,
 disambiguation is the frontend's job.
+
+## New `Expr` variants (APL primitives)
+
+This spec's own Motivation section always claimed to be the substrate for
+"every future array-family frontend (APL, J, K/Q, Scilab, IDL)," but the
+original cut above only populated the `Expr` variants MATLAB's own frontend
+needed. MATLAB has no first-class *operator* syntax for reduce, scan,
+outer product, reshape, iota, ravel, or catenate — it would call
+`sum(x)`/`reshape(x, ...)`/etc. as ordinary function calls, which this
+repo's MATLAB frontend subset doesn't yet support at all (only `disp` is a
+recognized builtin call today). APL (`apl-runtime`/`apl-parser`, already
+shipped) exposes all seven of these as first-class bare glyphs, so the
+original cut left a genuine gap between what this spec always claimed to
+cover and what it actually modeled. This addendum closes that gap.
+
+Every variant below carries `span` and is `Pure`, same as every other
+SIR22 node, and is mapped 1:1 onto an existing op shape — either
+`array_runtime::ops::{reduce,scan,outer}` (for the three that take an
+`ElementwiseOpKind`) or `apl-runtime::builtins`'s own bespoke,
+non-`BinOp`-shaped logic (for the rest) — the same "map 1:1 onto an
+existing op shape" discipline this spec's own Motivation states, extended
+to a second source op-shape since APL's `⍴`/`⍳`/`,` don't fit the `BinOp`
+shape any more than they did for `apl-runtime` itself.
+
+```text
+Reduce { op: ElementwiseOpKind, target: Box<Expr>, span }
+    -- `+/A` (APL reduce): folds `target` with `op` along its one axis.
+       Maps 1:1 onto `array_runtime::ops::reduce(op, a)`.
+
+Scan { op: ElementwiseOpKind, target: Box<Expr>, span }
+    -- `+\A` (APL scan): a running fold of `target` with `op`, emitting
+       one result per prefix. Maps 1:1 onto `array_runtime::ops::scan(op, a)`.
+
+OuterProduct { op: ElementwiseOpKind, lhs: Box<Expr>, rhs: Box<Expr>, span }
+    -- `A∘.×B` (APL outer product): every pairwise `op` application
+       between `lhs`'s and `rhs`'s elements. Maps 1:1 onto
+       `array_runtime::ops::outer(op, a, b)`.
+
+Shape { target: Box<Expr>, span }
+    -- monadic `⍴A` (APL shape): the dimensions of `target` as a vector.
+       Mirrors `apl-runtime::builtins::shape`.
+
+Reshape { shape: Box<Expr>, target: Box<Expr>, span }
+    -- dyadic `A⍴B` (APL reshape): reinterpret `target`'s data under the
+       new dimensions given by `shape`. Mirrors
+       `apl-runtime::builtins::reshape(a, b)`, where `a` is the shape
+       vector and `b` is the data — field names spell out that role
+       instead of reusing `lhs`/`rhs`, since (unlike `MatMul`/
+       `ElementwiseOp`) the two operands are not interchangeable in kind.
+
+IndexGenerator { count: Box<Expr>, span }
+    -- monadic `⍳N` (APL iota / index generator): the vector
+       `0, 1, ..., N-1` (0-based at the `Array` level, even though APL's
+       own surface syntax is 1-indexed). Mirrors
+       `apl-runtime::builtins::index_generator`.
+
+IndexOf { haystack: Box<Expr>, needle: Box<Expr>, span }
+    -- dyadic `A⍳B` (APL index-of / search): for each element of
+       `needle`, its position in `haystack` (or `haystack`'s length if
+       not found). Mirrors `apl-runtime::builtins::index_of(a, b)`, where
+       `a` is the haystack and `b` is the needle.
+
+Ravel { target: Box<Expr>, span }
+    -- monadic `,A` (APL ravel): flatten `target` to a rank-1 vector.
+       Mirrors `apl-runtime::builtins::ravel`.
+
+Catenate { lhs: Box<Expr>, rhs: Box<Expr>, span }
+    -- dyadic `A,B` (APL catenate): concatenate `lhs` and `rhs` along
+       their ravel order. Mirrors `apl-runtime::builtins::catenate`.
+```
+
+`ElementwiseOpKind` (used by `ElementwiseOp` above, and by `Reduce`/`Scan`/
+`OuterProduct` here) grew from five variants to thirteen in this addendum:
+`Add | Sub | Mul | Div | Pow | Max | Min | Eq | Ne | Lt | Le | Ge | Gt`. The
+eight new variants (`Max`/`Min`/the six comparisons) mirror
+`array_runtime::BinOp`'s own identical extension, added alongside
+`apl-runtime` for APL's `⌈`/`⌊` max/min glyphs and its six comparison
+glyphs `= ≠ < ≤ ≥ >` (PR #8072). `Reduce`/`Scan`/`OuterProduct` reuse the
+whole `ElementwiseOpKind` enum rather than a narrower subset — the IR does
+not restrict which `op` a frontend may pick for these adverbs (e.g. `Pow`
+has no APL reduce-adverb precedent, but nothing stops a frontend from
+constructing `Reduce { op: Pow, .. }`), mirroring how `ElementwiseOp`
+itself places no restriction on which arithmetic op appears there.
+
+No new `Feature` flag was added: `Reduce`/`Scan`/`OuterProduct`/`Shape`/
+`Reshape`/`Ravel`/`Catenate` observe both `Feature::MatrixOps` and
+`Feature::ArrayColumnMajor` — the same class of genuine array/matrix
+operation as `MatMul`/`Transpose` above. `IndexGenerator`/`IndexOf` observe
+only `Feature::NDArrays` — they construct/query arrays without inherently
+being a "matrix op" any more than `Range`/`IndexGet` are.
+
+No frontend crate consumes any of these nine variants yet. This addendum
+is IR-substrate-only, mirroring how `array-runtime`'s AR-2 task preceded
+`apl-runtime` as its own separate step before that runtime crate could be
+built — the actual `apl-to-semantic-ir` frontend that will emit these
+nodes from parsed APL source is a follow-up task, not part of this
+addendum.
 
 ## Storage convention
 
@@ -179,6 +279,14 @@ SIR16/SIR18/KW1 before it) — no existing module or backend match arm needs
 to change; backends simply gain new arms or explicitly decline the new
 features. Modules using SIR22 nodes bump `metadata.sir_version` to record
 that fact for validators.
+
+This spec has since received one additive addendum — the "New `Expr`
+variants (APL primitives)" section above — which bumped
+`metadata::CURRENT_SIR_VERSION` again (`"3"` → `"4"`, following SIR23's
+`"2"` → `"3"` bump). Both the original MATLAB-oriented cut and the APL
+addendum share this same versioning discipline: every SIR text token
+addition is a version bump, regardless of whether it lands in the spec's
+original PR or a later addendum to it.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Extends [SIR22](code/specs/SIR22-array-matrix-semantic-ir.md) with the array-family primitive *operators* the base spec's first cut never covered: `Reduce`, `Scan`, `OuterProduct`, `Shape`, `Reshape`, `IndexGenerator`, `IndexOf`, `Ravel`, `Catenate` — closing the gap between what the spec always claimed to support ("every future array-family frontend (APL, J, K/Q, Scilab, IDL)") and what it actually modeled (MATLAB/Octave's own vocabulary only, since MATLAB has no first-class operator syntax for these).
- Adds 8 new `ElementwiseOpKind` variants (`Max, Min, Eq, Ne, Lt, Le, Ge, Gt`), mirroring `array_runtime::BinOp`'s own identical extension shipped for APL in PR #8072.
- Every new node maps 1:1 onto an existing `array_runtime::ops::{reduce,scan,outer}` or `apl-runtime::builtins` op shape, following SIR22's own stated design discipline.
- This is **IR-substrate-only** — no frontend crate consumes these nodes yet. Mirrors the `array-runtime` AR-2 precedent (a prerequisite substrate extension shipped before the runtime crate that needed it). The actual `apl-to-semantic-ir` frontend is a tracked follow-up task.
- Additive only: no existing `Expr`/`Stmt`/`SirType`/`Feature` variant, validator rule, or backend behavior changed. `CURRENT_SIR_VERSION` bumped `"3"` → `"4"` per the established "adding a feature is a v.bump" policy. Crate version 0.22.0 → 0.23.0.
- **Compile-compat ripple** (discovered via `cargo build --workspace`, not assumed): 8 downstream crates carry exhaustive `match` statements over `Expr` (carried over from SIR23's own rollout) that needed a new arm to keep compiling — 5 backends (`semantic-ir-to-{javascript,typescript,rust,go,python}`) got panic-guard "deferred, not accepted" stubs gated by the same pre-existing capability check that already protects `ElementwiseOp`/`Transpose`/etc.; 3 frontends (`{javascript,ruby,python}-to-semantic-ir`) got faithful structural recursion in their internal analysis passes. No actual codegen was added anywhere — real backend support for any SIR22 node remains a separate, not-yet-started rollout item.

## Test plan
- [x] `cargo test -p semantic-ir`: 340 lib + 6 integration + 4 doc tests, all green (up from 314 before this change).
- [x] `cargo build --workspace --keep-going`: only pre-existing, unrelated failures remain (uefi/paint-vm-direct2d/paint-vm-gdi/font-parser-{python,ruby} — none depend on `semantic-ir`).
- [x] `cargo test` on all 8 touched downstream crates plus `wolfram-to-semantic-ir`, `matlab-to-semantic-ir`, `octave-to-semantic-ir`, `c-to-semantic-ir`, `twig-to-semantic-ir`, `semantic-ir-to-c`, `semantic-ir-to-ruby`, `sir-conformance`: all green.
- [x] `cargo clippy -p semantic-ir` and the 8 touched downstream crates: zero warnings.
- [x] `/security-review` run on the full diff — passed clean, including explicit adversarial checks on recursion-depth-guard participation for the new match arms and reachability of the new backend panic-guard stubs (confirmed unreachable through the normal `compile()` entry point, identical to the pre-existing `Convert`/`ElementwiseOp` pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)