### PR TITLE
[codex] Port LZ77 compression to Haskell

### DIFF
--- a/code/packages/haskell/lz77/BUILD
+++ b/code/packages/haskell/lz77/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lz77/BUILD_windows
+++ b/code/packages/haskell/lz77/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lz77/CHANGELOG.md
+++ b/code/packages/haskell/lz77/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-13
+
+- Add CMP00 LZ77 encoding and overlapping-match decoding for strict bytes.
+- Add configurable window and match thresholds with wire-width validation.
+- Add the fixed-width big-endian token serialisation format.
+- Reject malformed tokens, offsets, headers, and truncated token streams.
+- Add spec-vector, round-trip, parameter, wire-format, and behaviour tests.

--- a/code/packages/haskell/lz77/README.md
+++ b/code/packages/haskell/lz77/README.md
@@ -1,0 +1,34 @@
+# lz77
+
+Pure Haskell implementation of CMP00, the foundational LZ77 sliding-window
+compression algorithm.
+
+## API
+
+- `encode` and `encodeWith` turn a strict `ByteString` into literal and
+  backreference `Token` values.
+- `decode` and `decodeWithInitialBuffer` reconstruct bytes, including
+  self-referential overlapping matches.
+- `serialiseTokens` and `deserialiseTokens` implement the CMP00 teaching wire
+  format: a big-endian token count followed by four bytes per token.
+- `compress`, `compressWith`, and `decompress` provide one-shot byte APIs.
+
+Operations that can encounter invalid parameters, malformed tokens, or bad
+wire data return `Either String`. The decoder rejects impossible offsets,
+zero-offset backreferences, non-zero literal offsets, truncated headers, and
+truncated token streams.
+
+## Defaults
+
+- Window size: 4096 bytes
+- Maximum match: 255 bytes
+- Minimum match: 3 bytes
+
+The encoder uses deterministic earliest-position tie-breaking and reserves one
+byte after every match for `next_char`, as required by CMP00.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/lz77/cabal.project
+++ b/code/packages/haskell/lz77/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/lz77/lz77.cabal
+++ b/code/packages/haskell/lz77/lz77.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          lz77
+version:       0.1.0
+synopsis:      CMP00 LZ77 sliding-window byte compression
+description:   Pure Haskell LZ77 tokenisation, decoding, and fixed-width serialisation.
+category:      Compression
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  LZ77
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , containers >=0.6 && <0.8
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LZ77Spec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , hspec == 2.*
+                    , lz77
+    default-language: Haskell2010

--- a/code/packages/haskell/lz77/src/LZ77.hs
+++ b/code/packages/haskell/lz77/src/LZ77.hs
@@ -1,0 +1,233 @@
+-- | CMP00 LZ77 sliding-window compression for strict byte strings.
+module LZ77
+    ( Token (..)
+    , defaultWindowSize
+    , defaultMaxMatch
+    , defaultMinMatch
+    , encode
+    , encodeWith
+    , decode
+    , decodeWithInitialBuffer
+    , serialiseTokens
+    , deserialiseTokens
+    , compress
+    , compressWith
+    , decompress
+    ) where
+
+import Control.Monad (foldM)
+import Data.Bits ((.|.), shiftL, shiftR)
+import qualified Data.ByteString as BS
+import Data.Foldable (toList)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
+import Data.Word (Word8, Word16, Word32)
+
+-- | One LZ77 phrase. A zero length denotes a literal and requires offset 0.
+data Token = Token
+    { tokenOffset :: Word16
+    , tokenLength :: Word8
+    , tokenNextChar :: Word8
+    }
+    deriving (Eq, Show)
+
+defaultWindowSize :: Int
+defaultWindowSize = 4096
+
+defaultMaxMatch :: Int
+defaultMaxMatch = 255
+
+defaultMinMatch :: Int
+defaultMinMatch = 3
+
+-- | Encode with the CMP00 default window and match thresholds.
+encode :: BS.ByteString -> [Token]
+encode input = encodeUnchecked defaultWindowSize defaultMaxMatch defaultMinMatch input
+
+-- | Encode with explicit parameters. Values must fit the fixed-width wire format.
+encodeWith :: Int -> Int -> Int -> BS.ByteString -> Either String [Token]
+encodeWith windowSize maxMatch minMatch input = do
+    validateParameters windowSize maxMatch minMatch
+    Right (encodeUnchecked windowSize maxMatch minMatch input)
+
+encodeUnchecked :: Int -> Int -> Int -> BS.ByteString -> [Token]
+encodeUnchecked windowSize maxMatch minMatch input = go 0
+  where
+    inputLength = BS.length input
+
+    go cursor
+        | cursor >= inputLength = []
+        | bestLength >= minMatch =
+            Token
+                (fromIntegral bestOffset)
+                (fromIntegral bestLength)
+                (BS.index input (cursor + bestLength))
+                : go (cursor + bestLength + 1)
+        | otherwise =
+            Token 0 0 (BS.index input cursor) : go (cursor + 1)
+      where
+        (bestOffset, bestLength) =
+            findLongestMatch input cursor windowSize maxMatch
+
+findLongestMatch :: BS.ByteString -> Int -> Int -> Int -> (Int, Int)
+findLongestMatch input cursor windowSize maxMatch =
+    foldl chooseBetter (0, 0) [searchStart .. cursor - 1]
+  where
+    searchStart = max 0 (cursor - windowSize)
+    lookaheadEnd = min (cursor + maxMatch) (BS.length input - 1)
+
+    chooseBetter best@(_, bestLength) position
+        | candidateLength > bestLength = (cursor - position, candidateLength)
+        | otherwise = best
+      where
+        candidateLength = matchLength position 0
+
+    matchLength position matched
+        | cursor + matched >= lookaheadEnd = matched
+        | BS.index input (position + matched) /= BS.index input (cursor + matched) = matched
+        | otherwise = matchLength position (matched + 1)
+
+-- | Decode tokens with an empty initial search buffer.
+decode :: [Token] -> Either String BS.ByteString
+decode = decodeWithInitialBuffer BS.empty
+
+-- | Decode tokens after seeding the search buffer with existing bytes.
+-- The returned bytes include the initial buffer, matching CMP00 streaming semantics.
+decodeWithInitialBuffer :: BS.ByteString -> [Token] -> Either String BS.ByteString
+decodeWithInitialBuffer initialBuffer tokens = do
+    output <- foldM decodeToken (Seq.fromList (BS.unpack initialBuffer)) tokens
+    Right (BS.pack (toList output))
+
+decodeToken :: Seq Word8 -> Token -> Either String (Seq Word8)
+decodeToken output token = do
+    validateToken token
+    let offset = fromIntegral (tokenOffset token)
+        phraseLength = fromIntegral (tokenLength token)
+        outputLength = Seq.length output
+    if phraseLength > 0 && offset > outputLength
+        then
+            Left
+                ( "LZ77 offset "
+                    ++ show offset
+                    ++ " exceeds decoded prefix length "
+                    ++ show outputLength
+                )
+        else do
+            copied <- copyMatch (outputLength - offset) phraseLength 0 output
+            Right (copied |> tokenNextChar token)
+
+copyMatch :: Int -> Int -> Int -> Seq Word8 -> Either String (Seq Word8)
+copyMatch _ phraseLength copied output
+    | copied >= phraseLength = Right output
+copyMatch start phraseLength copied output =
+    let sourceIndex = start + copied
+     in if sourceIndex < 0 || sourceIndex >= Seq.length output
+            then Left "LZ77 backreference points outside the decoded prefix"
+            else
+                copyMatch
+                    start
+                    phraseLength
+                    (copied + 1)
+                    (output |> Seq.index output sourceIndex)
+
+-- | Serialise tokens as a big-endian uint32 count followed by four bytes per token.
+serialiseTokens :: [Token] -> Either String BS.ByteString
+serialiseTokens tokens
+    | toInteger (length tokens) > toInteger (maxBound :: Word32) =
+        Left "too many LZ77 tokens for the uint32 count field"
+    | otherwise = do
+        traverse_ validateToken tokens
+        Right
+            ( encodeWord32 (fromIntegral (length tokens))
+                <> BS.pack (concatMap encodeToken tokens)
+            )
+  where
+    encodeToken token =
+        [ fromIntegral (tokenOffset token `shiftR` 8)
+        , fromIntegral (tokenOffset token)
+        , tokenLength token
+        , tokenNextChar token
+        ]
+
+-- | Parse the fixed-width CMP00 teaching format.
+deserialiseTokens :: BS.ByteString -> Either String [Token]
+deserialiseTokens input
+    | BS.null input = Right []
+    | BS.length input < 4 = Left "truncated LZ77 token-count header"
+    | otherwise = do
+        tokenCount <- decodeWord32 input 0
+        let requiredLength = 4 + 4 * toInteger tokenCount
+        if toInteger (BS.length input) < requiredLength
+            then Left "truncated LZ77 token stream"
+            else traverse parseToken [0 .. fromIntegral tokenCount - 1]
+  where
+    parseToken index = do
+        let base = 4 + 4 * index
+            offset =
+                (fromIntegral (BS.index input base) `shiftL` 8)
+                    .|. fromIntegral (BS.index input (base + 1))
+            token =
+                Token
+                    offset
+                    (BS.index input (base + 2))
+                    (BS.index input (base + 3))
+        validateToken token
+        Right token
+
+-- | Compress with the CMP00 defaults.
+compress :: BS.ByteString -> Either String BS.ByteString
+compress = serialiseTokens . encode
+
+-- | Compress with an explicit window size, maximum match, and minimum match.
+compressWith :: Int -> Int -> Int -> BS.ByteString -> Either String BS.ByteString
+compressWith windowSize maxMatch minMatch input =
+    encodeWith windowSize maxMatch minMatch input >>= serialiseTokens
+
+-- | Decompress one fixed-width CMP00 payload.
+decompress :: BS.ByteString -> Either String BS.ByteString
+decompress input = deserialiseTokens input >>= decode
+
+validateParameters :: Int -> Int -> Int -> Either String ()
+validateParameters windowSize maxMatch minMatch
+    | windowSize <= 0 = Left "window size must be positive"
+    | windowSize > fromIntegral (maxBound :: Word16) =
+        Left "window size exceeds the uint16 offset field"
+    | maxMatch <= 0 = Left "maximum match length must be positive"
+    | maxMatch > fromIntegral (maxBound :: Word8) =
+        Left "maximum match length exceeds the uint8 length field"
+    | minMatch <= 0 = Left "minimum match length must be positive"
+    | minMatch > maxMatch = Left "minimum match length exceeds maximum match length"
+    | otherwise = Right ()
+
+validateToken :: Token -> Either String ()
+validateToken token
+    | tokenLength token == 0 && tokenOffset token /= 0 =
+        Left "literal LZ77 tokens must use offset 0"
+    | tokenLength token > 0 && tokenOffset token == 0 =
+        Left "LZ77 backreferences must use a positive offset"
+    | otherwise = Right ()
+
+encodeWord32 :: Word32 -> BS.ByteString
+encodeWord32 value =
+    BS.pack
+        [ fromIntegral (value `shiftR` 24)
+        , fromIntegral (value `shiftR` 16)
+        , fromIntegral (value `shiftR` 8)
+        , fromIntegral value
+        ]
+
+decodeWord32 :: BS.ByteString -> Int -> Either String Word32
+decodeWord32 input offset
+    | BS.length input < offset + 4 = Left "truncated uint32 field"
+    | otherwise =
+        Right
+            ( byteAt 0 `shiftL` 24
+                .|. byteAt 1 `shiftL` 16
+                .|. byteAt 2 `shiftL` 8
+                .|. byteAt 3
+            )
+  where
+    byteAt index = fromIntegral (BS.index input (offset + index))
+
+traverse_ :: (value -> Either String ()) -> [value] -> Either String ()
+traverse_ validator = foldM (\() value -> validator value) ()

--- a/code/packages/haskell/lz77/test/LZ77Spec.hs
+++ b/code/packages/haskell/lz77/test/LZ77Spec.hs
@@ -1,0 +1,150 @@
+module LZ77Spec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import Data.List (isInfixOf)
+import LZ77
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "spec vectors" $ do
+        it "encodes empty input as no tokens" $ do
+            encode BS.empty `shouldBe` []
+            decode [] `shouldBe` Right BS.empty
+        it "encodes ABCDE as literals" $
+            encode (ascii "ABCDE")
+                `shouldBe` map (Token 0 0) [65, 66, 67, 68, 69]
+        it "encodes seven identical bytes with an overlapping match" $
+            encode (ascii "AAAAAAA")
+                `shouldBe` [Token 0 0 65, Token 1 5 65]
+        it "encodes ABABABAB with the reference backreference" $
+            encode (ascii "ABABABAB")
+                `shouldBe` [Token 0 0 65, Token 0 0 66, Token 2 5 66]
+        it "keeps AABCBBABC literal-only at the default threshold" $
+            encode (ascii "AABCBBABC")
+                `shouldBe` map (Token 0 0) [65, 65, 66, 67, 66, 66, 65, 66, 67]
+        it "round-trips AABCBBABC with a lower match threshold" $ do
+            tokens <- expectRight (encodeWith 4096 255 2 (ascii "AABCBBABC"))
+            decode tokens `shouldBe` Right (ascii "AABCBBABC")
+
+    describe "round trips" $ do
+        it "round-trips representative text and binary data" $ do
+            mapM_
+                (\input -> decode (encode input) `shouldBe` Right input)
+                [ BS.empty
+                , ascii "A"
+                , ascii "hello world"
+                , ascii "the quick brown fox"
+                , ascii "ababababab"
+                , ascii "aaaaaaaaaa"
+                , BS.pack [0, 0, 0]
+                , BS.pack [255, 255, 255]
+                ]
+        it "round-trips all 256 byte values" $ do
+            let input = BS.pack [0 .. 255]
+            decode (encode input) `shouldBe` Right input
+        it "round-trips the one-shot wire format" $ do
+            mapM_
+                (\input -> roundTrip input `shouldBe` Right input)
+                [BS.empty, ascii "A", ascii "ABCDE", ascii "AAAAAAA", ascii "ABABABAB"]
+        it "round-trips long repetitive input" $ do
+            let input = BS.concat (replicate 100 (ascii "Hello, World! ")) <> BS.replicate 500 88
+            decode (encode input) `shouldBe` Right input
+
+    describe "parameters" $ do
+        it "never emits offsets beyond the configured window" $ do
+            let input = BS.singleton 88 <> BS.replicate 5000 89 <> BS.singleton 88
+            tokens <- expectRight (encodeWith 100 255 3 input)
+            map tokenOffset tokens `shouldSatisfy` all (<= 100)
+        it "never emits lengths beyond the configured maximum" $ do
+            tokens <- expectRight (encodeWith 4096 50 3 (BS.replicate 1000 65))
+            map tokenLength tokens `shouldSatisfy` all (<= 50)
+        it "rejects parameters that cannot fit the wire format" $ do
+            encodeWith 0 255 3 (ascii "A") `leftShouldContain` "window size"
+            encodeWith 65536 255 3 (ascii "A") `leftShouldContain` "uint16"
+            encodeWith 4096 256 3 (ascii "A") `leftShouldContain` "uint8"
+            encodeWith 4096 2 3 (ascii "A") `leftShouldContain` "exceeds"
+
+    describe "overlapping decoding and validation" $ do
+        it "copies overlapping matches byte by byte" $
+            decode [Token 0 0 65, Token 0 0 66, Token 2 5 90]
+                `shouldBe` Right (ascii "ABABABAZ")
+        it "uses and returns an initial search buffer" $
+            decodeWithInitialBuffer (ascii "AB") [Token 2 3 90]
+                `shouldBe` Right (ascii "ABABAZ")
+        it "rejects zero-offset backreferences" $
+            decode [Token 0 3 90] `leftShouldContain` "positive offset"
+        it "rejects offsets beyond the decoded prefix" $
+            decodeWithInitialBuffer (ascii "A") [Token 2 1 90]
+                `leftShouldContain` "exceeds decoded prefix"
+        it "rejects literal tokens with non-zero offsets" $
+            decode [Token 1 0 90] `leftShouldContain` "literal"
+
+    describe "wire format" $ do
+        it "writes the exact empty token-count header" $
+            compress BS.empty `shouldBe` Right (BS.replicate 4 0)
+        it "writes token count and fixed-width fields in big-endian order" $
+            serialiseTokens [Token 0 0 65, Token 0x0201 5 66]
+                `shouldBe` Right (BS.pack [0, 0, 0, 2, 0, 0, 0, 65, 2, 1, 5, 66])
+        it "writes the exact ABABABAB reference payload" $
+            compress (ascii "ABABABAB")
+                `shouldBe`
+                    Right
+                        ( BS.pack
+                            [ 0, 0, 0, 3
+                            , 0, 0, 0, 65
+                            , 0, 0, 0, 66
+                            , 0, 2, 5, 66
+                            ]
+                        )
+        it "serialises and deserialises tokens losslessly" $ do
+            let tokens = [Token 0 0 65, Token 1 3 66, Token 2 5 67]
+            serialised <- expectRight (serialiseTokens tokens)
+            deserialiseTokens serialised `shouldBe` Right tokens
+        it "treats an empty byte string as an empty token stream" $
+            deserialiseTokens BS.empty `shouldBe` Right []
+        it "rejects partial headers and truncated token streams" $ do
+            deserialiseTokens (BS.pack [0, 0, 0]) `leftShouldContain` "header"
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 2, 3])
+                `leftShouldContain` "truncated"
+        it "rejects malformed token fields during deserialisation" $ do
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 3, 90])
+                `leftShouldContain` "positive offset"
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 1, 0, 90])
+                `leftShouldContain` "literal"
+
+    describe "compression behaviour" $ do
+        it "compresses a long repeated byte into fewer than fifty tokens" $ do
+            let tokens = encode (BS.replicate 10000 65)
+            length tokens `shouldSatisfy` (< 50)
+            decode tokens `shouldBe` Right (BS.replicate 10000 65)
+        it "keeps incompressible input within fixed-width overhead" $ do
+            let input = BS.pack [0 .. 255]
+            compressed <- expectRight (compress input)
+            BS.length compressed `shouldSatisfy` (<= 4 * BS.length input + 10)
+        it "compresses repetitive input to fewer bytes" $ do
+            let input = BS.concat (replicate 100 (ascii "ABC"))
+            compressed <- expectRight (compress input)
+            BS.length compressed `shouldSatisfy` (< BS.length input)
+        it "produces deterministic output" $ do
+            let input = ascii "hello world test"
+            compress input `shouldBe` compress input
+
+roundTrip :: BS.ByteString -> Either String BS.ByteString
+roundTrip input = compress input >>= decompress
+
+ascii :: String -> BS.ByteString
+ascii = BS.pack . map (fromIntegral . fromEnum)
+
+expectRight :: Either String value -> IO value
+expectRight result =
+    case result of
+        Left message -> expectationFailure message >> fail message
+        Right value -> pure value
+
+leftShouldContain :: Either String value -> String -> Expectation
+leftShouldContain result expected =
+    case result of
+        Left message -> message `shouldSatisfy` isInfixOf expected
+        Right _ -> expectationFailure ("expected Left containing " ++ show expected)

--- a/code/packages/haskell/lz77/test/Spec.hs
+++ b/code/packages/haskell/lz77/test/Spec.hs
@@ -1,0 +1,5 @@
+import LZ77Spec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Fifteen package/language slots remain to turn 15 nearly complete packages into
+Fourteen package/language slots remain to turn 15 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,14 +145,13 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 3 remaining ports
+### Haskell: 2 remaining ports
 
-- `lz77`
 - `lzss`
 - `lzw`
 
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
-`huffman-tree`, `huffman-compression`.
+`huffman-tree`, `huffman-compression`, `lz77`.
 
 ### Swift: 3 ports
 


### PR DESCRIPTION
## Summary

- add a pure Haskell CMP00 LZ77 package with configurable sliding-window encoding and overlapping-match decoding
- implement the fixed-width big-endian token wire format with strict parameter, token, offset, header, and truncation validation
- update the package-parity roadmap after completing Haskell's `lz77` slot

## Validation

- `cabal test all --test-show-details=direct` (29 examples)
- `cabal check`
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` (6 tests)
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- `git diff origin/main --check`

The regenerated inventory reports `lz77` in all 15 implementation languages, with zero identity collisions and zero unknown language buckets.