### PR TITLE
feat(j): j.tokens + j-lexer crate (MA06 §6, MA-6b)

### DIFF
--- a/code/grammars/j/j.tokens
+++ b/code/grammars/j/j.tokens
@@ -1,0 +1,162 @@
+# J Token Grammar
+# ============================================================================
+#
+# Tokenizes the historical-core subset of J fixed by MA-6a
+# (code/specs/MA06-j-language.md §4): dense numeric arrays, the primitive
+# verbs `+ - * % ^ <. >. $ i. , # = ~: < > <: >:`, the two adverbs `/`
+# (reduce) `\` (scan), the one conjunction `@` (compose/atop), assignment
+# `=.`/`=:`, parenthesised grouping, and `NB.` line comments.
+#
+# ============================================================================
+# THE ONE MISTAKE TO NOT MAKE (MA06 §1 bullet 1)
+#
+# `/` is J's reduce ADVERB, not division. APL spells divide with its own
+# unambiguous glyph (`÷`); J, needing `/` for reduce (mirroring APL's own
+# `/`), moves division to `%`. A frontend built by transliterating APL's
+# glyphs one-for-one would get this specific primitive backwards — it is
+# the single most common APL-to-J transliteration mistake (MA06 §1), so it
+# gets its own callout here, at the one file where the mistake would
+# actually manifest as a wrong token.
+# ============================================================================
+#
+# Every other primitive pair shares ONE ASCII glyph or digraph — which
+# meaning applies (e.g. `+` conjugate vs. add) is a PARSER-production
+# concern (which application rule matched), not a lexer concern, exactly as
+# MA05 §3 bullet 3 already established for APL. The token name below is
+# neutral between the two readings, e.g. DOLLAR is "shape" monadically and
+# "reshape" dyadically.
+#
+# Unlike APL (MA05 §3 bullet 4: "every primitive is a single dedicated
+# Unicode code point"), J is ASCII-only, so an overloaded base character
+# needs an explicit `.`- or `:`-suffixed DIGRAPH to spell a related but
+# distinct primitive (MA06 §1 bullet 1, §3 last bullet) — e.g. `<` (less
+# than) vs. `<.` (floor/min) vs. `<:` (less-or-equal). This repo's lexer
+# matches the FIRST pattern (in declaration order) that matches at the
+# current position — not the longest — so every digraph below is declared
+# BEFORE the bare single-character token it could otherwise be swallowed
+# by. This is the same longest-match-first discipline `apl.tokens` already
+# uses for `∘.` (SECTION 1 there), applied far more pervasively here since
+# J has roughly a dozen base characters with a `.`- and/or `:`-suffixed
+# sibling, not just one.
+#
+# Negative number literals: MA06 §4 does not spell out a literal syntax, so
+# this file makes the same historically-faithful call J's own lexer makes —
+# a leading underscore (`_5`, not APL's high-minus `¯`) marks a negative
+# literal. J's real language overloads a bare `_` (and `__`) for
+# (positive/negative) infinity; NUMBER's regex below requires at least one
+# digit after the underscore, so a bare `_` is structurally excluded from
+# this cut rather than merely documented as out of scope — infinity is not
+# in MA06 §4's primitive list, so there is nothing for it to mean yet.
+#
+# @version 1
+
+# ============================================================================
+# SECTION 1: Two-character digraphs, declared before any single-character
+# token they could be confused with (this repo's longest-match-first lexer
+# convention — see e.g. code/grammars/wolfram/wolfram.tokens, and apl.tokens
+# SECTION 1 for the one-glyph precedent this file generalizes).
+#
+# floor / min, ceiling / max: MA06 §4 notes the mapping is the *opposite*
+# character from what APL's ⌊/⌈ might suggest — J's `<.` is floor because
+# `<` already means "less than", and floor rounds *down* toward the lesser
+# neighbor (`>.` / ceiling follows the same logic in the other direction).
+# ============================================================================
+
+FLOOR   = "<."
+CEILING = ">."
+
+# dyadic comparison digraphs (boolean 0/1 result, MA06 §4) — declared here,
+# ahead of the bare LT/GT/EQ tokens in SECTION 2.
+LE = "<:"
+GE = ">:"
+NE = "~:"
+
+# index-generator (monadic, 0-based per MA06 §1 bullet 3) / index-of
+# (dyadic) — declared ahead of NAME (SECTION 4), so `i.5` lexes as one
+# IDOT token followed by NUMBER, never as NAME "i" plus a stray ".".
+IDOT = "i."
+
+# local / global assignment (MA06 §4) — declared ahead of the bare EQ
+# token in SECTION 2, so `=.`/`=:` never lex as EQ followed by a stray
+# `.`/`:`.
+ASSIGN_LOCAL  = "=."
+ASSIGN_GLOBAL = "=:"
+
+# ============================================================================
+# SECTION 2: Single-character primitive verb and comparison glyphs (MA06
+# §4), each declared after any digraph sibling from SECTION 1 that shares
+# its first character.
+#
+# conjugate / add, negate / subtract, sign / multiply, reciprocal / divide
+# (NOT reduce — see the callout above), exponential / power, shape /
+# reshape, ravel / catenate, tally / copy-replicate — one glyph per row, in
+# MA06 §4's listed order.
+# ============================================================================
+
+PLUS    = "+"
+MINUS   = "-"
+STAR    = "*"
+PERCENT = "%"
+CARET   = "^"
+DOLLAR  = "$"
+RAVEL   = ","
+HASH    = "#"
+
+EQ = "="
+LT = "<"
+GT = ">"
+
+# ============================================================================
+# SECTION 3: Adverbs, the one in-scope conjunction, and grouping (MA06 §4).
+#
+# REDUCE and SCAN are postfix on the verb they modify (`+/`, `+\`), exactly
+# as APL's own `/` and `\` already are (MA06 §3: "adverbs, unlike verbs,
+# mostly didn't need re-spelling"). AT is J's `@` ("atop") compose
+# conjunction — a distinct primitive from a train (MA06 §4), applied
+# prefix between two verbs (`f@g`).
+# ============================================================================
+
+REDUCE = "/"
+SCAN   = "\"
+AT     = "@"
+
+LPAREN = "("
+RPAREN = ")"
+
+# ============================================================================
+# SECTION 4: Literal value tokens
+#
+# NUMBER uses a leading underscore for a negative literal (see the header
+# note above), in the mantissa and/or the exponent (e.g. `_3`, `1.5E_3`) —
+# never the ASCII `-`, which is always the MINUS verb token above, exactly
+# mirroring why apl.tokens keeps its own high-minus `¯` distinct from `-`.
+#
+# NAME is a plain ASCII identifier (previously-assigned variables). J's
+# real `u.`/`v.` locale-scoping vocabulary is out of scope for this first
+# cut (MA06 §4).
+# ============================================================================
+
+NUMBER = /_?[0-9]+(\.[0-9]+)?([Ee]_?[0-9]+)?/
+NAME   = /[A-Za-z][A-Za-z0-9]*/
+
+# ============================================================================
+# SECTION 5: Significant newlines + skip patterns
+#
+# A newline separates statements, exactly like APL (apl.tokens SECTION 5) —
+# the same "no dropped newlines inside `( … )`" simplification applies here
+# too: every parenthesised expression must stay on one line for now.
+#
+# `NB.` starts a line comment, consumed to (but not including) the end of
+# the line, so the following NEWLINE is still matched as its own token —
+# mirroring how apl.tokens' `⍝` skip pattern works, just ASCII-spelled and
+# three characters instead of one. Because skip patterns are always tried
+# before the token patterns above (this repo's lexer convention), `NB.`
+# never risks being swallowed by NAME matching a bare `NB` first, even
+# though no ordering precaution was needed in SECTION 1 for it specifically.
+# ============================================================================
+
+NEWLINE = /\r?\n/
+
+skip:
+  WHITESPACE = /[ \t]+/
+  COMMENT    = /NB\.[^\r\n]*/

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -246,6 +246,7 @@ members = [
     "apl-runtime",
     "apl-repl",
     "apl-to-semantic-ir",
+    "j-lexer",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/j-lexer/BUILD
+++ b/code/packages/rust/j-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-lexer -- --nocapture

--- a/code/packages/rust/j-lexer/BUILD_windows
+++ b/code/packages/rust/j-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-lexer -- --nocapture

--- a/code/packages/rust/j-lexer/CHANGELOG.md
+++ b/code/packages/rust/j-lexer/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [0.1.0] - 2026-07-12
+
+### Added
+
+- Initial grammar-driven Rust J tokenizer (MA06 §6, task MA-6b).
+- Statically linked compiled token grammar (`code/grammars/j/j.tokens`),
+  covering the historical-core subset fixed by MA-6a: dense numeric arrays,
+  the primitive verb glyphs (including the ASCII digraphs `<.`/`>.`), the
+  six comparison glyphs, the two adverbs (reduce/scan), the one conjunction
+  (`@` compose), assignment, parenthesised grouping, and `NB.` line
+  comments.
+- Longest-match-first digraph ordering for every `.`/`:`-suffixed sibling
+  of a base character (`<.`/`<:`/`<`, `>.`/`>:`/`>`, `~:`, `=.`/`=:`/`=`,
+  `i.`), applied far more pervasively than APL's own single precedent
+  (`∘.`), since J needs it for roughly a dozen base characters.
+- A dedicated regression test guarding MA06 §1's single most common
+  APL-to-J transliteration mistake: `/` is the reduce adverb, not division
+  (`%` is division).
+- A leading-underscore negative-literal convention (`_5`) for `NUMBER`,
+  since MA06 §4 does not spell out a literal syntax — documented in
+  `j.tokens`'s own header, with a bare `_`/`__` (infinity) structurally
+  excluded from this cut rather than merely documented as deferred.

--- a/code/packages/rust/j-lexer/Cargo.toml
+++ b/code/packages/rust/j-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-j-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "J lexer backed by statically compiled grammar data"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/j-lexer/README.md
+++ b/code/packages/rust/j-lexer/README.md
@@ -1,0 +1,72 @@
+# coding-adventures-j-lexer
+
+J tokenizer backed by `code/grammars/j/j.tokens`, compiled to Rust and
+statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the historical-core subset fixed by
+[MA06 §4](../../../specs/MA06-j-language.md): dense numeric arrays, the
+primitive verbs `+ - * % ^ <. >. $ i. , #`, the six comparison glyphs
+`= ~: < > <: >:`, the two adverbs `/` (reduce) and `\` (scan), the one
+conjunction `@` (compose/atop), assignment `=.`/`=:`, parenthesised
+grouping, and `NB.` line comments.
+
+## The one thing to get right: `/` is not division
+
+APL spells division with its own dedicated glyph (`÷`), so J — which needs
+`/` for the reduce adverb it inherits unchanged from APL — moves division
+to `%` instead. A frontend built by transliterating APL's glyphs one-for-one
+would get this specific primitive backwards; per
+[MA06 §1 bullet 1](../../../specs/MA06-j-language.md), it is the single most
+common APL-to-J transliteration mistake, and this crate's test suite has a
+dedicated regression test for it
+(`slash_is_reduce_not_divide_and_percent_is_divide`).
+
+## ASCII digraphs need lexer lookahead, unlike APL's single code points
+
+Every APL primitive in this repo's MA05 cut is one dedicated Unicode code
+point, so `apl-lexer` never needs to look more than one character ahead. J
+is ASCII-only, so an overloaded base character needs an explicit `.`- or
+`:`-suffixed digraph to spell a related but distinct primitive — e.g. `<`
+(less than) vs. `<.` (floor/min) vs. `<:` (less-or-equal). Since this
+repo's `GrammarLexer` matches the *first* pattern (in declaration order)
+that matches at the current position, not the longest, `j.tokens` declares
+every digraph ahead of the bare single-character token it could otherwise
+be swallowed by (see that file's own SECTION 1 for the full ordering, and
+the `digraphs_are_not_swallowed_by_their_single_character_prefix` test
+below for the regression coverage).
+
+Negative number literals use a leading underscore (`_5`), matching J's own
+historical convention, rather than APL's high-minus `¯` — MA06 §4 doesn't
+spell out a literal syntax, so this crate makes that call itself and
+documents it in `j.tokens`'s own header. A bare `_`/`__` (J's real spelling
+for infinity) is out of scope for this cut and is structurally excluded:
+the `NUMBER` pattern requires at least one digit after the underscore.
+
+Which of a glyph's two readings (monadic vs. dyadic) applies is a
+parser-production concern, not a lexer one, exactly as MA05 §3 bullet 3
+already established for APL — unchanged here.
+
+## Usage
+
+```rust
+use coding_adventures_j_lexer::tokenize_j;
+
+let tokens = tokenize_j("A=.i.5\nB=.+/A");
+```
+
+`tokenize_j` panics on a malformed source string (there is no recoverable
+lexer error to report to a caller yet); use `create_j_lexer` directly if
+you need the `Result`-returning `GrammarLexer::tokenize` instead.
+
+## Where this fits
+
+`j-lexer` is the first of J's frontend crates (MA-6b); the sibling
+`j-parser` crate (MA-6c) will consume this crate's token stream against
+`code/grammars/j/j.grammar` — including the one genuinely new grammar
+production this language needs, tacit hook/fork trains (MA06 §3) — to build
+the `GrammarASTNode` CST a future `j-runtime` will evaluate.

--- a/code/packages/rust/j-lexer/required_capabilities.json
+++ b/code/packages/rust/j-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/j-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/j-lexer/src/_grammar.rs
+++ b/code/packages/rust/j-lexer/src/_grammar.rs
@@ -1,0 +1,237 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: j.tokens
+// Regenerate with: grammar-tools compile-tokens j.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"FLOOR"#.to_string(),
+                pattern: r#"<."#.to_string(),
+                is_regex: false,
+                line_number: 65,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CEILING"#.to_string(),
+                pattern: r#">."#.to_string(),
+                is_regex: false,
+                line_number: 66,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<:"#.to_string(),
+                is_regex: false,
+                line_number: 70,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">:"#.to_string(),
+                is_regex: false,
+                line_number: 71,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NE"#.to_string(),
+                pattern: r#"~:"#.to_string(),
+                is_regex: false,
+                line_number: 72,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"IDOT"#.to_string(),
+                pattern: r#"i."#.to_string(),
+                is_regex: false,
+                line_number: 77,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ASSIGN_LOCAL"#.to_string(),
+                pattern: r#"=."#.to_string(),
+                is_regex: false,
+                line_number: 82,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"ASSIGN_GLOBAL"#.to_string(),
+                pattern: r#"=:"#.to_string(),
+                is_regex: false,
+                line_number: 83,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 96,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 97,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"STAR"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 98,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PERCENT"#.to_string(),
+                pattern: r#"%"#.to_string(),
+                is_regex: false,
+                line_number: 99,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"CARET"#.to_string(),
+                pattern: r#"^"#.to_string(),
+                is_regex: false,
+                line_number: 100,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"DOLLAR"#.to_string(),
+                pattern: r#"$"#.to_string(),
+                is_regex: false,
+                line_number: 101,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RAVEL"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 102,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"HASH"#.to_string(),
+                pattern: r#"#"#.to_string(),
+                is_regex: false,
+                line_number: 103,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 105,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LT"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 106,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GT"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 107,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"REDUCE"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 119,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SCAN"#.to_string(),
+                pattern: r#"\"#.to_string(),
+                is_regex: false,
+                line_number: 120,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"AT"#.to_string(),
+                pattern: r#"@"#.to_string(),
+                is_regex: false,
+                line_number: 121,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 123,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 124,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"_?[0-9]+(\.[0-9]+)?([Ee]_?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 139,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[A-Za-z][A-Za-z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 140,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEWLINE"#.to_string(),
+                pattern: r#"\r?\n"#.to_string(),
+                is_regex: true,
+                line_number: 158,
+                alias: None,
+            },
+        ],
+        keywords: vec![],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t]+"#.to_string(),
+                is_regex: true,
+                line_number: 161,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMENT"#.to_string(),
+                pattern: r#"NB\.[^\r\n]*"#.to_string(),
+                is_regex: true,
+                line_number: 162,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: None,
+        error_definitions: vec![],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/j-lexer/src/lib.rs
+++ b/code/packages/rust/j-lexer/src/lib.rs
@@ -1,0 +1,30 @@
+//! Grammar-driven J tokenizer.
+//!
+//! The token grammar is compiled into this crate at build time, so runtime
+//! callers do not need filesystem access to `code/grammars/j`.
+//!
+//! Unlike `apl-lexer` (MA05 §3 bullet 4: every APL primitive is a single
+//! dedicated Unicode code point), J is ASCII-only, so overloaded base
+//! characters need explicit `.`/`:`-suffixed digraphs to spell related but
+//! distinct primitives (MA06 §1 bullet 1, §3 last bullet) — see
+//! `code/grammars/j/j.tokens` for the full longest-match-first digraph
+//! ordering this crate's compiled grammar embeds. As with `apl-lexer`, which
+//! of a glyph's two readings (monadic vs. dyadic) applies is a
+//! parser-production concern, not a lexer one (MA06 §3 last bullet).
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::Token;
+
+mod _grammar;
+
+pub fn create_j_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    GrammarLexer::new(source, &grammar)
+}
+
+pub fn tokenize_j(source: &str) -> Vec<Token> {
+    let mut lexer = create_j_lexer(source);
+    lexer
+        .tokenize()
+        .unwrap_or_else(|err| panic!("J tokenization failed: {err}"))
+}

--- a/code/packages/rust/j-lexer/tests/test_tokenizer.rs
+++ b/code/packages/rust/j-lexer/tests/test_tokenizer.rs
@@ -1,0 +1,181 @@
+use coding_adventures_j_lexer::{create_j_lexer, tokenize_j};
+use lexer::token::TokenType;
+
+fn token_types(source: &str) -> Vec<String> {
+    tokenize_j(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.effective_type_name().to_string())
+        .collect()
+}
+
+fn token_values(source: &str) -> Vec<String> {
+    tokenize_j(source)
+        .into_iter()
+        .filter(|token| token.type_ != TokenType::Eof)
+        .map(|token| token.value)
+        .collect()
+}
+
+#[test]
+fn slash_is_reduce_not_divide_and_percent_is_divide() {
+    // MA06 §1 bullet 1: the single most common APL-to-J transliteration
+    // mistake is assuming `/` carries over as division the way APL's `÷`
+    // would suggest. It doesn't — `/` is the reduce adverb (shared with
+    // APL), and division is `%` instead. This is the one test in this
+    // suite that exists purely to guard against getting that backwards.
+    assert_eq!(token_types("+/"), vec!["PLUS", "REDUCE"]);
+    assert_eq!(token_types("A%B"), vec!["NAME", "PERCENT", "NAME"]);
+}
+
+#[test]
+fn tokenizes_every_primitive_verb_glyph() {
+    // One glyph per row of MA06 §4's listed order: conjugate/add,
+    // negate/subtract, sign/multiply, reciprocal/divide, exponential/power,
+    // floor·ceiling / min·max (digraphs), shape/reshape, index-generator/
+    // index-of (digraph), ravel/catenate, tally/copy-replicate.
+    assert_eq!(
+        token_types("+ - * % ^ <. >. $ i. , #"),
+        vec![
+            "PLUS", "MINUS", "STAR", "PERCENT", "CARET", "FLOOR", "CEILING", "DOLLAR", "IDOT",
+            "RAVEL", "HASH",
+        ]
+    );
+}
+
+#[test]
+fn tokenizes_all_six_comparison_glyphs() {
+    assert_eq!(
+        token_types("= ~: < > <: >:"),
+        vec!["EQ", "NE", "LT", "GT", "LE", "GE"]
+    );
+}
+
+#[test]
+fn digraphs_are_not_swallowed_by_their_single_character_prefix() {
+    // The core longest-match-first hazard this grammar has to get right:
+    // every `.`/`:`-suffixed digraph must win over the bare prefix
+    // character it starts with, at every position it appears.
+    assert_eq!(token_types("<."), vec!["FLOOR"]);
+    assert_eq!(token_types("<:"), vec!["LE"]);
+    assert_eq!(token_types("<"), vec!["LT"]);
+    assert_eq!(token_types(">."), vec!["CEILING"]);
+    assert_eq!(token_types(">:"), vec!["GE"]);
+    assert_eq!(token_types(">"), vec!["GT"]);
+    assert_eq!(token_types("~:"), vec!["NE"]);
+    assert_eq!(token_types("=."), vec!["ASSIGN_LOCAL"]);
+    assert_eq!(token_types("=:"), vec!["ASSIGN_GLOBAL"]);
+    assert_eq!(token_types("="), vec!["EQ"]);
+    assert_eq!(token_types("i."), vec!["IDOT"]);
+}
+
+#[test]
+fn idot_does_not_swallow_an_ordinary_name_starting_with_i() {
+    // `i.` is only the index-generator/index-of digraph when the very next
+    // character is a literal dot; a name like `iota`, `if`, or `i` alone
+    // must still tokenize as a plain NAME.
+    assert_eq!(token_types("iota"), vec!["NAME"]);
+    assert_eq!(token_types("i"), vec!["NAME"]);
+    assert_eq!(token_types("i.5"), vec!["IDOT", "NUMBER"]);
+}
+
+#[test]
+fn tokenizes_adverbs_conjunction_grouping_and_assignment() {
+    assert_eq!(
+        token_types("A=.(+/ B)"),
+        vec![
+            "NAME", "ASSIGN_LOCAL", "LPAREN", "PLUS", "REDUCE", "NAME", "RPAREN",
+        ]
+    );
+    assert_eq!(token_types("A=:B"), vec!["NAME", "ASSIGN_GLOBAL", "NAME"]);
+    assert_eq!(token_types("+\\ B"), vec!["PLUS", "SCAN", "NAME"]);
+    assert_eq!(token_types("f@g"), vec!["NAME", "AT", "NAME"]);
+}
+
+#[test]
+fn tokenizes_dense_numeric_arrays_via_vector_stranding() {
+    // Mirrors apl-lexer: stranding (juxtaposed literals separated only by
+    // whitespace) is a NUMBER NUMBER NUMBER token sequence at the lexer
+    // level — grouping into one array literal is the parser's job.
+    assert_eq!(token_types("1 2 3"), vec!["NUMBER", "NUMBER", "NUMBER"]);
+    assert_eq!(token_values("1 2 3"), vec!["1", "2", "3"]);
+}
+
+#[test]
+fn tokenizes_underscore_negative_numbers_distinctly_from_the_minus_verb() {
+    // A leading underscore marks a negative literal (this file's own
+    // design choice, MA06 §4 leaves the literal syntax unstated) — distinct
+    // from the MINUS verb glyph `-`, so `_3` is one NUMBER token but `A-B`
+    // keeps `-` as its own MINUS token.
+    assert_eq!(token_types("_3"), vec!["NUMBER"]);
+    assert_eq!(token_values("_3"), vec!["_3"]);
+    assert_eq!(token_types("A-B"), vec!["NAME", "MINUS", "NAME"]);
+    assert_eq!(token_types("A -_3"), vec!["NAME", "MINUS", "NUMBER"]);
+}
+
+#[test]
+fn a_bare_underscore_is_not_a_number() {
+    // Infinity (a bare `_`/`__`) is out of scope for this cut (MA06 §4
+    // never lists it as a primitive) — NUMBER's regex requires at least
+    // one digit after the underscore, so a lone `_` matches no token in
+    // this grammar at all (it is structurally excluded, not merely
+    // documented as deferred) and the lexer reports it as an error rather
+    // than silently inventing a meaning for it.
+    assert!(create_j_lexer("_").tokenize().is_err());
+}
+
+#[test]
+fn tokenizes_numbers_with_decimal_and_underscore_exponent() {
+    assert_eq!(token_types("1.5E_3"), vec!["NUMBER"]);
+    assert_eq!(token_values("1.5E_3"), vec!["1.5E_3"]);
+    assert_eq!(token_values("3.14"), vec!["3.14"]);
+}
+
+#[test]
+fn tokenizes_plain_ascii_names() {
+    assert_eq!(token_types("VAR1 x Result"), vec!["NAME", "NAME", "NAME"]);
+}
+
+#[test]
+fn skips_whitespace_and_nb_line_comments() {
+    assert_eq!(
+        token_types("NB. a whole comment line\nA=.1"),
+        vec!["NEWLINE", "NAME", "ASSIGN_LOCAL", "NUMBER"]
+    );
+    assert_eq!(
+        token_types("A=.1 NB. trailing comment\nB=.2"),
+        vec![
+            "NAME", "ASSIGN_LOCAL", "NUMBER", "NEWLINE", "NAME", "ASSIGN_LOCAL", "NUMBER",
+        ]
+    );
+}
+
+#[test]
+fn nb_comment_does_not_swallow_an_ordinary_name_starting_with_nb() {
+    // "NB." is only a comment starter when followed by a literal dot; a
+    // name that merely starts with those two letters (e.g. `NBA`) must
+    // still tokenize as a plain NAME.
+    assert_eq!(token_types("NBA=.1"), vec!["NAME", "ASSIGN_LOCAL", "NUMBER"]);
+}
+
+#[test]
+fn newline_is_its_own_significant_token() {
+    assert_eq!(
+        token_types("A=.1\nB=.2"),
+        vec!["NAME", "ASSIGN_LOCAL", "NUMBER", "NEWLINE", "NAME", "ASSIGN_LOCAL", "NUMBER"]
+    );
+}
+
+#[test]
+fn tokenizes_the_ma06_index_generator_and_sum_reduce_end_to_end() {
+    // `A=.i.5` then `B=.+/A` — 0-based index-generator followed by a
+    // sum-reduce, J's own ASCII-spelled analogue of MA05's `A←⍳5` / `B←+/A`
+    // running example.
+    assert_eq!(
+        token_types("A=.i.5\nB=.+/A"),
+        vec![
+            "NAME", "ASSIGN_LOCAL", "IDOT", "NUMBER", "NEWLINE", "NAME", "ASSIGN_LOCAL", "PLUS",
+            "REDUCE", "NAME",
+        ]
+    );
+}

--- a/code/specs/MA06-j-language.md
+++ b/code/specs/MA06-j-language.md
@@ -199,6 +199,15 @@ language here ([`MA01`](MA01-matlab-language.md),
   assignment statement (`name =. expr` / `name =: expr`); right-to-left
   evaluation, parenthesised grouping `( )`.
 - **Comments** `NB.` to end of line.
+- **Negative number literals** (addendum, fixed at MA-6b since this spec
+  did not originally settle it): a leading underscore (`_5`, `1.5E_3`) per
+  J's own real historical convention — not APL's high-minus `¯` (MA05 §4),
+  which has no ASCII spelling. J's real language also overloads a bare `_`/
+  `__` for (positive/negative) infinity; that reading is out of scope for
+  this cut (never listed among this section's primitives) and is excluded
+  structurally, not just by omission — `j.tokens`' `NUMBER` pattern requires
+  at least one digit after the underscore, so a lone `_` matches no token
+  in this grammar.
 
 **Deferred (post-MA-6):** boxing and nested/ragged arrays (§1), the
 `"` rank conjunction and axis-specific reduce/scan (§1 — the direct J


### PR DESCRIPTION
## Summary

Front2's turn: J's own kickoff spec ([MA06](code/specs/MA06-j-language.md), MA-6a, #8093) is design-only, so this is the first J implementation item, per MA06 §6's crate layout.

- **`code/grammars/j/j.tokens`**: the ASCII-spelled primitive verb/comparison/adverb/conjunction glyph set (MA06 §4). Digraph tokenization needs far more lookahead care than APL's single-code-point primitives — every `.`/`:`-suffixed sibling of a base character (`<.` `<:` `<`, `>.` `>:` `>`, `~:`, `=.` `=:` `=`, `i.`) is declared before the shorter prefix token it could otherwise be swallowed by, generalizing `apl.tokens`' own one-glyph `OUTER` (`∘.`) precedent across roughly a dozen base characters.
- **`code/packages/rust/j-lexer`**: the compiled-grammar tokenizer crate, mirroring `apl-lexer`'s shape exactly (`lib.rs` wrapping `GrammarLexer`, `_grammar.rs` generated via `grammar-tools compile-tokens`, README, CHANGELOG, BUILD/BUILD_windows, `required_capabilities.json`). 15 tests, including a dedicated regression guard for MA06 §1's single most common APL-to-J transliteration mistake: `/` is the reduce adverb, not division (`%` is division).
- **`MA06-j-language.md` §4 addendum**: documents a negative-number-literal design decision the original kickoff spec left unstated — a leading underscore (`_5`), matching J's real historical convention, with a bare `_`/`__` (infinity) structurally excluded from this cut via the `NUMBER` pattern requiring a digit after the underscore, not merely documented as deferred.

Per MA06 §6's crate layout, `j.grammar` + `j-parser` (the train production, MA06 §3's genuinely new grammar problem) is a separate later item (MA-6c), not part of this PR.

## Test plan

- [x] `grammar-tools validate-tokens code/grammars/j/j.tokens` passes
- [x] `cargo test -p coding-adventures-j-lexer` — 15/15 tests pass
- [x] `cargo clippy -p coding-adventures-j-lexer --all-targets` clean
- [x] Security review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)