### PR TITLE
[codex] Port Huffman tree to Haskell

### DIFF
--- a/code/packages/haskell/huffman-tree/BUILD
+++ b/code/packages/haskell/huffman-tree/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/huffman-tree/BUILD_windows
+++ b/code/packages/haskell/huffman-tree/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/huffman-tree/CHANGELOG.md
+++ b/code/packages/haskell/huffman-tree/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-12
+
+- Add deterministic heap-based Huffman tree construction.
+- Add ordinary and canonical prefix-code tables.
+- Add exact-count decoding and structural inspection.
+- Add tests for errors, edge cases, determinism, round trips, and invariants.

--- a/code/packages/haskell/huffman-tree/README.md
+++ b/code/packages/haskell/huffman-tree/README.md
@@ -1,0 +1,24 @@
+# huffman-tree
+
+Pure Haskell implementation of DT27, the deterministic Huffman tree used by
+the Huffman compression package.
+
+## API
+
+- `build` constructs a tree from `WeightPair` values through the existing
+  Haskell `heap` package.
+- `codeTable` and `codeFor` expose ordinary left-zero/right-one tree codes.
+- `canonicalCodeTable` derives deterministic DEFLATE-style codes from the
+  tree's code lengths.
+- `decodeAll` decodes an exact symbol count and reports exhausted streams.
+- `weight`, `depth`, `symbolCount`, `leaves`, and `isValid` expose structural
+  inspection.
+
+Construction follows the shared cross-language tie-break rules: lower weight,
+leaf before internal, lower leaf symbol, then FIFO internal-node creation.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/huffman-tree/cabal.project
+++ b/code/packages/haskell/huffman-tree/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../heap

--- a/code/packages/haskell/huffman-tree/huffman-tree.cabal
+++ b/code/packages/haskell/huffman-tree/huffman-tree.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          huffman-tree
+version:       0.1.0
+synopsis:      Deterministic Huffman tree and canonical prefix codes
+description:   A pure Haskell Huffman tree with deterministic construction, canonical codes, and decoding.
+category:      Data
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  HuffmanTree
+    build-depends:    base >=4.14 && <5
+                    , containers >=0.6 && <0.8
+                    , heap >=0.1 && <0.2
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HuffmanTreeSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , containers >=0.6 && <0.8
+                    , huffman-tree
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/huffman-tree/src/HuffmanTree.hs
+++ b/code/packages/haskell/huffman-tree/src/HuffmanTree.hs
@@ -1,0 +1,238 @@
+module HuffmanTree
+    ( WeightPair (..)
+    , HuffmanTree
+    , build
+    , codeTable
+    , codeFor
+    , canonicalCodeTable
+    , decodeAll
+    , weight
+    , depth
+    , symbolCount
+    , leaves
+    , isValid
+    ) where
+
+import Data.Bits (shiftL)
+import Data.Char (intToDigit)
+import Data.List (find, sortOn)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Heap
+import Numeric (showIntAtBase)
+
+-- | A symbol and its positive occurrence frequency.
+data WeightPair = WeightPair
+    { symbol :: Int
+    , frequency :: Int
+    }
+    deriving (Eq, Show)
+
+-- | A symbol-bearing leaf or a weighted internal node.
+data Node
+    = Leaf Int Int
+    | Internal Int Node Node Int
+    deriving (Eq, Show)
+
+-- | The tree root and the number of leaves supplied at construction time.
+data HuffmanTree = HuffmanTree Node Int
+    deriving (Eq, Show)
+
+-- The heap compares queue entries only by their deterministic priority key.
+-- Node payloads are deliberately excluded from comparison.
+data QueueItem = QueueItem (Int, Int, Int, Int) Node
+    deriving (Show)
+
+instance Eq QueueItem where
+    QueueItem keyA _ == QueueItem keyB _ = keyA == keyB
+
+instance Ord QueueItem where
+    compare (QueueItem keyA _) (QueueItem keyB _) = compare keyA keyB
+
+-- | Construct a deterministic Huffman tree from symbol-frequency pairs.
+--
+-- Equal-weight nodes use the cross-language tie-breaking contract:
+-- leaves precede internal nodes, lower symbols precede higher symbols, and
+-- internal nodes retain creation order.
+build :: [WeightPair] -> Either String HuffmanTree
+build [] = Left "weights must not be empty"
+build pairs =
+    case find ((<= 0) . frequency) pairs of
+        Just pair ->
+            Left
+                ( "frequency must be positive; got symbol="
+                    ++ show (symbol pair)
+                    ++ ", freq="
+                    ++ show (frequency pair)
+                )
+        Nothing -> combine initialQueue 0
+  where
+    initialQueue =
+        Heap.fromList
+            [ let node = Leaf (symbol pair) (frequency pair)
+               in QueueItem (priority node) node
+            | pair <- pairs
+            ]
+    symbolTotal = length pairs
+
+    combine queue order
+        | Heap.size queue == 1 = do
+            (root, _) <- takeMinimum queue
+            Right (HuffmanTree root symbolTotal)
+        | otherwise = do
+            (leftNode, afterLeft) <- takeMinimum queue
+            (rightNode, afterRight) <- takeMinimum afterLeft
+            let combinedWeight = nodeWeight leftNode + nodeWeight rightNode
+                parent = Internal combinedWeight leftNode rightNode order
+                nextQueue = Heap.push (QueueItem (priority parent) parent) afterRight
+            combine nextQueue (order + 1)
+
+-- | Return the ordinary tree-walk code for every symbol.
+codeTable :: HuffmanTree -> Map Int String
+codeTable (HuffmanTree root _) = Map.fromList (walkCodes root "")
+
+-- | Find one symbol's ordinary tree-walk code.
+codeFor :: HuffmanTree -> Int -> Maybe String
+codeFor (HuffmanTree root _) target = findCode root target ""
+
+-- | Return canonical Huffman codes sorted by code length and symbol value.
+canonicalCodeTable :: HuffmanTree -> Map Int String
+canonicalCodeTable (HuffmanTree root _) =
+    case sortedLengths of
+        [] -> Map.empty
+        [(leafSymbol, _)] -> Map.singleton leafSymbol "0"
+        (_, firstLength) : _ ->
+            Map.fromList (assignCodes 0 firstLength sortedLengths)
+  where
+    lengths = Map.fromList (collectLengths root 0)
+    sortedLengths = sortOn (\(leafSymbol, codeLength) -> (codeLength, leafSymbol)) (Map.toList lengths)
+
+-- | Decode exactly the requested number of symbols from an ordinary code stream.
+decodeAll :: HuffmanTree -> String -> Int -> Either String [Int]
+decodeAll _ _ count | count <= 0 = Right []
+decodeAll (HuffmanTree root _) bits count = go root bits []
+  where
+    singleLeaf = isLeaf root
+
+    go _ _ decoded | length decoded == count = Right (reverse decoded)
+    go node remaining decoded =
+        case node of
+            Leaf leafSymbol _ ->
+                let rest =
+                        if singleLeaf
+                            then case remaining of
+                                [] -> []
+                                _ : more -> more
+                            else remaining
+                 in go root rest (leafSymbol : decoded)
+            Internal _ leftNode rightNode _ ->
+                case remaining of
+                    [] ->
+                        Left
+                            ( "Bit stream exhausted after "
+                                ++ show (length decoded)
+                                ++ " symbols; expected "
+                                ++ show count
+                            )
+                    bit : more ->
+                        go (if bit == '0' then leftNode else rightNode) more decoded
+
+-- | The sum of all input frequencies.
+weight :: HuffmanTree -> Int
+weight (HuffmanTree root _) = nodeWeight root
+
+-- | The maximum number of edges from root to leaf.
+depth :: HuffmanTree -> Int
+depth (HuffmanTree root _) = maximumDepth root 0
+
+-- | The number of symbol-frequency pairs supplied to 'build'.
+symbolCount :: HuffmanTree -> Int
+symbolCount (HuffmanTree _ count) = count
+
+-- | Return leaves in left-to-right order with ordinary tree-walk codes.
+leaves :: HuffmanTree -> [(Int, String)]
+leaves (HuffmanTree root _) = walkCodes root ""
+
+-- | Check weight and symbol-uniqueness invariants.
+isValid :: HuffmanTree -> Bool
+isValid (HuffmanTree root _) = fst (checkNode root Set.empty)
+
+priority :: Node -> (Int, Int, Int, Int)
+priority (Leaf leafSymbol leafWeight) = (leafWeight, 0, leafSymbol, -1)
+priority (Internal internalWeight _ _ order) = (internalWeight, 1, -1, order)
+
+nodeWeight :: Node -> Int
+nodeWeight (Leaf _ leafWeight) = leafWeight
+nodeWeight (Internal internalWeight _ _ _) = internalWeight
+
+takeMinimum :: Heap.MinHeap QueueItem -> Either String (Node, Heap.MinHeap QueueItem)
+takeMinimum queue =
+    case Heap.minView queue of
+        Nothing -> Left "internal error: Huffman priority queue is empty"
+        Just (QueueItem _ node, rest) -> Right (node, rest)
+
+walkCodes :: Node -> String -> [(Int, String)]
+walkCodes (Leaf leafSymbol _) prefix = [(leafSymbol, nonEmptyCode prefix)]
+walkCodes (Internal _ leftNode rightNode _) prefix =
+    walkCodes leftNode (prefix ++ "0") ++ walkCodes rightNode (prefix ++ "1")
+
+findCode :: Node -> Int -> String -> Maybe String
+findCode (Leaf leafSymbol _) target prefix
+    | leafSymbol == target = Just (nonEmptyCode prefix)
+    | otherwise = Nothing
+findCode (Internal _ leftNode rightNode _) target prefix =
+    case findCode leftNode target (prefix ++ "0") of
+        Just result -> Just result
+        Nothing -> findCode rightNode target (prefix ++ "1")
+
+nonEmptyCode :: String -> String
+nonEmptyCode "" = "0"
+nonEmptyCode code = code
+
+collectLengths :: Node -> Int -> [(Int, Int)]
+collectLengths (Leaf leafSymbol _) currentDepth =
+    [(leafSymbol, max 1 currentDepth)]
+collectLengths (Internal _ leftNode rightNode _) currentDepth =
+    collectLengths leftNode (currentDepth + 1)
+        ++ collectLengths rightNode (currentDepth + 1)
+
+assignCodes :: Integer -> Int -> [(Int, Int)] -> [(Int, String)]
+assignCodes _ _ [] = []
+assignCodes current previousLength ((leafSymbol, codeLength) : rest) =
+    let shifted =
+            if codeLength > previousLength
+                then current `shiftL` (codeLength - previousLength)
+                else current
+        code = leftPad codeLength (toBinary shifted)
+     in (leafSymbol, code) : assignCodes (shifted + 1) codeLength rest
+
+toBinary :: Integer -> String
+toBinary 0 = "0"
+toBinary value = showIntAtBase 2 intToDigit value ""
+
+leftPad :: Int -> String -> String
+leftPad width value = replicate (max 0 (width - length value)) '0' ++ value
+
+maximumDepth :: Node -> Int -> Int
+maximumDepth (Leaf _ _) currentDepth = currentDepth
+maximumDepth (Internal _ leftNode rightNode _) currentDepth =
+    max
+        (maximumDepth leftNode (currentDepth + 1))
+        (maximumDepth rightNode (currentDepth + 1))
+
+isLeaf :: Node -> Bool
+isLeaf Leaf {} = True
+isLeaf Internal {} = False
+
+checkNode :: Node -> Set Int -> (Bool, Set Int)
+checkNode (Leaf leafSymbol _) seen
+    | Set.member leafSymbol seen = (False, seen)
+    | otherwise = (True, Set.insert leafSymbol seen)
+checkNode (Internal internalWeight leftNode rightNode _) seen
+    | internalWeight /= nodeWeight leftNode + nodeWeight rightNode = (False, seen)
+    | otherwise =
+        let (leftValid, afterLeft) = checkNode leftNode seen
+            (rightValid, afterRight) = checkNode rightNode afterLeft
+         in (leftValid && rightValid, afterRight)

--- a/code/packages/haskell/huffman-tree/test/HuffmanTreeSpec.hs
+++ b/code/packages/haskell/huffman-tree/test/HuffmanTreeSpec.hs
@@ -1,0 +1,140 @@
+module HuffmanTreeSpec (spec) where
+
+import Data.Either (isLeft)
+import Data.List (isPrefixOf)
+import qualified Data.Map.Strict as Map
+import HuffmanTree
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "build" $ do
+        it "constructs single-, two-, and three-symbol trees" $ do
+            fmap symbolCount (build [pair 65 5]) `shouldBe` Right 1
+            fmap weight (build [pair 65 3, pair 66 1]) `shouldBe` Right 4
+            fmap weight classicTree `shouldBe` Right 6
+        it "rejects an empty alphabet" $
+            build [] `shouldSatisfy` isLeft
+        it "rejects zero and negative frequencies with useful errors" $ do
+            build [pair 65 0] `shouldBe`
+                Left "frequency must be positive; got symbol=65, freq=0"
+            build [pair 42 (-5)] `shouldBe`
+                Left "frequency must be positive; got symbol=42, freq=-5"
+        it "builds a valid 256-symbol alphabet" $ do
+            tree <- expectTree (build [pair value (value + 1) | value <- [0 .. 255]])
+            symbolCount tree `shouldBe` 256
+            isValid tree `shouldBe` True
+
+    describe "codeTable and codeFor" $ do
+        it "assigns the shortest code to the highest-frequency symbol" $ do
+            tree <- expectTree classicTree
+            let table = codeTable tree
+            Map.lookup 65 table `shouldBe` Just "0"
+            Map.lookup 67 table `shouldBe` Just "10"
+            Map.lookup 66 table `shouldBe` Just "11"
+        it "uses zero for a single-symbol tree" $ do
+            tree <- expectTree (build [pair 65 1])
+            codeTable tree `shouldBe` Map.singleton 65 "0"
+            codeFor tree 65 `shouldBe` Just "0"
+        it "returns Nothing for a missing symbol" $ do
+            tree <- expectTree (build [pair 65 3, pair 66 1])
+            codeFor tree 99 `shouldBe` Nothing
+        it "produces prefix-free codes" $ do
+            tree <- expectTree (build [pair value (value + 1) | value <- [0 .. 9]])
+            prefixFree (Map.elems (codeTable tree)) `shouldBe` True
+
+    describe "canonicalCodeTable" $ do
+        it "assigns the canonical AAABBC table" $ do
+            tree <- expectTree classicTree
+            canonicalCodeTable tree `shouldBe`
+                Map.fromList [(65, "0"), (66, "10"), (67, "11")]
+        it "preserves every ordinary code length" $ do
+            tree <- expectTree (build [pair value (value + 1) | value <- [0 .. 7]])
+            let ordinary = Map.map length (codeTable tree)
+                canonical = Map.map length (canonicalCodeTable tree)
+            canonical `shouldBe` ordinary
+        it "uses zero for one symbol and remains prefix-free" $ do
+            single <- expectTree (build [pair 65 5])
+            canonicalCodeTable single `shouldBe` Map.singleton 65 "0"
+            tree <- expectTree (build [pair value (value + 1) | value <- [0 .. 9]])
+            prefixFree (Map.elems (canonicalCodeTable tree)) `shouldBe` True
+
+    describe "decodeAll" $ do
+        it "round-trips the AAABBC message" $ do
+            tree <- expectTree classicTree
+            let symbols = [65, 65, 65, 66, 66, 67]
+                bits = encode (codeTable tree) symbols
+            decodeAll tree bits (length symbols) `shouldBe` Right symbols
+        it "round-trips a single-symbol message" $ do
+            tree <- expectTree (build [pair 65 5])
+            decodeAll tree "000" 3 `shouldBe` Right [65, 65, 65]
+        it "round-trips all byte values" $ do
+            let symbols = [0 .. 255]
+            tree <- expectTree (build [pair value (value + 1) | value <- symbols])
+            decodeAll tree (encode (codeTable tree) symbols) 256 `shouldBe` Right symbols
+        it "reports an exhausted stream" $ do
+            tree <- expectTree classicTree
+            decodeAll tree "0" 5 `shouldBe`
+                Left "Bit stream exhausted after 1 symbols; expected 5"
+        it "decodes zero requested symbols without consuming input" $ do
+            tree <- expectTree classicTree
+            decodeAll tree "anything" 0 `shouldBe` Right []
+
+    describe "inspection" $ do
+        it "reports weight, depth, and symbol count" $ do
+            tree <- expectTree classicTree
+            weight tree `shouldBe` 6
+            depth tree `shouldBe` 2
+            symbolCount tree `shouldBe` 3
+        it "reports depth zero for a single leaf and one for two leaves" $ do
+            single <- expectTree (build [pair 65 1])
+            two <- expectTree (build [pair 65 3, pair 66 1])
+            depth single `shouldBe` 0
+            depth two `shouldBe` 1
+        it "returns leaves from left to right with matching codes" $ do
+            tree <- expectTree classicTree
+            leaves tree `shouldBe` [(65, "0"), (67, "10"), (66, "11")]
+
+    describe "deterministic tie-breaking and invariants" $ do
+        it "places the lower symbol on the left for equal-weight leaves" $ do
+            tree <- expectTree (build [pair 65 1, pair 66 1])
+            codeTable tree `shouldBe` Map.fromList [(65, "0"), (66, "1")]
+        it "places an equal-weight leaf before an internal node" $ do
+            tree <- expectTree (build [pair 65 1, pair 66 1, pair 67 2])
+            codeTable tree `shouldBe`
+                Map.fromList [(65, "10"), (66, "11"), (67, "0")]
+        it "uses FIFO creation order for equal-weight internal nodes" $ do
+            tree <- expectTree (build [pair 65 1, pair 66 1, pair 67 1, pair 68 1])
+            codeTable tree `shouldBe`
+                Map.fromList [(65, "00"), (66, "01"), (67, "10"), (68, "11")]
+        it "builds identical trees for identical equal-weight inputs" $ do
+            first <- expectTree (build [pair value 1 | value <- [0 .. 7]])
+            second <- expectTree (build [pair value 1 | value <- [0 .. 7]])
+            codeTable first `shouldBe` codeTable second
+            isValid first `shouldBe` True
+        it "detects duplicate symbols" $ do
+            tree <- expectTree (build [pair 7 1, pair 7 2])
+            isValid tree `shouldBe` False
+  where
+    classicTree = build [pair 65 3, pair 66 2, pair 67 1]
+
+pair :: Int -> Int -> WeightPair
+pair = WeightPair
+
+expectTree :: Either String HuffmanTree -> IO HuffmanTree
+expectTree result =
+    case result of
+        Left message -> expectationFailure message >> fail message
+        Right tree -> pure tree
+
+encode :: Map.Map Int String -> [Int] -> String
+encode table = concatMap (table Map.!)
+
+prefixFree :: [String] -> Bool
+prefixFree codes =
+    and
+        [ not (first `isPrefixOf` second)
+        | (firstIndex, first) <- zip [0 :: Int ..] codes
+        , (secondIndex, second) <- zip [0 :: Int ..] codes
+        , firstIndex /= secondIndex
+        ]

--- a/code/packages/haskell/huffman-tree/test/Spec.hs
+++ b/code/packages/haskell/huffman-tree/test/Spec.hs
@@ -1,0 +1,5 @@
+import HuffmanTreeSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Seventeen package/language slots remain to turn 17 nearly complete packages into
+Sixteen package/language slots remain to turn 16 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,15 +145,15 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 5 remaining ports
+### Haskell: 4 remaining ports
 
 - `huffman-compression`
-- `huffman-tree`
 - `lz77`
 - `lzss`
 - `lzw`
 
-Completed in the Haskell lane: `activation-functions`, `caesar-cipher`.
+Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
+`huffman-tree`.
 
 ### Swift: 3 ports
 


### PR DESCRIPTION
## Summary

- add a pure Haskell DT27 `huffman-tree` port backed by the existing Haskell `heap` package
- implement deterministic tree construction, ordinary and canonical code tables, exact-count decoding, and structural inspection
- cover edge cases, tie-breaking, 256-symbol round trips, and invariants with 24 Hspec examples
- update the package-parity roadmap from 17 to 16 remaining Priority 1 slots

## Why

Haskell was the only established language missing `huffman-tree`. This closes that 14-of-15 gap and provides the dependency needed for a future Haskell `huffman-compression` port.

## Validation

- `cabal test all --test-show-details=direct` (24 huffman-tree examples and 2 heap examples passed)
- `cabal check` (no errors or warnings)
- `python -m unittest discover -s scripts/tests -p 'test_package_parity_report.py'` (6 tests passed)
- `python scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions, 0 unknown-language buckets)
- `git diff origin/main --check`