### PR TITLE
feat(sir-runtime-symbolic): SIR23 term-rewriting runtime (HML01 Stream B, item 6)

### DIFF
--- a/code/packages/typescript/cas-algebraic/BUILD
+++ b/code/packages/typescript/cas-algebraic/BUILD
@@ -1,3 +1,4 @@
+while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
 cd ../cas-factor && npm ci --quiet
 npm ci --quiet
 npm run build

--- a/code/packages/typescript/cas-list-operations/BUILD
+++ b/code/packages/typescript/cas-list-operations/BUILD
@@ -1,3 +1,4 @@
+while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/cas-multivariate/BUILD
+++ b/code/packages/typescript/cas-multivariate/BUILD
@@ -1,3 +1,4 @@
+while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/cas-pretty-printer/BUILD
+++ b/code/packages/typescript/cas-pretty-printer/BUILD
@@ -1,3 +1,4 @@
+while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/cas-simplify/BUILD
+++ b/code/packages/typescript/cas-simplify/BUILD
@@ -1,3 +1,4 @@
+while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
 cd ../cas-pattern-matching && npm ci --quiet
 npm ci --quiet
 npm run build

--- a/code/packages/typescript/cas-substitution/BUILD
+++ b/code/packages/typescript/cas-substitution/BUILD
@@ -1,3 +1,4 @@
+while ! mkdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; do sleep 1; done; (cd ../symbolic-ir && npm ci --quiet); EC=$?; rmdir /tmp/ts-symbolic-ir-npm.lock 2>/dev/null; exit $EC
 npm ci --quiet
 npm run build
 npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-symbolic/BUILD
+++ b/code/packages/typescript/sir-runtime-symbolic/BUILD
@@ -1,0 +1,14 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "sir-runtime-symbolic",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        # file: deps must ALL be listed (npm install does not recursively
+        # install file deps' own file deps): cas-pattern-matching (the
+        # matcher/rewriter this package builds on) plus its own transitive
+        # dep symbolic-ir (the term-tree type this package operates over).
+        deps = ["typescript/cas-pattern-matching", "typescript/symbolic-ir"],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/sir-runtime-symbolic/BUILD_windows
+++ b/code/packages/typescript/sir-runtime-symbolic/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/packages/typescript/sir-runtime-symbolic/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-symbolic/CHANGELOG.md
@@ -37,6 +37,29 @@ All notable changes to this project will be documented in this file.
   rule's static pattern/RHS structure, not by the runtime expression being
   matched against; see `src/index.ts`'s module doc comment for the full
   reasoning.
+### Fixed
+
+- **`replaceRepeated`'s retry-on-fire step no longer recurses natively** —
+  found by this package's own `/security-review` before its first push.
+  The initial implementation mirrored `cas-pattern-matching`'s `rewrite()`
+  exactly, including a recursive `walk(replacement, depth)` call each time a
+  rule fired at a tree position — one more native stack frame per firing,
+  bounded only by the caller-supplied `maxIterations`, not by
+  `MAX_TERM_DEPTH`. A caller passing a large `maxIterations` on a slowly- or
+  never-converging rule set could exhaust the stack through that path
+  alone, regardless of how shallow the input expression was — the exact
+  class of bug `MAX_TERM_DEPTH` exists to close, reopened via a second,
+  unguarded path. Fixed by making the retry a local loop instead of a
+  recursive call: firing a rule now just updates `current` and loops back
+  (same call frame), so repeated firings at one position cost O(1) native
+  stack frames however many times they occur; `depth` (and thus
+  `MAX_TERM_DEPTH`) now only increases on a genuine descent into `head`/
+  `args`, and `maxIterations` bounds iteration count (CPU time) only, never
+  native recursion depth. Verified with a regression test cycling two
+  non-deepening rules (`a -> b`, `b -> a`) 50,000 times without a crash —
+  the earlier, recursive design would have overflowed the stack at that
+  volume.
+
 - `rule`/`ruleDelayed` currently match and substitute identically (no
   general expression evaluator exists yet in this runtime to make the
   eager-vs-delayed RHS-evaluation distinction observable) — documented and

--- a/code/packages/typescript/sir-runtime-symbolic/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-symbolic/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial release — the SIR23 symbolic-expression + pattern/rewrite runtime
+  (HML01 Stream B, item 6), imported by Semantic-IR-emitted TypeScript/
+  JavaScript as `__SirSym` for the Wolfram/Macsyma/Maxima CAS domain.
+- Re-exports `@coding-adventures/cas-pattern-matching`'s `Bindings`,
+  `blank`/`blankTyped`/`named`/`rule`/`ruleDelayed`, `isBlank`/`isPattern`/
+  `isRule`, `matchPattern`, `applyRule`, `substitute` unchanged — these
+  already faithfully port the Rust `cas-pattern-matching` crate's five-case
+  structural matcher algorithm.
+- `apply(head, args)` — thin wrapper over `@coding-adventures/symbolic-ir`'s
+  `app`, named to match the SIR23 spec's `__SirSym.apply(...)` call-site
+  convention.
+- **`replaceAll(expr, rules)`** — Wolfram `/.`, one pass: bottom-up walk,
+  first-match-wins per subtree, no retry at a position. Genuinely new code
+  (not a port — `cas-pattern-matching` has no equivalent of this single-pass
+  operator).
+- **`replaceRepeated(expr, rules, maxIterations)`** — Wolfram `//.`, a fixed
+  point. Algorithmically mirrors `cas-pattern-matching`'s own `rewrite()`
+  (bottom-up, per-node local fixed point, global iteration cap returning
+  `RewriteCycleError`) but is reimplemented rather than called directly, to
+  add the recursion-depth cap below.
+- **`MAX_TERM_DEPTH` (512) + `DepthLimitError`/`isDepthLimitError`** — an
+  explicit recursion-depth cap on `replaceAll`/`replaceRepeated`'s full-tree
+  walk, found necessary during design: `cas-pattern-matching`'s `rewrite()`
+  has no depth guard at all, and this package runs on compiled, potentially
+  deeply-nested runtime expressions rather than short hand-authored rule
+  literals, so carrying that gap forward would reopen a stack-overflow DoS.
+  The re-exported matcher primitives (`matchPattern`/`substitute`) don't
+  need the same treatment — their recursion depth is bounded by a single
+  rule's static pattern/RHS structure, not by the runtime expression being
+  matched against; see `src/index.ts`'s module doc comment for the full
+  reasoning.
+- `rule`/`ruleDelayed` currently match and substitute identically (no
+  general expression evaluator exists yet in this runtime to make the
+  eager-vs-delayed RHS-evaluation distinction observable) — documented and
+  locked in by a dedicated test, with the `delayed` flag still round-tripping
+  faithfully through the data model for future work to extend.
+- This PR also files a small, directly-motivating fix in a sibling package:
+  `@coding-adventures/symbolic-ir` (this package's core dependency) had no
+  `BUILD`/`BUILD_windows` file at all, meaning it wasn't a discovered node
+  in the build tool's dependency graph — every existing consumer's edge to
+  it (including `cas-pattern-matching`'s) was silently dropped as an
+  "external" dependency. Added a minimal `ts_library` `BUILD` file for it.
+- And a spec correction: `SIR23-symbolic-pattern-semantic-ir.md` §"Matcher
+  semantics" point 1 said backends must walk the tree "top-down,
+  left-to-right over `args`" — but `cas-pattern-matching`'s actual
+  `rewrite()` (the algorithm this point is supposed to describe) walks
+  **bottom-up** (post-order). Corrected the spec text to match the real,
+  tested algorithm this package ports, rather than silently implementing
+  the opposite of what the (wrong) prose said.

--- a/code/packages/typescript/sir-runtime-symbolic/README.md
+++ b/code/packages/typescript/sir-runtime-symbolic/README.md
@@ -1,0 +1,88 @@
+# @coding-adventures/sir-runtime-symbolic
+
+The **symbolic-expression + pattern/rewrite runtime** imported by
+Semantic-IR-emitted TypeScript/JavaScript for the CAS math-language domain
+(Wolfram/Macsyma/Maxima), per
+[`code/specs/SIR23-symbolic-pattern-semantic-ir.md`](../../../specs/SIR23-symbolic-pattern-semantic-ir.md).
+
+## What it is
+
+SIR23 adds five new `Expr` variants to Semantic IR — `SymApply`,
+`SymPatternBlank`, `SymPatternNamed`, `SymRule`, `SymReplaceAll` — so a
+compiled Wolfram/Macsyma program can still pattern-match and rewrite terms
+**at runtime**, not just lower a precomputed answer. This package is what
+those nodes compile down to: it's bound as `__SirSym` at the emitted call
+sites (`__SirSym.apply(...)`, `__SirSym.replaceAll(...)`,
+`__SirSym.replaceRepeated(...)`).
+
+It is intentionally thin — the term-tree type and the structural matcher
+algorithm already exist as two separate published packages:
+
+| Package | What it provides |
+|---|---|
+| `@coding-adventures/symbolic-ir` | The `IRNode` term-tree type (`Symbol`/`Integer`/`Rational`/`Float`/`String`/`Apply`) |
+| `@coding-adventures/cas-pattern-matching` | A faithful TypeScript port of the Rust `cas-pattern-matching` crate's five-case structural matcher (`Blank()`/`Blank(T)`/`Pattern(name, inner)`/compound/structural-equality), `substitute`, and `applyRule` |
+
+This package re-exports those primitives unchanged and adds exactly the two
+things neither sibling provides:
+
+1. **`replaceAll`/`replaceRepeated`** — the `/.`/`//.` tree-wide replacement
+   operators SIR23 requires. `cas-pattern-matching` ships `rewrite()`, which
+   already *is* `replaceRepeated`'s algorithm (bottom-up, per-node fixed
+   point, global iteration cap) — but has no equivalent of Wolfram's `/.`
+   (try each rule once per subtree, no retry, no fixed point). `replaceAll`
+   is genuinely new code here, not a port of anything upstream.
+2. **An explicit recursion-depth cap** (`MAX_TERM_DEPTH`, default 512) on
+   the full-tree walk both operations perform. `cas-pattern-matching`'s own
+   `rewrite()` has no depth guard at all; since this package runs on
+   compiled, potentially deeply-nested runtime expressions (not just
+   short, hand-authored rule literals), it adds one rather than carrying
+   that gap forward — see the module doc comment in `src/index.ts` for why
+   the re-exported matcher primitives *don't* need the same treatment.
+
+## How emitted code uses it
+
+```ts
+import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";
+
+// x_ + 0 -> x_   (a rule compiled from Wolfram `x_ + 0 -> x_`)
+const xPat = __SirSym.named("x", __SirSym.blank());
+const dropAddZero = __SirSym.rule(
+  __SirSym.apply(ADD, [xPat, int(0)]),
+  xPat,
+);
+
+const result = __SirSym.replaceAll(expr, [dropAddZero]);
+if (__SirSym.isDepthLimitError(result)) {
+  throw new Error(`expression too deep: exceeds ${result.maxDepth} levels`);
+}
+```
+
+## Current scope: matching and substitution only, no evaluator
+
+`SymRule { delayed }` faithfully carries Wolfram's `Rule` (`->`) vs.
+`RuleDelayed` (`:>`) distinction through the data model — but this package
+has **no general expression evaluator** yet (wiring the `cas-*` algorithm
+surface, e.g. `Expand`/`Factor`/`Solve`, into a JS runtime is separate,
+later work per the SIR23 spec's own "Explicitly out of scope" section). So
+today, `rule` and `ruleDelayed` match and substitute **identically** — the
+distinction (evaluate the RHS once at construction vs. fresh per match) only
+starts to matter once a real evaluator exists to do that evaluating. The
+`delayed` flag round-trips through the data so that future work has a clean
+seam to extend; see `tests/sir-runtime-symbolic.test.ts`'s
+`rule vs ruleDelayed` suite for the locked-in current contract.
+
+## Where it fits
+
+`wolfram-to-semantic-ir` / `macsyma-to-semantic-ir` / `maxima-to-semantic-ir`
+→ `semantic-ir` (SIR23 `Expr` variants) → `semantic-ir-to-typescript` /
+`semantic-ir-to-javascript` → emitted code that imports this package. See
+[`code/specs/HML01-math-to-semantic-ir.md`](../../../specs/HML01-math-to-semantic-ir.md).
+
+## Development
+
+```sh
+npm install
+npx tsc --noEmit
+npx vitest run
+```

--- a/code/packages/typescript/sir-runtime-symbolic/package-lock.json
+++ b/code/packages/typescript/sir-runtime-symbolic/package-lock.json
@@ -1,0 +1,1588 @@
+{
+  "name": "@coding-adventures/sir-runtime-symbolic",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@coding-adventures/sir-runtime-symbolic",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching",
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../cas-pattern-matching": {
+      "name": "@coding-adventures/cas-pattern-matching",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@coding-adventures/symbolic-ir": "file:../symbolic-ir"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "../symbolic-ir": {
+      "name": "@coding-adventures/symbolic-ir",
+      "version": "0.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.1.0",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@coding-adventures/cas-pattern-matching": {
+      "resolved": "../cas-pattern-matching",
+      "link": true
+    },
+    "node_modules/@coding-adventures/symbolic-ir": {
+      "resolved": "../symbolic-ir",
+      "link": true
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/code/packages/typescript/sir-runtime-symbolic/package.json
+++ b/code/packages/typescript/sir-runtime-symbolic/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@coding-adventures/sir-runtime-symbolic",
+  "version": "0.1.0",
+  "description": "Symbolic-expression + pattern/rewrite runtime for Semantic-IR-emitted TypeScript/JavaScript (SIR23)",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "keywords": [
+    "sir",
+    "semantic-ir",
+    "runtime",
+    "cas",
+    "pattern-matching",
+    "rewrite",
+    "compiler"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "dependencies": {
+    "@coding-adventures/symbolic-ir": "file:../symbolic-ir",
+    "@coding-adventures/cas-pattern-matching": "file:../cas-pattern-matching"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "^4.1.0"
+  }
+}

--- a/code/packages/typescript/sir-runtime-symbolic/required_capabilities.json
+++ b/code/packages/typescript/sir-runtime-symbolic/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "typescript/sir-runtime-symbolic",
+  "capabilities": [],
+  "justification": "Pure in-process term-rewriting engine (structural pattern matching and substitution over a symbolic-expression tree). No filesystem, network, process, or environment access."
+}

--- a/code/packages/typescript/sir-runtime-symbolic/src/index.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/src/index.ts
@@ -1,0 +1,385 @@
+/**
+ * sir-runtime-symbolic — the SIR23 symbolic-expression + pattern/rewrite
+ * runtime imported by Semantic-IR-emitted TypeScript/JavaScript, bound as
+ * `__SirSym` at call sites (see `code/specs/SIR23-symbolic-pattern-semantic-ir.md`
+ * §"Backend impact"). A compiled Wolfram/Macsyma/Maxima program's `SymApply`,
+ * `SymPatternBlank`, `SymPatternNamed`, `SymRule`, and `SymReplaceAll` IR
+ * nodes all become calls into this package at runtime.
+ *
+ * ## Why this package is thin
+ *
+ * The hard part — a term-tree type and a faithful structural pattern
+ * matcher/substitution algorithm — already exists as two separate, already
+ * *published* packages this one builds on rather than re-invents:
+ *
+ * - `@coding-adventures/symbolic-ir` — the term-tree type (`IRNode`: one of
+ *   `Symbol`/`Integer`/`Rational`/`Float`/`String`/`Apply`) this whole domain
+ *   is built on.
+ * - `@coding-adventures/cas-pattern-matching` — a pure-TypeScript port of the
+ *   Rust `cas-pattern-matching` crate's `Bindings`/`matchPattern`/
+ *   `applyRule`/`substitute` (five-case structural matcher: `Blank()`,
+ *   `Blank(T)`, `Pattern(name, inner)`, compound-vs-compound, and structural
+ *   equality — see that package's own docs for the full algorithm).
+ *
+ * This package re-exports those primitives unchanged, and adds exactly the
+ * two things neither sibling package has: (1) `replaceAll`/`replaceRepeated`
+ * — the `/.`/`//.` tree-wide replacement operators SIR23 requires and
+ * `cas-pattern-matching` doesn't expose as a matched pair (see "Two new
+ * operations" below), and (2) an explicit recursion-depth cap on the parts
+ * of this package that walk a full, potentially attacker-influenced runtime
+ * expression tree (see "Depth safety" below).
+ *
+ * ## Two new operations, one existing one reused as-is
+ *
+ * `cas-pattern-matching` ships `rewrite()`, which already conflates "walk
+ * bottom-up" with "retry every rule at each node until none fire" (a fixed
+ * point) — that IS `replaceRepeated`'s exact contract, so `replaceRepeated`
+ * below mirrors its algorithm closely (see the "Depth safety" note for why
+ * it's a parallel implementation rather than a direct call). But
+ * `cas-pattern-matching` has no equivalent of Wolfram's `/.` (`ReplaceAll`):
+ * try each rule **once** per subtree, first match wins, no retry at that
+ * position, no fixed point. `replaceAll` below is genuinely new code, not a
+ * port of anything in the Rust or TypeScript reference — see its own doc
+ * comment for the traversal-order choice.
+ *
+ * ## Depth safety
+ *
+ * `matchPattern`/`substitute`/`applyRule` (re-exported below, unmodified)
+ * recurse, but their recursion depth is bounded by the *static* structure of
+ * a single rule's pattern/RHS — authored by a compiler frontend or written
+ * as a rule literal, not by runtime data — so they're already safe
+ * regardless of how deep the *target* expression is: matching only
+ * continues past a node when the *pattern* itself also has more `Apply`
+ * structure at that exact position, and real patterns bottom out within a
+ * handful of levels no matter how deep the value being matched against is.
+ *
+ * `replaceAll`/`replaceRepeated`, by contrast, walk the *entire* target
+ * expression tree — ordinary runtime data a compiled program can build up
+ * to unbounded depth (e.g. many rounds of nested computation) — so this is
+ * the recursion that needs an explicit cap. `cas-pattern-matching`'s own
+ * `rewrite()` has no such cap; carrying that gap forward into a runtime
+ * meant to execute compiled, potentially attacker-influenced programs would
+ * reopen the exact class of stack-overflow DoS this repo's other SIR passes
+ * already guard against (`semantic-ir::limits::MAX_IR_DEPTH`, the
+ * `semantic-ir` walker's depth-bounded `Visitor` default implementations).
+ * `MAX_TERM_DEPTH` below is that cap, enforced by both new functions.
+ */
+
+import {
+  app,
+  equals,
+  type IRApply,
+  type IRNode,
+} from "@coding-adventures/symbolic-ir";
+import {
+  Bindings,
+  BLANK,
+  PATTERN,
+  RULE,
+  RULE_DELAYED,
+  applyRule,
+  blank,
+  blankTyped,
+  isBlank,
+  isPattern,
+  isRule,
+  matchPattern,
+  named,
+  rule,
+  ruleDelayed,
+  substitute,
+  type RewriteCycleError,
+} from "@coding-adventures/cas-pattern-matching";
+
+// ---------------------------------------------------------------------------
+// Re-exported term-tree type and constructors (symbolic-ir)
+// ---------------------------------------------------------------------------
+
+export type { IRNode, IRApply };
+
+/**
+ * Build a symbolic-expression `Apply` node `head(args…)` — the runtime
+ * representation of a `SymApply` IR node. Thin wrapper over symbolic-ir's
+ * `app`, exposed under the name SIR23's backend-impact section uses
+ * (`__SirSym.apply(head, args)`).
+ */
+export function apply(head: IRNode, args: readonly IRNode[]): IRNode {
+  return app(head, args);
+}
+
+// ---------------------------------------------------------------------------
+// Re-exported matcher/rewriter primitives (cas-pattern-matching, unmodified)
+// ---------------------------------------------------------------------------
+
+export {
+  Bindings,
+  BLANK,
+  PATTERN,
+  RULE,
+  RULE_DELAYED,
+  applyRule,
+  blank,
+  blankTyped,
+  isBlank,
+  isPattern,
+  isRule,
+  matchPattern,
+  named,
+  substitute,
+  type RewriteCycleError,
+};
+
+/**
+ * Build an eager-substitution rule `Rule(lhs, rhs)` — SIR23's `SymRule {
+ * delayed: false }`, Wolfram `->`.
+ *
+ * **Current behavior note:** `rule` and {@link ruleDelayed} produce
+ * data that is matched and substituted *identically* today — this package
+ * has no general expression evaluator (per the SIR23 spec's own "Explicitly
+ * out of scope" section, wiring the `cas-*` algorithm surface into this
+ * runtime is separate, later work), so there is nothing yet for "eager"
+ * (evaluate the RHS once, at rule-construction time) to actually evaluate.
+ * The `delayed` bit still round-trips faithfully through the data model —
+ * `rule`/`ruleDelayed` construct distinct `Rule`/`RuleDelayed` sentinel
+ * heads — so a future PR that adds a real evaluator has a clean, already-
+ * tested seam to branch on (see `rule-vs-rule-delayed.test.ts`). This
+ * mirrors `cas-pattern-matching`'s own `ruleDelayed` doc comment exactly
+ * ("reserved separately for future passes that distinguish evaluated vs.
+ * held RHSes").
+ */
+export { rule };
+
+/**
+ * Build a delayed-substitution rule `RuleDelayed(lhs, rhs)` — SIR23's
+ * `SymRule { delayed: true }`, Wolfram `:>`. See {@link rule}'s doc comment
+ * for the current (identical-to-`rule`) behavior and what's deferred.
+ */
+export { ruleDelayed };
+
+// ---------------------------------------------------------------------------
+// Depth guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum recursion depth for {@link replaceAll}/{@link replaceRepeated}'s
+ * tree walk. See the module doc comment's "Depth safety" section for why
+ * only these two functions (not the re-exported matcher primitives) need
+ * this cap. Chosen to be far higher than any realistic compiled expression
+ * tree, while staying comfortably under typical JS engine stack limits —
+ * mirrors `semantic-ir::limits::MAX_IR_DEPTH`'s "two orders of magnitude
+ * below the empirical overflow point" rationale, scaled down for JS's
+ * generally shallower default call stacks and this walk's heavier
+ * per-frame cost (each frame also holds a `rules` scan).
+ */
+export const MAX_TERM_DEPTH = 512;
+
+/** Returned by {@link replaceAll}/{@link replaceRepeated} when the walk's
+ * recursion depth would exceed {@link MAX_TERM_DEPTH}. */
+export interface DepthLimitError {
+  readonly kind: "depth-limit";
+  readonly maxDepth: number;
+}
+
+export function isDepthLimitError(value: unknown): value is DepthLimitError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === "depth-limit"
+  );
+}
+
+/**
+ * Local, broadened counterpart to `cas-pattern-matching`'s own
+ * `isRewriteCycleError` (whose parameter type is `IRNode | RewriteCycleError`
+ * — too narrow for this module's three-way `IRNode | RewriteCycleError |
+ * DepthLimitError` return unions). Behaviorally identical structural check.
+ */
+export function isRewriteCycleError(value: unknown): value is RewriteCycleError {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === "rewrite-cycle"
+  );
+}
+
+function isErrorResult(
+  value: IRNode | RewriteCycleError | DepthLimitError,
+): value is RewriteCycleError | DepthLimitError {
+  return isRewriteCycleError(value) || isDepthLimitError(value);
+}
+
+// ---------------------------------------------------------------------------
+// replaceAll — `expr /. rules`, one pass
+// ---------------------------------------------------------------------------
+
+/**
+ * `expr /. rules` — Wolfram's `ReplaceAll`, one pass over the whole tree.
+ *
+ * Walks `expr` **bottom-up** (post-order: a node's `head` and every `args`
+ * element are visited — and possibly replaced — before the node itself is
+ * tried against `rules`). This matches `cas-pattern-matching`'s own
+ * `rewrite()` traversal order (see this package's PR, which also corrects
+ * SIR23 spec §"Matcher semantics" point 1 — that prose said "top-down",
+ * which never matched what `rewrite()` actually does).
+ *
+ * At each subtree (after its children are already finalized), `rules` are
+ * tried **in order**; the first structural match wins, and its substituted
+ * replacement takes that subtree's place. Unlike {@link replaceRepeated},
+ * each subtree is visited and tried **exactly once** — a freshly-substituted
+ * replacement is not re-walked or retried against `rules` at the same
+ * position, matching Wolfram's `/.` (single-pass) contract exactly.
+ *
+ * Always terminates in a single bounded walk over `expr`'s existing node
+ * count — there is no fixed-point loop, so (unlike {@link replaceRepeated})
+ * there is no `maxIterations` parameter and no `RewriteCycleError` outcome.
+ * The only failure mode is {@link MAX_TERM_DEPTH}.
+ *
+ * @example
+ * ```ts
+ * // x_ + 0  ->  x_   applied once, everywhere in the tree
+ * const xPat = named("x", blank());
+ * const r = rule(apply(ADD, [xPat, int(0)]), xPat);
+ * const expr = apply(ADD, [apply(ADD, [sym("z"), int(0)]), int(0)]);
+ * replaceAll(expr, [r]); // => sym("z")  (both `+ 0`s fire, one pass each)
+ * ```
+ */
+export function replaceAll(
+  expr: IRNode,
+  rules: readonly IRNode[],
+): IRNode | DepthLimitError {
+  return walkOnce(expr, rules, 0);
+}
+
+function walkOnce(
+  node: IRNode,
+  rules: readonly IRNode[],
+  depth: number,
+): IRNode | DepthLimitError {
+  if (depth > MAX_TERM_DEPTH) {
+    return { kind: "depth-limit", maxDepth: MAX_TERM_DEPTH };
+  }
+
+  let current = node;
+  if (node.kind === "apply") {
+    const newHead = walkOnce(node.head, rules, depth + 1);
+    if (isDepthLimitError(newHead)) return newHead;
+    const newArgs: IRNode[] = [];
+    for (const arg of node.args) {
+      const nextArg = walkOnce(arg, rules, depth + 1);
+      if (isDepthLimitError(nextArg)) return nextArg;
+      newArgs.push(nextArg);
+    }
+    current = apply(newHead, newArgs);
+  }
+
+  for (const candidateRule of rules) {
+    const replacement = applyRule(candidateRule, current);
+    if (replacement !== null) {
+      return replacement; // first match wins; no retry at this position
+    }
+  }
+  return current;
+}
+
+// ---------------------------------------------------------------------------
+// replaceRepeated — `expr //. rules`, fixed point
+// ---------------------------------------------------------------------------
+
+/**
+ * `expr //. rules` — Wolfram's `ReplaceRepeated`, a fixed point.
+ *
+ * Like {@link replaceAll}, walks bottom-up, but at each subtree keeps
+ * retrying `rules` until none fire, re-walking any fresh replacement (so
+ * *its* sub-parts also converge) before moving up to the parent. This is
+ * `cas-pattern-matching`'s own `rewrite()` algorithm — reimplemented here
+ * (calling the same `applyRule`/`equals` primitives `rewrite()` itself
+ * uses) rather than called directly, because `rewrite()` has no
+ * recursion-depth parameter to hook a cap into (see the module doc
+ * comment's "Depth safety" section). Otherwise the algorithm is identical:
+ * bottom-up traversal, per-node local fixed point, and a **global**
+ * `maxIterations` cap shared across the whole walk (not per-node) — the
+ * same cap shape `rewrite()` uses, returning {@link RewriteCycleError} on
+ * the same terms.
+ *
+ * SIR23 §"Matcher semantics" point 6 requires every backend to enforce an
+ * iteration cap here ("an unbounded `//.` is a guaranteed non-terminating
+ * program for some inputs"); `maxIterations` (default 100, matching
+ * `rewrite()`'s own default) is that cap. {@link MAX_TERM_DEPTH} is the
+ * *additional* recursion-depth cap this package adds beyond what
+ * `rewrite()` itself enforces (see "Depth safety").
+ *
+ * **A caller-facing nuance worth calling out explicitly** (an existing
+ * property of the ported algorithm, not something new this package
+ * introduces): each time a rule fires, the local retry loop below recurses
+ * into `walk(replacement, depth)` — one native JS stack frame per firing,
+ * same as `rewrite()`'s own `cur = walk(replacement, ...)` — so `maxIterations`
+ * itself bounds a SEPARATE recursion (retry count), distinct from
+ * {@link MAX_TERM_DEPTH}'s tree-structural one. A caller that passes a very
+ * large `maxIterations` (well beyond the "well-behaved rules converge in
+ * 2-5 passes" norm this default assumes) could still exhaust the stack via
+ * that path before `MAX_TERM_DEPTH` or `maxIterations` itself is reached.
+ * Callers should keep `maxIterations` modest — SIR23's own point 6 already
+ * places this choice on the backend/caller, not this package.
+ *
+ * @example
+ * ```ts
+ * // x_ + 0  ->  x_   applied repeatedly, to a fixed point
+ * const xPat = named("x", blank());
+ * const r = rule(apply(ADD, [xPat, int(0)]), xPat);
+ * const expr = apply(ADD, [apply(ADD, [sym("z"), int(0)]), int(0)]);
+ * replaceRepeated(expr, [r], 100); // => sym("z")
+ * ```
+ */
+export function replaceRepeated(
+  expr: IRNode,
+  rules: readonly IRNode[],
+  maxIterations = 100,
+): IRNode | RewriteCycleError | DepthLimitError {
+  let counter = 0;
+
+  const walk = (
+    node: IRNode,
+    depth: number,
+  ): IRNode | RewriteCycleError | DepthLimitError => {
+    if (depth > MAX_TERM_DEPTH) {
+      return { kind: "depth-limit", maxDepth: MAX_TERM_DEPTH };
+    }
+
+    let current = node;
+    if (node.kind === "apply") {
+      const newHead = walk(node.head, depth + 1);
+      if (isErrorResult(newHead)) return newHead;
+      const newArgs: IRNode[] = [];
+      for (const arg of node.args) {
+        const nextArg = walk(arg, depth + 1);
+        if (isErrorResult(nextArg)) return nextArg;
+        newArgs.push(nextArg);
+      }
+      current = apply(newHead, newArgs);
+    }
+
+    while (true) {
+      let fired = false;
+      for (const candidateRule of rules) {
+        const replacement = applyRule(candidateRule, current);
+        if (replacement !== null && !equals(replacement, current)) {
+          counter += 1;
+          if (counter > maxIterations) {
+            return { kind: "rewrite-cycle", maxIterations };
+          }
+          // Re-walk the replacement at the SAME depth: this substitutes a
+          // new value at the current position, it does not descend to a
+          // child, so the depth budget for this position is unchanged.
+          const walked = walk(replacement, depth);
+          if (isErrorResult(walked)) return walked;
+          current = walked;
+          fired = true;
+          break;
+        }
+      }
+      if (!fired) return current;
+    }
+  };
+
+  return walk(expr, 0);
+}

--- a/code/packages/typescript/sir-runtime-symbolic/src/index.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/src/index.ts
@@ -308,18 +308,20 @@ function walkOnce(
  * *additional* recursion-depth cap this package adds beyond what
  * `rewrite()` itself enforces (see "Depth safety").
  *
- * **A caller-facing nuance worth calling out explicitly** (an existing
- * property of the ported algorithm, not something new this package
- * introduces): each time a rule fires, the local retry loop below recurses
- * into `walk(replacement, depth)` — one native JS stack frame per firing,
- * same as `rewrite()`'s own `cur = walk(replacement, ...)` — so `maxIterations`
- * itself bounds a SEPARATE recursion (retry count), distinct from
- * {@link MAX_TERM_DEPTH}'s tree-structural one. A caller that passes a very
- * large `maxIterations` (well beyond the "well-behaved rules converge in
- * 2-5 passes" norm this default assumes) could still exhaust the stack via
- * that path before `MAX_TERM_DEPTH` or `maxIterations` itself is reached.
- * Callers should keep `maxIterations` modest — SIR23's own point 6 already
- * places this choice on the backend/caller, not this package.
+ * **A gap this implementation deliberately does NOT port from `rewrite()`,
+ * found by this package's own `/security-review`:** `rewrite()`'s
+ * retry-on-fire step is a *recursive* call (`cur = walk(replacement, ...)`)
+ * — one more native stack frame per firing, chained for as long as retries
+ * keep happening at one tree position — so its native recursion depth is
+ * bounded only by `maxIterations`, not by any tree-depth cap; a caller
+ * passing a large `maxIterations` (well beyond the "well-behaved rules
+ * converge in 2-5 passes" norm the default assumes) could exhaust the stack
+ * through that path alone, independent of `MAX_TERM_DEPTH` and independent
+ * of how deep or shallow `expr` itself is. The version below
+ * instead loops locally when a rule fires at the current position — `depth`
+ * only ever increases on a genuine descent into `head`/`args`, so
+ * `maxIterations` now bounds only iteration *count* (CPU time), never
+ * native recursion depth, however large a value a caller passes.
  *
  * @example
  * ```ts
@@ -346,19 +348,27 @@ export function replaceRepeated(
     }
 
     let current = node;
-    if (node.kind === "apply") {
-      const newHead = walk(node.head, depth + 1);
-      if (isErrorResult(newHead)) return newHead;
-      const newArgs: IRNode[] = [];
-      for (const arg of node.args) {
-        const nextArg = walk(arg, depth + 1);
-        if (isErrorResult(nextArg)) return nextArg;
-        newArgs.push(nextArg);
-      }
-      current = apply(newHead, newArgs);
-    }
-
+    // Outer loop: each pass (re)processes `current`'s children bottom-up,
+    // then tries firing a rule at this position. A fired rule's
+    // replacement becomes the new `current` and the loop repeats --
+    // iteratively, at this SAME call frame, not via a recursive call --
+    // so however many times a rule fires at one tree position, that costs
+    // O(1) native stack frames, not O(firings). `depth` is unchanged across
+    // iterations of this loop (nothing here descends to a child); it only
+    // increases via the genuine `head`/`args` recursion below.
     while (true) {
+      if (current.kind === "apply") {
+        const newHead = walk(current.head, depth + 1);
+        if (isErrorResult(newHead)) return newHead;
+        const newArgs: IRNode[] = [];
+        for (const arg of current.args) {
+          const nextArg = walk(arg, depth + 1);
+          if (isErrorResult(nextArg)) return nextArg;
+          newArgs.push(nextArg);
+        }
+        current = apply(newHead, newArgs);
+      }
+
       let fired = false;
       for (const candidateRule of rules) {
         const replacement = applyRule(candidateRule, current);
@@ -367,17 +377,17 @@ export function replaceRepeated(
           if (counter > maxIterations) {
             return { kind: "rewrite-cycle", maxIterations };
           }
-          // Re-walk the replacement at the SAME depth: this substitutes a
-          // new value at the current position, it does not descend to a
-          // child, so the depth budget for this position is unchanged.
-          const walked = walk(replacement, depth);
-          if (isErrorResult(walked)) return walked;
-          current = walked;
+          current = replacement;
           fired = true;
           break;
         }
       }
       if (!fired) return current;
+      // Loop again: `current` (the fresh replacement) may itself contain
+      // sub-structure that hasn't been processed yet, so it goes through
+      // the same "process children, then try rules" pass before this
+      // position is considered stable -- matching `rewrite()`'s own
+      // "re-walk the replacement" behavior, just without recursing to do it.
     }
   };
 

--- a/code/packages/typescript/sir-runtime-symbolic/tests/sir-runtime-symbolic.test.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/tests/sir-runtime-symbolic.test.ts
@@ -109,20 +109,25 @@ describe("replaceRepeated (//. — fixed point)", () => {
     expect(replaceRepeated(expr, [dropAddZero], 100)).toEqual(expr);
   });
 
-  it("survives a moderately large maxIterations on a non-converging rule set without crashing", () => {
-    // Documents the caveat in this function's own doc comment: each firing
-    // recurses one more native JS stack frame (mirroring cas-pattern-
-    // matching's own `rewrite()` shape), so maxIterations bounds a SEPARATE
-    // recursion from MAX_TERM_DEPTH. For THIS particular rule shape
-    // (f(x_) -> f(f(x_)), which nests one level deeper each time it fires),
-    // depth and firing count grow together 1:1, so a maxIterations well
-    // under MAX_TERM_DEPTH (512) is needed for RewriteCycleError -- not
-    // DepthLimitError -- to be the one that fires first; 300 demonstrates
-    // an ordinary, non-extreme value resolving cleanly either way.
-    const f = sym("f");
-    const neverConverges = rule(app(f, [xPat]), app(f, [app(f, [xPat])]));
-    const result = replaceRepeated(app(f, [sym("a")]), [neverConverges], 300);
+  it("survives a huge maxIterations on a non-converging, non-deepening rule set without a stack overflow", () => {
+    // Isolates the exact bug this function's retry loop was rewritten to
+    // fix: a -> b, b -> a cycles forever WITHOUT ever building deeper tree
+    // structure (both sides are bare symbols, never an Apply), so
+    // MAX_TERM_DEPTH's tree-descent check never even triggers here -- if
+    // the retry step still recursed once per firing (the earlier,
+    // /security-review-flagged design), 50,000 firings would mean 50,000
+    // nested native stack frames and a real stack overflow. The current
+    // (loop-based-retry) implementation costs O(1) stack per firing
+    // regardless, so this resolves cleanly to RewriteCycleError instead.
+    const a = sym("a");
+    const b = sym("b");
+    const aToB = rule(a, b);
+    const bToA = rule(b, a);
+    const result = replaceRepeated(a, [aToB, bToA], 50_000);
     expect(isRewriteCycleError(result)).toBe(true);
+    if (isRewriteCycleError(result)) {
+      expect(result.maxIterations).toBe(50_000);
+    }
   });
 });
 

--- a/code/packages/typescript/sir-runtime-symbolic/tests/sir-runtime-symbolic.test.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/tests/sir-runtime-symbolic.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { ADD, app, int, sym } from "@coding-adventures/symbolic-ir";
+import {
+  Bindings,
+  DepthLimitError,
+  MAX_TERM_DEPTH,
+  RewriteCycleError,
+  apply,
+  applyRule,
+  blank,
+  isDepthLimitError,
+  isRewriteCycleError,
+  matchPattern,
+  named,
+  replaceAll,
+  replaceRepeated,
+  rule,
+  ruleDelayed,
+  substitute,
+} from "../src/index";
+
+// Reusable "x_ + 0 -> x_" identity-elimination rule, the running example in
+// this package's own doc comments and the Rust/TS cas-pattern-matching
+// crates' own examples.
+const xPat = named("x", blank());
+const dropAddZero = rule(app(ADD, [xPat, int(0)]), xPat);
+
+describe("re-exported matcher/rewriter primitives", () => {
+  it("matchPattern, applyRule, substitute, Bindings all work through this package's surface", () => {
+    const bindings = matchPattern(named("a", blank()), int(5), Bindings.empty());
+    expect(bindings?.get("a")).toEqual(int(5));
+    expect(applyRule(dropAddZero, app(ADD, [sym("z"), int(0)]))).toEqual(sym("z"));
+    expect(substitute(xPat, Bindings.empty().bind("x", int(9)))).toEqual(int(9));
+  });
+
+  it("apply() is a thin wrapper producing the same node as symbolic-ir's app()", () => {
+    expect(apply(ADD, [int(1), int(2)])).toEqual(app(ADD, [int(1), int(2)]));
+  });
+});
+
+describe("replaceAll (/. — one pass)", () => {
+  it("fires once per matching subtree, everywhere in the tree", () => {
+    // Add(Add(z, 0), 0) -- both "+ 0"s should be eliminated in one call.
+    const expr = app(ADD, [app(ADD, [sym("z"), int(0)]), int(0)]);
+    expect(replaceAll(expr, [dropAddZero])).toEqual(sym("z"));
+  });
+
+  it("does not retry a rule against its own freshly-substituted replacement", () => {
+    // A rule whose RHS is itself a fresh match candidate for the SAME rule:
+    // f(a) -> f(f(a)). A single pass must fire exactly once at the root
+    // (producing f(f(a))) and must NOT loop forever retrying at that spot --
+    // that's the one behavior that actually distinguishes replaceAll from
+    // replaceRepeated (which would need a cycle-detecting cap to survive
+    // this same rule).
+    const f = sym("f");
+    const selfWrap = rule(app(f, [xPat]), app(f, [app(f, [xPat])]));
+    const result = replaceAll(app(f, [sym("a")]), [selfWrap]);
+    expect(result).toEqual(app(f, [app(f, [sym("a")])]));
+  });
+
+  it("walks bottom-up: a child's rewrite is visible to a rule tried at the parent", () => {
+    // g(Add(z, 0)) with dropAddZero -- if children are rewritten first
+    // (bottom-up), the parent sees g(z). A hypothetical rule targeting
+    // exactly g(z) can then fire in the SAME pass, proving traversal order.
+    const g = sym("g");
+    const gOfZ = rule(app(g, [sym("z")]), sym("matched-g-of-z"));
+    const expr = app(g, [app(ADD, [sym("z"), int(0)])]);
+    expect(replaceAll(expr, [dropAddZero, gOfZ])).toEqual(sym("matched-g-of-z"));
+  });
+
+  it("leaves a non-matching tree unchanged", () => {
+    const expr = app(ADD, [sym("a"), sym("b")]);
+    expect(replaceAll(expr, [dropAddZero])).toEqual(expr);
+  });
+});
+
+describe("replaceRepeated (//. — fixed point)", () => {
+  it("matches replaceAll on a single-firing-per-subtree case", () => {
+    const expr = app(ADD, [app(ADD, [sym("z"), int(0)]), int(0)]);
+    expect(replaceRepeated(expr, [dropAddZero], 100)).toEqual(sym("z"));
+  });
+
+  it("keeps applying until a true fixed point, unlike replaceAll", () => {
+    // Add(Add(Add(z, 0), 0), 0) -- three nested "+0"s. A single replaceAll
+    // pass only guarantees each EXISTING subtree is tried once, but since
+    // this walks bottom-up the innermost eliminations are already visible
+    // by the time outer ones are tried, so replaceAll happens to also
+    // reach the fixed point here. The real distinguishing case is
+    // `does not retry a rule against its own freshly-substituted
+    // replacement`'s sibling test below, which replaceRepeated finishes
+    // (further) instead of stopping after one substitution.
+    const expr = app(ADD, [app(ADD, [app(ADD, [sym("z"), int(0)]), int(0)]), int(0)]);
+    expect(replaceRepeated(expr, [dropAddZero], 100)).toEqual(sym("z"));
+  });
+
+  it("reports RewriteCycleError instead of hanging on a non-terminating rule set", () => {
+    // f(a) -> f(f(a)) retried forever would never reach a fixed point.
+    const f = sym("f");
+    const neverConverges = rule(app(f, [xPat]), app(f, [app(f, [xPat])]));
+    const result = replaceRepeated(app(f, [sym("a")]), [neverConverges], 50);
+    expect(isRewriteCycleError(result)).toBe(true);
+    if (isRewriteCycleError(result)) {
+      expect(result.maxIterations).toBe(50);
+    }
+  });
+
+  it("leaves a non-matching tree unchanged", () => {
+    const expr = app(ADD, [sym("a"), sym("b")]);
+    expect(replaceRepeated(expr, [dropAddZero], 100)).toEqual(expr);
+  });
+
+  it("survives a moderately large maxIterations on a non-converging rule set without crashing", () => {
+    // Documents the caveat in this function's own doc comment: each firing
+    // recurses one more native JS stack frame (mirroring cas-pattern-
+    // matching's own `rewrite()` shape), so maxIterations bounds a SEPARATE
+    // recursion from MAX_TERM_DEPTH. For THIS particular rule shape
+    // (f(x_) -> f(f(x_)), which nests one level deeper each time it fires),
+    // depth and firing count grow together 1:1, so a maxIterations well
+    // under MAX_TERM_DEPTH (512) is needed for RewriteCycleError -- not
+    // DepthLimitError -- to be the one that fires first; 300 demonstrates
+    // an ordinary, non-extreme value resolving cleanly either way.
+    const f = sym("f");
+    const neverConverges = rule(app(f, [xPat]), app(f, [app(f, [xPat])]));
+    const result = replaceRepeated(app(f, [sym("a")]), [neverConverges], 300);
+    expect(isRewriteCycleError(result)).toBe(true);
+  });
+});
+
+describe("depth guard (MAX_TERM_DEPTH)", () => {
+  // Build a right-leaning chain f(f(f(...f(leaf)...))) `depth` levels deep.
+  function deepChain(depth: number): ReturnType<typeof app> {
+    const f = sym("f");
+    let node: ReturnType<typeof app> | ReturnType<typeof sym> = sym("leaf");
+    for (let i = 0; i < depth; i += 1) {
+      node = app(f, [node]);
+    }
+    return node as ReturnType<typeof app>;
+  }
+
+  it("replaceAll succeeds on a tree within the cap", () => {
+    const shallow = deepChain(MAX_TERM_DEPTH - 10);
+    const result = replaceAll(shallow, []);
+    expect(isDepthLimitError(result)).toBe(false);
+  });
+
+  it("replaceAll reports DepthLimitError (not a stack overflow) past the cap", () => {
+    const tooDeep = deepChain(MAX_TERM_DEPTH * 4);
+    const result = replaceAll(tooDeep, []);
+    expect(isDepthLimitError(result)).toBe(true);
+    if (isDepthLimitError(result)) {
+      expect(result.maxDepth).toBe(MAX_TERM_DEPTH);
+    }
+  });
+
+  it("replaceRepeated reports DepthLimitError (not a stack overflow) past the cap", () => {
+    const tooDeep = deepChain(MAX_TERM_DEPTH * 4);
+    const result = replaceRepeated(tooDeep, [], 100);
+    expect(isDepthLimitError(result)).toBe(true);
+  });
+
+  it("isDepthLimitError and isRewriteCycleError do not cross-match each other's shape", () => {
+    const depthErr: DepthLimitError = { kind: "depth-limit", maxDepth: MAX_TERM_DEPTH };
+    const cycleErr: RewriteCycleError = { kind: "rewrite-cycle", maxIterations: 100 };
+    expect(isDepthLimitError(depthErr)).toBe(true);
+    expect(isDepthLimitError(cycleErr)).toBe(false);
+    expect(isRewriteCycleError(cycleErr)).toBe(true);
+    expect(isRewriteCycleError(depthErr)).toBe(false);
+    expect(isDepthLimitError(int(1))).toBe(false);
+    expect(isRewriteCycleError(int(1))).toBe(false);
+  });
+});
+
+describe("rule vs ruleDelayed", () => {
+  it("currently match and substitute identically (no evaluator wired in yet)", () => {
+    const eager = rule(app(ADD, [xPat, int(0)]), xPat);
+    const delayed = ruleDelayed(app(ADD, [xPat, int(0)]), xPat);
+    const target = app(ADD, [sym("z"), int(0)]);
+
+    expect(applyRule(eager, target)).toEqual(applyRule(delayed, target));
+    expect(replaceAll(target, [eager])).toEqual(replaceAll(target, [delayed]));
+    expect(replaceRepeated(target, [eager], 10)).toEqual(replaceRepeated(target, [delayed], 10));
+  });
+});

--- a/code/packages/typescript/sir-runtime-symbolic/tsconfig.json
+++ b/code/packages/typescript/sir-runtime-symbolic/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/code/packages/typescript/sir-runtime-symbolic/vitest.config.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 80,
+      },
+    },
+  },
+});

--- a/code/packages/typescript/symbolic-ir/BUILD
+++ b/code/packages/typescript/symbolic-ir/BUILD
@@ -1,0 +1,10 @@
+load("code/packages/starlark/library-rules/typescript_library.star", "ts_library")
+
+_targets = [
+    ts_library(
+        name = "symbolic-ir",
+        srcs = ["src/**/*.ts", "tests/**/*.ts"],
+        deps = [],
+        test_runner = "vitest",
+    ),
+]

--- a/code/packages/typescript/symbolic-ir/BUILD_windows
+++ b/code/packages/typescript/symbolic-ir/BUILD_windows
@@ -1,0 +1,3 @@
+npm ci --quiet
+npx tsc --noEmit
+npx vitest run --coverage

--- a/code/specs/SIR23-symbolic-pattern-semantic-ir.md
+++ b/code/specs/SIR23-symbolic-pattern-semantic-ir.md
@@ -133,7 +133,13 @@ SymReplaceAll {
 A backend implementing `SymReplaceAll` must:
 
 1. Walk `expr`'s tree in the same traversal order `cas-pattern-matching`
-   uses today (top-down, left-to-right over `args`).
+   uses today — **bottom-up (post-order)**: a node's `head` and every
+   `args` element are visited (and possibly replaced) before the node
+   itself is tried against any rule. (An earlier draft of this bullet said
+   "top-down, left-to-right over `args`" — that never matched what
+   `cas-pattern-matching`'s `rewrite()` actually does; corrected here to
+   match the real, tested algorithm this spec's own "port, not a
+   reimplementation" framing below commits to.)
 2. At each subtree, try each `rules[i].lhs` in order; the first structural
    match wins (no backtracking across rules — matches the reference CAS
    behavior).


### PR DESCRIPTION
## Summary
- New `@coding-adventures/sir-runtime-symbolic` package — the runtime Semantic-IR-emitted JS/TS compiles `SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll` nodes down to, bound as `__SirSym` (HML01 Stream B, item 6 — the next unimplemented item in that rollout).
- Builds on two existing sibling packages rather than re-porting the matcher algorithm from scratch: `@coding-adventures/symbolic-ir` (term-tree type) and `@coding-adventures/cas-pattern-matching` (an already-tested TS port of the Rust `cas-pattern-matching` crate's structural matcher), both re-exported unchanged.
- Adds exactly what neither sibling provides: `replaceAll` (Wolfram `/.`, genuinely new one-pass code), `replaceRepeated` (Wolfram `//.`, mirrors `cas-pattern-matching`'s `rewrite()`), and an explicit `MAX_TERM_DEPTH` recursion-depth cap on both (the underlying `rewrite()` has none, and this runtime executes compiled, potentially deeply-nested expressions rather than short rule literals).
- Two small, directly-motivating collateral fixes: added a missing `BUILD`/`BUILD_windows` to `symbolic-ir` (it had none, so it wasn't a discovered node in the build graph — every existing consumer's edge to it was silently dropped), and corrected `SIR23-symbolic-pattern-semantic-ir.md`'s traversal-order prose (said "top-down", the real ported algorithm is bottom-up).
- Two rounds of `/security-review` on this branch found and fixed one real MEDIUM finding: `replaceRepeated`'s retry-on-fire step originally recursed natively per firing (bounded only by caller-supplied `maxIterations`, not `MAX_TERM_DEPTH`) — restructured into a local loop so retries cost O(1) native stack regardless of iteration count. Round 2 passed clean.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run --coverage` — 16/16 tests pass, 100% line/branch/function coverage
- [x] Regression test cycling two non-deepening rules 50,000 times confirms the retry-recursion fix (would have overflowed the stack under the earlier design)
- [x] CHANGELOG.md + README.md written; SIR23 spec kept in sync (traversal-order correction documented and explained)
- [x] `/security-review` — 2 rounds, converged to a clean pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)