### PR TITLE
feat(sir-runtime-oop): Array minmax — TS mirror (final backend)

### DIFF
--- a/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `@coding-adventures/sir-runtime-oop` are documented here.
 
+## [0.1.25] - 2026-07-12
+
+### Added
+
+- **`Array#minmax`** — the FINAL backend of the `minmax` cross-backend cascade
+  (Python reference #8092, Go #8098, Rust #8103, JS #8106), completing it across
+  all five backends.
+  - `minmax` (`arrayMethod` non-block + `ARRAY_METHODS`) → the two-element array
+    `[min, max]` in one pass, via `<`/`>` (the same comparison the `min`/`max`
+    arms use). `[3,1,2].minmax` → `[1, 3]`; `["b","a","c"].minmax` →
+    `["a", "c"]`. An empty array yields `[null, null]` (Ruby `[nil, nil]` — no
+    smallest/largest element), matching the Go/Rust/Python/JS references.
+  - `respond_to?("minmax")` now reports `true`.
+
 ## [0.1.24] - 2026-07-11
 
 ### Added

--- a/code/packages/typescript/sir-runtime-oop/README.md
+++ b/code/packages/typescript/sir-runtime-oop/README.md
@@ -62,7 +62,7 @@ through `@coding-adventures/sir-runtime-exceptions`' explicit-string `raiseError
 The catalog currently covers (item **M1a** of `code/specs/sir-method-dispatch.md`)
 the **non-block `Array`** surface — `length`/`size`/`count`, `first`/`last`,
 `include?`, `index`, `push`/`<<`/`pop`/`shift`/`unshift`, `reverse`, `sort`,
-`min`/`max`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
+`min`/`max`/`minmax`/`sum`, `uniq`/`flatten`/`compact`, `empty?`, `to_a`,
 `take`/`drop`/`values_at`, `rotate`/`zip`, `each_slice`/`each_cons`, `tally` — and the
 **universal `Object`** methods `nil?`, `==`, `!=`, `equal?`, `respond_to?`,
 `freeze`/`frozen?`, `dup`/`clone`, `itself`, `to_a` (`include?`/`index`/`==` use

--- a/code/packages/typescript/sir-runtime-oop/package.json
+++ b/code/packages/typescript/sir-runtime-oop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-oop",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "OOP runtime for Semantic-IR-emitted TypeScript/JavaScript — class registry, is_a?/ancestry, instance- and class-variable stores, and reflective method dispatch",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-oop/src/index.ts
+++ b/code/packages/typescript/sir-runtime-oop/src/index.ts
@@ -542,6 +542,7 @@ const ARRAY_METHODS = new Set<string>([
   "sort",
   "min",
   "max",
+  "minmax",
   "sum",
   "uniq",
   "flatten",
@@ -947,6 +948,21 @@ function arrayMethod(recv: Val[], name: string, args: Val[]): Val | typeof MISS 
       return recv.length > 0 ? recv.reduce((a: Val, b: Val) => (b < a ? b : a)) : null;
     case "max":
       return recv.length > 0 ? recv.reduce((a: Val, b: Val) => (b > a ? b : a)) : null;
+    case "minmax": {
+      // `minmax` (no block) — the two-element array `[min, max]` in one pass,
+      // via `<`/`>` (the same comparison the `min`/`max` arms use).
+      // `[3,1,2].minmax` → `[1, 3]`.  An empty array yields `[null, null]`
+      // (Ruby `[nil, nil]` — no smallest/largest element), matching the
+      // Go/Rust/Python/JS references' 2-element nil array.
+      if (recv.length === 0) return [null, null];
+      let lo = recv[0];
+      let hi = recv[0];
+      for (let i = 1; i < recv.length; i++) {
+        if (recv[i] < lo) lo = recv[i];
+        if (recv[i] > hi) hi = recv[i];
+      }
+      return [lo, hi];
+    }
     case "sum": {
       let total: Val = args.length > 0 ? args[0] : 0;
       for (const item of recv) total = total + item;

--- a/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
+++ b/code/packages/typescript/sir-runtime-oop/tests/oop.test.ts
@@ -211,6 +211,11 @@ describe("built-in method catalog: non-block Array (M1a)", () => {
     expect(callMethod([10, 2, 30], "sort")).toEqual([2, 10, 30]);
     expect(callMethod([3, 1, 2], "min")).toBe(1);
     expect(callMethod([3, 1, 2], "max")).toBe(3);
+    // `minmax` → [min, max] in one call; empty → [null, null] (Ruby [nil, nil]).
+    expect(callMethod([3, 1, 2], "minmax")).toEqual([1, 3]);
+    expect(callMethod(["b", "a", "c"], "minmax")).toEqual(["a", "c"]);
+    expect(callMethod([], "minmax")).toEqual([null, null]);
+    expect(callMethod([1], "respond_to?", "minmax")).toBe(true);
     expect(callMethod([1, 2, 3], "sum")).toBe(6);
     expect(callMethod([1, 2, 3], "sum", 10)).toBe(16);
     expect(callMethod([], "min")).toBeNull();


### PR DESCRIPTION
Completes the `Array#minmax` cross-backend cascade — now present across **all five backends**. (Python reference [#8092](https://github.com/adhithyan15/coding-adventures/pull/8092), Go [#8098](https://github.com/adhithyan15/coding-adventures/pull/8098), Rust [#8103](https://github.com/adhithyan15/coding-adventures/pull/8103), JS [#8106](https://github.com/adhithyan15/coding-adventures/pull/8106).)

## What

`minmax` (non-block) returns the two-element array `[min, max]` in one pass via `<`/`>` (the same comparison the `min`/`max` arms use):

- `[3,1,2].minmax` → `[1, 3]`
- `["b","a","c"].minmax` → `["a", "c"]`
- `[].minmax` → `[null, null]` (Ruby `[nil, nil]`)
- `respond_to?("minmax")` → `true`

Added to `arrayMethod` beside the existing `min`/`max` arms + the `ARRAY_METHODS` set.

## Tests

vitest covers int + string ordering, empty → `[null, null]`, and `respond_to?`. **Full suite 120 passed.**

Version 0.1.24 → 0.1.25. Security review passed (plain array — no prototype pollution; O(n); explicit-switch dispatch, no reflection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)