### PR TITLE
fix(matlab-to-semantic-ir,wolfram-to-semantic-ir): observe Feature::Floats

### DIFF
--- a/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/matlab-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Correctness: `Feature::Floats` was never observed for a `FloatLit`.**
+  `number_literal_expr` was a free function with no access to the
+  lowerer's feature-tracking state, so a module containing a float
+  literal never declared `Feature::Floats` in its manifest even though
+  `semantic-ir/src/validator.rs`'s `check_expr` requires it for every
+  `Expr::FloatLit` node — any MATLAB (and, transitively, Octave) program
+  with a float literal failed `semantic_ir::validate()`. Found while
+  implementing `macsyma-to-semantic-ir` (which cross-checked its own
+  `Feature::Floats` handling against every sibling frontend). Fixed by
+  converting `number_literal_expr` into an instance method that calls
+  `self.observed.add(Feature::Floats)` on every `FloatLit`-constructing
+  branch; added a regression test asserting a float-literal program both
+  validates and is accepted by the JS backend.
+
 ## [0.1.0] - 2026-07-11
 
 ### Added

--- a/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/src/lower.rs
@@ -1642,7 +1642,7 @@ impl Lowerer {
         if let Some(tok) = node.token() {
             let span = self.span_of(node);
             return match tok.type_ {
-                TokenType::Number => Ok(number_literal_expr(tok, &span)),
+                TokenType::Number => Ok(self.number_literal_expr(tok, &span)),
                 TokenType::String => Ok(Expr::StrLit {
                     value: tok.value.clone(),
                     span,
@@ -1932,6 +1932,44 @@ impl Lowerer {
         }
     }
 
+    /// A `NUMBER` lexeme is a float if it has a decimal point or exponent,
+    /// otherwise an int; an integer lexeme too large for `i64` falls back to
+    /// a float rather than silently truncating or erroring.
+    ///
+    /// **Must** be an instance method, not a free function: every branch
+    /// that constructs a `FloatLit` calls `self.observed.add(Feature::
+    /// Floats)` immediately. Previously this was a free function with no
+    /// access to `observed`, so a float-literal-only module never declared
+    /// the feature even though `semantic-ir/src/validator.rs`'s `check_expr`
+    /// requires it for every `Expr::FloatLit` node — a confirmed, live bug
+    /// (any MATLAB program with a float literal failed `semantic_ir::
+    /// validate()`), found while implementing `macsyma-to-semantic-ir` and
+    /// fixed here.
+    fn number_literal_expr(&mut self, tok: &Token, span: &Span) -> Expr {
+        let text = &tok.value;
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            self.observed.add(Feature::Floats);
+            Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span: span.clone(),
+            }
+        } else {
+            match text.parse::<i64>() {
+                Ok(v) => Expr::IntLit {
+                    value: v,
+                    span: span.clone(),
+                },
+                Err(_) => {
+                    self.observed.add(Feature::Floats);
+                    Expr::FloatLit {
+                        value: text.parse::<f64>().unwrap_or(0.0),
+                        span: span.clone(),
+                    }
+                }
+            }
+        }
+    }
+
     /// Reject a same-precedence operator chain (`additive`/`multiplicative`/
     /// `comparison`/`logical_or`/`logical_and`) with more than
     /// `MAX_EXPR_DEPTH` operands.
@@ -1985,30 +2023,6 @@ fn child_nodes(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
             ASTNodeOrToken::Token(_) => None,
         })
         .collect()
-}
-
-/// A `NUMBER` lexeme is a float if it has a decimal point or exponent,
-/// otherwise an int; an integer lexeme too large for `i64` falls back to a
-/// float rather than silently truncating or erroring.
-fn number_literal_expr(tok: &Token, span: &Span) -> Expr {
-    let text = &tok.value;
-    if text.contains('.') || text.contains('e') || text.contains('E') {
-        Expr::FloatLit {
-            value: text.parse::<f64>().unwrap_or(0.0),
-            span: span.clone(),
-        }
-    } else {
-        match text.parse::<i64>() {
-            Ok(v) => Expr::IntLit {
-                value: v,
-                span: span.clone(),
-            },
-            Err(_) => Expr::FloatLit {
-                value: text.parse::<f64>().unwrap_or(0.0),
-                span: span.clone(),
-            },
-        }
-    }
 }
 
 /// Is `e` provably a scalar? See the module doc comment's "Scalar/array

--- a/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/matlab-to-semantic-ir/tests/test_validator.rs
@@ -58,6 +58,27 @@ fn a_purely_literal_program_validates_and_the_js_backend_accepts_it() {
 }
 
 #[test]
+fn a_float_literal_program_validates_and_declares_floats() {
+    // Regression test for a confirmed, previously-shipped bug:
+    // `number_literal_expr` never called `self.observed.add(Feature::
+    // Floats)` (it was a free function with no access to `observed`), so a
+    // float-literal-only module failed `semantic_ir::validate()` even
+    // though `check_expr` requires the feature for every `Expr::FloatLit`
+    // node. Found while implementing `macsyma-to-semantic-ir`, fixed here.
+    let module = assert_valid("function r = half()\n  r = 1.5;\nend\ndisp(half());\n");
+    assert!(module
+        .manifest
+        .iter()
+        .any(|f| f == semantic_ir::Feature::Floats));
+    let backend = JavaScriptBackend;
+    let errors = backend.check_module(&module);
+    assert!(
+        errors.is_empty(),
+        "expected the JS backend to accept a purely-literal float module, got: {errors:?}"
+    );
+}
+
+#[test]
 fn control_flow_with_a_variable_accumulator_validates_but_needs_array_features() {
     let module = assert_valid(
         "total = 0;\nfor i = 1:10\n  if i > 5\n    total = total + i;\n  end\nend\ndisp(total);\n",

--- a/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/wolfram-to-semantic-ir/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Correctness: `Feature::Floats` was never observed for a `FloatLit`.**
+  `number_literal_expr` was a free function with no access to the
+  lowerer's feature-tracking state, so a module containing a float
+  literal never declared `Feature::Floats` in its manifest even though
+  `semantic-ir/src/validator.rs`'s `check_expr` requires it for every
+  `Expr::FloatLit` node — any Wolfram program with a float literal failed
+  `semantic_ir::validate()`. Found while implementing
+  `macsyma-to-semantic-ir` (which cross-checked its own `Feature::Floats`
+  handling against every sibling frontend). Fixed by converting
+  `number_literal_expr` into an instance method that calls
+  `self.observed.add(Feature::Floats)` on every `FloatLit`-constructing
+  branch; added a regression test.
+
 ## [0.1.0] - 2026-07-11
 
 ### Added

--- a/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/src/lower.rs
@@ -386,7 +386,7 @@ impl Lowerer {
     fn lower_token(&mut self, token: &Token) -> Result<Expr, WolframLowerError> {
         let span = self.token_span(token);
         match token_type(token) {
-            "NUMBER" => Ok(number_literal_expr(&token.value, span)),
+            "NUMBER" => Ok(self.number_literal_expr(&token.value, span)),
             "NAME" => Ok(self.sym_symbol(token.value.clone(), span)),
             "STRING" => Ok(Expr::StrLit {
                 value: strip_quotes(&token.value).to_string(),
@@ -1284,6 +1284,41 @@ impl Lowerer {
             column: node.start_column.unwrap_or(1),
         }
     }
+
+    /// Parse a `NUMBER` lexeme into an `IntLit` or `FloatLit`, matching the
+    /// native `wolfram-runtime::lower::lower_number`'s identical rule (a `.`,
+    /// `e`, or `E` means a real; otherwise an integer). An integer lexeme too
+    /// large for `i64` falls back to a float rather than silently truncating.
+    ///
+    /// **Must** be an instance method, not a free function: every branch
+    /// that constructs a `FloatLit` calls `self.observed.add(Feature::
+    /// Floats)` immediately. Previously this was a free function with no
+    /// access to `observed`, so a float-literal-only module never declared
+    /// the feature even though `semantic-ir/src/validator.rs`'s `check_expr`
+    /// requires it for every `Expr::FloatLit` node — a confirmed, live bug
+    /// (any Wolfram program with a float literal failed `semantic_ir::
+    /// validate()`), found while implementing `macsyma-to-semantic-ir` and
+    /// fixed here.
+    fn number_literal_expr(&mut self, text: &str, span: Span) -> Expr {
+        if text.contains('.') || text.contains('e') || text.contains('E') {
+            self.observed.add(Feature::Floats);
+            Expr::FloatLit {
+                value: text.parse::<f64>().unwrap_or(0.0),
+                span,
+            }
+        } else {
+            match text.parse::<i64>() {
+                Ok(v) => Expr::IntLit { value: v, span },
+                Err(_) => {
+                    self.observed.add(Feature::Floats);
+                    Expr::FloatLit {
+                        value: text.parse::<f64>().unwrap_or(0.0),
+                        span,
+                    }
+                }
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1322,27 +1357,6 @@ fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
 
 fn token_type(token: &Token) -> &str {
     token.effective_type_name()
-}
-
-/// Parse a `NUMBER` lexeme into an `IntLit` or `FloatLit`, matching the
-/// native `wolfram-runtime::lower::lower_number`'s identical rule (a `.`,
-/// `e`, or `E` means a real; otherwise an integer). An integer lexeme too
-/// large for `i64` falls back to a float rather than silently truncating.
-fn number_literal_expr(text: &str, span: Span) -> Expr {
-    if text.contains('.') || text.contains('e') || text.contains('E') {
-        Expr::FloatLit {
-            value: text.parse::<f64>().unwrap_or(0.0),
-            span,
-        }
-    } else {
-        match text.parse::<i64>() {
-            Ok(v) => Expr::IntLit { value: v, span },
-            Err(_) => Expr::FloatLit {
-                value: text.parse::<f64>().unwrap_or(0.0),
-                span,
-            },
-        }
-    }
 }
 
 /// Strip the surrounding double-quotes from a `STRING` lexeme (mirrors the

--- a/code/packages/rust/wolfram-to-semantic-ir/tests/test_validator.rs
+++ b/code/packages/rust/wolfram-to-semantic-ir/tests/test_validator.rs
@@ -52,6 +52,25 @@ fn bare_arithmetic_validates_and_declares_symbolic_expr() {
 }
 
 #[test]
+fn a_float_literal_module_validates_and_declares_floats() {
+    // Regression test for a confirmed, previously-shipped bug: `lower_token`'s
+    // number-literal handling never called `self.observed.add(Feature::
+    // Floats)` (it delegated to a free function with no access to
+    // `observed`), so a float-literal-only module failed
+    // `semantic_ir::validate()` even though `check_expr` requires the
+    // feature for every `Expr::FloatLit` node. Found while implementing
+    // `macsyma-to-semantic-ir`, fixed here.
+    //
+    // Paired with `x +` (a genuine `SymApply`) rather than a bare `1.5`
+    // alone: a bare float literal is a plain SIR16 node the JS backend
+    // already accepts, so it wouldn't exercise this file's own "every
+    // module is rejected" capability-gate assertion below.
+    let module = assert_valid("x + 1.5\n");
+    assert!(module.manifest.iter().any(|f| f == Feature::Floats));
+    assert_js_backend_rejects(&module);
+}
+
+#[test]
 fn a_bare_symbol_alone_validates_and_declares_symbolic_expr() {
     let module = assert_valid("x\n");
     assert!(module.manifest.iter().any(|f| f == Feature::SymbolicExpr));


### PR DESCRIPTION
## Summary

Front1's turn: a confirmed, live correctness bug found while implementing `macsyma-to-semantic-ir` (#8142), which cross-checked its own `Feature::Floats` handling against every sibling frontend.

- Neither `matlab-to-semantic-ir`'s nor `wolfram-to-semantic-ir`'s `number_literal_expr` ever called `self.observed.add(Feature::Floats)` — it was a free function with no access to the lowerer's feature-tracking state. Any program with a float literal therefore failed `semantic_ir::validate()`, since `validator.rs`'s `check_expr` requires the feature for every `Expr::FloatLit` node.
- Fixed identically in both crates: converted `number_literal_expr` into an instance method (matching the pattern already used correctly in `apl-to-semantic-ir` and `macsyma-to-semantic-ir`), calling `self.observed.add(Feature::Floats)` on every `FloatLit`-constructing branch.
- `octave-to-semantic-ir` inherits the fix automatically — it's a thin wrapper delegating to `matlab-to-semantic-ir::compile_source`, no code of its own to change.
- Audited every other `-to-semantic-ir` frontend for the same omission: `python`/`ruby`/`javascript`/`apl`/`macsyma` already observe the feature correctly; `twig` and `c-to-semantic-ir` have no float-literal code path yet, so there was nothing to fix there.
- Added a regression test to each crate's `test_validator.rs` asserting a float-literal program both validates and (for matlab) is accepted by the JS backend.

## Test plan

- [x] `cargo test -p matlab-to-semantic-ir -p wolfram-to-semantic-ir -p octave-to-semantic-ir` — all green (63 tests across the three crates)
- [x] `cargo clippy --all-targets` on both changed crates — clean
- [x] Security review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)