### PR TITLE
[codex] Port LZSS compression to Haskell

### DIFF
--- a/code/packages/haskell/lzss/BUILD
+++ b/code/packages/haskell/lzss/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lzss/BUILD_windows
+++ b/code/packages/haskell/lzss/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lzss/CHANGELOG.md
+++ b/code/packages/haskell/lzss/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-13
+
+- Add CMP02 LZSS literal and backreference tokenisation for strict bytes.
+- Add overlap-safe decoding and configurable window and match thresholds.
+- Add flag-block serialisation with big-endian length and block-count fields.
+- Reject malformed parameters, tokens, headers, blocks, and trailing data.
+- Add spec-vector, round-trip, parameter, wire-format, and behaviour tests.

--- a/code/packages/haskell/lzss/README.md
+++ b/code/packages/haskell/lzss/README.md
@@ -1,0 +1,33 @@
+# lzss
+
+Pure Haskell implementation of CMP02, the LZSS sliding-window compression
+algorithm.
+
+## API
+
+- `encode` and `encodeWith` produce `Literal` and `Match` tokens.
+- `decode` and `decodeWithLength` reconstruct bytes with overlap-safe copying.
+- `serialiseTokens` and `deserialiseTokens` implement CMP02 flag blocks: an
+  eight-byte big-endian header followed by groups of up to eight symbols.
+- `compress`, `compressWith`, and `decompress` provide one-shot byte APIs.
+
+Operations that can encounter invalid parameters, tokens, lengths, or wire data
+return `Either String`. The strict parser rejects invalid match fields,
+impossible block counts, truncated records, non-zero unused flag bits, and
+trailing data.
+
+## Defaults
+
+- Window size: 4096 bytes
+- Maximum match: 255 bytes
+- Minimum match: 3 bytes
+
+The encoder uses deterministic earliest-position tie-breaking. Matches can
+overlap their destination, so runs such as `AAAAAAA` become one literal followed
+by `Match 1 6`.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/lzss/cabal.project
+++ b/code/packages/haskell/lzss/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/lzss/lzss.cabal
+++ b/code/packages/haskell/lzss/lzss.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          lzss
+version:       0.1.0
+synopsis:      CMP02 LZSS flag-block byte compression
+description:   Pure Haskell LZSS tokenisation, overlapping decoding, and CMP02 serialisation.
+category:      Compression
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  LZSS
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , containers >=0.6 && <0.8
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LZSSSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , hspec == 2.*
+                    , lzss
+    default-language: Haskell2010

--- a/code/packages/haskell/lzss/src/LZSS.hs
+++ b/code/packages/haskell/lzss/src/LZSS.hs
@@ -1,0 +1,320 @@
+-- | CMP02 LZSS sliding-window compression for strict byte strings.
+module LZSS
+    ( Token (..)
+    , defaultWindowSize
+    , defaultMaxMatch
+    , defaultMinMatch
+    , encode
+    , encodeWith
+    , decode
+    , decodeWithLength
+    , serialiseTokens
+    , deserialiseTokens
+    , compress
+    , compressWith
+    , decompress
+    ) where
+
+import Control.Monad (foldM)
+import Data.Bits ((.&.), (.|.), setBit, shiftL, shiftR)
+import qualified Data.ByteString as BS
+import Data.Foldable (toList)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
+import Data.Word (Word8, Word16, Word32)
+
+-- | One LZSS symbol: either a byte or a backreference with no trailing byte.
+data Token
+    = Literal
+        { literalByte :: Word8
+        }
+    | Match
+        { matchOffset :: Word16
+        , matchLength :: Word8
+        }
+    deriving (Eq, Show)
+
+defaultWindowSize :: Int
+defaultWindowSize = 4096
+
+defaultMaxMatch :: Int
+defaultMaxMatch = 255
+
+defaultMinMatch :: Int
+defaultMinMatch = 3
+
+-- | Encode with the CMP02 default window and match thresholds.
+encode :: BS.ByteString -> [Token]
+encode = encodeUnchecked defaultWindowSize defaultMaxMatch defaultMinMatch
+
+-- | Encode with explicit parameters that must fit the CMP02 wire fields.
+encodeWith :: Int -> Int -> Int -> BS.ByteString -> Either String [Token]
+encodeWith windowSize maxMatch minMatch input = do
+    validateParameters windowSize maxMatch minMatch
+    Right (encodeUnchecked windowSize maxMatch minMatch input)
+
+encodeUnchecked :: Int -> Int -> Int -> BS.ByteString -> [Token]
+encodeUnchecked windowSize maxMatch minMatch input = go 0
+  where
+    inputLength = BS.length input
+
+    go cursor
+        | cursor >= inputLength = []
+        | bestLength >= minMatch =
+            Match (fromIntegral bestOffset) (fromIntegral bestLength)
+                : go (cursor + bestLength)
+        | otherwise =
+            Literal (BS.index input cursor) : go (cursor + 1)
+      where
+        (bestOffset, bestLength) =
+            findLongestMatch input cursor windowSize maxMatch
+
+findLongestMatch :: BS.ByteString -> Int -> Int -> Int -> (Int, Int)
+findLongestMatch input cursor windowSize maxMatch =
+    foldl chooseBetter (0, 0) [searchStart .. cursor - 1]
+  where
+    searchStart = max 0 (cursor - windowSize)
+    lookaheadEnd = min (cursor + maxMatch) (BS.length input)
+
+    chooseBetter best@(_, bestLength) position
+        | candidateLength > bestLength = (cursor - position, candidateLength)
+        | otherwise = best
+      where
+        candidateLength = measureMatch position 0
+
+    measureMatch position matched
+        | cursor + matched >= lookaheadEnd = matched
+        | BS.index input (position + matched) /= BS.index input (cursor + matched) = matched
+        | otherwise = measureMatch position (matched + 1)
+
+-- | Decode every token, including self-referential overlapping matches.
+decode :: [Token] -> Either String BS.ByteString
+decode tokens = do
+    output <- foldM decodeToken Seq.empty tokens
+    Right (BS.pack (toList output))
+
+-- | Decode and return exactly the length stored in a CMP02 header.
+decodeWithLength :: Int -> [Token] -> Either String BS.ByteString
+decodeWithLength originalLength tokens
+    | originalLength < 0 = Left "original length must not be negative"
+    | otherwise = do
+        output <- decode tokens
+        if BS.length output < originalLength
+            then Left "decoded LZSS stream is shorter than the original length"
+            else Right (BS.take originalLength output)
+
+decodeToken :: Seq Word8 -> Token -> Either String (Seq Word8)
+decodeToken output token = do
+    validateToken token
+    case token of
+        Literal byte -> Right (output |> byte)
+        Match offsetWord lengthWord ->
+            let offset = fromIntegral offsetWord
+                phraseLength = fromIntegral lengthWord
+                outputLength = Seq.length output
+             in if offset > outputLength
+                    then
+                        Left
+                            ( "LZSS offset "
+                                ++ show offset
+                                ++ " exceeds decoded prefix length "
+                                ++ show outputLength
+                            )
+                    else copyMatch (outputLength - offset) phraseLength 0 output
+
+copyMatch :: Int -> Int -> Int -> Seq Word8 -> Either String (Seq Word8)
+copyMatch _ phraseLength copied output
+    | copied >= phraseLength = Right output
+copyMatch start phraseLength copied output =
+    let sourceIndex = start + copied
+     in if sourceIndex < 0 || sourceIndex >= Seq.length output
+            then Left "LZSS backreference points outside the decoded prefix"
+            else
+                copyMatch
+                    start
+                    phraseLength
+                    (copied + 1)
+                    (output |> Seq.index output sourceIndex)
+
+-- | Serialise tokens as CMP02 flag blocks after an eight-byte header.
+serialiseTokens :: Int -> [Token] -> Either String BS.ByteString
+serialiseTokens originalLength tokens = do
+    originalLengthWord <- intToWord32 "original length" originalLength
+    traverse_ validateToken tokens
+    let blocks = chunksOfEight tokens
+    blockCountWord <- integerToWord32 "block count" (toInteger (length blocks))
+    Right
+        ( encodeWord32 originalLengthWord
+            <> encodeWord32 blockCountWord
+            <> BS.pack (concatMap serialiseBlock blocks)
+        )
+
+serialiseBlock :: [Token] -> [Word8]
+serialiseBlock tokens = flag : concatMap serialiseToken tokens
+  where
+    flag = foldl markMatch 0 (zip [0 ..] tokens)
+
+    markMatch value (bit, Match {}) = setBit value bit
+    markMatch value _ = value
+
+    serialiseToken (Literal byte) = [byte]
+    serialiseToken (Match offset lengthValue) =
+        [ fromIntegral (offset `shiftR` 8)
+        , fromIntegral offset
+        , lengthValue
+        ]
+
+chunksOfEight :: [value] -> [[value]]
+chunksOfEight [] = []
+chunksOfEight values =
+    let (chunk, rest) = splitAt 8 values
+     in chunk : chunksOfEight rest
+
+-- | Parse one strict CMP02 payload and reject malformed or trailing data.
+deserialiseTokens :: BS.ByteString -> Either String ([Token], Int)
+deserialiseTokens input
+    | BS.length input < 8 = Left "truncated LZSS header"
+    | otherwise = do
+        originalLengthWord <- decodeWord32 input 0
+        blockCountWord <- decodeWord32 input 4
+        originalLength <- word32ToInt "original length" originalLengthWord
+        blockCount <- word32ToInt "block count" blockCountWord
+        let payloadLength = BS.length input - 8
+        if blockCount > payloadLength
+            then Left "LZSS block count exceeds the available payload"
+            else do
+                (tokens, finalPosition) <- parseBlocks blockCount 8 []
+                if finalPosition /= BS.length input
+                    then Left "trailing bytes after declared LZSS blocks"
+                    else Right (reverse tokens, originalLength)
+  where
+    inputLength = BS.length input
+
+    parseBlocks :: Int -> Int -> [Token] -> Either String ([Token], Int)
+    parseBlocks 0 position tokens = Right (tokens, position)
+    parseBlocks remaining position tokens
+        | position >= inputLength = Left "truncated LZSS block flag"
+        | otherwise =
+            parseSymbols
+                (remaining == 1)
+                (BS.index input position)
+                0
+                (position + 1)
+                0
+                tokens
+                >>= \(nextPosition, nextTokens) ->
+                    parseBlocks (remaining - 1) nextPosition nextTokens
+
+    parseSymbols :: Bool -> Word8 -> Int -> Int -> Int -> [Token] -> Either String (Int, [Token])
+    parseSymbols isLast flag bit position symbolsInBlock tokens
+        | bit >= 8 = Right (position, tokens)
+        | position >= inputLength =
+            if isLast && symbolsInBlock > 0 && flag `shiftR` bit == 0
+                then Right (position, tokens)
+                else
+                    if isLast && flag `shiftR` bit /= 0
+                        then Left "truncated LZSS match record"
+                        else Left "truncated LZSS symbol block"
+        | flag `hasBit` bit =
+            if position + 3 > inputLength
+                then Left "truncated LZSS match record"
+                else do
+                    let offset =
+                            (fromIntegral (BS.index input position) `shiftL` 8)
+                                .|. fromIntegral (BS.index input (position + 1))
+                        token = Match offset (BS.index input (position + 2))
+                    validateToken token
+                    parseSymbols
+                        isLast
+                        flag
+                        (bit + 1)
+                        (position + 3)
+                        (symbolsInBlock + 1)
+                        (token : tokens)
+        | otherwise =
+            parseSymbols
+                isLast
+                flag
+                (bit + 1)
+                (position + 1)
+                (symbolsInBlock + 1)
+                (Literal (BS.index input position) : tokens)
+
+    hasBit value bit = (value `shiftR` bit) .&. 1 == 1
+
+-- | Compress with CMP02 defaults.
+compress :: BS.ByteString -> Either String BS.ByteString
+compress input = serialiseTokens (BS.length input) (encode input)
+
+-- | Compress with explicit window size, maximum match, and minimum match.
+compressWith :: Int -> Int -> Int -> BS.ByteString -> Either String BS.ByteString
+compressWith windowSize maxMatch minMatch input = do
+    tokens <- encodeWith windowSize maxMatch minMatch input
+    serialiseTokens (BS.length input) tokens
+
+-- | Decompress one strict CMP02 payload.
+decompress :: BS.ByteString -> Either String BS.ByteString
+decompress input = do
+    (tokens, originalLength) <- deserialiseTokens input
+    decodeWithLength originalLength tokens
+
+validateParameters :: Int -> Int -> Int -> Either String ()
+validateParameters windowSize maxMatch minMatch
+    | windowSize <= 0 = Left "window size must be positive"
+    | windowSize > fromIntegral (maxBound :: Word16) =
+        Left "window size exceeds the uint16 offset field"
+    | maxMatch <= 0 = Left "maximum match length must be positive"
+    | maxMatch > fromIntegral (maxBound :: Word8) =
+        Left "maximum match length exceeds the uint8 length field"
+    | minMatch <= 0 = Left "minimum match length must be positive"
+    | minMatch > maxMatch = Left "minimum match length exceeds maximum match length"
+    | otherwise = Right ()
+
+validateToken :: Token -> Either String ()
+validateToken (Literal _) = Right ()
+validateToken (Match offset lengthValue)
+    | offset == 0 = Left "LZSS backreferences must use a positive offset"
+    | lengthValue == 0 = Left "LZSS backreferences must use a positive length"
+    | otherwise = Right ()
+
+intToWord32 :: String -> Int -> Either String Word32
+intToWord32 label value
+    | value < 0 = Left (label ++ " must not be negative")
+    | otherwise = integerToWord32 label (toInteger value)
+
+integerToWord32 :: String -> Integer -> Either String Word32
+integerToWord32 label value
+    | value > toInteger (maxBound :: Word32) =
+        Left (label ++ " exceeds the uint32 field")
+    | otherwise = Right (fromInteger value)
+
+word32ToInt :: String -> Word32 -> Either String Int
+word32ToInt label value
+    | toInteger value > toInteger (maxBound :: Int) =
+        Left (label ++ " exceeds this platform's Int range")
+    | otherwise = Right (fromIntegral value)
+
+encodeWord32 :: Word32 -> BS.ByteString
+encodeWord32 value =
+    BS.pack
+        [ fromIntegral (value `shiftR` 24)
+        , fromIntegral (value `shiftR` 16)
+        , fromIntegral (value `shiftR` 8)
+        , fromIntegral value
+        ]
+
+decodeWord32 :: BS.ByteString -> Int -> Either String Word32
+decodeWord32 input offset
+    | BS.length input < offset + 4 = Left "truncated uint32 field"
+    | otherwise =
+        Right
+            ( byteAt 0 `shiftL` 24
+                .|. byteAt 1 `shiftL` 16
+                .|. byteAt 2 `shiftL` 8
+                .|. byteAt 3
+            )
+  where
+    byteAt index = fromIntegral (BS.index input (offset + index))
+
+traverse_ :: (value -> Either String ()) -> [value] -> Either String ()
+traverse_ validator = foldM (\() value -> validator value) ()

--- a/code/packages/haskell/lzss/test/LZSSSpec.hs
+++ b/code/packages/haskell/lzss/test/LZSSSpec.hs
@@ -1,0 +1,192 @@
+module LZSSSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.List (isInfixOf)
+import Data.Word (Word8, Word16)
+import LZSS
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "CMP02 vectors" $ do
+        it "encodes empty input as no tokens" $
+            encode BS.empty `shouldBe` []
+        it "encodes a single byte as a literal" $
+            encode (ascii "A") `shouldBe` [Literal 65]
+        it "keeps non-repeating bytes literal" $
+            encode (ascii "ABCDE")
+                `shouldBe` map Literal [65, 66, 67, 68, 69]
+        it "encodes the mixed AABCBBABC vector" $
+            encode (ascii "AABCBBABC")
+                `shouldBe`
+                    [ Literal 65
+                    , Literal 65
+                    , Literal 66
+                    , Literal 67
+                    , Literal 66
+                    , Literal 66
+                    , Match 5 3
+                    ]
+        it "encodes ABABAB with an overlapping match" $
+            encode (ascii "ABABAB")
+                `shouldBe` [Literal 65, Literal 66, Match 2 4]
+        it "encodes a repeated byte with a self-reference" $
+            encode (ascii "AAAAAAA")
+                `shouldBe` [Literal 65, Match 1 6]
+
+    describe "round trips" $ do
+        it "round-trips representative text and binary inputs" $ do
+            mapM_
+                (\input -> roundTrip input `shouldBe` Right input)
+                [ BS.empty
+                , ascii "A"
+                , ascii "ABCDE"
+                , ascii "AABCBBABC"
+                , ascii "ABABAB"
+                , ascii "hello world"
+                , BS.pack [0, 0, 0, 255, 255]
+                ]
+        it "round-trips every byte value" $ do
+            let input = BS.pack [0 .. 255]
+            roundTrip input `shouldBe` Right input
+        it "round-trips long repeated patterns" $ do
+            let input = BS.concat (replicate 500 (ascii "ABCDEF"))
+            roundTrip input `shouldBe` Right input
+        it "round-trips a long single-byte run" $ do
+            let input = BS.replicate 10000 66
+            roundTrip input `shouldBe` Right input
+
+    describe "parameters" $ do
+        it "keeps offsets within the configured window" $ do
+            tokens <- expectRight (encodeWith 4 255 3 (BS.concat (replicate 100 (ascii "ABCABC"))))
+            mapM_ (offsetShouldBeAtMost 4) tokens
+        it "keeps matches within the configured maximum" $ do
+            tokens <- expectRight (encodeWith 4096 5 3 (BS.replicate 100 65))
+            mapM_ (lengthShouldBeAtMost 5) tokens
+        it "lets a high threshold force literal output" $ do
+            tokens <- expectRight (encodeWith 4096 255 100 (ascii "ABABAB"))
+            tokens `shouldSatisfy` all isLiteral
+        it "rejects parameters that cannot fit the wire format" $ do
+            encodeWith 0 255 3 (ascii "A") `leftShouldContain` "window size"
+            encodeWith 65536 255 3 (ascii "A") `leftShouldContain` "uint16"
+            encodeWith 4096 256 3 (ascii "A") `leftShouldContain` "uint8"
+            encodeWith 4096 2 3 (ascii "A") `leftShouldContain` "exceeds"
+
+    describe "decoding and validation" $ do
+        it "copies overlapping matches byte by byte" $
+            decode [Literal 65, Match 1 6]
+                `shouldBe` Right (ascii "AAAAAAA")
+        it "decodes non-overlapping matches" $
+            decode [Literal 65, Literal 66, Literal 67, Match 3 3]
+                `shouldBe` Right (ascii "ABCABC")
+        it "uses the stored length as an authoritative truncation" $
+            decodeWithLength 2 [Literal 65, Literal 66, Literal 67]
+                `shouldBe` Right (ascii "AB")
+        it "rejects output shorter than the stored length" $
+            decodeWithLength 2 [Literal 65] `leftShouldContain` "shorter"
+        it "rejects zero offsets and lengths" $ do
+            decode [Literal 65, Match 0 3] `leftShouldContain` "positive offset"
+            decode [Literal 65, Match 1 0] `leftShouldContain` "positive length"
+        it "rejects offsets beyond the decoded prefix" $
+            decode [Literal 65, Match 2 3] `leftShouldContain` "exceeds"
+
+    describe "wire format" $ do
+        it "writes the exact empty header" $
+            compress BS.empty `shouldBe` Right (BS.replicate 8 0)
+        it "writes the exact ABABAB flag block" $
+            compress (ascii "ABABAB")
+                `shouldBe`
+                    Right
+                        ( BS.pack
+                            [ 0, 0, 0, 6
+                            , 0, 0, 0, 1
+                            , 4
+                            , 65, 66
+                            , 0, 2, 4
+                            ]
+                        )
+        it "groups eight literals into one block" $
+            compress (ascii "ABCDEFGH")
+                `shouldBe`
+                    Right
+                        ( BS.pack
+                            [ 0, 0, 0, 8
+                            , 0, 0, 0, 1
+                            , 0
+                            , 65, 66, 67, 68, 69, 70, 71, 72
+                            ]
+                        )
+        it "starts a second block for the ninth token" $ do
+            payload <- expectRight (compress (ascii "ABCDEFGHI"))
+            BS.take 8 payload
+                `shouldBe` BS.pack [0, 0, 0, 9, 0, 0, 0, 2]
+            BS.drop 8 payload
+                `shouldBe` BS.pack [0, 65, 66, 67, 68, 69, 70, 71, 72, 0, 73]
+        it "serialises and deserialises mixed tokens losslessly" $ do
+            let tokens = [Literal 65, Literal 66, Match 2 4]
+            payload <- expectRight (serialiseTokens 6 tokens)
+            deserialiseTokens payload `shouldBe` Right (tokens, 6)
+        it "rejects truncated headers and implausible block counts" $ do
+            deserialiseTokens (BS.replicate 7 0) `leftShouldContain` "header"
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 2, 0])
+                `leftShouldContain` "block count"
+        it "rejects missing block payload and truncated match records" $ do
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 1])
+                `leftShouldContain` "block count"
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1])
+                `leftShouldContain` "match record"
+        it "rejects set unused flag bits and trailing data" $ do
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 1, 2, 65])
+                `leftShouldContain` "match record"
+            deserialiseTokens (BS.pack [0, 0, 0, 0, 0, 0, 0, 0, 65])
+                `leftShouldContain` "trailing"
+        it "rejects invalid match fields from the wire" $ do
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 3])
+                `leftShouldContain` "positive offset"
+            deserialiseTokens (BS.pack [0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0])
+                `leftShouldContain` "positive length"
+
+    describe "compression behaviour" $ do
+        it "compresses repetitive input below its original size" $ do
+            let input = BS.concat (replicate 1000 (ascii "ABC"))
+            payload <- expectRight (compress input)
+            BS.length payload `shouldSatisfy` (< BS.length input)
+        it "compresses a long repeated byte below its original size" $ do
+            let input = BS.replicate 10000 66
+            payload <- expectRight (compress input)
+            BS.length payload `shouldSatisfy` (< BS.length input)
+        it "produces deterministic output" $
+            compress (ascii "hello world test")
+                `shouldBe` compress (ascii "hello world test")
+
+roundTrip :: BS.ByteString -> Either String BS.ByteString
+roundTrip input = compress input >>= decompress
+
+ascii :: String -> BS.ByteString
+ascii = BS.pack . map (fromIntegral . fromEnum)
+
+isLiteral :: Token -> Bool
+isLiteral Literal {} = True
+isLiteral Match {} = False
+
+offsetShouldBeAtMost :: Word16 -> Token -> Expectation
+offsetShouldBeAtMost maximumOffset Match {matchOffset = offset} =
+    offset `shouldSatisfy` (<= maximumOffset)
+offsetShouldBeAtMost _ Literal {} = pure ()
+
+lengthShouldBeAtMost :: Word8 -> Token -> Expectation
+lengthShouldBeAtMost maximumLength Match {matchLength = lengthValue} =
+    lengthValue `shouldSatisfy` (<= maximumLength)
+lengthShouldBeAtMost _ Literal {} = pure ()
+
+expectRight :: Either String value -> IO value
+expectRight result =
+    case result of
+        Left message -> expectationFailure message >> fail message
+        Right value -> pure value
+
+leftShouldContain :: Either String value -> String -> Expectation
+leftShouldContain result expected =
+    case result of
+        Left message -> message `shouldSatisfy` isInfixOf expected
+        Right _ -> expectationFailure ("expected Left containing " ++ show expected)

--- a/code/packages/haskell/lzss/test/Spec.hs
+++ b/code/packages/haskell/lzss/test/Spec.hs
@@ -1,0 +1,5 @@
+import LZSSSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Fourteen package/language slots remain to turn 15 nearly complete packages into
+Thirteen package/language slots remain to turn 13 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,13 +145,12 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 2 remaining ports
+### Haskell: 1 remaining port
 
-- `lzss`
 - `lzw`
 
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
-`huffman-tree`, `huffman-compression`, `lz77`.
+`huffman-tree`, `huffman-compression`, `lz77`, `lzss`.
 
 ### Swift: 3 ports
 


### PR DESCRIPTION
## What changed

- add a standalone pure-Haskell CMP02 LZSS package with literal and backreference tokens
- implement configurable sliding-window matching, overlap-safe decoding, and deterministic earliest-match tie-breaking
- implement the CMP02 big-endian header and flag-block wire format with strict malformed-input validation
- add 32 Hspec examples covering reference vectors, binary and long-input round trips, parameters, exact wire bytes, invalid streams, and compression behavior
- update the package-parity roadmap to mark `lzss` complete in Haskell

## Why this is next

`lzss` was one of the two remaining Haskell gaps in Priority 1's 14-of-15 set. It is a dependency-free pure compression algorithm with an existing language-neutral CMP02 specification and mature implementations in every other established language.

After this change, `lzss` reaches all 15 established implementation languages. Haskell's only remaining Priority 1 gap is `lzw`; the roadmap has 13 total 14-of-15 slots remaining.

No packages in this slice were classified as native, wrapper, web-only, target-specific, or not applicable.

## Validation

- `cabal build all --ghc-options='-Wall -fforce-recomp'`
- `cabal test all --test-show-details=direct --ghc-options='-Wall -fforce-recomp'` — 32 examples, 0 failures
- `cabal check` — no errors or warnings
- `python -m unittest discover -s code/scripts/tests -p 'test_package_parity_report.py'` — 6 tests passed
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — zero collisions, zero unknown buckets, `lzss` at 15 languages
- `git diff --check`
