### PR TITLE
feat(j): j-runtime + j-repl + j binary (MA06 §6, MA-6d)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -250,6 +250,8 @@ members = [
     "apl-to-semantic-ir",
     "j-lexer",
     "j-parser",
+    "j-runtime",
+    "j-repl",
     "logic-gates",
     "logic-core",
     "lookup-core",

--- a/code/packages/rust/j-repl/BUILD
+++ b/code/packages/rust/j-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-repl -- --nocapture

--- a/code/packages/rust/j-repl/BUILD_windows
+++ b/code/packages/rust/j-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-repl -- --nocapture

--- a/code/packages/rust/j-repl/CHANGELOG.md
+++ b/code/packages/rust/j-repl/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial release — the interactive REPL and the **`j` binary** (item
+  MA-6d), a sibling of `apl-repl`/`matlab-repl`/`s-repl`/`r-repl` over the
+  `j-runtime` interpreter.
+- `JRepl` with a persistent workspace, `>> `/`... ` prompts, and `quit`/
+  `exit`/EOF handling; `run()` drives a full stdio session.
+- **Line continuation across an open `(`** — the only grouping construct in
+  this language cut (no block keywords, no string type). Continuation lines
+  are joined with a space rather than a real newline, since `j.tokens` does
+  not drop newlines inside `(...)` in this first cut — mirrors `apl-repl`'s
+  own identical scanner design.
+- `NB.` line comments need zero REPL-level handling — they're stripped
+  entirely at the lexer's skip-pattern level, exactly like APL's `⍝`.
+- Errors are surfaced (`Error: …`) without ending the session.
+- `MAX_CONTINUATION_BUFFER` (64 KiB) caps the pending-continuation buffer
+  while a `(` is still unbalanced, discarding it with a clean error rather
+  than growing without bound — ported forward from `apl-repl`'s own
+  already-security-reviewed guard (same rationale: low severity under this
+  crate's stdio-only threat model, kept anyway for defense in depth).

--- a/code/packages/rust/j-repl/Cargo.toml
+++ b/code/packages/rust/j-repl/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-j-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `j` binary for the J language"
+
+[dependencies]
+coding-adventures-j-runtime = { path = "../j-runtime" }
+
+[[bin]]
+name = "j"
+path = "src/main.rs"

--- a/code/packages/rust/j-repl/README.md
+++ b/code/packages/rust/j-repl/README.md
@@ -1,0 +1,40 @@
+# J REPL
+
+The interactive REPL and the **`j` binary** for the J language. Wraps a
+persistent [`j-runtime`](../j-runtime) `Interpreter` and adds console
+behaviours. Item **MA-6d**; sibling of `apl-repl`/`matlab-repl`/`s-repl`/
+`r-repl`.
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-j-repl --bin j
+```
+
+```
+J (on array-runtime) — type quit to exit.
+>> A=.2 3$1 2 3 4 5 6
+>> A
+1 2 3
+4 5 6
+>> +/A
+6 15
+>> i.5
+0 1 2 3 4
+>> 2*3+4
+14
+>> quit
+```
+
+Lines **continue** across an open `(` (the `... ` prompt) — J has no block
+keywords and no string literal type, so (exactly like `apl-repl`'s own
+scanner) this one reduces to plain paren-balance tracking. `NB.` comments
+need no REPL-level handling at all — they're stripped entirely by the
+lexer's skip pattern before this crate ever sees a token. `quit`/`exit` (or
+Ctrl-D) leaves. Errors are shown, not fatal — the session continues.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-j-repl
+```

--- a/code/packages/rust/j-repl/required_capabilities.json
+++ b/code/packages/rust/j-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/j-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `j` binary reads J source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/j-repl/src/lib.rs
+++ b/code/packages/rust/j-repl/src/lib.rs
@@ -1,0 +1,257 @@
+//! # J REPL — an interactive Read-Eval-Print loop for J.
+//!
+//! [`JRepl`] wraps a persistent [`Interpreter`] and adds the interactive
+//! behaviours a console needs: line continuation across an open `(`, and
+//! echoing of auto-printed results. It is the sibling of `apl-repl`/
+//! `matlab-repl`/`s-repl`/`r-repl`; only the interpreter (and the
+//! continuation scanner) differ. See `code/specs/MA06-j-language.md`.
+//!
+//! ## Why this scanner is so much simpler than MATLAB's
+//!
+//! Exactly like `apl-repl::is_incomplete`'s own rationale (which this crate
+//! otherwise mirrors nearly verbatim): J (this language cut, MA06 §4) has no
+//! control flow, no user-defined verbs/blocks, and no string/char literal
+//! type at all (`j.tokens` has no `STRING` token). Re-reading `j.grammar`:
+//! the only grouping construct is `LPAREN noun_expr RPAREN` /
+//! `LPAREN verb_train RPAREN`, so an unbalanced `(` is the *only* way a
+//! statement can still be "in progress" — this scanner reduces to plain
+//! paren-balance tracking, identical in shape to `apl-repl`'s own.
+//!
+//! ## Why continuation lines are joined with a space, not a real newline
+//!
+//! `j.tokens`' own SECTION 5 doc comment notes this first cut does **not**
+//! drop newlines inside `(...)` — every parenthesised expression must stay
+//! on one physical line, the same simplification `apl.tokens` makes. So
+//! while a `(` is still open, joining physical lines with a literal `'\n'`
+//! would hand the parser a genuinely broken program (a `NEWLINE` token
+//! where `noun_expr`/`verb_train` expects a continuation or `)`). Joining
+//! with a single space instead keeps the accumulated source syntactically
+//! one logical line — exactly as if the user had typed it all without
+//! pressing Enter.
+//!
+//! ## `NB.` comments need no REPL-level handling at all
+//!
+//! Unlike a hypothetical language whose comments interact with line
+//! structure, `NB.` is stripped entirely at the lexer's skip-pattern level
+//! (`j.tokens` SECTION 5) — exactly like APL's `⍝`. This scanner therefore
+//! needs zero special-casing for comments, mirroring `apl-repl`'s own
+//! identical non-handling of `⍝`.
+//!
+//! Hand-rolled rather than built on the generic `repl` crate, mirroring
+//! `apl-repl`'s own rationale: the interpreter is single-threaded, and a
+//! console session is sequential anyway.
+
+use coding_adventures_j_runtime::Interpreter;
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// Text to display (may be empty — e.g. after a silent assignment).
+    Output(String),
+    /// The current statement is incomplete; read another line (`... ` prompt).
+    NeedMore,
+    /// End the session.
+    Quit,
+}
+
+/// Upper bound on the pending-continuation buffer (while a `(` is still
+/// unbalanced). Without this, a source that never closes its parens grows
+/// `buffer` without bound before anything is ever parsed — low severity for
+/// a human typing at a terminal, but a real memory-exhaustion vector if this
+/// REPL is ever driven by a network-facing or otherwise less-trusted line
+/// source. 64 KiB is far more than any legitimate hand-written J statement
+/// needs, mirroring `apl-repl::MAX_CONTINUATION_BUFFER`'s identical
+/// "generous but bounded" convention.
+const MAX_CONTINUATION_BUFFER: usize = 64 * 1024;
+
+/// A persistent interactive J session.
+pub struct JRepl {
+    interp: Interpreter,
+    buffer: String,
+}
+
+impl Default for JRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JRepl {
+    pub fn new() -> Self {
+        JRepl {
+            interp: Interpreter::new(),
+            buffer: String::new(),
+        }
+    }
+
+    /// `>> ` for a fresh statement, `... ` while continuing an incomplete one
+    /// (an open `(`).
+    pub fn prompt(&self) -> &'static str {
+        if self.buffer.is_empty() {
+            ">> "
+        } else {
+            "... "
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "quit" | "exit" | "quit()" | "exit()" => return ReplResponse::Quit,
+                _ => {}
+            }
+            self.buffer.push_str(line);
+        } else {
+            // See this module's doc comment: joining with a space (not a
+            // real '\n') keeps a still-open `(...)` on one logical line.
+            self.buffer.push(' ');
+            self.buffer.push_str(line);
+        }
+
+        if self.buffer.len() > MAX_CONTINUATION_BUFFER {
+            self.buffer.clear();
+            return ReplResponse::Output(format!(
+                "Error: statement exceeds the {MAX_CONTINUATION_BUFFER}-byte continuation limit; discarded\n"
+            ));
+        }
+
+        if paren_depth(&self.buffer) > 0 {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        // `j.grammar`'s `line = statement NEWLINE | statement | NEWLINE`
+        // accepts a bare `statement` with no trailing NEWLINE, but adding
+        // one keeps every call site consistent (and matches every fixture
+        // in `j-parser`'s own test suite).
+        match self.interp.feed(&format!("{src}\n")) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Count of unbalanced `(` in `src` (never negative — a stray `)` with no
+/// matching `(` does not make the statement "more open"; it is left for the
+/// parser to report as its own clean syntax error).
+fn paren_depth(src: &str) -> i32 {
+    let mut depth: i32 = 0;
+    for ch in src.chars() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = (depth - 1).max(0),
+            _ => {}
+        }
+    }
+    depth
+}
+
+/// Drive a full interactive J session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = JRepl::new();
+    writeln!(writer, "J (on array-runtime) — type quit to exit.")?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            writeln!(writer)?;
+            break;
+        }
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_expression_prints_assignment_is_silent() {
+        let mut r = JRepl::new();
+        assert!(matches!(r.feed("2+2"), ReplResponse::Output(t) if t.contains('4')));
+        assert_eq!(r.feed("A=.5"), ReplResponse::Output(String::new()));
+    }
+
+    #[test]
+    fn continues_across_an_open_paren() {
+        let mut r = JRepl::new();
+        assert_eq!(r.feed("(1+2"), ReplResponse::NeedMore);
+        assert!(r.is_continuing());
+        assert!(matches!(r.feed("+3)"), ReplResponse::Output(t) if t.contains('6')));
+        assert!(!r.is_continuing());
+    }
+
+    #[test]
+    fn an_unbounded_continuation_is_discarded_not_grown_forever() {
+        let mut r = JRepl::new();
+        assert_eq!(r.feed("(1"), ReplResponse::NeedMore);
+        let filler = "+1".repeat(MAX_CONTINUATION_BUFFER / 2 + 10);
+        match r.feed(&filler) {
+            ReplResponse::Output(t) => assert!(t.contains("Error")),
+            other => panic!("expected an Error output once the cap is exceeded, got {other:?}"),
+        }
+        assert!(!r.is_continuing());
+        assert!(matches!(r.feed("1+1"), ReplResponse::Output(t) if t.contains('2')));
+    }
+
+    #[test]
+    fn quit_commands() {
+        assert_eq!(JRepl::new().feed("quit"), ReplResponse::Quit);
+        assert_eq!(JRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn errors_are_shown_not_fatal() {
+        let mut r = JRepl::new();
+        assert!(matches!(r.feed("undefined_var"), ReplResponse::Output(t) if t.contains("Error")));
+        // The session keeps going.
+        assert!(matches!(r.feed("1+1"), ReplResponse::Output(t) if t.contains('2')));
+    }
+
+    #[test]
+    fn session_persists_across_lines() {
+        let mut r = JRepl::new();
+        r.feed("A=.10");
+        assert!(matches!(r.feed("A+5"), ReplResponse::Output(t) if t.contains("15")));
+    }
+
+    #[test]
+    fn zero_based_iota_survives_a_real_repl_session() {
+        // The single most safety-critical regression, exercised through the
+        // REPL surface too, not just `j-runtime`'s own unit tests.
+        let mut r = JRepl::new();
+        assert!(matches!(r.feed("i.5"), ReplResponse::Output(t) if t.trim() == "0 1 2 3 4"));
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = "A=.3\nA*2\nquit\n".as_bytes();
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('6'));
+    }
+}

--- a/code/packages/rust/j-repl/src/main.rs
+++ b/code/packages/rust/j-repl/src/main.rs
@@ -1,0 +1,17 @@
+//! The `j` binary — an interactive prompt for the J language.
+//!
+//! Reads one line at a time (continuing across an open `(`), evaluates over
+//! `array-runtime`, and prints the auto-printed result. Type `quit` / `exit`
+//! (or send EOF with Ctrl-D) to leave. All logic lives in
+//! [`coding_adventures_j_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_j_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("j: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/j-runtime/BUILD
+++ b/code/packages/rust/j-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-runtime -- --nocapture

--- a/code/packages/rust/j-runtime/BUILD_windows
+++ b/code/packages/rust/j-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-j-runtime -- --nocapture

--- a/code/packages/rust/j-runtime/CHANGELOG.md
+++ b/code/packages/rust/j-runtime/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial release — **MA-6d** of the J frontend: a tree-walking evaluator
+  over `array-runtime` (spec [`MA06`](../../../specs/MA06-j-language.md)).
+- `Interpreter` (persistent workspace) + `feed`/`eval` entry points. Auto-print
+  semantics: an assignment is silent, a bare `noun_expr` result auto-prints
+  (mirrors `apl-runtime`'s own real-session convention).
+- Right-to-left evaluation with no precedence cascade, reused directly from
+  APL's own grammar shape (MA06 §3) — no precedence climbing anywhere in
+  this crate.
+- All 12 `BinOp`-mappable primitive verbs (`+ - * % <. >. = ~: < > <: >:`),
+  each with its documented monadic meaning where one exists (conjugate,
+  negate, sign, reciprocal, floor, ceiling — the six comparisons have no
+  monadic form, a clean error) and its dyadic `ops::elementwise` meaning.
+  `<.`/`>.` map onto the same `Min`/`Max` `BinOp` variants APL's own
+  `⌊`/`⌈` already use — same underlying behavior, different ASCII digraph
+  spelling (MA06 §4).
+- `$`/`i.`/`,` — bespoke monadic+dyadic primitives (shape/reshape,
+  index-generator/index-of, ravel/catenate), re-derived fresh in this
+  crate's own `builtins.rs` (the APL originals are private to
+  `apl-runtime`) but kept behaviorally consistent across the two
+  frontends — **except** `i.`, which is deliberately **0-based**
+  (`i.5 == 0 1 2 3 4`), unlike APL's 1-based `⍳5`. Dyadic `i.`'s
+  not-found sentinel is `i.`'s own tally (`a.len()`), not APL's
+  `len() + 1`.
+- `#` (tally/replicate) and `^` (exponential/power) — two genuinely new
+  primitives with no APL precedent at all. `^` is implemented entirely
+  locally (no new `array_runtime::ops::BinOp` variant, per MA06 §2's
+  explicit "no new substrate needed" scope) via a small `elementwise_pow`
+  helper mirroring `ops::elementwise`'s exact broadcast-rule structure.
+  Dyadic `#` is scoped to a rank ≤ 1 right operand (a documented,
+  disclosed simplification, mirroring `array_runtime::ops::outer`'s own
+  rank-limiting convention); a rank-2 right operand is a clean error.
+- `/` (reduce), `\` (scan) lowered onto `array_runtime::ops::{reduce, scan}`
+  — inherently monadic derived verbs; applying one dyadically, or stacking
+  an adverb onto `$`/`i.`/`,`/`#`/`^`, is a clean scope error.
+- `@` (compose/"atop") — J's one in-scope conjunction. Monadic formula
+  (`f (g y)`) is MA06 §4's own; the dyadic formula (`f (x g y)`) is this
+  crate's own considered generalization, disclosed in `eval.rs`'s doc
+  comments, matching real J's standard atop semantics.
+- **Trains — the one genuinely new evaluation shape, with no APL
+  precedent.** `JFn` grows `Compose`/`Hook`/`Fork` variants beyond
+  `apl-runtime::eval::AplFn`'s shape (per MA06 §5's own explicit
+  instruction to generalize it). Hook (`(f g)`) and fork (`(f g h)`,
+  including the leading-noun case `(n g h)`) evaluate per MA06 §3's exact
+  formulas; a 4+-tooth train folds via `fold_train`'s peel-from-the-left
+  recursion (`(a b c d) = Hook(a, Fork(b, c, d))`), following this spec's
+  own corrected folding rule (an earlier draft of MA06 §3 described the
+  recursion in the opposite, incorrect direction — already fixed in the
+  spec before this crate was implemented).
+- J-style display (`value.rs`): a leading underscore `_` for negatives
+  (never ASCII `-`, which is reserved for the `MINUS` verb token, and
+  never APL's high-minus `¯`, which has no ASCII spelling), no trailing
+  `.0` on whole-valued floats, no name/`ans =` prefix, space-separated
+  vectors, right-aligned matrix rows.
+- DoS guards: an independent recursion-depth guard in the evaluator
+  (exercised not just by the noun-expression walk, like APL's own guard,
+  but also by `apply_monadic`/`apply_dyadic` themselves, since
+  `Compose`/`Hook`/`Fork` recurse back through those two functions — a
+  genuinely new recursion shape APL's evaluator never needed to guard), and
+  a `MAX_ARRAY_LENGTH` (1,000,000) cap on every primitive whose output size
+  or work is driven by runtime-computed values — monadic `i.n`, dyadic
+  `$`'s target element count, dyadic `,`'s combined output length, dyadic
+  `i.`'s `len(a)×len(b)` work, and dyadic `#`'s total replicated output
+  length — every one checked *before* allocating or scanning, mirroring
+  `apl-runtime`'s own already-security-reviewed guard set (ported forward
+  rather than re-discovered from scratch).
+
+### Notes
+
+- A direct white-box unit test of the depth-guard mechanism itself
+  (`eval.rs`'s `depth_guard_trips_after_max_depth_and_recovers`) was added
+  beyond `apl-runtime`'s own test suite (which has no such test at all) —
+  `j-parser`'s `MAX_RULE_DEPTH` (70) bounds any real parsed tree far below
+  this evaluator's own `MAX_DEPTH` (512), so a realistic `feed()` call can
+  never actually trip the guard; a direct `enter()`/`DepthGuard` test is the
+  only way to exercise it at all. Disclosed here since it is a small,
+  deliberate addition beyond the literal `apl-runtime` mirror the rest of
+  this crate otherwise follows closely.

--- a/code/packages/rust/j-runtime/Cargo.toml
+++ b/code/packages/rust/j-runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-j-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Tree-walking evaluator for the J language over array-runtime"
+
+[dependencies]
+coding-adventures-j-parser = { path = "../j-parser" }
+array-runtime = { package = "coding-adventures-array-runtime", path = "../array-runtime" }
+parser = { path = "../parser" }

--- a/code/packages/rust/j-runtime/README.md
+++ b/code/packages/rust/j-runtime/README.md
@@ -1,0 +1,119 @@
+# J Runtime
+
+A tree-walking evaluator for [J](https://en.wikipedia.org/wiki/J_(programming_language)),
+over [`array-runtime`](../array-runtime). Item **MA-6d** of the J frontend
+(spec [`MA06`](../../../specs/MA06-j-language.md)): the piece that makes the
+J lexer/parser (`j-lexer`/`j-parser`) executable.
+
+## Why J needed its own runtime, not a reused one
+
+J is APL's direct successor (MA06 §1) and reuses APL's own grammar shape
+almost verbatim (MA06 §3) — but three properties have no APL precedent at
+all:
+
+1. **Trains.** Two or more verbs (or a leading noun) written consecutively,
+   with no operands between them, form a brand-new derived verb: a **hook**
+   (exactly 2 teeth) or a **fork** (3+ teeth, folding right-to-left). `(+ *)`
+   is a hook; `(+ * -)` is a fork; `(+ - * %)` folds as `(+ (- * %))`. This
+   is the one genuinely new grammar/runtime problem MA06 fixes — no existing
+   frontend in this repo has a "juxtaposed-verbs-form-a-new-verb" production.
+2. **0-based indexing.** `i.5` is `0 1 2 3 4`, never APL's 1-based
+   `1 2 3 4 5` — the single most safety-critical numeric difference from
+   APL's own `⍳`.
+3. **`/` is never division.** J needs `/` for the reduce adverb (mirroring
+   APL's own `/`), so division is spelled `%` instead — the single most
+   common APL→J transliteration mistake.
+
+```rust
+use coding_adventures_j_runtime::eval;
+
+// i. is 0-based -- the signature difference from APL's ⍳.
+assert_eq!(eval("i.5\n").unwrap().trim(), "0 1 2 3 4");
+
+// / is reduce, never division -- % is divide.
+assert_eq!(eval("+/1 2 3 4\n").unwrap().trim(), "10");
+assert_eq!(eval("6%2\n").unwrap().trim(), "3");
+
+// Assignment is silent; a bare expression auto-prints.
+assert_eq!(eval("A=.5\n").unwrap(), "");
+assert_eq!(eval("A=.5\nA\n").unwrap().trim(), "5");
+```
+
+## What it evaluates
+
+- **Arrays only** (MA06 §4): dense, rectangular, numeric. A scalar is a
+  rank-0 array. No control flow, no user-defined verbs, no strings, no
+  boxing.
+- **Primitive verbs** (monadic / dyadic meaning): `+` (conjugate / add), `-`
+  (negate / subtract), `*` (sign / multiply), `%` (reciprocal / divide), `^`
+  (exponential / power), `<.`/`>.` (floor·ceiling / min·max — note the
+  digraph spelling is the *opposite* character from APL's `⌊`/`⌈`, since `<`
+  already means "less than"; the underlying min/max meaning is identical to
+  APL's own mapping), `$` (shape / reshape), `i.` (index generator,
+  **0-based** / index-of), `,` (ravel / catenate), `#` (tally / replicate —
+  new relative to this repo's APL cut, which never had a tally primitive),
+  `=` `~:` `<` `>` `<:` `>:` (dyadic-only comparison, `1`/`0` result).
+- **Adverbs**: `/` (reduce), `\` (scan) — lowered onto
+  `array_runtime::ops::{reduce, scan}` (item **AR-2**), same as APL.
+- **One conjunction**: `@` (compose/"atop" — `(f@g) y = f (g y)`).
+- **Trains**: hooks and forks, parenthesised only (`(f g)`, `(f g h)`, ...),
+  including the leading-noun fork case (`(5 * -)`) and the 4+-tooth
+  peel-from-the-left folding rule.
+- **Assignment** `=.` (local) / `=:` (global) — identical behavior in this
+  cut (right-associative chaining: `A=.B=.3` sets both) — and parenthesised
+  grouping `( )`.
+- **Comments** `NB.` and blank lines (both no-ops; stripped by the lexer).
+
+### Deferred (documented, MA06 §4)
+
+Boxing and nested/ragged arrays, the `"` rank conjunction and axis-specific
+reduce/scan, user-defined explicit verbs and named tacit definitions
+(only inline parenthesised trains are in scope), the `¨` each-equivalent,
+complex numbers, unparenthesised top-level trains (this cut requires
+parentheses to avoid a genuine grammar ambiguity). Dyadic `$` (reshape) and
+`,` (catenate) are additionally scoped to rank ≤ 2; dyadic `#` (replicate) is
+scoped to a rank ≤ 1 right operand.
+
+## Trains: the one genuinely new evaluation shape
+
+`JFn` (this crate's runtime function representation, generalizing
+`apl-runtime::eval::AplFn` per MA06 §5) grows three variants beyond APL's
+`Atom`/`NonScalar`/`Reduce`/`Scan`:
+
+- **`Compose(f, g)`** (`@`, atop): monadic `f (g y)`; dyadic
+  `f (x g y)` (this crate's own considered generalization of "atop" to the
+  dyadic case — MA06 only spells out the monadic formula).
+- **`Hook(f, g)`**: monadic `(f g) y = y f (g y)`; dyadic
+  `x (f g) y = x f (g y)` — `g` *always* applies monadically to `y` alone,
+  regardless of the surrounding call's arity. This is the hook's defining
+  property, not a bug.
+- **`Fork(left, g, h)`**: monadic `(f g h) y = (f y) g (h y)`; dyadic
+  `x (f g h) y = (x f y) g (x h y)`. When `left` is a captured literal noun
+  `n` instead of a verb: monadic `n g (h y)`; dyadic `n g (x h y)` (the noun
+  never depends on `x`/`y` since it isn't "applied" — only `h` picks up the
+  surrounding call's arity).
+
+A 4+-tooth train folds by peeling the leftmost tooth off and recursing on
+the rest — `(a b c d)` is `Hook(a, Fork(b, c, d))` — per MA06 §3's corrected
+folding rule.
+
+## DoS guards
+
+- An independent recursion-depth guard in the evaluator (`eval.rs::MAX_DEPTH`)
+  — defense in depth on top of `j-parser`'s own `MAX_RULE_DEPTH` (70), which
+  already bounds how deep an untrusted-input CST can be before it ever
+  reaches this crate. Unlike APL, this guard is also exercised by
+  `apply_monadic`/`apply_dyadic` themselves, since `Compose`/`Hook`/`Fork`
+  recurse back through those two functions — a genuinely new recursion
+  shape APL's own evaluator never had.
+- `builtins::MAX_ARRAY_LENGTH` (1,000,000) bounds every primitive whose
+  output size or work scales with runtime-computed values — monadic `i.n`,
+  dyadic `$`'s target element count, dyadic `,`'s combined output length,
+  dyadic `i.`'s `len(a)×len(b)` work, and dyadic `#`'s total replicated
+  output length — each checked *before* allocating or scanning.
+
+## Testing
+
+```sh
+cargo test -p coding-adventures-j-runtime
+```

--- a/code/packages/rust/j-runtime/required_capabilities.json
+++ b/code/packages/rust/j-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/j-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: a tree-walking evaluator over the in-memory array-runtime value model. No filesystem, network, or process access (the REPL crate owns stdio)."
+}

--- a/code/packages/rust/j-runtime/src/builtins.rs
+++ b/code/packages/rust/j-runtime/src/builtins.rs
@@ -1,0 +1,716 @@
+//! `$` (shape/reshape), `i.` (index-generator/index-of), `,`
+//! (ravel/catenate), `#` (tally/replicate), and `^` (exponential/power) — J's
+//! five "bespoke" primitives (MA06 §4).
+//!
+//! Every other primitive verb (`+ - * % <. >. = ~: < > <: >:`) shares *one*
+//! shape: a monadic and a dyadic meaning that both boil down to
+//! `array_runtime::ops::BinOp` — see `eval.rs`'s `apply_monadic_scalar` /
+//! `JFn::Atom`. These five do not fit that mould at all (each one's monadic
+//! and dyadic meanings are unrelated to each other, and none is "an
+//! elementwise scalar function"), so they get their own hand-rolled
+//! implementations here — mirroring `apl-runtime::builtins`'s own `⍴`/`⍳`/`,`
+//! (which are private to that crate and thus re-derived fresh here, not
+//! reused), plus two genuinely new primitives (`#`, `^`) that have no APL
+//! precedent at all.
+
+use array_runtime::Array;
+
+/// Upper bound on any array this crate allocates from a **runtime-computed**
+/// size, or any work whose cost scales with a runtime-computed value —
+/// monadic `i.n`'s `n`, dyadic `$`'s target element count, dyadic `,`'s
+/// combined output length, dyadic `i.`'s `len(a)×len(b)` work, and dyadic
+/// `#`'s total replicated-output length — checked *before* allocating or
+/// scanning, so a crafted `i.2000000` is a clean `Err` instead of a
+/// 2-million-element allocation. Same value, and the same "check before the
+/// expensive work" discipline, as `apl-runtime::builtins::MAX_ARRAY_LENGTH`
+/// (this repo's established cap for a user-controlled array length/work
+/// product).
+pub const MAX_ARRAY_LENGTH: usize = 1_000_000;
+
+// ── $ shape / reshape ───────────────────────────────────────────────────────
+
+/// Monadic `$` (shape-of): a scalar has **zero** dimensions, so its shape is
+/// the *empty* vector (not a scalar!) — `$5` is `i.0`-shaped, a length-0
+/// vector, exactly mirroring `Array::shape() == []` for a rank-0 value. A
+/// vector `[n]` has shape `[n]` (a 1-element vector); a matrix `[r, c]` has
+/// shape `[r, c]` (a 2-element vector).
+pub fn shape(a: &Array) -> Array {
+    let dims: Vec<f64> = a.shape().iter().map(|&d| d as f64).collect();
+    Array::from_vec(dims)
+}
+
+/// Dyadic `$` (reshape): `a` is the new shape — a scalar or vector (rank ≤ 1)
+/// of non-negative integers, itself capped at rank ≤ 2 (this crate's, and
+/// `array_runtime::ops`'s, established ceiling; a longer shape is a clean
+/// "not yet supported" error, the same honest-subset convention MA06 §4 uses
+/// throughout). `b`'s elements are ravelled (see [`ravel`]) and then
+/// cyclically repeated or truncated to fill the target shape's element
+/// count — real J reshape semantics (a deliberate, natural design choice,
+/// not an arbitrary invention: `2 3 $ 1 2` cycles `1 2` to `1 2 1 / 2 1 2`
+/// in a real J session exactly as it does here).
+pub fn reshape(a: &Array, b: &Array) -> Result<Array, String> {
+    let dims = shape_vector(a)?;
+    if dims.len() > 2 {
+        return Err(format!(
+            "$: reshape to rank > 2 is not yet supported (target shape {dims:?})"
+        ));
+    }
+    // Checked multiplication: a crafted shape whose product overflows usize
+    // must not wrap into a small count that spuriously slips past the cap
+    // below (mirrors `array_runtime::value::Array::from_shape`'s own guard).
+    let total: usize = dims
+        .iter()
+        .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+        .ok_or_else(|| format!("$: shape {dims:?} element count overflows usize"))?;
+    if total > MAX_ARRAY_LENGTH {
+        return Err(format!(
+            "$: reshape target of {total} elements exceeds the cap of {MAX_ARRAY_LENGTH}"
+        ));
+    }
+    let source = flatten(b);
+    if total > 0 && source.is_empty() {
+        return Err("$: cannot reshape an empty source into a non-empty shape".to_string());
+    }
+    // The cyclic fill is in ROW-MAJOR order (reshape fills the *last* axis
+    // fastest, same convention as ravel) -- `filled[k]` is the value at
+    // logical row-major position `k`.
+    // Safe: `total > 0` implies `source` is non-empty (checked above), and
+    // when `total == 0` the range below is empty so the closure never runs.
+    let filled: Vec<f64> = (0..total).map(|k| source[k % source.len()]).collect();
+    match dims.as_slice() {
+        // Rank ≤ 1: row-major and column-major coincide, so the fill is
+        // already in the right order for `Array::from_shape` (which expects
+        // column-major data).
+        [] | [_] => Array::from_shape(filled, dims),
+        // Rank 2: `Array::from_shape` expects COLUMN-major data
+        // (`value.rs`: element `(r, c)` lives at `c * nrows + r`), so the
+        // row-major `filled` sequence must be transposed into that layout —
+        // handing `filled` straight to `from_shape` would silently reshape
+        // column-major instead of the row-major convention documented above.
+        [r, c] => {
+            let mut data = vec![0.0; total];
+            for row in 0..*r {
+                for col in 0..*c {
+                    data[col * r + row] = filled[row * c + col];
+                }
+            }
+            Array::from_shape(data, dims)
+        }
+        _ => unreachable!("dims.len() > 2 was already rejected above"),
+    }
+}
+
+/// Read dyadic `$`'s left argument: a scalar (treated as a 1-element shape)
+/// or a vector of non-negative integers. Anything of rank > 1 is rejected
+/// up front (a matrix cannot itself describe a shape).
+fn shape_vector(a: &Array) -> Result<Vec<usize>, String> {
+    if a.ndims() > 1 {
+        return Err(format!(
+            "$: shape argument must be a scalar or vector (got rank {})",
+            a.ndims()
+        ));
+    }
+    a.data()
+        .iter()
+        .map(|&x| {
+            if x < 0.0 || x.fract() != 0.0 {
+                Err(format!(
+                    "$: shape elements must be non-negative integers, got {x}"
+                ))
+            } else {
+                Ok(x as usize)
+            }
+        })
+        .collect()
+}
+
+// ── i. index-generator / index-of ───────────────────────────────────────────
+
+/// Monadic `i.` (index generator): `i.n` is the **0-based** vector
+/// `[0, 1, …, n-1]`. Deliberately 0-based, unlike APL's `⍳n` (`[1, …, n]`,
+/// see `apl-runtime::builtins::index_generator`) — MA06 §1 bullet 3 calls
+/// this out as the single most safety-critical numeric difference between
+/// the two frontends: `i.5` must be `0 1 2 3 4`, never `1 2 3 4 5`. `n` must
+/// be a non-negative-integer-valued scalar; the result length is capped at
+/// [`MAX_ARRAY_LENGTH`] *before* allocating.
+pub fn index_generator(a: &Array) -> Result<Array, String> {
+    if !a.is_scalar() {
+        return Err("i.: monadic argument must be a scalar".to_string());
+    }
+    let x = a.data()[0];
+    if x < 0.0 || x.fract() != 0.0 {
+        return Err(format!(
+            "i.: monadic argument must be a non-negative integer, got {x}"
+        ));
+    }
+    let n = x as usize;
+    if n > MAX_ARRAY_LENGTH {
+        return Err(format!(
+            "i.: {n} exceeds the cap of {MAX_ARRAY_LENGTH} elements"
+        ));
+    }
+    Ok(Array::from_vec((0..n).map(|i| i as f64).collect()))
+}
+
+/// Dyadic `i.` (index-of): for every element of `b`, the **0-based** index
+/// of its first occurrence in the vector `a` (plain `f64` equality — no
+/// floating-point tolerance, matching every other comparison in this
+/// crate), or `a`'s own tally (`a.len()`) if it does not occur at all — real
+/// J's actual not-found convention, distinct from APL's `len() + 1` 1-based
+/// sentinel (`apl-runtime::builtins::index_of`). The result has `b`'s shape.
+pub fn index_of(a: &Array, b: &Array) -> Result<Array, String> {
+    if a.ndims() > 1 {
+        return Err(format!(
+            "i.: left argument must be a scalar or vector (got rank {})",
+            a.ndims()
+        ));
+    }
+    // Each of `a`/`b` can independently reach MAX_ARRAY_LENGTH, but the work
+    // done here is O(len(a) * len(b)) (a full linear scan of `a` per element
+    // of `b`) -- capping each operand's *length* alone still permits up to
+    // 10^12 comparisons. Cap the *product* before doing any scanning, the
+    // same "check before the expensive work, not after" discipline as the
+    // allocation caps elsewhere in this crate.
+    match a.len().checked_mul(b.len()) {
+        Some(work) if work <= MAX_ARRAY_LENGTH => {}
+        _ => {
+            return Err(format!(
+                "i.: index-of over {} × {} elements exceeds the cap of {} comparisons",
+                a.len(),
+                b.len(),
+                MAX_ARRAY_LENGTH
+            ));
+        }
+    }
+    let haystack = a.data();
+    let out: Vec<f64> = b
+        .data()
+        .iter()
+        .map(|&needle| {
+            haystack
+                .iter()
+                .position(|&x| x == needle)
+                .map(|i| i as f64) // 0-based -- no "+ 1" here (see doc comment)
+                .unwrap_or(haystack.len() as f64) // not found -> a's tally
+        })
+        .collect();
+    Array::from_shape(out, b.shape().to_vec())
+}
+
+// ── , ravel / catenate ──────────────────────────────────────────────────────
+
+/// Flatten any (rank ≤ 2, this crate's ceiling) array to **row-major**
+/// order — last axis varies fastest. `Array` itself stores data
+/// **column**-major (`array-runtime`'s own `value.rs` doc comment: element
+/// `(r, c)` lives at `c * nrows + r`), so a matrix must be walked "row, then
+/// column" to produce true row-major ravel order — simply returning the raw
+/// backing buffer would silently give *column*-major order instead. This
+/// mirrors `apl-runtime::builtins::flatten`'s exact convention, kept
+/// consistent across the two array-language frontends deliberately (MA06 §2:
+/// same substrate, same `array-runtime`, so the same ravel order is the
+/// natural choice rather than an arbitrary one).
+fn flatten(a: &Array) -> Vec<f64> {
+    match *a.shape() {
+        [] | [_] => a.data().to_vec(),
+        [r, c] => {
+            let mut out = Vec::with_capacity(r * c);
+            for row in 0..r {
+                for col in 0..c {
+                    out.push(a.get(row, col).expect("row/col in bounds"));
+                }
+            }
+            out
+        }
+        // Unreachable in practice: every value this evaluator can construct
+        // stays at rank ≤ 2. Falling back to the raw buffer keeps this total
+        // rather than panicking if that ever changes.
+        _ => a.data().to_vec(),
+    }
+}
+
+/// Monadic `,` (ravel): flatten `a` to a 1-D vector in row-major order.
+pub fn ravel(a: &Array) -> Array {
+    Array::from_vec(flatten(a))
+}
+
+/// Dyadic `,` (catenate): supports scalar⋅scalar, scalar⋅vector,
+/// vector⋅scalar, vector⋅vector (all producing a vector), and
+/// matrix⋅matrix-with-equal-row-counts (horizontal/last-axis catenate,
+/// producing `[r, c1 + c2]`) — mirroring
+/// `apl-runtime::builtins::catenate`'s exact shape rules (that function is
+/// private to `apl-runtime`, so this is re-derived fresh here, not reused,
+/// but kept behaviourally identical for consistency across the two
+/// frontends). Any other rank combination — mismatched-row matrices, or a
+/// matrix paired with a scalar/vector — is a clean "not yet supported"
+/// error: an honestly disclosed subset restriction, the same convention
+/// every other deferred construct in this language uses (MA06 §4's own
+/// "Deferred" list).
+pub fn catenate(a: &Array, b: &Array) -> Result<Array, String> {
+    // Neither operand alone need be oversized for the *result* to be: both
+    // can independently sit right at MAX_ARRAY_LENGTH, and a script that
+    // repeatedly catenates a value with itself (`A=.A,A`) doubles the size
+    // every line with no ceiling otherwise. Same cap and "check before
+    // allocating" discipline as `i.`/dyadic `$` elsewhere in this crate.
+    match a.len().checked_add(b.len()) {
+        Some(total) if total <= MAX_ARRAY_LENGTH => {}
+        _ => {
+            return Err(format!(
+                ",: catenate of {} and {} elements exceeds the cap of {} elements",
+                a.len(),
+                b.len(),
+                MAX_ARRAY_LENGTH
+            ));
+        }
+    }
+    match (a.ndims(), b.ndims()) {
+        (0, 0) => Ok(Array::from_vec(vec![a.data()[0], b.data()[0]])),
+        (0, 1) => {
+            let mut out = vec![a.data()[0]];
+            out.extend_from_slice(b.data());
+            Ok(Array::from_vec(out))
+        }
+        (1, 0) => {
+            let mut out = a.data().to_vec();
+            out.push(b.data()[0]);
+            Ok(Array::from_vec(out))
+        }
+        (1, 1) => {
+            let mut out = a.data().to_vec();
+            out.extend_from_slice(b.data());
+            Ok(Array::from_vec(out))
+        }
+        (2, 2) => {
+            if a.nrows() != b.nrows() {
+                return Err(format!(
+                    ",: matrix catenate needs equal row counts ({} vs {})",
+                    a.nrows(),
+                    b.nrows()
+                ));
+            }
+            let (r, ca, cb) = (a.nrows(), a.ncols(), b.ncols());
+            let mut data = vec![0.0; r * (ca + cb)];
+            for row in 0..r {
+                for col in 0..ca {
+                    data[col * r + row] = a.get(row, col).expect("in bounds");
+                }
+                for col in 0..cb {
+                    data[(ca + col) * r + row] = b.get(row, col).expect("in bounds");
+                }
+            }
+            Array::from_shape(data, vec![r, ca + cb])
+        }
+        (ra, rb) => Err(format!(
+            ",: catenate of rank {ra} and rank {rb} is not yet supported"
+        )),
+    }
+}
+
+// ── # tally / replicate ──────────────────────────────────────────────────────
+
+/// Monadic `#` (tally): the item count along the leading axis. Genuinely new
+/// relative to this repo's APL cut, which never added a tally primitive
+/// (MA06 §4) — no template to copy, so the rule is spelled out directly: a
+/// scalar has exactly **one** item (itself), a vector `[n]` has `n` items,
+/// and a matrix `[r, c]` has `r` items (one per row — the leading axis).
+/// Returned as a scalar `Array`.
+pub fn tally(a: &Array) -> Array {
+    let n = match *a.shape() {
+        [] => 1,
+        [n] => n,
+        [r, _] => r,
+        // Unreachable in practice (this crate's rank ≤ 2 ceiling, same as
+        // every other primitive here) -- the first dimension is still the
+        // most defensible "tally" if that ceiling is ever lifted.
+        ref dims => dims.first().copied().unwrap_or(1),
+    };
+    Array::scalar(n as f64)
+}
+
+/// Dyadic `#` (copy/replicate): `x # y`, where `x` is a vector (or scalar,
+/// for a length-1 `y`) of non-negative integer counts the same length as
+/// `y`'s tally ([`tally`]). Each item of `y` is repeated `x[i]` times and the
+/// results concatenated end to end; a count of `0` drops that item
+/// entirely.
+///
+/// **Disclosed scope limit**: `y` is restricted to rank ≤ 1 (a scalar or
+/// vector) — mirroring the same rank-limiting convention
+/// `array_runtime::ops::outer` already uses for its own operands. A rank-2
+/// `y` would need a genuinely different per-row replicate (repeating whole
+/// rows, not scalar items), which this first cut does not attempt; it is
+/// rejected here with a clear error rather than silently doing something
+/// less general than a caller might expect, the same honest-subset
+/// convention every other primitive in this crate follows.
+pub fn replicate(x: &Array, y: &Array) -> Result<Array, String> {
+    if y.ndims() > 1 {
+        return Err(format!(
+            "#: dyadic right argument must be a scalar or vector (rank ≤ 1), got rank {} — per-row replicate of a matrix is out of scope for this cut",
+            y.ndims()
+        ));
+    }
+    if x.ndims() > 1 {
+        return Err(format!(
+            "#: dyadic left argument (counts) must be a scalar or vector (rank ≤ 1), got rank {}",
+            x.ndims()
+        ));
+    }
+    let items = y.data();
+    let counts = x.data();
+    if counts.len() != items.len() {
+        return Err(format!(
+            "#: left argument's length must equal the right argument's tally ({} vs {})",
+            counts.len(),
+            items.len()
+        ));
+    }
+    // Validate every count is a non-negative integer, and cap the total
+    // output size *before* allocating -- same "check before the expensive
+    // work" discipline as every other primitive here (a script that
+    // replicates its own output over and over could otherwise grow without
+    // bound).
+    let mut parsed_counts = Vec::with_capacity(counts.len());
+    let mut total: usize = 0;
+    for &c in counts {
+        if c < 0.0 || c.fract() != 0.0 {
+            return Err(format!(
+                "#: replicate counts must be non-negative integers, got {c}"
+            ));
+        }
+        let c = c as usize;
+        total = total
+            .checked_add(c)
+            .ok_or_else(|| "#: replicate output size overflows usize".to_string())?;
+        parsed_counts.push(c);
+    }
+    if total > MAX_ARRAY_LENGTH {
+        return Err(format!(
+            "#: replicate output of {total} elements exceeds the cap of {MAX_ARRAY_LENGTH}"
+        ));
+    }
+    let mut out = Vec::with_capacity(total);
+    for (&val, &count) in items.iter().zip(parsed_counts.iter()) {
+        for _ in 0..count {
+            out.push(val);
+        }
+    }
+    Ok(Array::from_vec(out))
+}
+
+// ── ^ exponential / power ────────────────────────────────────────────────────
+
+/// Monadic `^` (natural exponential): `e` raised to each element of `y`.
+/// Genuinely new relative to APL (this repo's APL cut has no `^` primitive
+/// at all, and `array_runtime::ops::BinOp` has no `Pow` variant — MA06 §2
+/// confirms this cut needs no new `array-runtime` substrate, so `^` is
+/// implemented entirely locally in this crate rather than growing `BinOp`).
+pub fn monadic_exp(a: &Array) -> Array {
+    Array::from_shape(a.data().iter().map(|&v| v.exp()).collect(), a.shape().to_vec())
+        .expect("monadic map preserves shape/length")
+}
+
+/// Dyadic `^` (power): `x` raised to the power `y`, elementwise
+/// (`f64::powf`), with the *same* scalar-broadcast rule
+/// `array_runtime::ops::elementwise` uses (either operand may be a scalar
+/// broadcasting against the other's shape; otherwise shapes must match
+/// exactly) — see [`elementwise_pow`] for the actual broadcast logic,
+/// substituting `f64::powf` for `elementwise`'s `BinOp::apply` dispatch.
+pub fn dyadic_pow(a: &Array, b: &Array) -> Result<Array, String> {
+    elementwise_pow(a, b)
+}
+
+/// The `^`-specific elementwise combinator: mirrors
+/// `array_runtime::ops::elementwise`'s exact broadcast-rule structure
+/// (scalar⋅anything broadcasts, otherwise shapes must match exactly, result
+/// takes the non-scalar operand's shape), substituting `f64::powf` in place
+/// of `elementwise`'s `BinOp::apply` dispatch — `^` has no `BinOp` variant to
+/// share (MA06 §2 explicitly scopes this cut to *not* need new
+/// `array-runtime` substrate), so this small helper reimplements just enough
+/// of that shape locally rather than growing `BinOp` for one caller.
+fn elementwise_pow(a: &Array, b: &Array) -> Result<Array, String> {
+    let (ad, bd) = (a.data(), b.data());
+    let data: Vec<f64> = match (a.is_scalar(), b.is_scalar()) {
+        (true, _) => bd.iter().map(|&y| ad[0].powf(y)).collect(),
+        (_, true) => ad.iter().map(|&x| x.powf(bd[0])).collect(),
+        _ => {
+            if a.shape() != b.shape() {
+                return Err(format!(
+                    "^: non-conformable arrays: {:?} vs {:?}",
+                    a.shape(),
+                    b.shape()
+                ));
+            }
+            ad.iter().zip(bd).map(|(&x, &y)| x.powf(y)).collect()
+        }
+    };
+    let shape = if a.is_scalar() { b.shape() } else { a.shape() };
+    Array::from_shape(data, shape.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- $ -----------------------------------------------------------------
+
+    #[test]
+    fn shape_of_scalar_is_empty_vector_not_a_scalar() {
+        let s = shape(&Array::scalar(7.0));
+        assert_eq!(s.shape(), &[0]);
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn shape_of_vector_and_matrix() {
+        assert_eq!(shape(&Array::from_vec(vec![1.0, 2.0, 3.0])).data(), &[3.0]);
+        let m = Array::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+        assert_eq!(shape(&m).data(), &[2.0, 3.0]);
+    }
+
+    #[test]
+    fn reshape_cycles_a_shorter_source() {
+        // 2 3 $ 1 2 -- cycles [1,2] to fill 6 elements, row-major fill order.
+        let target = Array::from_vec(vec![2.0, 3.0]);
+        let source = Array::from_vec(vec![1.0, 2.0]);
+        let r = reshape(&target, &source).unwrap();
+        assert_eq!(r.shape(), &[2, 3]);
+        assert_eq!(r.get(0, 0), Some(1.0));
+        assert_eq!(r.get(0, 1), Some(2.0));
+        assert_eq!(r.get(0, 2), Some(1.0));
+        assert_eq!(r.get(1, 0), Some(2.0));
+        assert_eq!(r.get(1, 1), Some(1.0));
+        assert_eq!(r.get(1, 2), Some(2.0));
+    }
+
+    #[test]
+    fn reshape_truncates_a_longer_source() {
+        let target = Array::from_vec(vec![2.0, 2.0]);
+        let source = Array::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let r = reshape(&target, &source).unwrap();
+        assert_eq!(r.shape(), &[2, 2]);
+        assert_eq!(r.get(0, 0), Some(1.0));
+        assert_eq!(r.get(0, 1), Some(2.0));
+        assert_eq!(r.get(1, 0), Some(3.0));
+        assert_eq!(r.get(1, 1), Some(4.0));
+    }
+
+    #[test]
+    fn reshape_rejects_rank_above_2_target() {
+        let target = Array::from_vec(vec![2.0, 2.0, 2.0]);
+        let source = Array::from_vec(vec![1.0]);
+        assert!(reshape(&target, &source).is_err());
+    }
+
+    #[test]
+    fn reshape_of_empty_source_into_nonempty_target_is_an_error() {
+        let target = Array::from_vec(vec![3.0]);
+        let empty = Array::from_vec(vec![]);
+        assert!(reshape(&target, &empty).is_err());
+    }
+
+    #[test]
+    fn reshape_caps_target_element_count_before_allocating() {
+        let target = Array::from_vec(vec![(MAX_ARRAY_LENGTH + 1) as f64]);
+        let source = Array::from_vec(vec![1.0]);
+        assert!(reshape(&target, &source).is_err());
+    }
+
+    // --- i. ------------------------------------------------------------------
+
+    #[test]
+    fn index_generator_is_zero_based_not_one_based() {
+        // The single most safety-critical assertion in this whole crate
+        // (MA06 §1 bullet 3): `i.5` is `[0,1,2,3,4]`, NEVER `[1,2,3,4,5]`.
+        let r = index_generator(&Array::scalar(5.0)).unwrap();
+        assert_eq!(r.data(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn index_generator_of_zero_is_empty() {
+        let r = index_generator(&Array::scalar(0.0)).unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn index_generator_rejects_negative_and_noninteger() {
+        assert!(index_generator(&Array::scalar(-1.0)).is_err());
+        assert!(index_generator(&Array::scalar(2.5)).is_err());
+    }
+
+    #[test]
+    fn index_generator_caps_n_before_allocating() {
+        let huge = Array::scalar((MAX_ARRAY_LENGTH + 1) as f64);
+        assert!(index_generator(&huge).is_err());
+    }
+
+    #[test]
+    fn index_of_is_zero_based_with_tally_not_found_sentinel() {
+        let haystack = Array::from_vec(vec![10.0, 20.0, 30.0]);
+        let needles = Array::from_vec(vec![20.0, 99.0, 10.0]);
+        let r = index_of(&haystack, &needles).unwrap();
+        // 20 is at 0-based index 1, 99 is not found (tally = 3), 10 is at
+        // 0-based index 0 -- distinct from APL's 1-based [2, 4, 1].
+        assert_eq!(r.data(), &[1.0, 3.0, 0.0]);
+    }
+
+    #[test]
+    fn index_of_caps_the_work_product_before_scanning() {
+        let n = 2000; // 2000 * 2000 = 4,000,000 > MAX_ARRAY_LENGTH
+        let a = Array::from_vec(vec![0.0; n]);
+        let b = Array::from_vec(vec![0.0; n]);
+        assert!(index_of(&a, &b).is_err());
+    }
+
+    // --- , -----------------------------------------------------------------
+
+    #[test]
+    fn ravel_flattens_a_matrix_in_row_major_order() {
+        let m = Array::from_rows(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]).unwrap();
+        assert_eq!(ravel(&m).data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn ravel_of_scalar_and_vector_is_a_noop_reshape() {
+        assert_eq!(ravel(&Array::scalar(9.0)).data(), &[9.0]);
+        let v = Array::from_vec(vec![1.0, 2.0]);
+        assert_eq!(ravel(&v).data(), &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn catenate_scalar_and_scalar() {
+        let r = catenate(&Array::scalar(1.0), &Array::scalar(2.0)).unwrap();
+        assert_eq!(r.data(), &[1.0, 2.0]);
+    }
+
+    #[test]
+    fn catenate_scalar_and_vector_prepends_or_appends() {
+        let v = Array::from_vec(vec![2.0, 3.0]);
+        assert_eq!(
+            catenate(&Array::scalar(1.0), &v).unwrap().data(),
+            &[1.0, 2.0, 3.0]
+        );
+        assert_eq!(
+            catenate(&v, &Array::scalar(4.0)).unwrap().data(),
+            &[2.0, 3.0, 4.0]
+        );
+    }
+
+    #[test]
+    fn catenate_vector_and_vector() {
+        let a = Array::from_vec(vec![1.0, 2.0]);
+        let b = Array::from_vec(vec![3.0, 4.0, 5.0]);
+        assert_eq!(catenate(&a, &b).unwrap().data(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn catenate_matrices_with_equal_rows_concatenates_columns() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let b = Array::from_rows(vec![vec![5.0], vec![6.0]]).unwrap();
+        let r = catenate(&a, &b).unwrap();
+        assert_eq!(r.shape(), &[2, 3]);
+        assert_eq!(r.get(0, 0), Some(1.0));
+        assert_eq!(r.get(0, 2), Some(5.0));
+        assert_eq!(r.get(1, 2), Some(6.0));
+    }
+
+    #[test]
+    fn catenate_rejects_mismatched_matrix_row_counts() {
+        let a = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        let b = Array::from_rows(vec![vec![5.0, 6.0]]).unwrap();
+        assert!(catenate(&a, &b).is_err());
+    }
+
+    #[test]
+    fn catenate_caps_combined_length_before_allocating() {
+        let half = MAX_ARRAY_LENGTH / 2 + 1;
+        let a = Array::from_vec(vec![0.0; half]);
+        let b = Array::from_vec(vec![0.0; half]);
+        assert!(catenate(&a, &b).is_err());
+    }
+
+    // --- # -------------------------------------------------------------------
+
+    #[test]
+    fn tally_of_scalar_vector_and_matrix() {
+        assert_eq!(tally(&Array::scalar(7.0)).data(), &[1.0]);
+        assert_eq!(tally(&Array::from_vec(vec![1.0, 2.0, 3.0])).data(), &[3.0]);
+        let m = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0], vec![5.0, 6.0]]).unwrap();
+        assert_eq!(tally(&m).data(), &[3.0]); // 3 rows
+    }
+
+    #[test]
+    fn replicate_repeats_and_drops_items() {
+        let x = Array::from_vec(vec![2.0, 0.0, 3.0]);
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let r = replicate(&x, &y).unwrap();
+        assert_eq!(r.data(), &[1.0, 1.0, 3.0, 3.0, 3.0]);
+    }
+
+    #[test]
+    fn replicate_of_a_scalar_y_with_scalar_count() {
+        let x = Array::scalar(3.0);
+        let y = Array::scalar(9.0);
+        assert_eq!(replicate(&x, &y).unwrap().data(), &[9.0, 9.0, 9.0]);
+    }
+
+    #[test]
+    fn replicate_rejects_rank_2_right_argument() {
+        let x = Array::from_vec(vec![1.0, 1.0]);
+        let y = Array::from_rows(vec![vec![1.0, 2.0], vec![3.0, 4.0]]).unwrap();
+        assert!(replicate(&x, &y).is_err());
+    }
+
+    #[test]
+    fn replicate_rejects_mismatched_length() {
+        let x = Array::from_vec(vec![1.0, 2.0]);
+        let y = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert!(replicate(&x, &y).is_err());
+    }
+
+    #[test]
+    fn replicate_rejects_negative_or_noninteger_counts() {
+        let y = Array::from_vec(vec![1.0, 2.0]);
+        assert!(replicate(&Array::from_vec(vec![-1.0, 1.0]), &y).is_err());
+        assert!(replicate(&Array::from_vec(vec![1.5, 1.0]), &y).is_err());
+    }
+
+    #[test]
+    fn replicate_caps_total_output_before_allocating() {
+        let x = Array::from_vec(vec![(MAX_ARRAY_LENGTH + 1) as f64]);
+        let y = Array::scalar(1.0);
+        assert!(replicate(&x, &y).is_err());
+    }
+
+    // --- ^ -----------------------------------------------------------------
+
+    #[test]
+    fn monadic_exp_of_zero_is_one() {
+        assert_eq!(monadic_exp(&Array::scalar(0.0)).data(), &[1.0]);
+    }
+
+    #[test]
+    fn monadic_exp_is_elementwise() {
+        let v = Array::from_vec(vec![0.0, 1.0]);
+        let r = monadic_exp(&v);
+        assert_eq!(r.data()[0], 1.0);
+        assert!((r.data()[1] - std::f64::consts::E).abs() < 1e-9);
+    }
+
+    #[test]
+    fn dyadic_pow_basic() {
+        assert_eq!(dyadic_pow(&Array::scalar(2.0), &Array::scalar(3.0)).unwrap().data(), &[8.0]);
+    }
+
+    #[test]
+    fn dyadic_pow_broadcasts_either_side() {
+        let v = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        let s = Array::scalar(2.0);
+        assert_eq!(dyadic_pow(&v, &s).unwrap().data(), &[1.0, 4.0, 9.0]);
+        assert_eq!(dyadic_pow(&s, &v).unwrap().data(), &[2.0, 4.0, 8.0]);
+    }
+
+    #[test]
+    fn dyadic_pow_rejects_mismatched_shapes() {
+        let a = Array::from_vec(vec![1.0, 2.0]);
+        let b = Array::from_vec(vec![1.0, 2.0, 3.0]);
+        assert!(dyadic_pow(&a, &b).is_err());
+    }
+}

--- a/code/packages/rust/j-runtime/src/eval.rs
+++ b/code/packages/rust/j-runtime/src/eval.rs
@@ -1,0 +1,730 @@
+//! The tree-walking evaluator.
+//!
+//! [`Interpreter`] walks the [`GrammarASTNode`] tree from `j-parser` and
+//! computes `array_runtime::Array` values. J has exactly **two** expression
+//! nonterminals (MA06 §3, reused from APL's `value_expr`/`function_expr`
+//! split almost verbatim): `noun_expr` (arrays/scalars) and `verb_expr` (a
+//! primitive glyph, optionally combined with `/`/`\`/`@` into a *derived
+//! verb*, or a parenthesised **train** — the one genuinely new production
+//! with no APL precedent). This evaluator mirrors that split:
+//! [`Interpreter::eval_noun_expr`] walks the noun tree and calls
+//! [`Interpreter::apply_monadic`]/[`Interpreter::apply_dyadic`] whenever it
+//! meets a `verb_expr`, which in turn dispatch on an internal [`JFn`] — the
+//! runtime's own representation of "which verb, and with which
+//! adverb/conjunction/train structure (if any) applied". `JFn` generalizes
+//! `apl-runtime::eval::AplFn` exactly as MA06 §5 anticipated: the same
+//! `Atom`/`NonScalar`/`Reduce`/`Scan` shape, plus `Compose`/`Hook`/`Fork` for
+//! trains (APL has no train production at all, so those three variants are
+//! new here).
+//!
+//! The 12 primitive verbs that are ordinary scalar dyadic functions
+//! (`+ - * % <. >. = ~: < > <: >:`) share `array_runtime::ops::BinOp` for
+//! both their dyadic meaning (`ops::elementwise`) and reduce/scan (see
+//! `JFn::Atom`) — exactly like APL's own 12 atoms. `$`/`i.`/`,`/`#`/`^` do
+//! not fit that shape at all (their monadic and dyadic meanings are
+//! unrelated to each other, or — for `#`/`^` — have no shared kernel at
+//! all), so they get bespoke logic in `builtins.rs` instead (see
+//! `JFn::NonScalar`). Unlike APL, J has **no** outer-product operator in
+//! this cut's scope (MA06 §4 lists only `/` and `\` as adverbs), so there is
+//! no `JFn::Outer` counterpart to `AplFn::Outer`.
+
+use crate::builtins;
+use crate::value::display;
+use array_runtime::{ops, ops::BinOp, Array};
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Maximum recursion depth for this evaluator's own tree-walk. `j-parser`'s
+/// own `MAX_RULE_DEPTH` (70, see that crate's `lib.rs`) already bounds how
+/// deep a CST built from untrusted input can possibly be, so — exactly like
+/// `apl-runtime::eval::MAX_DEPTH`'s own rationale — this bound can never
+/// actually trip on a tree that came from `try_parse_j`; it exists purely as
+/// **defense in depth**.
+///
+/// This crate adds one genuinely new recursion shape APL's own evaluator
+/// never had: `JFn::Compose`/`Hook`/`Fork` recurse back through
+/// [`Interpreter::apply_monadic`]/[`Interpreter::apply_dyadic`] themselves
+/// (evaluating a train's tooth verbs against the same operand(s)), not just
+/// through the noun-expression walk `apl-runtime::eval::apply_monadic`/
+/// `apply_dyadic` never needed a guard for (APL's own `AplFn` variants are
+/// all leaf dispatches with no recursive calls back into `apply_*`). Both
+/// `apply_monadic` and `apply_dyadic` below take their own depth-guard entry
+/// for exactly this reason — real defense in depth for a real (if
+/// parser-bounded) new recursion shape, not a redundant copy-paste of
+/// APL's guard placement.
+const MAX_DEPTH: usize = 512;
+
+/// A persistent J session: a variable workspace and the current evaluation
+/// depth.
+pub struct Interpreter {
+    vars: HashMap<String, Array>,
+    depth: Rc<Cell<usize>>,
+}
+
+/// RAII guard that decrements the depth counter on every exit path
+/// (including a `?` early return).
+struct DepthGuard(Rc<Cell<usize>>);
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        self.0.set(self.0.get().saturating_sub(1));
+    }
+}
+
+impl Default for Interpreter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One of `j.tokens`' five bespoke (non-`BinOp`) primitive verbs, kept
+/// around so error messages can name the actual glyph (`"$"`, not
+/// `"DOLLAR"`).
+#[derive(Clone, Copy)]
+enum NonScalarAtom {
+    Dollar,
+    Idot,
+    Ravel,
+    Hash,
+    Caret,
+}
+
+impl NonScalarAtom {
+    fn glyph(self) -> &'static str {
+        match self {
+            NonScalarAtom::Dollar => "$",
+            NonScalarAtom::Idot => "i.",
+            NonScalarAtom::Ravel => ",",
+            NonScalarAtom::Hash => "#",
+            NonScalarAtom::Caret => "^",
+        }
+    }
+}
+
+/// The runtime's own representation of a `verb_expr`: "which verb, and with
+/// which adverb/conjunction/train structure (if any) applied" — generalizing
+/// `apl-runtime::eval::AplFn` per MA06 §5's own explicit instruction.
+enum JFn {
+    /// One of the 12 primitive verbs that map onto `array_runtime::ops::BinOp`
+    /// (`+ - * % <. >. = ~: < > <: >:`). Exactly one glyph per `BinOp`
+    /// variant, so `BinOp` alone is enough to recover which glyph this was
+    /// for monadic dispatch — no separate glyph tag needed here, unlike
+    /// [`NonScalar`](JFn::NonScalar).
+    Atom(BinOp),
+    /// `$`/`i.`/`,`/`#`/`^` — bespoke monadic+dyadic logic (`builtins.rs`)
+    /// that does not fit "an operator over a scalar dyadic function" at
+    /// all, so none of these ever plug into reduce/scan.
+    NonScalar(NonScalarAtom),
+    /// A `BinOp`-mappable atom with `/` (reduce) applied — inherently a
+    /// *monadic* derived verb (`+/A` reduces the one array `A`).
+    Reduce(BinOp),
+    /// A `BinOp`-mappable atom with `\` (scan) applied — also monadic.
+    Scan(BinOp),
+    /// `f@g` ("atop" compose, MA06 §4's one in-scope conjunction): monadic
+    /// `(f@g) y = f (g y)`; dyadic `x (f@g) y = f (x g y)` — see
+    /// [`Interpreter::apply_dyadic`]'s doc comment for why the dyadic
+    /// formula is this crate's own considered generalization, not something
+    /// MA06 spells out verbatim.
+    Compose(Box<JFn>, Box<JFn>),
+    /// A 2-tooth train (hook): monadic `(f g) y = y f (g y)`; dyadic
+    /// `x (f g) y = x f (g y)` — `g` always applies monadically to `y`
+    /// alone, regardless of the surrounding call's own arity (the defining
+    /// property of a hook, MA06 §3).
+    Hook(Box<JFn>, Box<JFn>),
+    /// A 3-tooth train (fork), or the 4+-tooth case peeled down to this base
+    /// case (MA06 §3's corrected folding rule — see `fold_train`). `left` is
+    /// either an ordinary verb tooth or a captured literal noun (only
+    /// meaningful in this leading position).
+    Fork(ForkLeft, Box<JFn>, Box<JFn>),
+}
+
+/// The first ("left") tooth of a [`JFn::Fork`]: either an ordinary verb, or
+/// a literal noun constant (MA06 §3's "leading noun" fork case — a bare
+/// noun tooth is only ever meaningful here, never in a hook or anywhere
+/// else, see `fold_train`/`tooth_to_verb`).
+enum ForkLeft {
+    Verb(Box<JFn>),
+    Noun(Array),
+}
+
+/// What one `train_tooth` evaluates to, before it's known whether the
+/// overall train needs it to be a verb or (in a fork's leading position
+/// only) accepts it as a literal noun — see [`Interpreter::eval_train_tooth`].
+enum ToothValue {
+    Verb(JFn),
+    Noun(Array),
+}
+
+impl Interpreter {
+    pub fn new() -> Self {
+        Interpreter {
+            vars: HashMap::new(),
+            depth: Rc::new(Cell::new(0)),
+        }
+    }
+
+    /// Enter one level of recursion, erroring if [`MAX_DEPTH`] is exceeded.
+    /// The returned guard decrements the counter when it drops.
+    fn enter(&self) -> Result<DepthGuard, String> {
+        self.depth.set(self.depth.get() + 1);
+        let guard = DepthGuard(Rc::clone(&self.depth));
+        if self.depth.get() > MAX_DEPTH {
+            return Err("j-runtime: expression nesting too deep".to_string());
+        }
+        Ok(guard)
+    }
+
+    /// Evaluate a whole `program` node, returning the auto-print output for
+    /// every statement that is *not* an assignment (MA06 §4: assignment is
+    /// silent; a bare `noun_expr` result auto-prints — mirrors
+    /// `apl-runtime::eval::Interpreter::run` exactly, since J's `program`/
+    /// `line`/`statement` productions are structurally identical to APL's).
+    pub fn run(&mut self, program: &GrammarASTNode) -> Result<String, String> {
+        let mut out = String::new();
+        for line in node_children(program) {
+            if line.rule_name != "line" {
+                continue;
+            }
+            // A `line` with just a bare NEWLINE (blank line, or a
+            // comment-only line — `NB.` comments are already stripped by
+            // the lexer's skip pattern) has no `statement` child at all;
+            // skip it.
+            let stmt = line.children.iter().find_map(|c| match c {
+                ASTNodeOrToken::Node(n) if n.rule_name == "statement" => Some(n),
+                _ => None,
+            });
+            let Some(stmt) = stmt else { continue };
+            if let Some(text) = self.eval_statement(stmt)? {
+                out.push_str(&text);
+                out.push('\n');
+            }
+        }
+        Ok(out)
+    }
+
+    /// `statement = assignment` (a pure passthrough rule, always exactly one
+    /// child) — evaluate the `assignment` and decide whether to print based
+    /// on whether it was an *actual* assignment (`NAME ASSIGN_LOCAL|ASSIGN_GLOBAL
+    /// assignment`, 3 children) or a plain `noun_expr` passthrough (1 child).
+    fn eval_statement(&mut self, stmt: &GrammarASTNode) -> Result<Option<String>, String> {
+        let assignment = only_node(stmt)?;
+        let is_assignment = assignment.children.len() == 3;
+        let value = self.eval_assignment(assignment)?;
+        if is_assignment {
+            Ok(None)
+        } else {
+            Ok(Some(display(&value)))
+        }
+    }
+
+    /// `assignment = NAME ASSIGN_LOCAL assignment | NAME ASSIGN_GLOBAL
+    /// assignment | noun_expr`. Both `=.` and `=:` do the identical thing in
+    /// this cut (MA06 §4: "not meaningfully different ... since this cut
+    /// has no user-defined verbs/tacit definitions yet"), so which token
+    /// matched doesn't need to be inspected at all — only whether this node
+    /// has 3 children (an actual assignment) or 1 (a passthrough). The
+    /// right-hand side of a 3-child node recurses back through `assignment`
+    /// itself, so `A=.B=.3` binds `3` to *both* `B` and `A` (right-
+    /// associative chained assignment, mirroring
+    /// `apl-runtime::eval::eval_assignment` exactly).
+    fn eval_assignment(&mut self, node: &GrammarASTNode) -> Result<Array, String> {
+        let _guard = self.enter()?;
+        if node.children.len() == 3 {
+            let name = assignment_target_name(node)?;
+            // `only_node` finds the lone `Node` child among
+            // `[Token(NAME), Token(ASSIGN_LOCAL|ASSIGN_GLOBAL), Node(assignment)]`
+            // — the nested `assignment` to recurse into.
+            let inner = only_node(node)?;
+            let value = self.eval_assignment(inner)?;
+            self.vars.insert(name, value.clone());
+            Ok(value)
+        } else {
+            let noun_expr = only_node(node)?;
+            self.eval_noun_expr(noun_expr)
+        }
+    }
+
+    /// `noun_expr`:
+    /// - 1 child `[Node(term)]` — a bare term.
+    /// - 2 children `[Node(verb_expr), Node(noun_expr)]` — monadic
+    ///   application.
+    /// - 3 children `[Node(term), Node(verb_expr), Node(noun_expr)]` —
+    ///   dyadic application, right-recursive (`A+B+C` is `A+(B+C)`).
+    fn eval_noun_expr(&self, node: &GrammarASTNode) -> Result<Array, String> {
+        let _guard = self.enter()?;
+        let kids = node_children(node);
+        match kids.len() {
+            1 => self.eval_term(kids[0]),
+            2 => {
+                let f = self.parse_verb_expr(kids[0])?;
+                let arg = self.eval_noun_expr(kids[1])?;
+                self.apply_monadic(&f, &arg)
+            }
+            3 => {
+                let lhs = self.eval_term(kids[0])?;
+                let f = self.parse_verb_expr(kids[1])?;
+                let rhs = self.eval_noun_expr(kids[2])?;
+                self.apply_dyadic(&f, &lhs, &rhs)
+            }
+            n => Err(format!("j-runtime: malformed noun_expr with {n} children")),
+        }
+    }
+
+    /// `term = NUMBER { NUMBER } | NAME | LPAREN noun_expr RPAREN`.
+    fn eval_term(&self, node: &GrammarASTNode) -> Result<Array, String> {
+        match node.children.first() {
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NUMBER" => {
+                // "Stranding": one or more juxtaposed NUMBER tokens form a
+                // single term — `1 2 3` is one 3-element vector, a lone `5`
+                // is a rank-0 scalar (MA06 §4, inherited unchanged from
+                // APL). This literal-construction path has no grammar-level
+                // depth bound on the *count* of stranded numbers (`term`'s
+                // repetition is flat, not recursive), so it is capped here
+                // directly, mirroring `apl-runtime::eval::eval_term`'s own
+                // identical guard.
+                if node.children.len() > builtins::MAX_ARRAY_LENGTH {
+                    return Err(format!(
+                        "j-runtime: stranded literal of {} numbers exceeds the cap of {} elements",
+                        node.children.len(),
+                        builtins::MAX_ARRAY_LENGTH
+                    ));
+                }
+                let mut nums = Vec::new();
+                for c in &node.children {
+                    if let ASTNodeOrToken::Token(tok) = c {
+                        nums.push(parse_j_number(&tok.value)?);
+                    }
+                }
+                if nums.len() == 1 {
+                    Ok(Array::scalar(nums[0]))
+                } else {
+                    Ok(Array::from_vec(nums))
+                }
+            }
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => self
+                .vars
+                .get(&t.value)
+                .cloned()
+                .ok_or_else(|| format!("j-runtime: undefined variable '{}'", t.value)),
+            Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "LPAREN" => {
+                let inner = only_node(node)?; // the Node(noun_expr) child
+                self.eval_noun_expr(inner)
+            }
+            _ => Err("j-runtime: malformed term".to_string()),
+        }
+    }
+
+    /// `verb_expr = simple_verb [ AT verb_expr ] | LPAREN verb_train RPAREN`.
+    /// The one production with no APL precedent (a parenthesised train)
+    /// needs `&self` (a train's leading-noun tooth may be a `NAME` needing a
+    /// variable lookup, see [`Interpreter::eval_train_tooth`]) — unlike
+    /// `apl-runtime::eval::parse_function_expr`/`parse_function_atom`, which
+    /// are free functions since APL's `function_expr` never evaluates a
+    /// noun.
+    fn parse_verb_expr(&self, node: &GrammarASTNode) -> Result<JFn, String> {
+        let _guard = self.enter()?;
+        match node.children.as_slice() {
+            [ASTNodeOrToken::Node(simple)] if simple.rule_name == "simple_verb" => {
+                parse_simple_verb(simple)
+            }
+            [ASTNodeOrToken::Node(simple), ASTNodeOrToken::Token(at), ASTNodeOrToken::Node(rest)]
+                if simple.rule_name == "simple_verb" && at.effective_type_name() == "AT" =>
+            {
+                let f = parse_simple_verb(simple)?;
+                let g = self.parse_verb_expr(rest)?;
+                Ok(JFn::Compose(Box::new(f), Box::new(g)))
+            }
+            [ASTNodeOrToken::Token(lparen), ASTNodeOrToken::Node(train), ASTNodeOrToken::Token(_rparen)]
+                if lparen.effective_type_name() == "LPAREN" =>
+            {
+                self.parse_verb_train(train)
+            }
+            _ => Err("j-runtime: malformed verb_expr".to_string()),
+        }
+    }
+
+    /// `verb_train = train_tooth train_tooth { train_tooth }` — a flat list
+    /// of 2+ `train_tooth` children. Evaluate each tooth to a
+    /// [`ToothValue`] first, then [`fold_train`] applies MA06 §3's
+    /// corrected right-to-left, peel-from-the-left folding rule.
+    fn parse_verb_train(&self, node: &GrammarASTNode) -> Result<JFn, String> {
+        let teeth = node_children(node)
+            .into_iter()
+            .map(|tooth| self.eval_train_tooth(tooth))
+            .collect::<Result<Vec<_>, _>>()?;
+        fold_train(teeth)
+    }
+
+    /// `train_tooth = verb_expr | term`. A `term` tooth is a literal noun
+    /// constant — no variables should appear there in practice, but if a
+    /// bare `NAME` does, it's looked up in the current bindings exactly like
+    /// any other noun evaluation, erroring cleanly if unbound.
+    fn eval_train_tooth(&self, node: &GrammarASTNode) -> Result<ToothValue, String> {
+        let _guard = self.enter()?;
+        match node.children.first() {
+            Some(ASTNodeOrToken::Node(n)) if n.rule_name == "verb_expr" => {
+                Ok(ToothValue::Verb(self.parse_verb_expr(n)?))
+            }
+            Some(ASTNodeOrToken::Node(n)) if n.rule_name == "term" => {
+                Ok(ToothValue::Noun(self.eval_term(n)?))
+            }
+            _ => Err("j-runtime: malformed train_tooth".to_string()),
+        }
+    }
+
+    /// Apply a monadic (one-argument) verb.
+    fn apply_monadic(&self, f: &JFn, y: &Array) -> Result<Array, String> {
+        let _guard = self.enter()?;
+        match f {
+            JFn::Atom(op) => apply_monadic_scalar(*op, y),
+            JFn::NonScalar(NonScalarAtom::Dollar) => Ok(builtins::shape(y)),
+            JFn::NonScalar(NonScalarAtom::Idot) => builtins::index_generator(y),
+            JFn::NonScalar(NonScalarAtom::Ravel) => Ok(builtins::ravel(y)),
+            JFn::NonScalar(NonScalarAtom::Hash) => Ok(builtins::tally(y)),
+            JFn::NonScalar(NonScalarAtom::Caret) => Ok(builtins::monadic_exp(y)),
+            JFn::Reduce(op) => ops::reduce(*op, y),
+            JFn::Scan(op) => ops::scan(*op, y),
+            // Compose (atop), monadic: `(f@g) y = f (g y)` (MA06 §4).
+            JFn::Compose(f, g) => {
+                let inner = self.apply_monadic(g, y)?;
+                self.apply_monadic(f, &inner)
+            }
+            // Hook, monadic: `(f g) y = y f (g y)` (MA06 §3).
+            JFn::Hook(f, g) => {
+                let gy = self.apply_monadic(g, y)?;
+                self.apply_dyadic(f, y, &gy)
+            }
+            // Fork, monadic: verb-left `(f g h) y = (f y) g (h y)`;
+            // leading-noun `(n g h) y = n g (h y)` (MA06 §3).
+            JFn::Fork(left, g, h) => match left {
+                ForkLeft::Verb(f) => {
+                    let fy = self.apply_monadic(f, y)?;
+                    let hy = self.apply_monadic(h, y)?;
+                    self.apply_dyadic(g, &fy, &hy)
+                }
+                ForkLeft::Noun(n) => {
+                    let hy = self.apply_monadic(h, y)?;
+                    self.apply_dyadic(g, n, &hy)
+                }
+            },
+        }
+    }
+
+    /// Apply a dyadic (two-argument) verb.
+    fn apply_dyadic(&self, f: &JFn, x: &Array, y: &Array) -> Result<Array, String> {
+        let _guard = self.enter()?;
+        match f {
+            JFn::Atom(op) => ops::elementwise(*op, x, y),
+            JFn::NonScalar(NonScalarAtom::Dollar) => builtins::reshape(x, y),
+            JFn::NonScalar(NonScalarAtom::Idot) => builtins::index_of(x, y),
+            JFn::NonScalar(NonScalarAtom::Ravel) => builtins::catenate(x, y),
+            JFn::NonScalar(NonScalarAtom::Hash) => builtins::replicate(x, y),
+            JFn::NonScalar(NonScalarAtom::Caret) => builtins::dyadic_pow(x, y),
+            JFn::Reduce(_) => Err(
+                "j-runtime: / (reduce) takes exactly one operand, but was applied dyadically"
+                    .to_string(),
+            ),
+            JFn::Scan(_) => Err(
+                "j-runtime: \\ (scan) takes exactly one operand, but was applied dyadically"
+                    .to_string(),
+            ),
+            // Compose (atop), dyadic: `x (f@g) y = f (x g y)`. MA06 §4 only
+            // spells out the monadic formula; this dyadic reading is this
+            // crate's own considered generalization -- real J's standard
+            // "atop" semantics work exactly this way (the right verb applies
+            // with the surrounding arity, the left verb always applies
+            // monadically to the result), matching the task's own explicit
+            // design note rather than an unstated assumption.
+            JFn::Compose(f, g) => {
+                let inner = self.apply_dyadic(g, x, y)?;
+                self.apply_monadic(f, &inner)
+            }
+            // Hook, dyadic: `x (f g) y = x f (g y)` -- `g` is ALWAYS applied
+            // monadically to `y` alone, regardless of this call's own
+            // dyadic arity (the defining property of a hook, MA06 §3).
+            JFn::Hook(f, g) => {
+                let gy = self.apply_monadic(g, y)?;
+                self.apply_dyadic(f, x, &gy)
+            }
+            // Fork, dyadic: verb-left `x (f g h) y = (x f y) g (x h y)`.
+            // Leading-noun `x (n g h) y = n g (x h y)` -- MA06 §3 only gives
+            // the monadic formula for the leading-noun case; this dyadic
+            // reading is this crate's own disclosed generalization: the
+            // noun `n` stays a literal constant regardless of arity (it is
+            // never "applied" at all), while `h` applies with the
+            // surrounding call's own arity, exactly mirroring how an
+            // ordinary (non-noun-leading) fork's `h` does the same.
+            JFn::Fork(left, g, h) => match left {
+                ForkLeft::Verb(f) => {
+                    let fxy = self.apply_dyadic(f, x, y)?;
+                    let hxy = self.apply_dyadic(h, x, y)?;
+                    self.apply_dyadic(g, &fxy, &hxy)
+                }
+                ForkLeft::Noun(n) => {
+                    let hxy = self.apply_dyadic(h, x, y)?;
+                    self.apply_dyadic(g, n, &hxy)
+                }
+            },
+        }
+    }
+}
+
+/// Monadic meaning of the six `BinOp`-mappable verbs that have one (MA06
+/// §4): `+` conjugate (identity — this cut has no complex numbers, so
+/// conjugate is a no-op), `-` negate, `*` sign, `%` reciprocal, `<.` floor,
+/// `>.` ceiling. The six comparisons (`= ~: < <: >: >`, mapped onto
+/// `Eq`/`Ne`/`Lt`/`Le`/`Ge`/`Gt`) have **no** monadic meaning in J either —
+/// a clean, explicit error rather than silently picking a behavior (mirrors
+/// `apl-runtime::eval::apply_monadic_scalar` exactly, just with J's own
+/// glyph spellings in the error text).
+fn apply_monadic_scalar(op: BinOp, x: &Array) -> Result<Array, String> {
+    let f: fn(f64) -> f64 = match op {
+        BinOp::Add => |v| v,
+        BinOp::Sub => |v| -v,
+        BinOp::Mul => j_sign,
+        BinOp::Div => |v| 1.0 / v,
+        BinOp::Min => f64::floor, // FLOOR atom (<.) -- floor monadically
+        BinOp::Max => f64::ceil,  // CEILING atom (>.) -- ceiling monadically
+        BinOp::Eq => return Err("j-runtime: no monadic form for =".to_string()),
+        BinOp::Ne => return Err("j-runtime: no monadic form for ~:".to_string()),
+        BinOp::Lt => return Err("j-runtime: no monadic form for <".to_string()),
+        BinOp::Le => return Err("j-runtime: no monadic form for <:".to_string()),
+        BinOp::Ge => return Err("j-runtime: no monadic form for >:".to_string()),
+        BinOp::Gt => return Err("j-runtime: no monadic form for >".to_string()),
+    };
+    Ok(
+        Array::from_shape(x.data().iter().map(|&v| f(v)).collect(), x.shape().to_vec())
+            .expect("monadic map preserves shape/length"),
+    )
+}
+
+/// J's monadic `*` (sign): `1` for positive, `_1` for negative, `0` for
+/// zero. **Not** `f64::signum()` — that returns `1.0` for `0.0`, which is
+/// wrong for this three-way sign function (mirrors
+/// `apl-runtime::eval::apl_sign`'s exact, already-correct logic).
+fn j_sign(x: f64) -> f64 {
+    if x.is_nan() {
+        f64::NAN
+    } else if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}
+
+/// Parse one `NUMBER` token's source text into an `f64`. J's own negative-
+/// literal convention (MA06 §4's addendum, `j.tokens` SECTION 4) is a
+/// leading underscore in the mantissa and/or exponent (`_3`, `1.5E_3`) —
+/// never APL's high-minus `¯` (no ASCII spelling) and never a bare `-`
+/// (already the `MINUS` verb token) — so every underscore is translated to
+/// ASCII `-` before handing the text to Rust's `f64` parser, mirroring
+/// `apl-runtime::eval::parse_apl_number`'s identical role for `¯`.
+fn parse_j_number(s: &str) -> Result<f64, String> {
+    s.replace('_', "-")
+        .parse::<f64>()
+        .map_err(|_| format!("j-runtime: invalid number literal '{s}'"))
+}
+
+/// `simple_verb = verb_primitive [ REDUCE | SCAN ]`. A free function (unlike
+/// [`Interpreter::parse_verb_expr`]) since a bare primitive/adverb pair never
+/// needs a variable lookup.
+fn parse_simple_verb(node: &GrammarASTNode) -> Result<JFn, String> {
+    match node.children.as_slice() {
+        [ASTNodeOrToken::Node(prim)] => parse_verb_primitive(prim),
+        [ASTNodeOrToken::Node(prim), ASTNodeOrToken::Token(adverb)] => {
+            let base = parse_verb_primitive(prim)?;
+            match adverb.effective_type_name() {
+                "REDUCE" => Ok(JFn::Reduce(require_scalar_binop(&base, "reduce")?)),
+                "SCAN" => Ok(JFn::Scan(require_scalar_binop(&base, "scan")?)),
+                other => Err(format!("j-runtime: unexpected adverb token '{other}'")),
+            }
+        }
+        _ => Err("j-runtime: malformed simple_verb".to_string()),
+    }
+}
+
+/// `verb_primitive`: always exactly one child, a single token naming the
+/// primitive glyph. Maps each of the 12 `BinOp`-compatible verbs onto its
+/// `BinOp` variant, and each of the 5 bespoke verbs onto its
+/// [`NonScalarAtom`] — **critically**, `FLOOR` (`<.`) maps to `BinOp::Min`
+/// and `CEILING` (`>.`) maps to `BinOp::Max`, the same mapping
+/// `apl-runtime::eval::parse_function_atom` already uses for APL's `⌊`/`⌈`
+/// (MA06 §4: "the mapping is the *opposite* character from what APL's
+/// `⌊`/`⌈` might suggest" refers to *which ASCII digraph* spells "floor" —
+/// `<.`, not `>.`, because `<` already means "less than" — not to a
+/// different `BinOp` target; the underlying `BinOp` values are identical to
+/// APL's own FLOOR→Min/CEILING→Max mapping).
+fn parse_verb_primitive(node: &GrammarASTNode) -> Result<JFn, String> {
+    let tok = match node.children.first() {
+        Some(ASTNodeOrToken::Token(t)) => t,
+        _ => return Err("j-runtime: malformed verb_primitive".to_string()),
+    };
+    Ok(match tok.effective_type_name() {
+        "PLUS" => JFn::Atom(BinOp::Add),
+        "MINUS" => JFn::Atom(BinOp::Sub),
+        "STAR" => JFn::Atom(BinOp::Mul),
+        "PERCENT" => JFn::Atom(BinOp::Div),
+        "FLOOR" => JFn::Atom(BinOp::Min),
+        "CEILING" => JFn::Atom(BinOp::Max),
+        "EQ" => JFn::Atom(BinOp::Eq),
+        "NE" => JFn::Atom(BinOp::Ne),
+        "LT" => JFn::Atom(BinOp::Lt),
+        "LE" => JFn::Atom(BinOp::Le),
+        "GE" => JFn::Atom(BinOp::Ge),
+        "GT" => JFn::Atom(BinOp::Gt),
+        "DOLLAR" => JFn::NonScalar(NonScalarAtom::Dollar),
+        "IDOT" => JFn::NonScalar(NonScalarAtom::Idot),
+        "RAVEL" => JFn::NonScalar(NonScalarAtom::Ravel),
+        "HASH" => JFn::NonScalar(NonScalarAtom::Hash),
+        "CARET" => JFn::NonScalar(NonScalarAtom::Caret),
+        other => return Err(format!("j-runtime: unknown verb primitive token '{other}'")),
+    })
+}
+
+/// Reduce/scan apply only to the 12 verbs that map onto a `BinOp` —
+/// `$`/`i.`/`,`/`#`/`^` are not "a scalar dyadic function" at all, so
+/// stacking an adverb onto one of them is a clean, explicit scope error
+/// (mirrors `apl-runtime::eval::require_scalar_binop` exactly).
+fn require_scalar_binop(f: &JFn, context: &str) -> Result<BinOp, String> {
+    match f {
+        JFn::Atom(op) => Ok(*op),
+        JFn::NonScalar(a) => Err(format!(
+            "{context}: {} is not a scalar dyadic verb",
+            a.glyph()
+        )),
+        JFn::Reduce(_) | JFn::Scan(_) | JFn::Compose(_, _) | JFn::Hook(_, _) | JFn::Fork(_, _, _) => {
+            unreachable!("parse_verb_primitive never produces an adverb/conjunction/train JFn")
+        }
+    }
+}
+
+/// Fold a flat list of `verb_train` teeth into a `JFn`, following MA06 §3's
+/// corrected right-to-left, peel-from-the-left recursive rule:
+///
+/// - **2 teeth** `[f, g]`: `Hook(f, g)` — both teeth must be verbs; a noun
+///   in either position of a 2-tooth train is a clean error (a leading noun
+///   is only meaningful in the 3-tooth fork's own first slot).
+/// - **3 teeth** `[left, g, h]`: `Fork(left, g, h)`, where `left` is
+///   `ForkLeft::Noun` if the first tooth evaluated to a noun, else
+///   `ForkLeft::Verb`.
+/// - **4+ teeth** `[t0, t1, …, tN-1]`: peel the FIRST tooth off (it must be
+///   a verb — a noun here has no defined meaning, since it would need to
+///   become a `Hook`'s left tooth) and recurse on the rest:
+///   `Hook(t0, fold_train([t1, …, tN-1]))`. Repeatedly peeling by exactly
+///   one tooth at a time means the recursion always bottoms out at the
+///   3-tooth fork base case (never the 2-tooth case, since `N - (N - 3) ==
+///   3` for every `N ≥ 4`) — so the *only* tooth that may ever be a noun in
+///   an N-tooth train is the one at index `N - 3` (the position that lands
+///   in the terminal fork's own leading slot), falling out naturally from
+///   this recursive structure with no extra position-tracking needed.
+fn fold_train(mut teeth: Vec<ToothValue>) -> Result<JFn, String> {
+    match teeth.len() {
+        n if n < 2 => Err(format!(
+            "j-runtime: a train needs at least 2 teeth, got {n}"
+        )),
+        2 => {
+            let g = tooth_to_verb(teeth.pop().expect("len == 2"), "a 2-tooth hook")?;
+            let f = tooth_to_verb(teeth.pop().expect("len == 2"), "a 2-tooth hook")?;
+            Ok(JFn::Hook(Box::new(f), Box::new(g)))
+        }
+        3 => {
+            let h = tooth_to_verb(teeth.pop().expect("len == 3"), "a fork's middle/right tooth")?;
+            let g = tooth_to_verb(teeth.pop().expect("len == 3"), "a fork's middle/right tooth")?;
+            let left = match teeth.pop().expect("len == 3") {
+                ToothValue::Noun(n) => ForkLeft::Noun(n),
+                ToothValue::Verb(f) => ForkLeft::Verb(Box::new(f)),
+            };
+            Ok(JFn::Fork(left, Box::new(g), Box::new(h)))
+        }
+        _ => {
+            let rest = teeth.split_off(1);
+            let first = tooth_to_verb(
+                teeth.pop().expect("split_off(1) leaves exactly one element"),
+                "a 4+-tooth train's peeled-off leading tooth",
+            )?;
+            let g = fold_train(rest)?;
+            Ok(JFn::Hook(Box::new(first), Box::new(g)))
+        }
+    }
+}
+
+/// Require a [`ToothValue`] to be a verb, with a clean error naming the
+/// context if it's a noun instead (see [`fold_train`]'s doc comment for
+/// exactly which positions this can legally reject).
+fn tooth_to_verb(t: ToothValue, context: &str) -> Result<JFn, String> {
+    match t {
+        ToothValue::Verb(f) => Ok(f),
+        ToothValue::Noun(_) => Err(format!(
+            "j-runtime: a bare noun tooth is only meaningful in a fork's leading position, not in {context}"
+        )),
+    }
+}
+
+/// The `NAME` token of an actual assignment's target — the first child of a
+/// 3-child `assignment` node
+/// (`[Token(NAME), Token(ASSIGN_LOCAL|ASSIGN_GLOBAL), Node(assignment)]`).
+fn assignment_target_name(node: &GrammarASTNode) -> Result<String, String> {
+    match node.children.first() {
+        Some(ASTNodeOrToken::Token(t)) if t.effective_type_name() == "NAME" => Ok(t.value.clone()),
+        _ => Err("j-runtime: malformed assignment (missing target name)".to_string()),
+    }
+}
+
+// ── AST helpers ──────────────────────────────────────────────────────────────
+
+fn node_children(node: &GrammarASTNode) -> Vec<&GrammarASTNode> {
+    node.children
+        .iter()
+        .filter_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            ASTNodeOrToken::Token(_) => None,
+        })
+        .collect()
+}
+
+fn first_node(node: &GrammarASTNode) -> Option<&GrammarASTNode> {
+    node.children.iter().find_map(|c| match c {
+        ASTNodeOrToken::Node(n) => Some(n),
+        ASTNodeOrToken::Token(_) => None,
+    })
+}
+
+fn only_node(node: &GrammarASTNode) -> Result<&GrammarASTNode, String> {
+    first_node(node).ok_or_else(|| format!("j-runtime: malformed '{}' node", node.rule_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A direct, white-box unit test of the depth guard mechanism itself
+    /// (`enter`/`DepthGuard`). Unlike `apl-runtime` (which has no such test
+    /// at all -- `j-parser`'s own `MAX_RULE_DEPTH` bounds any *real* parsed
+    /// tree far below `MAX_DEPTH`, so a realistic `feed()` call can never
+    /// actually trip this guard, exactly like APL's own equivalent comment
+    /// says), this crate adds one anyway: MA06-d's own task brief calls out
+    /// "the depth guard" as one of the minimum things to cover, and the only
+    /// way to actually exercise it at all is a direct test of `enter()`
+    /// itself, since driving it via genuine J source is architecturally
+    /// impossible (the parser's own cap fires first). This is a deliberate,
+    /// disclosed small addition beyond the literal apl-runtime mirror, not
+    /// an oversight in apl-runtime being copied forward.
+    #[test]
+    fn depth_guard_trips_after_max_depth_and_recovers() {
+        let interp = Interpreter::new();
+        let mut guards = Vec::new();
+        for _ in 0..MAX_DEPTH {
+            guards.push(interp.enter().expect("should stay under the cap"));
+        }
+        assert!(interp.enter().is_err(), "one more enter() must trip the cap");
+        drop(guards);
+        assert!(
+            interp.enter().is_ok(),
+            "dropping every guard must let a fresh enter() succeed again"
+        );
+    }
+}

--- a/code/packages/rust/j-runtime/src/eval.rs
+++ b/code/packages/rust/j-runtime/src/eval.rs
@@ -149,6 +149,67 @@ enum ForkLeft {
     Noun(Array),
 }
 
+/// Tear down a `JFn` tree **iteratively**, so dropping one can never itself
+/// overflow the native stack no matter how deep the tree is.
+///
+/// `Compose`/`Hook`/`Fork` box their operands, so `JFn` gets an ordinary
+/// *recursive* compiler-derived `Drop` for free — fine for the shallow
+/// trees any real, parser-bounded train produces (`j-parser`'s own
+/// `MAX_RULE_DEPTH` caps a genuine `verb_train` to roughly 61 teeth), but a
+/// `JFn` built another way (as `fold_train`'s own test for its *construction*-
+/// time stack safety does, deliberately, to exercise a shape no real parse
+/// can produce) can be arbitrarily deep, and tearing THAT down via ordinary
+/// recursive `Drop` overflows the stack exactly the same way `fold_train`'s
+/// own construction once could (found by that very test, which crashed here
+/// instead of in `fold_train`, once the construction side was already fixed
+/// — the same "fixed the forward walk, the backward one still crashes"
+/// lesson this repo's `wolfram-to-semantic-ir`/`macsyma-to-semantic-ir`
+/// crates already ran into for their own `Expr` trees).
+///
+/// The technique mirrors those crates' own `drop_iterative`: swap each
+/// boxed child out for a cheap non-recursive sentinel (`JFn::Atom` has no
+/// boxed fields of its own), push the *real* child onto an explicit
+/// heap-allocated work stack, and let the now-shallow original node's
+/// `Drop` run harmlessly on the sentinel it's left holding. Each loop
+/// iteration therefore drops only one node's own non-recursive fields.
+impl Drop for JFn {
+    fn drop(&mut self) {
+        // `Vec<JFn>`, not `Vec<Box<JFn>>` -- the `Vec` itself already puts
+        // its elements on the heap, so re-boxing each one would just be an
+        // extra unnecessary allocation on top (clippy's `vec_box` lint).
+        let mut stack: Vec<JFn> = Vec::new();
+        take_boxed_children(self, &mut stack);
+        while let Some(mut child) = stack.pop() {
+            take_boxed_children(&mut child, &mut stack);
+            // `child` drops here -- shallowly, since any boxed fields it
+            // had were already swapped out onto `stack` above.
+        }
+    }
+}
+
+/// Swap every `Box<JFn>` field `node` owns for a cheap `JFn::Atom`
+/// sentinel, pushing the real (possibly deep) subtree onto `out` (moved out
+/// of its box) instead of leaving it in place to be dropped recursively as
+/// part of `node`'s own teardown. `ForkLeft::Noun` and every other
+/// non-recursive variant have no boxed children and are left untouched.
+fn take_boxed_children(node: &mut JFn, out: &mut Vec<JFn>) {
+    let leaf = || Box::new(JFn::Atom(BinOp::Add));
+    match node {
+        JFn::Compose(f, g) | JFn::Hook(f, g) => {
+            out.push(*std::mem::replace(f, leaf()));
+            out.push(*std::mem::replace(g, leaf()));
+        }
+        JFn::Fork(left, g, h) => {
+            if let ForkLeft::Verb(f) = left {
+                out.push(*std::mem::replace(f, leaf()));
+            }
+            out.push(*std::mem::replace(g, leaf()));
+            out.push(*std::mem::replace(h, leaf()));
+        }
+        JFn::Atom(_) | JFn::NonScalar(_) | JFn::Reduce(_) | JFn::Scan(_) => {}
+    }
+}
+
 /// What one `train_tooth` evaluates to, before it's known whether the
 /// overall train needs it to be a verb or (in a fork's leading position
 /// only) accepts it as a literal noun — see [`Interpreter::eval_train_tooth`].
@@ -350,7 +411,24 @@ impl Interpreter {
     /// [`ToothValue`] first, then [`fold_train`] applies MA06 §3's
     /// corrected right-to-left, peel-from-the-left folding rule.
     fn parse_verb_train(&self, node: &GrammarASTNode) -> Result<JFn, String> {
-        let teeth = node_children(node)
+        // `verb_train`'s `{ train_tooth }` repetition is flat, not
+        // recursive -- exactly like `eval_term`'s stranded-number case
+        // above -- so it is capped here directly, before doing any of the
+        // O(tooth count) work of evaluating each one. `fold_train` below
+        // is already iterative (a security review caught and fixed a
+        // stack-overflow risk in an earlier, recursive version of it — see
+        // its own doc comment), so this cap is defense in depth against
+        // sheer resource exhaustion from an implausibly wide train, not a
+        // stack-safety requirement on its own.
+        let tooth_nodes = node_children(node);
+        if tooth_nodes.len() > builtins::MAX_ARRAY_LENGTH {
+            return Err(format!(
+                "j-runtime: a train of {} teeth exceeds the cap of {} elements",
+                tooth_nodes.len(),
+                builtins::MAX_ARRAY_LENGTH
+            ));
+        }
+        let teeth = tooth_nodes
             .into_iter()
             .map(|tooth| self.eval_train_tooth(tooth))
             .collect::<Result<Vec<_>, _>>()?;
@@ -603,7 +681,7 @@ fn require_scalar_binop(f: &JFn, context: &str) -> Result<BinOp, String> {
 }
 
 /// Fold a flat list of `verb_train` teeth into a `JFn`, following MA06 §3's
-/// corrected right-to-left, peel-from-the-left recursive rule:
+/// corrected right-to-left, peel-from-the-left rule:
 ///
 /// - **2 teeth** `[f, g]`: `Hook(f, g)` — both teeth must be verbs; a noun
 ///   in either position of a 2-tooth train is a clean error (a leading noun
@@ -613,43 +691,64 @@ fn require_scalar_binop(f: &JFn, context: &str) -> Result<BinOp, String> {
 ///   `ForkLeft::Verb`.
 /// - **4+ teeth** `[t0, t1, …, tN-1]`: peel the FIRST tooth off (it must be
 ///   a verb — a noun here has no defined meaning, since it would need to
-///   become a `Hook`'s left tooth) and recurse on the rest:
-///   `Hook(t0, fold_train([t1, …, tN-1]))`. Repeatedly peeling by exactly
-///   one tooth at a time means the recursion always bottoms out at the
-///   3-tooth fork base case (never the 2-tooth case, since `N - (N - 3) ==
-///   3` for every `N ≥ 4`) — so the *only* tooth that may ever be a noun in
-///   an N-tooth train is the one at index `N - 3` (the position that lands
-///   in the terminal fork's own leading slot), falling out naturally from
-///   this recursive structure with no extra position-tracking needed.
+///   become a `Hook`'s left tooth) and repeat on the rest, conceptually
+///   `Hook(t0, fold(t1, …, tN-1))`. Repeatedly peeling by exactly one tooth
+///   at a time means this always bottoms out at the 3-tooth fork base case
+///   (never the 2-tooth case, since `N - (N - 3) == 3` for every `N ≥ 4`) —
+///   so the *only* tooth that may ever be a noun in an N-tooth train is the
+///   one at index `N - 3` (the position that lands in the terminal fork's
+///   own leading slot).
+///
+/// **Implemented iteratively, not via self-recursion** — a security review
+/// of the original (recursive) version caught that `verb_train`'s
+/// `{ train_tooth }` repetition is a single *flat* CST node, exactly like
+/// the stranded-`NUMBER`-literal repetition `eval_term` already guards
+/// against (see that function's own `MAX_ARRAY_LENGTH` check): a
+/// parenthesized train with a very large number of teeth needs no *nested*
+/// parentheses at all to produce it, so `j-parser`'s own `MAX_RULE_DEPTH`
+/// (which bounds nesting, not repetition width) never engages, and this
+/// evaluator's own `MAX_DEPTH`/`DepthGuard` mechanism only guards recursive
+/// *evaluation*, not this construction-time helper. A wide-enough flat
+/// train could therefore overflow the native stack via plain recursion
+/// here, before any depth check ever ran. Building the result iteratively
+/// (start from the last three teeth's `Fork`, then walk the remaining
+/// teeth right-to-left wrapping each into a new `Hook`) keeps this
+/// function's own native stack usage `O(1)` regardless of tooth count, so
+/// there is nothing here left for a cap to guard — the checked `Vec`
+/// operations below (`split_off`, `pop`) are the only allocation-adjacent
+/// work, and none of them can panic given the length checks that gate them.
 fn fold_train(mut teeth: Vec<ToothValue>) -> Result<JFn, String> {
-    match teeth.len() {
-        n if n < 2 => Err(format!(
-            "j-runtime: a train needs at least 2 teeth, got {n}"
-        )),
-        2 => {
-            let g = tooth_to_verb(teeth.pop().expect("len == 2"), "a 2-tooth hook")?;
-            let f = tooth_to_verb(teeth.pop().expect("len == 2"), "a 2-tooth hook")?;
-            Ok(JFn::Hook(Box::new(f), Box::new(g)))
-        }
-        3 => {
-            let h = tooth_to_verb(teeth.pop().expect("len == 3"), "a fork's middle/right tooth")?;
-            let g = tooth_to_verb(teeth.pop().expect("len == 3"), "a fork's middle/right tooth")?;
-            let left = match teeth.pop().expect("len == 3") {
-                ToothValue::Noun(n) => ForkLeft::Noun(n),
-                ToothValue::Verb(f) => ForkLeft::Verb(Box::new(f)),
-            };
-            Ok(JFn::Fork(left, Box::new(g), Box::new(h)))
-        }
-        _ => {
-            let rest = teeth.split_off(1);
-            let first = tooth_to_verb(
-                teeth.pop().expect("split_off(1) leaves exactly one element"),
-                "a 4+-tooth train's peeled-off leading tooth",
-            )?;
-            let g = fold_train(rest)?;
-            Ok(JFn::Hook(Box::new(first), Box::new(g)))
-        }
+    let n = teeth.len();
+    if n < 2 {
+        return Err(format!("j-runtime: a train needs at least 2 teeth, got {n}"));
     }
+    if n == 2 {
+        let g = tooth_to_verb(teeth.pop().expect("len == 2"), "a 2-tooth hook")?;
+        let f = tooth_to_verb(teeth.pop().expect("len == 2"), "a 2-tooth hook")?;
+        return Ok(JFn::Hook(Box::new(f), Box::new(g)));
+    }
+
+    // n >= 3: `split_off(n - 3)` returns the LAST 3 teeth as a new `Vec`
+    // and leaves `teeth` holding the leading run [0 .. n-3) in original
+    // (left-to-right) order. The last 3 form the base-case `Fork`.
+    let mut last3 = teeth.split_off(n - 3);
+    let h = tooth_to_verb(last3.pop().expect("len == 3"), "a fork's middle/right tooth")?;
+    let g = tooth_to_verb(last3.pop().expect("len == 3"), "a fork's middle/right tooth")?;
+    let left = match last3.pop().expect("len == 3") {
+        ToothValue::Noun(noun) => ForkLeft::Noun(noun),
+        ToothValue::Verb(f) => ForkLeft::Verb(Box::new(f)),
+    };
+    let mut acc = JFn::Fork(left, Box::new(g), Box::new(h));
+
+    // Walk the leading run right-to-left, wrapping the accumulator in one
+    // more `Hook` per tooth -- iterative equivalent of peeling one tooth
+    // off the front and recursing, but bounded to O(1) native stack frames
+    // regardless of how many teeth this train has.
+    while let Some(tooth) = teeth.pop() {
+        let f = tooth_to_verb(tooth, "a 4+-tooth train's peeled-off leading tooth")?;
+        acc = JFn::Hook(Box::new(f), Box::new(acc));
+    }
+    Ok(acc)
 }
 
 /// Require a [`ToothValue`] to be a verb, with a clean error naming the
@@ -726,5 +825,36 @@ mod tests {
             interp.enter().is_ok(),
             "dropping every guard must let a fresh enter() succeed again"
         );
+    }
+
+    /// A direct, white-box test of `fold_train`'s own stack-safety, for the
+    /// identical reason the depth-guard test above needs one: a security
+    /// review caught that the original (recursive) `fold_train` had no
+    /// depth bound of its own, and — like `MAX_DEPTH` above — this can
+    /// never actually be exercised through genuine J source, because
+    /// `j-parser`'s own `MAX_RULE_DEPTH` (70) already bounds a real
+    /// `verb_train` CST node to roughly 61 teeth before its own guard
+    /// fires (its own measured "long train" recursion shape, per that
+    /// crate's changelog) — nowhere near enough to stack-overflow even
+    /// the *old* recursive `fold_train`. The fix (and this test) is
+    /// defense in depth for any caller that builds a `Vec<ToothValue>`
+    /// another way (directly, as this test does, or via some future
+    /// frontend that doesn't route through `try_parse_j`), not a
+    /// currently-reachable bug in the shipped `j`/`j-repl` binary — stated
+    /// plainly here rather than overstated, mirroring this crate's own
+    /// standing preference for accurate severity over alarmism.
+    #[test]
+    fn fold_train_handles_many_teeth_without_recursing_natively() {
+        let teeth: Vec<ToothValue> = (0..50_000)
+            .map(|_| ToothValue::Verb(JFn::Atom(BinOp::Add)))
+            .collect();
+        let folded = fold_train(teeth).expect("50,000 teeth must fold without overflowing");
+        // Sanity-check the shape is a `Hook` at the top (every peel wraps
+        // one more `Hook` around the accumulator) rather than asserting
+        // anything about evaluating it end-to-end (this many nested `+`
+        // hooks would itself trip `MAX_DEPTH` on evaluation, which is a
+        // separate, already-tested guard -- this test is only about
+        // `fold_train`'s own construction-time stack safety).
+        assert!(matches!(folded, JFn::Hook(_, _)));
     }
 }

--- a/code/packages/rust/j-runtime/src/lib.rs
+++ b/code/packages/rust/j-runtime/src/lib.rs
@@ -1,0 +1,568 @@
+//! # J Runtime — a tree-walking evaluator over `array-runtime`.
+//!
+//! This is item **MA-6d** of the J frontend (spec
+//! `code/specs/MA06-j-language.md`): the runtime that makes the J
+//! lexer/parser (`j-lexer`/`j-parser`, MA-6b/MA-6c) executable. It parses
+//! with [`coding_adventures_j_parser::try_parse_j`] and walks the resulting
+//! tree with a recursive [`Interpreter`], computing
+//! [`array_runtime::Array`] values directly — like APL, J in this cut is
+//! **arrays only** (MA06 §4: no control flow, no user-defined verbs, no
+//! strings/boxing), so there is no separate value-wrapper type.
+//!
+//! ## What makes J's evaluator different from APL's
+//!
+//! J is APL's direct descendant (MA06 §1) and reuses APL's own grammar shape
+//! almost verbatim (MA06 §3) — but three properties have no APL precedent at
+//! all and are the reason this is its own crate, not a thin recolor of
+//! `apl-runtime`:
+//!
+//! 1. **Trains** — two or more verbs (or a leading noun) written
+//!    consecutively with no operands between them form a brand-new derived
+//!    verb: a **hook** (exactly 2 teeth) or a **fork** (3+ teeth, folding
+//!    right-to-left). This evaluator's internal `JFn` (see `eval.rs`) grows
+//!    `Compose`/`Hook`/`Fork` variants beyond `apl-runtime::eval::AplFn`'s
+//!    `Atom`/`NonScalar`/`Reduce`/`Scan`/`Outer` shape specifically for
+//!    this — the one genuinely new grammar/runtime problem MA06 §3 fixes.
+//! 2. **0-based indexing** — `i.5` is `0 1 2 3 4`, never APL's 1-based
+//!    `1 2 3 4 5` (MA06 §1 bullet 3). Getting this backwards is the single
+//!    most safety-critical mistake this crate could make.
+//! 3. **`/` is never division** — J needs `/` for the reduce adverb
+//!    (exactly like APL's own `/`), so division is `%` instead (MA06 §1
+//!    bullet 1) — the single most common APL→J transliteration mistake.
+//!
+//! ## Auto-print semantics
+//!
+//! Assignment is silent; a bare (non-assignment) statement auto-prints its
+//! result — mirrors `apl-runtime`'s own real-session convention exactly. See
+//! [`Interpreter::feed`] and `eval.rs::Interpreter::run`.
+//!
+//! ```
+//! use coding_adventures_j_runtime::eval;
+//!
+//! // `i.` is 0-based -- the signature difference from APL's `⍳`.
+//! assert_eq!(eval("i.5\n").unwrap().trim(), "0 1 2 3 4");
+//!
+//! // `/` is reduce, never division -- `%` is divide.
+//! assert_eq!(eval("+/1 2 3 4\n").unwrap().trim(), "10");
+//! assert_eq!(eval("6%2\n").unwrap().trim(), "3");
+//!
+//! // Assignment is silent; a bare expression auto-prints.
+//! assert_eq!(eval("A=.5\n").unwrap(), "");
+//! assert_eq!(eval("A=.5\nA\n").unwrap().trim(), "5");
+//! ```
+//!
+//! For a persistent session (the REPL), construct an [`Interpreter`] and call
+//! [`Interpreter::feed`] repeatedly — variables persist between calls.
+
+mod builtins;
+mod eval;
+mod value;
+
+pub use eval::Interpreter;
+
+use coding_adventures_j_parser::try_parse_j;
+
+impl Interpreter {
+    /// Parse and evaluate a chunk of J source, returning the concatenated
+    /// auto-print output of every non-assignment statement (one line per
+    /// printed statement). Variables persist across calls. `j-parser`'s own
+    /// `MAX_RULE_DEPTH` already rejects pathologically deep *input* before a
+    /// tree is even built, so (mirroring
+    /// `apl-runtime::Interpreter::feed`'s identical rationale) this method
+    /// needs no separate pre-parse nesting scan — only this evaluator's own
+    /// `eval.rs::MAX_DEPTH` guard, which exists purely as defense in depth
+    /// against the *already-bounded* tree.
+    pub fn feed(&mut self, source: &str) -> Result<String, String> {
+        let tree = try_parse_j(source)?;
+        self.run(&tree)
+    }
+}
+
+/// Evaluate J source in a fresh session and return its auto-print output.
+pub fn eval(source: &str) -> Result<String, String> {
+    Interpreter::new().feed(source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Evaluate and return the raw output (may contain a trailing `\n` per
+    /// printed line, or be empty for an all-assignment program).
+    fn run(src: &str) -> String {
+        eval(src).unwrap_or_else(|e| panic!("eval failed for {src:?}: {e}"))
+    }
+
+    /// Evaluate and read back a single printed scalar, translating J's
+    /// leading-underscore negative spelling back to ASCII `-` so the test
+    /// can compare against a plain `f64`.
+    fn scalar(src: &str) -> f64 {
+        let out = run(src);
+        out.trim()
+            .replace('_', "-")
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("not a scalar echo: {out:?}"))
+    }
+
+    /// Like [`scalar`], but tolerant of floating-point error (for `^`'s
+    /// transcendental results).
+    fn scalar_approx(src: &str, expected: f64, epsilon: f64) {
+        let got = scalar(src);
+        assert!(
+            (got - expected).abs() < epsilon,
+            "expected {expected} (±{epsilon}), got {got} for {src:?}"
+        );
+    }
+
+    /// Evaluate and read back a single printed vector (one space-separated
+    /// line), as a `Vec<f64>`.
+    fn vector(src: &str) -> Vec<f64> {
+        let out = run(src);
+        out.split_whitespace()
+            .map(|s| {
+                s.replace('_', "-")
+                    .parse::<f64>()
+                    .unwrap_or_else(|_| panic!("not a numeric token: {s:?} in {out:?}"))
+            })
+            .collect()
+    }
+
+    /// Evaluate and read back a printed matrix (one row per line) as
+    /// `Vec<Vec<f64>>`.
+    fn matrix(src: &str) -> Vec<Vec<f64>> {
+        let out = run(src);
+        out.trim()
+            .lines()
+            .map(|line| {
+                line.split_whitespace()
+                    .map(|s| s.replace('_', "-").parse::<f64>().unwrap())
+                    .collect()
+            })
+            .collect()
+    }
+
+    // --- monadic primitives, scalar and vector ------------------------------
+
+    #[test]
+    fn monadic_plus_is_conjugate_identity() {
+        assert_eq!(scalar("+5\n"), 5.0);
+        assert_eq!(vector("+1 2 3\n"), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn monadic_minus_negates() {
+        assert_eq!(scalar("-5\n"), -5.0);
+        assert_eq!(vector("-1 2 _3\n"), vec![-1.0, -2.0, 3.0]);
+    }
+
+    #[test]
+    fn monadic_star_is_sign() {
+        assert_eq!(scalar("*5\n"), 1.0);
+        assert_eq!(scalar("*_5\n"), -1.0);
+        assert_eq!(scalar("*0\n"), 0.0);
+        assert_eq!(vector("*1 _2 0\n"), vec![1.0, -1.0, 0.0]);
+    }
+
+    #[test]
+    fn monadic_percent_is_reciprocal() {
+        assert_eq!(scalar("%4\n"), 0.25);
+        assert_eq!(vector("%1 2 4\n"), vec![1.0, 0.5, 0.25]);
+    }
+
+    #[test]
+    fn monadic_floor_and_ceiling() {
+        // <. is FLOOR (rounds down); >. is CEILING (rounds up) -- the
+        // digraph-to-meaning mapping MA06 §4 calls out as the "opposite
+        // character" from APL's own ⌊/⌈ glyphs.
+        assert_eq!(scalar("<.3.8\n"), 3.0);
+        assert_eq!(scalar(">.3.2\n"), 4.0);
+        assert_eq!(vector("<.1.1 2.9\n"), vec![1.0, 2.0]);
+        assert_eq!(vector(">.1.1 2.9\n"), vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn monadic_dollar_is_shape() {
+        assert_eq!(vector("$5\n"), Vec::<f64>::new()); // a scalar's shape is empty
+        assert_eq!(vector("$1 2 3\n"), vec![3.0]);
+        assert_eq!(vector("M=.2 3$1 2 3 4 5 6\n$M\n"), vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn monadic_idot_is_zero_based_index_generator() {
+        // THE single most safety-critical regression test in this crate
+        // (MA06 §1 bullet 3): i.5 is [0,1,2,3,4], NEVER APL's [1,2,3,4,5].
+        assert_eq!(vector("i.5\n"), vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(vector("i.0\n"), Vec::<f64>::new());
+    }
+
+    #[test]
+    fn monadic_ravel_flattens_row_major() {
+        assert_eq!(
+            vector("M=.2 3$1 2 3 4 5 6\n,M\n"),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        );
+    }
+
+    #[test]
+    fn monadic_hash_is_tally() {
+        assert_eq!(scalar("#5\n"), 1.0); // scalar tally is 1
+        assert_eq!(scalar("#1 2 3\n"), 3.0);
+        assert_eq!(scalar("M=.2 3$1 2 3 4 5 6\n#M\n"), 2.0); // 2 rows
+    }
+
+    #[test]
+    fn monadic_caret_is_natural_exponential() {
+        assert_eq!(scalar("^0\n"), 1.0);
+        scalar_approx("^1\n", std::f64::consts::E, 1e-9);
+    }
+
+    // --- dyadic primitives ---------------------------------------------------
+
+    #[test]
+    fn dyadic_arithmetic_and_reduce_vs_divide_distinction() {
+        assert_eq!(scalar("3+4\n"), 7.0);
+        assert_eq!(scalar("3-4\n"), -1.0);
+        assert_eq!(scalar("3*4\n"), 12.0);
+        // `%` is divide; `/` is reduce -- never confused with each other.
+        // The single most common APL->J transliteration mistake (MA06 §1
+        // bullet 1), tested end-to-end through actual evaluation.
+        assert_eq!(scalar("6%2\n"), 3.0);
+        assert_eq!(scalar("+/1 2 3 4\n"), 10.0);
+    }
+
+    #[test]
+    fn dyadic_floor_is_min_ceiling_is_max() {
+        assert_eq!(scalar("3<.7\n"), 3.0);
+        assert_eq!(scalar("3>.7\n"), 7.0);
+    }
+
+    #[test]
+    fn dyadic_comparisons_all_six() {
+        assert_eq!(scalar("3=3\n"), 1.0);
+        assert_eq!(scalar("3=4\n"), 0.0);
+        assert_eq!(scalar("3~:4\n"), 1.0);
+        assert_eq!(scalar("3<4\n"), 1.0);
+        assert_eq!(scalar("3<:3\n"), 1.0);
+        assert_eq!(scalar("3>:4\n"), 0.0);
+        assert_eq!(scalar("4>3\n"), 1.0);
+    }
+
+    #[test]
+    fn dyadic_dollar_reshapes_cycling_and_truncating() {
+        assert_eq!(
+            matrix("2 3$1 2\n"),
+            vec![vec![1.0, 2.0, 1.0], vec![2.0, 1.0, 2.0]]
+        );
+        assert_eq!(
+            matrix("2 2$1 2 3 4 5 6\n"),
+            vec![vec![1.0, 2.0], vec![3.0, 4.0]]
+        );
+    }
+
+    #[test]
+    fn dyadic_idot_is_zero_based_index_of_with_tally_sentinel() {
+        // 20 -> 0-based index 1; 99 -> not found -> tally (3); 10 -> index 0.
+        // Distinct from APL's 1-based [2, 4, 1] not-found-is-len+1 sentinel.
+        assert_eq!(vector("10 20 30 i.20 99 10\n"), vec![1.0, 3.0, 0.0]);
+    }
+
+    #[test]
+    fn dyadic_ravel_catenates_every_supported_rank_combination() {
+        assert_eq!(vector("1,2\n"), vec![1.0, 2.0]);
+        assert_eq!(vector("1,2 3\n"), vec![1.0, 2.0, 3.0]);
+        assert_eq!(vector("1 2,3\n"), vec![1.0, 2.0, 3.0]);
+        assert_eq!(vector("1 2,3 4 5\n"), vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert_eq!(
+            matrix("(2 2$1 2 3 4),(2 1$5 6)\n"),
+            vec![vec![1.0, 2.0, 5.0], vec![3.0, 4.0, 6.0]]
+        );
+    }
+
+    #[test]
+    fn dyadic_hash_replicates_and_drops_zero_counts() {
+        assert_eq!(vector("2 0 3#1 2 3\n"), vec![1.0, 1.0, 3.0, 3.0, 3.0]);
+    }
+
+    #[test]
+    fn dyadic_hash_rejects_rank_2_right_argument() {
+        assert!(eval("M=.2 2$1 2 3 4\n1 1#M\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_caret_is_power() {
+        assert_eq!(scalar("2^3\n"), 8.0);
+        scalar_approx("2^0.5\n", std::f64::consts::SQRT_2, 1e-9);
+    }
+
+    // --- @ compose (atop) ----------------------------------------------------
+
+    #[test]
+    fn compose_applies_monadically_right_to_left() {
+        // (-@-) y = -(-(y)) = y -- double negation via atop composition.
+        assert_eq!(scalar("-@-5\n"), 5.0);
+    }
+
+    #[test]
+    fn compose_applies_dyadically_per_this_crates_disclosed_generalization() {
+        // x (-@-) y = -(x - y) -- the right verb (-) applies dyadically to
+        // (x, y); the left verb (-) always applies monadically to that
+        // result.
+        assert_eq!(scalar("3-@-4\n"), 1.0); // -(3-4) = -(-1) = 1
+    }
+
+    // --- trains: hooks, forks, leading nouns, 4+-tooth folding --------------
+
+    #[test]
+    fn two_tooth_hook_monadic() {
+        // (+ *) y = y + (*y). For y=5: 5 + sign(5) = 5 + 1 = 6.
+        assert_eq!(scalar("(+ *)5\n"), 6.0);
+    }
+
+    #[test]
+    fn two_tooth_hook_dyadic() {
+        // x (+ *) y = x + (*y) -- * (sign) applies monadically to y ALONE,
+        // regardless of the surrounding dyadic call. For x=3, y=5:
+        // 3 + sign(5) = 3 + 1 = 4.
+        assert_eq!(scalar("3(+ *)5\n"), 4.0);
+    }
+
+    #[test]
+    fn three_tooth_fork_monadic_verb_left() {
+        // (+ * -) y = (+y) * (-y). For y=5: 5 * (-5) = -25.
+        assert_eq!(scalar("(+ * -)5\n"), -25.0);
+    }
+
+    #[test]
+    fn three_tooth_fork_dyadic_verb_left() {
+        // x (+ * -) y = (x+y) * (x-y). For x=3, y=5: 8 * (-2) = -16.
+        assert_eq!(scalar("3(+ * -)5\n"), -16.0);
+    }
+
+    #[test]
+    fn three_tooth_fork_with_leading_noun_monadic() {
+        // (5 * -) y = 5 * (-y). For y=3: 5 * (-3) = -15.
+        assert_eq!(scalar("(5 * -)3\n"), -15.0);
+    }
+
+    #[test]
+    fn three_tooth_fork_with_leading_noun_dyadic() {
+        // x (5 * -) y = 5 * (x - y) -- the noun stays a literal constant
+        // regardless of arity; `-` applies with the surrounding (dyadic)
+        // arity, per this crate's own disclosed generalization of MA06 §3's
+        // monadic-only leading-noun formula. For x=3, y=4: 5 * (3-4) = -5.
+        assert_eq!(scalar("3(5*-)4\n"), -5.0);
+    }
+
+    #[test]
+    fn four_tooth_train_folds_as_hook_of_first_and_fork_of_rest() {
+        // MA06 §3's corrected rule: (a b c d) = a-hook-(fold [b,c,d]) =
+        // Hook(+, Fork(-, *, %)). For y=5:
+        //   inner fork(-,*,%) y = (monadic - y) * (monadic % y)
+        //                       = (-5) * (1/5) = -1.0
+        //   outer hook: y + inner = 5 + (-1.0) = 4.0
+        assert_eq!(scalar("(+ - * %)5\n"), 4.0);
+    }
+
+    #[test]
+    fn four_tooth_train_dyadic_still_applies_the_fold_verb_monadically_via_hook() {
+        // x (+ - * %) y -- the whole 4-tooth train reduces to a Hook whose
+        // right side (the inner fork) is, per the Hook's own defining
+        // property, always applied MONADICALLY to y alone, regardless of
+        // this call's dyadic arity. So the inner fork's value doesn't
+        // depend on x at all: still -1.0 (see the monadic test above).
+        // Outer hook (dyadic): x + inner = 3 + (-1.0) = 2.0.
+        assert_eq!(scalar("3(+ - * %)5\n"), 2.0);
+    }
+
+    #[test]
+    fn a_noun_in_a_two_tooth_train_is_an_error() {
+        // A leading noun is only meaningful in a 3-tooth fork's own first
+        // slot -- a 2-tooth train (hook) requires BOTH teeth to be verbs.
+        //
+        // Note: only the "noun first" shape is reachable here as a genuine
+        // 2-tooth *train* application -- `(verb noun)` (e.g. `(- 5)`) is
+        // grammar-level ambiguous with a plain parenthesised MONADIC
+        // application (`- 5` alone already parses as a complete, valid
+        // `noun_expr`), and `noun_expr`'s own alternative ordering
+        // (`term [...] | verb_expr noun_expr`) always resolves that
+        // ambiguity in favor of the plain parenthesised value -- so
+        // `(- 5)3` parses as *two separate statements* (`(-5)` then `3`),
+        // never as a train applied to `3` at all. This is the same
+        // documented-by-example grammar ambiguity `j-parser`'s own test
+        // suite calls out for `(+@-)` (see that crate's
+        // `at_compose_conjunction_parses` test comment) -- not a gap in
+        // this crate's own train-folding logic, which still correctly
+        // rejects a non-leading noun whenever a shape *does* reach it (see
+        // `a_noun_in_a_forks_non_leading_position_is_an_error` below, using
+        // a 3-tooth shape that isn't subject to the same ambiguity).
+        assert!(eval("(5 -)3\n").is_err());
+    }
+
+    #[test]
+    fn a_noun_in_a_forks_non_leading_position_is_an_error() {
+        // `(+ 5 -)` -- a 3-tooth fork with the noun in the MIDDLE (`g`)
+        // position, not the leading position. Unlike the 2-tooth case
+        // above, this shape isn't swallowed by the "plain parenthesised
+        // value" ambiguity: `+ 5 -` does not itself reduce to a valid bare
+        // `noun_expr` (after `+ 5` parses as one monadic application, the
+        // trailing `-` is left with no operand of its own), so the parser
+        // falls through to reading `(+ 5 -)` as a genuine 3-tooth train --
+        // confirmed structurally via this crate's own parse-tree
+        // inspection during development. `fold_train` must still reject
+        // the noun here, since only a fork's leading tooth may ever be one.
+        assert!(eval("(+ 5 -)9\n").is_err());
+    }
+
+    #[test]
+    fn a_leading_noun_past_the_first_tooth_of_a_four_plus_train_is_an_error() {
+        // Only the tooth that lands in the terminal 3-tooth fork's leading
+        // slot may be a noun -- the very first tooth of a 4+-tooth train
+        // never can be (it must become a Hook's left/verb tooth).
+        assert!(eval("(5 - * %)3\n").is_err());
+    }
+
+    // --- the signature J semantics: right-to-left, grouping ------------------
+
+    #[test]
+    fn right_to_left_evaluation_has_no_precedence() {
+        // 2*3+4 = 2*(3+4) = 14, NOT (2*3)+4 = 10.
+        assert_eq!(scalar("2*3+4\n"), 14.0);
+    }
+
+    #[test]
+    fn parenthesised_grouping_overrides_right_to_left_order() {
+        assert_eq!(scalar("(2*3)+4\n"), 10.0);
+    }
+
+    #[test]
+    fn stranded_numeric_literal_is_one_vector_term() {
+        assert_eq!(vector("1 2 3\n"), vec![1.0, 2.0, 3.0]);
+    }
+
+    // --- assignment: chaining, silence, session persistence ------------------
+
+    #[test]
+    fn chained_assignment_sets_both_names() {
+        assert_eq!(scalar("A=.B=.3\nA\n"), 3.0);
+        assert_eq!(scalar("A=.B=.3\nB\n"), 3.0);
+    }
+
+    #[test]
+    fn local_and_global_assignment_do_the_identical_thing_in_this_cut() {
+        assert_eq!(scalar("A=:5\nA\n"), 5.0);
+    }
+
+    #[test]
+    fn assignment_is_silent_bare_expression_prints() {
+        assert_eq!(run("A=.5\n"), "");
+        assert!(run("A=.5\nA\n").contains('5'));
+    }
+
+    #[test]
+    fn variables_persist_across_feed_calls() {
+        let mut m = Interpreter::new();
+        m.feed("A=.10\n").unwrap();
+        m.feed("B=.20\n").unwrap();
+        let out = m.feed("A+B\n").unwrap();
+        assert!(out.contains("30"));
+    }
+
+    // --- comments and blank lines are no-ops --------------------------------
+
+    #[test]
+    fn comment_and_blank_lines_produce_no_output() {
+        assert_eq!(run("NB. just a comment\n\nA=.1\n"), "");
+    }
+
+    // --- errors ---------------------------------------------------------------
+
+    #[test]
+    fn undefined_variable_is_an_error() {
+        assert!(eval("undefined_thing\n").is_err());
+    }
+
+    #[test]
+    fn nonconformable_shapes_in_dyadic_arithmetic_is_an_error() {
+        assert!(eval("(1 2)+(1 2 3)\n").is_err());
+    }
+
+    #[test]
+    fn reduce_of_an_empty_vector_is_an_error() {
+        assert!(eval("+/i.0\n").is_err());
+    }
+
+    #[test]
+    fn idot_rejects_out_of_range_or_negative_argument() {
+        assert!(eval("i._1\n").is_err());
+        assert!(eval("i.2.5\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_reshape_rejects_rank_above_2_target() {
+        assert!(eval("2 2 2$1\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_ravel_rejects_mismatched_row_count_matrices() {
+        assert!(eval("(2 2$1 2 3 4),(1 2$5 6)\n").is_err());
+    }
+
+    #[test]
+    fn monadic_call_of_a_comparison_atom_is_an_error() {
+        assert!(eval("=5\n").is_err());
+    }
+
+    #[test]
+    fn reduce_applied_dyadically_is_an_error() {
+        // `/` (reduce) is monadic-only; the parser only ever produces a
+        // Reduce/Scan derived verb applied to one noun, but the evaluator's
+        // own arity check is exercised via a malformed-application path
+        // through a fork/hook that forces dyadic use of a Reduce tooth.
+        assert!(eval("3(+/ -)5\n").is_err());
+    }
+
+    #[test]
+    fn malformed_input_that_fails_to_parse_is_a_clean_error_not_a_panic() {
+        // A bare adverb with nothing to modify never parses at all.
+        assert!(eval("/A\n").is_err());
+    }
+
+    // --- DoS-guard size caps ---------------------------------------------------
+
+    #[test]
+    fn idot_rejects_an_oversized_argument_instead_of_allocating() {
+        assert!(eval("i.2000000\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_reshape_rejects_an_oversized_target_instead_of_allocating() {
+        assert!(eval("2000000$1\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_catenate_rejects_an_oversized_combined_result_instead_of_allocating() {
+        assert!(eval("(600000$1),(600000$1)\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_index_of_rejects_an_oversized_work_product_instead_of_scanning() {
+        assert!(eval("(2000$1)i.(2000$1)\n").is_err());
+    }
+
+    #[test]
+    fn dyadic_replicate_rejects_an_oversized_output_instead_of_allocating() {
+        assert!(eval("2000000#1\n").is_err());
+    }
+
+    #[test]
+    fn stranded_literal_rejects_an_oversized_count_instead_of_allocating() {
+        // Unlike every builtin, stranding (`1 1 1 ...`) has no grammar-level
+        // depth bound on the count of numbers -- `term`'s repetition is
+        // flat, not recursive -- so this must be capped at the literal-
+        // construction site itself (eval_term), not left to rely on any
+        // other guard in this crate.
+        let n = builtins::MAX_ARRAY_LENGTH + 1;
+        let src: String = "1 ".repeat(n) + "\n";
+        assert!(eval(&src).is_err());
+    }
+}

--- a/code/packages/rust/j-runtime/src/value.rs
+++ b/code/packages/rust/j-runtime/src/value.rs
@@ -1,0 +1,190 @@
+//! J-style display formatting for `array_runtime::Array`.
+//!
+//! `array_runtime::value::Array` already implements [`std::fmt::Display`],
+//! but (exactly like `apl-runtime::value::display`, whose rationale this
+//! module mirrors) that impl is tuned for MATLAB, not for a J console
+//! session. J's own conventions differ from `Array`'s default `Display` in
+//! the same places APL's did, plus one J-specific twist on the negative-sign
+//! spelling:
+//!
+//! | Rule                     | MATLAB (`Array::fmt`)         | J (this module)             |
+//! |---------------------------|--------------------------------|-------------------------------|
+//! | Negative sign              | ASCII `-3`                    | leading underscore `_3`      |
+//! | Name prefix                | caller adds `x = `            | none — bare value            |
+//! | Whole-valued float          | `3` (no `.0`)                 | `3` (no `.0`)                 |
+//! | Vector layout               | n/a (row vector = 1×n matrix) | one line, space-separated    |
+//! | Matrix layout                | 2-space gutter, right-aligned | 1-space gutter, right-aligned|
+//!
+//! ## Why a leading underscore, not APL's high-minus `¯` or a bare ASCII `-`
+//!
+//! `j.tokens`' own `NUMBER` rule (SECTION 4) already settled this at the
+//! *input* side: J has no Unicode high-minus glyph available (MA06 §4's
+//! negative-literal addendum — J is ASCII-only, §1 bullet 1), so a negative
+//! literal is spelled with a leading underscore (`_5`, `1.5E_3`) instead. A
+//! bare ASCII `-` is unusable for this purpose because `j.tokens` already
+//! reserves it exclusively for the `MINUS` verb token (subtraction/negate) —
+//! printing `-3` here would be genuinely ambiguous if pasted back into a
+//! session (is it the number `-3`, or `MINUS` followed by `3`?). Using the
+//! *same* underscore convention for output that `j.tokens` already uses for
+//! input keeps a printed session round-trippable, exactly the same
+//! input/output symmetry `apl-runtime::value`'s own doc comment calls out
+//! for APL's high-minus.
+use array_runtime::Array;
+
+/// Render `a` the way a J session echoes an unsuppressed result: no name
+/// prefix — just the bare value.
+///
+/// - A scalar (`shape == []`) prints as its one number.
+/// - A vector (`shape == [n]`) prints as its elements, space-separated, on
+///   one line (the empty vector prints as the empty string — a J session
+///   shows a blank line for `i.0`, `$5`, etc.).
+/// - A matrix (`shape == [r, c]`) prints one row per line, elements
+///   space-separated and right-aligned to the widest cell's width *in this
+///   display*.
+pub fn display(a: &Array) -> String {
+    match *a.shape() {
+        [] => fmt_num(a.data()[0]),
+        [n] => {
+            if n == 0 {
+                return String::new();
+            }
+            a.data()
+                .iter()
+                .map(|&x| fmt_num(x))
+                .collect::<Vec<_>>()
+                .join(" ")
+        }
+        [r, c] => {
+            // Format every cell once, up front, so the alignment width is
+            // computed the same way regardless of row/column traversal order.
+            let cells: Vec<String> = a.data().iter().map(|&x| fmt_num(x)).collect();
+            let width = cells.iter().map(|s| s.chars().count()).max().unwrap_or(1);
+            let mut lines = Vec::with_capacity(r);
+            for row in 0..r {
+                let row_cells: Vec<String> = (0..c)
+                    .map(|col| {
+                        // `Array` stores data column-major (`get` already
+                        // hides that), but `display` walks row-major — one
+                        // printed line per logical row — since that is how
+                        // a J session prints a matrix (mirrors
+                        // `apl-runtime::value::display` exactly).
+                        let x = a.get(row, col).expect("row/col in bounds");
+                        format!("{:>width$}", fmt_num(x), width = width)
+                    })
+                    .collect();
+                lines.push(row_cells.join(" "));
+            }
+            lines.join("\n")
+        }
+        // This crate (like `array-runtime` itself, and `ops::reduce`/`scan`/
+        // `outer`) is scoped to rank ≤ 2 — every value this evaluator ever
+        // produces stops there, so this arm is unreachable in practice. It
+        // exists only so `display` is total over `Array`'s public shape
+        // space rather than panicking if that ever changes.
+        _ => format!("{a}"),
+    }
+}
+
+/// Format one number the J way: a
+/// [`is_sign_negative`](f64::is_sign_negative) number gets a leading
+/// underscore `_` prefix (never ASCII `-`, never APL's high-minus `¯` — see
+/// this module's doc comment), and a whole-valued float prints without a
+/// trailing `.0` (`5`, not `5.0`).
+///
+/// Non-finite values (`inf`/`NaN`, reachable via monadic `%` on `0`, a
+/// `0%0`-shaped computation, or `^` overflowing — this crate deliberately
+/// does not special-case any of these, mirroring
+/// `apl-runtime::value::fmt_num`'s own choice not to) still get a readable
+/// rendering. **Design judgment call, not specified by MA06**: this cut's
+/// scope explicitly excludes J's own `_`/`__` infinity *literal* (MA06 §4's
+/// negative-literal addendum), so `inf`/`_inf` here does not roundtrip back
+/// into a parseable literal the way every finite number this module prints
+/// does — that asymmetry is accepted deliberately (mirroring
+/// `apl-runtime::value::fmt_num`'s own `¯∞`/`∞`, which has the identical
+/// property: APL's `apl.tokens` has no infinity literal either), rather than
+/// inventing a new literal syntax this cut's grammar doesn't have.
+fn fmt_num(x: f64) -> String {
+    if x.is_nan() {
+        return "NaN".to_string();
+    }
+    if x.is_infinite() {
+        return if x.is_sign_negative() {
+            "_inf".to_string()
+        } else {
+            "inf".to_string()
+        };
+    }
+    let mag = x.abs();
+    let body = if mag.fract() == 0.0 && mag < 1e15 {
+        format!("{}", mag as i64)
+    } else {
+        format!("{mag}")
+    };
+    // `-0.0` is sign-negative but has zero magnitude; there is no notion of
+    // a "negative zero" literal in this cut, so treat it as plain `0`.
+    if x.is_sign_negative() && mag != 0.0 {
+        format!("_{body}")
+    } else {
+        body
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalar_displays_bare() {
+        assert_eq!(display(&Array::scalar(3.0)), "3");
+        assert_eq!(display(&Array::scalar(3.5)), "3.5");
+    }
+
+    #[test]
+    fn negative_numbers_use_leading_underscore_not_ascii_minus() {
+        assert_eq!(display(&Array::scalar(-3.0)), "_3");
+        assert_eq!(display(&Array::scalar(-3.5)), "_3.5");
+        assert!(!display(&Array::scalar(-3.0)).contains('-'));
+    }
+
+    #[test]
+    fn negative_zero_prints_as_plain_zero() {
+        assert_eq!(display(&Array::scalar(-0.0)), "0");
+    }
+
+    #[test]
+    fn whole_valued_floats_have_no_trailing_dot_zero() {
+        assert_eq!(display(&Array::scalar(5.0)), "5");
+        assert_eq!(display(&Array::scalar(5.25)), "5.25");
+    }
+
+    #[test]
+    fn vector_is_space_separated_one_line() {
+        let v = Array::from_vec(vec![1.0, -2.0, 3.0]);
+        assert_eq!(display(&v), "1 _2 3");
+    }
+
+    #[test]
+    fn empty_vector_displays_as_empty_string() {
+        assert_eq!(display(&Array::from_vec(vec![])), "");
+    }
+
+    #[test]
+    fn matrix_is_row_per_line_right_aligned() {
+        let m = Array::from_rows(vec![vec![1.0, 20.0], vec![300.0, 4.0]]).unwrap();
+        assert_eq!(display(&m), "  1  20\n300   4");
+    }
+
+    #[test]
+    fn matrix_with_negatives_uses_underscore_in_alignment() {
+        let m = Array::from_rows(vec![vec![1.0, -20.0], vec![-3.0, 4.0]]).unwrap();
+        // Widest cell is "_20" (3 characters).
+        assert_eq!(display(&m), "  1 _20\n _3   4");
+    }
+
+    #[test]
+    fn infinities_and_nan_render_readably() {
+        assert_eq!(display(&Array::scalar(f64::INFINITY)), "inf");
+        assert_eq!(display(&Array::scalar(f64::NEG_INFINITY)), "_inf");
+        assert_eq!(display(&Array::scalar(f64::NAN)), "NaN");
+    }
+}

--- a/code/specs/MA06-j-language.md
+++ b/code/specs/MA06-j-language.md
@@ -124,10 +124,19 @@ so for J's:
     `(x f y) g (x h y)`; a leading noun `n` in `f`'s position is used as
     a literal constant instead of being applied — `(n g h) y` =
     `n g (h y)`.
-  - **4 or more verbs** recursively reduce as a fork whose left tooth is
-    itself the fork/hook of everything before the last two elements —
-    i.e. `(a b c d)` parses as the fork `(a (b c d))`, recursing until a
-    2- or 3-element base case remains. This right-to-left recursive
+  - **4 or more verbs** recursively reduce as a **hook** whose right
+    tooth is itself the fork/hook of every remaining tooth after the
+    first — i.e. `(a b c d)` parses as the hook `(a (b c d))`, peeling
+    one tooth off the left at each step and recursing until a 2- or
+    3-element base case remains (`(b c d)` here is already a 3-element
+    fork base case, so the recursion stops after one peel). Implemented
+    at MA-6d: an earlier draft of this bullet described the recursion
+    the other way around ("left tooth is the fork/hook of everything
+    before the last two elements"), which does not match this bullet's
+    own worked example (that phrasing would parse `(a b c d)` as
+    `((a b) c d)`, grouping `a`/`b` together, not `a`/`(b c d)`) —
+    corrected here to match the example, which is unambiguous and is
+    what `j-runtime` actually implements. This right-to-left recursive
     reduction is the *same* shape as APL's own right-recursive
     `value_expr` (MA05 §3 bullet 2) — trains are not a fundamentally
     different recursion, just one more production folding the same way.


### PR DESCRIPTION
## Summary

Front2's turn, completing J's core rollout: `j-lexer` ([#8127](https://github.com/adhithyan15/coding-adventures/pull/8127)) and `j-parser` ([#8152](https://github.com/adhithyan15/coding-adventures/pull/8152)) are already merged, so this is the evaluator + REPL half.

- **`j-runtime`**: a `JFn` enum generalizing `apl-runtime`'s own `AplFn` (per MA06 §5's explicit instruction), adding `Compose`/`Hook`/`Fork` alongside `Atom`/`NonScalar`/`Reduce`/`Scan`. Reuses `array-runtime`'s AR-2 kernels (`elementwise`/`reduce`/`scan`) directly for the 12 scalar-dyadic atoms; hand-rolls `$`/`i.`/`,`/`#`/`^` locally (none map to a shared `BinOp` — MA06 §2 explicitly scopes this cut to need zero new `array-runtime` substrate).
- The single most safety-critical numeric difference from APL: `i.`'s index generator is **0-based** (`i.5` = `[0,1,2,3,4]`), not APL's 1-based `⍳5` = `[1,2,3,4,5]` — dedicated regression test guards this.
- `<.`/`>.` map to `Min`/`Max` respectively when read monadically as floor/ceiling — the *opposite* character from what APL's `⌊`/`⌈` might suggest (MA06 §4's own callout), verified against `BinOp`'s dyadic min/max meaning too.
- Train evaluation implements MA06 §3's exact hook/fork formulas (including the leading-noun fork case) plus two disclosed, considered generalizations MA06 doesn't spell out explicitly: `@` compose's dyadic form and a leading-noun fork's dyadic form.
- Fixed a genuine inconsistency in MA06 §3 discovered while implementing this: the prose describing how 4+-tooth trains fold didn't match that same bullet's own worked example — corrected the prose to match the example, which is what `j-runtime` actually implements.
- `j-repl` + the `j` binary mirror `apl-repl` exactly (`NB.` comments need zero REPL-level handling, confirmed already true of `apl-repl`'s own `⍝` handling).

## Security review — one HIGH finding, fixed, plus a follow-on catch

The first review round found `fold_train` self-recursing once per train tooth with no depth guard — a genuine (if narrow: `j-parser`'s own `MAX_RULE_DEPTH` already bounds a real parsed train to ~61 teeth) stack-overflow gap for any caller building a tree another way. Fixed by making `fold_train` iterative (`O(1)` native stack frames regardless of tooth count) plus a defense-in-depth tooth-count cap. My own regression test for that fix then surfaced a **second**, related issue: dropping the resulting deeply-nested `JFn` tree still overflowed via ordinary recursive `Drop` — the same "fixed the forward walk, the backward one still crashes" lesson `wolfram-to-semantic-ir`/`macsyma-to-semantic-ir` already hit this session. Fixed with an iterative `Drop for JFn`. A second re-review round confirmed both fixes are correct and complete, with no new issues introduced.

One LOW finding (`j-repl`'s per-line read has no size bound before the existing continuation-buffer cap runs — low exploitability given the stdio-only threat model, likely shared with `apl-repl`'s identical pattern) is tracked separately (not fixed here, to avoid leaving the two sibling crates inconsistent).

## Test plan

- [x] `cargo test -p coding-adventures-j-runtime -p coding-adventures-j-repl` — 108/108 tests + doctest pass
- [x] `cargo clippy -p coding-adventures-j-runtime -p coding-adventures-j-repl --all-targets` clean
- [x] Manual end-to-end smoke test of the actual `j` binary (0-based `i.`, matrix reshape/display, reduce, a leading-noun fork, dyadic power) with hand-verified expected output
- [x] Two rounds of security review — HIGH finding fixed and re-verified independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)