### PR TITLE
[codex] Port WASM simulator to Swift

### DIFF
--- a/code/packages/swift/wasm-simulator/BUILD
+++ b/code/packages/swift/wasm-simulator/BUILD
@@ -1,0 +1,1 @@
+if command -v xcrun >/dev/null 2>&1; then xcrun swift test; else swift test; fi

--- a/code/packages/swift/wasm-simulator/BUILD_windows
+++ b/code/packages/swift/wasm-simulator/BUILD_windows
@@ -1,0 +1,1 @@
+swift test

--- a/code/packages/swift/wasm-simulator/CHANGELOG.md
+++ b/code/packages/swift/wasm-simulator/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 - 2026-07-13
+
+- Added the pure Swift decoder and executor for the six-opcode WASM subset.
+- Added deterministic step traces, locals, stack state, reset, and bounded runs.
+- Added little-endian encoding helpers and wrapping `i32` arithmetic.
+- Added tests for execution, traces, state reset, limits, and error handling.

--- a/code/packages/swift/wasm-simulator/Package.swift
+++ b/code/packages/swift/wasm-simulator/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+  name: "wasm-simulator",
+  products: [
+    .library(name: "WasmSimulator", targets: ["WasmSimulator"])
+  ],
+  targets: [
+    .target(name: "WasmSimulator"),
+    .testTarget(name: "WasmSimulatorTests", dependencies: ["WasmSimulator"]),
+  ]
+)

--- a/code/packages/swift/wasm-simulator/README.md
+++ b/code/packages/swift/wasm-simulator/README.md
@@ -1,0 +1,44 @@
+# swift/wasm-simulator
+
+A pure Swift implementation of the minimal WebAssembly stack-machine simulator
+specified in [`07c-wasm-simulator.md`](../../../specs/07c-wasm-simulator.md).
+It models the six-instruction educational subset shared by the other language
+ports:
+
+| Opcode | Instruction | Effect |
+|---:|---|---|
+| `0x0B` | `end` | Halt execution |
+| `0x20` | `local.get` | Push a local onto the operand stack |
+| `0x21` | `local.set` | Pop a value into a local |
+| `0x41` | `i32.const` | Push a signed 32-bit constant |
+| `0x6A` | `i32.add` | Add the top two values with i32 wrapping |
+| `0x6B` | `i32.sub` | Subtract the top two values with i32 wrapping |
+
+Every step records the program counter, decoded instruction, stack before and
+after execution, local snapshot, description, and halted state.
+
+## Usage
+
+```swift
+import WasmSimulator
+
+let program = assembleWasm([
+    encodeI32Const(1),
+    encodeI32Const(2),
+    encodeI32Add(),
+    encodeLocalSet(0),
+    encodeEnd(),
+])
+
+let simulator = WasmSimulator(localCount: 4)
+let traces = try simulator.run(program)
+
+assert(traces.count == 5)
+assert(simulator.locals[0] == 3)
+```
+
+## Development
+
+```sh
+swift test
+```

--- a/code/packages/swift/wasm-simulator/Sources/WasmSimulator/WasmSimulator.swift
+++ b/code/packages/swift/wasm-simulator/Sources/WasmSimulator/WasmSimulator.swift
@@ -1,0 +1,320 @@
+public enum WasmSimulatorVersion {
+  public static let version = "0.1.0"
+}
+
+public enum WasmOpcode {
+  public static let end: UInt8 = 0x0B
+  public static let localGet: UInt8 = 0x20
+  public static let localSet: UInt8 = 0x21
+  public static let i32Const: UInt8 = 0x41
+  public static let i32Add: UInt8 = 0x6A
+  public static let i32Sub: UInt8 = 0x6B
+}
+
+public enum WasmSimulatorError: Error, Equatable, CustomStringConvertible {
+  case halted
+  case localIndexOutOfRange(Int)
+  case missingOperand(String)
+  case stackUnderflow
+  case truncatedInstruction(pc: Int, expectedBytes: Int, availableBytes: Int)
+  case unknownOpcode(UInt8, pc: Int)
+
+  public var description: String {
+    switch self {
+    case .halted:
+      return "WASM simulator has halted"
+    case .localIndexOutOfRange(let index):
+      return "Local index \(index) is out of range"
+    case .missingOperand(let mnemonic):
+      return "WASM instruction \(mnemonic) requires an operand"
+    case .stackUnderflow:
+      return "Stack underflow"
+    case .truncatedInstruction(let pc, let expectedBytes, let availableBytes):
+      return
+        "Truncated WASM instruction at PC=\(pc): expected \(expectedBytes) byte(s), found \(availableBytes)"
+    case .unknownOpcode(let opcode, let pc):
+      let rawHex = String(opcode, radix: 16, uppercase: true)
+      let hex = rawHex.count == 1 ? "0\(rawHex)" : rawHex
+      return "Unknown WASM opcode 0x\(hex) at PC=\(pc)"
+    }
+  }
+}
+
+public struct WasmInstruction: Equatable, Sendable {
+  public let opcode: UInt8
+  public let mnemonic: String
+  public let operand: Int32?
+  public let size: Int
+
+  public init(opcode: UInt8, mnemonic: String, operand: Int32?, size: Int) {
+    self.opcode = opcode
+    self.mnemonic = mnemonic
+    self.operand = operand
+    self.size = size
+  }
+}
+
+public struct WasmStepTrace: Equatable, Sendable {
+  public let pc: Int
+  public let instruction: WasmInstruction
+  public let stackBefore: [Int32]
+  public let stackAfter: [Int32]
+  public let localsSnapshot: [Int32]
+  public let description: String
+  public let halted: Bool
+
+  public init(
+    pc: Int,
+    instruction: WasmInstruction,
+    stackBefore: [Int32],
+    stackAfter: [Int32],
+    localsSnapshot: [Int32],
+    description: String,
+    halted: Bool
+  ) {
+    self.pc = pc
+    self.instruction = instruction
+    self.stackBefore = stackBefore
+    self.stackAfter = stackAfter
+    self.localsSnapshot = localsSnapshot
+    self.description = description
+    self.halted = halted
+  }
+}
+
+public struct WasmDecoder: Sendable {
+  public init() {}
+
+  public func decode(_ bytecode: [UInt8], at pc: Int) throws -> WasmInstruction {
+    try requireBytes(bytecode, at: pc, count: 1)
+    let opcode = bytecode[pc]
+
+    switch opcode {
+    case WasmOpcode.i32Const:
+      try requireBytes(bytecode, at: pc, count: 5)
+      let bits =
+        UInt32(bytecode[pc + 1])
+        | (UInt32(bytecode[pc + 2]) << 8)
+        | (UInt32(bytecode[pc + 3]) << 16)
+        | (UInt32(bytecode[pc + 4]) << 24)
+      return WasmInstruction(
+        opcode: opcode,
+        mnemonic: "i32.const",
+        operand: Int32(bitPattern: bits),
+        size: 5
+      )
+    case WasmOpcode.i32Add:
+      return WasmInstruction(opcode: opcode, mnemonic: "i32.add", operand: nil, size: 1)
+    case WasmOpcode.i32Sub:
+      return WasmInstruction(opcode: opcode, mnemonic: "i32.sub", operand: nil, size: 1)
+    case WasmOpcode.localGet:
+      try requireBytes(bytecode, at: pc, count: 2)
+      return WasmInstruction(
+        opcode: opcode,
+        mnemonic: "local.get",
+        operand: Int32(bytecode[pc + 1]),
+        size: 2
+      )
+    case WasmOpcode.localSet:
+      try requireBytes(bytecode, at: pc, count: 2)
+      return WasmInstruction(
+        opcode: opcode,
+        mnemonic: "local.set",
+        operand: Int32(bytecode[pc + 1]),
+        size: 2
+      )
+    case WasmOpcode.end:
+      return WasmInstruction(opcode: opcode, mnemonic: "end", operand: nil, size: 1)
+    default:
+      throw WasmSimulatorError.unknownOpcode(opcode, pc: pc)
+    }
+  }
+
+  private func requireBytes(_ bytecode: [UInt8], at pc: Int, count: Int) throws {
+    let available = pc >= 0 && pc < bytecode.count ? bytecode.count - pc : 0
+    guard pc >= 0, available >= count else {
+      throw WasmSimulatorError.truncatedInstruction(
+        pc: pc,
+        expectedBytes: count,
+        availableBytes: available
+      )
+    }
+  }
+}
+
+public struct WasmExecutor: Sendable {
+  public init() {}
+
+  public func execute(
+    _ instruction: WasmInstruction,
+    stack: inout [Int32],
+    locals: inout [Int32],
+    pc: Int
+  ) throws -> WasmStepTrace {
+    let stackBefore = stack
+    let halted: Bool
+    let description: String
+
+    switch instruction.opcode {
+    case WasmOpcode.i32Const:
+      guard let value = instruction.operand else {
+        throw WasmSimulatorError.missingOperand(instruction.mnemonic)
+      }
+      stack.append(value)
+      description = "push \(value)"
+      halted = false
+    case WasmOpcode.i32Add:
+      guard stack.count >= 2 else { throw WasmSimulatorError.stackUnderflow }
+      let right = stack.removeLast()
+      let left = stack.removeLast()
+      let result = left &+ right
+      stack.append(result)
+      description = "pop \(right) and \(left), push \(result)"
+      halted = false
+    case WasmOpcode.i32Sub:
+      guard stack.count >= 2 else { throw WasmSimulatorError.stackUnderflow }
+      let right = stack.removeLast()
+      let left = stack.removeLast()
+      let result = left &- right
+      stack.append(result)
+      description = "pop \(right) and \(left), push \(result)"
+      halted = false
+    case WasmOpcode.localGet:
+      let index = try checkedLocalIndex(instruction, locals: locals)
+      stack.append(locals[index])
+      description = "push local[\(index)]"
+      halted = false
+    case WasmOpcode.localSet:
+      let index = try checkedLocalIndex(instruction, locals: locals)
+      guard let value = stack.popLast() else { throw WasmSimulatorError.stackUnderflow }
+      locals[index] = value
+      description = "store \(value) in local[\(index)]"
+      halted = false
+    case WasmOpcode.end:
+      description = "halt"
+      halted = true
+    default:
+      throw WasmSimulatorError.unknownOpcode(instruction.opcode, pc: pc)
+    }
+
+    return WasmStepTrace(
+      pc: pc,
+      instruction: instruction,
+      stackBefore: stackBefore,
+      stackAfter: stack,
+      localsSnapshot: locals,
+      description: description,
+      halted: halted
+    )
+  }
+
+  private func checkedLocalIndex(_ instruction: WasmInstruction, locals: [Int32]) throws -> Int {
+    guard let operand = instruction.operand else {
+      throw WasmSimulatorError.missingOperand(instruction.mnemonic)
+    }
+    let index = Int(operand)
+    guard locals.indices.contains(index) else {
+      throw WasmSimulatorError.localIndexOutOfRange(index)
+    }
+    return index
+  }
+}
+
+public final class WasmSimulator {
+  private let decoder = WasmDecoder()
+  private let executor = WasmExecutor()
+
+  public private(set) var stack: [Int32] = []
+  public private(set) var locals: [Int32]
+  public private(set) var pc = 0
+  public private(set) var cycle = 0
+  public private(set) var halted = false
+  public private(set) var bytecode: [UInt8] = []
+
+  public init(localCount: Int = 16) {
+    precondition(localCount >= 0, "localCount must be non-negative")
+    locals = Array(repeating: 0, count: localCount)
+  }
+
+  public func load(_ program: [UInt8]) {
+    bytecode = program
+    pc = 0
+    cycle = 0
+    halted = false
+    stack.removeAll(keepingCapacity: true)
+    locals = Array(repeating: 0, count: locals.count)
+  }
+
+  @discardableResult
+  public func step() throws -> WasmStepTrace {
+    guard !halted else { throw WasmSimulatorError.halted }
+
+    let instruction = try decoder.decode(bytecode, at: pc)
+    let trace = try executor.execute(
+      instruction,
+      stack: &stack,
+      locals: &locals,
+      pc: pc
+    )
+    pc += instruction.size
+    cycle += 1
+    halted = trace.halted
+    return trace
+  }
+
+  public func run(_ program: [UInt8], maxSteps: Int = 1_000) throws -> [WasmStepTrace] {
+    precondition(maxSteps >= 0, "maxSteps must be non-negative")
+    load(program)
+
+    var traces: [WasmStepTrace] = []
+    traces.reserveCapacity(min(maxSteps, program.count))
+    while !halted, traces.count < maxSteps {
+      traces.append(try step())
+    }
+    return traces
+  }
+
+  public func reset() {
+    bytecode = []
+    pc = 0
+    cycle = 0
+    halted = false
+    stack.removeAll(keepingCapacity: true)
+    locals = Array(repeating: 0, count: locals.count)
+  }
+}
+
+public func encodeI32Const(_ value: Int32) -> [UInt8] {
+  let bits = UInt32(bitPattern: value)
+  return [
+    WasmOpcode.i32Const,
+    UInt8(truncatingIfNeeded: bits),
+    UInt8(truncatingIfNeeded: bits >> 8),
+    UInt8(truncatingIfNeeded: bits >> 16),
+    UInt8(truncatingIfNeeded: bits >> 24),
+  ]
+}
+
+public func encodeI32Add() -> [UInt8] {
+  [WasmOpcode.i32Add]
+}
+
+public func encodeI32Sub() -> [UInt8] {
+  [WasmOpcode.i32Sub]
+}
+
+public func encodeLocalGet(_ index: UInt8) -> [UInt8] {
+  [WasmOpcode.localGet, index]
+}
+
+public func encodeLocalSet(_ index: UInt8) -> [UInt8] {
+  [WasmOpcode.localSet, index]
+}
+
+public func encodeEnd() -> [UInt8] {
+  [WasmOpcode.end]
+}
+
+public func assembleWasm(_ instructions: [[UInt8]]) -> [UInt8] {
+  instructions.flatMap { $0 }
+}

--- a/code/packages/swift/wasm-simulator/Tests/WasmSimulatorTests/WasmSimulatorTests.swift
+++ b/code/packages/swift/wasm-simulator/Tests/WasmSimulatorTests/WasmSimulatorTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+
+@testable import WasmSimulator
+
+final class WasmSimulatorTests: XCTestCase {
+  func testVersionAndEncodingHelpers() {
+    XCTAssertEqual(WasmSimulatorVersion.version, "0.1.0")
+    XCTAssertEqual(encodeI32Add(), [0x6A])
+    XCTAssertEqual(encodeLocalSet(2), [0x21, 0x02])
+    XCTAssertEqual(encodeI32Const(-2), [0x41, 0xFE, 0xFF, 0xFF, 0xFF])
+  }
+
+  func testDecoderReadsSignedI32Const() throws {
+    let instruction = try WasmDecoder().decode(encodeI32Const(-42), at: 0)
+
+    XCTAssertEqual(instruction.mnemonic, "i32.const")
+    XCTAssertEqual(instruction.operand, -42)
+    XCTAssertEqual(instruction.size, 5)
+  }
+
+  func testSimulatorRunsSimpleAdditionProgram() throws {
+    let simulator = WasmSimulator(localCount: 2)
+    let program = assembleWasm([
+      encodeI32Const(1),
+      encodeI32Const(2),
+      encodeI32Add(),
+      encodeLocalSet(0),
+      encodeEnd(),
+    ])
+
+    let traces = try simulator.run(program)
+
+    XCTAssertEqual(traces.count, 5)
+    XCTAssertEqual(traces[2].stackBefore, [1, 2])
+    XCTAssertEqual(traces[2].stackAfter, [3])
+    XCTAssertEqual(simulator.locals[0], 3)
+    XCTAssertEqual(simulator.stack, [])
+    XCTAssertEqual(simulator.pc, program.count)
+    XCTAssertEqual(simulator.cycle, 5)
+    XCTAssertTrue(simulator.halted)
+  }
+
+  func testLocalGetRestoresStoredValue() throws {
+    let simulator = WasmSimulator(localCount: 2)
+    let program = assembleWasm([
+      encodeI32Const(42),
+      encodeLocalSet(1),
+      encodeLocalGet(1),
+      encodeEnd(),
+    ])
+
+    let traces = try simulator.run(program)
+
+    XCTAssertEqual(traces[2].stackAfter, [42])
+    XCTAssertEqual(traces[2].localsSnapshot, [0, 42])
+    XCTAssertEqual(simulator.stack, [42])
+  }
+
+  func testSubtractionUsesWrappingI32Arithmetic() throws {
+    let simulator = WasmSimulator()
+    let program = assembleWasm([
+      encodeI32Const(.min),
+      encodeI32Const(1),
+      encodeI32Sub(),
+      encodeEnd(),
+    ])
+
+    _ = try simulator.run(program)
+
+    XCTAssertEqual(simulator.stack, [.max])
+  }
+
+  func testRunHonorsStepLimit() throws {
+    let simulator = WasmSimulator()
+    let program = assembleWasm([
+      encodeI32Const(1),
+      encodeI32Const(2),
+      encodeI32Add(),
+      encodeEnd(),
+    ])
+
+    let traces = try simulator.run(program, maxSteps: 2)
+
+    XCTAssertEqual(traces.count, 2)
+    XCTAssertEqual(simulator.stack, [1, 2])
+    XCTAssertFalse(simulator.halted)
+  }
+
+  func testLoadAndResetClearState() throws {
+    let simulator = WasmSimulator(localCount: 1)
+    _ = try simulator.run(
+      assembleWasm([
+        encodeI32Const(7),
+        encodeLocalSet(0),
+        encodeEnd(),
+      ]))
+
+    simulator.load(assembleWasm([encodeI32Const(3), encodeEnd()]))
+    XCTAssertEqual(simulator.locals, [0])
+    XCTAssertEqual(simulator.stack, [])
+    XCTAssertEqual(simulator.pc, 0)
+    XCTAssertEqual(simulator.cycle, 0)
+    XCTAssertFalse(simulator.halted)
+
+    _ = try simulator.step()
+    simulator.reset()
+    XCTAssertEqual(simulator.bytecode, [])
+    XCTAssertEqual(simulator.stack, [])
+    XCTAssertEqual(simulator.pc, 0)
+    XCTAssertEqual(simulator.cycle, 0)
+  }
+
+  func testDecoderRejectsUnknownAndTruncatedInstructions() {
+    XCTAssertThrowsError(try WasmDecoder().decode([0xFF], at: 0)) { error in
+      XCTAssertEqual(error as? WasmSimulatorError, .unknownOpcode(0xFF, pc: 0))
+    }
+    XCTAssertThrowsError(try WasmDecoder().decode([WasmOpcode.i32Const, 0x01], at: 0)) { error in
+      XCTAssertEqual(
+        error as? WasmSimulatorError,
+        .truncatedInstruction(pc: 0, expectedBytes: 5, availableBytes: 2)
+      )
+    }
+  }
+
+  func testSimulatorReportsExecutionErrors() throws {
+    let simulator = WasmSimulator(localCount: 1)
+
+    XCTAssertThrowsError(try simulator.run(assembleWasm([encodeI32Add()]))) { error in
+      XCTAssertEqual(error as? WasmSimulatorError, .stackUnderflow)
+    }
+    XCTAssertThrowsError(
+      try simulator.run(assembleWasm([encodeLocalGet(1)]))
+    ) { error in
+      XCTAssertEqual(error as? WasmSimulatorError, .localIndexOutOfRange(1))
+    }
+
+    _ = try simulator.run(assembleWasm([encodeEnd()]))
+    XCTAssertThrowsError(try simulator.step()) { error in
+      XCTAssertEqual(error as? WasmSimulatorError, .halted)
+    }
+  }
+
+  func testExecutorRejectsMissingOperands() {
+    var stack: [Int32] = []
+    var locals: [Int32] = [0]
+    let malformed = WasmInstruction(
+      opcode: WasmOpcode.i32Const,
+      mnemonic: "i32.const",
+      operand: nil,
+      size: 5
+    )
+
+    XCTAssertThrowsError(
+      try WasmExecutor().execute(malformed, stack: &stack, locals: &locals, pc: 0)
+    ) { error in
+      XCTAssertEqual(error as? WasmSimulatorError, .missingOperand("i32.const"))
+    }
+  }
+}

--- a/code/packages/swift/wasm-simulator/required_capabilities.json
+++ b/code/packages/swift/wasm-simulator/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "swift/wasm-simulator",
+  "capabilities": [],
+  "justification": "Pure bytecode decoding and deterministic stack-machine simulation. No filesystem, network, process, or environment access needed."
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -127,7 +127,7 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Nine package/language slots remain to turn 9 nearly complete packages into
+Eight package/language slots remain to turn 8 nearly complete packages into
 fully covered packages.
 
 ### Dart: 6 remaining ports
@@ -147,11 +147,12 @@ Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
 `huffman-tree`, `huffman-compression`, `lz77`, `lzss`, `lzw`.
 
-### Swift: 3 ports
+### Swift: 2 ports
 
 - `cli-builder`
 - `sql-execution-engine`
-- `wasm-simulator`
+
+Completed in the Swift lane: `wasm-simulator`.
 
 Port dependency families together when doing so avoids temporary broken package
 graphs. Grammar-generated lexer/parser pairs should be generated from the shared
@@ -159,7 +160,7 @@ grammar sources rather than independently handwritten.
 
 ## Priority 2: Complete The High-Consensus Core
 
-The 171 packages present in at least ten implementation languages need 383
+The 171 packages present in at least ten implementation languages need 382
 ports to reach all 15. After Priority 1, select work in this order:
 
 | Language lane | Current high-consensus gaps | Pairing rule |
@@ -171,7 +172,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | C# | 17 | Move with F# |
 | F# | 17 | Move with C# |
 | Haskell | 34 | Dependency-shaped compression, graphics, ML, and protocol waves |
-| Swift | 53 | Data structures and generated frontends before native app surfaces |
+| Swift | 52 | Data structures and generated frontends before native app surfaces |
 | Java | 57 | Move with Kotlin |
 | Kotlin | 57 | Move with Java |
 | Dart | 112 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |


### PR DESCRIPTION
## Summary

- add a pure Swift port of the WASM stack-machine simulator
- implement decoding and execution for the six supported opcodes, signed `i32.const` operands, locals, traces, step limits, and structured errors
- add SwiftPM packaging, BUILD metadata, documentation, capability metadata, and 10 focused tests
- complete `wasm-simulator` across all 15 established implementation languages and update the package-parity roadmap

## Validation

- `swift-format lint --strict --recursive Sources Tests`
- `swift test --package-path code/packages/swift/wasm-simulator --scratch-path <external-temp-dir>` — 10 tests, 0 failures
- `python code/scripts/package_parity_report.py --format json --fail-on-collisions`
- `python code/scripts/package_parity_report.py --format markdown --fail-on-collisions`
- `git diff --check origin/main...HEAD`

Current inventory: 4,169 implementation package slots, 382 high-consensus gaps, Swift at 158 present / 52 high-consensus gaps, `wasm-simulator` at 15 languages, 0 collisions, and 0 unknown language buckets.
