### PR TITLE
feat(j): j.grammar + j-parser crate (MA06 §6, MA-6c)

### DIFF
--- a/code/grammars/j/j.grammar
+++ b/code/grammars/j/j.grammar
@@ -1,0 +1,156 @@
+# @version 1
+
+# =============================================================================
+# j.grammar — Parser grammar for the J historical core (MA-6c)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from the J lexer (code/grammars/j/j.tokens). See
+# code/specs/MA06-j-language.md, especially §3 (the grammar design this file
+# implements) and §4 (the exact primitive/adverb/conjunction scope).
+#
+# Token names (UPPERCASE) come from the J lexer:
+#   NUMBER NAME                                      literals and variables
+#   ASSIGN_LOCAL (=.)  ASSIGN_GLOBAL (=:)             assignment
+#   PLUS MINUS STAR PERCENT CARET FLOOR CEILING       primitive verbs
+#   DOLLAR IDOT RAVEL HASH
+#   EQ NE LT GT LE GE                                 dyadic comparison verbs
+#   REDUCE (/)  SCAN (\)                               adverbs
+#   AT (@)                                             the one in-scope conjunction
+#   LPAREN RPAREN                                      grouping
+#   NEWLINE
+#
+# -----------------------------------------------------------------------------
+# Two nonterminals, reused from APL almost verbatim (MA06 §3)
+# -----------------------------------------------------------------------------
+# Exactly like `apl.grammar`, J needs TWO expression nonterminals, because its
+# adverbs (`/`, `\`) and its one conjunction (`@`) combine with VERBS, not
+# nouns:
+#
+#   noun_expr  — arrays and scalars (APL's `value_expr`, renamed to J's own
+#                terminology). Built from `term`s combined by `verb_expr`s.
+#   verb_expr  — a primitive glyph, a primitive glyph with an adverb applied
+#                (a "derived verb"), two verbs joined by the `@` conjunction
+#                (compose), or — MA06 §3's one genuinely new production,
+#                with no APL precedent — a parenthesised TRAIN (hook/fork).
+#
+# -----------------------------------------------------------------------------
+# One precedence tier, right-to-left — unchanged from APL (MA06 §3)
+# -----------------------------------------------------------------------------
+# `noun_expr`'s dyadic continuation stays the SAME single right-recursive
+# rule MA05 §3 already designed for APL: `a F b G c` parses as `a F (b G c)`.
+# Trains don't change this at all — see the `verb_expr` comment below.
+#
+# -----------------------------------------------------------------------------
+# Monadic vs. dyadic dispatch is still a runtime concern, not a lexer or
+# grammar concern (MA06 §3, unchanged from MA05 §3 bullet 3)
+# -----------------------------------------------------------------------------
+# `noun_expr`'s two productions that start with a `verb_expr` (monadic:
+# nothing precedes it) vs. that have a `term` before it (dyadic) are exactly
+# the "which application rule matched" a later runtime reads off — this is
+# true whether the `verb_expr` in question is a bare primitive or a train.
+#
+# -----------------------------------------------------------------------------
+# The one genuinely new grammar problem: trains (MA06 §3)
+# -----------------------------------------------------------------------------
+# A `verb_train` is 2+ consecutive `train_tooth`s (a bare primitive/derived
+# verb, a parenthesised sub-verb or sub-train, or — only meaningful in the
+# LEADING position of a 3+-tooth fork — a bare noun used as a literal
+# constant) with no application between them. Per MA06 §3's own disclosed
+# restriction, trains are scoped to the PARENTHESISED form only in this cut
+# (`(f g)`, `(f g h)`, ...) — this sidesteps a genuine grammar ambiguity an
+# unparenthesised top-level train would introduce without deeper lookahead
+# than this cut's grammar needs (an unparenthesised run of verbs and nouns
+# would otherwise be indistinguishable from an ordinary application chain).
+#
+# `verb_train`'s own production only needs to recognise the SHAPE (a flat
+# run of 2+ teeth) — whether that run means a hook (exactly 2 teeth) or a
+# fork (3+, right-to-left recursively reduced per MA06 §3's exact formulas,
+# `(a b c d)` = the fork `(a (b c d))`) is resolved by a later pass
+# (lowering), exactly the same "grammar builds the flat shape, a later pass
+# assigns meaning" division APL's own stranding (`NUMBER { NUMBER }`, MA05
+# §4) already established: the grammar doesn't know or care whether three
+# juxtaposed numbers form a 3-element vector any more than this grammar
+# knows or cares whether three juxtaposed verbs form a fork.
+#
+# This grammar also does not itself enforce "a bare noun tooth may only
+# appear in a fork's leading position, never in a hook, and never anywhere
+# else" — exactly like `apl.grammar`'s own `function_atom`/REDUCE-SCAN
+# restriction and `semantic-ir`'s own `Expr::SymPatternBlank` placement
+# restriction, this is a semantic constraint a later pass enforces, not a
+# syntactic one this grammar encodes. A concrete, disclosed consequence:
+# `(A B)` (two bare NAMEs) parses successfully as a syntactically well-formed
+# 2-tooth train under this grammar, even though no real J hook or fork has
+# an all-noun shape — lowering is expected to reject that combination with a
+# clear error, not this grammar.
+# =============================================================================
+
+program = { line } ;
+
+line = statement NEWLINE
+     | statement
+     | NEWLINE ;
+
+statement = assignment ;
+
+# Assignment (MA06 §4): `=.` (local) / `=:` (global), right-associative and
+# right-to-left evaluated — mirrors `apl.grammar`'s own `assignment`
+# production exactly (including chained assignment, `A=.B=.3`), with J's own
+# two assignment operators standing in for APL's one `ARROW`.
+assignment = NAME ASSIGN_LOCAL assignment
+           | NAME ASSIGN_GLOBAL assignment
+           | noun_expr ;
+
+# The core two-nonterminal, one-precedence-tier, right-to-left application
+# chain (MA06 §3), reused from `apl.grammar`'s `value_expr` verbatim in
+# shape (renamed nonterminals only). Ordered as ONE alternative per
+# starting-token class (a `term`-starting noun vs. a `verb_expr`-starting
+# one) with the dyadic continuation as an OPTIONAL trailing part of the
+# first alternative — NOT two competing "bare term" vs. "term then more"
+# alternatives, for the identical reason `apl.grammar` gives.
+noun_expr = term [ verb_expr noun_expr ]
+          | verb_expr noun_expr ;
+
+# A noun atom: a run of one or more juxtaposed NUMBER literals (stranding,
+# MA06 §4 inherits APL's own numeric-only restriction unchanged: `1 2 3`
+# strands, `A B` does not), a NAME, or a fully parenthesised noun_expr.
+term = NUMBER { NUMBER }
+     | NAME
+     | LPAREN noun_expr RPAREN ;
+
+# The other nonterminal (MA06 §3): verb-valued expressions. A bare
+# primitive verb, optionally with one adverb applied (a "derived verb",
+# e.g. `+/`); two verb_exprs joined by the `@` conjunction (compose,
+# right-recursive so `f@g@h` falls out naturally — MA06 §4 only specifies
+# the 2-verb case, but nothing restricts chaining, and this mirrors the
+# same "optional trailing continuation, recurse for free" idiom this
+# grammar already uses for assignment chaining); or — the one genuinely
+# new shape (see the header note above) — a parenthesised train.
+verb_expr = simple_verb [ AT verb_expr ]
+          | LPAREN verb_train RPAREN ;
+
+# One primitive verb glyph (MA06 §4's full primitive list), optionally
+# postfixed by one adverb. REDUCE and SCAN are the same two AR-2 primitives
+# APL already uses — adverbs, unlike verbs, mostly didn't need re-spelling
+# (MA06 §3). Like `apl.grammar`'s own REDUCE/SCAN restriction, stacking
+# adverbs (applying one to an already-adverbed verb) is not part of this
+# first cut's scope.
+simple_verb = verb_primitive [ REDUCE | SCAN ] ;
+
+verb_primitive = PLUS | MINUS | STAR | PERCENT | CARET | FLOOR | CEILING
+               | DOLLAR | IDOT | RAVEL | HASH
+               | EQ | NE | LT | GT | LE | GE ;
+
+# MA06 §3's one new production: a flat run of 2+ train teeth, parenthesised
+# only (see the header note above for the full ambiguity-avoidance
+# rationale and the "grammar builds the shape, lowering assigns hook/fork
+# meaning" division of labour).
+verb_train = train_tooth train_tooth { train_tooth } ;
+
+# One tooth of a train: a bare or adverbed primitive verb, a `@`-composed
+# verb, a parenthesised sub-verb or sub-train (so trains can nest, e.g.
+# `((f g) h)`), or a bare noun (only meaningful in a fork's leading
+# position — see the header note on why that restriction is not encoded
+# here syntactically).
+train_tooth = verb_expr
+            | term ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -248,6 +248,7 @@ members = [
     "apl-repl",
     "apl-to-semantic-ir",
     "j-lexer",
+    "j-parser",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/j-parser/BUILD
+++ b/code/packages/rust/j-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-parser -- --nocapture

--- a/code/packages/rust/j-parser/BUILD_windows
+++ b/code/packages/rust/j-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-parser -- --nocapture

--- a/code/packages/rust/j-parser/CHANGELOG.md
+++ b/code/packages/rust/j-parser/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial grammar-driven Rust J parser (MA06 §6, task MA-6c): consumes
+  `j-lexer`'s token stream, drives it through the compiled
+  `code/grammars/j/j.grammar` (the two-nonterminal `noun_expr`/`verb_expr`
+  design, reused from `apl.grammar` almost verbatim, plus the one genuinely
+  new `verb_train` production), and produces a `GrammarASTNode` CST rooted
+  at `program`. Exposes `create_j_parser`/`parse_j`/`try_parse_j`, matching
+  every sibling parser crate's established shape.
+- Ships with a recursion-depth cap (`MAX_RULE_DEPTH = 70`) from day one,
+  following MA06 §6's explicit instruction to measure the *actual*
+  native-stack crash floor for **every** distinct way this grammar can
+  recurse deeply, rather than assuming `apl-parser`'s own (twice-corrected)
+  cap or floor ordering transfers unchanged. `j.grammar` has three such
+  shapes, all measured independently:
+
+  1. **Parenthesised nesting**, `((((…5…))))`. Measured (binary search, a
+     `std::thread::spawn` worker on the **default ~2 MiB stack**, uncapped
+     `GrammarParser`, **debug** build to match `cargo test`'s own profile):
+     safe up to 100 levels, crashes the process at 101.
+  2. **A flat, unparenthesised dyadic chain**, `1+1+1+…+1` — the exact shape
+     that bit `apl-parser` originally (see that crate's own `0.1.1`
+     changelog entry). Same methodology: safe up to 135 terms, crashes at
+     136 — close to `apl-parser`'s own measured flat-chain floor (136 safe /
+     137 crashing), since the grammar shape and per-level native-stack cost
+     are nearly identical between the two crates.
+  3. **A long train**, `(+ + + … +) 5` (N `+` teeth in one paren pair,
+     applied monadically) — this grammar's own genuinely new recursion
+     shape, with no `apl-parser` precedent, exercising `verb_train`'s flat
+     `train_tooth { train_tooth }` repetition. Same methodology: safe up to
+     200 teeth, crashes at 201.
+
+  **The binding constraint is a genuine surprise**: parenthesised nesting
+  (100) is the *lowest* of the three floors here, ahead of the flat chain
+  (135) and the train (200) — the **opposite** ranking from `apl-parser`,
+  where the flat chain was binding. This is precisely the failure mode MA06
+  §6 warns against: a shape's measured floor (even from this same grammar's
+  *other* shapes, not just a sibling crate) does not predict another
+  shape's floor. `MAX_RULE_DEPTH` is set to `70` — about 30% below the
+  binding 100 floor (comparable margin to `apl-parser`'s own ~26.5%), and
+  therefore safely below the other two floors as well. Measured headroom at
+  `70` (using the *capped* parser, so no crash risk at all): parenthesised
+  nesting parses cleanly to 32 levels (33 trips the cap), a flat chain to 63
+  terms (64 trips), and a train to 61 teeth (62 trips) — all three far
+  beyond any hand-written J expression's needs. See `MAX_RULE_DEPTH`'s doc
+  comment in `src/lib.rs` for the full derivation.
+- 33 tests: one per grammar production (bare number, numeric stranding,
+  local/global/chained assignment, monadic/dyadic application, the
+  right-to-left dyadic chain, reduce, scan, `@` compose both monadically and
+  dyadically, parenthesised grouping, every comparison verb, every primitive
+  verb parsed monadically, comment/blank lines, multi-line programs), six
+  dedicated train tests (2-tooth hook, 3-tooth fork, 4+-tooth fork, a
+  leading-noun fork, dyadic train application, a train nested inside a
+  train), a dedicated `/`-is-reduce-not-division structural regression test,
+  malformed-input rejection, plus the 9 depth-cap regression tests (3 shapes
+  × {huge-input-on-32MiB-worker, exact-boundary-at-the-cap,
+  cap-trips-before-overflow-on-default-stack}) — three more than
+  `apl-parser`'s own 6, for this grammar's third (train) recursion shape.
+- Marks MA-6c done in `MA06-j-language.md` §6.
+
+### Design notes / divergences from the task's suggested test examples
+
+- The task's suggested `@`-compose example, `(+@-) A`, is **not** valid
+  syntax under this grammar: `verb_expr`'s `LPAREN verb_train RPAREN`
+  alternative requires **2 or more** train teeth, but `+@-` greedily parses
+  as **one** whole tooth via `verb_expr`'s own `simple_verb [ AT verb_expr ]`
+  alternative (the AT-continuation is tried before the grammar ever
+  considers treating `+`/`-` as two separate teeth), leaving nothing for a
+  required second tooth — confirmed empirically (a "expected train_tooth,
+  got `)`" parse error) while writing the test. A lone compose doesn't need
+  parens at all, since `verb_expr` already covers it wherever a `verb_expr`
+  is expected; the test instead confirms `+@-A` (monadic) and `A+@-B`
+  (dyadic) both parse.

--- a/code/packages/rust/j-parser/Cargo.toml
+++ b/code/packages/rust/j-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-j-parser"
+version = "0.1.0"
+edition = "2021"
+description = "J parser backed by statically compiled grammar data"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-j-lexer = { path = "../j-lexer" }

--- a/code/packages/rust/j-parser/README.md
+++ b/code/packages/rust/j-parser/README.md
@@ -1,0 +1,103 @@
+# coding-adventures-j-parser
+
+J parser backed by `code/grammars/j/j.grammar`, compiled to Rust and
+statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Where this fits
+
+Consumes the token stream from `j-lexer` (MA-6b) and drives it through
+`j.grammar`'s two-nonterminal design (`noun_expr`/`verb_expr`, see
+[MA06 §3](../../../specs/MA06-j-language.md)) to produce a `GrammarASTNode`
+CST rooted at `program` — the second of the two frontend crates for J
+(MA-6c); a future `j-runtime` crate (MA-6d) will walk this tree to evaluate.
+
+## The two-nonterminal design, reused from APL
+
+J's grammar reuses `apl.grammar`'s exact two-nonterminal shape (MA06 §3),
+with terminology renamed to J's own vocabulary:
+
+- **`noun_expr`** — arrays and scalars (APL's `value_expr`). Built from
+  `term`s combined by `verb_expr`s, one precedence tier, right-to-left
+  (`a F b G c` parses as `a F (b G c)`, unchanged from APL).
+- **`verb_expr`** — a primitive glyph, a primitive glyph with an adverb
+  applied (a "derived verb", e.g. `+/`), two verbs joined by the `@`
+  conjunction (compose), or the one production with no APL precedent: a
+  parenthesised **train**.
+
+Exactly like `apl.grammar`, whether a `verb_expr` application is monadic or
+dyadic is a runtime concern the grammar doesn't decide — it's read off
+which of `noun_expr`'s two alternatives matched (a `term` before the
+`verb_expr`, or none).
+
+## Trains — the one genuinely new production
+
+A **train** is a flat run of 2+ `train_tooth`s (a bare/adverbed primitive
+verb, an `@`-composed verb, a parenthesised sub-verb or sub-train, or a bare
+noun — only meaningful in a fork's leading position) with no application
+between them:
+
+- **Hook** (exactly 2 teeth): `(f g) x` means `x f (g x)`.
+- **Fork** (3+ teeth, right-to-left): `(f g h) x` means `(f x) g (h x)`,
+  and `(a b c d)` reduces to the fork `(a (b c d))`.
+
+This grammar builds the flat *shape* only; deciding whether a given shape
+means a hook or a fork (and rejecting a bare-noun tooth outside a fork's
+leading position) is left to a later lowering pass, exactly the same
+division of labour `apl.grammar`'s own numeric stranding already uses (the
+grammar doesn't know three juxtaposed numbers form a vector any more than it
+knows three juxtaposed verbs form a fork).
+
+**Trains are parenthesised-only in this cut** (MA06 §3): an unparenthesised
+top-level train would be ambiguous with an ordinary application chain
+without deeper lookahead than this grammar needs, so `verb_train` only
+appears inside `LPAREN verb_train RPAREN`. One consequence worth knowing: a
+lone `@`-composed verb (e.g. `+@-`) does *not* need parens at all (it's
+already a complete `verb_expr` wherever one is expected), and — because
+`LPAREN verb_train RPAREN` requires **2 or more** teeth — wrapping a single
+composed verb in parens, e.g. `(+@-)`, is **not** valid syntax under this
+grammar: `+@-` greedily parses as one whole tooth via `verb_expr`'s own
+`AT`-alternative, leaving nothing for the required second tooth.
+
+## Usage
+
+```rust
+use coding_adventures_j_parser::try_parse_j;
+
+let tree = try_parse_j("A=.i.5\nB=.+/A\n")?;
+assert_eq!(tree.rule_name, "program");
+```
+
+`parse_j`/`create_j_parser` panic on a lexical or syntax error; `try_parse_j`
+returns a `Result` instead.
+
+## Recursion-depth guard
+
+`create_j_parser` opts the shared `GrammarParser` into a recursion-depth cap
+(`MAX_RULE_DEPTH = 70`), empirically derived via the same binary-search
+methodology `apl-parser` used for its own (twice-corrected) cap — measured
+fresh for this grammar, not copied from `apl-parser`.
+
+`j.grammar` inherits `apl.grammar`'s two ways to recurse `noun_expr`
+arbitrarily deep (parenthesised nesting, and a flat unparenthesised dyadic
+chain), plus one genuinely new J-only way: a long parenthesised **train**
+(`verb_train`'s own flat `train_tooth { train_tooth }` repetition). All
+three were measured independently (binary search, on a `std::thread::spawn`
+worker with the **default ~2 MiB stack**, in a **debug** build to match how
+`cargo test` actually runs):
+
+| Shape                              | Safe (default stack) | Crashes at |
+|-------------------------------------|----------------------|------------|
+| Parenthesised nesting `((((5))))`   | 100 levels           | 101        |
+| Flat dyadic chain `1+1+1+…+1`       | 135 terms            | 136        |
+| Long train `(+ + + … +) 5`          | 200 teeth            | 201        |
+
+**Parenthesised nesting is the binding (lowest) floor here** — the opposite
+ranking from `apl-parser`'s own finding, where the flat chain was binding.
+This is exactly the outcome MA06 §6 warns about: a shape's floor from a
+sibling crate (or even this grammar's own other shapes) does not predict
+another shape's floor; each needs its own measurement. See `MAX_RULE_DEPTH`'s
+doc comment in `src/lib.rs` for the full derivation, and `CHANGELOG.md` for
+the measurement methodology.

--- a/code/packages/rust/j-parser/required_capabilities.json
+++ b/code/packages/rust/j-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/j-parser",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/j-parser/src/_grammar.rs
+++ b/code/packages/rust/j-parser/src/_grammar.rs
@@ -1,0 +1,157 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: j.grammar
+// Regenerate with: grammar-tools compile-grammar j.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"line"#.to_string() }) },
+            line_number: 88,
+        },
+        GrammarRule {
+            name: r#"line"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 90,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            line_number: 94,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"ASSIGN_LOCAL"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"ASSIGN_GLOBAL"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+            ] },
+            line_number: 100,
+        },
+        GrammarRule {
+            name: r#"noun_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"term"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::RuleReference { name: r#"verb_expr"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"verb_expr"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                ] },
+            ] },
+            line_number: 111,
+        },
+        GrammarRule {
+            name: r#"term"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() }) },
+                ] },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"noun_expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 117,
+        },
+        GrammarRule {
+            name: r#"verb_expr"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"simple_verb"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::TokenReference { name: r#"AT"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"verb_expr"#.to_string() },
+                        ] }) },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"verb_train"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                ] },
+            ] },
+            line_number: 129,
+        },
+        GrammarRule {
+            name: r#"simple_verb"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"verb_primitive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
+                        GrammarElement::TokenReference { name: r#"REDUCE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"SCAN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 138,
+        },
+        GrammarRule {
+            name: r#"verb_primitive"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                GrammarElement::TokenReference { name: r#"STAR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"PERCENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"CARET"#.to_string() },
+                GrammarElement::TokenReference { name: r#"FLOOR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"CEILING"#.to_string() },
+                GrammarElement::TokenReference { name: r#"DOLLAR"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDOT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RAVEL"#.to_string() },
+                GrammarElement::TokenReference { name: r#"HASH"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+            ] },
+            line_number: 140,
+        },
+        GrammarRule {
+            name: r#"verb_train"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"train_tooth"#.to_string() },
+                GrammarElement::RuleReference { name: r#"train_tooth"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"train_tooth"#.to_string() }) },
+            ] },
+            line_number: 148,
+        },
+        GrammarRule {
+            name: r#"train_tooth"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::RuleReference { name: r#"verb_expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"term"#.to_string() },
+            ] },
+            line_number: 155,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/j-parser/src/lib.rs
+++ b/code/packages/rust/j-parser/src/lib.rs
@@ -1,0 +1,587 @@
+//! Grammar-driven J parser.
+//!
+//! The parser grammar is compiled into this crate at build time, so runtime
+//! callers do not need filesystem access to `code/grammars/j`.
+
+use coding_adventures_j_lexer::create_j_lexer;
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+
+mod _grammar;
+
+/// Recursion-depth cap for the J [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep recursion through `parse_rule` can overflow the
+/// *native* thread stack — an uncatchable process abort — before this
+/// crate's own `Result`-returning entry points ever get a chance to report
+/// anything).
+///
+/// # Three crash shapes, not two — `apl-parser`'s own lesson, generalized
+///
+/// `apl-parser`'s `MAX_RULE_DEPTH` doc comment documents a twice-corrected
+/// history: its first value (`150`) was validated against only ONE way its
+/// grammar recurses deeply (parenthesised nesting) and was silently unsafe
+/// against a SECOND, independently measured way (a flat unparenthesised
+/// dyadic chain) — the corrected value respects the *lower* of the two
+/// floors, not whichever was measured first. `j.grammar` reuses
+/// `apl.grammar`'s `noun_expr`/`term` shape almost verbatim (MA06 §3), so it
+/// inherits both of those crash shapes — plus a third, genuinely new one
+/// this grammar introduces on its own (MA06 §6, MA-6b bullet): `verb_train`'s
+/// flat `train_tooth { train_tooth }` repetition, exercised by a long
+/// parenthesised train like `(+ + + ... +) 5`. All three were measured
+/// independently here, exactly like MA06 §6 requires, rather than assuming
+/// one shape's floor bounds the others — and, as it turns out below, the
+/// shape that ends up *binding* is not the one `apl-parser`'s own history
+/// would suggest.
+///
+/// All three measurements below use the identical methodology: binary
+/// search, driving a throwaway subprocess per data point (a real native
+/// stack overflow calls `process::abort()` and kills the *whole* process,
+/// not just the offending thread, so a single in-process loop cannot survive
+/// past the first crash), each subprocess parsing on a `std::thread::spawn`
+/// worker with the **default ~2 MiB stack** (no `stack_size` override) using
+/// an *uncapped* `GrammarParser` (`max_depth = usize::MAX`, i.e.
+/// `with_max_depth` never called) — this is what finds the real native-stack
+/// crash floor rather than the depth-guard's own configured trip point. This
+/// crate's own `cargo test` runs in a debug (unoptimized) build by default,
+/// and debug frames are meaningfully larger than release frames, so these
+/// floors were measured in a **debug** build (`cargo build` without
+/// `--release`) to match the conditions real callers of this crate's test
+/// suite actually run under.
+///
+/// 1. **Parenthesised nesting**, `((((…5…))))` — `noun_expr -> term ->
+///    LPAREN noun_expr RPAREN -> term -> …`. Measured: parses safely up to
+///    **100 levels**, crashes the process at **101**.
+/// 2. **A flat, unparenthesised dyadic chain**, `1+1+1+…+1` —
+///    `noun_expr`'s own right-recursive continuation (`term [ verb_expr
+///    noun_expr ]`), exactly the shape that bit `apl-parser` originally.
+///    Measured: parses safely up to **135 terms**, crashes at **136** —
+///    close to `apl-parser`'s own measured flat-chain floor (136 safe / 137
+///    crashing), since the grammar shape and per-level cost are nearly
+///    identical (only `PLUS`/`term` token spellings differ, not the parse
+///    tree shape).
+/// 3. **A long train**, `(+ + + … +) 5` (N `PLUS` teeth inside one paren
+///    pair, applied monadically so it parses as a real top-level statement)
+///    — `verb_expr -> LPAREN verb_train RPAREN`, then `verb_train`'s own
+///    flat `train_tooth { train_tooth }` repetition, where each additional
+///    tooth recurses through `train_tooth -> verb_expr -> simple_verb ->
+///    verb_primitive`, plus the fixed `noun_expr`/`term` cost of the
+///    monadic-application wrapper around the whole thing. Measured: parses
+///    safely up to **200 teeth**, crashes at **201**.
+///
+/// # The binding constraint — and a genuine surprise
+///
+/// Naively one might expect the flat dyadic chain to bind again here, since
+/// it was the shape that bit `apl-parser`. It does **not**: measured on
+/// *this* grammar, in *this* environment, **parenthesised nesting is the
+/// lowest of the three floors** (100, vs. 135 for the flat chain and 200 for
+/// the train) — the opposite ranking from `apl-parser`'s own finding. This
+/// is exactly the failure mode MA06 §6 warns against: assuming a sibling
+/// crate's (or even this same grammar's *other* shape's) measured floor
+/// transfers is not a substitute for measuring this grammar's own three
+/// shapes independently. (The likely cause: `j.grammar`'s `verb_expr`/
+/// `simple_verb`/`verb_primitive` chain adds extra named-rule hops the flat
+/// dyadic chain and the train both route through on every level in ways the
+/// bare `LPAREN noun_expr RPAREN` parenthesised-nesting path does not, but
+/// the exact per-shape native-stack cost is an implementation detail of the
+/// shared `GrammarParser` — what matters here is the measured outcome, not a
+/// predicted one.)
+///
+/// `MAX_RULE_DEPTH` is set to **70** — about 30% below the binding
+/// parenthesised-nesting floor of 100 (comparable margin to `apl-parser`'s
+/// own ~26.5%), and therefore safely below the other two floors (135, 200)
+/// as well. Measured real-input headroom at `70` (using the CAPPED parser,
+/// i.e. `create_j_parser`/`try_parse_j`, so no crash risk at all): a
+/// parenthesised nesting parses cleanly up to 32 levels (33 trips the cap),
+/// a flat dyadic chain parses cleanly up to 63 terms (64 trips the cap), and
+/// a long train parses cleanly up to 61 teeth (62 trips the cap) — all
+/// three comfortably beyond anything a hand-written J expression needs, and
+/// all three independently confirmed not to crash a default-stack thread
+/// even thousands of levels/terms/teeth past the cap (see this crate's
+/// tests).
+const MAX_RULE_DEPTH: usize = 70;
+
+/// Create a [`GrammarParser`] wired to the J grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+///
+/// # Panics
+///
+/// Panics if tokenization fails. Use [`try_parse_j`] for a `Result`.
+pub fn create_j_parser(source: &str) -> GrammarParser {
+    let tokens = create_j_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|err| panic!("J tokenization failed: {err}"));
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse J source into a syntax tree rooted at the `program` rule.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_j`] for a `Result`.
+pub fn parse_j(source: &str) -> GrammarASTNode {
+    create_j_parser(source)
+        .parse()
+        .unwrap_or_else(|err| panic!("J parse failed: {err}"))
+}
+
+/// Parse J source, returning a `Result` instead of panicking on a lexical or
+/// syntax error.
+pub fn try_parse_j(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = create_j_lexer(source)
+        .tokenize()
+        .map_err(|err| err.to_string())?;
+    let grammar = _grammar::parser_grammar();
+    GrammarParser::new(tokens, grammar)
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------
+    // Parsing correctness — one example per grammar production (MA06 §3/§4)
+    // -------------------------------------------------------------------
+
+    fn rule_names(node: &GrammarASTNode) -> Vec<String> {
+        use parser::grammar_parser::ASTNodeOrToken;
+        node.children
+            .iter()
+            .filter_map(|c| match c {
+                ASTNodeOrToken::Node(n) => Some(n.rule_name.clone()),
+                ASTNodeOrToken::Token(_) => None,
+            })
+            .collect()
+    }
+
+    /// Recursively collect every token *name* (e.g. `"REDUCE"`) appearing
+    /// anywhere in the tree — used by the reduce-vs-divide regression test
+    /// below to make a structural assertion without decoding semantics.
+    fn token_names(node: &GrammarASTNode) -> Vec<String> {
+        use parser::grammar_parser::ASTNodeOrToken;
+        let mut out = Vec::new();
+        for child in &node.children {
+            match child {
+                ASTNodeOrToken::Token(t) => out.push(t.effective_type_name().to_string()),
+                ASTNodeOrToken::Node(n) => out.extend(token_names(n)),
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn a_bare_number_parses() {
+        let ast = parse_j("5\n");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn stranded_numbers_form_one_term() {
+        // `1 2 3` is a single 3-element vector term, not three statements.
+        let ast = try_parse_j("1 2 3\n").expect("stranding should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn simple_assignment_parses() {
+        let ast = try_parse_j("A=.5\n").expect("local assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn chained_assignment_is_right_associative() {
+        // A=.B=.3 assigns 3 to both B and A (MA06 §4, mirrors apl.grammar's
+        // own `assignment`).
+        let ast = try_parse_j("A=.B=.3\n").expect("chained assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn global_assignment_parses() {
+        let ast = try_parse_j("A=:5\n").expect("global assignment should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn monadic_application_parses() {
+        // $ with nothing to its left is monadic (shape-of).
+        let ast = try_parse_j("$A\n").expect("monadic application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn dyadic_application_parses() {
+        let ast = try_parse_j("A+B\n").expect("dyadic application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn right_to_left_dyadic_chain_parses_as_one_noun_expr() {
+        // 2*3+4 is 2*(3+4) -- a single right-recursive noun_expr, not three
+        // separate statements (MA06 §3: one precedence tier, right-to-left,
+        // unchanged from APL).
+        let ast = try_parse_j("2*3+4\n").expect("chain should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn reduce_operator_parses() {
+        let ast = try_parse_j("+/A\n").expect("reduce should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn scan_operator_parses() {
+        let ast = try_parse_j("+\\A\n").expect("scan should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn at_compose_conjunction_parses() {
+        // `@` composes two verb_exprs directly -- `verb_expr`'s own
+        // `simple_verb [ AT verb_expr ]` alternative handles this without
+        // any parens, unlike a train, which is parenthesised-only. Note:
+        // `(+@-)` is NOT valid under this grammar -- `LPAREN verb_train
+        // RPAREN` requires 2+ train teeth, but `+@-` greedily parses as
+        // exactly ONE tooth via verb_expr's own AT-alternative, leaving
+        // nothing for a required second tooth, so it fails with a "expected
+        // train_tooth, got )" error. Confirmed empirically while writing
+        // this test.
+        let monadic = try_parse_j("+@-A\n").expect("@ compose should parse monadically");
+        assert_eq!(monadic.rule_name, "program");
+
+        let dyadic = try_parse_j("A+@-B\n").expect("@ compose should parse dyadically");
+        assert_eq!(dyadic.rule_name, "program");
+    }
+
+    #[test]
+    fn parenthesised_grouping_parses() {
+        let ast = try_parse_j("(A+B)*C\n").expect("grouping should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn every_comparison_verb_parses() {
+        for op in ["=", "~:", "<", ">", "<:", ">:"] {
+            let src = format!("A{op}B\n");
+            try_parse_j(&src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn every_primitive_verb_parses_monadically() {
+        for op in [
+            "+", "-", "*", "%", "^", "<.", ">.", "$", "i.", ",", "#", "=", "~:", "<", ">", "<:",
+            ">:",
+        ] {
+            let src = format!("{op}A\n");
+            try_parse_j(&src).unwrap_or_else(|e| panic!("`{src}` should parse: {e}"));
+        }
+    }
+
+    #[test]
+    fn a_comment_line_and_a_blank_line_both_parse() {
+        // `NB.` comments are stripped by the lexer's skip pattern; a bare
+        // NEWLINE is its own `line` alternative.
+        let ast = try_parse_j("NB. just a comment\n\nA=.1\n").expect("should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_multi_line_program_parses_into_multiple_lines() {
+        let ast = try_parse_j("A=.1\nB=.2\nA+B\n").expect("multi-line program should parse");
+        let lines = rule_names(&ast);
+        assert_eq!(lines.iter().filter(|n| *n == "line").count(), 3);
+    }
+
+    // -------------------------------------------------------------------
+    // Train tests (MA06 §3's one genuinely new production) — the whole
+    // point of this grammar, over and above what `apl.grammar` already
+    // covers.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn a_two_tooth_hook_parses() {
+        let ast = try_parse_j("(+ -)A\n").expect("2-tooth hook should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_three_tooth_fork_parses() {
+        let ast = try_parse_j("(+ - *)A\n").expect("3-tooth fork should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_four_plus_tooth_fork_parses() {
+        let ast = try_parse_j("(+ - * % ^)A\n").expect("5-tooth fork should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_fork_with_a_leading_noun_parses() {
+        // A bare noun tooth is only *semantically* meaningful in a fork's
+        // leading position -- this grammar accepts the shape syntactically
+        // and leaves the restriction to a later lowering pass (see
+        // `j.grammar`'s own header comment).
+        let ast = try_parse_j("(5 - *)A\n").expect("leading-noun fork should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_dyadic_application_of_a_train_parses() {
+        let ast = try_parse_j("A(+ -)B\n").expect("dyadic train application should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    #[test]
+    fn a_train_nested_within_a_train_parses() {
+        let ast = try_parse_j("((+ -) - *)A\n").expect("nested train should parse");
+        assert_eq!(ast.rule_name, "program");
+    }
+
+    // -------------------------------------------------------------------
+    // Reduce-vs-divide regression (MA06's own "one mistake to not make")
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn reduce_parses_as_reduce_not_division() {
+        // `+/A` must lower `/` as the REDUCE adverb (postfix on `+`), never
+        // as a divide-like binary operator between `+` and `A`. Check this
+        // structurally: the tree must contain a REDUCE token, and `A` must
+        // not appear as a second operand of some divide-shaped production
+        // (there is no such production in this grammar at all -- `%` is the
+        // only divide primitive, and it is spelled with its own dedicated
+        // token, so a REDUCE token anywhere in the tree already proves `/`
+        // was not swallowed as some other primitive).
+        let ast = try_parse_j("+/A\n").expect("reduce should parse");
+        let tokens = token_names(&ast);
+        assert!(
+            tokens.iter().any(|t| t == "REDUCE"),
+            "expected a REDUCE token in the parse tree for `+/A`, got: {tokens:?}"
+        );
+        assert!(
+            !tokens.iter().any(|t| t == "PERCENT"),
+            "`+/A` must never produce a PERCENT (division) token, got: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_input_is_rejected_not_panicking() {
+        // A bare adverb with nothing to modify is not a valid verb_expr.
+        assert!(try_parse_j("/A\n").is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Recursion-depth guard (DoS hardening) -- mirrors the exact methodology
+    // used to validate `apl-parser`'s own `MAX_RULE_DEPTH` (see that crate's
+    // `CHANGELOG.md`), but exercises the REAL J grammar and its THIRD,
+    // train-shaped way to recurse deeply (MA06 §6).
+    // -------------------------------------------------------------------
+
+    /// Build `n` nested parens around a `5`, e.g. `((5))` for `n == 2`.
+    fn nested_paren_source(n: usize) -> String {
+        format!("{}5{}\n", "(".repeat(n), ")".repeat(n))
+    }
+
+    /// Build a flat, unparenthesised dyadic chain `1+1+1+…+1` with `n` `+`s
+    /// -- the *second* way to drive `noun_expr` deep (its own right-
+    /// recursive continuation), see `MAX_RULE_DEPTH`'s doc comment.
+    fn flat_chain_source(n: usize) -> String {
+        let mut s = String::from("1");
+        for _ in 0..n {
+            s.push_str("+1");
+        }
+        s.push('\n');
+        s
+    }
+
+    /// Build a long train of `n` `+` teeth wrapped in one paren pair and
+    /// applied monadically, e.g. `(+ + +)5` for `n == 3` -- the *third*,
+    /// J-only way to drive recursion deeply (`verb_train`'s own flat
+    /// repetition), see `MAX_RULE_DEPTH`'s doc comment.
+    fn train_source(n: usize) -> String {
+        let teeth = vec!["+"; n].join(" ");
+        format!("({teeth})5\n")
+    }
+
+    /// Deeply-nested parenthesised input must produce a recoverable error,
+    /// not overflow the native stack (an uncatchable process abort). We
+    /// parse 5000 levels -- far past `MAX_RULE_DEPTH` -- on a worker thread
+    /// with a generous 32 MiB stack, so the *guard* is what stops the
+    /// recursion, not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("j-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = nested_paren_source(5000);
+                let result = try_parse_j(&source);
+                assert!(
+                    result.is_err(),
+                    "deeply-nested input must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// The flat-chain analogue of the parenthesised-nesting test above.
+    #[test]
+    fn test_huge_flat_chain_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("j-chain-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = flat_chain_source(5000);
+                let result = try_parse_j(&source);
+                assert!(
+                    result.is_err(),
+                    "a huge flat dyadic chain must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// The train analogue of the two tests above -- this grammar's own
+    /// third, genuinely new recursion shape (MA06 §6).
+    #[test]
+    fn test_huge_train_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("j-train-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let source = train_source(5000);
+                let result = try_parse_j(&source);
+                assert!(
+                    result.is_err(),
+                    "a huge train must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH`'s measured boundary
+    /// still parses cleanly, and one layer deeper cleanly trips the guard.
+    /// These exact boundary counts (32 legitimate levels at
+    /// `MAX_RULE_DEPTH = 70`) were found empirically by binary-searching
+    /// `create_j_parser` against increasing nesting counts -- see
+    /// `MAX_RULE_DEPTH`'s doc comment. This is the *binding* constraint
+    /// `MAX_RULE_DEPTH` was set against for this grammar (parenthesised
+    /// nesting has the lowest raw native-stack crash floor of the three
+    /// measured shapes here -- the opposite ranking from `apl-parser`'s own
+    /// finding, see the doc comment) -- without this test, a future change
+    /// to the constant could silently re-introduce a crash for this shape
+    /// while the other two boundary tests below kept passing.
+    #[test]
+    fn test_nesting_up_to_cap_still_parses() {
+        let ok_source = nested_paren_source(32);
+        let ast = try_parse_j(&ok_source).expect("32 levels must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = nested_paren_source(33);
+        assert!(
+            try_parse_j(&tripped_source).is_err(),
+            "one nesting level past the cap's measured limit must fail"
+        );
+    }
+
+    /// The flat-chain analogue of the boundary test above -- 63 terms is the
+    /// measured safe limit at `MAX_RULE_DEPTH = 70`, one more (64) trips it.
+    /// This is the exact shape that bit `apl-parser` originally -- carried
+    /// here so a future change to the constant can't silently re-introduce
+    /// that crash for this grammar either.
+    #[test]
+    fn test_flat_chain_up_to_cap_still_parses() {
+        let ok_source = flat_chain_source(63);
+        let ast = try_parse_j(&ok_source).expect("63 chain terms must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = flat_chain_source(64);
+        assert!(
+            try_parse_j(&tripped_source).is_err(),
+            "one chain term past the cap's measured limit must fail"
+        );
+    }
+
+    /// The train analogue of the boundary tests above -- 61 teeth is the
+    /// measured safe limit at `MAX_RULE_DEPTH = 70`, one more (62) trips it.
+    /// This is this grammar's own third, genuinely new recursion shape
+    /// (MA06 §6) that has no `apl-parser` precedent at all.
+    #[test]
+    fn test_train_up_to_cap_still_parses() {
+        let ok_source = train_source(61);
+        let ast = try_parse_j(&ok_source).expect("61 train teeth must stay under the cap");
+        assert_eq!(ast.rule_name, "program");
+
+        let tripped_source = train_source(62);
+        assert!(
+            try_parse_j(&tripped_source).is_err(),
+            "one train tooth past the cap's measured limit must fail"
+        );
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread --
+    /// otherwise a production caller (e.g. a future `j-runtime`, or `cargo
+    /// test`'s own per-test thread) would still crash. We parse far-too-deep
+    /// input on a worker thread with **no** `stack_size` override (the same
+    /// ~2 MiB a default thread gets). A clean `Err` (not a `join()` failure
+    /// from a crashed thread) proves `MAX_RULE_DEPTH` sits safely below the
+    /// native overflow point on the default stack, for all three crash
+    /// shapes.
+    #[test]
+    fn test_opt_in_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = nested_paren_source(5000);
+            let result = try_parse_j(&source);
+            assert!(result.is_err(), "deeply-nested input must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// The flat-chain analogue of the default-stack test above.
+    #[test]
+    fn test_flat_chain_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = flat_chain_source(5000);
+            let result = try_parse_j(&source);
+            assert!(result.is_err(), "a huge flat chain must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+
+    /// The train analogue of the default-stack test above -- the test that
+    /// would catch a future `MAX_RULE_DEPTH` change that is unsafe for this
+    /// grammar's own third crash shape.
+    #[test]
+    fn test_train_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let source = train_source(5000);
+            let result = try_parse_j(&source);
+            assert!(result.is_err(), "a huge train must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+}


### PR DESCRIPTION
## Summary

Front2's turn, continuing J's rollout: `j-lexer` (MA-6b, [#8127](https://github.com/adhithyan15/coding-adventures/pull/8127)) is already merged, so this is the parser half.

- **`code/grammars/j/j.grammar`**: the verb/noun two-nonterminal design reused from `apl.grammar` almost verbatim (`noun_expr`/`verb_expr`, one precedence tier, right-to-left), plus MA06 §3's one genuinely new production: `verb_train`, a flat run of 2+ train teeth (bare/adverbed primitive verb, `@`-composed verb, parenthesised sub-verb/sub-train, or — fork-leading-position only — a bare noun), scoped to the parenthesised form only in this cut to sidestep the grammar ambiguity an unparenthesised train would introduce. The grammar builds the flat shape only; hook-vs-fork meaning is left to a later lowering pass, mirroring how `apl.grammar`'s own numeric stranding already divides "grammar builds shape, later pass assigns meaning."
- **`code/packages/rust/j-parser`**: `create_j_parser`/`parse_j`/`try_parse_j`, mirroring `apl-parser`'s exact shape. `MAX_RULE_DEPTH` (70) was derived by independently measuring all THREE ways this grammar recurses deeply (parenthesised nesting, a flat right-recursive dyadic chain, and the new long-train shape), per MA06 §6's explicit instruction not to assume one shape's floor bounds the others — `apl-parser`'s own twice-corrected history is exactly this mistake made and fixed once already. The measured floors here invert `apl-parser`'s own ranking: parenthesised nesting binds (100 safe / 101 crash) rather than the flat chain (135/136) or the train (200/201) — confirming the instruction's own point that a sibling crate's measured ranking doesn't transfer.
- 33 tests: one per grammar production plus J-specific train coverage (2-tooth hook, 3-tooth and 4+-tooth fork, leading-noun fork, dyadic train application, nested train-within-a-train), a structural regression confirming `/` parses as REDUCE never division, and 9 depth-guard tests across all three measured recursion shapes.

## Test plan

- [x] `cargo test -p coding-adventures-j-parser` — 33/33 tests pass
- [x] `cargo clippy -p coding-adventures-j-parser --all-targets` clean
- [x] Targeted build of `j-parser`/`j-lexer` together — no interference
- [x] Security review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)