### PR TITLE
feat(apl-to-semantic-ir): APL → Semantic IR frontend (MA-4f, v0.1.0)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -245,6 +245,7 @@ members = [
     "apl-parser",
     "apl-runtime",
     "apl-repl",
+    "apl-to-semantic-ir",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/apl-to-semantic-ir/BUILD
+++ b/code/packages/rust/apl-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p apl-to-semantic-ir -- --nocapture

--- a/code/packages/rust/apl-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/apl-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p apl-to-semantic-ir -- --nocapture

--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## [0.1.0] - 2026-07-12
+
+### Added
+
+- Initial `apl-to-semantic-ir` frontend crate (MA-4f, per
+  [HML01](../../../specs/HML01-math-to-semantic-ir.md) §2/§5) — the last
+  remaining APL rollout item, and the first frontend to consume the SIR22
+  addendum (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+  `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`, plus the `Max`/`Min`/`Eq`/
+  `Ne`/`Lt`/`Le`/`Ge`/`Gt` `ElementwiseOpKind` variants) that `semantic-ir`
+  shipped specifically for APL ahead of this crate landing.
+- `compile`/`compile_source` lowering `coding-adventures-apl-parser`'s
+  `GrammarASTNode` CST into a `semantic_ir::Module`.
+- Supported: number literals (int/float, high-minus `¯` negative sign),
+  stranded literals (`1 2 3` → a single rank-1 `ArrayLit`), variables,
+  parenthesised grouping; assignment including right-associative chained
+  assignment (`A←B←3`, unrolled into dependency-ordered statements); all 12
+  scalar dyadic atoms (`+ - × ÷ ⌈ ⌊ = ≠ < ≤ ≥ >`), unconditionally lowered to
+  `ElementwiseOp` (no scalar-vs-array disambiguation needed — a genuine
+  simplification over `matlab-to-semantic-ir`, since none of APL's atoms
+  have a non-elementwise reading); the 6 atoms with a monadic meaning (`+ -
+  × ÷ ⌈ ⌊`), mapped onto `"neg"`/`"sign"`/`"recip"`/`"ceil"`/`"floor"`
+  builtins (`+` is a pass-through no-op — no complex numbers in this cut);
+  `⍴`/`⍳`/`,` (shape-reshape, index-generator-index-of, ravel-catenate),
+  monadic and dyadic; `/` (reduce) and `\` (scan), monadic-only; `∘.` (outer
+  product), dyadic-only; auto-print of a bare top-level value expression
+  onto the shared `"print"` builtin (APL's own real language semantic per
+  MA05 §4, unlike MATLAB's `;`-suppression convention).
+- Explicit, disclosed rejections (each a clean `AplLowerError`, never
+  silently mis-lowered): the 6 comparison atoms used monadically (no
+  monadic meaning in APL); a reduce/scan-decorated function used dyadically
+  (both are inherently monadic); an outer-product-decorated function used
+  monadically (inherently dyadic); `⍴`/`⍳`/`,` decorated with an operator
+  (not scalar dyadic functions). Constructs the grammar itself cannot
+  produce (boxing, the rank conjunction, user-defined functions, control
+  flow) need no explicit rejection code.
+- 44 tests: 41 unit tests in `tests/test_lower.rs` covering every dyadic
+  atom individually, every monadic atom (valid and rejected), reduce/scan
+  (valid + rejected arity), outer product (valid + rejected arity),
+  `⍴`/`⍳`/`,` (monadic and dyadic, plus operator-decoration rejection),
+  stranded literals, high-minus literals, chained assignment,
+  first-occurrence-vs-reassignment, parenthesised grouping, undefined-
+  variable rejection, parse-error propagation, and a full multi-line
+  program that validates cleanly via `semantic_ir::validate`; 3 tests in
+  `tests/test_validator.rs` mirroring `matlab-to-semantic-ir`'s own
+  capability-rejection pattern (`semantic-ir-to-javascript` correctly
+  rejects any module using SIR22/SIR22-addendum nodes, which is nearly
+  every APL program).
+- No `tests/e2e_node.rs`: unlike MATLAB, APL has no literal-only escape
+  hatch from the array domain (every dyadic scalar op is unconditionally an
+  `ElementwiseOp`), so a real round-trip through a backend needs
+  `sir-runtime-array`'s SIR22 codegen, which does not exist yet (tracked
+  separately, HML01 §4).
+- Marks MA-4f done in `MA05-apl-language.md` §6, with a design-notes
+  writeup mirroring MA-4d/MA-4e's own style.

--- a/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/apl-to-semantic-ir/CHANGELOG.md
@@ -36,7 +36,7 @@
   (not scalar dyadic functions). Constructs the grammar itself cannot
   produce (boxing, the rank conjunction, user-defined functions, control
   flow) need no explicit rejection code.
-- 44 tests: 41 unit tests in `tests/test_lower.rs` covering every dyadic
+- 44 tests: 40 unit tests in `tests/test_lower.rs` covering every dyadic
   atom individually, every monadic atom (valid and rejected), reduce/scan
   (valid + rejected arity), outer product (valid + rejected arity),
   `⍴`/`⍳`/`,` (monadic and dyadic, plus operator-decoration rejection),

--- a/code/packages/rust/apl-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/apl-to-semantic-ir/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "apl-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "APL CST → narrow-waist Semantic IR (SIR22 + SIR22 addendum array/matrix domain). MA-4f, the last APL rollout item per HML01."
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+coding-adventures-apl-parser = { path = "../apl-parser" }
+# The parser emits a generic `parser::grammar_parser::GrammarASTNode` whose
+# leaf tokens are `lexer::token::Token`; we walk both directly. Note this
+# crate deliberately does NOT depend on `coding-adventures-apl-runtime` --
+# lowering only needs the parse tree shape (`apl-parser`), not the tree-
+# walking evaluator.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }
+
+[dev-dependencies]
+# Every lowered module uses at least one SIR22/SIR22-addendum node (there is
+# no purely-scalar-literal escape hatch the way matlab-to-semantic-ir has,
+# since even `3+4` is an `ElementwiseOp` here -- see `src/lower.rs`'s module
+# doc comment, point 1). No backend implements codegen for these nodes yet
+# (`sir-runtime-array`'s SIR22 codegen is separate, not-yet-shipped
+# follow-on work per HML01 §4), so this dev-dependency exists solely to
+# verify the *capability-rejection* path: a real `Module`, checked through
+# the actual `Backend::check_module`, mirroring the same verification
+# pattern `matlab-to-semantic-ir`'s own `tests/test_validator.rs` uses.
+semantic-ir-to-javascript = { path = "../semantic-ir-to-javascript" }

--- a/code/packages/rust/apl-to-semantic-ir/README.md
+++ b/code/packages/rust/apl-to-semantic-ir/README.md
@@ -1,0 +1,121 @@
+# apl-to-semantic-ir
+
+APL CST → narrow-waist Semantic IR. Task **MA-4f** — the last remaining
+rollout item for APL (see
+[MA05](../../../specs/MA05-apl-language.md) §5/§6) — and the first frontend
+to actually *consume* the SIR22 addendum
+(`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/
+`Ravel`/`Catenate`) that [semantic-ir](../semantic-ir) shipped specifically
+for APL ahead of this crate landing.
+
+## Where this fits
+
+```
+APL source
+   │
+   ▼  coding_adventures_apl_parser::try_parse_apl(src)
+parser::grammar_parser::GrammarASTNode   (generic CST)
+   │
+   ▼  apl_to_semantic_ir::compile
+semantic_ir::Module                      (per SIR10 + SIR22 + SIR22 addendum)
+```
+
+The lowered `Module` can then be validated (`semantic_ir::validate`) and
+handed to any SIR backend — "write the APL frontend once, target every SIR
+backend" is the whole point of this narrow-waist design. This crate depends
+only on `coding-adventures-apl-parser` (the CST), **not**
+`coding-adventures-apl-runtime` (the tree-walking evaluator) — lowering only
+needs the parse-tree shape.
+
+## Usage
+
+```rust
+use apl_to_semantic_ir::compile_source;
+
+let module = compile_source("A←3+4\n", "demo")?;
+```
+
+## Scope (v0.1.0)
+
+APL's grammar (per MA05 §4, as already implemented by `apl-parser`/
+`apl-runtime`) has **no control flow and no user-defined functions** in this
+cut — just straight-line assignment and value expressions. That makes this
+frontend simpler than `matlab-to-semantic-ir` in two concrete ways:
+
+1. **No scalar/array disambiguation.** Every one of APL's 12 scalar dyadic
+   atoms (`+ - × ÷ ⌈ ⌊ = ≠ < ≤ ≥ >`) lowers *unconditionally* to
+   `Expr::ElementwiseOp` — none of them has a non-elementwise reading the way
+   MATLAB's `*` does, so there is no `expr_is_known_scalar`-style heuristic
+   to write at all. `3+4` and `A+B` produce the exact same node shape.
+2. **A single `main` function.** There are no separate named functions to
+   collect in a first pass; the whole program lowers into one `main`.
+
+See `src/lower.rs`'s module doc comment for the exact per-construct lowering
+table, the chained-assignment (`A←B←3`) unrolling design, the auto-print
+convention (APL's bare `value_expr` auto-prints — a real language semantic
+per MA05 §4, not a REPL nicety), and the handful of deliberately-rejected
+constructs:
+
+- The 6 comparison atoms (`= ≠ < ≤ ≥ >`) used monadically — no monadic
+  meaning in APL.
+- A reduce/scan-decorated `function_expr` used dyadically (`3+/4`) — both
+  are inherently monadic.
+- An outer-product-decorated `function_expr` used monadically (`∘.×1`) —
+  outer product is inherently dyadic.
+- `⍴`/`⍳`/`,` decorated with `/`/`\`/`∘.` — these three primitives are not
+  "scalar dyadic functions" the way the other 12 atoms are.
+
+Each of the above is syntactically constructible by `apl-parser`'s grammar
+but semantically invalid, and gets a clean `AplLowerError` rather than a
+silent misinterpretation or a panic — mirroring
+`apl-runtime::eval`'s identical set of runtime rejections, just caught at
+lowering time instead of evaluation time.
+
+Boxing/nested arrays, the rank conjunction, user-defined functions, and
+control flow are **not** rejection-tested here because `apl-parser`'s
+grammar cannot produce them at all — there is no CST shape for this lowerer
+to ever reach.
+
+## Well-known `BuiltinCall` names introduced here
+
+`+` (conjugate) is the one monadic case that needs no wrapper at all — it is
+a genuine no-op since this cut has no complex numbers, so the operand passes
+through unchanged. The other five monadic scalar atoms map onto
+`Expr::BuiltinCall`:
+
+| Atom | Meaning     | Builtin name |
+|------|-------------|--------------|
+| `-`  | negate      | `"neg"` (reused from `matlab-to-semantic-ir`) |
+| `×`  | sign        | `"sign"` (new) |
+| `÷`  | reciprocal  | `"recip"` (new) |
+| `⌈`  | ceiling     | `"ceil"` (new) |
+| `⌊`  | floor       | `"floor"` (new) |
+
+A bare top-level value expression is wrapped in `BuiltinCall("print", ...)`,
+reusing the exact name `matlab-to-semantic-ir` maps its own `disp(x)` call
+onto.
+
+### Testing
+
+- `tests/test_lower.rs` — unit tests over every dyadic atom (all 12), every
+  monadic atom (6 valid + 6 rejected), reduce/scan (valid monadic use +
+  rejected dyadic use), outer product (valid dyadic use + rejected monadic
+  use), `⍴`/`⍳`/`,` (both monadic and dyadic forms, plus rejection when
+  decorated with an operator), stranded literals, high-minus negative
+  literals, chained assignment, first-occurrence-vs-reassignment,
+  parenthesised grouping, undefined-variable rejection, parse-error
+  propagation, and a full multi-line program that validates cleanly via
+  `semantic_ir::validate`.
+- `tests/test_validator.rs` — mirrors `matlab-to-semantic-ir`'s own
+  capability-rejection pattern: every lowered module validates, and
+  `semantic-ir-to-javascript` (which does not implement SIR22/SIR22-addendum
+  codegen yet) correctly *rejects* any module using those nodes — which, for
+  APL, is nearly every program (see the "No scalar/array disambiguation"
+  point above: even `3+4` is an `ElementwiseOp`).
+- **No `tests/e2e_node.rs`.** Unlike MATLAB (whose purely-literal arithmetic
+  subset avoids the array domain entirely), APL's *every* dyadic scalar
+  operation is unconditionally `Expr::ElementwiseOp` — there is no
+  literal-only escape hatch. A genuine round-trip through a real backend
+  therefore needs `sir-runtime-array`'s SIR22 codegen, which does not exist
+  yet (tracked separately per HML01 §4) — an e2e-through-`node` test isn't
+  possible for this crate today.

--- a/code/packages/rust/apl-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/apl-to-semantic-ir/src/lib.rs
@@ -1,0 +1,79 @@
+//! # apl-to-semantic-ir
+//!
+//! APL CST → narrow-waist Semantic IR, **v0.1.0** — task **MA-4f**, the last
+//! remaining rollout item for APL (see
+//! [`MA05`](../../../specs/MA05-apl-language.md) §5/§6 and
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)'s standing
+//! convention that every math-language frontend also emits SIR from day
+//! one).
+//!
+//! This is the first frontend to actually *consume* the SIR22 addendum
+//! (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/
+//! `IndexOf`/`Ravel`/`Catenate`, plus the `Max`/`Min`/`Eq`/`Ne`/`Lt`/`Le`/
+//! `Ge`/`Gt` `ElementwiseOpKind` variants) that `semantic-ir` shipped
+//! specifically for APL ahead of this crate landing — see that addendum's
+//! own doc comment in `semantic-ir/src/nodes.rs`. It walks the
+//! [`parser::grammar_parser::GrammarASTNode`] CST produced by
+//! `coding-adventures-apl-parser` and emits a [`semantic_ir::Module`].
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! APL source
+//!    │
+//!    ▼  coding_adventures_apl_parser::try_parse_apl(src)
+//! parser::grammar_parser::GrammarASTNode   (generic CST)
+//!    │
+//!    ▼  apl_to_semantic_ir::compile
+//! semantic_ir::Module                      (per SIR10 + SIR22 + SIR22 addendum)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use apl_to_semantic_ir::compile_source;
+//! let module = compile_source("A←3+4\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+//!
+//! ## Scope (v0.1.0)
+//!
+//! APL's grammar (per MA05 §4, as implemented by `apl-parser`/`apl-runtime`)
+//! has **no control flow and no user-defined functions** in this cut — just
+//! straight-line assignment and value expressions. That makes this frontend
+//! genuinely simpler than `matlab-to-semantic-ir` in two concrete ways:
+//!
+//! 1. Every one of APL's 12 scalar dyadic atoms (`+ - × ÷ ⌈ ⌊ = ≠ < ≤ ≥ >`)
+//!    lowers **unconditionally** to [`semantic_ir::Expr::ElementwiseOp`] —
+//!    there is no MATLAB-`*`-style non-elementwise alternate reading to
+//!    disambiguate, so this frontend has no scalar-vs-array heuristic to
+//!    write at all (contrast `matlab-to-semantic-ir`'s `expr_is_known_scalar`).
+//! 2. The whole program lowers into a single `main` [`semantic_ir::Function`]
+//!    — there are no separate named functions to collect in a first pass the
+//!    way MATLAB's `func_def`s require.
+//!
+//! See `lower.rs`'s module doc comment for the exact per-construct lowering
+//! table, the chained-assignment unrolling design, the auto-print
+//! convention, and the handful of deliberately-rejected constructs (reduce/
+//! scan used dyadically, outer product used monadically, `⍴`/`⍳`/`,`
+//! decorated with an operator) — each is syntactically constructible by the
+//! grammar but semantically invalid, and gets a clean [`AplLowerError`]
+//! rather than a silent misinterpretation.
+
+mod lower;
+pub use lower::{compile, AplLowerError};
+
+/// Parse `source` as APL and lower it into a [`semantic_ir::Module`] in one
+/// step, mirroring every other `-to-semantic-ir` frontend's `compile_source`
+/// convenience wrapper.
+pub fn compile_source(
+    source: &str,
+    module_name: &str,
+) -> Result<semantic_ir::Module, AplLowerError> {
+    let tree = coding_adventures_apl_parser::try_parse_apl(source).map_err(|msg| AplLowerError {
+        message: format!("parse error: {msg}"),
+        line: 1,
+        column: 1,
+    })?;
+    compile(&tree, module_name)
+}

--- a/code/packages/rust/apl-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/src/lower.rs
@@ -1,0 +1,917 @@
+//! The lowering pass from `coding_adventures_apl_parser`'s generic
+//! [`GrammarASTNode`] CST → [`semantic_ir::Module`], **v0.1.0**.
+//!
+//! # APL's CST shape (a quick refresher, confirmed against `apl-parser`'s
+//! own grammar and the tree-walk `apl-runtime::eval` already does over it)
+//!
+//! ```text
+//! program    = { line }
+//! line       = [ statement ]           -- no `statement` child: blank/comment line, skip
+//! statement  = assignment              -- pure passthrough, always 1 child
+//! assignment = NAME ARROW assignment   -- 3 children: chained/actual assignment
+//!            | value_expr              -- 1 child: base case
+//! value_expr = term                                    -- 1 child: bare term
+//!            | function_expr value_expr                -- 2 children: monadic
+//!            | term function_expr value_expr           -- 3 children: dyadic (right-recursive)
+//! term       = NUMBER { NUMBER }        -- 1+ stranded numbers (1 = scalar, 2+ = vector)
+//!            | NAME
+//!            | LPAREN value_expr RPAREN
+//! function_expr  = function_atom [ REDUCE | SCAN ]   -- operator trails the atom
+//!                | OUTER function_atom               -- operator precedes the atom
+//! function_atom  = one of the 15 primitive glyph tokens
+//! ```
+//!
+//! # Scope
+//!
+//! **Supported** (every construct `apl-parser`'s grammar can produce):
+//! - Number literals (`NUMBER`, high-minus `¯` negative sign), stranded
+//!   literals (`1 2 3` → one rank-1 [`Expr::ArrayLit`]), variables (`NAME`),
+//!   parenthesised grouping.
+//! - Assignment (`←`), including right-associative chained assignment
+//!   (`A←B←3`) — see "Chained assignment" below.
+//! - All 12 scalar dyadic atoms (`+ - × ÷ ⌈ ⌊ = ≠ < ≤ ≥ >`), unconditionally
+//!   lowered to [`Expr::ElementwiseOp`] — see "No scalar/array
+//!   disambiguation" below.
+//! - The 6 scalar atoms that have a monadic meaning (`+ - × ÷ ⌈ ⌊`), each
+//!   mapped onto a well-known [`Expr::BuiltinCall`] name (or, for `+`, no
+//!   wrapping at all — see point 2 in this file's PR description / the
+//!   `apply_monadic_scalar` doc comment).
+//! - `⍴`/`⍳`/`,` (shape-reshape, index-generator-index-of,
+//!   ravel-catenate), monadic and dyadic.
+//! - `/` (reduce) and `\` (scan), monadic-only, over any of the 12 scalar
+//!   atoms.
+//! - `∘.` (outer product), dyadic-only, over any of the 12 scalar atoms.
+//! - Auto-print of a bare top-level value expression (mapped onto the same
+//!   `"print"` [`Expr::BuiltinCall`] every SIR backend already implements).
+//!
+//! **Deliberately rejected** with a clean [`AplLowerError`] (each is
+//! syntactically constructible by `apl-parser`'s grammar but semantically
+//! invalid — the grammar alone cannot rule these out, exactly as
+//! `apl-runtime::eval`'s own evaluator discovers at *runtime*, and this
+//! frontend discovers at *lowering time* instead):
+//! - The 6 comparison atoms (`= ≠ < ≤ ≥ >`) used monadically — they have no
+//!   monadic meaning in APL (see `apply_monadic_scalar`).
+//! - A reduce- or scan-decorated `function_expr` used dyadically (`3+/4`) —
+//!   both operators are inherently monadic (`+/A` takes exactly one
+//!   operand).
+//! - An outer-product-decorated `function_expr` used monadically (`∘.×1`) —
+//!   outer product is inherently dyadic (`A∘.×B` needs both operands).
+//! - `⍴`/`⍳`/`,` decorated with `/`/`\`/`∘.` (e.g. `⍴/A`) — these three
+//!   primitives are not "scalar dyadic functions" the way the other 12
+//!   atoms are, so stacking an operator on one of them is rejected, mirroring
+//!   `apl-runtime::eval::require_scalar_binop`'s identical restriction.
+//!
+//! **Not applicable** (the grammar `apl-parser` compiles literally cannot
+//! produce these — boxing/nested arrays, the rank conjunction,
+//! user-defined functions/dfns, control flow — so there is no rejection
+//! code to write for them; they simply have no CST shape to reach this
+//! lowerer at all).
+//!
+//! # No scalar/array disambiguation (unlike `matlab-to-semantic-ir`)
+//!
+//! MATLAB's `matlab-to-semantic-ir` frontend has to guess, per operator use,
+//! whether `*`/`/`/`\` mean scalar arithmetic or a matrix operation (`*` is
+//! matrix multiply between two non-scalars, elementwise between two provable
+//! scalars) — that guess is the entire reason `expr_is_known_scalar` exists
+//! in that crate. **None of APL's 12 scalar dyadic atoms have a second,
+//! non-elementwise reading** — `+ - × ÷ ⌈ ⌊ = ≠ < ≤ ≥ >` are always
+//! elementwise/broadcast, full stop, whether the operands are two scalars or
+//! two arrays (this mirrors `array_runtime::BinOp`'s own single meaning per
+//! variant, and `apl-runtime::eval::AplFn::Atom`'s own doc comment making the
+//! same point). So `3+4` lowers to the *exact same* node shape as `A+B`:
+//! `Expr::ElementwiseOp { op: Add, lhs: IntLit(3), rhs: IntLit(4), .. }` —
+//! there is deliberately no "fold two known-scalar literals into a bare
+//! `BuiltinCall`" optimisation here the way MATLAB's frontend has. This is a
+//! genuine simplification, not a missed optimisation: writing one would only
+//! reintroduce, for zero semantic benefit, the exact kind of syntactic
+//! scalar-provability heuristic APL's own semantics make unnecessary.
+//!
+//! # Chained assignment (`A←B←3`)
+//!
+//! `assignment`'s right-recursive `NAME ARROW assignment` production means
+//! `A←B←3` parses as `A ← (B ← 3)`, one CST node nested inside another. This
+//! lowerer's [`Lowerer::lower_assignment_chain`] mirrors that recursive
+//! shape: it lowers the *inner* `assignment` first (producing the
+//! statements it emits, plus an `Expr` for "the value that was just bound"),
+//! then appends **one more** statement binding the outer `NAME` to that same
+//! value. Two design points worth spelling out:
+//!
+//! - The value threaded back up is a [`Expr::VarRef`] to the name **just
+//!   bound**, not a re-lowered copy of the RHS expression tree. For
+//!   `A←B←3`, `A` receives a `VarRef("B")`, not a duplicated `IntLit(3)`.
+//!   This avoids re-lowering (and potentially duplicating, in the emitted
+//!   IR, a large) sub-expression tree, and is observationally identical
+//!   here since this cut has no side-effecting expressions between the two
+//!   assignments (`apl-runtime::eval::eval_assignment` — the reference
+//!   evaluator — does something equivalent at the *value* level: it inserts
+//!   into `self.vars` and returns the same `Array` clone up the recursion).
+//! - Statements come out in the CORRECT dependency order despite the
+//!   recursion going "outer calls inner first": `lower_assignment_chain`
+//!   only appends the outer binding's own statement **after** the
+//!   recursive call to the inner one returns, so for `A←B←3` the emitted
+//!   sequence is `[LetStarBinding(B, 3), LetStarBinding(A, VarRef(B))]` —
+//!   `B` is always bound before anything references it.
+//!
+//! # Auto-print, not MATLAB-style suppression
+//!
+//! A bare top-level `value_expr` (an `assignment` node that never reaches
+//! the `NAME ARROW …` production) is wrapped in
+//! `Expr::BuiltinCall { name: "print", .. }` — reusing the *exact* builtin
+//! name `matlab-to-semantic-ir` already maps its own `disp(x)` call onto, so
+//! every backend that already implements `"print"` needs no APL-specific
+//! change. This is a deliberately different design decision from MATLAB's
+//! own frontend, which does not model `;`-suppression as a language
+//! semantic at all (MATLAB scripts have no auto-print concept to preserve).
+//! APL's auto-print, by contrast, *is* a real language semantic (MA05 §4:
+//! "assignment is silent, a bare value_expr result auto-prints" — the same
+//! rule `apl-runtime::eval::run`'s own doc comment states), so this frontend
+//! models it explicitly rather than leaving it as a REPL nicety the IR
+//! doesn't know about.
+
+use std::collections::HashSet;
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use semantic_ir::{
+    Block, EffectSet, ElementwiseOpKind, Expr, Feature, FeatureManifest, Function, Metadata,
+    Module, Scope, Span, Stmt,
+};
+
+/// Maximum expression-nesting depth. Mirrors every other SIR frontend's
+/// identically-named, identically-justified guard ("defense in depth,
+/// exactly like every other runtime crate in this repo" —
+/// `apl-runtime::eval::MAX_DEPTH`'s own doc comment states the same
+/// rationale): `apl-parser`'s own `MAX_RULE_DEPTH` (100) already bounds how
+/// deep a CST built from untrusted source can possibly be, so this bound can
+/// never actually trip on a tree that came from `try_parse_apl` — it exists
+/// purely so a *hand-built* `GrammarASTNode` (or a future change to
+/// `apl-parser`'s own cap) can't turn a deep-but-technically-parseable input
+/// into an uncatchable native stack overflow while walking it here. This
+/// cut has no blocks or control-flow constructs at all (MA05 §4), so unlike
+/// `matlab-to-semantic-ir` there is no separate `MAX_BLOCK_DEPTH` to define.
+const MAX_EXPR_DEPTH: usize = 256;
+
+/// Synthetic file name used for all spans (the CST does not carry the
+/// original path).
+const FILE: &str = "<apl>";
+
+// ---------------------------------------------------------------------------
+// Public error type
+// ---------------------------------------------------------------------------
+
+/// An error encountered during APL → SIR lowering.
+///
+/// Mirrors `MatlabLowerError`/`WolframLowerError`'s shape exactly (a
+/// `message` plus 1-based `line`/`column`) so tooling can treat every SIR
+/// frontend uniformly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AplLowerError {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl std::fmt::Display for AplLowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "AplLowerError at {}:{}: {}",
+            self.line, self.column, self.message
+        )
+    }
+}
+
+impl std::error::Error for AplLowerError {}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Lower a parsed APL CST (rooted at the `program` rule) into a SIR module.
+pub fn compile(tree: &GrammarASTNode, module_name: &str) -> Result<Module, AplLowerError> {
+    Lowerer::new(module_name).lower_file(tree)
+}
+
+// ---------------------------------------------------------------------------
+// Function-expression representation
+// ---------------------------------------------------------------------------
+
+/// A glyph naming one of `apl.tokens`' three "bespoke" primitives, kept
+/// around so error messages can name the actual glyph (`"⍴"`, not `"RHO"`) —
+/// mirrors `apl-runtime::eval::NonScalarAtom` exactly.
+#[derive(Clone, Copy)]
+enum NonScalarAtom {
+    Rho,
+    Iota,
+    Ravel,
+}
+
+impl NonScalarAtom {
+    fn glyph(self) -> &'static str {
+        match self {
+            NonScalarAtom::Rho => "⍴",
+            NonScalarAtom::Iota => "⍳",
+            NonScalarAtom::Ravel => ",",
+        }
+    }
+}
+
+/// This lowerer's own representation of a `function_expr`: "which function,
+/// and with which operator (if any) applied" — mirrors
+/// `apl-runtime::eval::AplFn` exactly (that crate's evaluator and this
+/// crate's lowerer both dispatch on the identical CST shape, so it is not a
+/// coincidence the two enums line up one-for-one).
+enum FnKind {
+    /// One of the 12 atoms that map onto [`ElementwiseOpKind`] (`+ - × ÷ ⌈ ⌊
+    /// = ≠ < ≤ ≥ >`). There is exactly one glyph per `ElementwiseOpKind`
+    /// variant this frontend ever constructs, so the kind alone is enough to
+    /// recover which glyph this was for monadic dispatch.
+    Atom(ElementwiseOpKind),
+    /// `⍴`/`⍳`/`,` — bespoke monadic+dyadic logic that does not fit "an
+    /// operator over a scalar dyadic function" at all, so it never plugs
+    /// into reduce/scan/outer-product.
+    NonScalar(NonScalarAtom),
+    /// An atom decorated with `/` (reduce) — inherently monadic.
+    Reduce(ElementwiseOpKind),
+    /// An atom decorated with `\` (scan) — inherently monadic.
+    Scan(ElementwiseOpKind),
+    /// An atom decorated with `∘.` (outer product) — inherently dyadic.
+    Outer(ElementwiseOpKind),
+}
+
+// ---------------------------------------------------------------------------
+// The lowerer
+// ---------------------------------------------------------------------------
+
+/// APL scopes every variable to the *whole program* (there are no blocks,
+/// loops, or functions in this cut — MA05 §4) — so, unlike
+/// `matlab-to-semantic-ir`'s per-function `FunctionCtx`, this lowerer needs
+/// only ONE flat set of bound names for its entire lifetime, never rewound.
+struct Lowerer {
+    module_name: String,
+    /// Features observed while lowering, used to build the manifest so it
+    /// declares *exactly* what the module emits.
+    observed: FeatureManifest,
+    /// Every name assigned so far, in program order. Used to decide
+    /// first-occurrence (`LetStarBinding`) vs. re-assignment (`Assign`) for
+    /// an assignment target, and to reject a `NAME` term reference to a
+    /// variable that has never been assigned (mirroring
+    /// `apl-runtime::eval::eval_term`'s own "undefined variable" runtime
+    /// error, but caught at lowering time instead).
+    locals: HashSet<String>,
+}
+
+impl Lowerer {
+    fn new(module_name: &str) -> Self {
+        Self {
+            module_name: module_name.to_string(),
+            observed: FeatureManifest::new(),
+            locals: HashSet::new(),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // top level: `program` → one `main` function
+    // -------------------------------------------------------------------
+
+    fn lower_file(&mut self, program: &GrammarASTNode) -> Result<Module, AplLowerError> {
+        if program.rule_name != "program" {
+            return Err(self.err_at(
+                program,
+                format!("expected `program` root, got `{}`", program.rule_name),
+            ));
+        }
+
+        // Every APL value carries no static type declaration -- this is
+        // itself what the validator's own ground truth treats as "using"
+        // dynamic typing (see `semantic-ir/src/validator.rs`'s comment to
+        // that effect, and `matlab-to-semantic-ir`'s identical observation),
+        // so it is unconditionally true for every module this crate emits.
+        self.observed.add(Feature::DynamicTyping);
+
+        let mut stmts: Vec<Stmt> = Vec::new();
+        for line in child_nodes(program) {
+            if line.rule_name != "line" {
+                continue;
+            }
+            // A `line` with no `statement` child (a blank line, or a
+            // comment-only line -- `⍝` comments are already stripped by the
+            // lexer's skip pattern) is a bare NEWLINE production; skip it,
+            // don't error.
+            let Some(stmt_node) = first_child_named(line, "statement") else {
+                continue;
+            };
+            // `statement = assignment` is a pure passthrough rule (always
+            // exactly one child).
+            let assignment_node = only_node(stmt_node)
+                .ok_or_else(|| self.err_at(stmt_node, "malformed statement".to_string()))?;
+            let mut new_stmts = self.lower_top_level_statement(assignment_node, 0)?;
+            stmts.append(&mut new_stmts);
+        }
+
+        let span = Span::point(FILE, 1, 1);
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value: Expr::NilLit { span: span.clone() },
+                span: span.clone(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: span.clone(),
+        };
+
+        let metadata = Metadata::new()
+            .with_source_language("apl")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION);
+
+        Ok(Module {
+            name: self.module_name.clone(),
+            manifest: self.observed.clone(),
+            imports: vec![],
+            exports: vec![],
+            functions: vec![main],
+            globals: vec![],
+            metadata,
+            span,
+        })
+    }
+
+    /// Dispatch one top-level `assignment` node (a `statement`'s sole
+    /// child) into zero or more [`Stmt`]s.
+    fn lower_top_level_statement(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<Vec<Stmt>, AplLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.len() {
+            // Base case: a bare `value_expr`, not an assignment. Real APL
+            // auto-print session semantics (MA05 §4) -- see this file's
+            // module doc comment's "Auto-print" section.
+            1 => {
+                let value_expr_node = only_node(node)
+                    .ok_or_else(|| self.err_at(node, "malformed value_expr statement".to_string()))?;
+                let v = self.lower_value_expr(value_expr_node, depth + 1)?;
+                let span = v.span().clone();
+                Ok(vec![Stmt::ExprStmt {
+                    expr: Expr::BuiltinCall {
+                        name: "print".to_string(),
+                        args: vec![v],
+                        effects: EffectSet::PURE,
+                        span: span.clone(),
+                    },
+                    span,
+                }])
+            }
+            // `NAME ARROW assignment` -- an actual assignment (possibly
+            // chained). Assignment is silent (MA05 §4): emit every
+            // statement the chain unrolled into, and nothing else.
+            3 => {
+                let (stmts, _final_value) = self.lower_assignment_chain(node, depth)?;
+                Ok(stmts)
+            }
+            n => Err(self.err_at(node, format!("malformed assignment with {n} children"))),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // assignment (including chained assignment)
+    // -------------------------------------------------------------------
+
+    /// Recursively lower an `assignment` node. Returns the statements the
+    /// chain unrolled into (in dependency order) and an [`Expr`] the OUTER
+    /// caller can reuse to reference "the value just bound" -- see this
+    /// file's module doc comment's "Chained assignment" section for the full
+    /// design rationale.
+    fn lower_assignment_chain(
+        &mut self,
+        node: &GrammarASTNode,
+        depth: usize,
+    ) -> Result<(Vec<Stmt>, Expr), AplLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.len() {
+            // Base case: `value_expr`, nothing to bind.
+            1 => {
+                let value_expr_node = only_node(node).ok_or_else(|| {
+                    self.err_at(node, "malformed value_expr in assignment".to_string())
+                })?;
+                let v = self.lower_value_expr(value_expr_node, depth + 1)?;
+                Ok((vec![], v))
+            }
+            // Recursive case: `NAME ARROW assignment`.
+            3 => {
+                let name = self.assignment_target_name(node)?;
+                let inner = only_node(node).ok_or_else(|| {
+                    self.err_at(node, "malformed assignment: no nested assignment".to_string())
+                })?;
+                let (mut stmts, inner_value) = self.lower_assignment_chain(inner, depth + 1)?;
+                let span = self.span_of(node);
+                // First occurrence of `name` in this (whole-program) scope
+                // -> `LetStarBinding`; already-seen -> `Assign` (and observe
+                // `Feature::MutableBindings`), mirroring every other SIR
+                // frontend's first-occurrence-vs-reassignment convention.
+                if self.locals.insert(name.clone()) {
+                    stmts.push(Stmt::LetStarBinding {
+                        name: name.clone(),
+                        sir_type: None,
+                        value: inner_value,
+                        span: span.clone(),
+                    });
+                } else {
+                    self.observed.add(Feature::MutableBindings);
+                    stmts.push(Stmt::Assign {
+                        name: name.clone(),
+                        scope: Scope::Local,
+                        value: inner_value,
+                        span: span.clone(),
+                    });
+                }
+                Ok((stmts, Expr::VarRef { name, scope: Scope::Local, span }))
+            }
+            n => Err(self.err_at(node, format!("malformed assignment with {n} children"))),
+        }
+    }
+
+    /// The `NAME` token of an actual assignment's target -- the first child
+    /// of a 3-child `assignment` node (`[Token(NAME), Token(ARROW),
+    /// Node(assignment)]`), mirroring
+    /// `apl-runtime::eval::assignment_target_name` exactly.
+    fn assignment_target_name(&self, node: &GrammarASTNode) -> Result<String, AplLowerError> {
+        match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {
+                Ok(t.value.clone())
+            }
+            _ => Err(self.err_at(node, "malformed assignment (missing target name)".to_string())),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // value_expr / term
+    // -------------------------------------------------------------------
+
+    /// `value_expr = term | function_expr value_expr | term function_expr
+    /// value_expr` -- mirrors `apl-runtime::eval::eval_value_expr`'s own
+    /// dispatch on child-count exactly (arity alone disambiguates the three
+    /// productions; the parser has already resolved which alternative
+    /// matched, so no further rule-name inspection of the children is
+    /// needed).
+    fn lower_value_expr(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AplLowerError> {
+        self.check_depth(node, depth)?;
+        let span = self.span_of(node);
+        let kids = child_nodes(node);
+        match kids.as_slice() {
+            [term] => self.lower_term(term, depth + 1),
+            [fexpr, sub] => {
+                let f = self.lower_function_expr(fexpr)?;
+                let arg = self.lower_value_expr(sub, depth + 1)?;
+                self.apply_monadic(f, arg, span)
+            }
+            [lhs_term, fexpr, sub] => {
+                let lhs = self.lower_term(lhs_term, depth + 1)?;
+                let f = self.lower_function_expr(fexpr)?;
+                let rhs = self.lower_value_expr(sub, depth + 1)?;
+                self.apply_dyadic(f, lhs, rhs, span)
+            }
+            other => Err(self.err_at(
+                node,
+                format!("malformed value_expr with {} children", other.len()),
+            )),
+        }
+    }
+
+    /// `term = NUMBER { NUMBER } | NAME | LPAREN value_expr RPAREN`.
+    fn lower_term(&mut self, node: &GrammarASTNode, depth: usize) -> Result<Expr, AplLowerError> {
+        self.check_depth(node, depth)?;
+        match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NUMBER" => {
+                // "Stranding": one or more juxtaposed NUMBER tokens form a
+                // single term -- `1 2 3` is one 3-element vector, a lone `5`
+                // is a rank-0 scalar (MA05 §4).
+                let numbers: Vec<&Token> = node
+                    .children
+                    .iter()
+                    .filter_map(|c| match c {
+                        ASTNodeOrToken::Token(tok) if tok.effective_type_name() == "NUMBER" => {
+                            Some(tok)
+                        }
+                        _ => None,
+                    })
+                    .collect();
+                if numbers.len() == 1 {
+                    Ok(self.number_literal(numbers[0]))
+                } else {
+                    // Per the SIR22 spec's own doc comment on `ArrayLit`,
+                    // `rows.len() == 1` is precisely how a row/rank-1 vector
+                    // is represented -- exactly APL's stranded-literal shape.
+                    self.observed.add(Feature::NDArrays);
+                    self.observed.add(Feature::ArrayColumnMajor);
+                    let span = self.span_of(node);
+                    let row: Vec<Expr> = numbers.iter().map(|tok| self.number_literal(tok)).collect();
+                    Ok(Expr::ArrayLit { rows: vec![row], span })
+                }
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => {
+                let span = self.span_of(node);
+                if !self.locals.contains(&t.value) {
+                    return Err(self.err_at(
+                        node,
+                        format!("undefined variable `{}` (not previously assigned)", t.value),
+                    ));
+                }
+                Ok(Expr::VarRef {
+                    name: t.value.clone(),
+                    scope: Scope::Local,
+                    span,
+                })
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "LPAREN" => {
+                let inner = only_node(node)
+                    .ok_or_else(|| self.err_at(node, "malformed parenthesised term".to_string()))?;
+                self.lower_value_expr(inner, depth + 1)
+            }
+            _ => Err(self.err_at(node, "malformed term".to_string())),
+        }
+    }
+
+    /// Convert one `NUMBER` token into an `Expr::IntLit`/`Expr::FloatLit`,
+    /// observing `Feature::Floats` when it is the latter (the validator's
+    /// own ground truth: `Expr::FloatLit` requires `Feature::Floats`
+    /// declared -- see `semantic-ir/src/validator.rs`'s `FloatLit` arm).
+    fn number_literal(&mut self, tok: &Token) -> Expr {
+        let span = Span::point(FILE, tok.line, tok.column);
+        let expr = number_literal_expr(&tok.value, &span);
+        if matches!(expr, Expr::FloatLit { .. }) {
+            self.observed.add(Feature::Floats);
+        }
+        expr
+    }
+
+    // -------------------------------------------------------------------
+    // function_expr / function_atom
+    // -------------------------------------------------------------------
+
+    /// `function_expr = function_atom [ REDUCE | SCAN ] | OUTER
+    /// function_atom` -- mirrors `apl-runtime::eval::parse_function_expr`
+    /// exactly, including the shape ambiguity note: both the
+    /// reduce/scan-decorated and outer-decorated alternatives have exactly
+    /// two children, so they are told apart by *which position* holds the
+    /// bare token, not by length alone.
+    fn lower_function_expr(&self, node: &GrammarASTNode) -> Result<FnKind, AplLowerError> {
+        match node.children.as_slice() {
+            [ASTNodeOrToken::Node(atom)] => self.lower_function_atom(atom),
+            [ASTNodeOrToken::Node(atom), ASTNodeOrToken::Token(op)] => match op.effective_type_name()
+            {
+                "REDUCE" => Ok(FnKind::Reduce(self.require_scalar_atom(atom, "reduce (/)")?)),
+                "SCAN" => Ok(FnKind::Scan(self.require_scalar_atom(atom, "scan (\\)")?)),
+                other => Err(self.err_at(node, format!("unexpected operator token `{other}`"))),
+            },
+            [ASTNodeOrToken::Token(_outer), ASTNodeOrToken::Node(atom)] => {
+                Ok(FnKind::Outer(self.require_scalar_atom(atom, "outer product (∘.)")?))
+            }
+            _ => Err(self.err_at(node, "malformed function_expr".to_string())),
+        }
+    }
+
+    /// `function_atom`: always exactly one child, a single token naming the
+    /// primitive glyph -- mirrors `apl-runtime::eval::parse_function_atom`'s
+    /// token-name-to-variant table exactly (confirmed against that
+    /// function and `array_runtime::BinOp`'s own identical mapping).
+    fn lower_function_atom(&self, node: &GrammarASTNode) -> Result<FnKind, AplLowerError> {
+        let tok = match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) => t,
+            _ => return Err(self.err_at(node, "malformed function_atom".to_string())),
+        };
+        Ok(match tok.effective_type_name() {
+            "PLUS" => FnKind::Atom(ElementwiseOpKind::Add),
+            "MINUS" => FnKind::Atom(ElementwiseOpKind::Sub),
+            "TIMES" => FnKind::Atom(ElementwiseOpKind::Mul),
+            "DIVIDE" => FnKind::Atom(ElementwiseOpKind::Div),
+            "CEILING" => FnKind::Atom(ElementwiseOpKind::Max),
+            "FLOOR" => FnKind::Atom(ElementwiseOpKind::Min),
+            "EQ" => FnKind::Atom(ElementwiseOpKind::Eq),
+            "NE" => FnKind::Atom(ElementwiseOpKind::Ne),
+            "LT" => FnKind::Atom(ElementwiseOpKind::Lt),
+            "LE" => FnKind::Atom(ElementwiseOpKind::Le),
+            "GE" => FnKind::Atom(ElementwiseOpKind::Ge),
+            "GT" => FnKind::Atom(ElementwiseOpKind::Gt),
+            "RHO" => FnKind::NonScalar(NonScalarAtom::Rho),
+            "IOTA" => FnKind::NonScalar(NonScalarAtom::Iota),
+            "RAVEL" => FnKind::NonScalar(NonScalarAtom::Ravel),
+            other => return Err(self.err_at(node, format!("unknown function atom `{other}`"))),
+        })
+    }
+
+    /// Reduce/scan/outer-product apply only to the 12 atoms that map onto an
+    /// [`ElementwiseOpKind`] -- `⍴`/`⍳`/`,` are not "a scalar dyadic
+    /// function" at all, so stacking an operator on one of them is a clean,
+    /// explicit error, mirroring `apl-runtime::eval::require_scalar_binop`'s
+    /// identical restriction (and its error-message style).
+    fn require_scalar_atom(
+        &self,
+        atom: &GrammarASTNode,
+        context: &str,
+    ) -> Result<ElementwiseOpKind, AplLowerError> {
+        match self.lower_function_atom(atom)? {
+            FnKind::Atom(op) => Ok(op),
+            FnKind::NonScalar(a) => Err(self.err_at(
+                atom,
+                format!(
+                    "{} is not a scalar dyadic function and cannot take the {context} operator",
+                    a.glyph()
+                ),
+            )),
+            FnKind::Reduce(_) | FnKind::Scan(_) | FnKind::Outer(_) => {
+                unreachable!("lower_function_atom never itself produces an operator-bearing FnKind")
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // monadic / dyadic application
+    // -------------------------------------------------------------------
+
+    /// Apply a monadic (one-argument) function-expression to `arg`.
+    fn apply_monadic(&mut self, f: FnKind, arg: Expr, span: Span) -> Result<Expr, AplLowerError> {
+        match f {
+            FnKind::Atom(op) => self.apply_monadic_scalar(op, arg),
+            FnKind::NonScalar(NonScalarAtom::Rho) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Shape { target: Box::new(arg), span })
+            }
+            FnKind::NonScalar(NonScalarAtom::Iota) => {
+                self.observed.add(Feature::NDArrays);
+                Ok(Expr::IndexGenerator { count: Box::new(arg), span })
+            }
+            FnKind::NonScalar(NonScalarAtom::Ravel) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Ravel { target: Box::new(arg), span })
+            }
+            FnKind::Reduce(op) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Reduce { op, target: Box::new(arg), span })
+            }
+            FnKind::Scan(op) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Scan { op, target: Box::new(arg), span })
+            }
+            FnKind::Outer(_) => Err(self.err_at_span(
+                &span,
+                "∘. (outer product) needs two operands, but was applied monadically".to_string(),
+            )),
+        }
+    }
+
+    /// Apply a dyadic (two-argument) function-expression to `lhs`/`rhs`.
+    fn apply_dyadic(
+        &mut self,
+        f: FnKind,
+        lhs: Expr,
+        rhs: Expr,
+        span: Span,
+    ) -> Result<Expr, AplLowerError> {
+        match f {
+            FnKind::Atom(op) => {
+                // Point 1 of this file's module doc comment: unconditional,
+                // no scalar-vs-array disambiguation -- every one of the 12
+                // scalar dyadic atoms is always elementwise in APL.
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::ElementwiseOp {
+                    op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                    span,
+                })
+            }
+            FnKind::NonScalar(NonScalarAtom::Rho) => {
+                // `apl-runtime::builtins::reshape(a, b)`: `a` is the shape
+                // vector (APL's LHS), `b` is the data (APL's RHS) --
+                // `Expr::Reshape`'s `shape`/`target` fields map to that same
+                // A/B order.
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Reshape {
+                    shape: Box::new(lhs),
+                    target: Box::new(rhs),
+                    span,
+                })
+            }
+            FnKind::NonScalar(NonScalarAtom::Iota) => {
+                // `apl-runtime::builtins::index_of(a, b)`: `a` is the
+                // haystack, `b` is the needle.
+                self.observed.add(Feature::NDArrays);
+                Ok(Expr::IndexOf {
+                    haystack: Box::new(lhs),
+                    needle: Box::new(rhs),
+                    span,
+                })
+            }
+            FnKind::NonScalar(NonScalarAtom::Ravel) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::Catenate {
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                    span,
+                })
+            }
+            FnKind::Outer(op) => {
+                self.observed.add(Feature::MatrixOps);
+                self.observed.add(Feature::ArrayColumnMajor);
+                Ok(Expr::OuterProduct {
+                    op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                    span,
+                })
+            }
+            FnKind::Reduce(_) => Err(self.err_at_span(
+                &span,
+                "/ (reduce) takes exactly one operand, but was applied dyadically".to_string(),
+            )),
+            FnKind::Scan(_) => Err(self.err_at_span(
+                &span,
+                "\\ (scan) takes exactly one operand, but was applied dyadically".to_string(),
+            )),
+        }
+    }
+
+    /// Monadic meaning of the six atoms that have one (MA05 §4): `+`
+    /// conjugate, `-` negate, `×` sign, `÷` reciprocal, `⌈` ceiling, `⌊`
+    /// floor. The six comparisons have **no** monadic meaning -- a clean,
+    /// explicit error rather than silently picking a behavior, mirroring
+    /// `apl-runtime::eval::apply_monadic_scalar`'s identical restriction.
+    ///
+    /// `+` (conjugate) is the one case that emits the operand **unchanged**:
+    /// this cut has no complex numbers, so conjugate is a genuine identity,
+    /// and wrapping it in a synthetic no-op node would just be noise. Every
+    /// other case wraps the operand in a well-known [`Expr::BuiltinCall`]:
+    /// `"neg"` reuses the *exact* name `matlab-to-semantic-ir`'s own unary
+    /// negate already established (confirmed by grepping that crate for
+    /// `"neg"`) -- establishing the precedent that a `BuiltinCall` name is a
+    /// generic operation any backend implements polymorphically over
+    /// whatever value flows through it (SIR10's "types carry, don't
+    /// verify"): it is fine and expected that `"neg"` here may receive an
+    /// array-typed value even though MATLAB only ever proves it a scalar.
+    /// `"sign"`/`"recip"`/`"ceil"`/`"floor"` are new well-known names this
+    /// frontend introduces.
+    fn apply_monadic_scalar(&mut self, op: ElementwiseOpKind, operand: Expr) -> Result<Expr, AplLowerError> {
+        match op {
+            ElementwiseOpKind::Add => Ok(operand),
+            ElementwiseOpKind::Sub => Ok(wrap_builtin("neg", operand)),
+            ElementwiseOpKind::Mul => Ok(wrap_builtin("sign", operand)),
+            ElementwiseOpKind::Div => Ok(wrap_builtin("recip", operand)),
+            ElementwiseOpKind::Max => Ok(wrap_builtin("ceil", operand)),
+            ElementwiseOpKind::Min => Ok(wrap_builtin("floor", operand)),
+            ElementwiseOpKind::Eq
+            | ElementwiseOpKind::Ne
+            | ElementwiseOpKind::Lt
+            | ElementwiseOpKind::Le
+            | ElementwiseOpKind::Ge
+            | ElementwiseOpKind::Gt => {
+                let span = operand.span().clone();
+                Err(self.err_at_span(
+                    &span,
+                    format!(
+                        "no monadic form for {} (comparison atoms are dyadic-only in APL)",
+                        glyph_for_comparison(op)
+                    ),
+                ))
+            }
+            ElementwiseOpKind::Pow => unreachable!(
+                "APL frontend never constructs ElementwiseOpKind::Pow -- there is no `^` atom \
+                 among this cut's 12 scalar dyadic atoms (MA05 §4)"
+            ),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // small helpers
+    // -------------------------------------------------------------------
+
+    fn span_of(&self, node: &GrammarASTNode) -> Span {
+        Span::point(FILE, node.start_line.unwrap_or(1), node.start_column.unwrap_or(1))
+    }
+
+    fn err_at(&self, node: &GrammarASTNode, message: String) -> AplLowerError {
+        AplLowerError {
+            message,
+            line: node.start_line.unwrap_or(1),
+            column: node.start_column.unwrap_or(1),
+        }
+    }
+
+    fn err_at_span(&self, span: &Span, message: String) -> AplLowerError {
+        AplLowerError {
+            message,
+            line: span.start_line,
+            column: span.start_col,
+        }
+    }
+
+    fn check_depth(&self, node: &GrammarASTNode, depth: usize) -> Result<(), AplLowerError> {
+        if depth > MAX_EXPR_DEPTH {
+            return Err(self.err_at(
+                node,
+                format!("expression nesting too deep (exceeds {MAX_EXPR_DEPTH} levels)"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+/// Collect the *node* children of `node` (dropping tokens).
+fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+/// The first *node* child named `kind`, or `None`.
+fn first_child_named<'a>(node: &'a GrammarASTNode, kind: &str) -> Option<&'a GrammarASTNode> {
+    child_nodes(node).into_iter().find(|n| n.rule_name == kind)
+}
+
+/// The first (and, for every rule this crate lowers, only) *node* child --
+/// mirrors `apl-runtime::eval::only_node`'s exact "first Node child found"
+/// behavior.
+fn only_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) => Some(n),
+        ASTNodeOrToken::Token(_) => None,
+    })
+}
+
+/// Wrap `operand` in a well-known, pure, single-argument
+/// [`Expr::BuiltinCall`] named `name`, reusing `operand`'s own span.
+fn wrap_builtin(name: &str, operand: Expr) -> Expr {
+    let span = operand.span().clone();
+    Expr::BuiltinCall {
+        name: name.to_string(),
+        args: vec![operand],
+        effects: EffectSet::PURE,
+        span,
+    }
+}
+
+/// The glyph for one of the six comparison [`ElementwiseOpKind`]s -- used
+/// only to name the offending atom in the "no monadic form" error message.
+fn glyph_for_comparison(op: ElementwiseOpKind) -> &'static str {
+    match op {
+        ElementwiseOpKind::Eq => "=",
+        ElementwiseOpKind::Ne => "≠",
+        ElementwiseOpKind::Lt => "<",
+        ElementwiseOpKind::Le => "≤",
+        ElementwiseOpKind::Ge => "≥",
+        ElementwiseOpKind::Gt => ">",
+        other => unreachable!("glyph_for_comparison called with non-comparison op {other:?}"),
+    }
+}
+
+/// Convert one `NUMBER` token's lexeme text into an `Expr::IntLit` (a whole
+/// number that fits `i64`) or `Expr::FloatLit` (has a decimal point or
+/// exponent, or is too large for `i64`) -- mirrors
+/// `matlab-to-semantic-ir::lower::number_literal_expr`'s own lexeme-based
+/// int-vs-float convention exactly, so every `-to-semantic-ir` frontend in
+/// this repo picks the same literal-kind boundary.
+///
+/// APL's lexer spells a negative literal's sign with the historical "high
+/// minus" `¯` (U+00AF) instead of ASCII `-` (`apl.tokens`'s `NUMBER` rule:
+/// `-` is reserved, unambiguously, for the `MINUS` function token, so a
+/// literal sign needs its own glyph). The `¯` is translated to `-` first,
+/// exactly as `apl-runtime::eval::parse_apl_number` already does
+/// (`s.replace('¯', "-")`), before either numeric parser ever sees the text.
+fn number_literal_expr(raw_text: &str, span: &Span) -> Expr {
+    let text = raw_text.replace('¯', "-");
+    if text.contains('.') || text.contains('e') || text.contains('E') {
+        Expr::FloatLit {
+            value: text.parse::<f64>().unwrap_or(0.0),
+            span: span.clone(),
+        }
+    } else {
+        match text.parse::<i64>() {
+            Ok(v) => Expr::IntLit { value: v, span: span.clone() },
+            Err(_) => Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span: span.clone(),
+            },
+        }
+    }
+}

--- a/code/packages/rust/apl-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/src/lower.rs
@@ -503,7 +503,7 @@ impl Lowerer {
                     })
                     .collect();
                 if numbers.len() == 1 {
-                    Ok(self.number_literal(numbers[0]))
+                    self.number_literal(numbers[0])
                 } else {
                     // Per the SIR22 spec's own doc comment on `ArrayLit`,
                     // `rows.len() == 1` is precisely how a row/rank-1 vector
@@ -511,7 +511,10 @@ impl Lowerer {
                     self.observed.add(Feature::NDArrays);
                     self.observed.add(Feature::ArrayColumnMajor);
                     let span = self.span_of(node);
-                    let row: Vec<Expr> = numbers.iter().map(|tok| self.number_literal(tok)).collect();
+                    let row: Vec<Expr> = numbers
+                        .iter()
+                        .map(|tok| self.number_literal(tok))
+                        .collect::<Result<Vec<_>, _>>()?;
                     Ok(Expr::ArrayLit { rows: vec![row], span })
                 }
             }
@@ -542,13 +545,27 @@ impl Lowerer {
     /// observing `Feature::Floats` when it is the latter (the validator's
     /// own ground truth: `Expr::FloatLit` requires `Feature::Floats`
     /// declared -- see `semantic-ir/src/validator.rs`'s `FloatLit` arm).
-    fn number_literal(&mut self, tok: &Token) -> Expr {
+    ///
+    /// Returns a clean [`AplLowerError`] rather than silently substituting
+    /// `0.0` if the token's lexeme somehow fails to parse as a number. Under
+    /// the normal `compile_source` path this can never actually trigger --
+    /// `apl-parser`'s own `NUMBER` lexer rule guarantees a parseable lexeme
+    /// -- but `compile` is also a public entry point over a hand-built
+    /// `GrammarASTNode`, and every other malformed-input case in this file
+    /// is rejected explicitly rather than silently coerced to a default
+    /// value, so this one should be no different (caught by security
+    /// review).
+    fn number_literal(&mut self, tok: &Token) -> Result<Expr, AplLowerError> {
         let span = Span::point(FILE, tok.line, tok.column);
-        let expr = number_literal_expr(&tok.value, &span);
+        let expr = number_literal_expr(&tok.value, &span).map_err(|message| AplLowerError {
+            message,
+            line: tok.line,
+            column: tok.column,
+        })?;
         if matches!(expr, Expr::FloatLit { .. }) {
             self.observed.add(Feature::Floats);
         }
-        expr
+        Ok(expr)
     }
 
     // -------------------------------------------------------------------
@@ -898,20 +915,27 @@ fn glyph_for_comparison(op: ElementwiseOpKind) -> &'static str {
 /// literal sign needs its own glyph). The `¯` is translated to `-` first,
 /// exactly as `apl-runtime::eval::parse_apl_number` already does
 /// (`s.replace('¯', "-")`), before either numeric parser ever sees the text.
-fn number_literal_expr(raw_text: &str, span: &Span) -> Expr {
+///
+/// Returns `Err` (rather than silently substituting `0.0`) if `raw_text`
+/// fails to parse as a number at all -- unreachable via `compile_source`
+/// (the lexer's own `NUMBER` rule guarantees a parseable lexeme), but
+/// `compile` is also a public entry point over a hand-built
+/// `GrammarASTNode`, and every other malformed-input case in this file is
+/// rejected explicitly rather than silently coerced, so this one matches
+/// that same discipline (caught by security review).
+fn number_literal_expr(raw_text: &str, span: &Span) -> Result<Expr, String> {
     let text = raw_text.replace('¯', "-");
+    let invalid = || format!("invalid number literal `{raw_text}`");
     if text.contains('.') || text.contains('e') || text.contains('E') {
-        Expr::FloatLit {
-            value: text.parse::<f64>().unwrap_or(0.0),
-            span: span.clone(),
-        }
+        let value = text.parse::<f64>().map_err(|_| invalid())?;
+        Ok(Expr::FloatLit { value, span: span.clone() })
     } else {
         match text.parse::<i64>() {
-            Ok(v) => Expr::IntLit { value: v, span: span.clone() },
-            Err(_) => Expr::FloatLit {
-                value: text.parse::<f64>().unwrap_or(0.0),
-                span: span.clone(),
-            },
+            Ok(v) => Ok(Expr::IntLit { value: v, span: span.clone() }),
+            Err(_) => {
+                let value = text.parse::<f64>().map_err(|_| invalid())?;
+                Ok(Expr::FloatLit { value, span: span.clone() })
+            }
         }
     }
 }

--- a/code/packages/rust/apl-to-semantic-ir/tests/test_lower.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/test_lower.rs
@@ -1,0 +1,520 @@
+use apl_to_semantic_ir::compile_source;
+use semantic_ir::{ElementwiseOpKind, Expr, Feature, Function, Module, Stmt};
+
+fn compile_ok(src: &str) -> Module {
+    compile_source(src, "prog").unwrap_or_else(|e| panic!("expected lowering to succeed: {e}"))
+}
+
+fn compile_err(src: &str) -> String {
+    compile_source(src, "prog")
+        .err()
+        .unwrap_or_else(|| panic!("expected lowering to fail for `{src}`"))
+        .message
+}
+
+fn main_fn(m: &Module) -> &Function {
+    m.functions.iter().find(|f| f.name == "main").expect("main function")
+}
+
+/// The `Expr` inside the sole `print(...)` wrapper of a bare-expression
+/// top-level statement (see the "Auto-print" design in `lower.rs`).
+fn printed_value(stmt: &Stmt) -> &Expr {
+    match stmt {
+        Stmt::ExprStmt {
+            expr: Expr::BuiltinCall { name, args, .. },
+            ..
+        } if name == "print" => {
+            assert_eq!(args.len(), 1, "print should take exactly one argument");
+            &args[0]
+        }
+        other => panic!("expected ExprStmt(print(..)), got {other:?}"),
+    }
+}
+
+// ── literals ─────────────────────────────────────────────────────────────
+
+#[test]
+fn bare_int_literal_is_wrapped_in_print() {
+    let m = compile_ok("5\n");
+    let main = main_fn(&m);
+    assert_eq!(main.body.stmts.len(), 1);
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::IntLit { value: 5, .. }));
+}
+
+#[test]
+fn float_literal_is_recognised_by_decimal_point() {
+    let m = compile_ok("2.5\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::FloatLit { value, .. } => assert!((*value - 2.5).abs() < 1e-9),
+        other => panic!("expected FloatLit, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::Floats));
+}
+
+#[test]
+fn high_minus_negative_integer_literal() {
+    let m = compile_ok("¯3\n");
+    let main = main_fn(&m);
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::IntLit { value: -3, .. }));
+}
+
+#[test]
+fn high_minus_negative_float_literal() {
+    let m = compile_ok("¯3.5\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::FloatLit { value, .. } => assert!((*value - (-3.5)).abs() < 1e-9),
+        other => panic!("expected FloatLit, got {other:?}"),
+    }
+}
+
+#[test]
+fn stranded_literal_is_a_single_row_array_lit() {
+    let m = compile_ok("1 2 3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::ArrayLit { rows, .. } => {
+            assert_eq!(rows.len(), 1, "stranded literal must be a single row (rank-1 vector)");
+            assert_eq!(rows[0].len(), 3);
+            assert!(matches!(rows[0][0], Expr::IntLit { value: 1, .. }));
+            assert!(matches!(rows[0][1], Expr::IntLit { value: 2, .. }));
+            assert!(matches!(rows[0][2], Expr::IntLit { value: 3, .. }));
+        }
+        other => panic!("expected ArrayLit, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::NDArrays));
+    assert!(m.manifest.iter().any(|f| f == Feature::ArrayColumnMajor));
+}
+
+#[test]
+fn a_lone_number_is_a_scalar_not_an_array_lit() {
+    let m = compile_ok("5\n");
+    let main = main_fn(&m);
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::IntLit { .. }));
+}
+
+#[test]
+fn parenthesised_grouping() {
+    // (1+2)×3 -- the group is purely syntactic, no wrapper node.
+    let m = compile_ok("(1+2)×3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Mul, lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::ElementwiseOp { op: ElementwiseOpKind::Add, .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 3, .. }));
+        }
+        other => panic!("expected ElementwiseOp(Mul, ...), got {other:?}"),
+    }
+}
+
+// ── all 12 dyadic scalar atoms ───────────────────────────────────────────
+
+#[test]
+fn every_dyadic_atom_lowers_to_elementwise_op() {
+    let cases: &[(&str, ElementwiseOpKind)] = &[
+        ("+", ElementwiseOpKind::Add),
+        ("-", ElementwiseOpKind::Sub),
+        ("×", ElementwiseOpKind::Mul),
+        ("÷", ElementwiseOpKind::Div),
+        ("⌈", ElementwiseOpKind::Max),
+        ("⌊", ElementwiseOpKind::Min),
+        ("=", ElementwiseOpKind::Eq),
+        ("≠", ElementwiseOpKind::Ne),
+        ("<", ElementwiseOpKind::Lt),
+        ("≤", ElementwiseOpKind::Le),
+        ("≥", ElementwiseOpKind::Ge),
+        (">", ElementwiseOpKind::Gt),
+    ];
+    for (glyph, expected) in cases {
+        let src = format!("3{glyph}4\n");
+        let m = compile_ok(&src);
+        let main = main_fn(&m);
+        match printed_value(&main.body.stmts[0]) {
+            Expr::ElementwiseOp { op, lhs, rhs, .. } => {
+                assert_eq!(op, expected, "glyph `{glyph}` mapped to the wrong op");
+                assert!(matches!(**lhs, Expr::IntLit { value: 3, .. }));
+                assert!(matches!(**rhs, Expr::IntLit { value: 4, .. }));
+            }
+            other => panic!("`{src}`: expected ElementwiseOp, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn dyadic_atoms_lower_identically_for_literals_and_variables() {
+    // Point 1 of the module doc: no scalar/array disambiguation -- `A+B`
+    // and `3+4` produce the exact same node shape (ElementwiseOp), unlike
+    // matlab-to-semantic-ir's literal-folding fast path.
+    let m = compile_ok("A←3\nB←4\nA+B\n");
+    let main = main_fn(&m);
+    // stmts: [LetStarBinding(A,3), LetStarBinding(B,4), ExprStmt(print(...))]
+    assert_eq!(main.body.stmts.len(), 3);
+    match printed_value(&main.body.stmts[2]) {
+        Expr::ElementwiseOp { op: ElementwiseOpKind::Add, lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::VarRef { ref name, .. } if name == "A"));
+            assert!(matches!(**rhs, Expr::VarRef { ref name, .. } if name == "B"));
+        }
+        other => panic!("expected ElementwiseOp, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::MatrixOps));
+    assert!(m.manifest.iter().any(|f| f == Feature::ArrayColumnMajor));
+}
+
+// ── monadic atoms: 6 valid, 6 invalid ────────────────────────────────────
+
+#[test]
+fn monadic_plus_is_identity_no_wrapping() {
+    let m = compile_ok("+1\n");
+    let main = main_fn(&m);
+    // No BuiltinCall wrapper at all -- the operand passes through unchanged.
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::IntLit { value: 1, .. }));
+}
+
+#[test]
+fn monadic_minus_is_neg_builtin() {
+    let m = compile_ok("-1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::BuiltinCall { name, args, .. } => {
+            assert_eq!(name, "neg");
+            assert!(matches!(args[0], Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected BuiltinCall(\"neg\", ..), got {other:?}"),
+    }
+}
+
+#[test]
+fn monadic_times_is_sign_builtin() {
+    let m = compile_ok("×1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::BuiltinCall { name, .. } => assert_eq!(name, "sign"),
+        other => panic!("expected BuiltinCall(\"sign\", ..), got {other:?}"),
+    }
+}
+
+#[test]
+fn monadic_divide_is_recip_builtin() {
+    let m = compile_ok("÷1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::BuiltinCall { name, .. } => assert_eq!(name, "recip"),
+        other => panic!("expected BuiltinCall(\"recip\", ..), got {other:?}"),
+    }
+}
+
+#[test]
+fn monadic_ceiling_is_ceil_builtin() {
+    let m = compile_ok("⌈1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::BuiltinCall { name, .. } => assert_eq!(name, "ceil"),
+        other => panic!("expected BuiltinCall(\"ceil\", ..), got {other:?}"),
+    }
+}
+
+#[test]
+fn monadic_floor_is_floor_builtin() {
+    let m = compile_ok("⌊1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::BuiltinCall { name, .. } => assert_eq!(name, "floor"),
+        other => panic!("expected BuiltinCall(\"floor\", ..), got {other:?}"),
+    }
+}
+
+#[test]
+fn the_six_comparison_atoms_have_no_monadic_form() {
+    for glyph in ["=", "≠", "<", "≤", "≥", ">"] {
+        let src = format!("{glyph}1\n");
+        let err = compile_err(&src);
+        assert!(
+            err.contains("no monadic form"),
+            "`{src}` should reject with a clean 'no monadic form' error, got: {err}"
+        );
+    }
+}
+
+// ── reduce / scan (monadic-only) ─────────────────────────────────────────
+
+#[test]
+fn reduce_over_stranded_vector() {
+    let m = compile_ok("+/1 2 3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Reduce { op, target, .. } => {
+            assert_eq!(*op, ElementwiseOpKind::Add);
+            assert!(matches!(**target, Expr::ArrayLit { .. }));
+        }
+        other => panic!("expected Reduce, got {other:?}"),
+    }
+    assert!(m.manifest.iter().any(|f| f == Feature::MatrixOps));
+    assert!(m.manifest.iter().any(|f| f == Feature::ArrayColumnMajor));
+}
+
+#[test]
+fn scan_over_stranded_vector() {
+    let m = compile_ok("×\\1 2 3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Scan { op, .. } => assert_eq!(*op, ElementwiseOpKind::Mul),
+        other => panic!("expected Scan, got {other:?}"),
+    }
+}
+
+#[test]
+fn reduce_used_dyadically_is_rejected() {
+    let err = compile_err("3+/4\n");
+    assert!(
+        err.contains("reduce") && err.contains("dyadically"),
+        "expected a clean dyadic-reduce rejection, got: {err}"
+    );
+}
+
+#[test]
+fn scan_used_dyadically_is_rejected() {
+    let err = compile_err("3×\\4\n");
+    assert!(
+        err.contains("scan") && err.contains("dyadically"),
+        "expected a clean dyadic-scan rejection, got: {err}"
+    );
+}
+
+// ── outer product (dyadic-only) ──────────────────────────────────────────
+
+#[test]
+fn outer_product_dyadic_use() {
+    let m = compile_ok("1∘.×2\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::OuterProduct { op, lhs, rhs, .. } => {
+            assert_eq!(*op, ElementwiseOpKind::Mul);
+            assert!(matches!(**lhs, Expr::IntLit { value: 1, .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 2, .. }));
+        }
+        other => panic!("expected OuterProduct, got {other:?}"),
+    }
+}
+
+#[test]
+fn outer_product_used_monadically_is_rejected() {
+    let err = compile_err("∘.×1\n");
+    assert!(
+        err.contains("outer product") && err.contains("monadically"),
+        "expected a clean monadic-outer rejection, got: {err}"
+    );
+}
+
+// ── ⍴ (shape / reshape) ───────────────────────────────────────────────────
+
+#[test]
+fn monadic_rho_is_shape() {
+    let m = compile_ok("⍴1\n");
+    let main = main_fn(&m);
+    assert!(matches!(printed_value(&main.body.stmts[0]), Expr::Shape { .. }));
+}
+
+#[test]
+fn dyadic_rho_is_reshape_with_a_as_shape_and_b_as_target() {
+    // 2 3⍴1 -- shape=[2,3] (LHS), target=1 (RHS).
+    let m = compile_ok("2 3⍴1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Reshape { shape, target, .. } => {
+            assert!(matches!(**shape, Expr::ArrayLit { .. }));
+            assert!(matches!(**target, Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected Reshape, got {other:?}"),
+    }
+}
+
+// ── ⍳ (index generator / index-of) ───────────────────────────────────────
+
+#[test]
+fn monadic_iota_is_index_generator() {
+    let m = compile_ok("⍳3\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::IndexGenerator { count, .. } => assert!(matches!(**count, Expr::IntLit { value: 3, .. })),
+        other => panic!("expected IndexGenerator, got {other:?}"),
+    }
+}
+
+#[test]
+fn dyadic_iota_is_index_of_with_a_as_haystack_and_b_as_needle() {
+    let m = compile_ok("3⍳1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::IndexOf { haystack, needle, .. } => {
+            assert!(matches!(**haystack, Expr::IntLit { value: 3, .. }));
+            assert!(matches!(**needle, Expr::IntLit { value: 1, .. }));
+        }
+        other => panic!("expected IndexOf, got {other:?}"),
+    }
+}
+
+// ── , (ravel / catenate) ──────────────────────────────────────────────────
+
+#[test]
+fn monadic_ravel() {
+    let m = compile_ok(",1\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Ravel { target, .. } => assert!(matches!(**target, Expr::IntLit { value: 1, .. })),
+        other => panic!("expected Ravel, got {other:?}"),
+    }
+}
+
+#[test]
+fn dyadic_catenate() {
+    let m = compile_ok("1,2\n");
+    let main = main_fn(&m);
+    match printed_value(&main.body.stmts[0]) {
+        Expr::Catenate { lhs, rhs, .. } => {
+            assert!(matches!(**lhs, Expr::IntLit { value: 1, .. }));
+            assert!(matches!(**rhs, Expr::IntLit { value: 2, .. }));
+        }
+        other => panic!("expected Catenate, got {other:?}"),
+    }
+}
+
+// ── ⍴/⍳/, rejecting operator decoration ──────────────────────────────────
+
+#[test]
+fn rho_decorated_with_reduce_is_rejected() {
+    let err = compile_err("⍴/1\n");
+    assert!(
+        err.contains("⍴") && err.contains("scalar dyadic function"),
+        "expected a clean rejection naming ⍴, got: {err}"
+    );
+}
+
+#[test]
+fn iota_decorated_with_scan_is_rejected() {
+    let err = compile_err("⍳\\1\n");
+    assert!(err.contains("⍳"), "expected a clean rejection naming ⍳, got: {err}");
+}
+
+#[test]
+fn ravel_decorated_with_outer_is_rejected() {
+    let err = compile_err("∘.,1 2\n");
+    assert!(err.contains(","), "expected a clean rejection naming ',', got: {err}");
+}
+
+// ── assignment: first occurrence vs. reassignment ────────────────────────
+
+#[test]
+fn first_assignment_is_a_let_star_binding() {
+    let m = compile_ok("A←5\n");
+    let main = main_fn(&m);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { name, value, .. } => {
+            assert_eq!(name, "A");
+            assert!(matches!(value, Expr::IntLit { value: 5, .. }));
+        }
+        other => panic!("expected LetStarBinding, got {other:?}"),
+    }
+    // A pure assignment prints nothing.
+    assert_eq!(main.body.stmts.len(), 1);
+}
+
+#[test]
+fn reassignment_is_assign_not_let() {
+    let m = compile_ok("A←1\nA←2\n");
+    let main = main_fn(&m);
+    assert!(matches!(main.body.stmts[0], Stmt::LetStarBinding { .. }));
+    assert!(matches!(main.body.stmts[1], Stmt::Assign { .. }));
+    assert!(m.manifest.iter().any(|f| f == Feature::MutableBindings));
+}
+
+#[test]
+fn chained_assignment_unrolls_into_two_statements_in_dependency_order() {
+    // A←B←3 -- per the module doc's "Chained assignment" design: B is bound
+    // first (to 3), then A is bound to a VarRef("B"), not a duplicated 3.
+    let m = compile_ok("A←B←3\n");
+    let main = main_fn(&m);
+    assert_eq!(main.body.stmts.len(), 2);
+    match &main.body.stmts[0] {
+        Stmt::LetStarBinding { name, value, .. } => {
+            assert_eq!(name, "B");
+            assert!(matches!(value, Expr::IntLit { value: 3, .. }));
+        }
+        other => panic!("expected LetStarBinding(B, 3), got {other:?}"),
+    }
+    match &main.body.stmts[1] {
+        Stmt::LetStarBinding { name, value, .. } => {
+            assert_eq!(name, "A");
+            assert!(matches!(value, Expr::VarRef { name, .. } if name == "B"));
+        }
+        other => panic!("expected LetStarBinding(A, VarRef(B)), got {other:?}"),
+    }
+}
+
+// ── undefined variable ────────────────────────────────────────────────────
+
+#[test]
+fn referencing_an_undefined_variable_is_a_clean_error() {
+    let err = compile_err("A+1\n");
+    assert!(err.contains("undefined variable"), "got: {err}");
+}
+
+#[test]
+fn self_referential_first_assignment_is_rejected() {
+    // A←A+1 as the very first use of A: the RHS is lowered before A is bound
+    // (mirrors apl-runtime's own runtime evaluation order), so this is
+    // "undefined variable", not a self-reference.
+    let err = compile_err("A←A+1\n");
+    assert!(err.contains("undefined variable"), "got: {err}");
+}
+
+// ── parse-error propagation ────────────────────────────────────────────────
+
+#[test]
+fn a_parse_error_is_mapped_into_an_apl_lower_error() {
+    let err = compile_source("←←←\n", "prog");
+    assert!(err.is_err());
+    let e = err.unwrap_err();
+    assert!(e.message.contains("parse error"));
+    assert_eq!(e.line, 1);
+    assert_eq!(e.column, 1);
+}
+
+// ── full end-to-end: multi-line program validates cleanly ────────────────
+
+#[test]
+fn a_multi_line_program_compiles_and_validates_cleanly() {
+    let src = "A←3\nB←4\nA+B\n+/1 2 3\nA←A+1\n";
+    let m = compile_ok(src);
+    let report = semantic_ir::validate(&m);
+    assert!(
+        report.is_ok(),
+        "expected the lowered module to validate cleanly, got: {:?}",
+        report.errors().collect::<Vec<_>>()
+    );
+
+    let main = main_fn(&m);
+    // A←3, B←4, print(A+B), print(+/1 2 3), A←A+1 (reassignment)
+    assert_eq!(main.body.stmts.len(), 5);
+    assert!(matches!(main.body.stmts[0], Stmt::LetStarBinding { .. }));
+    assert!(matches!(main.body.stmts[1], Stmt::LetStarBinding { .. }));
+    assert!(matches!(main.body.stmts[4], Stmt::Assign { .. }));
+    assert!(m.manifest.iter().any(|f| f == Feature::MutableBindings));
+    assert!(m.manifest.iter().any(|f| f == Feature::DynamicTyping));
+}
+
+#[test]
+fn an_empty_program_compiles_and_validates_cleanly() {
+    let m = compile_ok("");
+    let report = semantic_ir::validate(&m);
+    assert!(report.is_ok(), "empty program should validate cleanly: {:?}", report.issues);
+    assert!(main_fn(&m).body.stmts.is_empty());
+}
+
+#[test]
+fn comment_and_blank_lines_are_skipped_not_errors() {
+    let m = compile_ok("⍝ just a comment\n\nA←1\n");
+    let main = main_fn(&m);
+    assert_eq!(main.body.stmts.len(), 1);
+    assert!(matches!(main.body.stmts[0], Stmt::LetStarBinding { .. }));
+}

--- a/code/packages/rust/apl-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/apl-to-semantic-ir/tests/test_validator.rs
@@ -1,0 +1,69 @@
+//! Structural verification of lowered modules, mirroring
+//! `matlab-to-semantic-ir`'s own `tests/test_validator.rs` capability-
+//! rejection pattern: every module this frontend produces must pass the
+//! shared SIR validator, and (since **every** APL program here emits at
+//! least one SIR22/SIR22-addendum node -- there is no purely-scalar escape
+//! hatch the way MATLAB's literal-only subset has, see `src/lower.rs`'s
+//! module doc comment point 1) a real backend that doesn't implement SIR22
+//! codegen yet must cleanly *reject* the module rather than silently
+//! producing wrong output.
+//!
+//! `semantic-ir-to-javascript` does not implement codegen for any SIR22 or
+//! SIR22-addendum node (see that backend's `emit.rs`, which panics with
+//! "not accepted yet" if one is ever reached post-check -- the panic only
+//! guards the capability check never drifting, since `Feature::NDArrays`/
+//! `MatrixOps` are not in that backend's `ACCEPTED_FEATURES`), so these
+//! tests confirm the *gate* works, not that codegen runs.
+
+use apl_to_semantic_ir::compile_source;
+use semantic_ir::backend::Backend;
+use semantic_ir_to_javascript::JavaScriptBackend;
+
+fn assert_valid(src: &str) -> semantic_ir::Module {
+    let module = compile_source(src, "prog").unwrap_or_else(|e| panic!("lowering failed: {e}"));
+    let report = semantic_ir::validate(&module);
+    assert!(
+        report.is_ok(),
+        "SIR validation failed for `{src}`: {:?}",
+        report.issues
+    );
+    module
+}
+
+#[test]
+fn every_apl_program_validates_but_the_js_backend_rejects_it() {
+    // Even the simplest possible dyadic program -- `3+4` -- lowers to an
+    // `ElementwiseOp`, which is a SIR22 node no backend accepts yet.
+    let module = assert_valid("3+4\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        !errors.is_empty(),
+        "expected the JS backend to reject an ElementwiseOp-using module"
+    );
+}
+
+#[test]
+fn a_pure_scalar_literal_with_no_operator_at_all_still_validates() {
+    // The one shape of APL program that emits *no* SIR22 node at all: a
+    // bare literal with nothing applied to it. `print` is a plain builtin
+    // every backend already implements, so this is the sole case that could
+    // in principle run through the JS backend today.
+    let module = assert_valid("5\n");
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a pure-literal, no-operator module, got: {errors:?}"
+    );
+}
+
+#[test]
+fn reduce_and_outer_product_modules_validate_but_are_rejected_by_js() {
+    let module = assert_valid("+/1 2 3\n");
+    let backend = JavaScriptBackend;
+    assert!(!backend.check_module(&module).is_empty());
+
+    let module = assert_valid("1∘.×2\n");
+    assert!(!backend.check_module(&module).is_empty());
+}

--- a/code/specs/MA05-apl-language.md
+++ b/code/specs/MA05-apl-language.md
@@ -308,8 +308,81 @@ apl-repl/     src/{lib.rs, main.rs}       ← MA-4e (the `apl` binary)
     fails → restored → passes) per this repo's standing DoS-guard-
     verification discipline. See `apl-runtime/CHANGELOG.md` for the full
     writeup.
-- **MA-4f — `apl-to-semantic-ir`**, per [`HML01`](HML01-math-to-semantic-ir.md)
-  §2 — built in this same wave rather than as a later retrofit.
+- **MA-4f — `apl-to-semantic-ir`** (✅ done), per
+  [`HML01`](HML01-math-to-semantic-ir.md) §2 — built in this same wave rather
+  than as a later retrofit, and the first frontend to actually *consume* the
+  SIR22 addendum (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/
+  `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) `semantic-ir` shipped
+  specifically for APL ahead of this crate landing. `compile`/
+  `compile_source` lower `apl-parser`'s CST into a `semantic_ir::Module`; 44
+  tests (41 unit + 3 capability-rejection). Design notes:
+  - **No scalar/array disambiguation needed, unlike MATLAB.**
+    `matlab-to-semantic-ir` has to guess, per operator use, whether `*`/`/`/
+    `\` mean scalar arithmetic or a matrix operation, because MATLAB's `*`
+    genuinely has two different meanings depending on operand shape — that
+    guess (`expr_is_known_scalar`) is real machinery this frontend simply
+    does not need. None of APL's 12 scalar dyadic atoms (`+ - × ÷ ⌈ ⌊ = ≠ <
+    ≤ ≥ >`) have a non-elementwise reading: every one is always elementwise/
+    broadcast, full stop, mirroring `array_runtime::BinOp`'s own one-meaning-
+    per-variant design. So `3+4` and `A+B` lower to the *exact same* node
+    shape (`Expr::ElementwiseOp`) — there is deliberately no "fold two
+    known-scalar literals into a bare `BuiltinCall`" fast path the way
+    MATLAB's frontend has, since writing one would only reintroduce, for
+    zero semantic benefit, the exact heuristic APL's own semantics make
+    unnecessary.
+  - **Chained assignment (`A←B←3`) unrolls via a recursive
+    `(Vec<Stmt>, Expr)` return.** The grammar's right-recursive `assignment =
+    NAME ARROW assignment | value_expr` parses `A←B←3` as `A ← (B ← 3)`, one
+    CST node nested inside another. The lowerer mirrors that shape exactly:
+    it lowers the *inner* assignment first, then appends **one more**
+    statement binding the outer name to the value just bound — returning an
+    `Expr::VarRef` to that name (not a re-lowered copy of the RHS) so the
+    caller above can reuse it without duplicating a potentially large
+    sub-tree. Because the recursion descends into the inner assignment
+    *before* the outer one appends its own statement, the emitted sequence
+    comes out in correct dependency order despite the "outer calls inner
+    first" recursion shape: `[LetStarBinding(B, 3), LetStarBinding(A,
+    VarRef(B))]` — `B` is always bound before anything references it.
+  - **Auto-print reuses the existing `"print"` builtin, and is a real
+    language semantic here, not a REPL nicety.** A bare top-level
+    `value_expr` (an `assignment` node that never reaches the `NAME ARROW …`
+    production) is wrapped in `Expr::BuiltinCall { name: "print", .. }` —
+    the exact builtin name `matlab-to-semantic-ir` already maps its own
+    `disp(x)` call onto, so no backend needs an APL-specific change to
+    support it. This is a deliberately different design choice from
+    MATLAB's own frontend, which does not attempt to model `;`-suppression
+    as a language semantic at all (MATLAB scripts have no auto-print
+    concept to preserve). APL's auto-print, by contrast, genuinely is part
+    of the language (MA05 §4: "assignment is silent, a bare `value_expr`
+    result auto-prints" — the same rule `apl-runtime::eval::run`'s own doc
+    comment already states), so this frontend models it explicitly.
+  - **Five new well-known `BuiltinCall` names, plus two reused from
+    existing frontends.** Of the six atoms with a monadic meaning, `+`
+    (conjugate) needs no wrapper at all — a genuine identity in a cut with
+    no complex numbers, so the operand passes through unchanged rather than
+    being wrapped in a synthetic no-op node. `-` (negate) reuses the *exact*
+    `"neg"` name `matlab-to-semantic-ir`'s own unary negate already
+    established, confirming that a `BuiltinCall` name is a generic
+    operation any backend must implement polymorphically over whatever
+    value flows through it (SIR10's "types carry, don't verify") — it is
+    fine and expected that `"neg"` may receive an array-typed value here
+    even though MATLAB only ever proves it a scalar. `×` (sign), `÷`
+    (reciprocal), `⌈` (ceiling), and `⌊` (floor) introduce four genuinely
+    new well-known names: `"sign"`/`"recip"`/`"ceil"`/`"floor"`. The
+    top-level auto-print wrapper reuses the existing `"print"` name (see
+    above) rather than introducing a sixth.
+  - No discrepancies found against `semantic-ir`'s own `nodes.rs`/
+    `validator.rs` for the SIR22 addendum's field names or `Feature` splits
+    — every design point (`Reshape.shape`/`.target`, `IndexOf.haystack`/
+    `.needle`, the `MatrixOps`+`ArrayColumnMajor` pairing for
+    `Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`Ravel`/`Catenate`, and
+    `NDArrays`-alone for `IndexGenerator`/`IndexOf`) matched the validator's
+    ground truth exactly on the first read. One genuine surprise: `ArrayLit`
+    itself requires **both** `NDArrays` *and* `ArrayColumnMajor` (not
+    `NDArrays` alone, as an early design note for this crate assumed) —
+    confirmed against `validator.rs`'s own `ArrayLit` arm and
+    `matlab-to-semantic-ir`'s identical existing comment on that exact
+    point; this crate's stranded-literal lowering declares both.
 - **Next**: J — kickoff spec [`MA06`](MA06-j-language.md) (shares APL's
   function/operator grammar shape almost wholesale, ASCII-spelled instead
   of glyph-spelled, plus one genuinely new grammar production for tacit

--- a/code/specs/MA05-apl-language.md
+++ b/code/specs/MA05-apl-language.md
@@ -315,7 +315,7 @@ apl-repl/     src/{lib.rs, main.rs}       ← MA-4e (the `apl` binary)
   `IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) `semantic-ir` shipped
   specifically for APL ahead of this crate landing. `compile`/
   `compile_source` lower `apl-parser`'s CST into a `semantic_ir::Module`; 44
-  tests (41 unit + 3 capability-rejection). Design notes:
+  tests (40 unit + 3 capability-rejection + 1 doctest). Design notes:
   - **No scalar/array disambiguation needed, unlike MATLAB.**
     `matlab-to-semantic-ir` has to guess, per operator use, whether `*`/`/`/
     `\` mean scalar arithmetic or a matrix operation, because MATLAB's `*`


### PR DESCRIPTION
## Summary
- New crate `apl-to-semantic-ir` — task **MA-4f**, the last remaining rollout item for APL, and the first frontend to actually *consume* the SIR22 addendum (`Reduce`/`Scan`/`OuterProduct`/`Shape`/`Reshape`/`IndexGenerator`/`IndexOf`/`Ravel`/`Catenate`) that PR #8104 shipped specifically for APL ahead of this crate landing.
- `compile`/`compile_source` lower `apl-parser`'s `GrammarASTNode` CST into a `semantic_ir::Module`.
- **Genuinely simpler than `matlab-to-semantic-ir`** in two concrete ways: (1) none of APL's 12 scalar dyadic atoms have a non-elementwise reading the way MATLAB's `*` does, so every one lowers unconditionally to `Expr::ElementwiseOp` — no scalar-vs-array disambiguation heuristic needed at all; (2) this cut has no control flow or user-defined functions, so the whole program lowers into a single `main` function.
- Handles right-associative chained assignment (`A←B←3`), APL's real auto-print session semantics (mapped onto the same `print` builtin every backend already implements, distinct from MATLAB's `;`-suppression convention), 5 new well-known `BuiltinCall` names (`sign`/`recip`/`ceil`/`floor`, plus reusing existing `neg`/`print`), and explicit rejection of the handful of syntactically-constructible-but-semantically-invalid APL constructs (reduce/scan used dyadically, outer product used monadically, `⍴`/`⍳`/`,` decorated with an operator).
- Marks MA-4f done in `MA05-apl-language.md` with a design-notes writeup, including one confirmed divergence from the original design sketch: `ArrayLit` requires both `Feature::NDArrays` *and* `Feature::ArrayColumnMajor` per the validator's actual ground truth (not `NDArrays` alone) — caught during implementation, not assumed.

## Test plan
- [x] 44 tests (40 unit + 3 capability-rejection + 1 doctest), all green — covers every dyadic atom, every monadic atom (6 valid + 6 rejected), reduce/scan/outer-product (valid + rejected arity), `⍴`/`⍳`/`,` (monadic/dyadic/rejected-decoration), stranded literals, high-minus negative literals, chained assignment, first-occurrence-vs-reassignment, undefined-variable rejection, parse-error propagation, and a full multi-line program validating cleanly via `semantic_ir::validate`.
- [x] `cargo build --workspace` — clean (only pre-existing, unrelated environment-specific failures reproduced identically with this crate excluded too).
- [x] `cargo clippy -p apl-to-semantic-ir --all-targets -- -D warnings` — zero warnings.
- [x] `/security-review` — passed with one INFO-level finding (silent `0.0` fallback on a malformed number-literal parse, unreachable via the real parser path but inconsistent with this file's own error-handling discipline) — fixed in a follow-up commit rather than just reported, since it was a small, contained, in-scope change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)