### PR TITLE
feat(sir-runtime-to-go): Array#cycle(n) block method (Go mirror)

### DIFF
--- a/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-go/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.33.0 — Array `cycle(n)`
+
+Mirrors the Python reference (PR #8117) into the Go backend's inline `__sir`
+runtime (`_sir_array_block_method` beside the existing `chunk_while`/`slice_when`
+arms + the `_sir_array_responds` `respond_to?` arm), continuing the `cycle`
+cross-backend cascade.
+
+- `cycle(n) { |x| … }` (block) → iterate the array `n` full passes in order,
+  yielding each element on every pass; always returns nil. `[1,2,3].cycle(2)`
+  yields `1,2,3,1,2,3`. `n <= 0`, a negative count, an empty receiver, or a nil
+  / non-integer count (Ruby's block-less Enumerator and infinite no-`n` forms)
+  yields nothing rather than hanging — a boolean count is not an `int64`/`int`
+  in Go, so it falls through to the no-yield path.
+- The `array_methods_compile_and_run` suite gains `array_cycle_compile_and_run`:
+  the block `puts`es each yielded element, so the two passes (`1,2,3,1,2,3`) and
+  the `nil` returns for `cycle(2)`, `cycle(0)`, and `[].cycle(5)` are proven
+  under a real `go run`.
+
 ## 0.32.0 — Array `minmax`
 
 Mirrors the Python reference (PR #8092) into the Go backend's inline `__sir`

--- a/code/packages/rust/semantic-ir-to-go/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-go"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 description = "Semantic IR → self-contained Go source code (SIR15). Fourth backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-go/README.md
+++ b/code/packages/rust/semantic-ir-to-go/README.md
@@ -183,7 +183,7 @@ Catalog coverage (v0): **Array** `length`/`size`/`count`, `first`, `last`,
 `empty?`, `include?`, `index`, `push`/`append`, `<<`, `pop`, `shift`, `reverse`,
 `sort`, `min`/`max`/`minmax`/`sum`, `join`, `to_a`, `each`, `map`/`collect`, `select`/`filter`, `reject`,
 `reduce`/`inject`, `find`/`detect`, `any?`, `all?`, `none?`,
-`each_slice`/`each_cons`, `chunk_while`/`slice_when`; **Hash** `keys`,
+`each_slice`/`each_cons`, `chunk_while`/`slice_when`, `cycle`; **Hash** `keys`,
 `values`, `has_key?`/`key?`/`include?`/`member?`, `has_value?`/`value?`, `size`/
 `length`, `empty?`, `each`/`each_pair`, `each_key`, `each_value`, `map`,
 `select`/`filter`, `reject`, `transform_values`, `transform_keys`, and the

--- a/code/packages/rust/semantic-ir-to-go/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-go/src/runtime.rs
@@ -1704,7 +1704,7 @@ func _sir_array_responds(name string) bool {
 		"reject", "reduce", "inject", "find", "detect", "any?", "all?", "none?",
 		"sort_by", "min_by", "max_by", "group_by", "partition", "flat_map",
 		"collect_concat", "take_while", "drop_while", "each_with_object",
-		"chunk_while", "slice_when":
+		"chunk_while", "slice_when", "cycle":
 		return true
 	}
 	return false
@@ -2381,6 +2381,39 @@ func _sir_array_block_method(recv *Seq, name string, args []Value, block *Closur
 			}
 		}
 		return &Seq{Items: slices}, true
+	case "cycle":
+		// `cycle(n) { |x| ... }` -> iterate the array n full passes in order,
+		// yielding each element on every pass; always returns nil.
+		//
+		//   [1,2,3].cycle(2) { |x| out << x }  ->  out == [1,2,3,1,2,3]
+		//   [1,2,3].cycle(0) { ... }           ->  no yields, returns nil
+		//   [].cycle(5) { ... }                ->  no yields (empty run body)
+		//
+		// n <= 0, a negative count, an empty receiver, or a nil / non-integer
+		// count (Ruby's block-less Enumerator and infinite no-`n` forms) yields
+		// nothing rather than hanging, so emitted programs can never spin forever.
+		// A boolean count is not an int64/int in Go, so it falls through to nil.
+		var n int64
+		if len(args) > 0 {
+			if iv, ok := args[0].(int64); ok {
+				n = iv
+			} else if iv, ok := args[0].(int); ok {
+				n = int64(iv)
+			} else {
+				return nil, true
+			}
+		} else {
+			return nil, true
+		}
+		if n <= 0 {
+			return nil, true
+		}
+		for p := int64(0); p < n; p++ {
+			for _, item := range recv.Items {
+				_sir_apply(block, []Value{item})
+			}
+		}
+		return nil, true
 	}
 	return nil, false
 }

--- a/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
+++ b/code/packages/rust/semantic-ir-to-go/tests/compile_and_run_array_methods.rs
@@ -87,6 +87,26 @@ fn puts_stmt(expr: Expr) -> Stmt {
     }
 }
 
+/// One-parameter lambda (for `cycle`'s block), registered top-level.
+fn lambda_fn1(fn_name: &str, p0: &str, body: Block) -> Function {
+    Function {
+        name: fn_name.into(),
+        params: vec![semantic_ir::Param {
+            name: p0.into(),
+            kind: semantic_ir::ParamKind::Required,
+            sir_type: None,
+            default: None,
+            span: s(),
+        }],
+        return_type: None,
+        captures: vec![],
+        body,
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
 /// Two-parameter lambda (for `each_with_index`), registered top-level.
 fn lambda_fn2(fn_name: &str, p0: &str, p1: &str, body: Block) -> Function {
     Function {
@@ -439,6 +459,85 @@ fn array_slice_when_compile_and_run() {
             "[[1, 2], [4], [9, 10, 11, 12]]", // slice_when { b-a>1 }
             "[[9]]",                          // single element
             "[]",                             // [].slice_when → []
+        ],
+        "unexpected stdout:\n{stdout}"
+    );
+}
+
+// ── Array cycle(n) ─────────────────────────────────────────────────────────
+//
+// `cycle(n) { |x| ... }` iterates the array n full passes in order, yielding
+// each element on every pass, and always returns nil.  n <= 0, a negative
+// count, or an empty receiver yields nothing.  Mirrors the Python reference
+// (#8117): the block `puts`es each element so the passes are observable, and
+// the method's nil return is printed after each call.
+fn cycle_module() -> Function {
+    Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block {
+            stmts: vec![
+                // [1,2,3].cycle(2) { |x| puts x.to_s }  → 1 2 3 1 2 3, then nil
+                print_stmt(method(
+                    seq(vec![ilit(1), ilit(2), ilit(3)]),
+                    "cycle",
+                    vec![ilit(2), closure("__lam_puts")],
+                )),
+                // [1,2,3].cycle(0) { … }  → no yields, nil
+                print_stmt(method(
+                    seq(vec![ilit(1), ilit(2), ilit(3)]),
+                    "cycle",
+                    vec![ilit(0), closure("__lam_puts")],
+                )),
+                // [].cycle(5) { … }  → no yields, nil
+                print_stmt(method(seq(vec![]), "cycle", vec![ilit(5), closure("__lam_puts")])),
+            ],
+            value: nil(),
+            span: s(),
+        },
+        effects: EffectSet::PURE.with(Effect::MayPrint),
+        metadata: Metadata::new(),
+        span: s(),
+    }
+}
+
+#[test]
+fn array_cycle_compile_and_run() {
+    if !go_available() {
+        eprintln!("skipping: go not on PATH");
+        return;
+    }
+    // { |x| puts x.to_s } — emit one line per yielded element.
+    let puts_lam = lambda_fn1(
+        "__lam_puts",
+        "x",
+        Block {
+            stmts: vec![puts_stmt(method(var_p("x"), "to_s", vec![]))],
+            value: nil(),
+            span: s(),
+        },
+    );
+    let module = program(vec![cycle_module(), puts_lam]);
+    let artifact = compile(&module).expect("module should compile to Go source");
+    let run_out = run_go(&artifact.source, "cycle");
+    if !run_out.status.success() {
+        panic!(
+            "emitted Go failed:\n--- stderr ---\n{}\n--- source ---\n{}",
+            String::from_utf8_lossy(&run_out.stderr),
+            artifact.source,
+        );
+    }
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "1", "2", "3", "1", "2", "3", // cycle(2) yields two full passes
+            "nil", // cycle(2) returns nil
+            "nil", // cycle(0) — no yields, nil
+            "nil", // [].cycle(5) — no yields, nil
         ],
         "unexpected stdout:\n{stdout}"
     );


### PR DESCRIPTION
## Summary

Mirrors the Python reference ([#8117](https://github.com/adhithyan15/coding-adventures/pull/8117), merged) into the **Go** backend's embedded `__sir` runtime: `Array#cycle(n) { |x| … }` iterates the array `n` full passes in order, yielding each element on every pass, and always returns nil. Second backend in the `cycle` cascade (Python → **Go** → Rust → JS → TS).

## Semantics

- `n` full passes: `[1,2,3].cycle(2) { … }` yields `1,2,3,1,2,3`.
- `n <= 0`, a negative count, or an empty receiver yields nothing.
- A nil / non-integer count — including Ruby's block-less Enumerator form and the **infinite no-`n` form** — yields nothing rather than hanging. A boolean count is not an `int64`/`int` in Go, so it falls through to the no-yield path.
- Always returns nil.

## Changes

- `runtime.rs`: `cycle` arm in `_sir_array_block_method` + `"cycle"` in the `_sir_array_responds` block-method list (Go runtime string).
- `tests/compile_and_run_array_methods.rs`: `array_cycle_compile_and_run` — the block `puts`es each yielded element so the two passes and the `nil` returns for `cycle(2)`, `cycle(0)`, and `[].cycle(5)` are proven under a real `go run`. Adds a one-param `lambda_fn1` helper.

## Verification

- `cargo test -p semantic-ir-to-go --test compile_and_run_array_methods array_cycle_compile_and_run` — **passes** (`go run` exec-proof, stdout diffed against the Python reference).
- Security review passed (guarded comma-ok type assertions can't panic; only a strictly-positive `n` reaches the finite loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)