### PR TITLE
[codex] Port LZW compression to Haskell

### DIFF
--- a/code/packages/haskell/lzw/BUILD
+++ b/code/packages/haskell/lzw/BUILD
@@ -1,0 +1,1 @@
+if command -v cabal >/dev/null 2>&1; then cabal test all; else echo 'cabal not found -- skipping'; fi

--- a/code/packages/haskell/lzw/BUILD_windows
+++ b/code/packages/haskell/lzw/BUILD_windows
@@ -1,0 +1,1 @@
+echo "haskell support not enabled in windows CI yet -- skipping"

--- a/code/packages/haskell/lzw/CHANGELOG.md
+++ b/code/packages/haskell/lzw/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 - 2026-07-13
+
+- Add CMP03 LZW coding with a pre-seeded 256-byte dictionary.
+- Add the CLEAR, STOP, and self-referential tricky-token behaviours.
+- Add variable-width 9-to-16-bit LSB-first code packing.
+- Reject malformed headers, code streams, padding, and truncated payloads.
+- Add reference-vector, round-trip, wire-format, growth, and validation tests.

--- a/code/packages/haskell/lzw/README.md
+++ b/code/packages/haskell/lzw/README.md
@@ -1,0 +1,38 @@
+# lzw
+
+Pure Haskell implementation of CMP03, the LZW dictionary compression
+algorithm.
+
+## API
+
+- `encode` turns strict bytes into logical LZW codes, including the leading
+  `clearCode` and trailing `stopCode`.
+- `decode` reconstructs bytes and handles the classic self-referential
+  `code == nextCode` case.
+- `packCodes` and `unpackCodes` implement the CMP03 wire format: a four-byte
+  big-endian original length followed by variable-width, LSB-first codes.
+- `compress` and `decompress` provide strict one-shot byte APIs.
+
+Operations that can encounter invalid lengths, codes, or wire data return
+`Either String`. The parser requires an initial CLEAR code, a STOP code, and
+zero-only terminal padding. Decoded data must be at least as long as the stored
+length before authoritative length trimming is applied.
+
+## Format constants
+
+- Single-byte codes: 0 through 255
+- CLEAR code: 256
+- STOP code: 257
+- First dynamic code: 258
+- Initial width: 9 bits
+- Maximum width: 16 bits
+
+The width grows after the first 512 code values are exhausted. A full 16-bit
+dictionary causes the encoder to emit CLEAR and restart from the pre-seeded
+dictionary.
+
+## Running the tests
+
+```sh
+cabal test all
+```

--- a/code/packages/haskell/lzw/cabal.project
+++ b/code/packages/haskell/lzw/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/code/packages/haskell/lzw/lzw.cabal
+++ b/code/packages/haskell/lzw/lzw.cabal
@@ -1,0 +1,32 @@
+cabal-version: 3.0
+name:          lzw
+version:       0.1.0
+synopsis:      CMP03 variable-width LZW byte compression
+description:   Pure Haskell LZW coding, dictionary reconstruction, and LSB-first CMP03 serialisation.
+category:      Compression
+license:       MIT
+author:        Adhithya Rajasekaran
+maintainer:    Adhithya Rajasekaran
+build-type:    Simple
+extra-doc-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:  LZW
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , containers >=0.6 && <0.8
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    other-modules:    LZWSpec
+    hs-source-dirs:   test
+    build-depends:    base >=4.14 && <5
+                    , bytestring >=0.10 && <0.13
+                    , hspec == 2.*
+                    , lzw
+    default-language: Haskell2010

--- a/code/packages/haskell/lzw/src/LZW.hs
+++ b/code/packages/haskell/lzw/src/LZW.hs
@@ -1,0 +1,346 @@
+-- | CMP03 LZW compression for strict byte strings.
+module LZW
+    ( clearCode
+    , stopCode
+    , initialNextCode
+    , initialCodeSize
+    , maxCodeSize
+    , encode
+    , decode
+    , packCodes
+    , unpackCodes
+    , compress
+    , decompress
+    ) where
+
+import Data.Bits ((.&.), (.|.), shiftL, shiftR)
+import qualified Data.ByteString as BS
+import qualified Data.IntMap.Strict as IntMap
+import qualified Data.Map.Strict as Map
+import Data.Word (Word8, Word16, Word32, Word64)
+
+clearCode :: Word16
+clearCode = 256
+
+stopCode :: Word16
+stopCode = 257
+
+initialNextCode :: Int
+initialNextCode = 258
+
+initialCodeSize :: Int
+initialCodeSize = 9
+
+maxCodeSize :: Int
+maxCodeSize = 16
+
+maximumEntries :: Int
+maximumEntries = 1 `shiftL` maxCodeSize
+
+initialEncodeDictionary :: Map.Map BS.ByteString Int
+initialEncodeDictionary =
+    Map.fromList [(BS.singleton byte, fromIntegral byte) | byte <- [0 .. 255]]
+
+initialDecodeDictionary :: IntMap.IntMap BS.ByteString
+initialDecodeDictionary =
+    IntMap.fromList
+        ( [(fromIntegral byte, BS.singleton byte) | byte <- [0 .. 255]]
+            ++ [(fromIntegral clearCode, BS.empty), (fromIntegral stopCode, BS.empty)]
+        )
+
+-- | Encode bytes as logical LZW codes, including CLEAR and STOP.
+encode :: BS.ByteString -> [Word16]
+encode input = clearCode : encodeBytes initialEncodeDictionary initialNextCode BS.empty (BS.unpack input)
+
+encodeBytes :: Map.Map BS.ByteString Int -> Int -> BS.ByteString -> [Word8] -> [Word16]
+encodeBytes dictionary _ prefix []
+    | BS.null prefix = [stopCode]
+    | otherwise = [lookupEncodeCode dictionary prefix, stopCode]
+encodeBytes dictionary nextCode prefix (byte : rest)
+    | Map.member extended dictionary = encodeBytes dictionary nextCode extended rest
+    | otherwise =
+        let emitted = lookupEncodeCode dictionary prefix
+            restarted = BS.singleton byte
+         in if nextCode < maximumEntries
+                then
+                    emitted
+                        : encodeBytes
+                            (Map.insert extended nextCode dictionary)
+                            (nextCode + 1)
+                            restarted
+                            rest
+                else
+                    emitted
+                        : clearCode
+                        : encodeBytes initialEncodeDictionary initialNextCode restarted rest
+  where
+    extended = BS.snoc prefix byte
+
+lookupEncodeCode :: Map.Map BS.ByteString Int -> BS.ByteString -> Word16
+lookupEncodeCode dictionary prefix =
+    case Map.lookup prefix dictionary of
+        Just code -> fromIntegral code
+        Nothing -> error "internal LZW encoder dictionary mismatch"
+
+-- | Decode a logical code stream. The first code must be CLEAR and the stream
+-- must contain STOP.
+decode :: [Word16] -> Either String BS.ByteString
+decode [] = Left "empty LZW code stream"
+decode (first : rest)
+    | first /= clearCode =
+        Left
+            ( "expected CLEAR code 256 at start, got "
+                ++ show first
+            )
+    | otherwise = decodeCodes initialDecodeDictionary initialNextCode Nothing [] rest
+
+decodeCodes :: IntMap.IntMap BS.ByteString -> Int -> Maybe Int -> [BS.ByteString] -> [Word16] -> Either String BS.ByteString
+decodeCodes _ _ _ _ [] = Left "LZW code stream is missing STOP"
+decodeCodes dictionary nextCode previous chunks (codeWord : rest)
+    | codeWord == clearCode =
+        decodeCodes initialDecodeDictionary initialNextCode Nothing chunks rest
+    | codeWord == stopCode = Right (BS.concat (reverse chunks))
+    | otherwise = do
+        entry <- resolveEntry dictionary nextCode previous code
+        (nextDictionary, nextDynamicCode) <- addDecodeEntry dictionary nextCode previous entry
+        decodeCodes nextDictionary nextDynamicCode (Just code) (entry : chunks) rest
+  where
+    code = fromIntegral codeWord
+
+resolveEntry :: IntMap.IntMap BS.ByteString -> Int -> Maybe Int -> Int -> Either String BS.ByteString
+resolveEntry dictionary nextCode previous code =
+    case IntMap.lookup code dictionary of
+        Just entry
+            | not (BS.null entry) -> Right entry
+        _
+            | code == nextCode -> do
+                previousCode <- maybe (Left "tricky LZW token has no previous code") Right previous
+                previousEntry <- lookupDecodeEntry dictionary previousCode
+                firstByte <- maybe (Left "tricky LZW token has an empty previous entry") Right (fst <$> BS.uncons previousEntry)
+                Right (BS.snoc previousEntry firstByte)
+            | otherwise ->
+                Left
+                    ( "invalid LZW code "
+                        ++ show code
+                        ++ ": next dynamic code is "
+                        ++ show nextCode
+                    )
+
+addDecodeEntry :: IntMap.IntMap BS.ByteString -> Int -> Maybe Int -> BS.ByteString -> Either String (IntMap.IntMap BS.ByteString, Int)
+addDecodeEntry dictionary nextCode Nothing _ = Right (dictionary, nextCode)
+addDecodeEntry dictionary nextCode (Just previousCode) entry
+    | nextCode >= maximumEntries = Right (dictionary, nextCode)
+    | otherwise = do
+        previousEntry <- lookupDecodeEntry dictionary previousCode
+        firstByte <- maybe (Left "decoded LZW entry is empty") Right (fst <$> BS.uncons entry)
+        Right (IntMap.insert nextCode (BS.snoc previousEntry firstByte) dictionary, nextCode + 1)
+
+lookupDecodeEntry :: IntMap.IntMap BS.ByteString -> Int -> Either String BS.ByteString
+lookupDecodeEntry dictionary code =
+    case IntMap.lookup code dictionary of
+        Just entry
+            | not (BS.null entry) -> Right entry
+        _ -> Left ("invalid previous LZW code " ++ show code)
+
+data BitWriter = BitWriter
+    { writerBuffer :: Word64
+    , writerBitCount :: Int
+    , writerBytesReversed :: [Word8]
+    }
+
+emptyWriter :: BitWriter
+emptyWriter = BitWriter 0 0 []
+
+writeCode :: Word16 -> Int -> BitWriter -> BitWriter
+writeCode code width writer = drainWriter filled
+  where
+    filled =
+        writer
+            { writerBuffer = writerBuffer writer .|. (fromIntegral code `shiftL` writerBitCount writer)
+            , writerBitCount = writerBitCount writer + width
+            }
+
+drainWriter :: BitWriter -> BitWriter
+drainWriter writer
+    | writerBitCount writer < 8 = writer
+    | otherwise =
+        drainWriter
+            writer
+                { writerBuffer = writerBuffer writer `shiftR` 8
+                , writerBitCount = writerBitCount writer - 8
+                , writerBytesReversed = fromIntegral (writerBuffer writer .&. 0xff) : writerBytesReversed writer
+                }
+
+finishWriter :: BitWriter -> BS.ByteString
+finishWriter writer =
+    BS.pack
+        ( reverse
+            ( if writerBitCount writer == 0
+                then writerBytesReversed writer
+                else fromIntegral (writerBuffer writer .&. 0xff) : writerBytesReversed writer
+            )
+        )
+
+data BitReader = BitReader
+    { readerData :: BS.ByteString
+    , readerPosition :: Int
+    , readerBuffer :: Word64
+    , readerBitCount :: Int
+    }
+
+newReader :: BS.ByteString -> BitReader
+newReader bytes = BitReader bytes 0 0 0
+
+readCode :: Int -> BitReader -> Either String (Word16, BitReader)
+readCode width reader = do
+    filled <- fillReader width reader
+    if readerBitCount filled < width
+        then Left "truncated LZW bit stream"
+        else
+            let mask = (1 `shiftL` width) - 1 :: Word64
+                code = fromIntegral (readerBuffer filled .&. mask)
+             in Right
+                    ( code
+                    , filled
+                        { readerBuffer = readerBuffer filled `shiftR` width
+                        , readerBitCount = readerBitCount filled - width
+                        }
+                    )
+
+fillReader :: Int -> BitReader -> Either String BitReader
+fillReader width reader
+    | readerBitCount reader >= width = Right reader
+    | readerPosition reader >= BS.length (readerData reader) = Right reader
+    | otherwise =
+        let byte = BS.index (readerData reader) (readerPosition reader)
+         in fillReader
+                width
+                reader
+                    { readerPosition = readerPosition reader + 1
+                    , readerBuffer = readerBuffer reader .|. (fromIntegral byte `shiftL` readerBitCount reader)
+                    , readerBitCount = readerBitCount reader + 8
+                    }
+
+readerHasValidPadding :: BitReader -> Bool
+readerHasValidPadding reader = bufferedBitsAreZero && noRemainingBytes
+  where
+    bufferedMask
+        | readerBitCount reader == 0 = 0
+        | otherwise = (1 `shiftL` readerBitCount reader) - 1
+    bufferedBitsAreZero = readerBuffer reader .&. bufferedMask == 0
+    noRemainingBytes = readerPosition reader == BS.length (readerData reader)
+
+-- | Pack logical codes as a four-byte big-endian length followed by
+-- variable-width LSB-first codes.
+packCodes :: Int -> [Word16] -> Either String BS.ByteString
+packCodes originalLength codes = do
+    lengthWord <- intToWord32 originalLength
+    validateOpeningCode codes
+    payload <- packCodeStream initialCodeSize initialNextCode emptyWriter codes
+    Right (encodeWord32 lengthWord <> payload)
+
+validateOpeningCode :: [Word16] -> Either String ()
+validateOpeningCode [] = Left "empty LZW code stream"
+validateOpeningCode (first : _)
+    | first == clearCode = Right ()
+    | otherwise = Left ("expected CLEAR code 256 at start, got " ++ show first)
+
+packCodeStream :: Int -> Int -> BitWriter -> [Word16] -> Either String BS.ByteString
+packCodeStream _ _ _ [] = Left "LZW code stream is missing STOP"
+packCodeStream width nextCode writer (code : rest)
+    | fromIntegral code >= (1 `shiftL` width :: Int) =
+        Left ("LZW code " ++ show code ++ " does not fit in " ++ show width ++ " bits")
+    | code == stopCode =
+        if null rest
+            then Right (finishWriter written)
+            else Left "LZW code stream contains data after STOP"
+    | code == clearCode =
+        packCodeStream initialCodeSize initialNextCode written rest
+    | otherwise =
+        let (nextWidth, followingCode) = advanceWireWidth width nextCode
+         in packCodeStream nextWidth followingCode written rest
+  where
+    written = writeCode code width writer
+
+advanceWireWidth :: Int -> Int -> (Int, Int)
+advanceWireWidth width nextCode
+    | nextCode >= maximumEntries = (width, nextCode)
+    | followingCode > (1 `shiftL` width) && width < maxCodeSize = (width + 1, followingCode)
+    | otherwise = (width, followingCode)
+  where
+    followingCode = nextCode + 1
+
+-- | Parse one strict CMP03 payload and return its logical codes and stored
+-- original length.
+unpackCodes :: BS.ByteString -> Either String ([Word16], Int)
+unpackCodes input
+    | BS.length input < 4 = Left "input too short: missing four-byte LZW header"
+    | otherwise = do
+        originalLengthWord <- decodeWord32 input
+        originalLength <- word32ToInt originalLengthWord
+        let reader = newReader (BS.drop 4 input)
+        (first, afterFirst) <- readCode initialCodeSize reader
+        if first /= clearCode
+            then Left ("expected CLEAR code 256 at start, got " ++ show first)
+            else do
+                codes <- unpackCodeStream initialCodeSize initialNextCode afterFirst [clearCode]
+                Right (codes, originalLength)
+
+unpackCodeStream :: Int -> Int -> BitReader -> [Word16] -> Either String [Word16]
+unpackCodeStream width nextCode reader codesReversed = do
+    (code, afterCode) <- readCode width reader
+    if code == stopCode
+        then
+            if readerHasValidPadding afterCode
+                then Right (reverse (stopCode : codesReversed))
+                else Left "non-zero padding or trailing bytes follow the LZW STOP code"
+        else
+            if code == clearCode
+                then unpackCodeStream initialCodeSize initialNextCode afterCode (code : codesReversed)
+                else
+                    let (nextWidth, followingCode) = advanceWireWidth width nextCode
+                     in unpackCodeStream nextWidth followingCode afterCode (code : codesReversed)
+
+-- | Compress bytes to the CMP03 wire format.
+compress :: BS.ByteString -> Either String BS.ByteString
+compress input = packCodes (BS.length input) (encode input)
+
+-- | Decompress one strict CMP03 payload.
+decompress :: BS.ByteString -> Either String BS.ByteString
+decompress input = do
+    (codes, originalLength) <- unpackCodes input
+    output <- decode codes
+    if BS.length output < originalLength
+        then Left "decoded LZW stream is shorter than the stored original length"
+        else Right (BS.take originalLength output)
+
+intToWord32 :: Int -> Either String Word32
+intToWord32 value
+    | value < 0 = Left "original length must not be negative"
+    | toInteger value > toInteger (maxBound :: Word32) = Left "original length exceeds the uint32 field"
+    | otherwise = Right (fromIntegral value)
+
+word32ToInt :: Word32 -> Either String Int
+word32ToInt value
+    | toInteger value > toInteger (maxBound :: Int) = Left "original length exceeds this platform's Int range"
+    | otherwise = Right (fromIntegral value)
+
+encodeWord32 :: Word32 -> BS.ByteString
+encodeWord32 value =
+    BS.pack
+        [ fromIntegral (value `shiftR` 24)
+        , fromIntegral (value `shiftR` 16)
+        , fromIntegral (value `shiftR` 8)
+        , fromIntegral value
+        ]
+
+decodeWord32 :: BS.ByteString -> Either String Word32
+decodeWord32 input =
+    Right
+        ( byteAt 0 `shiftL` 24
+            .|. byteAt 1 `shiftL` 16
+            .|. byteAt 2 `shiftL` 8
+            .|. byteAt 3
+        )
+  where
+    byteAt index = fromIntegral (BS.index input index)

--- a/code/packages/haskell/lzw/test/LZWSpec.hs
+++ b/code/packages/haskell/lzw/test/LZWSpec.hs
@@ -1,0 +1,158 @@
+module LZWSpec (spec) where
+
+import qualified Data.ByteString as BS
+import Data.Bits (shiftR)
+import Data.List (isInfixOf)
+import Data.Word (Word32)
+import LZW
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "CMP03 code vectors" $ do
+        it "encodes empty input" $
+            encode BS.empty `shouldBe` [clearCode, stopCode]
+        it "encodes a single byte" $
+            encode (ascii "A") `shouldBe` [clearCode, 65, stopCode]
+        it "encodes two distinct bytes" $
+            encode (ascii "AB") `shouldBe` [clearCode, 65, 66, stopCode]
+        it "encodes the repeated-pair vector" $
+            encode (ascii "ABABAB")
+                `shouldBe` [clearCode, 65, 66, 258, 258, stopCode]
+        it "encodes the tricky-token vector" $
+            encode (ascii "AAAAAAA")
+                `shouldBe` [clearCode, 65, 258, 259, 65, stopCode]
+        it "decodes every reference vector" $ do
+            decode [clearCode, stopCode] `shouldBe` Right BS.empty
+            decode [clearCode, 65, stopCode] `shouldBe` Right (ascii "A")
+            decode [clearCode, 65, 66, stopCode] `shouldBe` Right (ascii "AB")
+            decode [clearCode, 65, 66, 258, 258, stopCode]
+                `shouldBe` Right (ascii "ABABAB")
+            decode [clearCode, 65, 258, 259, 65, stopCode]
+                `shouldBe` Right (ascii "AAAAAAA")
+
+    describe "round trips" $ do
+        it "round-trips representative text and binary inputs" $ do
+            mapM_
+                (\input -> roundTrip input `shouldBe` Right input)
+                [ BS.empty
+                , ascii "A"
+                , ascii "AB"
+                , ascii "ABABAB"
+                , ascii "AAAAAAA"
+                , ascii "hello world"
+                , BS.pack [0, 0, 0, 255, 255]
+                ]
+        it "round-trips every byte value" $
+            roundTrip (BS.pack [0 .. 255]) `shouldBe` Right (BS.pack [0 .. 255])
+        it "round-trips beyond the 9-bit width" $ do
+            let input = BS.pack (take 4096 (cycle [0 .. 255]))
+            roundTrip input `shouldBe` Right input
+        it "round-trips long repeated patterns" $ do
+            let input = BS.concat (replicate 10000 (ascii "ABCDEFGHIJ"))
+            roundTrip input `shouldBe` Right input
+        it "round-trips a long single-byte run" $ do
+            let input = BS.replicate 10000 66
+            roundTrip input `shouldBe` Right input
+
+    describe "wire format" $ do
+        it "writes the exact empty payload" $
+            compress BS.empty
+                `shouldBe` Right (BS.pack [0, 0, 0, 0, 0, 3, 2])
+        it "matches the cross-language bytes for the reference vectors" $ do
+            compress (ascii "A")
+                `shouldBe` Right (BS.pack [0, 0, 0, 1, 0, 131, 4, 4])
+            compress (ascii "AB")
+                `shouldBe` Right (BS.pack [0, 0, 0, 2, 0, 131, 8, 9, 8])
+            compress (ascii "ABABAB")
+                `shouldBe` Right (BS.pack [0, 0, 0, 6, 0, 131, 8, 17, 40, 48, 32])
+            compress (ascii "AAAAAAA")
+                `shouldBe` Right (BS.pack [0, 0, 0, 7, 0, 131, 8, 28, 24, 36, 32])
+        it "stores the original length as big-endian uint32" $ do
+            payload <- expectRight (compress (ascii "hello"))
+            BS.take 4 payload `shouldBe` BS.pack [0, 0, 0, 5]
+        it "packs one 9-bit CLEAR code LSB-first" $
+            packCodes 0 [clearCode, stopCode]
+                `shouldBe` Right (BS.pack [0, 0, 0, 0, 0, 3, 2])
+        it "round-trips logical codes through variable-width packing" $ do
+            let input = BS.pack (take 4096 (cycle [0 .. 255]))
+                codes = encode input
+            payload <- expectRight (packCodes (BS.length input) codes)
+            unpackCodes payload `shouldBe` Right (codes, BS.length input)
+        it "accepts a mid-stream CLEAR reset" $ do
+            let codes = [clearCode, 65, clearCode, 66, stopCode]
+            payload <- expectRight (packCodes 2 codes)
+            decompress payload `shouldBe` Right (ascii "AB")
+        it "uses the stored length as authoritative truncation" $ do
+            payload <- expectRight (packCodes 1 [clearCode, 65, 66, stopCode])
+            decompress payload `shouldBe` Right (ascii "A")
+        it "produces deterministic output" $
+            compress (ascii "hello world test")
+                `shouldBe` compress (ascii "hello world test")
+        it "emits CLEAR and round-trips when the 16-bit dictionary fills" $ do
+            let input = pseudoRandomBytes 100000
+                codes = encode input
+            length (filter (== clearCode) codes) `shouldSatisfy` (> 1)
+            roundTrip input `shouldBe` Right input
+
+    describe "validation" $ do
+        it "rejects a truncated header and empty payload" $ do
+            decompress (BS.replicate 3 0) `leftShouldContain` "header"
+            decompress (BS.replicate 4 0) `leftShouldContain` "truncated"
+        it "requires CLEAR as the opening code" $ do
+            packCodes 1 [65, stopCode] `leftShouldContain` "CLEAR"
+            decompress (BS.pack [0, 0, 0, 1, 65, 0]) `leftShouldContain` "CLEAR"
+        it "requires a STOP code" $ do
+            packCodes 1 [clearCode, 65] `leftShouldContain` "STOP"
+            decompress (BS.pack [0, 0, 0, 0, 0, 1]) `leftShouldContain` "truncated"
+        it "rejects truly invalid and initial tricky codes" $ do
+            decode [clearCode, 400, stopCode] `leftShouldContain` "invalid"
+            decode [clearCode, 258, stopCode] `leftShouldContain` "previous"
+        it "rejects non-zero data after STOP" $ do
+            payload <- expectRight (compress BS.empty)
+            decompress (payload <> BS.singleton 1) `leftShouldContain` "non-zero"
+        it "rejects extra zero bytes after STOP" $ do
+            payload <- expectRight (compress BS.empty)
+            decompress (payload <> BS.singleton 0) `leftShouldContain` "trailing"
+        it "rejects decoded output shorter than the stored length" $ do
+            payload <- expectRight (packCodes 2 [clearCode, 65, stopCode])
+            decompress payload `leftShouldContain` "shorter"
+        it "rejects code data after STOP when packing" $
+            packCodes 0 [clearCode, stopCode, 65] `leftShouldContain` "after STOP"
+
+    describe "compression behaviour" $ do
+        it "compresses repetitive input below its original size" $ do
+            let input = BS.concat (replicate 1000 (ascii "ABC"))
+            payload <- expectRight (compress input)
+            BS.length payload `shouldSatisfy` (< BS.length input)
+        it "compresses a long repeated byte below its original size" $ do
+            let input = BS.replicate 10000 66
+            payload <- expectRight (compress input)
+            BS.length payload `shouldSatisfy` (< BS.length input)
+
+roundTrip :: BS.ByteString -> Either String BS.ByteString
+roundTrip input = compress input >>= decompress
+
+ascii :: String -> BS.ByteString
+ascii = BS.pack . map (fromIntegral . fromEnum)
+
+pseudoRandomBytes :: Int -> BS.ByteString
+pseudoRandomBytes count =
+    BS.pack
+        ( map (fromIntegral . (`shiftR` 24))
+            (take count (drop 1 (iterate nextState (1 :: Word32))))
+        )
+  where
+    nextState state = 1664525 * state + 1013904223
+
+expectRight :: Either String value -> IO value
+expectRight result =
+    case result of
+        Left message -> expectationFailure message >> fail message
+        Right value -> pure value
+
+leftShouldContain :: Either String value -> String -> Expectation
+leftShouldContain result expected =
+    case result of
+        Left message -> message `shouldSatisfy` isInfixOf expected
+        Right _ -> expectationFailure ("expected Left containing " ++ show expected)

--- a/code/packages/haskell/lzw/test/Spec.hs
+++ b/code/packages/haskell/lzw/test/Spec.hs
@@ -1,0 +1,5 @@
+import LZWSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -108,12 +108,12 @@ The missing matrix is heavily concentrated in singleton packages:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 411 |
+| Present in 10-15 languages | 171 | 386 |
 | Present in 5-9 languages | 122 | 917 |
-| Present in 2-4 languages | 153 | 1,924 |
-| Present in one language | 656 | 9,184 |
+| Present in 2-4 languages | 157 | 1,972 |
+| Present in one language | 685 | 9,590 |
 
-The loop must not start by attempting 9,184 singleton ports. It should finish
+The loop must not start by attempting 9,590 singleton ports. It should finish
 the broadly established portable core, then classify the sparse majority.
 
 ## Priority 0: Inventory And Identity Integrity
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Thirteen package/language slots remain to turn 13 nearly complete packages into
+Twelve package/language slots remain to turn 12 nearly complete packages into
 fully covered packages.
 
 ### Dart: 9 remaining ports
@@ -145,12 +145,10 @@ fully covered packages.
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`.
 
-### Haskell: 1 remaining port
-
-- `lzw`
+### Haskell: complete
 
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
-`huffman-tree`, `huffman-compression`, `lz77`, `lzss`.
+`huffman-tree`, `huffman-compression`, `lz77`, `lzss`, `lzw`.
 
 ### Swift: 3 ports
 
@@ -164,7 +162,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 411
+The 171 packages present in at least ten implementation languages need 386
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -175,11 +173,11 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Perl | 16 | Pair with Lua data-structure/storage wave |
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
-| Haskell | 41 | Dependency-shaped compression, graphics, ML, and protocol waves |
-| Swift | 56 | Data structures and generated frontends before native app surfaces |
-| Java | 60 | Move with Kotlin |
-| Kotlin | 60 | Move with Java |
-| Dart | 124 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
+| Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
+| Swift | 53 | Data structures and generated frontends before native app surfaces |
+| Java | 57 | Move with Kotlin |
+| Kotlin | 57 | Move with Java |
+| Dart | 115 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
 
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.


### PR DESCRIPTION
## Summary

- add a pure Haskell CMP03 LZW package with logical code encoding/decoding
- implement 9-to-16-bit LSB-first wire packing, CLEAR resets, STOP termination, and the self-referential tricky token
- reject malformed headers, invalid codes, missing terminators, non-zero padding, trailing bytes, and short decoded output
- refresh the parity roadmap after completing the Haskell Priority 1 lane

## Why

LZW was the last 14-of-15 package missing only from Haskell. This port completes the Haskell Priority 1 queue while retaining the cross-language CMP03 wire contract.

## Validation

- `cabal test all --ghc-options=-Wall` — 30 examples passed with no warnings
- `cabal check` — no errors or warnings
- cross-language 100,000-byte stress comparison — Haskell and Python emitted identical 138,521-byte streams and Haskell decoded the Python stream exactly
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions` — zero collisions and zero unknown buckets
- `git diff --check`
