### PR TITLE
feat(sir-to-javascript): Array minmax — JS mirror

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.33.0 — Array `minmax`
+
+Mirrors the Python reference (PR #8092), Go (PR #8098), and Rust (PR #8103) into
+the JS backend's inline `arrayMethod` (beside the existing `min`/`max` arms + the
+`ARRAY_METHODS` `respond_to?` set), continuing the `minmax` cross-backend
+cascade.
+
+- `minmax` (non-block) → the two-element array `[min, max]` in one pass, via
+  `<`/`>` (the same comparison the `min`/`max` arms use). `[3,1,2].minmax` →
+  `[1, 3]`. An empty array yields `[null, null]` (Ruby `[nil, nil]` — no
+  smallest/largest element), matching the Go/Rust/Python references' 2-element
+  nil array.
+- The `array_catalog_methods` exec-proof test gains `minmax` (non-empty and
+  empty), run through `node`, asserting `[1, 3]` / `[nil, nil]`.
+
 ## 0.32.0 — Array `slice_when`
 
 Mirrors the Python reference (PR #8070), Go (PR #8073), and Rust (PR #8077) into

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -1292,7 +1292,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
   const ARRAY_METHODS = new Set([
     "each", "each_with_index", "map", "collect", "select", "filter", "reject",
     "find", "detect", "reduce", "inject", "any?", "all?", "none?", "count",
-    "sort", "sort_by", "min", "max", "min_by", "max_by", "group_by",
+    "sort", "sort_by", "min", "max", "minmax", "min_by", "max_by", "group_by",
     "partition", "flat_map", "collect_concat", "take_while", "drop_while",
     "each_with_object", "sum", "uniq", "first", "last", "empty?", "to_a",
     "take", "drop", "values_at",
@@ -1393,6 +1393,21 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
       }
       case "min": return recv.length ? recv.reduce((a, b) => (b < a ? b : a)) : null;
       case "max": return recv.length ? recv.reduce((a, b) => (b > a ? b : a)) : null;
+      case "minmax": {
+        // `minmax` (no block) — the two-element array `[min, max]` in one pass,
+        // via `<`/`>` (the same comparison the `min`/`max` arms use).
+        // `[3,1,2].minmax` → `[1, 3]`.  An empty array yields `[null, null]`
+        // (Ruby `[nil, nil]` — no smallest/largest element), matching the
+        // Go/Rust/Python references' 2-element nil array.
+        if (recv.length === 0) { return [null, null]; }
+        let lo = recv[0];
+        let hi = recv[0];
+        for (let i = 1; i < recv.length; i++) {
+          if (recv[i] < lo) { lo = recv[i]; }
+          if (recv[i] > hi) { hi = recv[i]; }
+        }
+        return [lo, hi];
+      }
       case "min_by": case "max_by": {
         if (!blk) { return ARR_MISS; }
         if (recv.length === 0) { return null; }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -2694,6 +2694,8 @@ fn array_catalog_module() -> Module {
         print(method(a1234(), "count", vec![method_closure("__ba_even")])),      // 2
         print(method(a312(), "min", vec![])),                                    // 1
         print(method(a312(), "max", vec![])),                                    // 3
+        print(method(a312(), "minmax", vec![])),                                 // [1, 3]
+        print(method(arr(vec![]), "minmax", vec![])),                            // [nil, nil]
         print(method(arr(vec![int(1), int(2), int(3)]), "sum", vec![])),         // 6
         print(method(arr(vec![int(1), int(1), int(2), int(3)]), "uniq", vec![])), // [1, 2, 3]
     ];
@@ -2735,7 +2737,7 @@ fn array_catalog_methods() {
         assert_eq!(
             stdout,
             "[1, 2, 3]\n[2, 4]\n[1, 3]\n10\n[1, 2, 3]\n[[2, 4], [1, 3]]\n\
-             [1, 1, 2, 2, 3, 3]\n[1, 2]\n2\n1\n3\n6\n[1, 2, 3]"
+             [1, 1, 2, 2, 3, 3]\n[1, 2]\n2\n1\n3\n[1, 3]\n[nil, nil]\n6\n[1, 2, 3]"
         );
     }
 }


### PR DESCRIPTION
Mirrors the Python reference ([#8092](https://github.com/adhithyan15/coding-adventures/pull/8092)), Go ([#8098](https://github.com/adhithyan15/coding-adventures/pull/8098)), and Rust ([#8103](https://github.com/adhithyan15/coding-adventures/pull/8103)) into the **JS backend**'s inline `arrayMethod` (beside the existing `min`/`max` arms + the `ARRAY_METHODS` `respond_to?` set), continuing the `minmax` cross-backend cascade. Only the TS mirror remains after this.

## What

`minmax` (non-block) returns the two-element array `[min, max]` in one pass via `<`/`>` (the same comparison the `min`/`max` arms use):

- `[3,1,2].minmax` → `[1, 3]`
- `[].minmax` → `[null, null]` (Ruby `[nil, nil]`)

## Tests

The `array_catalog_methods` exec-proof test gains `minmax` (non-empty and empty), run through `node`, asserting `[1, 3]` / `[nil, nil]`. Passes locally.

Version 0.32.0 → 0.33.0. Security review passed (static runtime string, plain array — no prototype pollution, O(n), explicit-switch dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)