### PR TITLE
feat(adj-formula-stdlib): FL-4 percent + average libraries (compose cited primitives)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/fl4_percent_average_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/fl4_percent_average_e2e.rs
@@ -1,0 +1,170 @@
+//! End-to-end tests for ADJ-FORMULA-LIBRARIES FL-4 — the `percent.adj` and
+//! `average.adj` elementary libraries — driven through the built CLI binary
+//! against the SHIPPED stdlib. Each proves the FL-4 invariant: the new library
+//! COMPOSES the cited `arithmetic.adj` primitives (it re-derives no arithmetic),
+//! computes the exact value on the CPU, and carries BOTH its own citation and the
+//! primitives' as corroborations — write-once-use-many all the way down.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_fl4_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file (by relative path under the stdlib) into `dir`
+/// under its basename, so a consumer's relative `import` resolves.
+fn place(dir: &Path, rel: &str) {
+    let src = stdlib().join(rel);
+    let name = Path::new(rel).file_name().unwrap();
+    std::fs::copy(&src, dir.join(name)).unwrap_or_else(|e| panic!("copy {rel}: {e}"));
+}
+
+// ---------------------------------------------------------------------------
+// percent — a share per hundred, composing quotient.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn percent_composes_quotient_and_carries_both_citations() {
+    let dir = scratch("percent");
+    place(&dir, "arithmetic/arithmetic.adj");
+    place(&dir, "arithmetic/percent.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"percent.adj\"\n\
+         observe part(30)\n\
+         observe whole(40)\n\
+         ? percent(part, whole)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 30 / 40 * 100 = 75, via quotient on the CPU.
+    assert!(
+        s.contains("\"name\":\"percent\"") && s.contains("\"value\":75"),
+        "percent(30, 40) = 75: {s}"
+    );
+    // BOTH citations: percent's own definition (primary) AND the quotient
+    // primitive it composed (corroboration).
+    assert!(
+        s.contains("mathworld.wolfram.com/Percent.html"),
+        "primary cites the percent definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Quotient.html"),
+        "corroboration cites the quotient primitive it composed: {s}"
+    );
+}
+
+#[test]
+fn percent_change_composes_difference_and_quotient() {
+    let dir = scratch("pctchg");
+    place(&dir, "arithmetic/arithmetic.adj");
+    place(&dir, "arithmetic/percent.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"percent.adj\"\n\
+         observe old_amount(200)\n\
+         observe new_amount(250)\n\
+         ? percent_change(old_amount, new_amount)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (250 - 200) / 200 * 100 = 25, composing difference then quotient.
+    assert!(
+        s.contains("\"name\":\"percent_change\"") && s.contains("\"value\":25"),
+        "percent_change(200, 250) = 25: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/PercentageChange.html"),
+        "primary cites the percentage-change definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Difference.html"),
+        "cites the difference primitive it composed: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// average — the arithmetic mean, composing sum then quotient.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mean_two_composes_sum_and_quotient() {
+    let dir = scratch("mean2");
+    place(&dir, "arithmetic/arithmetic.adj");
+    place(&dir, "arithmetic/average.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"average.adj\"\n\
+         observe value_one(4)\n\
+         observe value_two(6)\n\
+         ? mean_two(value_one, value_two)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (4 + 6) / 2 = 5, composing sum then quotient.
+    assert!(
+        s.contains("\"name\":\"mean_two\"") && s.contains("\"value\":5"),
+        "mean_two(4, 6) = 5: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/ArithmeticMean.html"),
+        "primary cites the arithmetic-mean definition: {s}"
+    );
+    assert!(
+        s.contains("mathworld.wolfram.com/Sum.html"),
+        "cites the sum primitive it composed: {s}"
+    );
+}
+
+#[test]
+fn mean_three_pools_three_values_over_three() {
+    let dir = scratch("mean3");
+    place(&dir, "arithmetic/arithmetic.adj");
+    place(&dir, "arithmetic/average.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"average.adj\"\n\
+         observe value_one(3)\n\
+         observe value_two(5)\n\
+         observe value_three(10)\n\
+         ? mean_three(value_one, value_two, value_three)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (3 + 5 + 10) / 3 = 6, composing sum twice then quotient.
+    assert!(
+        s.contains("\"name\":\"mean_three\"") && s.contains("\"value\":6"),
+        "mean_three(3, 5, 10) = 6: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/average.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/average.adj
@@ -1,0 +1,69 @@
+% ============================================================================
+% average.adj — the arithmetic-mean formula library (ADJ-FORMULA-LIBRARIES FL-4).
+% ============================================================================
+% The elementary "share it out evenly" track of the compute standard library,
+% built ENTIRELY by composing the cited primitives of `arithmetic.adj`. The
+% arithmetic mean of n quantities is their sum divided by n, so every formula
+% here pools its inputs with the cited `sum` and then divides the pool by the
+% count with the cited `quotient` — it re-derives no arithmetic. Write-once-
+% use-many: a consumer imports this file, binds the numbers from its own
+% byte-provenance decomposition, and asks the engine to apply the cited formula
+% on the CPU; the model performs zero arithmetic.
+%
+%     import "average.adj"                    % transitively imports arithmetic.adj
+%     observe value_one(4)                    % "…4…"   (span cited by the model)
+%     observe value_two(6)                    % "…6…"   (span cited by the model)
+%     ? mean_two(value_one, value_two)        % engine → 5, carrying every citation
+%
+% The engine expands `mean_two` → `sum` then `quotient` (both from
+% arithmetic.adj) on the CPU and composes the provenance chain, so the answer
+% cites MathWorld's *arithmetic mean* definition (primary) alongside the `sum`
+% and `quotient` primitives it builds on. The audit trail names every formula
+% that participated.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% This library depends on the elementary primitives — `sum` and `quotient`. The
+% import is RELATIVE to this file, so a consumer that imports `average.adj` gets
+% those primitives transitively and the bodies below resolve.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The values being averaged and their mean. Rung-0 types an
+% observable slot as `finding`; the `surface` synonyms let a decomposer map
+% everyday phrasing ("average", "on average", "mean of") onto the canonical
+% terms.
+% ----------------------------------------------------------------------------
+dictionary average_vocab {
+    define value_one   : finding  surface "first value", "first number", "one value"
+    define value_two   : finding  surface "second value", "second number", "other value"
+    define value_three : finding  surface "third value", "third number", "last value"
+    define mean_two    : finding  surface "average", "mean", "average of two", "mean of two"
+    define mean_three  : finding  surface "average", "mean", "average of three", "mean of three"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formulas. Each pools its inputs with the cited `sum` and divides
+% the pool by the count with the cited `quotient` — the arithmetic mean is the
+% sum over the count, cited as such.
+%
+%   mean_two(a, b)      = (a + b) / 2
+%   mean_three(a, b, c) = (a + b + c) / 3
+% ----------------------------------------------------------------------------
+formulabook averages {
+    use average_vocab
+
+    % The arithmetic mean of two quantities — their sum shared evenly in two.
+    formula mean_two(value_one, value_two) = quotient(sum(value_one, value_two), 2)
+        source "The arithmetic mean of a set of numbers is the sum of the numbers divided by how many numbers there are in the set."
+        locator "https://mathworld.wolfram.com/ArithmeticMean.html"
+        trust authoritative
+
+    % The arithmetic mean of three quantities — their pooled sum shared evenly in
+    % three. Composes `sum` twice (associatively) then `quotient`.
+    formula mean_three(value_one, value_two, value_three) = quotient(sum(sum(value_one, value_two), value_three), 3)
+        source "The arithmetic mean of a set of numbers is the sum of the numbers divided by how many numbers there are in the set."
+        locator "https://mathworld.wolfram.com/ArithmeticMean.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/arithmetic/percent.adj
+++ b/code/specs/data/adj-formula-stdlib/arithmetic/percent.adj
@@ -1,0 +1,72 @@
+% ============================================================================
+% percent.adj — the percentage formula library (ADJ-FORMULA-LIBRARIES FL-4).
+% ============================================================================
+% The elementary "out of a hundred" track of the compute standard library, built
+% ENTIRELY by composing the cited primitives of `arithmetic.adj` — it re-derives
+% nothing. A percentage is a ratio expressed per hundred, so every formula here
+% is a quotient (share) scaled by a hundred, and a percentage change is the same
+% over the amount of change. Write-once-use-many: a consumer imports this file,
+% binds the numbers from its own byte-provenance decomposition, and asks the
+% engine to apply the cited formula on the CPU — the model performs zero
+% arithmetic.
+%
+%     import "percent.adj"                    % transitively imports arithmetic.adj
+%     observe part(30)                        % "…30 correct…"  (span cited by the model)
+%     observe whole(40)                       % "…out of 40…"   (span cited by the model)
+%     ? percent(part, whole)                  % engine → 75, carrying every citation
+%
+% The engine expands `percent` → `quotient` (from arithmetic.adj) on the CPU, then
+% scales by a hundred, and composes the provenance chain so the answer cites BOTH
+% MathWorld's *percent* definition (primary) and the *quotient* primitive it
+% builds on (corroboration). The audit trail names every formula that participated.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% This library depends on the elementary primitives — `quotient` and
+% `difference` in particular. The import is RELATIVE to this file, so a consumer
+% that imports `percent.adj` gets those primitives transitively and the bodies
+% below resolve.
+% ----------------------------------------------------------------------------
+import "arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. `percent` compares a part to a whole; `percent_change` compares a
+% new amount to an old one. Rung-0 types an observable slot as `finding`; the
+% `surface` synonyms let a decomposer map everyday phrasing ("out of", "what
+% percent", "grew by") onto the canonical terms.
+% ----------------------------------------------------------------------------
+dictionary percent_vocab {
+    define part          : finding  surface "part", "amount", "portion", "number that is"
+    define whole         : finding  surface "whole", "total", "out of", "base"
+    define percent       : finding  surface "percent", "percentage", "per cent", "percent of the whole"
+
+    define old_amount    : finding  surface "old amount", "original amount", "starting value", "amount before"
+    define new_amount    : finding  surface "new amount", "final amount", "ending value", "amount after"
+    define percent_change : finding  surface "percent change", "percentage change", "percent increase", "percent decrease"
+}
+
+% ----------------------------------------------------------------------------
+% The composed formulas. Neither writes a bare `/` or `-`: each APPLIES the cited
+% primitive from `arithmetic.adj` and scales the share by a hundred, so the
+% percentage is a percentage BECAUSE it is a quotient per hundred, cited as such.
+%
+%   percent(part, whole)        = (part / whole) * 100
+%   percent_change(old, new)    = ((new - old) / old) * 100
+% ----------------------------------------------------------------------------
+formulabook percentages {
+    use percent_vocab
+
+    % A percentage — the part as a share of the whole, expressed per hundred.
+    formula percent(part, whole) = quotient(part, whole) * 100
+        source "A percentage is a number or ratio expressed as a fraction of 100; it is often denoted by the percent sign, %."
+        locator "https://mathworld.wolfram.com/Percent.html"
+        trust authoritative
+
+    % A percentage change — the change from the old amount to the new one, as a
+    % share of the old amount, expressed per hundred. Composes `difference` and
+    % `quotient` from arithmetic.adj.
+    formula percent_change(old_amount, new_amount) = quotient(difference(new_amount, old_amount), old_amount) * 100
+        source "Percentage change is the difference between the final and initial value of a quantity, divided by the initial value, expressed as a percentage."
+        locator "https://mathworld.wolfram.com/PercentageChange.html"
+        trust authoritative
+}


### PR DESCRIPTION
## FL-4 — resume the FORMULA-LIBRARY ladder (K→med)

Pivots back to building **reusable ADJ math libraries** (the real ladder) after a detour into two-arm eval-scoreboard fixtures. Two new elementary libraries under `adj-formula-stdlib/arithmetic/`, each built **entirely by composing the cited `arithmetic.adj` primitives** — write-once-use-many, zero model arithmetic:

**percent.adj**
```adj
formula percent(part, whole)          = quotient(part, whole) * 100
formula percent_change(old, new)      = quotient(difference(new, old), old) * 100
```

**average.adj**
```adj
formula mean_two(a, b)      = quotient(sum(a, b), 2)
formula mean_three(a, b, c) = quotient(sum(sum(a, b), c), 3)
```

Every formula **applies** the cited leaf primitive (no bare `/ − +`), so the engine composes the provenance chain on the CPU: the answer carries the library's own MathWorld definition (primary source) **plus** each primitive it built on (corroboration).

### Engine-verified (through the CLI, exact rationals)
| call | value |
|------|-------|
| `percent(30, 40)` | **75** |
| `percent_change(200, 250)` | **25** |
| `mean_two(4, 6)` | **5** |
| `mean_three(3, 5, 10)` | **6** |

### Tests
`fl4_percent_average_e2e.rs` — 4 e2e tests drive each library through the shipped stdlib and assert both the value and the composed citations. Additive only (no existing file changed). Security review passed.

The FL-4 `fraction` library is left for the next FL rotation (`ratio` already ships). This is one front of an alternating three-front cadence — libraries (FL) ↔ substrate (RS-2 multi-step formula bodies) ↔ facts/recall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)