### PR TITLE
[codex] Port Caesar cipher to Haskell

### DIFF
--- a/code/packages/haskell/caesar-cipher/BUILD
+++ b/code/packages/haskell/caesar-cipher/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/caesar-cipher/BUILD_windows
+++ b/code/packages/haskell/caesar-cipher/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/caesar-cipher/CHANGELOG.md
+++ b/code/packages/haskell/caesar-cipher/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-12
+
+- Add case-preserving Caesar encryption, decryption, and ROT13.
+- Add brute-force enumeration of all non-trivial shifts.
+- Add chi-squared English frequency analysis.
+- Add tests for normalization, Unicode pass-through, round trips, attacks,
+  and the frequency table.

--- a/code/packages/haskell/caesar-cipher/README.md
+++ b/code/packages/haskell/caesar-cipher/README.md
@@ -1,0 +1,20 @@
+# caesar-cipher
+
+Pure Haskell implementation of the classic Caesar shift cipher and two
+classical attacks against it.
+
+## API
+
+- `encrypt`, `decrypt`, and `rot13` transform ASCII letters while preserving
+  case and passing every other character through unchanged.
+- `bruteForce` returns all 25 non-identity candidate plaintexts.
+- `frequencyAnalysis` selects the candidate with the closest chi-squared fit
+  to `englishFrequencies`.
+
+The library depends only on `base`. Tests use Hspec.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/caesar-cipher/cabal.project
+++ b/code/packages/haskell/caesar-cipher/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/caesar-cipher/caesar-cipher.cabal
+++ b/code/packages/haskell/caesar-cipher/caesar-cipher.cabal
@@ -1,0 +1,29 @@
+cabal-version: 3.0
+name:          caesar-cipher
+version:       0.1.0
+synopsis:      Caesar cipher with brute-force and frequency analysis
+description:   A pure Haskell Caesar cipher implementation with classical attacks.
+category:      Cryptography
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  CaesarCipher
+    build-depends:    base >=4.14 && <5
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    CaesarCipherSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , caesar-cipher
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/caesar-cipher/src/CaesarCipher.hs
+++ b/code/packages/haskell/caesar-cipher/src/CaesarCipher.hs
@@ -1,0 +1,105 @@
+-- | The Caesar cipher, brute-force enumeration, and frequency analysis.
+module CaesarCipher
+    ( encrypt
+    , decrypt
+    , rot13
+    , BruteForceResult (..)
+    , bruteForce
+    , englishFrequencies
+    , frequencyAnalysis
+    ) where
+
+import Data.Char (chr, isAsciiLower, isAsciiUpper, ord, toUpper)
+import Data.List (foldl')
+
+-- | Encrypt ASCII letters with a Caesar shift while preserving case.
+-- Non-ASCII and non-letter characters pass through unchanged.
+encrypt :: String -> Int -> String
+encrypt text shift = map (shiftChar normalizedShift) text
+  where
+    normalizedShift = shift `mod` 26
+
+-- | Reverse an encryption performed with the given shift.
+decrypt :: String -> Int -> String
+decrypt text shift = encrypt text (-shift)
+
+-- | Apply the self-inverse Caesar shift of 13.
+rot13 :: String -> String
+rot13 text = encrypt text 13
+
+shiftChar :: Int -> Char -> Char
+shiftChar shift char
+    | isAsciiUpper char = shiftFrom 'A'
+    | isAsciiLower char = shiftFrom 'a'
+    | otherwise = char
+  where
+    shiftFrom base = chr (ord base + (ord char - ord base + shift) `mod` 26)
+
+-- | One candidate plaintext from a brute-force attack.
+data BruteForceResult = BruteForceResult
+    { bruteForceShift :: Int
+    , bruteForcePlaintext :: String
+    }
+    deriving (Eq, Show)
+
+-- | Try all 25 non-identity shifts in ascending order.
+bruteForce :: String -> [BruteForceResult]
+bruteForce ciphertext =
+    [ BruteForceResult shift (decrypt ciphertext shift)
+    | shift <- [1 .. 25]
+    ]
+
+-- | Expected English letter frequencies from A through Z.
+englishFrequencies :: [Double]
+englishFrequencies =
+    [ 0.08167, 0.01492, 0.02782, 0.04253, 0.12702, 0.02228
+    , 0.02015, 0.06094, 0.06966, 0.00153, 0.00772, 0.04025
+    , 0.02406, 0.06749, 0.07507, 0.01929, 0.00095, 0.05987
+    , 0.06327, 0.09056, 0.02758, 0.00978, 0.02360, 0.00150
+    , 0.01974, 0.00074
+    ]
+
+-- | Select the shift whose plaintext has the lowest chi-squared distance
+-- from expected English letter frequencies. With no alphabetic signal the
+-- first candidate, shift 1, is returned.
+frequencyAnalysis :: String -> (Int, String)
+frequencyAnalysis ciphertext =
+    let firstPlaintext = decrypt ciphertext 1
+        first = (1, firstPlaintext, chiSquared firstPlaintext)
+        (bestShift, bestPlaintext, _) = foldl' chooseBetter first candidates
+     in (bestShift, bestPlaintext)
+  where
+    candidates =
+        [ (shift, plaintext, chiSquared plaintext)
+        | shift <- [2 .. 25]
+        , let plaintext = decrypt ciphertext shift
+        ]
+    chooseBetter best@(_, _, bestScore) candidate@(_, _, score)
+        | score < bestScore = candidate
+        | otherwise = best
+
+letterCounts :: String -> [Int]
+letterCounts text =
+    [ length
+        [ ()
+        | char <- text
+        , (isAsciiUpper char || isAsciiLower char)
+        , toUpper char == chr (ord 'A' + index)
+        ]
+    | index <- [0 .. 25]
+    ]
+
+chiSquared :: String -> Double
+chiSquared text
+    | total == 0 = 1 / 0
+    | otherwise = sum (zipWith contribution counts englishFrequencies)
+  where
+    counts = letterCounts text
+    total = sum counts
+    totalDouble = fromIntegral total
+    contribution observed frequency
+        | expected < 1e-10 = 0.0
+        | otherwise = difference * difference / expected
+      where
+        expected = totalDouble * frequency
+        difference = fromIntegral observed - expected

--- a/code/packages/haskell/caesar-cipher/test/CaesarCipherSpec.hs
+++ b/code/packages/haskell/caesar-cipher/test/CaesarCipherSpec.hs
@@ -1,0 +1,82 @@
+module CaesarCipherSpec (spec) where
+
+import CaesarCipher
+import Data.List (maximumBy, minimumBy)
+import Data.Ord (comparing)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "encrypt" $ do
+        it "shifts uppercase and lowercase while preserving case" $ do
+            encrypt "HELLO" 3 `shouldBe` "KHOOR"
+            encrypt "hello" 3 `shouldBe` "khoor"
+            encrypt "Hello, World!" 3 `shouldBe` "Khoor, Zruog!"
+        it "passes non-letters and non-ASCII characters through" $ do
+            encrypt "a-b-c 123!" 1 `shouldBe` "b-c-d 123!"
+            encrypt "caf\x00e9 \x2764" 5 `shouldBe` "hfk\x00e9 \x2764"
+        it "normalizes zero, full, large, and negative shifts" $ do
+            encrypt "The Quick Brown Fox" 0 `shouldBe` "The Quick Brown Fox"
+            encrypt "The Quick Brown Fox" 26 `shouldBe` "The Quick Brown Fox"
+            encrypt "ABC" 52 `shouldBe` "ABC"
+            encrypt "ABC" 29 `shouldBe` "DEF"
+            encrypt "ABC" (-1) `shouldBe` "ZAB"
+            encrypt "ABC" (-27) `shouldBe` "ZAB"
+        it "wraps at the alphabet boundary" $ do
+            encrypt "XYZ" 3 `shouldBe` "ABC"
+            encrypt "xyz" 3 `shouldBe` "abc"
+
+    describe "decrypt" $ do
+        it "inverts the classic example" $
+            decrypt "KHOOR" 3 `shouldBe` "HELLO"
+        it "round-trips every shift from -30 through 30" $ do
+            let original = "Attack at dawn! (meet by the OLD oak, 5pm)"
+            mapM_ (checkRoundTrip original) [-30 .. 30]
+
+    describe "rot13" $ do
+        it "matches known values" $ do
+            rot13 "Hello" `shouldBe` "Uryyb"
+            rot13 "123!" `shouldBe` "123!"
+        it "is its own inverse" $ do
+            let text = "The Quick Brown Fox jumps over 13 lazy dogs."
+            rot13 (rot13 text) `shouldBe` text
+        it "equals encrypt with shift 13" $
+            rot13 "Spoiler: the butler did it." `shouldBe`
+                encrypt "Spoiler: the butler did it." 13
+
+    describe "bruteForce" $ do
+        it "returns all 25 non-trivial shifts in order" $
+            map bruteForceShift (bruteForce "KHOOR") `shouldBe` [1 .. 25]
+        it "contains the correct plaintext" $ do
+            let result = bruteForce "KHOOR" !! 2
+            result `shouldBe` BruteForceResult 3 "HELLO"
+        it "preserves non-alphabetic ciphertext in every candidate" $
+            map bruteForcePlaintext (bruteForce "123!!!") `shouldBe`
+                replicate 25 "123!!!"
+
+    describe "frequencyAnalysis" $ do
+        it "recovers a shift from a pangram" $ do
+            let plaintext = "THE QUICK BROWN FOX JUMPS OVER THE LAZY DOG"
+            frequencyAnalysis (encrypt plaintext 3) `shouldBe` (3, plaintext)
+        it "recovers a shift from longer English text" $ do
+            let plaintext =
+                    "IN CRYPTOGRAPHY A CAESAR CIPHER ALSO KNOWN AS SHIFT CIPHER " ++
+                    "IS ONE OF THE SIMPLEST AND MOST WIDELY KNOWN ENCRYPTION " ++
+                    "TECHNIQUES IT IS A TYPE OF SUBSTITUTION CIPHER"
+            frequencyAnalysis (encrypt plaintext 17) `shouldBe` (17, plaintext)
+        it "defaults to shift one without alphabetic signal" $
+            frequencyAnalysis "12345 !!! ???" `shouldBe` (1, "12345 !!! ???")
+
+    describe "englishFrequencies" $ do
+        it "contains 26 positive entries that sum to approximately one" $ do
+            length englishFrequencies `shouldBe` 26
+            all (> 0.0) englishFrequencies `shouldBe` True
+            abs (sum englishFrequencies - 1.0) `shouldSatisfy` (< 0.01)
+        it "identifies E as most common and Z as least common" $ do
+            maximumBy (comparing snd) (zip [0 :: Int ..] englishFrequencies)
+                `shouldBe` (4, englishFrequencies !! 4)
+            minimumBy (comparing snd) (zip [0 :: Int ..] englishFrequencies)
+                `shouldBe` (25, englishFrequencies !! 25)
+  where
+    checkRoundTrip original shift =
+        decrypt (encrypt original shift) shift `shouldBe` original

--- a/code/packages/haskell/caesar-cipher/test/Spec.hs
+++ b/code/packages/haskell/caesar-cipher/test/Spec.hs
@@ -1,0 +1,5 @@
+import CaesarCipherSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Eighteen package/language slots remain to turn 18 nearly complete packages into
+Seventeen package/language slots remain to turn 17 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,16 +145,15 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 6 remaining ports
+### Haskell: 5 remaining ports
 
-- `caesar-cipher`
 - `huffman-compression`
 - `huffman-tree`
 - `lz77`
 - `lzss`
 - `lzw`
 
-Completed in the Haskell lane: `activation-functions`.
+Completed in the Haskell lane: `activation-functions`, `caesar-cipher`.
 
 ### Swift: 3 ports
 


### PR DESCRIPTION
## Summary

- add a pure Haskell Caesar cipher package with encryption, decryption, and ROT13
- add brute-force enumeration and chi-squared English frequency analysis
- add 17 Hspec examples covering normalization, Unicode pass-through, round trips, classical attacks, and frequency data
- update the package-parity roadmap from 18 to 17 remaining Priority 1 slots

## Validation

- `cabal test all --test-show-details=direct` (17 examples, 0 failures)
- `cabal check` (no errors or warnings)
- `python -m unittest scripts.tests.test_package_parity_report` (6 tests)
- `python scripts/package_parity_report.py --format json --fail-on-collisions`
- scoped CI planner: only `haskell/caesar-cipher` affected and only Haskell required
- `git diff --check`