### PR TITLE
[codex] Port Huffman compression to Haskell

### DIFF
--- a/code/packages/haskell/huffman-compression/BUILD
+++ b/code/packages/haskell/huffman-compression/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/huffman-compression/BUILD_windows
+++ b/code/packages/haskell/huffman-compression/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/huffman-compression/CHANGELOG.md
+++ b/code/packages/haskell/huffman-compression/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-12
+
+- Add CMP04 compression and decompression for strict `ByteString` values.
+- Reuse the deterministic Haskell `huffman-tree` implementation.
+- Add canonical code reconstruction and LSB-first bit packing.
+- Validate malformed headers, length tables, prefixes, and truncated streams.
+- Add round-trip, wire-format, effectiveness, determinism, and error tests.

--- a/code/packages/haskell/huffman-compression/README.md
+++ b/code/packages/haskell/huffman-compression/README.md
@@ -1,0 +1,28 @@
+# huffman-compression
+
+Pure Haskell implementation of CMP04, the canonical Huffman byte codec.
+
+## API
+
+- `compress` counts byte frequencies, delegates deterministic tree construction
+  to the Haskell `huffman-tree` package, and emits the self-contained CMP04 wire
+  format.
+- `decompress` reconstructs canonical codes from the transmitted length table
+  and decodes the LSB-first bit stream.
+
+Both functions return `Either String ByteString`. The decoder validates header
+lengths, symbol counts, table ordering, duplicate symbols, code-length bounds,
+canonical oversubscription, invalid prefixes, and exhausted streams.
+
+## Wire format
+
+The payload contains an eight-byte big-endian header, a two-byte
+`(symbol, code length)` entry for every distinct byte, and an LSB-first packed
+bit stream. Code-length entries are sorted by `(length, symbol)` so the decoder
+can reconstruct the same canonical codes without transmitting the tree.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/huffman-compression/cabal.project
+++ b/code/packages/haskell/huffman-compression/cabal.project
@@ -1,0 +1,1 @@
+packages: . ../huffman-tree ../heap

--- a/code/packages/haskell/huffman-compression/huffman-compression.cabal
+++ b/code/packages/haskell/huffman-compression/huffman-compression.cabal
@@ -1,0 +1,33 @@
+cabal-version: 3.0
+name:          huffman-compression
+version:       0.1.0
+synopsis:      CMP04 canonical Huffman byte compression
+description:   Pure Haskell CMP04 compression with canonical Huffman codes and strict wire-format validation.
+category:      Compression
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  HuffmanCompression
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , containers >=0.6 && <0.8
+                    , huffman-tree >=0.1 && <0.2
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    HuffmanCompressionSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , huffman-compression
+                    , hspec == 2.*
+    default-language: Haskell2010

--- a/code/packages/haskell/huffman-compression/src/HuffmanCompression.hs
+++ b/code/packages/haskell/huffman-compression/src/HuffmanCompression.hs
@@ -1,0 +1,223 @@
+module HuffmanCompression
+    ( compress
+    , decompress
+    ) where
+
+import Data.Bits ((.|.), setBit, shiftL, shiftR, testBit)
+import qualified Data.ByteString as BS
+import Data.Char (intToDigit)
+import Data.List (find, foldl', sortOn)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Word (Word8, Word32)
+import qualified HuffmanTree
+import Numeric (showIntAtBase)
+
+maxCodeLength :: Int
+maxCodeLength = 16
+
+alphabetSize :: Word32
+alphabetSize = 256
+
+-- | Compress bytes into the self-contained CMP04 wire format.
+compress :: BS.ByteString -> Either String BS.ByteString
+compress input
+    | BS.null input = Right (encodeWord32 0 <> encodeWord32 0)
+    | toInteger (BS.length input) > toInteger (maxBound :: Word32) =
+        Left "input is too large for the CMP04 uint32 length field"
+    | otherwise = do
+        tree <- HuffmanTree.build weightPairs
+        let canonical = HuffmanTree.canonicalCodeTable tree
+            entries =
+                sortOn
+                    (\(byte, codeLength) -> (codeLength, byte))
+                    [ (fromIntegral symbol, length code)
+                    | (symbol, code) <- Map.toList canonical
+                    ]
+        case find ((> maxCodeLength) . snd) entries of
+            Just (byte, codeLength) ->
+                Left
+                    ( "Huffman code for symbol "
+                        ++ show byte
+                        ++ " exceeds the 16-bit CMP04 limit: "
+                        ++ show codeLength
+                    )
+            Nothing -> do
+                bitString <- encodeInput canonical (BS.unpack input)
+                let header =
+                        encodeWord32 (fromIntegral (BS.length input))
+                            <> encodeWord32 (fromIntegral (length entries))
+                    lengthTable =
+                        BS.pack
+                            (concatMap (\(byte, codeLength) -> [byte, fromIntegral codeLength]) entries)
+                Right (header <> lengthTable <> packBitsLsbFirst bitString)
+  where
+    frequencies =
+        BS.foldl'
+            (\counts byte -> Map.insertWith (+) byte 1 counts)
+            Map.empty
+            input
+    weightPairs =
+        [ HuffmanTree.WeightPair (fromIntegral byte) count
+        | (byte, count) <- Map.toList frequencies
+        ]
+
+-- | Decompress one CMP04 payload, rejecting malformed headers and code tables.
+decompress :: BS.ByteString -> Either String BS.ByteString
+decompress input
+    | BS.length input < 8 = Left "truncated CMP04 header: expected at least 8 bytes"
+    | otherwise = do
+        originalLength <- decodeWord32 input 0
+        symbolCount <- decodeWord32 input 4
+        if symbolCount > alphabetSize
+            then Left "symbol count exceeds the 256-byte alphabet"
+            else do
+                let count = fromIntegral symbolCount
+                    tableEnd = 8 + 2 * count
+                if BS.length input < tableEnd
+                    then Left "truncated CMP04 code-length table"
+                    else do
+                        let entries =
+                                [ (BS.index input (8 + 2 * index), fromIntegral (BS.index input (9 + 2 * index)))
+                                | index <- [0 .. count - 1]
+                                ]
+                        validateHeader originalLength symbolCount
+                        if originalLength == 0
+                            then Right BS.empty
+                            else do
+                                decodeTable <- canonicalDecodeTable entries
+                                let maxLength = maximum (map snd entries)
+                                    bits = unpackBitsLsbFirst (BS.drop tableEnd input)
+                                decoded <- decodeSymbols originalLength maxLength decodeTable bits
+                                Right (BS.pack decoded)
+
+validateHeader :: Word32 -> Word32 -> Either String ()
+validateHeader originalLength symbolCount
+    | originalLength == 0 && symbolCount /= 0 =
+        Left "zero-length payload must have a zero symbol count"
+    | originalLength /= 0 && symbolCount == 0 =
+        Left "non-empty payload must have at least one symbol"
+    | otherwise = Right ()
+
+canonicalDecodeTable :: [(Word8, Int)] -> Either String (Map String Word8)
+canonicalDecodeTable [] = Left "non-empty payload has an empty code-length table"
+canonicalDecodeTable entries@((_, firstLength) : _) = do
+    case find ((== 0) . snd) entries of
+        Just (byte, _) -> Left ("code length is zero for symbol " ++ show byte)
+        Nothing -> Right ()
+    case find ((> maxCodeLength) . snd) entries of
+        Just (byte, codeLength) ->
+            Left
+                ( "code length exceeds 16 bits for symbol "
+                    ++ show byte
+                    ++ ": "
+                    ++ show codeLength
+                )
+        Nothing -> Right ()
+    let symbols = map fst entries
+    if Set.size (Set.fromList symbols) /= length symbols
+        then Left "duplicate symbol in CMP04 code-length table"
+        else Right ()
+    if entries /= sortOn (\(byte, codeLength) -> (codeLength, byte)) entries
+        then Left "CMP04 code-length table is not sorted by length and symbol"
+        else do
+            codes <- assignCanonicalCodes 0 firstLength entries
+            Right (Map.fromList [(bits, byte) | (byte, bits) <- codes])
+
+assignCanonicalCodes :: Integer -> Int -> [(Word8, Int)] -> Either String [(Word8, String)]
+assignCanonicalCodes _ _ [] = Right []
+assignCanonicalCodes current previousLength ((byte, codeLength) : rest) = do
+    let shifted =
+            if codeLength > previousLength
+                then current `shiftL` (codeLength - previousLength)
+                else current
+        limit = (1 :: Integer) `shiftL` codeLength
+    if shifted >= limit
+        then Left "oversubscribed canonical Huffman code lengths"
+        else do
+            let code = leftPad codeLength (toBinary shifted)
+            remaining <- assignCanonicalCodes (shifted + 1) codeLength rest
+            Right ((byte, code) : remaining)
+
+encodeInput :: Map Int String -> [Word8] -> Either String String
+encodeInput table = fmap concat . traverse lookupCode
+  where
+    lookupCode byte =
+        case Map.lookup (fromIntegral byte) table of
+            Nothing -> Left ("internal error: missing Huffman code for symbol " ++ show byte)
+            Just code -> Right code
+
+decodeSymbols :: Word32 -> Int -> Map String Word8 -> String -> Either String [Word8]
+decodeSymbols expected maxLength table = go expected 0 "" []
+  where
+    go 0 _ _ decoded _ = Right (reverse decoded)
+    go remaining decodedCount accumulated decoded bits =
+        case bits of
+            [] ->
+                Left
+                    ( "bit stream exhausted after "
+                        ++ show decodedCount
+                        ++ " symbols; expected "
+                        ++ show expected
+                    )
+            bit : more ->
+                let candidate = accumulated ++ [bit]
+                 in case Map.lookup candidate table of
+                        Just byte -> go (remaining - 1) (decodedCount + 1) "" (byte : decoded) more
+                        Nothing
+                            | length candidate >= maxLength ->
+                                Left "invalid prefix in CMP04 bit stream"
+                            | otherwise ->
+                                go remaining decodedCount candidate decoded more
+
+packBitsLsbFirst :: String -> BS.ByteString
+packBitsLsbFirst bits = BS.pack (reverse (finish (foldl' step ([], 0, 0) bits)))
+  where
+    step :: ([Word8], Word8, Int) -> Char -> ([Word8], Word8, Int)
+    step (output, buffer, bitPosition) bit =
+        let nextBuffer = if bit == '1' then setBit buffer bitPosition else buffer
+         in if bitPosition == 7
+                then (nextBuffer : output, 0, 0)
+                else (output, nextBuffer, bitPosition + 1)
+
+    finish :: ([Word8], Word8, Int) -> [Word8]
+    finish (output, _, 0) = output
+    finish (output, buffer, _) = buffer : output
+
+unpackBitsLsbFirst :: BS.ByteString -> String
+unpackBitsLsbFirst = concatMap byteBits . BS.unpack
+  where
+    byteBits byte =
+        [ if testBit byte bitPosition then '1' else '0'
+        | bitPosition <- [0 .. 7]
+        ]
+
+encodeWord32 :: Word32 -> BS.ByteString
+encodeWord32 value =
+    BS.pack
+        [ fromIntegral (value `shiftR` 24)
+        , fromIntegral (value `shiftR` 16)
+        , fromIntegral (value `shiftR` 8)
+        , fromIntegral value
+        ]
+
+decodeWord32 :: BS.ByteString -> Int -> Either String Word32
+decodeWord32 input offset
+    | BS.length input < offset + 4 = Left "truncated uint32 field"
+    | otherwise =
+        Right
+            ( byteAt 0 `shiftL` 24
+                .|. byteAt 1 `shiftL` 16
+                .|. byteAt 2 `shiftL` 8
+                .|. byteAt 3
+            )
+  where
+    byteAt index = fromIntegral (BS.index input (offset + index))
+
+toBinary :: Integer -> String
+toBinary 0 = "0"
+toBinary value = showIntAtBase 2 intToDigit value ""
+
+leftPad :: Int -> String -> String
+leftPad width value = replicate (max 0 (width - length value)) '0' ++ value

--- a/code/packages/haskell/huffman-compression/test/HuffmanCompressionSpec.hs
+++ b/code/packages/haskell/huffman-compression/test/HuffmanCompressionSpec.hs
@@ -1,0 +1,127 @@
+module HuffmanCompressionSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import Data.List (isInfixOf, sort)
+import Data.Word (Word8, Word32)
+import HuffmanCompression
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "round trips" $ do
+        it "round-trips empty input" $
+            roundTrip BS.empty `shouldBe` Right BS.empty
+        it "round-trips the AAABBC reference vector" $
+            roundTrip (ascii "AAABBC") `shouldBe` Right (ascii "AAABBC")
+        it "round-trips hello world and binary bytes" $ do
+            roundTrip (ascii "hello world") `shouldBe` Right (ascii "hello world")
+            let binary = BS.pack [0, 1, 2, 3, 255, 254, 128, 64, 32]
+            roundTrip binary `shouldBe` Right binary
+        it "round-trips all 256 byte values" $ do
+            let allBytes = BS.pack [0 .. 255]
+            roundTrip allBytes `shouldBe` Right allBytes
+        it "round-trips all byte values repeated" $ do
+            let allBytes = BS.concat (replicate 10 (BS.pack [0 .. 255]))
+            roundTrip allBytes `shouldBe` Right allBytes
+        it "round-trips one repeated symbol" $ do
+            let repeated = BS.replicate 100 65
+            roundTrip repeated `shouldBe` Right repeated
+        it "round-trips two equal-frequency symbols" $ do
+            let alternating = BS.concat (replicate 100 (ascii "AB"))
+            roundTrip alternating `shouldBe` Right alternating
+        it "round-trips a long repeated pattern" $ do
+            let patternBytes = BS.concat (replicate 500 (ascii "the quick brown fox "))
+            roundTrip patternBytes `shouldBe` Right patternBytes
+
+    describe "wire format" $ do
+        it "writes the exact empty header" $
+            compress BS.empty `shouldBe` Right (BS.replicate 8 0)
+        it "writes the exact AAABBC bytes" $
+            compress (ascii "AAABBC") `shouldBe`
+                Right (BS.pack [0, 0, 0, 6, 0, 0, 0, 3, 65, 1, 66, 2, 67, 2, 0xA8, 0x01])
+        it "writes the original length and symbol count as big-endian uint32 values" $ do
+            compressed <- expectRight (compress (ascii "hello"))
+            BS.take 4 compressed `shouldBe` BS.pack [0, 0, 0, 5]
+            BS.take 4 (BS.drop 4 compressed) `shouldBe` BS.pack [0, 0, 0, 4]
+        it "sorts table entries by code length and symbol" $ do
+            compressed <- expectRight (compress (ascii "AAABBC"))
+            let pairs = [(BS.index compressed offset, BS.index compressed (offset + 1)) | offset <- [8, 10, 12]]
+            map (\(symbol, codeLength) -> (codeLength, symbol)) pairs
+                `shouldBe` sort (map (\(symbol, codeLength) -> (codeLength, symbol)) pairs)
+        it "uses one bit per occurrence for a single symbol" $ do
+            compressed <- expectRight (compress (BS.replicate 8 65))
+            BS.length compressed `shouldBe` 11
+            BS.drop 8 compressed `shouldBe` BS.pack [65, 1, 0]
+        it "packs the bit stream LSB-first" $ do
+            compressed <- expectRight (compress (ascii "AAABBC"))
+            BS.drop 14 compressed `shouldBe` BS.pack [0xA8, 0x01]
+
+    describe "compression effectiveness and stability" $ do
+        it "shrinks a highly repetitive input" $ do
+            let input = BS.replicate 1000 88
+            compressed <- expectRight (compress input)
+            BS.length compressed `shouldSatisfy` (< BS.length input)
+        it "expands a short uniform alphabet because of metadata" $ do
+            let input = BS.pack [0 .. 255]
+            compressed <- expectRight (compress input)
+            BS.length compressed `shouldSatisfy` (> BS.length input)
+        it "produces deterministic output" $ do
+            let input = ascii "the quick brown fox jumps over the lazy dog"
+            compress input `shouldBe` compress input
+
+    describe "malformed input" $ do
+        it "rejects truncated headers" $ do
+            decompress BS.empty `shouldSatisfy` isLeft
+            decompress (BS.replicate 7 0) `shouldSatisfy` isLeft
+        it "rejects a zero symbol count for non-empty output" $
+            decompress (wire 1 0 []) `leftShouldContain` "at least one symbol"
+        it "rejects a non-zero symbol count for empty output" $
+            decompress (wire 0 1 [65, 1]) `leftShouldContain` "zero symbol count"
+        it "rejects symbol counts larger than the byte alphabet" $
+            decompress (wire 1 257 []) `leftShouldContain` "256-byte alphabet"
+        it "rejects truncated code-length tables" $
+            decompress (wire 1 2 [65, 1]) `leftShouldContain` "truncated"
+        it "rejects zero and overlong code lengths" $ do
+            decompress (wire 1 1 [65, 0, 0]) `leftShouldContain` "length is zero"
+            decompress (wire 1 1 [65, 17, 0]) `leftShouldContain` "exceeds 16"
+        it "rejects duplicate symbols" $
+            decompress (wire 1 2 [65, 1, 65, 2, 0]) `leftShouldContain` "duplicate symbol"
+        it "rejects unsorted code-length entries" $
+            decompress (wire 1 2 [66, 2, 65, 1, 0]) `leftShouldContain` "not sorted"
+        it "rejects oversubscribed canonical lengths" $
+            decompress (wire 1 3 [65, 1, 66, 1, 67, 1, 0]) `leftShouldContain` "oversubscribed"
+        it "rejects exhausted bit streams" $
+            decompress (wire 2 1 [65, 1]) `leftShouldContain` "exhausted"
+        it "rejects invalid bit prefixes" $
+            decompress (wire 1 1 [65, 1, 1]) `leftShouldContain` "invalid prefix"
+
+roundTrip :: BS.ByteString -> Either String BS.ByteString
+roundTrip input = compress input >>= decompress
+
+ascii :: String -> BS.ByteString
+ascii = BS.pack . map (fromIntegral . fromEnum)
+
+expectRight :: Either String value -> IO value
+expectRight result =
+    case result of
+        Left message -> expectationFailure message >> fail message
+        Right value -> pure value
+
+leftShouldContain :: Either String value -> String -> Expectation
+leftShouldContain result expected =
+    case result of
+        Left message -> message `shouldSatisfy` isInfixOf expected
+        Right _ -> expectationFailure ("expected Left containing " ++ show expected)
+
+wire :: Word32 -> Word32 -> [Word8] -> BS.ByteString
+wire originalLength symbolCount rest =
+    BS.pack (word32 originalLength ++ word32 symbolCount ++ rest)
+
+word32 :: Word32 -> [Word8]
+word32 value =
+    [ fromIntegral (value `div` 16777216)
+    , fromIntegral (value `div` 65536)
+    , fromIntegral (value `div` 256)
+    , fromIntegral value
+    ]

--- a/code/packages/haskell/huffman-compression/test/Spec.hs
+++ b/code/packages/haskell/huffman-compression/test/Spec.hs
@@ -1,0 +1,5 @@
+import HuffmanCompressionSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Sixteen package/language slots remain to turn 16 nearly complete packages into
+Fifteen package/language slots remain to turn 15 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,15 +145,14 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 4 remaining ports
+### Haskell: 3 remaining ports
 
-- `huffman-compression`
 - `lz77`
 - `lzss`
 - `lzw`
 
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
-`huffman-tree`.
+`huffman-tree`, `huffman-compression`.
 
 ### Swift: 3 ports
 


### PR DESCRIPTION
## Summary

- add a pure Haskell CMP04 `huffman-compression` port using strict `ByteString` inputs and outputs
- reuse the Haskell `huffman-tree` dependency for deterministic canonical codes
- implement the specified big-endian header, sorted code-length table, and LSB-first bit stream
- reject truncated headers/tables, contradictory counts, invalid lengths, duplicate symbols, unsorted or oversubscribed tables, invalid prefixes, and exhausted streams
- update the package-parity roadmap from 16 to 15 remaining Priority 1 slots

## Why

Haskell was the only established language missing `huffman-compression`. The prerequisite `huffman-tree` port merged in #8122, making this the smallest dependency-safe remaining Haskell parity item.

## Impact

Haskell now has a self-contained CMP04 codec compatible with the repository wire-format vector. The remaining Haskell Priority 1 lane is reduced to `lz77`, `lzss`, and `lzw`.

## Validation

- `cabal test all --test-show-details=direct` (28 codec, 24 huffman-tree, and 2 heap examples passed)
- `cabal check` (no errors or warnings)
- `python -m unittest discover -s scripts/tests -p 'test_package_parity_report.py'` (6 tests passed)
- `python scripts/package_parity_report.py --format json --fail-on-collisions` (0 collisions, 0 unknown-language buckets)
- `git diff --cached --check`