### PR TITLE
[codex] Port activation functions to Haskell

### DIFF
--- a/code/packages/haskell/activation-functions/BUILD
+++ b/code/packages/haskell/activation-functions/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/activation-functions/BUILD_windows
+++ b/code/packages/haskell/activation-functions/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/activation-functions/CHANGELOG.md
+++ b/code/packages/haskell/activation-functions/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-12
+
+- Add pure Haskell implementations of six activation functions and their
+  derivatives.
+- Preserve the consensus overflow guards and numerically stable softplus
+  behavior.
+- Add reference-value, derivative, sweep, and extreme-input tests.

--- a/code/packages/haskell/activation-functions/README.md
+++ b/code/packages/haskell/activation-functions/README.md
@@ -1,0 +1,23 @@
+# activation-functions
+
+Pure Haskell neural-network activation functions and their derivatives.
+
+## API
+
+The package exports `linear`, `sigmoid`, `relu`, `leakyRelu`, `tanh`, and
+`softplus`, together with a derivative for each function and the
+`leakyReluSlope` constant (`0.01`).
+
+The sigmoid implementation guards the finite `Double` exponent range, and
+softplus uses `log (1 + exp (-abs x)) + max x 0` with a small-value correction
+to remain finite and precise at extreme inputs.
+
+## Dependencies
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/activation-functions/activation-functions.cabal
+++ b/code/packages/haskell/activation-functions/activation-functions.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          activation-functions
+version:       0.1.0
+synopsis:      Neural-network activation functions and derivatives
+description:   Pure neural-network activation functions and their derivatives.
+category:      Math
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  ActivationFunctions
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    ActivationFunctionsSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , activation-functions
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/activation-functions/cabal.project
+++ b/code/packages/haskell/activation-functions/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/activation-functions/src/ActivationFunctions.hs
+++ b/code/packages/haskell/activation-functions/src/ActivationFunctions.hs
@@ -1,0 +1,95 @@
+-- | Pure neural-network activation functions and their derivatives.
+module ActivationFunctions
+    ( leakyReluSlope
+    , linear
+    , linearDerivative
+    , sigmoid
+    , sigmoidDerivative
+    , relu
+    , reluDerivative
+    , leakyRelu
+    , leakyReluDerivative
+    , tanh
+    , tanhDerivative
+    , softplus
+    , softplusDerivative
+    ) where
+
+import Prelude hiding (tanh)
+import qualified Prelude as P
+
+-- | The slope applied to non-positive inputs by 'leakyRelu'.
+leakyReluSlope :: Double
+leakyReluSlope = 0.01
+
+-- | Identity activation, commonly used for regression outputs.
+linear :: Double -> Double
+linear x = x
+
+-- | Derivative of 'linear'.
+linearDerivative :: Double -> Double
+linearDerivative _ = 1.0
+
+-- | Logistic sigmoid with guards around the finite Double exponent range.
+sigmoid :: Double -> Double
+sigmoid x
+    | x < -709.0 = 0.0
+    | x > 709.0 = 1.0
+    | otherwise = 1.0 / (1.0 + exp (-x))
+
+-- | Derivative of 'sigmoid'.
+sigmoidDerivative :: Double -> Double
+sigmoidDerivative x = s * (1.0 - s)
+  where
+    s = sigmoid x
+
+-- | Rectified linear unit.
+relu :: Double -> Double
+relu x
+    | x > 0.0 = x
+    | otherwise = 0.0
+
+-- | Derivative of 'relu', defined as zero at the origin.
+reluDerivative :: Double -> Double
+reluDerivative x
+    | x > 0.0 = 1.0
+    | otherwise = 0.0
+
+-- | ReLU with a small gradient for non-positive inputs.
+leakyRelu :: Double -> Double
+leakyRelu x
+    | x > 0.0 = x
+    | otherwise = leakyReluSlope * x
+
+-- | Derivative of 'leakyRelu'.
+leakyReluDerivative :: Double -> Double
+leakyReluDerivative x
+    | x > 0.0 = 1.0
+    | otherwise = leakyReluSlope
+
+-- | Hyperbolic tangent activation.
+tanh :: Double -> Double
+tanh = P.tanh
+
+-- | Derivative of 'tanh'.
+tanhDerivative :: Double -> Double
+tanhDerivative x = 1.0 - t * t
+  where
+    t = tanh x
+
+-- | Stable softplus: @log (1 + exp x)@ without overflow for large @x@.
+softplus :: Double -> Double
+softplus x = log1p (exp (-abs x)) + max x 0.0
+
+-- | Derivative of 'softplus'.
+softplusDerivative :: Double -> Double
+softplusDerivative = sigmoid
+
+-- | Accurate @log (1 + value)@ for the small positive values used by
+-- 'softplus'. The correction recovers bits lost when @1 + value@ rounds.
+log1p :: Double -> Double
+log1p value
+    | w == 1.0 = value
+    | otherwise = log w * (value / (w - 1.0))
+  where
+    w = 1.0 + value

--- a/code/packages/haskell/activation-functions/test/ActivationFunctionsSpec.hs
+++ b/code/packages/haskell/activation-functions/test/ActivationFunctionsSpec.hs
@@ -1,0 +1,94 @@
+module ActivationFunctionsSpec (spec) where
+
+import ActivationFunctions
+import Prelude hiding (tanh)
+import Test.Hspec
+
+tolerance :: Double
+tolerance = 1e-12
+
+shouldBeCloseTo :: Double -> Double -> Expectation
+actual `shouldBeCloseTo` expected =
+    abs (actual - expected) `shouldSatisfy` (<= tolerance)
+
+spec :: Spec
+spec = do
+    describe "linear" $ do
+        it "is the identity" $ do
+            linear (-3.0) `shouldBeCloseTo` (-3.0)
+            linear 0.0 `shouldBeCloseTo` 0.0
+            linear 5.0 `shouldBeCloseTo` 5.0
+        it "has derivative one everywhere" $
+            map linearDerivative [-3.0, 0.0, 5.0] `shouldBe` [1.0, 1.0, 1.0]
+
+    describe "sigmoid" $ do
+        it "matches reference values" $ do
+            sigmoid 0.0 `shouldBeCloseTo` 0.5
+            sigmoid 1.0 `shouldBeCloseTo` 0.7310585786300049
+            sigmoid (-1.0) `shouldBeCloseTo` 0.2689414213699951
+            sigmoid 10.0 `shouldBeCloseTo` 0.9999546021312976
+        it "saturates without overflowing at extremes" $ do
+            sigmoid (-710.0) `shouldBeCloseTo` 0.0
+            sigmoid 710.0 `shouldBeCloseTo` 1.0
+            sigmoid 1e9 `shouldBeCloseTo` 1.0
+            sigmoid (-1e9) `shouldBeCloseTo` 0.0
+        it "has the expected derivative" $ do
+            sigmoidDerivative 0.0 `shouldBeCloseTo` 0.25
+            sigmoidDerivative 1.0 `shouldBeCloseTo` 0.19661193324148185
+
+    describe "relu" $ do
+        it "is max zero x" $ do
+            relu 5.0 `shouldBeCloseTo` 5.0
+            relu (-3.0) `shouldBeCloseTo` 0.0
+            relu 0.0 `shouldBeCloseTo` 0.0
+        it "has derivative zero at and below the origin" $ do
+            reluDerivative 5.0 `shouldBeCloseTo` 1.0
+            reluDerivative (-3.0) `shouldBeCloseTo` 0.0
+            reluDerivative 0.0 `shouldBeCloseTo` 0.0
+
+    describe "leakyRelu" $ do
+        it "keeps a small negative slope" $ do
+            leakyRelu 5.0 `shouldBeCloseTo` 5.0
+            leakyRelu (-3.0) `shouldBeCloseTo` (-0.03)
+            leakyRelu 0.0 `shouldBeCloseTo` 0.0
+        it "uses the leak slope at and below the origin" $ do
+            leakyReluDerivative 5.0 `shouldBeCloseTo` 1.0
+            leakyReluDerivative (-3.0) `shouldBeCloseTo` 0.01
+            leakyReluDerivative 0.0 `shouldBeCloseTo` 0.01
+
+    describe "tanh" $ do
+        it "matches reference values" $ do
+            tanh 0.0 `shouldBeCloseTo` 0.0
+            tanh 1.0 `shouldBeCloseTo` 0.7615941559557649
+            tanh (-1.0) `shouldBeCloseTo` (-0.7615941559557649)
+        it "saturates at large magnitudes" $ do
+            tanh 50.0 `shouldBeCloseTo` 1.0
+            tanh (-50.0) `shouldBeCloseTo` (-1.0)
+        it "has the expected derivative" $ do
+            tanhDerivative 0.0 `shouldBeCloseTo` 1.0
+            tanhDerivative 1.0 `shouldBeCloseTo` 0.41997434161402614
+        it "agrees with the exponential definition on a sweep" $
+            mapM_ checkTanh [-6.0, -5.5 .. 6.0]
+
+    describe "softplus" $ do
+        it "matches reference values" $ do
+            softplus 0.0 `shouldBeCloseTo` 0.6931471805599453
+            softplus 1.0 `shouldBeCloseTo` 1.3132616875182228
+            softplus (-1.0) `shouldBeCloseTo` 0.31326168751822286
+        it "does not overflow for large positive input" $ do
+            softplus 1000.0 `shouldSatisfy` (> 999.0)
+            isInfinite (softplus 1000.0) `shouldBe` False
+        it "has derivative equal to sigmoid" $ do
+            softplusDerivative 0.0 `shouldBeCloseTo` 0.5
+            softplusDerivative 1.0 `shouldBeCloseTo` sigmoid 1.0
+            softplusDerivative (-1.0) `shouldBeCloseTo` sigmoid (-1.0)
+
+    describe "leakyReluSlope" $
+        it "is 0.01" $
+            leakyReluSlope `shouldBeCloseTo` 0.01
+  where
+    checkTanh x = do
+        let ex = exp x
+            enx = exp (-x)
+            reference = (ex - enx) / (ex + enx)
+        tanh x `shouldBeCloseTo` reference

--- a/code/packages/haskell/activation-functions/test/Spec.hs
+++ b/code/packages/haskell/activation-functions/test/Spec.hs
@@ -1,0 +1,5 @@
+import ActivationFunctionsSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Nineteen package/language slots remain to turn 19 nearly complete packages into
+Eighteen package/language slots remain to turn 18 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,15 +145,16 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 7 ports
+### Haskell: 6 remaining ports
 
-- `activation-functions`
 - `caesar-cipher`
 - `huffman-compression`
 - `huffman-tree`
 - `lz77`
 - `lzss`
 - `lzw`
+
+Completed in the Haskell lane: `activation-functions`.
 
 ### Swift: 3 ports
 


### PR DESCRIPTION
## Summary

- add a pure Haskell `activation-functions` package with six activations and their derivatives
- preserve consensus overflow guards and numerically stable softplus behavior
- add 17 Hspec examples covering reference values, derivatives, sweeps, and extreme inputs
- update the package-parity roadmap from 19 to 18 remaining Priority 1 slots

## Validation

- `cabal test all --test-show-details=direct` (17 examples, 0 failures)
- `cabal check` (no errors or warnings)
- `python -m unittest scripts.tests.test_package_parity_report` (6 tests)
- `python scripts/package_parity_report.py --format json --fail-on-collisions`
- scoped CI planner: only `haskell/activation-functions` affected and only Haskell required
- `git diff --check`

The repository-wide BUILD validator still reports pre-existing Windows metadata issues in unrelated Python, Swift, and TypeScript packages; the new Haskell package is not among them.