### PR TITLE
[codex] Port pixel container to Dart

### DIFF
--- a/code/packages/dart/pixel-container/BUILD
+++ b/code/packages/dart/pixel-container/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/pixel-container/CHANGELOG.md
+++ b/code/packages/dart/pixel-container/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog — coding_adventures_pixel_container
+
+## 0.1.0 — 2026-07-12
+
+### Added
+
+- Initial pure-Dart IC00 `PixelContainer` and `ImageCodec` implementation.
+- Checked RGBA8 construction, pixel access, mutation, fill, copy, and equality.
+- Top-level parity helpers and codec-contract tests.

--- a/code/packages/dart/pixel-container/README.md
+++ b/code/packages/dart/pixel-container/README.md
@@ -1,0 +1,32 @@
+# coding_adventures_pixel_container
+
+IC00's universal RGBA8 pixel buffer and image codec interface, implemented in
+pure Dart with zero runtime dependencies.
+
+`PixelContainer` stores four bytes per pixel in row-major red, green, blue,
+alpha order. `ImageCodec` is the shared interface implemented by encoders and
+decoders throughout the image-codec family.
+
+## Usage
+
+```dart
+import 'package:coding_adventures_pixel_container/coding_adventures_pixel_container.dart';
+
+final pixels = PixelContainer(4, 4);
+pixels.fill(255, 255, 255, 255);
+pixels.setPixel(1, 1, 255, 0, 0, 255);
+
+final (red, green, blue, alpha) = pixels.pixelAt(1, 1);
+```
+
+The package also exports `createPixelContainer`, `pixelAt`, `setPixel`, and
+`fillPixels` top-level helpers for parity with the TypeScript API.
+
+## Development
+
+```text
+dart pub get
+dart format --output=none --set-exit-if-changed .
+dart analyze
+dart test
+```

--- a/code/packages/dart/pixel-container/lib/coding_adventures_pixel_container.dart
+++ b/code/packages/dart/pixel-container/lib/coding_adventures_pixel_container.dart
@@ -1,0 +1,4 @@
+/// IC00 universal RGBA8 pixel buffer and image codec interface in pure Dart.
+library coding_adventures_pixel_container;
+
+export 'src/pixel_container.dart';

--- a/code/packages/dart/pixel-container/lib/src/pixel_container.dart
+++ b/code/packages/dart/pixel-container/lib/src/pixel_container.dart
@@ -1,0 +1,178 @@
+import 'dart:typed_data';
+
+/// Package semantic version.
+const String version = '0.1.0';
+
+/// One red, green, blue, alpha pixel in that order.
+typedef Rgba = (int, int, int, int);
+
+/// Fully transparent black, returned for out-of-bounds reads.
+const Rgba transparent = (0, 0, 0, 0);
+
+/// Contract implemented by image encoders and decoders.
+abstract interface class ImageCodec {
+  /// IANA MIME type for this image format.
+  String get mimeType;
+
+  /// Encode [pixels] as a complete image file.
+  Uint8List encode(PixelContainer pixels);
+
+  /// Decode a complete image file into RGBA8 pixels.
+  PixelContainer decode(Uint8List bytes);
+}
+
+/// A flat, row-major RGBA8 pixel buffer with a top-left origin.
+///
+/// Each pixel occupies four bytes in [data]: red, green, blue, then alpha.
+/// The byte offset for `(x, y)` is `(y * width + x) * 4`.
+class PixelContainer {
+  /// Create a transparent, zero-filled buffer.
+  PixelContainer(int width, int height)
+      : width = width,
+        height = height,
+        data = Uint8List(_checkedByteCount(width, height));
+
+  PixelContainer._(this.width, this.height, this.data);
+
+  /// Create a buffer by copying existing RGBA8 [data].
+  factory PixelContainer.fromData(int width, int height, Uint8List data) {
+    final expected = _checkedByteCount(width, height);
+    if (data.length != expected) {
+      throw ArgumentError.value(
+        data.length,
+        'data.length',
+        'expected $expected bytes for ${width}x$height RGBA8 pixels',
+      );
+    }
+    return PixelContainer._(width, height, Uint8List.fromList(data));
+  }
+
+  /// Width in pixels.
+  final int width;
+
+  /// Height in pixels.
+  final int height;
+
+  /// Mutable RGBA8 bytes in row-major order.
+  final Uint8List data;
+
+  /// Number of pixels in the buffer.
+  int get pixelCount => width * height;
+
+  /// Number of bytes in the backing buffer.
+  int get byteCount => data.length;
+
+  /// Read `(r, g, b, a)` at ([x], [y]), or [transparent] when out of bounds.
+  Rgba pixelAt(int x, int y) {
+    if (!_contains(x, y)) return transparent;
+    final offset = _offset(x, y);
+    return (data[offset], data[offset + 1], data[offset + 2], data[offset + 3]);
+  }
+
+  /// Write an RGBA8 pixel. Out-of-bounds coordinates are a no-op.
+  void setPixel(int x, int y, int red, int green, int blue, int alpha) {
+    if (!_contains(x, y)) return;
+    _checkChannel(red, 'red');
+    _checkChannel(green, 'green');
+    _checkChannel(blue, 'blue');
+    _checkChannel(alpha, 'alpha');
+    final offset = _offset(x, y);
+    data[offset] = red;
+    data[offset + 1] = green;
+    data[offset + 2] = blue;
+    data[offset + 3] = alpha;
+  }
+
+  /// Fill every pixel with one RGBA8 colour.
+  void fill(int red, int green, int blue, int alpha) {
+    _checkChannel(red, 'red');
+    _checkChannel(green, 'green');
+    _checkChannel(blue, 'blue');
+    _checkChannel(alpha, 'alpha');
+    for (var offset = 0; offset < data.length; offset += 4) {
+      data[offset] = red;
+      data[offset + 1] = green;
+      data[offset + 2] = blue;
+      data[offset + 3] = alpha;
+    }
+  }
+
+  /// Create an independent copy, including its pixel bytes.
+  PixelContainer copy() => PixelContainer.fromData(width, height, data);
+
+  bool _contains(int x, int y) => x >= 0 && y >= 0 && x < width && y < height;
+
+  int _offset(int x, int y) => (y * width + x) * 4;
+
+  static int _checkedByteCount(int width, int height) {
+    if (width < 0) {
+      throw RangeError.value(width, 'width', 'must be non-negative');
+    }
+    if (height < 0) {
+      throw RangeError.value(height, 'height', 'must be non-negative');
+    }
+    final count = BigInt.from(width) * BigInt.from(height) * BigInt.from(4);
+    final maxInt = BigInt.parse('9223372036854775807');
+    if (count > maxInt) {
+      throw RangeError('pixel dimensions exceed addressable memory');
+    }
+    return count.toInt();
+  }
+
+  static void _checkChannel(int value, String name) {
+    if (value < 0 || value > 255) {
+      throw RangeError.range(value, 0, 255, name);
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! PixelContainer ||
+        width != other.width ||
+        height != other.height ||
+        data.length != other.data.length) {
+      return false;
+    }
+    for (var index = 0; index < data.length; index++) {
+      if (data[index] != other.data[index]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(width, height, Object.hashAll(data));
+
+  @override
+  String toString() =>
+      'PixelContainer(width: $width, height: $height, bytes: ${data.length})';
+}
+
+/// Top-level factory matching the TypeScript port.
+PixelContainer createPixelContainer(int width, int height) =>
+    PixelContainer(width, height);
+
+/// Top-level read helper matching the TypeScript port.
+Rgba pixelAt(PixelContainer container, int x, int y) => container.pixelAt(x, y);
+
+/// Top-level write helper matching the TypeScript port.
+void setPixel(
+  PixelContainer container,
+  int x,
+  int y,
+  int red,
+  int green,
+  int blue,
+  int alpha,
+) =>
+    container.setPixel(x, y, red, green, blue, alpha);
+
+/// Top-level fill helper matching the TypeScript port.
+void fillPixels(
+  PixelContainer container,
+  int red,
+  int green,
+  int blue,
+  int alpha,
+) =>
+    container.fill(red, green, blue, alpha);

--- a/code/packages/dart/pixel-container/pubspec.yaml
+++ b/code/packages/dart/pixel-container/pubspec.yaml
@@ -1,0 +1,11 @@
+name: coding_adventures_pixel_container
+version: 0.1.0
+description: IC00 universal RGBA8 pixel buffer and image codec interface in pure Dart.
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/pixel-container/required_capabilities.json
+++ b/code/packages/dart/pixel-container/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/pixel-container",
+  "capabilities": [],
+  "justification": "Pure in-memory RGBA8 pixel operations with no OS access."
+}

--- a/code/packages/dart/pixel-container/test/pixel_container_test.dart
+++ b/code/packages/dart/pixel-container/test/pixel_container_test.dart
@@ -1,0 +1,164 @@
+import 'dart:typed_data';
+
+import 'package:coding_adventures_pixel_container/coding_adventures_pixel_container.dart';
+import 'package:test/test.dart';
+
+final class StubCodec implements ImageCodec {
+  @override
+  String get mimeType => 'image/x-stub';
+
+  @override
+  Uint8List encode(PixelContainer pixels) =>
+      Uint8List.fromList([pixels.width, pixels.height, ...pixels.data]);
+
+  @override
+  PixelContainer decode(Uint8List bytes) {
+    if (bytes.length < 2) throw const FormatException('stub image too short');
+    return PixelContainer.fromData(
+      bytes[0],
+      bytes[1],
+      Uint8List.fromList(bytes.sublist(2)),
+    );
+  }
+}
+
+void main() {
+  group('construction', () {
+    test('allocates width * height * 4 transparent bytes', () {
+      final pixels = PixelContainer(4, 3);
+      expect(pixels.width, 4);
+      expect(pixels.height, 3);
+      expect(pixels.pixelCount, 12);
+      expect(pixels.byteCount, 48);
+      expect(pixels.data, everyElement(0));
+    });
+
+    test('supports zero dimensions', () {
+      expect(PixelContainer(0, 0).data, isEmpty);
+      expect(PixelContainer(0, 5).data, isEmpty);
+      expect(PixelContainer(5, 0).data, isEmpty);
+    });
+
+    test('rejects negative dimensions', () {
+      expect(() => PixelContainer(-1, 1), throwsRangeError);
+      expect(() => PixelContainer(1, -1), throwsRangeError);
+    });
+
+    test('fromData copies valid bytes', () {
+      final source = Uint8List.fromList([255, 128, 64, 32]);
+      final pixels = PixelContainer.fromData(1, 1, source);
+      source[0] = 0;
+      expect(pixels.data, [255, 128, 64, 32]);
+    });
+
+    test('fromData rejects the wrong byte count', () {
+      expect(
+        () => PixelContainer.fromData(1, 1, Uint8List(3)),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('pixel access', () {
+    test('setPixel and pixelAt round-trip RGBA values', () {
+      final pixels = PixelContainer(4, 4);
+      pixels.setPixel(1, 2, 200, 100, 50, 255);
+      expect(pixels.pixelAt(1, 2), (200, 100, 50, 255));
+    });
+
+    test('uses row-major RGBA byte layout', () {
+      final pixels = PixelContainer(3, 2);
+      pixels.setPixel(2, 1, 11, 22, 33, 44);
+      expect(pixels.data.sublist(20, 24), [11, 22, 33, 44]);
+    });
+
+    test('out-of-bounds reads return transparent', () {
+      final pixels = PixelContainer(3, 3);
+      for (final coordinate in [(-1, 0), (0, -1), (3, 0), (0, 3)]) {
+        expect(pixels.pixelAt(coordinate.$1, coordinate.$2), transparent);
+      }
+    });
+
+    test('out-of-bounds writes are no-ops', () {
+      final pixels = PixelContainer(2, 2);
+      pixels.setPixel(99, 0, 1, 2, 3, 4);
+      pixels.setPixel(0, -1, 1, 2, 3, 4);
+      expect(pixels.data, everyElement(0));
+    });
+
+    test('valid writes reject channels outside RGBA8', () {
+      final pixels = PixelContainer(1, 1);
+      expect(() => pixels.setPixel(0, 0, -1, 0, 0, 0), throwsRangeError);
+      expect(() => pixels.setPixel(0, 0, 0, 256, 0, 0), throwsRangeError);
+    });
+
+    test('does not modify neighbouring pixels', () {
+      final pixels = PixelContainer(4, 4);
+      pixels.setPixel(2, 1, 255, 0, 0, 255);
+      expect(pixels.pixelAt(1, 1), transparent);
+      expect(pixels.pixelAt(3, 1), transparent);
+    });
+  });
+
+  group('fill', () {
+    test('sets every pixel and overwrites previous data', () {
+      final pixels = PixelContainer(3, 3)..setPixel(0, 0, 1, 2, 3, 4);
+      pixels.fill(100, 150, 200, 255);
+      for (var y = 0; y < pixels.height; y++) {
+        for (var x = 0; x < pixels.width; x++) {
+          expect(pixels.pixelAt(x, y), (100, 150, 200, 255));
+        }
+      }
+    });
+
+    test('works on empty buffers and validates channels', () {
+      expect(() => PixelContainer(0, 0).fill(1, 2, 3, 4), returnsNormally);
+      expect(() => PixelContainer(0, 0).fill(0, 0, 0, 999), throwsRangeError);
+    });
+  });
+
+  group('value behavior', () {
+    test('copy is deeply independent', () {
+      final original = PixelContainer(2, 2)..setPixel(0, 0, 1, 2, 3, 4);
+      final copied = original.copy();
+      copied.setPixel(0, 0, 99, 99, 99, 99);
+      expect(original.pixelAt(0, 0), (1, 2, 3, 4));
+      expect(copied.pixelAt(0, 0), (99, 99, 99, 99));
+    });
+
+    test('equality and hash include dimensions and all bytes', () {
+      final a = PixelContainer.fromData(1, 1, Uint8List.fromList([1, 2, 3, 4]));
+      final b = PixelContainer.fromData(1, 1, Uint8List.fromList([1, 2, 3, 4]));
+      final c = PixelContainer.fromData(1, 1, Uint8List.fromList([1, 2, 3, 5]));
+      expect(a == b, isTrue);
+      expect(a.hashCode, b.hashCode);
+      expect(a == c, isFalse);
+      expect(a == PixelContainer(2, 0), isFalse);
+    });
+  });
+
+  group('top-level parity helpers', () {
+    test('factory, access, write, and fill delegate to the class', () {
+      final pixels = createPixelContainer(2, 2);
+      setPixel(pixels, 1, 0, 10, 20, 30, 40);
+      expect(pixelAt(pixels, 1, 0), (10, 20, 30, 40));
+      fillPixels(pixels, 9, 8, 7, 6);
+      expect(pixelAt(pixels, 0, 1), (9, 8, 7, 6));
+    });
+  });
+
+  group('ImageCodec contract', () {
+    test('exposes MIME type and round-trips pixels', () {
+      final codec = StubCodec();
+      final original = PixelContainer(2, 1)
+        ..setPixel(0, 0, 10, 20, 30, 40)
+        ..setPixel(1, 0, 50, 60, 70, 80);
+      expect(codec.mimeType, 'image/x-stub');
+      expect(codec.decode(codec.encode(original)), original);
+    });
+
+    test('implementations can report decode failures', () {
+      expect(() => StubCodec().decode(Uint8List(0)), throwsFormatException);
+    });
+  });
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,10 +127,10 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Twenty-one package/language slots turn 21 nearly complete packages into fully
-covered packages.
+Twenty package/language slots remain to turn 20 nearly complete packages into
+fully covered packages.
 
-### Dart: 11 remaining ports
+### Dart: 10 remaining ports
 
 - `algol-lexer`
 - `algol-parser`
@@ -141,10 +141,9 @@ covered packages.
 - `logic-gates`
 - `mosaic-lexer`
 - `mosaic-parser`
-- `pixel-container`
 - `toml-lexer`
 
-Completed in the Dart lane: `heap`, `bitset`.
+Completed in the Dart lane: `heap`, `bitset`, `pixel-container`.
 
 ### Haskell: 7 ports
 


### PR DESCRIPTION
## Summary

- add a zero-dependency pure-Dart IC00 PixelContainer backed by Uint8List
- provide checked RGBA8 construction, row-major access, mutation, fill, copying, equality, and byte/pixel counts
- add the ImageCodec interface and TypeScript-compatible top-level helper functions
- refresh Priority 1 to reflect 20 remaining 14-of-15 gaps

## Impact

PixelContainer now has a pure implementation in all 15 established implementation languages and provides the Dart foundation needed by future image codec and image operation ports.

## Verification

- Dart SDK 3.12.2
- `dart pub get`
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` — 18 tests passed
- package parity reporter unit tests — 6 passed
- live parity report — PixelContainer 15/15, 20 remaining 14-of-15 gaps, 0 collisions
- build planner — affected package `dart/pixel-container`, Dart toolchain only
- `git diff --check`