### PR TITLE
[codex] Port image point operations to Dart

### DIFF
--- a/code/packages/dart/image-point-ops/BUILD
+++ b/code/packages/dart/image-point-ops/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/image-point-ops/CHANGELOG.md
+++ b/code/packages/dart/image-point-ops/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog - coding_adventures_image_point_ops
+
+## 0.1.0 - 2026-07-12
+
+### Added
+
+- Initial pure-Dart IMG03 implementation over `PixelContainer`.
+- Encoded-byte, linear-light, colorspace, and one-dimensional LUT operations.
+- Cross-port conformance tests plus argument and source-immutability coverage.

--- a/code/packages/dart/image-point-ops/README.md
+++ b/code/packages/dart/image-point-ops/README.md
@@ -1,0 +1,30 @@
+# coding_adventures_image_point_ops
+
+IMG03 per-pixel point operations for the shared `PixelContainer` image type,
+implemented in pure Dart. Each operation returns a new RGBA8 image and preserves
+alpha unless alpha is the selected channel.
+
+The package includes encoded-byte operations (`invert`, thresholds, posterize,
+channel operations, brightness), linear-light transforms (contrast, gamma,
+exposure, greyscale, sepia, colour matrices, saturation, hue rotation), sRGB
+conversion helpers, and one-dimensional LUT builders/applicators.
+
+## Usage
+
+```dart
+import 'package:coding_adventures_image_point_ops/coding_adventures_image_point_ops.dart';
+import 'package:coding_adventures_pixel_container/coding_adventures_pixel_container.dart';
+
+final image = PixelContainer(1, 1)..setPixel(0, 0, 10, 100, 200, 255);
+final inverted = invert(image);
+final monochrome = greyscale(image);
+```
+
+## Development
+
+```text
+dart pub get
+dart format --output=none --set-exit-if-changed .
+dart analyze
+dart test
+```

--- a/code/packages/dart/image-point-ops/lib/coding_adventures_image_point_ops.dart
+++ b/code/packages/dart/image-point-ops/lib/coding_adventures_image_point_ops.dart
@@ -1,0 +1,4 @@
+/// IMG03 per-pixel point operations for RGBA8 images in pure Dart.
+library coding_adventures_image_point_ops;
+
+export 'src/image_point_ops.dart';

--- a/code/packages/dart/image-point-ops/lib/src/image_point_ops.dart
+++ b/code/packages/dart/image-point-ops/lib/src/image_point_ops.dart
@@ -1,0 +1,354 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:coding_adventures_pixel_container/coding_adventures_pixel_container.dart';
+
+/// Package semantic version.
+const String version = '0.1.0';
+
+/// Luminance weighting used by [greyscale].
+enum GreyscaleMethod {
+  /// Rec. 709 weights for modern sRGB displays.
+  rec709,
+
+  /// BT. 601 weights for legacy standard-definition video.
+  bt601,
+
+  /// Equal red, green, and blue weights.
+  average,
+}
+
+typedef _PixelMap = Rgba Function(int red, int green, int blue, int alpha);
+
+final List<double> _srgbToLinear = List<double>.generate(256, (value) {
+  final channel = value / 255;
+  return channel <= 0.04045
+      ? channel / 12.92
+      : math.pow((channel + 0.055) / 1.055, 2.4).toDouble();
+}, growable: false);
+
+double _decode(int value) => _srgbToLinear[value];
+
+int _encode(num linear) {
+  final encoded = linear <= 0.0031308
+      ? linear * 12.92
+      : 1.055 * math.pow(linear, 1 / 2.4) - 0.055;
+  return (encoded.clamp(0.0, 1.0) * 255).round();
+}
+
+PixelContainer _mapPixels(PixelContainer source, _PixelMap transform) {
+  final output = PixelContainer(source.width, source.height);
+  for (var offset = 0; offset < source.data.length; offset += 4) {
+    final (red, green, blue, alpha) = transform(
+      source.data[offset],
+      source.data[offset + 1],
+      source.data[offset + 2],
+      source.data[offset + 3],
+    );
+    output.data[offset] = red;
+    output.data[offset + 1] = green;
+    output.data[offset + 2] = blue;
+    output.data[offset + 3] = alpha;
+  }
+  return output;
+}
+
+/// Invert every RGB byte while preserving alpha.
+PixelContainer invert(PixelContainer source) => _mapPixels(
+      source,
+      (red, green, blue, alpha) => (255 - red, 255 - green, 255 - blue, alpha),
+    );
+
+/// Binarize using the arithmetic mean of the three RGB bytes.
+PixelContainer threshold(PixelContainer source, num value) =>
+    _mapPixels(source, (red, green, blue, alpha) {
+      final output = (red + green + blue) / 3 >= value ? 255 : 0;
+      return (output, output, output, alpha);
+    });
+
+/// Binarize using Rec. 709 luma over the encoded RGB bytes.
+PixelContainer thresholdLuminance(PixelContainer source, num value) =>
+    _mapPixels(source, (red, green, blue, alpha) {
+      final luma = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+      final output = luma >= value ? 255 : 0;
+      return (output, output, output, alpha);
+    });
+
+/// Quantize RGB into [levels] equally spaced values.
+PixelContainer posterize(PixelContainer source, int levels) {
+  if (levels < 2) {
+    throw RangeError.range(levels, 2, null, 'levels');
+  }
+  final step = 255 / (levels - 1);
+  int quantize(int value) =>
+      ((value / step).round() * step).round().clamp(0, 255).toInt();
+  return _mapPixels(
+    source,
+    (red, green, blue, alpha) =>
+        (quantize(red), quantize(green), quantize(blue), alpha),
+  );
+}
+
+/// Swap the red and blue channels.
+PixelContainer swapRgbBgr(PixelContainer source) =>
+    _mapPixels(source, (red, green, blue, alpha) => (blue, green, red, alpha));
+
+/// Retain one channel (`0=R`, `1=G`, `2=B`, `3=A`).
+///
+/// RGB extraction zeroes the other two colour channels and preserves alpha.
+/// Alpha extraction leaves the RGB bytes unchanged, matching the shared API.
+PixelContainer extractChannel(PixelContainer source, int channel) {
+  if (channel < 0 || channel > 3) {
+    throw RangeError.range(channel, 0, 3, 'channel');
+  }
+  return _mapPixels(source, (red, green, blue, alpha) {
+    return switch (channel) {
+      0 => (red, 0, 0, alpha),
+      1 => (0, green, 0, alpha),
+      2 => (0, 0, blue, alpha),
+      _ => (red, green, blue, alpha),
+    };
+  });
+}
+
+/// Add [offset] to each RGB byte and clamp to the byte range.
+PixelContainer brightness(PixelContainer source, num offset) => _mapPixels(
+      source,
+      (red, green, blue, alpha) => (
+        (red + offset).round().clamp(0, 255),
+        (green + offset).round().clamp(0, 255),
+        (blue + offset).round().clamp(0, 255),
+        alpha,
+      ),
+    );
+
+/// Scale decoded linear-light RGB around 0.5.
+PixelContainer contrast(PixelContainer source, num factor) => _mapPixels(
+      source,
+      (red, green, blue, alpha) => (
+        _encode(0.5 + factor * (_decode(red) - 0.5)),
+        _encode(0.5 + factor * (_decode(green) - 0.5)),
+        _encode(0.5 + factor * (_decode(blue) - 0.5)),
+        alpha,
+      ),
+    );
+
+/// Raise decoded linear-light RGB to [exponent].
+PixelContainer gamma(PixelContainer source, num exponent) => _mapPixels(
+      source,
+      (red, green, blue, alpha) => (
+        _encode(math.pow(_decode(red), exponent).toDouble()),
+        _encode(math.pow(_decode(green), exponent).toDouble()),
+        _encode(math.pow(_decode(blue), exponent).toDouble()),
+        alpha,
+      ),
+    );
+
+/// Multiply decoded linear-light RGB by `2 ^ stops`.
+PixelContainer exposure(PixelContainer source, num stops) {
+  final factor = math.pow(2, stops).toDouble();
+  return _mapPixels(
+    source,
+    (red, green, blue, alpha) => (
+      _encode(_decode(red) * factor),
+      _encode(_decode(green) * factor),
+      _encode(_decode(blue) * factor),
+      alpha,
+    ),
+  );
+}
+
+/// Convert RGB to linear-light luminance, then encode it as sRGB.
+PixelContainer greyscale(
+  PixelContainer source, [
+  GreyscaleMethod method = GreyscaleMethod.rec709,
+]) =>
+    _mapPixels(source, (red, green, blue, alpha) {
+      final linearRed = _decode(red);
+      final linearGreen = _decode(green);
+      final linearBlue = _decode(blue);
+      final luminance = switch (method) {
+        GreyscaleMethod.rec709 =>
+          0.2126 * linearRed + 0.7152 * linearGreen + 0.0722 * linearBlue,
+        GreyscaleMethod.bt601 =>
+          0.2989 * linearRed + 0.5870 * linearGreen + 0.1140 * linearBlue,
+        GreyscaleMethod.average => (linearRed + linearGreen + linearBlue) / 3,
+      };
+      final output = _encode(luminance);
+      return (output, output, output, alpha);
+    });
+
+/// Apply the classic sepia matrix in linear light.
+PixelContainer sepia(PixelContainer source) =>
+    _mapPixels(source, (red, green, blue, alpha) {
+      final linearRed = _decode(red);
+      final linearGreen = _decode(green);
+      final linearBlue = _decode(blue);
+      return (
+        _encode(0.393 * linearRed + 0.769 * linearGreen + 0.189 * linearBlue),
+        _encode(0.349 * linearRed + 0.686 * linearGreen + 0.168 * linearBlue),
+        _encode(0.272 * linearRed + 0.534 * linearGreen + 0.131 * linearBlue),
+        alpha,
+      );
+    });
+
+/// Multiply decoded linear RGB by a row-major 3-by-3 [matrix].
+PixelContainer colourMatrix(PixelContainer source, List<List<num>> matrix) {
+  if (matrix.length != 3 || matrix.any((row) => row.length != 3)) {
+    throw ArgumentError.value(matrix, 'matrix', 'must be a 3-by-3 matrix');
+  }
+  return _mapPixels(source, (red, green, blue, alpha) {
+    final channels = [_decode(red), _decode(green), _decode(blue)];
+    double multiplyRow(int row) => (matrix[row][0] * channels[0] +
+            matrix[row][1] * channels[1] +
+            matrix[row][2] * channels[2])
+        .toDouble();
+    return (
+      _encode(multiplyRow(0)),
+      _encode(multiplyRow(1)),
+      _encode(multiplyRow(2)),
+      alpha,
+    );
+  });
+}
+
+/// Scale saturation around Rec. 709 linear-light luminance.
+PixelContainer saturate(PixelContainer source, num factor) =>
+    _mapPixels(source, (red, green, blue, alpha) {
+      final linearRed = _decode(red);
+      final linearGreen = _decode(green);
+      final linearBlue = _decode(blue);
+      final grey =
+          0.2126 * linearRed + 0.7152 * linearGreen + 0.0722 * linearBlue;
+      return (
+        _encode(grey + factor * (linearRed - grey)),
+        _encode(grey + factor * (linearGreen - grey)),
+        _encode(grey + factor * (linearBlue - grey)),
+        alpha,
+      );
+    });
+
+(double, double, double) _rgbToHsv(double red, double green, double blue) {
+  final maximum = math.max(red, math.max(green, blue));
+  final minimum = math.min(red, math.min(green, blue));
+  final delta = maximum - minimum;
+  final saturation = maximum == 0 ? 0.0 : delta / maximum;
+  var hue = 0.0;
+  if (delta != 0) {
+    if (maximum == red) {
+      hue = ((green - blue) / delta) % 6;
+    } else if (maximum == green) {
+      hue = (blue - red) / delta + 2;
+    } else {
+      hue = (red - green) / delta + 4;
+    }
+    hue = (hue * 60 + 360) % 360;
+  }
+  return (hue, saturation, maximum);
+}
+
+(double, double, double) _hsvToRgb(
+  double hue,
+  double saturation,
+  double value,
+) {
+  final chroma = value * saturation;
+  final intermediate = chroma * (1 - ((hue / 60) % 2 - 1).abs());
+  final match = value - chroma;
+  var red = 0.0;
+  var green = 0.0;
+  var blue = 0.0;
+  if (hue < 60) {
+    red = chroma;
+    green = intermediate;
+  } else if (hue < 120) {
+    red = intermediate;
+    green = chroma;
+  } else if (hue < 180) {
+    green = chroma;
+    blue = intermediate;
+  } else if (hue < 240) {
+    green = intermediate;
+    blue = chroma;
+  } else if (hue < 300) {
+    red = intermediate;
+    blue = chroma;
+  } else {
+    red = chroma;
+    blue = intermediate;
+  }
+  return (red + match, green + match, blue + match);
+}
+
+/// Rotate linear-light HSV hue by [degrees].
+PixelContainer hueRotate(PixelContainer source, num degrees) =>
+    _mapPixels(source, (red, green, blue, alpha) {
+      final (hue, saturation, value) = _rgbToHsv(
+        _decode(red),
+        _decode(green),
+        _decode(blue),
+      );
+      final rotatedHue = (hue + degrees) % 360;
+      final (newRed, newGreen, newBlue) = _hsvToRgb(
+        rotatedHue.toDouble(),
+        saturation,
+        value,
+      );
+      return (_encode(newRed), _encode(newGreen), _encode(newBlue), alpha);
+    });
+
+/// Convert encoded sRGB bytes to linear-light bytes.
+PixelContainer srgbToLinearImage(PixelContainer source) => _mapPixels(
+      source,
+      (red, green, blue, alpha) => (
+        (_decode(red) * 255).round(),
+        (_decode(green) * 255).round(),
+        (_decode(blue) * 255).round(),
+        alpha,
+      ),
+    );
+
+/// Convert linear-light bytes to encoded sRGB bytes.
+PixelContainer linearToSrgbImage(PixelContainer source) => _mapPixels(
+      source,
+      (red, green, blue, alpha) => (
+        _encode(red / 255),
+        _encode(green / 255),
+        _encode(blue / 255),
+        alpha
+      ),
+    );
+
+/// Apply one 256-entry byte LUT to each RGB channel.
+PixelContainer applyLut1dU8(
+  PixelContainer source,
+  Uint8List redLut,
+  Uint8List greenLut,
+  Uint8List blueLut,
+) {
+  for (final (name, lut) in [
+    ('redLut', redLut),
+    ('greenLut', greenLut),
+    ('blueLut', blueLut),
+  ]) {
+    if (lut.length != 256) {
+      throw ArgumentError.value(lut.length, name, 'must contain 256 entries');
+    }
+  }
+  return _mapPixels(
+    source,
+    (red, green, blue, alpha) =>
+        (redLut[red], greenLut[green], blueLut[blue], alpha),
+  );
+}
+
+/// Sample a linear-light mapping function into a 256-entry sRGB byte LUT.
+Uint8List buildLut1dU8(double Function(double linearInput) transform) =>
+    Uint8List.fromList([
+      for (var value = 0; value < 256; value++)
+        _encode(transform(_decode(value))),
+    ]);
+
+/// Build the LUT equivalent of [gamma].
+Uint8List buildGammaLut(num exponent) =>
+    buildLut1dU8((value) => math.pow(value, exponent).toDouble());

--- a/code/packages/dart/image-point-ops/pubspec.yaml
+++ b/code/packages/dart/image-point-ops/pubspec.yaml
@@ -1,0 +1,15 @@
+name: coding_adventures_image_point_ops
+version: 0.1.0
+description: IMG03 per-pixel image operations over RGBA8 PixelContainer data in pure Dart.
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  coding_adventures_pixel_container:
+    path: ../pixel-container
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/image-point-ops/required_capabilities.json
+++ b/code/packages/dart/image-point-ops/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/image-point-ops",
+  "capabilities": [],
+  "justification": "Pure deterministic in-memory pixel transforms with no OS access."
+}

--- a/code/packages/dart/image-point-ops/test/image_point_ops_test.dart
+++ b/code/packages/dart/image-point-ops/test/image_point_ops_test.dart
@@ -1,0 +1,290 @@
+import 'dart:typed_data';
+
+import 'package:coding_adventures_image_point_ops/coding_adventures_image_point_ops.dart';
+import 'package:coding_adventures_pixel_container/coding_adventures_pixel_container.dart';
+import 'package:test/test.dart';
+
+PixelContainer solid(int red, int green, int blue, int alpha) =>
+    PixelContainer(1, 1)..setPixel(0, 0, red, green, blue, alpha);
+
+void expectNear(Rgba actual, Rgba expected, {int tolerance = 1}) {
+  expect((actual.$1 - expected.$1).abs(), lessThanOrEqualTo(tolerance));
+  expect((actual.$2 - expected.$2).abs(), lessThanOrEqualTo(tolerance));
+  expect((actual.$3 - expected.$3).abs(), lessThanOrEqualTo(tolerance));
+  expect(actual.$4, expected.$4);
+}
+
+void main() {
+  group('encoded-byte operations', () {
+    test('invert preserves dimensions and alpha', () {
+      final source = PixelContainer(3, 5)..setPixel(0, 0, 10, 100, 200, 128);
+      final output = invert(source);
+      expect((output.width, output.height), (3, 5));
+      expect(output.pixelAt(0, 0), (245, 155, 55, 128));
+    });
+
+    test('double invert is exact identity', () {
+      final source = solid(30, 80, 180, 255);
+      expect(invert(invert(source)), source);
+    });
+
+    test('threshold splits below, at, and above the boundary', () {
+      expect(threshold(solid(50, 50, 50, 17), 128).pixelAt(0, 0), (
+        0,
+        0,
+        0,
+        17,
+      ));
+      expect(threshold(solid(128, 128, 128, 18), 128).pixelAt(0, 0), (
+        255,
+        255,
+        255,
+        18,
+      ));
+      expect(threshold(solid(200, 200, 200, 19), 128).pixelAt(0, 0), (
+        255,
+        255,
+        255,
+        19,
+      ));
+    });
+
+    test('luminance threshold uses Rec. 709 encoded-byte weights', () {
+      expect(thresholdLuminance(solid(255, 0, 0, 255), 100).pixelAt(0, 0), (
+        0,
+        0,
+        0,
+        255,
+      ));
+      expect(thresholdLuminance(solid(0, 255, 0, 255), 100).pixelAt(0, 0), (
+        255,
+        255,
+        255,
+        255,
+      ));
+    });
+
+    test('posterize creates equally spaced levels', () {
+      expect(posterize(solid(0, 63, 128, 200), 3).pixelAt(0, 0), (
+        0,
+        0,
+        128,
+        200,
+      ));
+      expect(posterize(solid(191, 255, 50, 200), 3).pixelAt(0, 0), (
+        128,
+        255,
+        0,
+        200,
+      ));
+      expect(() => posterize(solid(0, 0, 0, 0), 1), throwsRangeError);
+    });
+
+    test('swapRgbBgr exchanges red and blue', () {
+      expect(swapRgbBgr(solid(255, 20, 0, 128)).pixelAt(0, 0), (
+        0,
+        20,
+        255,
+        128,
+      ));
+    });
+
+    test('extractChannel supports all four channel indices', () {
+      final source = solid(100, 150, 200, 77);
+      expect(extractChannel(source, 0).pixelAt(0, 0), (100, 0, 0, 77));
+      expect(extractChannel(source, 1).pixelAt(0, 0), (0, 150, 0, 77));
+      expect(extractChannel(source, 2).pixelAt(0, 0), (0, 0, 200, 77));
+      expect(extractChannel(source, 3).pixelAt(0, 0), (100, 150, 200, 77));
+      expect(() => extractChannel(source, 4), throwsRangeError);
+    });
+
+    test('brightness adds, rounds, and clamps', () {
+      expect(brightness(solid(250, 10, 5, 99), 20).pixelAt(0, 0), (
+        255,
+        30,
+        25,
+        99,
+      ));
+      expect(brightness(solid(5, 10, 250, 99), -20).pixelAt(0, 0), (
+        0,
+        0,
+        230,
+        99,
+      ));
+    });
+  });
+
+  group('linear-light operations', () {
+    final identitySource = solid(100, 150, 200, 231);
+
+    test('contrast factor one is identity within rounding', () {
+      expectNear(
+        contrast(identitySource, 1).pixelAt(0, 0),
+        identitySource.pixelAt(0, 0),
+      );
+    });
+
+    test('gamma one is identity and gamma below one brightens', () {
+      expectNear(
+        gamma(identitySource, 1).pixelAt(0, 0),
+        identitySource.pixelAt(0, 0),
+      );
+      expect(
+        gamma(solid(128, 128, 128, 255), 0.5).pixelAt(0, 0).$1,
+        greaterThan(128),
+      );
+    });
+
+    test('positive exposure brightens without changing alpha', () {
+      final output = exposure(solid(100, 100, 100, 42), 1).pixelAt(0, 0);
+      expect(output.$1, greaterThan(100));
+      expect(output.$4, 42);
+    });
+
+    test('all greyscale methods preserve black and white', () {
+      for (final method in GreyscaleMethod.values) {
+        expect(greyscale(solid(255, 255, 255, 255), method).pixelAt(0, 0), (
+          255,
+          255,
+          255,
+          255,
+        ));
+        expect(greyscale(solid(0, 0, 0, 128), method).pixelAt(0, 0), (
+          0,
+          0,
+          0,
+          128,
+        ));
+      }
+    });
+
+    test('greyscale returns equal RGB channels', () {
+      final output = greyscale(solid(200, 100, 50, 255)).pixelAt(0, 0);
+      expect(output.$1, output.$2);
+      expect(output.$2, output.$3);
+    });
+
+    test('sepia preserves alpha and creates warm ordering', () {
+      final output = sepia(solid(128, 128, 128, 200)).pixelAt(0, 0);
+      expect(output.$1, greaterThanOrEqualTo(output.$2));
+      expect(output.$2, greaterThan(output.$3));
+      expect(output.$4, 200);
+    });
+
+    test('identity colour matrix is identity', () {
+      final output = colourMatrix(identitySource, const [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+      ]);
+      expectNear(output.pixelAt(0, 0), identitySource.pixelAt(0, 0));
+    });
+
+    test('colour matrix rejects invalid shape', () {
+      expect(
+        () => colourMatrix(identitySource, const [
+          [1, 0],
+          [0, 1],
+        ]),
+        throwsArgumentError,
+      );
+    });
+
+    test('zero saturation produces equal channels', () {
+      final output = saturate(solid(200, 100, 50, 255), 0).pixelAt(0, 0);
+      expect(output.$1, output.$2);
+      expect(output.$2, output.$3);
+    });
+
+    test('360 degree hue rotation is identity within rounding', () {
+      final source = solid(200, 80, 40, 240);
+      expectNear(
+        hueRotate(source, 360).pixelAt(0, 0),
+        source.pixelAt(0, 0),
+        tolerance: 2,
+      );
+    });
+
+    test('negative hue rotation wraps around the colour wheel', () {
+      final source = solid(200, 80, 40, 240);
+      expectNear(
+        hueRotate(source, -360).pixelAt(0, 0),
+        source.pixelAt(0, 0),
+        tolerance: 2,
+      );
+    });
+  });
+
+  group('colorspace and LUT operations', () {
+    test('sRGB to linear byte round trip is approximate identity', () {
+      final source = solid(100, 150, 200, 255);
+      final output = linearToSrgbImage(srgbToLinearImage(source));
+      expectNear(output.pixelAt(0, 0), source.pixelAt(0, 0), tolerance: 2);
+    });
+
+    test('applyLut1dU8 applies independent channel tables', () {
+      final invertLut = Uint8List.fromList([
+        for (var index = 0; index < 256; index++) 255 - index,
+      ]);
+      final identityLut = Uint8List.fromList([
+        for (var index = 0; index < 256; index++) index,
+      ]);
+      final zeroLut = Uint8List(256);
+      final output = applyLut1dU8(
+        solid(100, 25, 200, 123),
+        invertLut,
+        identityLut,
+        zeroLut,
+      );
+      expect(output.pixelAt(0, 0), (155, 25, 0, 123));
+    });
+
+    test('applyLut1dU8 requires 256 entries per channel', () {
+      final valid = Uint8List(256);
+      expect(
+        () => applyLut1dU8(solid(0, 0, 0, 0), Uint8List(255), valid, valid),
+        throwsArgumentError,
+      );
+    });
+
+    test('identity mapping builds identity LUT within rounding', () {
+      final lut = buildLut1dU8((value) => value);
+      expect(lut.length, 256);
+      for (var index = 0; index < 256; index++) {
+        expect(
+          (lut[index] - index).abs(),
+          lessThanOrEqualTo(1),
+          reason: 'LUT entry $index',
+        );
+      }
+    });
+
+    test('gamma one builds identity LUT within rounding', () {
+      final lut = buildGammaLut(1);
+      for (var index = 0; index < 256; index++) {
+        expect(
+          (lut[index] - index).abs(),
+          lessThanOrEqualTo(1),
+          reason: 'gamma LUT entry $index',
+        );
+      }
+    });
+  });
+
+  test('operations return independent images and do not mutate source', () {
+    final source = solid(10, 20, 30, 40);
+    final output = invert(source);
+    output.setPixel(0, 0, 1, 2, 3, 4);
+    expect(source.pixelAt(0, 0), (10, 20, 30, 40));
+  });
+
+  test('zero-sized images are accepted by every operation family', () {
+    final empty = PixelContainer(0, 0);
+    expect(invert(empty).data, isEmpty);
+    expect(greyscale(empty).data, isEmpty);
+    expect(
+      applyLut1dU8(empty, Uint8List(256), Uint8List(256), Uint8List(256)).data,
+      isEmpty,
+    );
+  });
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,23 +127,23 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Twenty package/language slots remain to turn 20 nearly complete packages into
+Nineteen package/language slots remain to turn 19 nearly complete packages into
 fully covered packages.
 
-### Dart: 10 remaining ports
+### Dart: 9 remaining ports
 
 - `algol-lexer`
 - `algol-parser`
 - `b-plus-tree`
 - `b-tree`
 - `image-geometric-transforms`
-- `image-point-ops`
 - `logic-gates`
 - `mosaic-lexer`
 - `mosaic-parser`
 - `toml-lexer`
 
-Completed in the Dart lane: `heap`, `bitset`, `pixel-container`.
+Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
+`image-point-ops`.
 
 ### Haskell: 7 ports
 


### PR DESCRIPTION
## Summary

- add a pure Dart IMG03 `image-point-ops` package over the shared `PixelContainer`
- implement encoded-byte, linear-light, colorspace, and 1D LUT operations with argument validation
- add 26 conformance and edge-case tests, package metadata, documentation, and roadmap progress

## Why

`image-point-ops` was one of the remaining 14-of-15 package gaps. The recently merged Dart `pixel-container` port now provides its only local dependency, so this closes the package to all 15 established language lanes.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` (26 passed)
- `python -m unittest discover -s scripts/tests -p 'test_package_parity_report.py'` (6 passed)
- `python scripts/package_parity_report.py --format json --fail-on-collisions` (15/15, zero collisions)
- CI build planner: affected packages are `dart/pixel-container` and `dart/image-point-ops`; only Dart is required