### PR TITLE
feat(maxima-to-semantic-ir): thin re-export over macsyma-to-semantic-ir

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -237,6 +237,7 @@ members = [
     "octave-to-semantic-ir",
     "maxima-runtime",
     "maxima-repl",
+    "maxima-to-semantic-ir",
     "wolfram-lexer",
     "wolfram-parser",
     "wolfram-runtime",

--- a/code/packages/rust/maxima-to-semantic-ir/BUILD
+++ b/code/packages/rust/maxima-to-semantic-ir/BUILD
@@ -1,0 +1,1 @@
+cargo test -p maxima-to-semantic-ir -- --nocapture

--- a/code/packages/rust/maxima-to-semantic-ir/BUILD_windows
+++ b/code/packages/rust/maxima-to-semantic-ir/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p maxima-to-semantic-ir -- --nocapture

--- a/code/packages/rust/maxima-to-semantic-ir/CHANGELOG.md
+++ b/code/packages/rust/maxima-to-semantic-ir/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial release — HML01 Stream B rollout, the item right after
+  `macsyma-to-semantic-ir`: a direct `pub use` re-export of
+  `macsyma_to_semantic_ir::{compile, compile_source, MacsymaLowerError}`
+  under Maxima's own crate name. No new grammar, no new SIR node kinds, no
+  shim function at all — Maxima and Macsyma share the exact same algebraic
+  surface (`maxima-runtime`'s own doc comment: "a program written for one
+  runs on the other"), a stronger guarantee than Octave's relationship to
+  MATLAB, which still needs `octave-runtime`'s `octavify` source-rewriting
+  shim for a handful of real surface departures. This crate is therefore
+  thinner than `octave-to-semantic-ir`: *delegate*, not *shim-then-delegate*.
+- Both `compile_source` (source-in) and `compile` (already-parsed
+  `GrammarASTNode`-in) are re-exported, matching every other
+  `-to-semantic-ir` frontend's own pair — `octave-to-semantic-ir`
+  deliberately omits `compile(tree, ...)` since its shim rewrites text, not
+  a tree; Maxima has no shim, so the full pair applies unchanged here.
+- 6 tests: bare arithmetic, Maxima's own `;`/`$` display/suppress
+  terminator pair (unchanged from Macsyma), `diff`/`integrate` builtin
+  bridging, a `block`/`for`/control-flow program that also passes
+  `semantic_ir::validate`, malformed-input rejection, and a symmetry check
+  confirming both `compile` and `compile_source` are reachable under this
+  crate's own name.

--- a/code/packages/rust/maxima-to-semantic-ir/Cargo.toml
+++ b/code/packages/rust/maxima-to-semantic-ir/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "maxima-to-semantic-ir"
+version = "0.1.0"
+edition = "2021"
+description = "Maxima source -> narrow-waist Semantic IR, a direct re-export of macsyma-to-semantic-ir (same algebraic surface, zero shim)"
+
+[dependencies]
+semantic-ir = { path = "../semantic-ir" }
+macsyma-to-semantic-ir = { path = "../macsyma-to-semantic-ir" }
+
+[dev-dependencies]
+# Used only by the compile()/compile_source() symmetry test.
+coding-adventures-macsyma-parser = { path = "../macsyma-parser" }

--- a/code/packages/rust/maxima-to-semantic-ir/README.md
+++ b/code/packages/rust/maxima-to-semantic-ir/README.md
@@ -1,0 +1,55 @@
+# maxima-to-semantic-ir
+
+Maxima source → narrow-waist [Semantic IR](../semantic-ir), by directly
+re-exporting `macsyma-to-semantic-ir`'s public API under Maxima's own name.
+The next item in [`HML01`](../../../specs/HML01-math-to-semantic-ir.md)
+Stream B's rollout, right after `macsyma-to-semantic-ir`.
+
+## Where it fits in the stack
+
+```
+Maxima source
+   │
+   ▼  macsyma_to_semantic_ir::compile_source   (no shim -- same surface)
+semantic_ir::Module
+```
+
+This mirrors how [`maxima-runtime`](../maxima-runtime) reuses
+`macsyma-runtime` wholesale for *evaluation* — this crate reuses
+`macsyma-to-semantic-ir` wholesale for *compilation*. Unlike
+[`octave-to-semantic-ir`](../octave-to-semantic-ir) (which needs
+`octave-runtime`'s `octavify` source-rewriting shim for a handful of real
+surface departures from MATLAB — `#` comments, `endif`/`endfor`/…, `!=`/`!`),
+Maxima needs **zero** surface normalization at all: per `maxima-runtime`'s
+own doc comment, "a program written for one runs on the other." So where
+`octave-to-semantic-ir` is *shim, then delegate*, this crate is just
+*delegate* — a plain `pub use` re-export, no wrapper function in between.
+
+## Usage
+
+```rust
+use maxima_to_semantic_ir::compile_source;
+
+let module = compile_source("diff(x^3, x)$\n", "demo").unwrap();
+assert!(module.functions.iter().any(|f| f.name == "main"));
+```
+
+Both `compile_source` (source-in) and `compile` (an already-parsed
+`GrammarASTNode`-in) are re-exported, matching every other `-to-semantic-ir`
+frontend's own pair — unlike `octave-to-semantic-ir`, which deliberately has
+no `compile(tree, ...)` (its shim rewrites text, not a tree). Maxima has no
+shim at all, so the full pair applies unchanged.
+
+## Scope
+
+Identical to [`macsyma-to-semantic-ir`](../macsyma-to-semantic-ir) v0.1.0's
+own scope — see that crate's module doc comment for the full node-by-node
+mapping and its disclosed "no pattern-matching/rewrite-rule syntax in this
+cut" boundary. There is nothing Maxima-specific to add or restrict, since
+the surface is unchanged.
+
+## Testing
+
+```sh
+cargo test -p maxima-to-semantic-ir
+```

--- a/code/packages/rust/maxima-to-semantic-ir/required_capabilities.json
+++ b/code/packages/rust/maxima-to-semantic-ir/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/maxima-to-semantic-ir",
+  "capabilities": [],
+  "justification": "Pure re-export of macsyma-to-semantic-ir's in-memory compilation API. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/maxima-to-semantic-ir/src/lib.rs
+++ b/code/packages/rust/maxima-to-semantic-ir/src/lib.rs
@@ -1,0 +1,113 @@
+//! # maxima-to-semantic-ir
+//!
+//! Maxima source → narrow-waist Semantic IR, **v0.1.0** — the next item in
+//! [`HML01`](../../../specs/HML01-math-to-semantic-ir.md) Stream B's rollout,
+//! right after `macsyma-to-semantic-ir`.
+//!
+//! Maxima and Macsyma share the *exact same* algebraic surface — see
+//! [`coding_adventures_maxima_runtime`]'s own doc comment: "A program
+//! written for one runs on the other." This is a **stronger** guarantee
+//! than Octave's relationship to MATLAB (which needs `octave-runtime`'s
+//! `octavify` source-rewriting shim for a small set of surface departures —
+//! `#` comments, `endif`/`endfor`/…, `!=`/`!`): Maxima needs **zero**
+//! surface normalization at all. So where `octave-to-semantic-ir` is a thin
+//! wrapper (shim, then delegate), this crate is thinner still — a direct
+//! re-export of [`macsyma_to_semantic_ir`]'s public API under Maxima's own
+//! name, with no shim function in between at all.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! Maxima source
+//!    │
+//!    ▼  macsyma_to_semantic_ir::compile_source   (no shim -- same surface)
+//! semantic_ir::Module                            (per SIR10 + SIR23)
+//! ```
+//!
+//! ## Public API
+//!
+//! ```
+//! use maxima_to_semantic_ir::compile_source;
+//! let module = compile_source("diff(x^3, x)$\n", "demo").unwrap();
+//! assert!(module.functions.iter().any(|f| f.name == "main"));
+//! ```
+//!
+//! `compile` (taking an already-parsed `GrammarASTNode`) is re-exported
+//! too, for symmetry with `macsyma-to-semantic-ir` and every other
+//! `-to-semantic-ir` frontend's own `compile`/`compile_source` pair — there
+//! is no Maxima-specific CST; the only tree ever built is the Macsyma one
+//! `macsyma_to_semantic_ir::compile`/`compile_source` construct directly.
+//!
+//! ## Scope
+//!
+//! Identical to `macsyma-to-semantic-ir` v0.1.0's own scope (see that
+//! crate's module doc comment for the full node-by-node mapping and the
+//! disclosed "no pattern-matching/rewrite-rule syntax" boundary) — there is
+//! nothing Maxima-specific to add or restrict, since the surface is
+//! unchanged.
+
+pub use macsyma_to_semantic_ir::{compile, compile_source, MacsymaLowerError};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn main_fn(m: &semantic_ir::Module) -> &semantic_ir::Function {
+        m.functions
+            .iter()
+            .find(|f| f.name == "main")
+            .expect("module must have a main function")
+    }
+
+    #[test]
+    fn bare_arithmetic_compiles_unchanged() {
+        let module = compile_source("1 + 2$\n", "demo").unwrap();
+        assert!(!main_fn(&module).body.stmts.is_empty());
+    }
+
+    #[test]
+    fn a_maxima_style_display_terminated_statement_compiles() {
+        // `;` (display) vs `$` (suppress) is the same Macsyma terminator
+        // pair Maxima itself uses unchanged -- no rewriting needed.
+        let module = compile_source("x: 3;\n", "demo").unwrap();
+        assert!(!main_fn(&module).body.stmts.is_empty());
+    }
+
+    #[test]
+    fn diff_and_integrate_builtins_bridge_to_canonical_heads() {
+        let module = compile_source("diff(x^3, x)$\nintegrate(x, x)$\n", "demo").unwrap();
+        assert_eq!(main_fn(&module).body.stmts.len(), 2);
+    }
+
+    #[test]
+    fn control_flow_compiles_and_the_lowered_module_validates() {
+        let src = "block([x: 0], for i: 1 thru 5 do x: x + i, x)$\n";
+        let module = compile_source(src, "demo").unwrap();
+        let report = semantic_ir::validate(&module);
+        assert!(
+            report.is_ok(),
+            "lowered module must pass validation: {:?}",
+            report.issues
+        );
+    }
+
+    #[test]
+    fn a_malformed_program_errors_cleanly_not_panicking() {
+        assert!(compile_source("(((\n", "demo").is_err());
+    }
+
+    #[test]
+    fn compile_and_compile_source_are_both_reexported() {
+        // Symmetry check: both entry points must exist under this crate's
+        // own name, mirroring every other `-to-semantic-ir` frontend's
+        // `compile`/`compile_source` pair (unlike `octave-to-semantic-ir`,
+        // which deliberately has no `compile(tree, ...)` since its shim
+        // rewrites text, not a tree -- Maxima has no shim at all, so the
+        // full pair applies here).
+        let tree = coding_adventures_macsyma_parser::create_macsyma_parser("1$\n")
+            .parse()
+            .expect("parse should succeed");
+        let module = compile(&tree, "demo").expect("compile should succeed");
+        assert!(main_fn(&module).body.stmts.len() == 1);
+    }
+}


### PR DESCRIPTION
## Summary

Front3's turn, continuing HML01 Stream B's rollout right after `macsyma-to-semantic-ir` ([#8142](https://github.com/adhithyan15/coding-adventures/pull/8142)).

Maxima and Macsyma share the exact same algebraic surface — `maxima-runtime`'s own doc comment already establishes this: "a program written for one runs on the other" — a stronger guarantee than Octave's relationship to MATLAB, which still needs `octave-runtime`'s `octavify` source-rewriting shim for real surface departures (`#` comments, `endif`/`endfor`/…, `!=`/`!`). Maxima needs zero surface normalization at all, so this crate is thinner than `octave-to-semantic-ir`: a plain `pub use` re-export of `macsyma_to_semantic_ir::{compile, compile_source, MacsymaLowerError}`, no shim function in between at all.

Both `compile_source` (source-in) and `compile` (already-parsed `GrammarASTNode`-in) are re-exported, matching every other `-to-semantic-ir` frontend's own pair — `octave-to-semantic-ir` deliberately omits `compile(tree, ...)` since its shim rewrites text, not a tree; Maxima has no shim, so the full pair applies unchanged.

6 tests: bare arithmetic, Maxima's own `;`/`$` display/suppress pair (unchanged from Macsyma), `diff`/`integrate` builtin bridging, a `block`/`for`/control-flow program that also passes `semantic_ir::validate`, malformed-input rejection, and a symmetry check confirming both `compile` and `compile_source` are reachable under this crate's own name.

## Test plan

- [x] `cargo test -p maxima-to-semantic-ir` — 6/6 tests + doctest pass
- [x] `cargo clippy -p maxima-to-semantic-ir --all-targets` clean
- [x] Security review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)