### PR TITLE
fix(deps): bump ws to 8.21.0, resolves 4 Dependabot alerts

### DIFF
--- a/code/packages/typescript/paint-vm-canvas/package-lock.json
+++ b/code/packages/typescript/paint-vm-canvas/package-lock.json
@@ -1961,9 +1961,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/packages/typescript/store/package-lock.json
+++ b/code/packages/typescript/store/package-lock.json
@@ -2527,9 +2527,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/code/packages/typescript/ui-components/package-lock.json
+++ b/code/packages/typescript/ui-components/package-lock.json
@@ -2507,10 +2507,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/code/programs/typescript/code39-visualizer/package-lock.json
+++ b/code/programs/typescript/code39-visualizer/package-lock.json
@@ -10977,7 +10977,9 @@
       }
     },
     "../../../packages/typescript/paint-vm-canvas/node_modules/ws": {
-      "version": "8.20.0",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- Fixes 4 open Dependabot alerts (#2794, #2790, #2786, #2785), all the same HIGH-severity GHSA advisory: `ws` memory exhaustion DoS from tiny WebSocket fragments/data chunks, affecting `ws >= 8.0.0, < 8.21.0`.
- `ws` is a transitive dev dependency of `jsdom` (the vitest test environment) in `paint-vm-canvas`, `store`, `ui-components`, and `code39-visualizer` (which pulls in its own nested copy via `paint-vm-canvas`). Never shipped in production builds.
- `jsdom`'s own declared range (`^8.18.0`) already permits `8.21.0`, so `npm update ws` resolves cleanly — no `jsdom` version bump needed, no `package.json` changes at all.
- Diff scoped to exactly the four flagged manifests: two incidental `package-lock.json` version-string drifts (`grammar-tools`, `lexer` — both stale relative to their own `package.json` since an earlier unrelated merge, picked up incidentally by running `npm install`) were reverted rather than bundled in.

## Test plan
- [x] `npm ls ws` / `npm audit` in each of the 4 packages: 0 vulnerabilities.
- [x] Each package's own test suite green: `store` 20/20, `ui-components` 225/225, `paint-vm-canvas` 73/73, `code39-visualizer` 4/4 (322 tests total).
- [x] `ui-components`/`code39-visualizer` required chain-installing sibling `file:` dependencies leaf-to-root first (per this repo's own documented lesson on transitive local deps) — confirmed this is pre-existing monorepo behavior, not a regression from this change.
- [x] `/security-review` passed clean — reviewer additionally verified the `ws@8.21.0` integrity hash against the live npm registry and confirmed an exact match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)