### PR TITLE
fix(apl-repl,j-repl): cap unbounded single-line read before continuation check

### DIFF
--- a/code/packages/rust/apl-repl/CHANGELOG.md
+++ b/code/packages/rust/apl-repl/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`MAX_LINE_LEN` (64 KiB) caps a single physical line read from the input
+  stream**, applied via the new `read_bounded_line` helper *before*
+  `MAX_CONTINUATION_BUFFER`'s own check ever runs. `BufRead::read_line` has
+  no length bound of its own — it grows until it sees `\n` or EOF — so a
+  single, arbitrarily long physical line (no embedded newline at all) was
+  previously fully buffered in memory regardless of the continuation-buffer
+  cap. Found (LOW severity, given this crate's stdio-only threat model) by
+  the security review of the `j-runtime`/`j-repl` PR, which mirrors this
+  crate closely enough that the same gap applied here too. An oversized
+  line is now rejected cleanly (`Error: line exceeds the 65536-byte limit;
+  discarded`) with its remainder drained (one more bounded chunk) rather
+  than left to be picked up mid-line by the next read.
+
 ## [0.1.0] - 2026-07-11
 
 ### Added

--- a/code/packages/rust/apl-repl/CHANGELOG.md
+++ b/code/packages/rust/apl-repl/CHANGELOG.md
@@ -38,6 +38,19 @@ All notable changes to this project will be documented in this file.
   line's remainder is now propagated rather than swallowed, for the same
   reason (a broken pipe there isn't the same thing as "no more bytes to
   discard").
+- The discard step now **loops** over as many further capped chunks as it
+  takes to reach the oversized line's real end (a real `\n`) or true EOF,
+  instead of draining exactly one extra chunk and stopping — found by a
+  third `/security-review` round: a line whose true length spanned more
+  than two cap-widths left its remaining tail (ending in a real `\n`)
+  sitting in the reader, so the *next* read picked that fragment up and
+  misinterpreted it as a fresh, independently-typed statement, defeating
+  the "the whole oversized line is discarded" guarantee. The same round
+  also confirmed a related boundary case is handled correctly: a final
+  line whose length lands *exactly* on the cap, immediately followed by
+  genuine EOF, is a maximal ordinary line, not an oversized one — resolved
+  by checking for at least one more byte beyond the cap before reporting
+  "oversized".
 
 ## [0.1.0] - 2026-07-11
 

--- a/code/packages/rust/apl-repl/CHANGELOG.md
+++ b/code/packages/rust/apl-repl/CHANGELOG.md
@@ -18,6 +18,16 @@ All notable changes to this project will be documented in this file.
   line is now rejected cleanly (`Error: line exceeds the 65536-byte limit;
   discarded`) with its remainder drained (one more bounded chunk) rather
   than left to be picked up mid-line by the next read.
+- `read_bounded_line` reads raw bytes (`read_until(b'\n', ..)`) and only
+  decodes UTF-8 after confirming the byte run ended at a genuine `\n`
+  within the cap, rather than calling `BufRead::read_line` directly on the
+  `Take`-wrapped reader — found by `/security-review` on this same change:
+  `Take` truncates at an arbitrary byte offset with no notion of a
+  character boundary, so a valid UTF-8 line only slightly over the cap
+  could have a multi-byte character straddle that offset and make
+  `read_line` report a spurious (and fatal — it aborted the whole session)
+  `InvalidData` error instead of the intended clean "line too long"
+  message.
 
 ## [0.1.0] - 2026-07-11
 

--- a/code/packages/rust/apl-repl/CHANGELOG.md
+++ b/code/packages/rust/apl-repl/CHANGELOG.md
@@ -28,6 +28,16 @@ All notable changes to this project will be documented in this file.
   `read_line` report a spurious (and fatal — it aborted the whole session)
   `InvalidData` error instead of the intended clean "line too long"
   message.
+- The "oversized?" check itself now requires **both** no trailing `\n`
+  *and* the byte count actually reaching `MAX_LINE_LEN` — found by a
+  second `/security-review` round on the fix above: `read_until` also
+  stops with no trailing `\n` at genuine EOF (e.g. the very last line of
+  input has no closing newline), and checking `\n`-absence alone
+  misclassified that ordinary, short, valid line as "oversized" and
+  silently discarded it. A real I/O error while draining an oversized
+  line's remainder is now propagated rather than swallowed, for the same
+  reason (a broken pipe there isn't the same thing as "no more bytes to
+  discard").
 
 ## [0.1.0] - 2026-07-11
 

--- a/code/packages/rust/apl-repl/src/lib.rs
+++ b/code/packages/rust/apl-repl/src/lib.rs
@@ -76,12 +76,13 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 ///   newline-less line at genuine EOF (same as [`BufRead::read_line`]'s own
 ///   contract — an unterminated last line is not "oversized", it's just
 ///   short of a full cap's worth of bytes).
-/// - `Ok(Some(Err(())))` — a single physical line reached the cap before
-///   any `\n` appeared. The oversized remainder of that same line is
-///   drained and discarded (up to one more [`MAX_LINE_LEN`]-byte chunk,
-///   itself bounded for the same reason) so a well-behaved caller's next
-///   read starts at (or very near) a genuine line boundary instead of
-///   picking up mid-line.
+/// - `Ok(Some(Err(())))` — a single physical line's true length exceeds the
+///   cap. The entire oversized remainder of that same line is fully drained
+///   and discarded, however many more [`MAX_LINE_LEN`]-byte chunks that
+///   takes, so a well-behaved caller's next read always starts at a genuine
+///   line boundary — never mid-line. A line whose length is *exactly* the
+///   cap with nothing at all following it (genuine EOF right at the
+///   boundary) is **not** oversized; see below.
 ///
 /// Reads raw **bytes** (`read_until(b'\n', ..)`), not [`BufRead::read_line`]
 /// directly, and only attempts UTF-8 decoding *after* confirming whether the
@@ -97,11 +98,29 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 /// split a character is correctly treated as just another oversized line,
 /// not a decoding failure.
 ///
-/// Oversized is judged by **both** "no trailing `\n`" *and* "the byte count
-/// actually hit the cap" — not `\n`-absence alone. `read_until` also stops
-/// (with no trailing `\n`) at genuine EOF, e.g. a final line with no closing
-/// newline; checking length too keeps that ordinary, short, valid case from
-/// being misclassified as oversized and silently dropped.
+/// Oversized is judged by **all three** of: no trailing `\n` in the initial
+/// capped read, the byte count actually hitting the cap, *and* there being
+/// at least one more byte beyond it — not `\n`-absence alone. Two false
+/// positives that `\n`-absence alone would produce, both fixed here:
+/// - `read_until` also stops with no trailing `\n` at genuine EOF, e.g. a
+///   final line with no closing newline at all (length < the cap) — length
+///   too short to even reach the cap, so never mistaken for oversized.
+/// - A final line whose length lands *exactly* on the cap, immediately
+///   followed by genuine EOF, looks identical to "cap hit, more data still
+///   coming" from the initial read alone — resolved by attempting one more
+///   read past the cap: if that confirms EOF with zero further bytes, the
+///   original capped bytes *are* the whole (maximal, but not over-long)
+///   line, not a truncated one.
+///
+/// When a line genuinely does exceed the cap, the discard step **loops**
+/// over as many further capped chunks as it takes to reach either a real
+/// `\n` or true EOF — draining exactly one extra chunk and stopping there
+/// (an earlier version of this function) left any additional overflow
+/// sitting in the reader, so the *next* call could pick up a short tail
+/// fragment of the same rejected line — ending in its real `\n` — and
+/// misinterpret that fragment as a fresh, legitimate, independently-typed
+/// line. Looping until the true end of the oversized line is found closes
+/// that gap: nothing from a rejected line can ever reach [`AplRepl::feed`].
 fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
     let mut buf: Vec<u8> = Vec::new();
     // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
@@ -120,22 +139,40 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     }
     let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
     if hit_cap {
-        // The cap was genuinely exhausted with no newline in sight -- discard
-        // the rest of this same oversized line (one more bounded chunk; if
-        // the line somehow exceeds even that, the next call will simply
-        // report another oversized chunk rather than hang or grow memory
-        // further, which is a safe, if repetitive, degradation for a threat
-        // model this crate does not otherwise need to defend against today).
-        // This path is taken purely on byte length -- never on whether `buf`
-        // happens to be valid UTF-8 -- so a cap that splits a multi-byte
-        // character lands here too, not in the `from_utf8` error arm below.
-        let mut discard: Vec<u8> = Vec::new();
-        let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-        // Propagated with `?`, not swallowed: a genuine I/O error draining
-        // the remainder (e.g. a broken pipe) is a real failure, not just
-        // "no more oversized bytes to discard" -- it shouldn't be misreported
-        // as an ordinary oversized-line event.
-        limited.read_until(b'\n', &mut discard)?;
+        // The initial capped read filled up with no newline in sight -- but
+        // that alone doesn't yet prove the line is actually longer than the
+        // cap (see doc comment: it could be a maximal line at genuine EOF).
+        // Keep reading further capped chunks -- accumulating none of them,
+        // since all of this is being discarded regardless -- until either a
+        // real `\n` is found (line was genuinely longer than the cap) or a
+        // chunk comes back empty (true EOF).
+        let mut saw_more_data = false;
+        loop {
+            let mut chunk: Vec<u8> = Vec::new();
+            let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+            // Propagated with `?`, not swallowed: a genuine I/O error while
+            // draining the remainder (e.g. a broken pipe) is a real failure,
+            // not just "no more oversized bytes to discard" -- it shouldn't
+            // be misreported as an ordinary oversized-line event.
+            let n = limited.read_until(b'\n', &mut chunk)?;
+            if n == 0 {
+                if !saw_more_data {
+                    // Nothing at all followed the cap-sized initial read: it
+                    // was an ordinary, maximal-length line at genuine EOF,
+                    // not an oversized one. Decode and return it normally.
+                    return match String::from_utf8(buf) {
+                        Ok(line) => Ok(Some(Ok(line))),
+                        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+                    };
+                }
+                break; // true EOF reached while draining real overflow
+            }
+            saw_more_data = true;
+            if chunk.last() == Some(&b'\n') {
+                break; // found the oversized line's real end
+            }
+            // else: the line continues past this chunk too -- keep draining.
+        }
         return Ok(Some(Err(())));
     }
     // The byte run genuinely ended at a real `\n` within the cap, so any
@@ -439,6 +476,54 @@ mod tests {
         assert!(
             text.contains('2'),
             "session must keep working after a boundary-splitting oversized line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_treats_an_exactly_cap_sized_final_line_as_ordinary_not_oversized() {
+        // No trailing '\n' at all, and genuinely nothing follows -- EOF lands
+        // right at the cap. This is a maximal ordinary line (indistinguishable
+        // in length from an oversized one until a further read confirms EOF),
+        // not an oversized one, so it must decode normally rather than being
+        // reported and discarded as "exceeds the limit".
+        let line = "+".repeat(MAX_LINE_LEN as usize);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line.clone())));
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_fully_drains_a_line_spanning_multiple_cap_chunks() {
+        // True length 2.5x the cap -- past the initial capped read AND a
+        // second full capped chunk -- with a real newline only after that.
+        // An earlier version of this function discarded only one extra
+        // chunk and stopped, leaving the remaining 0.5x-cap tail (ending in
+        // the real '\n') to be picked up by the *next* call and misread as
+        // a fresh, legitimate line. The discard must now loop until the
+        // oversized line's true end is found, so the next call sees only
+        // the genuinely separate line that follows.
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1\n");
+        let mut input = input.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("1+1\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn run_executes_the_correct_follow_up_statement_after_a_multi_chunk_oversized_line() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(
+            text.contains('2'),
+            "the real follow-up statement (1+1), not a fragment of the \
+             discarded line, must be what gets evaluated, got: {text}"
         );
     }
 

--- a/code/packages/rust/apl-repl/src/lib.rs
+++ b/code/packages/rust/apl-repl/src/lib.rs
@@ -58,6 +58,59 @@ pub enum ReplResponse {
 /// convention for a single logical unit of input.
 const MAX_CONTINUATION_BUFFER: usize = 64 * 1024;
 
+/// Upper bound on a single *physical* line read from the input stream,
+/// applied in [`read_bounded_line`] before [`MAX_CONTINUATION_BUFFER`]'s own
+/// check ever runs. `BufRead::read_line` has no length bound of its own — it
+/// grows its buffer until it sees a `\n` or EOF — so without this, a single,
+/// arbitrarily long physical line (no embedded newline at all) is fully
+/// buffered in memory before `AplRepl::feed` ever gets a chance to reject
+/// anything, regardless of `MAX_CONTINUATION_BUFFER`. Same bound, same
+/// rationale, as that constant — the two together mean neither one physical
+/// line nor an accumulated multi-line continuation can grow unbounded.
+const MAX_LINE_LEN: u64 = 64 * 1024;
+
+/// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
+///
+/// - `Ok(None)` — genuine end of input.
+/// - `Ok(Some(Ok(line)))` — an ordinary line (including its trailing `\n`,
+///   same as [`BufRead::read_line`]'s own contract).
+/// - `Ok(Some(Err(())))` — a single physical line exceeded the cap before
+///   any `\n` appeared. The oversized remainder of that same line is
+///   drained and discarded (up to one more [`MAX_LINE_LEN`]-byte chunk,
+///   itself bounded for the same reason) so a well-behaved caller's next
+///   read starts at (or very near) a genuine line boundary instead of
+///   picking up mid-line.
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut line = String::new();
+    // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
+    // `reader.take(...)` method-call syntax: `Read`/`BufRead` are
+    // implemented both for `R` itself and for `&mut R`, and ordinary
+    // autoref method resolution prefers the *by-value* `R` candidate over
+    // the reference one even when the receiver expression is already a
+    // reference -- silently trying to MOVE `*reader` (illegal, since we
+    // only borrow it) instead of taking a bounded view of it. Naming the
+    // trait and the exact `&mut R` receiver explicitly removes that
+    // ambiguity.
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let read = limited.read_line(&mut line)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    if line.ends_with('\n') {
+        return Ok(Some(Ok(line)));
+    }
+    // Hit the cap without ever seeing a newline -- discard the rest of this
+    // same oversized line (one more bounded chunk; if the line somehow
+    // exceeds even that, the next call will simply report another oversized
+    // chunk rather than hang or grow memory further, which is a safe, if
+    // repetitive, degradation for a threat model this crate does not
+    // otherwise need to defend against today).
+    let mut discard = String::new();
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let _ = limited.read_line(&mut discard);
+    Ok(Some(Err(())))
+}
+
 /// A persistent interactive APL session.
 pub struct AplRepl {
     interp: Interpreter,
@@ -157,11 +210,21 @@ pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Resul
         write!(writer, "{}", repl.prompt())?;
         writer.flush()?;
 
-        let mut line = String::new();
-        if reader.read_line(&mut line)? == 0 {
-            writeln!(writer)?;
-            break;
-        }
+        let line = match read_bounded_line(&mut reader)? {
+            None => {
+                writeln!(writer)?;
+                break;
+            }
+            Some(Err(())) => {
+                writeln!(
+                    writer,
+                    "Error: line exceeds the {MAX_LINE_LEN}-byte limit; discarded"
+                )?;
+                writer.flush()?;
+                continue;
+            }
+            Some(Ok(line)) => line,
+        };
         let line = line.strip_suffix('\n').unwrap_or(&line);
         let line = line.strip_suffix('\r').unwrap_or(line);
 
@@ -240,5 +303,60 @@ mod tests {
         run(input, &mut output).unwrap();
         let text = String::from_utf8(output).unwrap();
         assert!(text.contains('6'));
+    }
+
+    #[test]
+    fn read_bounded_line_returns_an_ordinary_line_unchanged() {
+        let mut input = "A←5\nA×2\n".as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("A←5\n".to_string()))
+        );
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("A×2\n".to_string()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_rejects_a_line_exceeding_the_cap_without_buffering_it_whole() {
+        // A single physical line with no embedded newline at all, well past
+        // MAX_LINE_LEN -- exactly the shape `BufRead::read_line` alone would
+        // buffer in full before anything else got a chance to reject it.
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 3);
+        let mut input = oversized.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        // The next read should reach EOF (the whole oversized "line" -- one
+        // capped read plus one capped discard chunk -- was consumed, not
+        // left half-read for a following call to pick up mid-garbage).
+        // This particular input is 3x the cap, so a second oversized chunk
+        // may still remain; either an Err or eventual None is acceptable --
+        // what matters is the first call didn't attempt to allocate the
+        // whole 3x-cap string at once, which the cap itself already proves.
+        let _ = read_bounded_line(&mut input);
+    }
+
+    #[test]
+    fn read_bounded_line_at_exactly_the_cap_with_a_trailing_newline_is_not_oversized() {
+        let mut line = "+".repeat(MAX_LINE_LEN as usize - 1);
+        line.push('\n');
+        assert_eq!(line.len() as u64, MAX_LINE_LEN);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line)));
+    }
+
+    #[test]
+    fn run_reports_an_oversized_line_cleanly_and_keeps_the_session_alive() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 2);
+        let input = format!("{oversized}\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(
+            text.contains('2'),
+            "session must keep working after an oversized line, got: {text}"
+        );
     }
 }

--- a/code/packages/rust/apl-repl/src/lib.rs
+++ b/code/packages/rust/apl-repl/src/lib.rs
@@ -80,8 +80,21 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 ///   itself bounded for the same reason) so a well-behaved caller's next
 ///   read starts at (or very near) a genuine line boundary instead of
 ///   picking up mid-line.
+///
+/// Reads raw **bytes** (`read_until(b'\n', ..)`), not [`BufRead::read_line`]
+/// directly, and only attempts UTF-8 decoding *after* confirming the byte
+/// run actually ended at a real `\n` within the cap. `read_line` validates
+/// UTF-8 over whatever byte run it stops at — and `Take` stops at an
+/// arbitrary **byte** offset with no notion of a character boundary, so an
+/// ordinary, fully valid UTF-8 line whose true length only slightly exceeds
+/// [`MAX_LINE_LEN`] can have a multi-byte character straddle that exact
+/// offset, making `read_line` alone report a spurious `InvalidData` I/O
+/// error (fatal — it aborts the whole session, see `main.rs`) for input that
+/// isn't actually malformed, just long. Deciding "oversized?" on bytes first
+/// means a cap that happens to split a character is correctly treated as
+/// just another oversized line, not a decoding failure.
 fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
-    let mut line = String::new();
+    let mut buf: Vec<u8> = Vec::new();
     // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
     // `reader.take(...)` method-call syntax: `Read`/`BufRead` are
     // implemented both for `R` itself and for `&mut R`, and ordinary
@@ -92,23 +105,33 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     // trait and the exact `&mut R` receiver explicitly removes that
     // ambiguity.
     let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-    let read = limited.read_line(&mut line)?;
+    let read = limited.read_until(b'\n', &mut buf)?;
     if read == 0 {
         return Ok(None);
     }
-    if line.ends_with('\n') {
-        return Ok(Some(Ok(line)));
+    if buf.last() != Some(&b'\n') {
+        // Hit the cap without ever seeing a newline -- discard the rest of
+        // this same oversized line (one more bounded chunk; if the line
+        // somehow exceeds even that, the next call will simply report
+        // another oversized chunk rather than hang or grow memory further,
+        // which is a safe, if repetitive, degradation for a threat model
+        // this crate does not otherwise need to defend against today). This
+        // path is taken purely on byte length -- never on whether `buf`
+        // happens to be valid UTF-8 -- so a cap that splits a multi-byte
+        // character lands here too, not in the `from_utf8` error arm below.
+        let mut discard: Vec<u8> = Vec::new();
+        let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+        let _ = limited.read_until(b'\n', &mut discard);
+        return Ok(Some(Err(())));
     }
-    // Hit the cap without ever seeing a newline -- discard the rest of this
-    // same oversized line (one more bounded chunk; if the line somehow
-    // exceeds even that, the next call will simply report another oversized
-    // chunk rather than hang or grow memory further, which is a safe, if
-    // repetitive, degradation for a threat model this crate does not
-    // otherwise need to defend against today).
-    let mut discard = String::new();
-    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-    let _ = limited.read_line(&mut discard);
-    Ok(Some(Err(())))
+    // The byte run genuinely ended at a real `\n` within the cap, so any
+    // UTF-8 error here is real malformed input, not a truncation artifact --
+    // propagated as an I/O error, same as `BufRead::read_line` would have
+    // done for this same (uncapped) byte run.
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(Ok(line))),
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
 }
 
 /// A persistent interactive APL session.
@@ -344,6 +367,39 @@ mod tests {
         assert_eq!(line.len() as u64, MAX_LINE_LEN);
         let mut input = line.as_bytes();
         assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line)));
+    }
+
+    #[test]
+    fn read_bounded_line_handles_a_multibyte_char_straddling_the_cap_boundary() {
+        // A line whose true length only slightly exceeds MAX_LINE_LEN, with
+        // a 2-byte UTF-8 character ('é') positioned so the cap lands right
+        // in the middle of it. Before the byte-oriented rewrite, this made
+        // `read_line` (validating whatever partial byte run `Take` handed
+        // it) return a spurious `InvalidData` I/O error -- fatal, per
+        // `run`'s `?` propagation -- for a line that is not malformed, just
+        // long. It must now be treated exactly like any other oversized
+        // line: `Some(Err(()))`, not a hard I/O error.
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes()); // 2-byte char, straddles the cap
+        oversized.push(b'\n');
+        let mut input = oversized.as_slice();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+    }
+
+    #[test]
+    fn run_survives_a_multibyte_char_straddling_the_cap_boundary() {
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes());
+        let mut input = oversized;
+        input.extend_from_slice(b"\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_slice(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(
+            text.contains('2'),
+            "session must keep working after a boundary-splitting oversized line, got: {text}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/apl-repl/src/lib.rs
+++ b/code/packages/rust/apl-repl/src/lib.rs
@@ -72,9 +72,11 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 /// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
 ///
 /// - `Ok(None)` — genuine end of input.
-/// - `Ok(Some(Ok(line)))` — an ordinary line (including its trailing `\n`,
-///   same as [`BufRead::read_line`]'s own contract).
-/// - `Ok(Some(Err(())))` — a single physical line exceeded the cap before
+/// - `Ok(Some(Ok(line)))` — an ordinary line. Includes a final,
+///   newline-less line at genuine EOF (same as [`BufRead::read_line`]'s own
+///   contract — an unterminated last line is not "oversized", it's just
+///   short of a full cap's worth of bytes).
+/// - `Ok(Some(Err(())))` — a single physical line reached the cap before
 ///   any `\n` appeared. The oversized remainder of that same line is
 ///   drained and discarded (up to one more [`MAX_LINE_LEN`]-byte chunk,
 ///   itself bounded for the same reason) so a well-behaved caller's next
@@ -82,17 +84,24 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 ///   picking up mid-line.
 ///
 /// Reads raw **bytes** (`read_until(b'\n', ..)`), not [`BufRead::read_line`]
-/// directly, and only attempts UTF-8 decoding *after* confirming the byte
-/// run actually ended at a real `\n` within the cap. `read_line` validates
-/// UTF-8 over whatever byte run it stops at — and `Take` stops at an
-/// arbitrary **byte** offset with no notion of a character boundary, so an
-/// ordinary, fully valid UTF-8 line whose true length only slightly exceeds
-/// [`MAX_LINE_LEN`] can have a multi-byte character straddle that exact
-/// offset, making `read_line` alone report a spurious `InvalidData` I/O
-/// error (fatal — it aborts the whole session, see `main.rs`) for input that
-/// isn't actually malformed, just long. Deciding "oversized?" on bytes first
-/// means a cap that happens to split a character is correctly treated as
-/// just another oversized line, not a decoding failure.
+/// directly, and only attempts UTF-8 decoding *after* confirming whether the
+/// byte run stopped because of a real `\n` or because it genuinely
+/// exhausted the cap. `read_line` validates UTF-8 over whatever byte run it
+/// stops at — and `Take` stops at an arbitrary **byte** offset with no
+/// notion of a character boundary, so an ordinary, fully valid UTF-8 line
+/// whose true length only slightly exceeds [`MAX_LINE_LEN`] can have a
+/// multi-byte character straddle that exact offset, making `read_line` alone
+/// report a spurious `InvalidData` I/O error (fatal — it aborts the whole
+/// session, see `main.rs`) for input that isn't actually malformed, just
+/// long. Deciding "oversized?" on bytes first means a cap that happens to
+/// split a character is correctly treated as just another oversized line,
+/// not a decoding failure.
+///
+/// Oversized is judged by **both** "no trailing `\n`" *and* "the byte count
+/// actually hit the cap" — not `\n`-absence alone. `read_until` also stops
+/// (with no trailing `\n`) at genuine EOF, e.g. a final line with no closing
+/// newline; checking length too keeps that ordinary, short, valid case from
+/// being misclassified as oversized and silently dropped.
 fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
     let mut buf: Vec<u8> = Vec::new();
     // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
@@ -109,19 +118,24 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     if read == 0 {
         return Ok(None);
     }
-    if buf.last() != Some(&b'\n') {
-        // Hit the cap without ever seeing a newline -- discard the rest of
-        // this same oversized line (one more bounded chunk; if the line
-        // somehow exceeds even that, the next call will simply report
-        // another oversized chunk rather than hang or grow memory further,
-        // which is a safe, if repetitive, degradation for a threat model
-        // this crate does not otherwise need to defend against today). This
-        // path is taken purely on byte length -- never on whether `buf`
+    let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
+    if hit_cap {
+        // The cap was genuinely exhausted with no newline in sight -- discard
+        // the rest of this same oversized line (one more bounded chunk; if
+        // the line somehow exceeds even that, the next call will simply
+        // report another oversized chunk rather than hang or grow memory
+        // further, which is a safe, if repetitive, degradation for a threat
+        // model this crate does not otherwise need to defend against today).
+        // This path is taken purely on byte length -- never on whether `buf`
         // happens to be valid UTF-8 -- so a cap that splits a multi-byte
         // character lands here too, not in the `from_utf8` error arm below.
         let mut discard: Vec<u8> = Vec::new();
         let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-        let _ = limited.read_until(b'\n', &mut discard);
+        // Propagated with `?`, not swallowed: a genuine I/O error draining
+        // the remainder (e.g. a broken pipe) is a real failure, not just
+        // "no more oversized bytes to discard" -- it shouldn't be misreported
+        // as an ordinary oversized-line event.
+        limited.read_until(b'\n', &mut discard)?;
         return Ok(Some(Err(())));
     }
     // The byte run genuinely ended at a real `\n` within the cap, so any
@@ -326,6 +340,32 @@ mod tests {
         run(input, &mut output).unwrap();
         let text = String::from_utf8(output).unwrap();
         assert!(text.contains('6'));
+    }
+
+    #[test]
+    fn read_bounded_line_returns_a_final_line_without_a_trailing_newline() {
+        // A genuine EOF before the cap with no trailing '\n' at all (e.g.
+        // `printf '%s' quit` piped in, or a file with no final newline) is
+        // an ordinary short line, not an oversized one -- the byte run
+        // stopped at EOF, not because the cap was exhausted.
+        let mut input = "quit".as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("quit".to_string()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn run_quits_cleanly_on_a_final_line_without_a_trailing_newline() {
+        let input = "quit".as_bytes(); // no trailing '\n' anywhere in the input
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            !text.contains("exceeds"),
+            "a short, unterminated final line must not be treated as oversized, got: {text}"
+        );
     }
 
     #[test]

--- a/code/packages/rust/j-repl/CHANGELOG.md
+++ b/code/packages/rust/j-repl/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`MAX_LINE_LEN` (64 KiB) caps a single physical line read from the input
+  stream**, applied via the new `read_bounded_line` helper *before*
+  `MAX_CONTINUATION_BUFFER`'s own check ever runs. `BufRead::read_line` has
+  no length bound of its own — it grows until it sees `\n` or EOF — so a
+  single, arbitrarily long physical line (no embedded newline at all) was
+  previously fully buffered in memory regardless of the continuation-buffer
+  cap. Found (LOW severity, given this crate's stdio-only threat model) by
+  the security review of this crate's own MA-6d PR, then mirrored back into
+  `apl-repl` since both crates share the identical scanner design. An
+  oversized line is now rejected cleanly (`Error: line exceeds the
+  65536-byte limit; discarded`) with its remainder drained (one more
+  bounded chunk) rather than left to be picked up mid-line by the next
+  read.
+
 ## [0.1.0] - 2026-07-13
 
 ### Added

--- a/code/packages/rust/j-repl/CHANGELOG.md
+++ b/code/packages/rust/j-repl/CHANGELOG.md
@@ -38,6 +38,19 @@ All notable changes to this project will be documented in this file.
   silently discarded it. A real I/O error while draining an oversized
   line's remainder is now propagated rather than swallowed, for the same
   reason. Ported from `apl-repl`'s identical fix.
+- The discard step now **loops** over as many further capped chunks as it
+  takes to reach the oversized line's real end (a real `\n`) or true EOF,
+  instead of draining exactly one extra chunk and stopping — found by a
+  third `/security-review` round: a line whose true length spanned more
+  than two cap-widths left its remaining tail (ending in a real `\n`)
+  sitting in the reader, so the *next* read picked that fragment up and
+  misinterpreted it as a fresh, independently-typed statement, defeating
+  the "the whole oversized line is discarded" guarantee. The same round
+  also confirmed a related boundary case is handled correctly: a final
+  line whose length lands *exactly* on the cap, immediately followed by
+  genuine EOF, is a maximal ordinary line, not an oversized one — resolved
+  by checking for at least one more byte beyond the cap before reporting
+  "oversized". Ported from `apl-repl`'s identical fix.
 
 ## [0.1.0] - 2026-07-13
 

--- a/code/packages/rust/j-repl/CHANGELOG.md
+++ b/code/packages/rust/j-repl/CHANGELOG.md
@@ -29,6 +29,15 @@ All notable changes to this project will be documented in this file.
   `read_line` report a spurious (and fatal — it aborted the whole session)
   `InvalidData` error instead of the intended clean "line too long"
   message. Ported from `apl-repl`'s identical fix.
+- The "oversized?" check itself now requires **both** no trailing `\n`
+  *and* the byte count actually reaching `MAX_LINE_LEN` — found by a
+  second `/security-review` round on the fix above: `read_until` also
+  stops with no trailing `\n` at genuine EOF (e.g. the very last line of
+  input has no closing newline), and checking `\n`-absence alone
+  misclassified that ordinary, short, valid line as "oversized" and
+  silently discarded it. A real I/O error while draining an oversized
+  line's remainder is now propagated rather than swallowed, for the same
+  reason. Ported from `apl-repl`'s identical fix.
 
 ## [0.1.0] - 2026-07-13
 

--- a/code/packages/rust/j-repl/CHANGELOG.md
+++ b/code/packages/rust/j-repl/CHANGELOG.md
@@ -19,6 +19,16 @@ All notable changes to this project will be documented in this file.
   65536-byte limit; discarded`) with its remainder drained (one more
   bounded chunk) rather than left to be picked up mid-line by the next
   read.
+- `read_bounded_line` reads raw bytes (`read_until(b'\n', ..)`) and only
+  decodes UTF-8 after confirming the byte run ended at a genuine `\n`
+  within the cap, rather than calling `BufRead::read_line` directly on the
+  `Take`-wrapped reader — found by `/security-review` on this same change:
+  `Take` truncates at an arbitrary byte offset with no notion of a
+  character boundary, so a valid UTF-8 line only slightly over the cap
+  could have a multi-byte character straddle that offset and make
+  `read_line` report a spurious (and fatal — it aborted the whole session)
+  `InvalidData` error instead of the intended clean "line too long"
+  message. Ported from `apl-repl`'s identical fix.
 
 ## [0.1.0] - 2026-07-13
 

--- a/code/packages/rust/j-repl/src/lib.rs
+++ b/code/packages/rust/j-repl/src/lib.rs
@@ -84,12 +84,13 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 ///   newline-less line at genuine EOF (same as [`BufRead::read_line`]'s own
 ///   contract — an unterminated last line is not "oversized", it's just
 ///   short of a full cap's worth of bytes).
-/// - `Ok(Some(Err(())))` — a single physical line reached the cap before
-///   any `\n` appeared. The oversized remainder of that same line is
-///   drained and discarded (up to one more [`MAX_LINE_LEN`]-byte chunk,
-///   itself bounded for the same reason) so a well-behaved caller's next
-///   read starts at (or very near) a genuine line boundary instead of
-///   picking up mid-line.
+/// - `Ok(Some(Err(())))` — a single physical line's true length exceeds the
+///   cap. The entire oversized remainder of that same line is fully drained
+///   and discarded, however many more [`MAX_LINE_LEN`]-byte chunks that
+///   takes, so a well-behaved caller's next read always starts at a genuine
+///   line boundary — never mid-line. A line whose length is *exactly* the
+///   cap with nothing at all following it (genuine EOF right at the
+///   boundary) is **not** oversized; see below.
 ///
 /// Reads raw **bytes** (`read_until(b'\n', ..)`), not [`BufRead::read_line`]
 /// directly, and only attempts UTF-8 decoding *after* confirming whether the
@@ -106,11 +107,29 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 /// not a decoding failure (mirrors `apl-repl::read_bounded_line`'s identical
 /// fix exactly).
 ///
-/// Oversized is judged by **both** "no trailing `\n`" *and* "the byte count
-/// actually hit the cap" — not `\n`-absence alone. `read_until` also stops
-/// (with no trailing `\n`) at genuine EOF, e.g. a final line with no closing
-/// newline; checking length too keeps that ordinary, short, valid case from
-/// being misclassified as oversized and silently dropped.
+/// Oversized is judged by **all three** of: no trailing `\n` in the initial
+/// capped read, the byte count actually hitting the cap, *and* there being
+/// at least one more byte beyond it — not `\n`-absence alone. Two false
+/// positives that `\n`-absence alone would produce, both fixed here:
+/// - `read_until` also stops with no trailing `\n` at genuine EOF, e.g. a
+///   final line with no closing newline at all (length < the cap) — length
+///   too short to even reach the cap, so never mistaken for oversized.
+/// - A final line whose length lands *exactly* on the cap, immediately
+///   followed by genuine EOF, looks identical to "cap hit, more data still
+///   coming" from the initial read alone — resolved by attempting one more
+///   read past the cap: if that confirms EOF with zero further bytes, the
+///   original capped bytes *are* the whole (maximal, but not over-long)
+///   line, not a truncated one.
+///
+/// When a line genuinely does exceed the cap, the discard step **loops**
+/// over as many further capped chunks as it takes to reach either a real
+/// `\n` or true EOF — draining exactly one extra chunk and stopping there
+/// (an earlier version of this function) left any additional overflow
+/// sitting in the reader, so the *next* call could pick up a short tail
+/// fragment of the same rejected line — ending in its real `\n` — and
+/// misinterpret that fragment as a fresh, legitimate, independently-typed
+/// line. Looping until the true end of the oversized line is found closes
+/// that gap: nothing from a rejected line can ever reach [`JRepl::feed`].
 fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
     let mut buf: Vec<u8> = Vec::new();
     // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
@@ -129,22 +148,40 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     }
     let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
     if hit_cap {
-        // The cap was genuinely exhausted with no newline in sight -- discard
-        // the rest of this same oversized line (one more bounded chunk; if
-        // the line somehow exceeds even that, the next call will simply
-        // report another oversized chunk rather than hang or grow memory
-        // further, which is a safe, if repetitive, degradation for a threat
-        // model this crate does not otherwise need to defend against today).
-        // This path is taken purely on byte length -- never on whether `buf`
-        // happens to be valid UTF-8 -- so a cap that splits a multi-byte
-        // character lands here too, not in the `from_utf8` error arm below.
-        let mut discard: Vec<u8> = Vec::new();
-        let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-        // Propagated with `?`, not swallowed: a genuine I/O error draining
-        // the remainder (e.g. a broken pipe) is a real failure, not just
-        // "no more oversized bytes to discard" -- it shouldn't be misreported
-        // as an ordinary oversized-line event.
-        limited.read_until(b'\n', &mut discard)?;
+        // The initial capped read filled up with no newline in sight -- but
+        // that alone doesn't yet prove the line is actually longer than the
+        // cap (see doc comment: it could be a maximal line at genuine EOF).
+        // Keep reading further capped chunks -- accumulating none of them,
+        // since all of this is being discarded regardless -- until either a
+        // real `\n` is found (line was genuinely longer than the cap) or a
+        // chunk comes back empty (true EOF).
+        let mut saw_more_data = false;
+        loop {
+            let mut chunk: Vec<u8> = Vec::new();
+            let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+            // Propagated with `?`, not swallowed: a genuine I/O error while
+            // draining the remainder (e.g. a broken pipe) is a real failure,
+            // not just "no more oversized bytes to discard" -- it shouldn't
+            // be misreported as an ordinary oversized-line event.
+            let n = limited.read_until(b'\n', &mut chunk)?;
+            if n == 0 {
+                if !saw_more_data {
+                    // Nothing at all followed the cap-sized initial read: it
+                    // was an ordinary, maximal-length line at genuine EOF,
+                    // not an oversized one. Decode and return it normally.
+                    return match String::from_utf8(buf) {
+                        Ok(line) => Ok(Some(Ok(line))),
+                        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+                    };
+                }
+                break; // true EOF reached while draining real overflow
+            }
+            saw_more_data = true;
+            if chunk.last() == Some(&b'\n') {
+                break; // found the oversized line's real end
+            }
+            // else: the line continues past this chunk too -- keep draining.
+        }
         return Ok(Some(Err(())));
     }
     // The byte run genuinely ended at a real `\n` within the cap, so any
@@ -467,6 +504,56 @@ mod tests {
         assert!(
             text.contains('2'),
             "session must keep working after a boundary-splitting oversized line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_treats_an_exactly_cap_sized_final_line_as_ordinary_not_oversized() {
+        // No trailing '\n' at all, and genuinely nothing follows -- EOF lands
+        // right at the cap. This is a maximal ordinary line (indistinguishable
+        // in length from an oversized one until a further read confirms EOF),
+        // not an oversized one, so it must decode normally rather than being
+        // reported and discarded as "exceeds the limit". Mirrors `apl-repl`'s
+        // identical regression test.
+        let line = "+".repeat(MAX_LINE_LEN as usize);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line.clone())));
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_fully_drains_a_line_spanning_multiple_cap_chunks() {
+        // True length 2.5x the cap -- past the initial capped read AND a
+        // second full capped chunk -- with a real newline only after that.
+        // An earlier version of this function discarded only one extra
+        // chunk and stopped, leaving the remaining 0.5x-cap tail (ending in
+        // the real '\n') to be picked up by the *next* call and misread as
+        // a fresh, legitimate line. The discard must now loop until the
+        // oversized line's true end is found, so the next call sees only
+        // the genuinely separate line that follows. Mirrors `apl-repl`'s
+        // identical regression test.
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1\n");
+        let mut input = input.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("1+1\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn run_executes_the_correct_follow_up_statement_after_a_multi_chunk_oversized_line() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(
+            text.contains('2'),
+            "the real follow-up statement (1+1), not a fragment of the \
+             discarded line, must be what gets evaluated, got: {text}"
         );
     }
 }

--- a/code/packages/rust/j-repl/src/lib.rs
+++ b/code/packages/rust/j-repl/src/lib.rs
@@ -88,8 +88,22 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 ///   itself bounded for the same reason) so a well-behaved caller's next
 ///   read starts at (or very near) a genuine line boundary instead of
 ///   picking up mid-line.
+///
+/// Reads raw **bytes** (`read_until(b'\n', ..)`), not [`BufRead::read_line`]
+/// directly, and only attempts UTF-8 decoding *after* confirming the byte
+/// run actually ended at a real `\n` within the cap. `read_line` validates
+/// UTF-8 over whatever byte run it stops at — and `Take` stops at an
+/// arbitrary **byte** offset with no notion of a character boundary, so an
+/// ordinary, fully valid UTF-8 line whose true length only slightly exceeds
+/// [`MAX_LINE_LEN`] can have a multi-byte character straddle that exact
+/// offset, making `read_line` alone report a spurious `InvalidData` I/O
+/// error (fatal — it aborts the whole session, see `main.rs`) for input that
+/// isn't actually malformed, just long. Deciding "oversized?" on bytes first
+/// means a cap that happens to split a character is correctly treated as
+/// just another oversized line, not a decoding failure (mirrors
+/// `apl-repl::read_bounded_line`'s identical fix exactly).
 fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
-    let mut line = String::new();
+    let mut buf: Vec<u8> = Vec::new();
     // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
     // `reader.take(...)` method-call syntax: `Read`/`BufRead` are
     // implemented both for `R` itself and for `&mut R`, and ordinary
@@ -100,23 +114,33 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     // trait and the exact `&mut R` receiver explicitly removes that
     // ambiguity.
     let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-    let read = limited.read_line(&mut line)?;
+    let read = limited.read_until(b'\n', &mut buf)?;
     if read == 0 {
         return Ok(None);
     }
-    if line.ends_with('\n') {
-        return Ok(Some(Ok(line)));
+    if buf.last() != Some(&b'\n') {
+        // Hit the cap without ever seeing a newline -- discard the rest of
+        // this same oversized line (one more bounded chunk; if the line
+        // somehow exceeds even that, the next call will simply report
+        // another oversized chunk rather than hang or grow memory further,
+        // which is a safe, if repetitive, degradation for a threat model
+        // this crate does not otherwise need to defend against today). This
+        // path is taken purely on byte length -- never on whether `buf`
+        // happens to be valid UTF-8 -- so a cap that splits a multi-byte
+        // character lands here too, not in the `from_utf8` error arm below.
+        let mut discard: Vec<u8> = Vec::new();
+        let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+        let _ = limited.read_until(b'\n', &mut discard);
+        return Ok(Some(Err(())));
     }
-    // Hit the cap without ever seeing a newline -- discard the rest of this
-    // same oversized line (one more bounded chunk; if the line somehow
-    // exceeds even that, the next call will simply report another oversized
-    // chunk rather than hang or grow memory further, which is a safe, if
-    // repetitive, degradation for a threat model this crate does not
-    // otherwise need to defend against today).
-    let mut discard = String::new();
-    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-    let _ = limited.read_line(&mut discard);
-    Ok(Some(Err(())))
+    // The byte run genuinely ended at a real `\n` within the cap, so any
+    // UTF-8 error here is real malformed input, not a truncation artifact --
+    // propagated as an I/O error, same as `BufRead::read_line` would have
+    // done for this same (uncapped) byte run.
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(Ok(line))),
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
 }
 
 /// A persistent interactive J session.
@@ -368,6 +392,40 @@ mod tests {
         assert!(
             text.contains('2'),
             "session must keep working after an oversized line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_handles_a_multibyte_char_straddling_the_cap_boundary() {
+        // A line whose true length only slightly exceeds MAX_LINE_LEN, with
+        // a 2-byte UTF-8 character ('é') positioned so the cap lands right
+        // in the middle of it. Before the byte-oriented rewrite, this made
+        // `read_line` (validating whatever partial byte run `Take` handed
+        // it) return a spurious `InvalidData` I/O error -- fatal, per
+        // `run`'s `?` propagation -- for a line that is not malformed, just
+        // long. It must now be treated exactly like any other oversized
+        // line: `Some(Err(()))`, not a hard I/O error. Mirrors
+        // `apl-repl`'s identical regression test.
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes()); // 2-byte char, straddles the cap
+        oversized.push(b'\n');
+        let mut input = oversized.as_slice();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+    }
+
+    #[test]
+    fn run_survives_a_multibyte_char_straddling_the_cap_boundary() {
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes());
+        let mut input = oversized;
+        input.extend_from_slice(b"\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_slice(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(
+            text.contains('2'),
+            "session must keep working after a boundary-splitting oversized line, got: {text}"
         );
     }
 }

--- a/code/packages/rust/j-repl/src/lib.rs
+++ b/code/packages/rust/j-repl/src/lib.rs
@@ -65,6 +65,60 @@ pub enum ReplResponse {
 /// "generous but bounded" convention.
 const MAX_CONTINUATION_BUFFER: usize = 64 * 1024;
 
+/// Upper bound on a single *physical* line read from the input stream,
+/// applied in [`read_bounded_line`] before [`MAX_CONTINUATION_BUFFER`]'s own
+/// check ever runs. `BufRead::read_line` has no length bound of its own — it
+/// grows its buffer until it sees a `\n` or EOF — so without this, a single,
+/// arbitrarily long physical line (no embedded newline at all) is fully
+/// buffered in memory before `JRepl::feed` ever gets a chance to reject
+/// anything, regardless of `MAX_CONTINUATION_BUFFER`. Same bound, same
+/// rationale, as that constant (mirroring `apl-repl::MAX_LINE_LEN` exactly)
+/// — the two together mean neither one physical line nor an accumulated
+/// multi-line continuation can grow unbounded.
+const MAX_LINE_LEN: u64 = 64 * 1024;
+
+/// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
+///
+/// - `Ok(None)` — genuine end of input.
+/// - `Ok(Some(Ok(line)))` — an ordinary line (including its trailing `\n`,
+///   same as [`BufRead::read_line`]'s own contract).
+/// - `Ok(Some(Err(())))` — a single physical line exceeded the cap before
+///   any `\n` appeared. The oversized remainder of that same line is
+///   drained and discarded (up to one more [`MAX_LINE_LEN`]-byte chunk,
+///   itself bounded for the same reason) so a well-behaved caller's next
+///   read starts at (or very near) a genuine line boundary instead of
+///   picking up mid-line.
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut line = String::new();
+    // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
+    // `reader.take(...)` method-call syntax: `Read`/`BufRead` are
+    // implemented both for `R` itself and for `&mut R`, and ordinary
+    // autoref method resolution prefers the *by-value* `R` candidate over
+    // the reference one even when the receiver expression is already a
+    // reference -- silently trying to MOVE `*reader` (illegal, since we
+    // only borrow it) instead of taking a bounded view of it. Naming the
+    // trait and the exact `&mut R` receiver explicitly removes that
+    // ambiguity.
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let read = limited.read_line(&mut line)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    if line.ends_with('\n') {
+        return Ok(Some(Ok(line)));
+    }
+    // Hit the cap without ever seeing a newline -- discard the rest of this
+    // same oversized line (one more bounded chunk; if the line somehow
+    // exceeds even that, the next call will simply report another oversized
+    // chunk rather than hang or grow memory further, which is a safe, if
+    // repetitive, degradation for a threat model this crate does not
+    // otherwise need to defend against today).
+    let mut discard = String::new();
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let _ = limited.read_line(&mut discard);
+    Ok(Some(Err(())))
+}
+
 /// A persistent interactive J session.
 pub struct JRepl {
     interp: Interpreter,
@@ -164,11 +218,21 @@ pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Resul
         write!(writer, "{}", repl.prompt())?;
         writer.flush()?;
 
-        let mut line = String::new();
-        if reader.read_line(&mut line)? == 0 {
-            writeln!(writer)?;
-            break;
-        }
+        let line = match read_bounded_line(&mut reader)? {
+            None => {
+                writeln!(writer)?;
+                break;
+            }
+            Some(Err(())) => {
+                writeln!(
+                    writer,
+                    "Error: line exceeds the {MAX_LINE_LEN}-byte limit; discarded"
+                )?;
+                writer.flush()?;
+                continue;
+            }
+            Some(Ok(line)) => line,
+        };
         let line = line.strip_suffix('\n').unwrap_or(&line);
         let line = line.strip_suffix('\r').unwrap_or(line);
 
@@ -253,5 +317,57 @@ mod tests {
         run(input, &mut output).unwrap();
         let text = String::from_utf8(output).unwrap();
         assert!(text.contains('6'));
+    }
+
+    #[test]
+    fn read_bounded_line_returns_an_ordinary_line_unchanged() {
+        let mut input = "A=.5\nA*2\n".as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("A=.5\n".to_string()))
+        );
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("A*2\n".to_string()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_rejects_a_line_exceeding_the_cap_without_buffering_it_whole() {
+        // A single physical line with no embedded newline at all, well past
+        // MAX_LINE_LEN -- exactly the shape `BufRead::read_line` alone would
+        // buffer in full before anything else got a chance to reject it.
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 3);
+        let mut input = oversized.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        // Whatever remains (this input is 3x the cap, so a second oversized
+        // chunk may still be pending) doesn't matter for this test -- what
+        // matters is the first call didn't attempt to allocate the whole
+        // 3x-cap string at once, which the cap itself already proves.
+        let _ = read_bounded_line(&mut input);
+    }
+
+    #[test]
+    fn read_bounded_line_at_exactly_the_cap_with_a_trailing_newline_is_not_oversized() {
+        let mut line = "+".repeat(MAX_LINE_LEN as usize - 1);
+        line.push('\n');
+        assert_eq!(line.len() as u64, MAX_LINE_LEN);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line)));
+    }
+
+    #[test]
+    fn run_reports_an_oversized_line_cleanly_and_keeps_the_session_alive() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 2);
+        let input = format!("{oversized}\n1+1\nquit\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("exceeds"), "expected an oversized-line error, got: {text}");
+        assert!(
+            text.contains('2'),
+            "session must keep working after an oversized line, got: {text}"
+        );
     }
 }

--- a/code/packages/rust/j-repl/src/lib.rs
+++ b/code/packages/rust/j-repl/src/lib.rs
@@ -80,9 +80,11 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 /// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
 ///
 /// - `Ok(None)` — genuine end of input.
-/// - `Ok(Some(Ok(line)))` — an ordinary line (including its trailing `\n`,
-///   same as [`BufRead::read_line`]'s own contract).
-/// - `Ok(Some(Err(())))` — a single physical line exceeded the cap before
+/// - `Ok(Some(Ok(line)))` — an ordinary line. Includes a final,
+///   newline-less line at genuine EOF (same as [`BufRead::read_line`]'s own
+///   contract — an unterminated last line is not "oversized", it's just
+///   short of a full cap's worth of bytes).
+/// - `Ok(Some(Err(())))` — a single physical line reached the cap before
 ///   any `\n` appeared. The oversized remainder of that same line is
 ///   drained and discarded (up to one more [`MAX_LINE_LEN`]-byte chunk,
 ///   itself bounded for the same reason) so a well-behaved caller's next
@@ -90,18 +92,25 @@ const MAX_LINE_LEN: u64 = 64 * 1024;
 ///   picking up mid-line.
 ///
 /// Reads raw **bytes** (`read_until(b'\n', ..)`), not [`BufRead::read_line`]
-/// directly, and only attempts UTF-8 decoding *after* confirming the byte
-/// run actually ended at a real `\n` within the cap. `read_line` validates
-/// UTF-8 over whatever byte run it stops at — and `Take` stops at an
-/// arbitrary **byte** offset with no notion of a character boundary, so an
-/// ordinary, fully valid UTF-8 line whose true length only slightly exceeds
-/// [`MAX_LINE_LEN`] can have a multi-byte character straddle that exact
-/// offset, making `read_line` alone report a spurious `InvalidData` I/O
-/// error (fatal — it aborts the whole session, see `main.rs`) for input that
-/// isn't actually malformed, just long. Deciding "oversized?" on bytes first
-/// means a cap that happens to split a character is correctly treated as
-/// just another oversized line, not a decoding failure (mirrors
-/// `apl-repl::read_bounded_line`'s identical fix exactly).
+/// directly, and only attempts UTF-8 decoding *after* confirming whether the
+/// byte run stopped because of a real `\n` or because it genuinely
+/// exhausted the cap. `read_line` validates UTF-8 over whatever byte run it
+/// stops at — and `Take` stops at an arbitrary **byte** offset with no
+/// notion of a character boundary, so an ordinary, fully valid UTF-8 line
+/// whose true length only slightly exceeds [`MAX_LINE_LEN`] can have a
+/// multi-byte character straddle that exact offset, making `read_line` alone
+/// report a spurious `InvalidData` I/O error (fatal — it aborts the whole
+/// session, see `main.rs`) for input that isn't actually malformed, just
+/// long. Deciding "oversized?" on bytes first means a cap that happens to
+/// split a character is correctly treated as just another oversized line,
+/// not a decoding failure (mirrors `apl-repl::read_bounded_line`'s identical
+/// fix exactly).
+///
+/// Oversized is judged by **both** "no trailing `\n`" *and* "the byte count
+/// actually hit the cap" — not `\n`-absence alone. `read_until` also stops
+/// (with no trailing `\n`) at genuine EOF, e.g. a final line with no closing
+/// newline; checking length too keeps that ordinary, short, valid case from
+/// being misclassified as oversized and silently dropped.
 fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
     let mut buf: Vec<u8> = Vec::new();
     // Explicit UFCS + an explicit reborrow (`&mut *reader`), not plain
@@ -118,19 +127,24 @@ fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Resul
     if read == 0 {
         return Ok(None);
     }
-    if buf.last() != Some(&b'\n') {
-        // Hit the cap without ever seeing a newline -- discard the rest of
-        // this same oversized line (one more bounded chunk; if the line
-        // somehow exceeds even that, the next call will simply report
-        // another oversized chunk rather than hang or grow memory further,
-        // which is a safe, if repetitive, degradation for a threat model
-        // this crate does not otherwise need to defend against today). This
-        // path is taken purely on byte length -- never on whether `buf`
+    let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
+    if hit_cap {
+        // The cap was genuinely exhausted with no newline in sight -- discard
+        // the rest of this same oversized line (one more bounded chunk; if
+        // the line somehow exceeds even that, the next call will simply
+        // report another oversized chunk rather than hang or grow memory
+        // further, which is a safe, if repetitive, degradation for a threat
+        // model this crate does not otherwise need to defend against today).
+        // This path is taken purely on byte length -- never on whether `buf`
         // happens to be valid UTF-8 -- so a cap that splits a multi-byte
         // character lands here too, not in the `from_utf8` error arm below.
         let mut discard: Vec<u8> = Vec::new();
         let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
-        let _ = limited.read_until(b'\n', &mut discard);
+        // Propagated with `?`, not swallowed: a genuine I/O error draining
+        // the remainder (e.g. a broken pipe) is a real failure, not just
+        // "no more oversized bytes to discard" -- it shouldn't be misreported
+        // as an ordinary oversized-line event.
+        limited.read_until(b'\n', &mut discard)?;
         return Ok(Some(Err(())));
     }
     // The byte run genuinely ended at a real `\n` within the cap, so any
@@ -341,6 +355,33 @@ mod tests {
         run(input, &mut output).unwrap();
         let text = String::from_utf8(output).unwrap();
         assert!(text.contains('6'));
+    }
+
+    #[test]
+    fn read_bounded_line_returns_a_final_line_without_a_trailing_newline() {
+        // A genuine EOF before the cap with no trailing '\n' at all (e.g.
+        // `printf '%s' quit` piped in, or a file with no final newline) is
+        // an ordinary short line, not an oversized one -- the byte run
+        // stopped at EOF, not because the cap was exhausted. Mirrors
+        // `apl-repl`'s identical regression test.
+        let mut input = "quit".as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("quit".to_string()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn run_quits_cleanly_on_a_final_line_without_a_trailing_newline() {
+        let input = "quit".as_bytes(); // no trailing '\n' anywhere in the input
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            !text.contains("exceeds"),
+            "a short, unterminated final line must not be treated as oversized, got: {text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `BufRead::read_line` has no length bound of its own — a single physical line with no embedded newline was fully buffered in memory before `MAX_CONTINUATION_BUFFER`'s own check ever ran. Adds a `MAX_LINE_LEN` (64 KiB) cap and a `read_bounded_line` helper to both `apl-repl` and `j-repl` (identical scanner design), applied *before* that check.
- This was task #32, originally deferred as a LOW finding out of PR #8173's (`j-runtime`/`j-repl`) security review, since fixing only one of the two sibling crates would leave them inconsistent.
- Four rounds of `/security-review` on this branch itself found and fixed, in order: (1) a spurious fatal I/O error when a multi-byte UTF-8 character straddles the cap boundary, (2) a final unterminated line at genuine EOF being misclassified as "oversized" and silently dropped, (3) an incomplete discard that could leave a tail fragment of a rejected oversized line to be misread as a fresh statement by the *next* read, plus a related exact-cap/EOF edge case. Round 4 passed clean.

## Test plan
- [x] `cargo test -p coding-adventures-apl-repl -p coding-adventures-j-repl` — 18 + 19 tests pass
- [x] `cargo clippy -p coding-adventures-apl-repl -p coding-adventures-j-repl --all-targets` — clean
- [x] CHANGELOG.md updated in both crates documenting the fix and each security-review round
- [x] `/security-review` — 4 rounds, converged to a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)