### PR TITLE
feat(sir-runtime-to-rust): Array#cycle(n) block method (Rust mirror)

### DIFF
--- a/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-rust/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.35.0 — Array `cycle(n)`
+
+Mirrors the Python reference (PR #8117) and the Go backend (PR #8123) into the
+Rust backend's inline `__sir` runtime (`array_method` beside the existing
+`chunk_while`/`slice_when` block arms; the array-method `responds_to` set gains
+`cycle`), continuing the `cycle` cross-backend cascade.
+
+- `cycle(n) { |x| … }` (block) → iterate the array `n` full passes in order,
+  yielding each element on every pass; always returns `Value::Nil`.
+  `[1,2,3].cycle(2)` yields `1,2,3,1,2,3`. `n <= 0`, a negative count, an empty
+  receiver, or a nil / non-integer count (Ruby's block-less Enumerator and
+  infinite no-`n` forms) yields nothing rather than hanging. As with
+  `each_slice`, the count is validated in the `usize` domain (`usize::try_from`)
+  so a huge positive `n` that truncates to 0 on a 32-bit target is rejected; the
+  items are snapshotted before iterating so a block that mutates the receiver
+  sees a stable sequence.
+- The `compile_and_run_array_aggregates` suite gains `array_cycle_compile_and_run`:
+  the block `print`s each yielded element, proving the two passes
+  (`1,2,3,1,2,3`) and the `nil` returns for `cycle(2)`, `cycle(0)`, and
+  `[].cycle(5)` under a real `rustc` compile-and-run.
+
 ## 0.34.0 — Array `minmax`
 
 Mirrors the Python reference (PR #8092) and the Go backend (PR #8098) into the

--- a/code/packages/rust/semantic-ir-to-rust/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-rust"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Semantic IR → self-contained Rust source code (SIR13). Second backend for the SIR10 narrow-waist IR."
 

--- a/code/packages/rust/semantic-ir-to-rust/README.md
+++ b/code/packages/rust/semantic-ir-to-rust/README.md
@@ -142,7 +142,7 @@ rather than panicking:
   - **Array** (`Seq`): `length`/`size`, `first`, `last`, `push`/`append`,
     `pop`, `include?`, `reverse`, `sort`, `min`/`max`/`minmax`/`sum`, `join`, `map`, `select`/`filter`,
     `reject`, `find`, `reduce`/`inject`, `each`, `any?`/`all?`/`none?`,
-    `each_slice`/`each_cons`, `chunk_while`/`slice_when`.
+    `each_slice`/`each_cons`, `chunk_while`/`slice_when`, `cycle`.
   - **Hash** (`Map`): `keys`, `values`, `size`/`length`, `empty?`, `has_key?`,
     `fetch`, `to_a`, `merge`, `dig` (nested), `invert`, `store`/`[]=`, `delete`,
     `clear`, `each`/`each_pair`, `each_key`, `each_value`, `map`, `select`,

--- a/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-rust/src/runtime.rs
@@ -1472,6 +1472,7 @@ pub const RUNTIME: &str = r##"mod __sir {
                     | "take" | "drop" | "values_at"
                     // consecutive-grouping family
                     | "each_slice" | "each_cons" | "chunk_while" | "slice_when"
+                    | "cycle"
             ),
             Value::Map(_) => matches!(
                 name,
@@ -2282,6 +2283,35 @@ pub const RUNTIME: &str = r##"mod __sir {
                         }
                     }
                     seq_lit(slices.into_iter().map(seq_lit).collect())
+                }
+                None => unknown_method(&recv, name),
+            },
+            // `cycle(n) { |x| … }` — iterate the array `n` full passes in order,
+            // yielding each element on every pass; always returns nil.
+            // `[1,2,3].cycle(2)` yields `1,2,3,1,2,3`.  `n <= 0`, a negative
+            // count, an empty receiver, or a nil / non-integer count (Ruby's
+            // block-less Enumerator and infinite no-`n` forms) yields nothing
+            // rather than hanging.  As with `each_slice`, the count is validated
+            // in the `usize` domain so a huge positive `n` that would truncate
+            // to 0 on a 32-bit target is rejected rather than mis-looped.  The
+            // items are snapshotted before iterating so a block that mutates the
+            // receiver sees a stable sequence.
+            "cycle" => match &block {
+                Some(b) => {
+                    let n = match pos.first() {
+                        Some(Value::Int(v)) if *v > 0 => match usize::try_from(*v) {
+                            Ok(n) if n > 0 => n,
+                            _ => return Value::Nil,
+                        },
+                        _ => return Value::Nil,
+                    };
+                    let snapshot = items_rc.borrow().clone();
+                    for _ in 0..n {
+                        for item in &snapshot {
+                            apply_closure(b, vec![item.clone()]);
+                        }
+                    }
+                    Value::Nil
                 }
                 None => unknown_method(&recv, name),
             },

--- a/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
+++ b/code/packages/rust/semantic-ir-to-rust/tests/compile_and_run_array_aggregates.rs
@@ -694,3 +694,96 @@ fn array_slice_when_compile_and_run() {
     let _ = std::fs::remove_file(&src_path);
     let _ = std::fs::remove_file(&bin_path);
 }
+
+// ── Array cycle(n) ─────────────────────────────────────────────────────────
+//
+// `cycle(n) { |x| … }` iterates the array n full passes in order, yielding each
+// element on every pass, and always returns nil.  n <= 0, a negative count, or
+// an empty receiver yields nothing.  Mirrors the Python reference (#8117) and
+// the Go backend (#8123): the block `print`s each yielded element, so the two
+// passes (1,2,3,1,2,3) are observable, and the nil return is printed after each
+// call.
+fn cycle_demo() -> Module {
+    // `{ |x| print x }` — emit one line per yielded element.
+    let puts = block_fn("__b_puts", &["x"], print_expr(param("x")));
+    let main_stmts = vec![
+        // [1,2,3].cycle(2) { |x| print x }  → 1 2 3 1 2 3, then nil
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(3)]),
+            "cycle",
+            vec![ilit(2), block("__b_puts")],
+        )),
+        // [1,2,3].cycle(0) { … }  → no yields, nil
+        print_stmt(method(
+            seq(vec![ilit(1), ilit(2), ilit(3)]),
+            "cycle",
+            vec![ilit(0), block("__b_puts")],
+        )),
+        // [].cycle(5) { … }  → no yields, nil
+        print_stmt(method(seq(vec![]), "cycle", vec![ilit(5), block("__b_puts")])),
+    ];
+    demo_module(main_stmts, vec![puts])
+}
+
+#[test]
+fn array_cycle_compile_and_run() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not on PATH");
+        return;
+    }
+
+    let artifact = compile(&cycle_demo()).expect("module should compile to Rust source");
+
+    let dir = std::env::temp_dir();
+    let nonce = std::process::id();
+    let src_path = dir.join(format!("sir_arr_cycle_{nonce}.rs"));
+    let bin_path =
+        dir.join(format!("sir_arr_cycle_{nonce}{}", if cfg!(windows) { ".exe" } else { "" }));
+    std::fs::write(&src_path, &artifact.source).expect("write temp source");
+
+    let mut cmd = Command::new("rustc");
+    cmd.arg("--edition").arg("2021").arg("-O");
+    if let Ok(linker) = std::env::var("SIR_TEST_RUSTC_LINKER") {
+        if !linker.is_empty() {
+            cmd.arg("-C").arg(format!("linker={linker}"));
+        }
+    }
+    let compile_out = cmd.arg(&src_path).arg("-o").arg(&bin_path).output().expect("invoke rustc");
+    if !compile_out.status.success() {
+        let stderr = String::from_utf8_lossy(&compile_out.stderr);
+        if stderr.contains("linker")
+            && (stderr.contains("not found") || stderr.contains("No such file"))
+        {
+            eprintln!("skipping: no usable linker on host\n{stderr}");
+            let _ = std::fs::remove_file(&src_path);
+            return;
+        }
+        panic!(
+            "emitted Rust failed to compile:\n--- stderr ---\n{stderr}\n--- source ---\n{}",
+            artifact.source,
+        );
+    }
+
+    let run_out = Command::new(&bin_path).output().expect("run compiled binary");
+    assert!(
+        run_out.status.success(),
+        "compiled binary exited non-zero:\n{}",
+        String::from_utf8_lossy(&run_out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&run_out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    assert_eq!(
+        lines,
+        vec![
+            "1", "2", "3", "1", "2", "3", // cycle(2) yields two full passes
+            "nil", // cycle(2) returns nil
+            "nil", // cycle(0) — no yields, nil
+            "nil", // [].cycle(5) — no yields, nil
+        ],
+        "unexpected program output; full stdout:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_file(&src_path);
+    let _ = std::fs::remove_file(&bin_path);
+}


### PR DESCRIPTION
## Summary

Mirrors the Python reference ([#8117](https://github.com/adhithyan15/coding-adventures/pull/8117)) and the Go backend ([#8123](https://github.com/adhithyan15/coding-adventures/pull/8123)) — both merged — into the **Rust** backend's embedded `__sir` RUNTIME: `Array#cycle(n) { |x| … }` iterates the array `n` full passes in order, yielding each element on every pass, and always returns nil. Third backend in the cascade (Python → Go → **Rust** → JS → TS).

## Semantics

- `n` full passes: `[1,2,3].cycle(2) { … }` yields `1,2,3,1,2,3`.
- `n <= 0`, a negative count, or an empty receiver yields nothing.
- A nil / non-integer count — including Ruby's block-less Enumerator form and the **infinite no-`n` form** — yields nothing rather than hanging.
- Always returns `Value::Nil`.

## Changes

- `runtime.rs`: `cycle` arm in `array_method` (beside `chunk_while`/`slice_when`) + `"cycle"` in the array-method `responds_to` set. The count is validated in the `usize` domain (`usize::try_from`) so a huge positive `n` that truncates to 0 on a 32-bit target is rejected; the items are snapshotted before iterating so a block that mutates the receiver sees a stable sequence (no RefCell re-borrow hazard).
- `tests/compile_and_run_array_aggregates.rs`: `array_cycle_compile_and_run` — the block `print`s each yielded element, proving the two passes and the `nil` returns for `cycle(2)`, `cycle(0)`, and `[].cycle(5)` under a real `rustc` compile-and-run.

## Verification

- `cargo test -p semantic-ir-to-rust --test compile_and_run_array_aggregates array_cycle_compile_and_run` — **passes** (`rustc` compile-and-run exec-proof).
- Security review passed (no panic path; `usize::try_from` guard; only a strictly-positive `n` reaches the finite loop; snapshot-before-iterate avoids borrow conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)