### PR TITLE
feat(adj-ladder): rung-141 grid density — (a+b)/(c*d) sum over a product

### DIFF
--- a/code/specs/data/adj-ladder/rung141_grid_density/gen_items.py
+++ b/code/specs/data/adj-ladder/rung141_grid_density/gen_items.py
@@ -1,0 +1,237 @@
+"""Generate rung-141 (grid density / a SUM-numerator over a PRODUCT — divide a total by an area) items.json.
+
+Rung 141 **opens the fourth two-part-denominator family: OVER A PRODUCT**. The ladder walked the numerator-op x denominator-shape matrix
+across rungs 130-140 for three denominators — a rate `c/d`, a sum `c+d`, and a difference `c-d`. The fourth elementary two-part denominator
+is a PRODUCT `c*d`, and rung-141 opens that column with a SUM numerator, `(a+b)/(c*d)`.
+
+`(a+b)/(c*d)` is a SUM `a+b` divided by a PRODUCT `c*d` (an area). The sum `a+b` binds and stays grouped over the bar, and the two-part
+denominator `c*d` is ONE area the whole numerator is divided by. A product denominator has its own two canonical slips, and they are NOT the
+sum/difference/rate slips: dividing by two factors in turn IS the same as dividing by their product (`x/c/d = x/(c*d)`), so that is not a
+wrong distractor. The two canonical divide-by-a-product slips that a student actually makes are: using the WRONG denominator operation,
+ADDING the two dimensions instead of multiplying them (`(a+b)/(c+d)` — a perimeter-style total instead of an area), and INVERTING the ratio,
+dividing the area by the total instead of the total by the area (`(c*d)/(a+b)` — the reciprocal, the ratio upside down).
+
+The setup: a `north_count` combined with a `south_count` (a combined count `north_count + south_count`), spread over a grid formed from
+`grid_rows` times `grid_cols` (a grid area `grid_rows * grid_cols`). The figures are:
+
+  GRID DENSITY   (north_count + south_count) / (grid_rows * grid_cols)  [ sum-numerator OVER a product: combined count / grid area ]
+  COMBINED COUNT north_count + south_count                            [ the sum numerator (divided by the grid area) ]
+  GRID AREA      grid_rows * grid_cols                                [ the product the combined count is divided by ]
+
+The **grid density** is the ladder's first **(a sum) over (a product) as a headline** — a density (how much combined count sits in each cell
+of the grid area), framed as a *density* to keep it dimensionless-clean, the same discipline rungs 100/.../139/140 used for their ratios,
+spans, concentrations, densities, indices, slopes. (The combined count `a+b` and the grid area `c*d` ride alongside as component readouts,
+so the panel teaches the whole calculation — exactly as rungs 47-140 shipped their component figures beside the headline. The two components
+anchor the "add the counts FIRST, multiply out the area, then divide the count by the area" structure against both distractors.)
+
+Each figure is a `compute_dimensioned` program (`observe` the four quantities + `let answer = formula`); the ADJ engine carries the
+arithmetic — the addition to form the combined count, the multiplication to form the grid area, then the division of the combined count by
+the grid area to form the compound figure (so (a+b)/(c*d) evaluates as ((a+b)/(c*d))) — and the harness reads the scalar via the existing
+`compute_dimensioned` extractor. No harness/engine change, exactly as rungs 8/16/.../139/140. This rung exercises the engine across a
+**sum divided by a product** — the fact that `(a+b)/(c*d)` is one sum over one area and NOT `(a+b)/(c+d)` and NOT `(c*d)/(a+b)` made
+computable. The golds are exact rationals rendered as f64s; the engine's IEEE-double division matches Python's the same way rungs
+100/.../139/140 relied on (well within the harness's 1e-9 tolerance).
+
+Contamination-safe by construction: every formula is built ONLY from the four observed quantities via `+`, `/`, and `*` — **no structural
+constants** — so no numeric literal appears in any program, and neither the combined count, the grid area, nor the grid density is ever a
+literal (each is computed from the observed quantities). The observed quantities carry **digit-free identifiers** (`north_count`,
+`south_count`, `grid_rows`, `grid_cols`) so no numeral hides inside a variable name.
+
+The five options are a tight family over the same four quantities: the three real readouts plus the two classic slips —
+
+  ADDED      (north_count + south_count) / (grid_rows + grid_cols)  divide the combined count by the SUM of the dimensions instead of their
+                                                                product, using a perimeter-style total where an area belongs (the wrong
+                                                                denominator operation), and
+  INVERTED   (grid_rows * grid_cols) / (north_count + south_count)  divide the grid area BY the combined count, the ratio upside down (the
+                                                                reciprocal of the grid density, the wrong direction),
+
+which are exactly the mistakes a student makes with a product denominator (adding the dimensions instead of multiplying, or inverting the
+ratio). Gold rotates A-E by index. QUERIED (used as gold) = the three real readouts; all five always appear as options.
+
+Distinctness and positivity: this rung uses only `+`, `*`, and `/` over positive quantities, so **every figure is automatically positive**
+(no subtraction anywhere) — like rungs 128/130/131/132/134/135, no positivity guards are needed. Every observed quantity is `>= 2`. Every
+family member is asserted `> 0` at build time as a belt-and-suspenders check. The seven tables give distinct grid densities, distinct
+combined counts, and distinct grid areas so all three queried readouts vary across the panel; the five family values are pairwise distinct
+with a comfortable margin.
+"""
+import json
+
+LETTERS = ["A", "B", "C", "D", "E"]
+
+# (NORTH_COUNT, SOUTH_COUNT, GRID_ROWS, GRID_COLS) — a combined count (north_count + south_count) divided by a grid area (grid_rows *
+# grid_cols), giving the grid density as a sum over a product (a+b)/(c*d). This rung uses only +, *, and / over positive quantities, so every
+# figure is automatically positive; no positivity guards are needed. The seven tables give distinct combined counts (a+b), distinct grid
+# areas (c*d), and distinct grid densities ((a+b)/(c*d)); the five family values are asserted pairwise-distinct below.
+TABLES = [
+    (4, 2, 2, 5),      # count = 6,  area = 10, density = 0.6
+    (5, 3, 2, 3),      # count = 8,  area = 6,  density = 1.333...
+    (6, 4, 2, 4),      # count = 10, area = 8,  density = 1.25
+    (7, 5, 3, 5),      # count = 12, area = 15, density = 0.8
+    (9, 5, 4, 5),      # count = 14, area = 20, density = 0.7
+    (5, 4, 3, 4),      # count = 9,  area = 12, density = 0.75
+    (9, 7, 2, 7),      # count = 16, area = 14, density = 1.142...
+]
+
+# The option family (5 members), all built from the four observed quantities via +, *, and /. Every identifier is DIGIT-FREE.
+# key -> (display name, formula-as-adj). Only the first three are *queried* (used as gold); all five always appear as the options.
+FAMILY = [
+    (
+        "grid_density",
+        "grid density (the combined count divided by the grid area)",
+        "(north_count + south_count) / (grid_rows * grid_cols)",
+    ),
+    (
+        "combined_count",
+        "the combined count (the north count plus the south count, the numerator that is divided by the grid area)",
+        "north_count + south_count",
+    ),
+    (
+        "grid_area",
+        "the grid area (the grid rows times the grid cols, the product the combined count is divided by)",
+        "grid_rows * grid_cols",
+    ),
+    (
+        "added",
+        "the combined count divided by the grid rows plus the grid cols, using the sum of the dimensions instead of their product as the divisor (a wrong operation)",
+        "(north_count + south_count) / (grid_rows + grid_cols)",
+    ),
+    (
+        "inverted",
+        "the grid area divided by the combined count, the ratio upside down instead of the combined count over the grid area (a wrong operation)",
+        "(grid_rows * grid_cols) / (north_count + south_count)",
+    ),
+]
+QUERIED = ["grid_density", "combined_count", "grid_area"]
+ORDER = [k for k, _, _ in FAMILY]
+
+
+def scalar(v):
+    return {"value": v, "unit": "scalar"}
+
+
+def family_values(north_count, south_count, grid_rows, grid_cols):
+    # Operation order mirrors the ADJ programs exactly (the addition forms the combined count, the multiplication forms the grid area, then
+    # the combined count is divided by the grid area to form the compound figure, so (a+b)/(c*d) evaluates as ((a+b)/(c*d))), so the Python
+    # option value and the engine result are the same IEEE-double (well within the 1e-9 tolerance).
+    count = north_count + south_count
+    area = grid_rows * grid_cols
+    return {
+        "grid_density": count / area,
+        "combined_count": count,
+        "grid_area": area,
+        "added": count / (grid_rows + grid_cols),
+        "inverted": area / count,
+    }
+
+
+def build():
+    name_of = {k: nm for k, nm, _ in FAMILY}
+    formula_of = {k: f for k, _, f in FAMILY}
+    items = []
+    idx = 0
+
+    def num(x):
+        return int(x) if float(x).is_integer() else x
+
+    for north_count, south_count, grid_rows, grid_cols in TABLES:
+        # Every observed quantity is a plain positive number >= 2. This rung uses only +, *, and / over positive quantities, so positivity is
+        # automatic — no positivity guards are needed.
+        assert (
+            north_count >= 2
+            and south_count >= 2
+            and grid_rows >= 2
+            and grid_cols >= 2
+        ), (north_count, south_count, grid_rows, grid_cols)
+        fv = family_values(north_count, south_count, grid_rows, grid_cols)
+        for key, v in fv.items():
+            assert v > 0, (key, north_count, south_count, grid_rows, grid_cols, fv)
+        # Pairwise-distinct with a comfortable margin so the harness never sees two options
+        # matching the gold value within its 1e-9 tolerance.
+        vals = [fv[key] for key in ORDER]
+        for i in range(len(vals)):
+            for j in range(i + 1, len(vals)):
+                assert abs(vals[i] - vals[j]) > 1e-6, (
+                    north_count,
+                    south_count,
+                    grid_rows,
+                    grid_cols,
+                    ORDER[i],
+                    ORDER[j],
+                    fv,
+                )
+        for key in QUERIED:
+            gold_val = fv[key]
+            gold_pos = idx % 5
+            others = [fv[k2] for k2 in ORDER if abs(fv[k2] - gold_val) > 1e-12]
+            opts_vals = others[:]
+            opts_vals.insert(gold_pos, gold_val)
+            opts_vals = opts_vals[:5]
+            if abs(opts_vals[gold_pos] - gold_val) > 1e-12:
+                opts_vals[gold_pos] = gold_val
+            assert len({round(v, 9) for v in opts_vals}) == 5, (
+                key,
+                north_count,
+                south_count,
+                grid_rows,
+                grid_cols,
+                opts_vals,
+            )
+            options = {LETTERS[i]: scalar(opts_vals[i]) for i in range(5)}
+            items.append({
+                "id": f"r141gda-{idx + 1:02d}",
+                "qtype": "grid_density",
+                "stem": (
+                    f"A grid study records a north count of {num(north_count)} combined with a south count of "
+                    f"{num(south_count)}, spread over a grid of {num(grid_rows)} rows by {num(grid_cols)} cols. "
+                    f"What is the {name_of[key]}?"
+                ),
+                "program": (
+                    f"observe north_count({num(north_count)})\n"
+                    f"observe south_count({num(south_count)})\n"
+                    f"observe grid_rows({num(grid_rows)})\n"
+                    f"observe grid_cols({num(grid_cols)})\n"
+                    f"let answer = {formula_of[key]}\n"
+                    "? answer\n"
+                ),
+                "answer_from": {"type": "compute_dimensioned", "name": "answer"},
+                "options": options,
+                "gold_letter": LETTERS[gold_pos],
+            })
+            idx += 1
+    return {
+        "description": (
+            "ADJ-LADDER rung 141 — grid density from four stated quantities (a NEW panel: grid, OPENING the fourth two-part-denominator "
+            "family, OVER A PRODUCT). The ladder walked the numerator-op x denominator-shape matrix (rungs 130-140) for a rate (c/d), a "
+            "sum (c+d), and a difference (c-d); the fourth elementary two-part denominator is a PRODUCT (c*d), and rung-141 opens that "
+            "column with a SUM numerator (a+b)/(c*d). From a combined count (north_count + south_count) divided by a grid area (grid_rows "
+            "* grid_cols), compute the grid density ((north_count+south_count)/(grid_rows*grid_cols)), the combined count "
+            "(north_count+south_count), or the grid area (grid_rows*grid_cols). Each item is a compute_dimensioned program (observe the "
+            "four quantities, let answer = formula); the ADJ engine carries the arithmetic — a SUM NUMERATOR OVER A PRODUCT (a+b)/(c*d) "
+            "(add the counts, multiply out the area, then divide the count by the area — the two-part denominator is ONE area, not two "
+            "divisors). A product denominator has its own slips: dividing by two factors in turn equals dividing by their product "
+            "(x/c/d = x/(c*d)), so that is not a wrong distractor; the two canonical slips are used instead. The harness matches the "
+            "scalar to the printed options. The grid density is a density (how much combined count sits in each cell of the grid area), "
+            "framed as a DENSITY so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four "
+            "observed quantities via +, *, and / — no constant leaks, and neither the combined count, the grid area, nor the grid density "
+            "ever appears as a literal (each is computed) — and the observed quantities carry digit-free identifiers so no numeral hides "
+            "inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips "
+            "students make with a product denominator: dividing by the SUM of the dimensions instead of their product ((a+b)/(c+d), a "
+            "perimeter-style total where an area belongs, a wrong operation) and INVERTING the ratio ((c*d)/(a+b), the area over the "
+            "count, the reciprocal, a wrong operation). The core confusion tested is that (a+b)/(c*d) is one sum over one area, not "
+            "(a+b)/(c+d) and not (c*d)/(a+b). This rung uses only +, *, and / over positive quantities, so every figure is automatically "
+            "positive — no positivity guards are needed — and the five family values are kept pairwise distinct with all three queried "
+            "readouts varying across the panel, all asserted strictly positive at build time."
+        ),
+        "items": items,
+    }
+
+
+if __name__ == "__main__":
+    doc = build()
+    with open("items.json", "w") as f:
+        json.dump(doc, f, indent=2)
+        f.write("\n")
+    print("wrote items.json:", len(doc["items"]), "items")
+    for it in doc["items"]:
+        print(it["id"], it["qtype"], "gold", it["gold_letter"],
+              "=", round(it["options"][it["gold_letter"]]["value"], 6))

--- a/code/specs/data/adj-ladder/rung141_grid_density/items.json
+++ b/code/specs/data/adj-ladder/rung141_grid_density/items.json
@@ -1,0 +1,698 @@
+{
+  "description": "ADJ-LADDER rung 141 \u2014 grid density from four stated quantities (a NEW panel: grid, OPENING the fourth two-part-denominator family, OVER A PRODUCT). The ladder walked the numerator-op x denominator-shape matrix (rungs 130-140) for a rate (c/d), a sum (c+d), and a difference (c-d); the fourth elementary two-part denominator is a PRODUCT (c*d), and rung-141 opens that column with a SUM numerator (a+b)/(c*d). From a combined count (north_count + south_count) divided by a grid area (grid_rows * grid_cols), compute the grid density ((north_count+south_count)/(grid_rows*grid_cols)), the combined count (north_count+south_count), or the grid area (grid_rows*grid_cols). Each item is a compute_dimensioned program (observe the four quantities, let answer = formula); the ADJ engine carries the arithmetic \u2014 a SUM NUMERATOR OVER A PRODUCT (a+b)/(c*d) (add the counts, multiply out the area, then divide the count by the area \u2014 the two-part denominator is ONE area, not two divisors). A product denominator has its own slips: dividing by two factors in turn equals dividing by their product (x/c/d = x/(c*d)), so that is not a wrong distractor; the two canonical slips are used instead. The harness matches the scalar to the printed options. The grid density is a density (how much combined count sits in each cell of the grid area), framed as a DENSITY so the dimensionless value stays honest. Contamination-safe: every figure is built only from the four observed quantities via +, *, and / \u2014 no constant leaks, and neither the combined count, the grid area, nor the grid density ever appears as a literal (each is computed) \u2014 and the observed quantities carry digit-free identifiers so no numeral hides inside a variable name. The five options are a family over the same four quantities, so the distractors are exactly the slips students make with a product denominator: dividing by the SUM of the dimensions instead of their product ((a+b)/(c+d), a perimeter-style total where an area belongs, a wrong operation) and INVERTING the ratio ((c*d)/(a+b), the area over the count, the reciprocal, a wrong operation). The core confusion tested is that (a+b)/(c*d) is one sum over one area, not (a+b)/(c+d) and not (c*d)/(a+b). This rung uses only +, *, and / over positive quantities, so every figure is automatically positive \u2014 no positivity guards are needed \u2014 and the five family values are kept pairwise distinct with all three queried readouts varying across the panel, all asserted strictly positive at build time.",
+  "items": [
+    {
+      "id": "r141gda-01",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 4 combined with a south count of 2, spread over a grid of 2 rows by 5 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(4)\nobserve south_count(2)\nobserve grid_rows(2)\nobserve grid_cols(5)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8571428571428571,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r141gda-02",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 4 combined with a south count of 2, spread over a grid of 2 rows by 5 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(4)\nobserve south_count(2)\nobserve grid_rows(2)\nobserve grid_cols(5)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8571428571428571,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r141gda-03",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 4 combined with a south count of 2, spread over a grid of 2 rows by 5 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(4)\nobserve south_count(2)\nobserve grid_rows(2)\nobserve grid_cols(5)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.8571428571428571,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r141gda-04",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 5 combined with a south count of 3, spread over a grid of 2 rows by 3 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(5)\nobserve south_count(3)\nobserve grid_rows(2)\nobserve grid_cols(3)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r141gda-05",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 5 combined with a south count of 3, spread over a grid of 2 rows by 3 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(5)\nobserve south_count(3)\nobserve grid_rows(2)\nobserve grid_cols(3)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.6,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r141gda-06",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 5 combined with a south count of 3, spread over a grid of 2 rows by 3 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(5)\nobserve south_count(3)\nobserve grid_rows(2)\nobserve grid_cols(3)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 6,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.6,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.75,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r141gda-07",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 6 combined with a south count of 4, spread over a grid of 2 rows by 4 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(6)\nobserve south_count(4)\nobserve grid_rows(2)\nobserve grid_cols(4)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r141gda-08",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 6 combined with a south count of 4, spread over a grid of 2 rows by 4 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(6)\nobserve south_count(4)\nobserve grid_rows(2)\nobserve grid_cols(4)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r141gda-09",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 6 combined with a south count of 4, spread over a grid of 2 rows by 4 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(6)\nobserve south_count(4)\nobserve grid_rows(2)\nobserve grid_cols(4)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 10,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.6666666666666667,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 8,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r141gda-10",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 7 combined with a south count of 5, spread over a grid of 3 rows by 5 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(7)\nobserve south_count(5)\nobserve grid_rows(3)\nobserve grid_cols(5)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.25,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.8,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r141gda-11",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 7 combined with a south count of 5, spread over a grid of 3 rows by 5 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(7)\nobserve south_count(5)\nobserve grid_rows(3)\nobserve grid_cols(5)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r141gda-12",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 7 combined with a south count of 5, spread over a grid of 3 rows by 5 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(7)\nobserve south_count(5)\nobserve grid_rows(3)\nobserve grid_cols(5)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.8,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 15,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.25,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r141gda-13",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 9 combined with a south count of 5, spread over a grid of 4 rows by 5 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(9)\nobserve south_count(5)\nobserve grid_rows(4)\nobserve grid_cols(5)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 0.7,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.5555555555555556,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.4285714285714286,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r141gda-14",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 9 combined with a south count of 5, spread over a grid of 4 rows by 5 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(9)\nobserve south_count(5)\nobserve grid_rows(4)\nobserve grid_cols(5)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 20,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5555555555555556,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.4285714285714286,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r141gda-15",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 9 combined with a south count of 5, spread over a grid of 4 rows by 5 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(9)\nobserve south_count(5)\nobserve grid_rows(4)\nobserve grid_cols(5)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.7,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.5555555555555556,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.4285714285714286,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 20,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r141gda-16",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 5 combined with a south count of 4, spread over a grid of 3 rows by 4 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(5)\nobserve south_count(4)\nobserve grid_rows(3)\nobserve grid_cols(4)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.2857142857142858,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    },
+    {
+      "id": "r141gda-17",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 5 combined with a south count of 4, spread over a grid of 3 rows by 4 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(5)\nobserve south_count(4)\nobserve grid_rows(3)\nobserve grid_cols(4)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.2857142857142858,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "B"
+    },
+    {
+      "id": "r141gda-18",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 5 combined with a south count of 4, spread over a grid of 3 rows by 4 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(5)\nobserve south_count(4)\nobserve grid_rows(3)\nobserve grid_cols(4)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 0.75,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 9,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 12,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.2857142857142858,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 1.3333333333333333,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "C"
+    },
+    {
+      "id": "r141gda-19",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 9 combined with a south count of 7, spread over a grid of 2 rows by 7 cols. What is the grid density (the combined count divided by the grid area)?",
+      "program": "observe north_count(9)\nobserve south_count(7)\nobserve grid_rows(2)\nobserve grid_cols(7)\nlet answer = (north_count + south_count) / (grid_rows * grid_cols)\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.7777777777777777,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.1428571428571428,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "D"
+    },
+    {
+      "id": "r141gda-20",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 9 combined with a south count of 7, spread over a grid of 2 rows by 7 cols. What is the the combined count (the north count plus the south count, the numerator that is divided by the grid area)?",
+      "program": "observe north_count(9)\nobserve south_count(7)\nobserve grid_rows(2)\nobserve grid_cols(7)\nlet answer = north_count + south_count\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 1.1428571428571428,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 1.7777777777777777,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 0.875,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 16,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "E"
+    },
+    {
+      "id": "r141gda-21",
+      "qtype": "grid_density",
+      "stem": "A grid study records a north count of 9 combined with a south count of 7, spread over a grid of 2 rows by 7 cols. What is the the grid area (the grid rows times the grid cols, the product the combined count is divided by)?",
+      "program": "observe north_count(9)\nobserve south_count(7)\nobserve grid_rows(2)\nobserve grid_cols(7)\nlet answer = grid_rows * grid_cols\n? answer\n",
+      "answer_from": {
+        "type": "compute_dimensioned",
+        "name": "answer"
+      },
+      "options": {
+        "A": {
+          "value": 14,
+          "unit": "scalar"
+        },
+        "B": {
+          "value": 1.1428571428571428,
+          "unit": "scalar"
+        },
+        "C": {
+          "value": 16,
+          "unit": "scalar"
+        },
+        "D": {
+          "value": 1.7777777777777777,
+          "unit": "scalar"
+        },
+        "E": {
+          "value": 0.875,
+          "unit": "scalar"
+        }
+      },
+      "gold_letter": "A"
+    }
+  ]
+}

--- a/code/specs/data/adj-ladder/test_ladder_eval.py
+++ b/code/specs/data/adj-ladder/test_ladder_eval.py
@@ -178,6 +178,7 @@ SELF_CONTAINED_RUNGS = (
     "rung138_pressure_ratio",
     "rung139_slope_ratio",
     "rung140_yield_ratio",
+    "rung141_grid_density",
 )
 
 


### PR DESCRIPTION
## ADJ-LADDER rung 141 — grid density

Climbs the ladder one rung and **opens the fourth two-part-denominator family: OVER A PRODUCT**. A **SUM numerator over a PRODUCT denominator**, `(north_count+south_count)/(grid_rows*grid_cols)`. The ladder walked the numerator-op × denominator-shape matrix (rungs 130–140) for a rate, a sum, and a difference; the fourth elementary two-part denominator is a **product** `(c*d)`, opened here with a sum numerator:

| denominator shape | example |
|--|--|
| rate `c/d` | 130–134 |
| sum `c+d` | 132/135/136/37 |
| difference `c-d` | 137–140 |
| **product `c*d`** | **141** ← this rung |

Three queried readouts — grid density `(a+b)/(c*d)`, combined count `a+b`, grid area `c*d`.

**Why different distractors:** a product denominator has its own error profile — dividing by two factors in turn **equals** dividing by their product (`x/c/d = x/(c*d)`), so that isn't a wrong distractor. The two canonical divide-by-a-product slips are:
- **added**: `(a+b)/(c+d)` — divide by the SUM of the dimensions instead of their product (a perimeter-style total where an area belongs; the wrong denominator operation)
- **inverted**: `(c*d)/(a+b)` — the area over the count, the ratio upside down (reciprocal; wrong direction)

The core confusion tested is that `(a+b)/(c*d)` is one sum over one area, not `(a+b)/(c+d)` and not `(c*d)/(a+b)`.

## Verification
- **Engine-verified**: the compound formula and both distractors evaluate to the exact rationals the generator computes (first table: density `3/5`, added `6/7`, inverted `5/3`) — the ADJ engine's exact-rational arithmetic matches Python.
- `pytest test_ladder_eval.py -k rung141` → **3 passed**.
- Generator runs clean: 21 items, all pairwise-distinctness / positivity / 5-option-distinctness asserts pass.

## Discipline
Data-only, no harness/engine change — each figure is a `compute_dimensioned` program (observe the four quantities, `let answer = formula`); the engine carries the arithmetic. Contamination-safe: every formula is built only from the four observed quantities via `+`, `*`, `/`; no numeric literal appears in any program and every observed quantity carries a digit-free identifier. Uses only `+`, `*`, `/` over positive quantities, so every figure is automatically positive — no positivity guards needed. Three files touched (new rung dir + one registry line). `/security-review` passed (round 1, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)