### PR TITLE
feat(sir-runtime-to-javascript): Array#cycle(n) block method (JS mirror)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.34.0 — Array `cycle(n)`
+
+Mirrors the Python reference (PR #8117), Go (PR #8123), and Rust (PR #8131) into
+the JS backend's inline `arrayMethod` (beside the existing `chunk_while`/
+`slice_when` arms + the `ARRAY_METHODS` `respond_to?` set), continuing the
+`cycle` cross-backend cascade.
+
+- `cycle(n) { |x| … }` (block) → iterate the array `n` full passes in order,
+  yielding each element on every pass; always returns `null` (Ruby nil).
+  `[1,2,3].cycle(2)` yields `1,2,3,1,2,3`. `n <= 0`, a negative count, an empty
+  receiver, or a nil / non-integer count (Ruby's block-less Enumerator and
+  infinite no-`n` forms) yields nothing rather than hanging — the count is taken
+  only when `Number.isInteger(args[0])`, so a `null` / non-number falls through
+  to the no-yield path. `respond_to?("cycle")` reports `true`.
+- The `run_with_node` suite gains `array_cycle`: the block `print`s each yielded
+  element, proving the two passes (`1,2,3,1,2,3`) and the `nil` returns for
+  `cycle(2)`, `cycle(0)`, and `[].cycle(5)` under a real `node` run.
+
 ## 0.33.0 — Array `minmax`
 
 Mirrors the Python reference (PR #8092), Go (PR #8098), and Rust (PR #8103) into

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.33.0"
+version = "0.34.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -1298,7 +1298,7 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     "take", "drop", "values_at",
     "flatten", "compact", "rotate", "zip",
     "include?", "index",
-    "each_slice", "each_cons", "chunk_while", "slice_when", "tally",
+    "each_slice", "each_cons", "chunk_while", "slice_when", "tally", "cycle",
   ]);
   // Numeric-aware comparator (`<`/`>` keeps numbers numeric, never throws) —
   // the same ordering the Ruby `sort` reference uses.
@@ -1628,6 +1628,19 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         const counts = new Map();
         for (const x of recv) { counts.set(x, (counts.get(x) || 0) + 1); }
         return counts;
+      }
+      case "cycle": {
+        // `cycle(n) { |x| … }` — iterate the array n full passes in order,
+        // yielding each element on every pass; always returns null (Ruby nil).
+        // `[1,2,3].cycle(2)` yields 1,2,3,1,2,3.  n <= 0, a negative count, an
+        // empty receiver, or a nil / non-integer count (Ruby's block-less
+        // Enumerator and infinite no-`n` forms) yields nothing rather than
+        // hanging, so emitted programs can never spin forever.
+        if (typeof blk !== "function") { return ARR_MISS; }
+        const n = args.length > 0 && Number.isInteger(args[0]) ? args[0] : 0;
+        if (n <= 0) { return null; }
+        for (let p = 0; p < n; p++) { for (const x of recv) { blk(x); } }
+        return null;
       }
     }
     return ARR_MISS;

--- a/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/run_with_node.rs
@@ -3147,6 +3147,70 @@ fn array_slice_when() {
     }
 }
 
+// ── Ruby Array#cycle(n) ────────────────────────────────────────────────────
+// `cycle(n) { |x| … }` iterates the array n full passes in order, yielding each
+// element on every pass, and always returns nil.  n <= 0, a negative count, or
+// an empty receiver yields nothing.  Mirrors the Python reference (#8117), Go
+// (#8123), Rust (#8131): the block `print`s each yielded element, so the two
+// passes are observable, and the nil return is printed after each call.
+#[test]
+fn array_cycle() {
+    // `{ |x| print x }` — emit one line per yielded element.
+    let puts = func("__t_puts", vec![param("x")], vec![print(param_ref("x"))], Expr::NilLit { span: sp() });
+    let stmts = vec![
+        // [1,2,3].cycle(2) { |x| print x }  → 1 2 3 1 2 3, then nil
+        print(method(
+            seq(vec![int(1), int(2), int(3)]),
+            "cycle",
+            vec![int(2), method_closure("__t_puts")],
+        )),
+        // [1,2,3].cycle(0) { … }  → no yields, nil
+        print(method(
+            seq(vec![int(1), int(2), int(3)]),
+            "cycle",
+            vec![int(0), method_closure("__t_puts")],
+        )),
+        // [].cycle(5) { … }  → no yields, nil
+        print(method(seq(vec![]), "cycle", vec![int(5), method_closure("__t_puts")])),
+    ];
+    let main = Function {
+        name: "main".into(),
+        params: vec![],
+        return_type: None,
+        captures: vec![],
+        body: Block { stmts, value: Expr::NilLit { span: sp() }, span: sp() },
+        effects: EffectSet::PURE,
+        metadata: Metadata::new(),
+        span: sp(),
+    };
+    let module = Module {
+        name: "arrcycle".into(),
+        manifest: FeatureManifest::from_features(&[
+            Feature::Sequences,
+            Feature::Strings,
+            Feature::Closures,
+            Feature::DynamicTyping,
+        ]),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![main, puts],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    };
+    if let Some(stdout) = run_module(&module, "arrcycle") {
+        assert_eq!(
+            stdout,
+            "1\n2\n3\n1\n2\n3\n\
+             nil\n\
+             nil\n\
+             nil"
+        );
+    }
+}
+
 // ── Ruby Array#tally ───────────────────────────────────────────────────────
 // `tally` counts occurrences into a Hash keyed in first-seen order — the JS
 // runtime realises it as an insertion-ordered `Map`, printed `{k: v}` (the same


### PR DESCRIPTION
## Summary

Mirrors the Python reference ([#8117](https://github.com/adhithyan15/coding-adventures/pull/8117)), Go ([#8123](https://github.com/adhithyan15/coding-adventures/pull/8123)), and Rust ([#8131](https://github.com/adhithyan15/coding-adventures/pull/8131)) — all merged — into the **JS** backend's embedded `arrayMethod` runtime: `Array#cycle(n) { |x| … }` iterates the array `n` full passes in order, yielding each element on every pass, and always returns null (Ruby nil). Fourth backend in the cascade (Python → Go → Rust → **JS** → TS).

## Semantics

- `n` full passes: `[1,2,3].cycle(2) { … }` yields `1,2,3,1,2,3`.
- `n <= 0`, a negative count, or an empty receiver yields nothing.
- A nil / non-integer count — including Ruby's block-less Enumerator form and the **infinite no-`n` form** — yields nothing rather than hanging (the count is taken only when `Number.isInteger(args[0])`, so `null` / non-number / `NaN` / `Infinity` fall through to the no-yield path).
- Always returns `null`.

## Changes

- `runtime.rs`: `cycle` case in `arrayMethod` (beside `chunk_while`/`slice_when`) + `"cycle"` in the `ARRAY_METHODS` `respond_to?` set.
- `tests/run_with_node.rs`: `array_cycle` — the block `print`s each yielded element, proving the two passes and the `nil` returns for `cycle(2)`, `cycle(0)`, and `[].cycle(5)` under a real `node` run.

## Verification

- `cargo test -p semantic-ir-to-javascript --test run_with_node array_cycle` — **passes** (`node` exec-proof).
- Security review passed (`Number.isInteger` rejects all non-int/sentinel counts; only a strictly-positive `n` reaches the finite loop; no prototype-pollution or injection surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)