### PR TITLE
[codex] Port TOML lexer to Dart

### DIFF
--- a/code/packages/dart/lexer/CHANGELOG.md
+++ b/code/packages/dart/lexer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Strip matching single, double, and triple delimiters from named string token
+  types such as `BASIC_STRING` and `ML_LITERAL_STRING`.
+
 ## 0.1.0
 
 - Initial release.

--- a/code/packages/dart/lexer/lib/src/grammar_lexer.dart
+++ b/code/packages/dart/lexer/lib/src/grammar_lexer.dart
@@ -4,10 +4,8 @@ import 'token.dart';
 import 'tokenizer.dart';
 
 class _CompiledPattern {
-  _CompiledPattern({
-    required this.definition,
-    required this.caseSensitive,
-  }) : regex = definition.isRegex
+  _CompiledPattern({required this.definition, required this.caseSensitive})
+      : regex = definition.isRegex
             ? RegExp(
                 '^(?:${definition.pattern})',
                 caseSensitive: caseSensitive,
@@ -192,17 +190,25 @@ String _resolveTokenType(
 }
 
 String _resolveTokenValue(String matchedText, String type, String? escapeMode) {
-  if (type == 'STRING' &&
-      matchedText.length >= 2 &&
-      matchedText.startsWith('"') &&
-      matchedText.endsWith('"')) {
-    final inner = matchedText.substring(1, matchedText.length - 1);
-    if (escapeMode == 'none') {
-      return inner;
-    }
-    return _decodeEscapes(inner);
+  if (type != 'STRING' && !type.contains('STRING')) {
+    return matchedText;
   }
-  return matchedText;
+
+  String? inner;
+  if (matchedText.length >= 6 &&
+      ((matchedText.startsWith('"""') && matchedText.endsWith('"""')) ||
+          (matchedText.startsWith("'''") && matchedText.endsWith("'''")))) {
+    inner = matchedText.substring(3, matchedText.length - 3);
+  } else if (matchedText.length >= 2 &&
+      ((matchedText.startsWith('"') && matchedText.endsWith('"')) ||
+          (matchedText.startsWith("'") && matchedText.endsWith("'")))) {
+    inner = matchedText.substring(1, matchedText.length - 1);
+  }
+
+  if (inner == null || escapeMode == 'none') {
+    return inner ?? matchedText;
+  }
+  return _decodeEscapes(inner);
 }
 
 String _decodeEscapes(String value) {

--- a/code/packages/dart/lexer/test/grammar_lexer_test.dart
+++ b/code/packages/dart/lexer/test/grammar_lexer_test.dart
@@ -47,6 +47,28 @@ STRING = /"([^"\\\\]|\\\\.)*"/
       expect(tokens.first.value, r'line1\nline2');
     });
 
+    test('strips single-quoted and named string delimiters', () {
+      final grammar = parseTokenGrammar('''
+escapes: none
+LITERAL_STRING = /'[^']*'/
+''');
+
+      final token = grammarTokenize("'hello'", grammar).first;
+      expect(token.type, 'LITERAL_STRING');
+      expect(token.value, 'hello');
+    });
+
+    test('strips triple delimiters from multiline string types', () {
+      final grammar = parseTokenGrammar(r'''
+escapes: none
+ML_BASIC_STRING = /"""[\s\S]*?"""/
+''');
+
+      final token = grammarTokenize('"""hello\nworld"""', grammar).first;
+      expect(token.type, 'ML_BASIC_STRING');
+      expect(token.value, 'hello\nworld');
+    });
+
     test('emits NEWLINE when newline is not skipped', () {
       final grammar = parseTokenGrammar('NUMBER = /[0-9]+/');
 

--- a/code/packages/dart/toml-lexer/.gitignore
+++ b/code/packages/dart/toml-lexer/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/toml-lexer/BUILD
+++ b/code/packages/dart/toml-lexer/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/toml-lexer/BUILD_windows
+++ b/code/packages/dart/toml-lexer/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/toml-lexer/CHANGELOG.md
+++ b/code/packages/dart/toml-lexer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Dart `toml-lexer` package.
+- Added grammar-driven TOML tokenization backed by the canonical compiled
+  token grammar.

--- a/code/packages/dart/toml-lexer/README.md
+++ b/code/packages/dart/toml-lexer/README.md
@@ -1,0 +1,18 @@
+# coding_adventures_toml_lexer
+
+Grammar-driven TOML lexer for Dart.
+
+This package is a thin wrapper around the shared Dart `lexer` and
+`grammar-tools` packages. It embeds the canonical `toml.tokens` grammar as
+Dart data and delegates tokenization to `grammarTokenize`, so tokenization does
+not depend on repository-relative files at run time.
+
+```dart
+import 'package:coding_adventures_toml_lexer/toml_lexer.dart';
+
+final tokens = tokenizeToml('title = "TOML Example"');
+```
+
+The lexer recognizes TOML strings, integers, floats, booleans, date/time
+literals, bare keys, structural delimiters, and significant newlines. Comments
+and horizontal whitespace are skipped.

--- a/code/packages/dart/toml-lexer/lib/src/_grammar.dart
+++ b/code/packages/dart/toml-lexer/lib/src/_grammar.dart
@@ -1,0 +1,229 @@
+// AUTO-GENERATED FILE - DO NOT EDIT
+// Source: code/grammars/toml/toml.tokens
+// Regenerate with: grammar-tools compile-tokens <source.tokens>
+import 'package:coding_adventures_grammar_tools/grammar_tools.dart';
+
+final tokenGrammar = TokenGrammar(
+  version: 1,
+  caseInsensitive: false,
+  definitions: [
+    TokenDefinition(
+        name: "ML_BASIC_STRING",
+        pattern: "\"\"\"([^\\\\]|\\\\(.|\\n)|\\n)*?\"\"\"",
+        isRegex: true,
+        lineNumber: 60,
+        alias: null),
+    TokenDefinition(
+        name: "ML_LITERAL_STRING",
+        pattern: "'''[\\s\\S]*?'''",
+        isRegex: true,
+        lineNumber: 61,
+        alias: null),
+    TokenDefinition(
+        name: "BASIC_STRING",
+        pattern: "\"([^\"\\\\\\n]|\\\\.)*\"",
+        isRegex: true,
+        lineNumber: 70,
+        alias: null),
+    TokenDefinition(
+        name: "LITERAL_STRING",
+        pattern: "'[^'\\n]*'",
+        isRegex: true,
+        lineNumber: 71,
+        alias: null),
+    TokenDefinition(
+        name: "OFFSET_DATETIME_FRAC_TZ",
+        pattern:
+            "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}\\.\\d+[+-]\\d{2}:\\d{2}",
+        isRegex: true,
+        lineNumber: 91,
+        alias: "OFFSET_DATETIME"),
+    TokenDefinition(
+        name: "OFFSET_DATETIME_FRAC_Z",
+        pattern: "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}\\.\\d+Z",
+        isRegex: true,
+        lineNumber: 92,
+        alias: "OFFSET_DATETIME"),
+    TokenDefinition(
+        name: "OFFSET_DATETIME_TZ",
+        pattern:
+            "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}[+-]\\d{2}:\\d{2}",
+        isRegex: true,
+        lineNumber: 93,
+        alias: "OFFSET_DATETIME"),
+    TokenDefinition(
+        name: "OFFSET_DATETIME_Z",
+        pattern: "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}Z",
+        isRegex: true,
+        lineNumber: 94,
+        alias: "OFFSET_DATETIME"),
+    TokenDefinition(
+        name: "LOCAL_DATETIME_FRAC",
+        pattern: "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}\\.\\d+",
+        isRegex: true,
+        lineNumber: 95,
+        alias: "LOCAL_DATETIME"),
+    TokenDefinition(
+        name: "LOCAL_DATETIME",
+        pattern: "\\d{4}-\\d{2}-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}",
+        isRegex: true,
+        lineNumber: 96,
+        alias: null),
+    TokenDefinition(
+        name: "LOCAL_DATE",
+        pattern: "\\d{4}-\\d{2}-\\d{2}",
+        isRegex: true,
+        lineNumber: 97,
+        alias: null),
+    TokenDefinition(
+        name: "LOCAL_TIME_FRAC",
+        pattern: "\\d{2}:\\d{2}:\\d{2}\\.\\d+",
+        isRegex: true,
+        lineNumber: 98,
+        alias: "LOCAL_TIME"),
+    TokenDefinition(
+        name: "LOCAL_TIME",
+        pattern: "\\d{2}:\\d{2}:\\d{2}",
+        isRegex: true,
+        lineNumber: 99,
+        alias: null),
+    TokenDefinition(
+        name: "FLOAT_INF",
+        pattern: "[+-]?inf",
+        isRegex: true,
+        lineNumber: 114,
+        alias: "FLOAT"),
+    TokenDefinition(
+        name: "FLOAT_NAN",
+        pattern: "[+-]?nan",
+        isRegex: true,
+        lineNumber: 115,
+        alias: "FLOAT"),
+    TokenDefinition(
+        name: "FLOAT_EXP",
+        pattern: "[+-]?[0-9][0-9_]*\\.?[0-9_]*[eE][+-]?[0-9][0-9_]*",
+        isRegex: true,
+        lineNumber: 116,
+        alias: "FLOAT"),
+    TokenDefinition(
+        name: "FLOAT_DEC",
+        pattern: "[+-]?[0-9][0-9_]*\\.[0-9][0-9_]*",
+        isRegex: true,
+        lineNumber: 117,
+        alias: "FLOAT"),
+    TokenDefinition(
+        name: "HEX_INTEGER",
+        pattern: "0x[0-9a-fA-F][0-9a-fA-F_]*",
+        isRegex: true,
+        lineNumber: 129,
+        alias: "INTEGER"),
+    TokenDefinition(
+        name: "OCT_INTEGER",
+        pattern: "0o[0-7][0-7_]*",
+        isRegex: true,
+        lineNumber: 130,
+        alias: "INTEGER"),
+    TokenDefinition(
+        name: "BIN_INTEGER",
+        pattern: "0b[01][01_]*",
+        isRegex: true,
+        lineNumber: 131,
+        alias: "INTEGER"),
+    TokenDefinition(
+        name: "INTEGER",
+        pattern: "[+-]?[0-9][0-9_]*",
+        isRegex: true,
+        lineNumber: 132,
+        alias: null),
+    TokenDefinition(
+        name: "TRUE",
+        pattern: "true",
+        isRegex: false,
+        lineNumber: 143,
+        alias: null),
+    TokenDefinition(
+        name: "FALSE",
+        pattern: "false",
+        isRegex: false,
+        lineNumber: 144,
+        alias: null),
+    TokenDefinition(
+        name: "BARE_KEY",
+        pattern: "[A-Za-z0-9_-]+",
+        isRegex: true,
+        lineNumber: 158,
+        alias: null),
+    TokenDefinition(
+        name: "EQUALS",
+        pattern: "=",
+        isRegex: false,
+        lineNumber: 168,
+        alias: null),
+    TokenDefinition(
+        name: "DOT",
+        pattern: ".",
+        isRegex: false,
+        lineNumber: 169,
+        alias: null),
+    TokenDefinition(
+        name: "COMMA",
+        pattern: ",",
+        isRegex: false,
+        lineNumber: 170,
+        alias: null),
+    TokenDefinition(
+        name: "LBRACKET",
+        pattern: "[",
+        isRegex: false,
+        lineNumber: 171,
+        alias: null),
+    TokenDefinition(
+        name: "RBRACKET",
+        pattern: "]",
+        isRegex: false,
+        lineNumber: 172,
+        alias: null),
+    TokenDefinition(
+        name: "LBRACE",
+        pattern: "{",
+        isRegex: false,
+        lineNumber: 173,
+        alias: null),
+    TokenDefinition(
+        name: "RBRACE",
+        pattern: "}",
+        isRegex: false,
+        lineNumber: 174,
+        alias: null),
+    TokenDefinition(
+        name: "NEWLINE",
+        pattern: "\\r?\\n",
+        isRegex: true,
+        lineNumber: 175,
+        alias: null),
+  ],
+  keywords: const [],
+  mode: null,
+  skipDefinitions: [
+    TokenDefinition(
+        name: "COMMENT",
+        pattern: "#[^\\n]*",
+        isRegex: true,
+        lineNumber: 28,
+        alias: null),
+    TokenDefinition(
+        name: "WHITESPACE",
+        pattern: "[ \\t]+",
+        isRegex: true,
+        lineNumber: 29,
+        alias: null),
+  ],
+  reservedKeywords: const [],
+  escapeMode: "none",
+  errorDefinitions: const [],
+  groups: const {},
+  caseSensitive: true,
+  layoutKeywords: const [],
+  contextKeywords: const [],
+  softKeywords: const [],
+);

--- a/code/packages/dart/toml-lexer/lib/src/tokenizer.dart
+++ b/code/packages/dart/toml-lexer/lib/src/tokenizer.dart
@@ -1,0 +1,7 @@
+import 'package:coding_adventures_lexer/lexer.dart';
+
+import '_grammar.dart';
+
+/// Tokenizes TOML source using the embedded canonical token grammar.
+List<Token> tokenizeToml(String source) =>
+    grammarTokenize(source, tokenGrammar);

--- a/code/packages/dart/toml-lexer/lib/toml_lexer.dart
+++ b/code/packages/dart/toml-lexer/lib/toml_lexer.dart
@@ -1,0 +1,3 @@
+library;
+
+export 'src/tokenizer.dart';

--- a/code/packages/dart/toml-lexer/pubspec.yaml
+++ b/code/packages/dart/toml-lexer/pubspec.yaml
@@ -1,0 +1,18 @@
+name: coding_adventures_toml_lexer
+description: >
+  Grammar-driven TOML lexer for Dart backed by the shared TokenGrammar format.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dependencies:
+  coding_adventures_grammar_tools:
+    path: ../grammar-tools
+  coding_adventures_lexer:
+    path: ../lexer
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/toml-lexer/required_capabilities.json
+++ b/code/packages/dart/toml-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/toml-lexer",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/toml-lexer/test/toml_lexer_test.dart
+++ b/code/packages/dart/toml-lexer/test/toml_lexer_test.dart
@@ -1,0 +1,155 @@
+import 'package:coding_adventures_lexer/lexer.dart';
+import 'package:coding_adventures_toml_lexer/toml_lexer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  List<String> meaningfulTypes(String source) => tokenizeToml(source)
+      .where((token) => token.type != 'NEWLINE' && token.type != 'EOF')
+      .map((token) => token.type)
+      .toList();
+
+  group('TOML strings', () {
+    test('strips matching basic and literal string delimiters', () {
+      expect(tokenizeToml('"hello"').first.value, 'hello');
+      expect(tokenizeToml("'hello'").first.value, 'hello');
+      expect(tokenizeToml(r'"hello\nworld"').first.value, r'hello\nworld');
+      expect(
+        tokenizeToml(r"'C:\Users\name'").first.value,
+        r'C:\Users\name',
+      );
+    });
+
+    test('strips triple delimiters and preserves multiline contents', () {
+      final basic = tokenizeToml('"""hello\nworld"""').first;
+      expect(basic.type, 'ML_BASIC_STRING');
+      expect(basic.value, 'hello\nworld');
+
+      final literal = tokenizeToml("'''hello\nworld'''").first;
+      expect(literal.type, 'ML_LITERAL_STRING');
+      expect(literal.value, 'hello\nworld');
+    });
+  });
+
+  group('TOML values', () {
+    test('tokenizes integer forms with aliases', () {
+      for (final source in [
+        '42',
+        '+42',
+        '-42',
+        '1_000',
+        '0xDEAD',
+        '0o755',
+        '0b1010'
+      ]) {
+        final token = tokenizeToml(source).first;
+        expect(token.type, 'INTEGER', reason: source);
+        expect(token.value, source, reason: source);
+      }
+    });
+
+    test('tokenizes float forms with aliases', () {
+      for (final source in [
+        '3.14',
+        '1e10',
+        '6.626e-34',
+        'inf',
+        '-inf',
+        'nan'
+      ]) {
+        final token = tokenizeToml(source).first;
+        expect(token.type, 'FLOAT', reason: source);
+        expect(token.value, source, reason: source);
+      }
+    });
+
+    test('recognizes booleans before bare keys', () {
+      expect(tokenizeToml('true').first.type, 'TRUE');
+      expect(tokenizeToml('false').first.type, 'FALSE');
+      expect(tokenizeToml('server-name').first.type, 'BARE_KEY');
+    });
+
+    test('recognizes date and time literals before numbers and keys', () {
+      final cases = {
+        '1979-05-27T07:32:00Z': 'OFFSET_DATETIME',
+        '1979-05-27T07:32:00+09:00': 'OFFSET_DATETIME',
+        '1979-05-27T07:32:00': 'LOCAL_DATETIME',
+        '1979-05-27': 'LOCAL_DATE',
+        '07:32:00': 'LOCAL_TIME',
+        '07:32:00.999': 'LOCAL_TIME',
+      };
+      for (final entry in cases.entries) {
+        expect(
+          tokenizeToml(entry.key).first.type,
+          entry.value,
+          reason: entry.key,
+        );
+      }
+    });
+  });
+
+  group('TOML documents', () {
+    test('tokenizes dotted keys, tables, arrays, and inline tables', () {
+      expect(
+        meaningfulTypes('a.b = [1, 2]'),
+        [
+          'BARE_KEY',
+          'DOT',
+          'BARE_KEY',
+          'EQUALS',
+          'LBRACKET',
+          'INTEGER',
+          'COMMA',
+          'INTEGER',
+          'RBRACKET'
+        ],
+      );
+      expect(
+        meaningfulTypes('[[products]]'),
+        ['LBRACKET', 'LBRACKET', 'BARE_KEY', 'RBRACKET', 'RBRACKET'],
+      );
+      expect(
+        meaningfulTypes('{ x = 1, y = 2 }'),
+        [
+          'LBRACE',
+          'BARE_KEY',
+          'EQUALS',
+          'INTEGER',
+          'COMMA',
+          'BARE_KEY',
+          'EQUALS',
+          'INTEGER',
+          'RBRACE'
+        ],
+      );
+    });
+
+    test('keeps newlines significant and skips comments', () {
+      final tokens = tokenizeToml('a = 1\n# comment\nb = 2');
+      expect(tokens.where((token) => token.type == 'NEWLINE'), hasLength(2));
+      expect(tokens.any((token) => token.type == 'COMMENT'), isFalse);
+      expect(
+        meaningfulTypes('a = 1\n# comment\nb = 2'),
+        ['BARE_KEY', 'EQUALS', 'INTEGER', 'BARE_KEY', 'EQUALS', 'INTEGER'],
+      );
+    });
+
+    test('tracks token positions across lines', () {
+      final tokens = tokenizeToml('a = 1\nb = 2');
+      final b = tokens.firstWhere(
+        (token) => token.type == 'BARE_KEY' && token.value == 'b',
+      );
+      expect(b.line, 2);
+      expect(b.column, 1);
+    });
+
+    test('returns only EOF for empty or ignored input', () {
+      expect(tokenizeToml('').map((token) => token.type), ['EOF']);
+      expect(
+          tokenizeToml('  \t # comment').map((token) => token.type), ['EOF']);
+    });
+
+    test('rejects characters outside the TOML token grammar', () {
+      expect(() => tokenizeToml('@'), throwsA(isA<LexerError>()));
+    });
+  });
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -108,7 +108,7 @@ The missing matrix is heavily concentrated in singleton packages:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 384 |
+| Present in 10-15 languages | 171 | 383 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 687 | 9,618 |
@@ -127,10 +127,10 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Ten package/language slots remain to turn 10 nearly complete packages into
+Nine package/language slots remain to turn 9 nearly complete packages into
 fully covered packages.
 
-### Dart: 7 remaining ports
+### Dart: 6 remaining ports
 
 - `algol-lexer`
 - `algol-parser`
@@ -138,10 +138,9 @@ fully covered packages.
 - `b-tree`
 - `mosaic-lexer`
 - `mosaic-parser`
-- `toml-lexer`
 
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
-`image-point-ops`, `logic-gates`, `image-geometric-transforms`.
+`image-point-ops`, `logic-gates`, `image-geometric-transforms`, `toml-lexer`.
 
 ### Haskell: complete
 
@@ -160,7 +159,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 384
+The 171 packages present in at least ten implementation languages need 383
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -175,7 +174,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Swift | 53 | Data structures and generated frontends before native app surfaces |
 | Java | 57 | Move with Kotlin |
 | Kotlin | 57 | Move with Java |
-| Dart | 113 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
+| Dart | 112 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
 
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.


### PR DESCRIPTION
## Summary

- add a pure-Dart `toml-lexer` package backed by the compiled canonical `toml.tokens` grammar
- extend the shared Dart grammar lexer to strip single, double, and triple delimiters from named string token types
- add TOML value, document, position, comment, and error conformance coverage
- refresh the package-parity roadmap from the live collision-gated inventory

## Why

`toml-lexer` was a Priority 1 14-of-15 gap. Dart already has the required pure-language `grammar-tools` and `lexer` dependencies, so this closes the slot without runtime grammar-file access or a platform wrapper.

## Impact

TOML tokenization is now available in all 15 established implementation lanes. The live high-consensus gap count falls from 384 to 383, and Dart's high-consensus gap count falls from 113 to 112.

## Validation

- Dart lexer: format check on changed files, `dart analyze`, 14 tests
- Dart TOML lexer: `dart format --output=none --set-exit-if-changed .`, `dart analyze`, 11 tests
- Dart JSON lexer: `dart analyze`, 5 tests
- Dart JSON parser: `dart analyze`, 5 tests
- `package_parity_report.py` JSON and Markdown with `--fail-on-collisions`
- `git diff --check`