### PR TITLE
feat(sir-runtime-oop): Array#cycle(n) block method (Python reference)

### DIFF
--- a/code/packages/python/sir-runtime-oop/CHANGELOG.md
+++ b/code/packages/python/sir-runtime-oop/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `coding-adventures-sir-runtime-oop` are documented here.
 
+## [0.1.26] - 2026-07-12
+
+### Added
+
+- **`Array#cycle(n)`** — the block-taking Array method that iterates the array
+  `n` full passes in order, yielding each element on every pass, and always
+  returns nil (`[1,2,3].cycle(2) { |x| … }` yields `1,2,3,1,2,3`). A count of
+  `0`, a negative count, or an empty receiver yields nothing; a non-integer /
+  nil count (including the block-less and infinite no-`n` Enumerator forms) is a
+  documented v0 boundary that yields nothing rather than hanging. This is the
+  Python **reference** for the new cross-backend cascade (Go/Rust/JS/TS mirrors
+  to follow). `respond_to?("cycle")` reports `true`.
+
 ## [0.1.25] - 2026-07-11
 
 ### Added

--- a/code/packages/python/sir-runtime-oop/README.md
+++ b/code/packages/python/sir-runtime-oop/README.md
@@ -72,7 +72,7 @@ flow-control** group `send`/`__send__`/`public_send`, `tap`, `then`/`yield_self`
 (item **M6**); and (item **M1b**)
 **block-taking `Array`/`Enumerable`** methods `each`, `each_with_index`,
 `map`/`collect`, `select`/`filter`, `reject`, `reduce`/`inject`, `find`/`detect`,
-`flat_map`, `any?`/`all?`/`none?`, `chunk_while`/`slice_when` — a trailing `Closure` block is applied via
+`flat_map`, `any?`/`all?`/`none?`, `chunk_while`/`slice_when`, `cycle` — a trailing `Closure` block is applied via
 `sir-runtime-core`'s `apply` (proc-lenient), predicates routed through SIR
 `truthy`; (item **M1c**) the **`Hash`** catalog
 (`keys`/`values`/`has_key?`/`fetch`/`merge`/`each`/`map`/`select`/`transform_values`/`transform_keys`/`to_h`/`each_with_index`/`each_with_object`/ Enumerable aggregates `find`/`any?`/`all?`/`none?`/`count`/`sort_by`/`min_by`/`max_by`/`group_by`/`partition`/`flat_map`/`reduce`/`sum`/…);

--- a/code/packages/python/sir-runtime-oop/pyproject.toml
+++ b/code/packages/python/sir-runtime-oop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coding-adventures-sir-runtime-oop"
-version = "0.1.25"
+version = "0.1.26"
 description = "OOP runtime for Semantic-IR-emitted Python — class registry, is_a?/ancestry, instance- and class-variable stores, reflective method dispatch"
 requires-python = ">=3.12"
 dependencies = [

--- a/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
+++ b/code/packages/python/sir-runtime-oop/src/coding_adventures_sir_runtime_oop/oop.py
@@ -615,6 +615,7 @@ _ARRAY_BLOCK_METHODS = frozenset(
         "each_with_object",
         "chunk_while",
         "slice_when",
+        "cycle",
     }
 )
 
@@ -1225,6 +1226,27 @@ def _array_block_method(recv: list[Val], name: str, args: list[Val], block: Clos
             else:
                 slices[-1].append(cur)
         return slices
+    if name == "cycle":
+        # ``cycle(n) { |x| … }`` — iterate the array ``n`` full passes in order,
+        # yielding each element on every pass.  ``n <= 0`` (or a nil / non-integer
+        # count) yields nothing.  Always returns nil.
+        #
+        #   ``[1, 2, 3].cycle(2) { |x| out << x }``  →  out == [1, 2, 3, 1, 2, 3]
+        #   ``[1, 2, 3].cycle(0) { … }``             →  no yields, returns nil
+        #   ``[].cycle(5) { … }``                    →  no yields (empty run body)
+        #
+        # Ruby's block-less ``cycle`` (an Enumerator) and its infinite no-``n``
+        # form (which never returns) are documented v0 boundaries: we require a
+        # block and a finite non-negative count, so emitted programs can never
+        # hang.  A truthy/``bool`` count is rejected too — ``True`` is an ``int``
+        # in Python, and a boolean cycle count is a type error in Ruby.
+        n = args[0] if args else None
+        if isinstance(n, bool) or not isinstance(n, int) or n <= 0:
+            return None
+        for _ in range(n):
+            for item in recv:
+                apply(block, [item])
+        return None
     return _MISS
 
 

--- a/code/packages/python/sir-runtime-oop/tests/test_oop.py
+++ b/code/packages/python/sir-runtime-oop/tests/test_oop.py
@@ -309,6 +309,35 @@ def test_array_slice_when() -> None:
     assert oop.call_method([1], "respond_to?", "slice_when") is True
 
 
+def test_array_cycle() -> None:
+    # `cycle(n) { |x| … }` iterates the array n full passes in order, yielding
+    # each element on every pass; it always returns nil.
+    seen: list[int] = []
+    assert (
+        oop.call_method([1, 2, 3], "cycle", 2, Closure(lambda x: seen.append(x)))
+        is None
+    )
+    assert seen == [1, 2, 3, 1, 2, 3]
+    # A single pass is just the array in order.
+    once: list[int] = []
+    oop.call_method([7, 8], "cycle", 1, Closure(lambda x: once.append(x)))
+    assert once == [7, 8]
+    # n <= 0 yields nothing (and still returns nil).
+    zero: list[int] = []
+    assert oop.call_method([1, 2], "cycle", 0, Closure(lambda x: zero.append(x))) is None
+    assert zero == []
+    neg: list[int] = []
+    oop.call_method([1, 2], "cycle", -3, Closure(lambda x: neg.append(x)))
+    assert neg == []
+    # An empty receiver yields nothing no matter how many passes are requested.
+    empty: list[int] = []
+    oop.call_method([], "cycle", 5, Closure(lambda x: empty.append(x)))
+    assert empty == []
+    # respond_to? advertises it; a still-uncatalogued method reports False.
+    assert oop.call_method([1], "respond_to?", "cycle") is True
+    assert oop.call_method([1], "respond_to?", "combination") is False
+
+
 def test_array_mutating_push_pop_shift_unshift() -> None:
     a = [1, 2]
     assert oop.call_method(a, "push", 3) == [1, 2, 3]


### PR DESCRIPTION
## Summary

Adds **`Array#cycle(n) { |x| … }`** to the imported Python OOP runtime (`sir-runtime-oop`): iterate the array `n` full passes in order, yielding each element on every pass, and always return nil. This is the **Python reference** kicking off a new cross-backend cascade — Go → Rust → JS → TS mirrors follow, one PR each.

## Semantics

- `n` full passes: `[1,2,3].cycle(2) { … }` yields `1,2,3,1,2,3`.
- `n <= 0`, a negative count, or an empty receiver yields nothing.
- A nil / non-integer count — including Ruby's block-less Enumerator form and the **infinite no-`n` form** — is a documented v0 boundary: it yields nothing rather than hanging, so emitted programs can never spin forever. A `bool` count is rejected too (Python's `True`/`1` int trap).
- Always returns nil.

## Changes

- `oop.py`: `cycle` arm in `_array_block_method` + `"cycle"` in `_ARRAY_BLOCK_METHODS`.
- `test_oop.py`: `test_array_cycle` — multi-pass, single-pass, zero, negative, empty receiver, `respond_to?` (negative example uses the still-uncatalogued `combination`).

## Verification

- `ruff check` clean.
- **131 pytest pass, 97% coverage**.
- Security review passed (no vulnerabilities; the finite-count guard eliminates the only real DoS hazard — the runtime being coerced into an unbounded loop it didn't author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)