### PR TITLE
feat(semantic-ir-to-typescript): SIR23 symbolic/pattern codegen (HML01 Stream B, item 7)

### DIFF
--- a/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-typescript/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 0.9.0 — SIR23 symbolic/pattern codegen (HML01 Stream B, item 7)
+
+Real codegen for the SIR23 symbolic-expression + pattern/rewrite domain —
+previously deferred (panicking on `Expr::SymSymbol`/`SymRational`/`SymApply`/
+`SymPatternBlank`/`SymPatternNamed`/`SymRule`/`SymReplaceAll`, gated out at
+the capability check). A compiled Wolfram/Macsyma/Maxima program using
+pattern-matching or rewrite rules (`x /. a -> b`, `x //. rules`) now compiles
+to TypeScript that constructs/consumes a real term-tree value at runtime via
+the imported `@coding-adventures/sir-runtime-symbolic` package, bound as
+`__SirSym`:
+
+- `SymSymbol`/`SymRational` → `__SirSym.sym(...)`/`__SirSym.rational(...)`.
+- `SymApply { head, args }` → `__SirSym.apply(head, [args...])`, recursing
+  through `emit_sym_operand` — a child that is an `IntLit`/`FloatLit`/
+  `StrLit` (the three literal kinds SIR23 "reuses directly" rather than
+  defining new leaf nodes for) gets wrapped into the matching
+  `__SirSym.int`/`numberNode`/`stringNode` constructor, since a bare host
+  number/string is never a valid `IRNode` term; every other child (a nested
+  symbolic node, or a `VarRef`/call whose value is already a term by the
+  frontend's own convention) emits unchanged.
+- `SymPatternBlank`/`SymPatternNamed` → `__SirSym.blank()`/`blankTyped(...)`/
+  `named(...)`.
+- `SymRule { delayed }` → `__SirSym.rule(...)` (`->`) or `ruleDelayed(...)`
+  (`:>`).
+- `SymReplaceAll { repeated }` → `__SirSym.unwrap(__SirSym.replaceAll(...))`
+  (`/.`) or `unwrap(replaceRepeated(...))` (`//.`) — wrapped in `unwrap`
+  because both rewrite functions can return a `DepthLimitError`/
+  `RewriteCycleError` sentinel instead of a real term; a compiled
+  `SymReplaceAll` must evaluate to a term value or fail loudly, never
+  silently hand that sentinel to code expecting an `IRNode`.
+
+Accepts `Feature::SymbolicExpr`, `Feature::PatternMatching`, and
+`Feature::Rationals` (the last shared with SIR22, scoped exactly to
+`SymRational` — no other construct in this backend triggers it yet). The
+`@coding-adventures/sir-runtime-symbolic` import is gated by `uses_symbolic`
+(either feature), so a purely-numeric module never gains the dependency.
+
+Required a small, additive extension to `@coding-adventures/sir-runtime-symbolic`
+itself (0.1.0 → 0.2.0): re-exports of `symbolic-ir`'s leaf-term constructors
+(`sym`/`int`/`rational`/`numberNode`/`stringNode`, previously missing) and a
+new `unwrap(result)` helper for the depth/cycle-error-sentinel handling
+above.
+
+Tested with unit shape assertions for every new node kind (leaf constructors,
+literal wrapping, both pattern-blank forms, `rule` vs `ruleDelayed`,
+`replaceAll` vs `replaceRepeated`, the import gate) plus a real end-to-end
+test compiling actual Wolfram source (`x /. a -> b`) through
+`wolfram-to-semantic-ir` and this backend, not just hand-built `Module`s.
+
+The JavaScript backend (`semantic-ir-to-javascript`) still defers these nodes
+— it inlines its own runtime rather than importing packages, so SIR23 there
+needs a from-scratch inlined term-rewriting engine, not a straightforward
+import; tracked as follow-up work.
+
 ## 0.8.0 — source-language display convention: Ruby booleans (`true`/`false`)
 
 Emits the display-convention selection (SIR display-convention spec) for the

--- a/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-typescript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-typescript"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Semantic IR → self-contained TypeScript source code (SIR12). First backend for the SIR10 narrow-waist IR."
 
@@ -10,3 +10,4 @@ semantic-ir = { path = "../semantic-ir" }
 [dev-dependencies]
 twig-to-semantic-ir = { path = "../twig-to-semantic-ir" }
 ruby-to-semantic-ir = { path = "../ruby-to-semantic-ir" }
+wolfram-to-semantic-ir = { path = "../wolfram-to-semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-typescript/README.md
+++ b/code/packages/rust/semantic-ir-to-typescript/README.md
@@ -63,6 +63,17 @@ The TypeScript backend accepts these SIR features:
   `const { x, y = 1 } = (__kw ?? {}) as { [k: string]: __Sir.Val };`. On the
   call side every `KeywordArg` collapses into one trailing object literal:
   `f(1, y: 2)` emits `f(1, { y: 2 })`. Direct lowering, no runtime helper.
+- `SymbolicExpr` / `PatternMatching` (SIR23) — a compiled Wolfram/Macsyma/
+  Maxima program's symbolic-expression and pattern/rewrite nodes
+  (`SymSymbol`/`SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/
+  `SymReplaceAll`) construct/consume a real term-tree value at runtime via
+  the imported `@coding-adventures/sir-runtime-symbolic` package, bound as
+  `__SirSym` (gated by either feature, so a purely-numeric module never
+  gains the dependency). `x /. a -> b` emits
+  `__SirSym.unwrap(__SirSym.replaceAll(__SirSym.sym("x"), [__SirSym.rule(__SirSym.sym("a"), __SirSym.sym("b"))]))`.
+- `Rationals` (shared with SIR22) — accepted only for `SymRational`
+  (`__SirSym.rational(numer, denom)`); no other construct in this backend
+  triggers it yet.
 
 It **rejects**:
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/emit.rs
@@ -257,6 +257,17 @@ fn uses_range(m: &Module) -> bool {
     module_uses_builtin(m, "range")
 }
 
+/// True if the module uses the SIR23 symbolic/pattern domain, in which case
+/// the emitted artifact imports `@coding-adventures/sir-runtime-symbolic`.
+/// Both `Feature::SymbolicExpr` (`SymSymbol`/`SymApply`) and
+/// `Feature::PatternMatching` (`SymPatternBlank`/`SymPatternNamed`/
+/// `SymRule`/`SymReplaceAll`) gate the same single import — a module using
+/// only bare symbolic values with no pattern/rule ever still needs `sym`/
+/// `apply` from this package.
+fn uses_symbolic(m: &Module) -> bool {
+    m.manifest.contains(Feature::SymbolicExpr) || m.manifest.contains(Feature::PatternMatching)
+}
+
 /// Walk every function body for a `BuiltinCall` named `name` — gates
 /// per-concern imports for builtins that carry no `Feature` flag.  Exhaustive
 /// over `Stmt`/`Expr` so a new node can't silently hide a use.
@@ -537,6 +548,10 @@ pub fn emit_module(m: &Module) -> String {
     // Only range-using modules import the range runtime.
     if uses_range(m) {
         out.push_str(crate::runtime::RUNTIME_RANGE);
+    }
+    // Only symbolic/pattern-using modules import the SIR23 runtime.
+    if uses_symbolic(m) {
+        out.push_str(crate::runtime::RUNTIME_SYM);
     }
     // E2: thread user `class Child < Parent` ancestry into the exception
     // matcher at program init, *before* any function or main body runs, so a
@@ -1573,25 +1588,127 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 e.span()
             );
         }
-        // SIR23 symbolic-expression/pattern nodes.  This backend does not
-        // declare `Feature::SymbolicExpr`/`Feature::PatternMatching` in
-        // `accepts_features` (see lib.rs), so `Backend::check_module` rejects
-        // any module using these nodes before it ever reaches emission.
-        // Panic here to catch a backend/validator drift (mirrors the
-        // SIR22/SIR26 guard above).
-        Expr::SymSymbol { .. }
-        | Expr::SymRational { .. }
-        | Expr::SymApply { .. }
-        | Expr::SymPatternBlank { .. }
-        | Expr::SymPatternNamed { .. }
-        | Expr::SymRule { .. }
-        | Expr::SymReplaceAll { .. } => {
-            panic!(
-                "typescript backend reached a deferred SIR23 expression ({}) at {} — not accepted yet",
-                e.kind_name(),
-                e.span()
-            );
+        // SIR23 symbolic-expression/pattern nodes — construct/consume a
+        // tagged term-tree value at runtime via `sir-runtime-symbolic`,
+        // imported as `__SirSym` (gated by `uses_symbolic`, see
+        // `emit_module`).  See the SIR23 spec's "Backend impact" and
+        // `emit_sym_operand`'s doc comment for why a plain `IntLit`/
+        // `FloatLit`/`StrLit` child needs wrapping but every other child
+        // expression does not.
+        Expr::SymSymbol { name, .. } => {
+            out.push_str("__SirSym.sym(");
+            out.push_str(&quote_ts_string(name));
+            out.push(')');
         }
+        Expr::SymRational { numer, denom, .. } => {
+            let _ = write!(out, "__SirSym.rational({}, {})", numer, denom);
+        }
+        Expr::SymApply { head, args, .. } => {
+            out.push_str("__SirSym.apply(");
+            emit_sym_operand(out, head, indent);
+            out.push_str(", [");
+            for (i, a) in args.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_sym_operand(out, a, indent);
+            }
+            out.push_str("])");
+        }
+        Expr::SymPatternBlank { head: None, .. } => {
+            out.push_str("__SirSym.blank()");
+        }
+        Expr::SymPatternBlank {
+            head: Some(head), ..
+        } => match head.as_ref() {
+            Expr::SymSymbol { name, .. } => {
+                out.push_str("__SirSym.blankTyped(");
+                out.push_str(&quote_ts_string(name));
+                out.push(')');
+            }
+            _ => panic!(
+                "typescript backend: SymPatternBlank's head-constraint must be a SymSymbol, got {} at {}",
+                head.kind_name(),
+                head.span()
+            ),
+        },
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            out.push_str("__SirSym.named(");
+            out.push_str(&quote_ts_string(name));
+            out.push_str(", ");
+            emit_sym_operand(out, pattern, indent);
+            out.push(')');
+        }
+        Expr::SymRule {
+            lhs, rhs, delayed, ..
+        } => {
+            out.push_str(if *delayed {
+                "__SirSym.ruleDelayed("
+            } else {
+                "__SirSym.rule("
+            });
+            emit_sym_operand(out, lhs, indent);
+            out.push_str(", ");
+            emit_sym_operand(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::SymReplaceAll {
+            expr,
+            rules,
+            repeated,
+            ..
+        } => {
+            out.push_str("__SirSym.unwrap(");
+            out.push_str(if *repeated {
+                "__SirSym.replaceRepeated("
+            } else {
+                "__SirSym.replaceAll("
+            });
+            emit_sym_operand(out, expr, indent);
+            out.push_str(", [");
+            for (i, r) in rules.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_sym_operand(out, r, indent);
+            }
+            out.push_str("]))");
+        }
+    }
+}
+
+/// Emit `e` as a value usable as a `symbolic-ir` `IRNode` term — used for
+/// the `head`/`args`/`lhs`/`rhs`/`pattern`/`expr`/rule-list children of
+/// `SymApply`/`SymPatternBlank`/`SymPatternNamed`/`SymRule`/
+/// `SymReplaceAll`, where the SIR23 spec requires a real term-tree node,
+/// not a bare host value.
+///
+/// The three literal kinds SIR23 "reuses directly" instead of defining new
+/// leaf nodes for (`IntLit`/`FloatLit`/`StrLit`, per the spec's "New Expr
+/// variants" section) need wrapping into the matching `__SirSym`
+/// constructor here — a bare JS number or string is never a valid
+/// `IRNode`. Every other expression (a `SymSymbol`/`SymRational`/
+/// `SymApply`/pattern/rule node, which already constructs a term via the
+/// ordinary `emit_expr` arms above, or a `VarRef`/call whose runtime value
+/// is already a term by the frontend's own convention) emits unchanged.
+fn emit_sym_operand(out: &mut String, e: &Expr, indent: usize) {
+    match e {
+        Expr::IntLit { .. } => {
+            out.push_str("__SirSym.int(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::FloatLit { .. } => {
+            out.push_str("__SirSym.numberNode(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::StrLit { .. } => {
+            out.push_str("__SirSym.stringNode(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        _ => emit_expr(out, e, indent),
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/lib.rs
@@ -122,6 +122,20 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // call collapses its keyword args into one trailing object literal.  Direct
     // lowering, no runtime helper — mirrors how `DefaultParams` is declared.
     Feature::KeywordParams,
+    // SIR23: the symbolic-expression + pattern/rewrite domain.  A
+    // `SymSymbol`/`SymApply` node sets `SymbolicExpr`; a `SymPatternBlank`/
+    // `SymPatternNamed`/`SymRule`/`SymReplaceAll` node sets
+    // `PatternMatching`.  Both route through the imported
+    // `@coding-adventures/sir-runtime-symbolic` package (`__SirSym`), gated
+    // by `uses_symbolic` — see `emit`'s SIR23 arms and
+    // `code/specs/SIR23-symbolic-pattern-semantic-ir.md` §"Backend impact".
+    Feature::SymbolicExpr,
+    Feature::PatternMatching,
+    // A `SymRational` node sets this (shared with SIR22 rather than a new
+    // flag of its own — see the SIR23 spec's "New Feature flags"); no other
+    // construct in this backend triggers it yet, so accepting it is scoped
+    // exactly to `SymRational`.
+    Feature::Rationals,
 ];
 
 impl Backend for TypeScriptBackend {
@@ -1565,6 +1579,245 @@ mod tests {
         assert!(
             src.contains("g(7)") && !src.contains("g(7, {"),
             "a call with no keyword args emits no trailing object; got:\n{src}"
+        );
+    }
+
+    // ── SIR23: symbolic-expression/pattern codegen ──────────────────────
+
+    #[test]
+    fn accepts_sir23_symbolic_features() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::SymbolicExpr,
+            Feature::PatternMatching,
+            Feature::Rationals,
+        ]);
+        compile(&m).expect("SIR23 features accepted");
+    }
+
+    #[test]
+    fn non_symbolic_module_omits_sir_runtime_symbolic_import() {
+        let a = compile(&minimal_module()).expect("compile");
+        assert!(
+            !a.source.contains("sir-runtime-symbolic"),
+            "a module with no symbolic node must not import sir-runtime-symbolic; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn symbolic_module_imports_sir_runtime_symbolic() {
+        let m = module_with_main_body(
+            vec![],
+            Expr::SymSymbol { name: "z".into(), span: s() },
+            &[Feature::SymbolicExpr],
+        );
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(
+                r#"import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";"#
+            ),
+            "a module using SymSymbol must import sir-runtime-symbolic; got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn sym_symbol_and_sym_rational_emit_leaf_constructors() {
+        let m = module_with_main_body(
+            vec![],
+            Expr::SymApply {
+                head: Box::new(Expr::SymSymbol { name: "f".into(), span: s() }),
+                args: vec![Expr::SymRational { numer: 1, denom: 3, span: s() }],
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::Rationals],
+        );
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(r#"__SirSym.apply(__SirSym.sym("f"), [__SirSym.rational(1, 3)])"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn literal_children_of_sym_apply_are_wrapped_as_terms() {
+        // IntLit/FloatLit/StrLit are reused directly per the SIR23 spec, but
+        // a bare JS number/string is never a valid IRNode, so a SymApply's
+        // literal args must be wrapped through the matching __SirSym
+        // constructor rather than emitted as bare host values.
+        let m = module_with_main_body(
+            vec![],
+            Expr::SymApply {
+                head: Box::new(Expr::SymSymbol { name: "f".into(), span: s() }),
+                args: vec![
+                    Expr::IntLit { value: 2, span: s() },
+                    Expr::FloatLit { value: 1.5, span: s() },
+                    Expr::StrLit { value: "hi".into(), span: s() },
+                ],
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::Floats, Feature::Strings],
+        );
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(
+                r#"__SirSym.apply(__SirSym.sym("f"), [__SirSym.int(2), __SirSym.numberNode(1.5), __SirSym.stringNode("hi")])"#
+            ),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn untyped_and_typed_pattern_blanks_emit_blank_and_blank_typed() {
+        let m = module_with_main_body(
+            vec![],
+            Expr::SymApply {
+                head: Box::new(Expr::SymSymbol { name: "f".into(), span: s() }),
+                args: vec![
+                    Expr::SymPatternBlank { head: None, span: s() },
+                    Expr::SymPatternBlank {
+                        head: Some(Box::new(Expr::SymSymbol { name: "Integer".into(), span: s() })),
+                        span: s(),
+                    },
+                ],
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::PatternMatching],
+        );
+        let a = compile(&m).expect("compile");
+        assert!(a.source.contains("__SirSym.blank()"), "got:\n{}", a.source);
+        assert!(
+            a.source.contains(r#"__SirSym.blankTyped("Integer")"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "SymPatternBlank's head-constraint must be a SymSymbol")]
+    fn pattern_blank_with_non_symbol_head_panics_rather_than_miscompiling() {
+        let m = module_with_main_body(
+            vec![],
+            Expr::SymPatternBlank {
+                head: Some(Box::new(Expr::IntLit { value: 1, span: s() })),
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::PatternMatching],
+        );
+        let _ = compile(&m);
+    }
+
+    #[test]
+    fn rule_vs_rule_delayed_emit_distinct_constructors() {
+        let xpat = Expr::SymPatternNamed {
+            name: "x".into(),
+            pattern: Box::new(Expr::SymPatternBlank { head: None, span: s() }),
+            span: s(),
+        };
+        let m = module_with_main_body(
+            vec![],
+            Expr::SymRule {
+                lhs: Box::new(xpat.clone()),
+                rhs: Box::new(xpat),
+                delayed: true,
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::PatternMatching],
+        );
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(r#"__SirSym.ruleDelayed(__SirSym.named("x", __SirSym.blank()), __SirSym.named("x", __SirSym.blank()))"#),
+            "delayed: true must emit ruleDelayed, not rule; got:\n{}",
+            a.source
+        );
+        assert!(!a.source.contains("__SirSym.rule("), "got:\n{}", a.source);
+    }
+
+    #[test]
+    fn replace_all_and_replace_repeated_both_route_through_unwrap() {
+        let xpat = Expr::SymPatternNamed {
+            name: "x".into(),
+            pattern: Box::new(Expr::SymPatternBlank { head: None, span: s() }),
+            span: s(),
+        };
+        let make_rule = |xpat: Expr| Expr::SymRule {
+            lhs: Box::new(Expr::SymApply {
+                head: Box::new(Expr::SymSymbol { name: "Add".into(), span: s() }),
+                args: vec![xpat.clone(), Expr::IntLit { value: 0, span: s() }],
+                span: s(),
+            }),
+            rhs: Box::new(xpat),
+            delayed: false,
+            span: s(),
+        };
+        let target = Expr::SymApply {
+            head: Box::new(Expr::SymSymbol { name: "Add".into(), span: s() }),
+            args: vec![
+                Expr::SymSymbol { name: "z".into(), span: s() },
+                Expr::IntLit { value: 0, span: s() },
+            ],
+            span: s(),
+        };
+
+        let one_pass = module_with_main_body(
+            vec![],
+            Expr::SymReplaceAll {
+                expr: Box::new(target.clone()),
+                rules: vec![make_rule(xpat.clone())],
+                repeated: false,
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::PatternMatching],
+        );
+        let a1 = compile(&one_pass).expect("compile");
+        assert!(
+            a1.source.contains("__SirSym.unwrap(__SirSym.replaceAll("),
+            "repeated: false must route through replaceAll; got:\n{}",
+            a1.source
+        );
+        assert!(!a1.source.contains("replaceRepeated"), "got:\n{}", a1.source);
+
+        let fixed_point = module_with_main_body(
+            vec![],
+            Expr::SymReplaceAll {
+                expr: Box::new(target),
+                rules: vec![make_rule(xpat)],
+                repeated: true,
+                span: s(),
+            },
+            &[Feature::SymbolicExpr, Feature::PatternMatching],
+        );
+        let a2 = compile(&fixed_point).expect("compile");
+        assert!(
+            a2.source.contains("__SirSym.unwrap(__SirSym.replaceRepeated("),
+            "repeated: true must route through replaceRepeated; got:\n{}",
+            a2.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_wolfram_replace_all_compiles_and_emits_expected_calls() {
+        // A real Wolfram program (not a hand-built IR) through the actual
+        // wolfram-to-semantic-ir frontend, proving this backend's SIR23
+        // codegen matches what the frontend genuinely produces, not just
+        // synthetic `Module`s built by hand elsewhere in this file.
+        let module = wolfram_to_semantic_ir::compile_source("x /. a -> b\n", "demo")
+            .expect("lower wolfram");
+        let a = compile(&module).expect("compile to ts");
+        assert!(
+            a.source.contains(
+                r#"import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";"#
+            ),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains(r#"__SirSym.unwrap(__SirSym.replaceAll(__SirSym.sym("x"), [__SirSym.rule(__SirSym.sym("a"), __SirSym.sym("b"))]))"#),
+            "got:\n{}",
+            a.source
         );
     }
 }

--- a/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-typescript/src/runtime.rs
@@ -62,6 +62,16 @@ pub const RUNTIME_SHELL: &str = r##"import * as __SirShell from "@coding-adventu
 pub const RUNTIME_RANGE: &str = r##"import * as __SirRange from "@coding-adventures/sir-runtime-range";
 "##;
 
+/// The symbolic-expression runtime import, emitted **only** when a module
+/// uses the SIR23 symbolic/pattern domain (`Feature::SymbolicExpr` or
+/// `Feature::PatternMatching` — a `SymApply`/`SymPatternBlank`/
+/// `SymPatternNamed`/`SymRule`/`SymReplaceAll` node).  Pure non-symbolic
+/// modules (e.g. a MATLAB program) never gain a dependency on it.  Bound as
+/// `__SirSym` so the emitter's `__SirSym.*` call sites resolve; see
+/// `code/specs/SIR23-symbolic-pattern-semantic-ir.md` §"Backend impact".
+pub const RUNTIME_SYM: &str = r##"import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";
+"##;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,5 +112,13 @@ mod tests {
         assert!(RUNTIME_PAIRS.ends_with('\n'));
         // cons/car/cdr no longer come from the core namespace import.
         assert!(!RUNTIME.contains("cons"));
+    }
+
+    #[test]
+    fn symbolic_import_binds_its_namespace() {
+        assert!(RUNTIME_SYM.contains(
+            r#"import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";"#
+        ));
+        assert!(RUNTIME_SYM.ends_with('\n'));
     }
 }

--- a/code/packages/typescript/sir-runtime-symbolic/CHANGELOG.md
+++ b/code/packages/typescript/sir-runtime-symbolic/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-07-13
+
+### Added
+
+- Re-exports `@coding-adventures/symbolic-ir`'s leaf-term constructors —
+  `sym`, `int`, `rational`, `numberNode`, `stringNode` — unchanged. These
+  were missing from 0.1.0: a compiled `SymSymbol`/`SymRational` node, or a
+  bare `IntLit`/`FloatLit`/`StrLit` appearing as a child of a `SymApply`/
+  `SymRule`/`SymReplaceAll` (which SIR23 "reuses directly" rather than
+  defining new leaf node kinds for), has nowhere else to become a real
+  `IRNode` at the single `__SirSym` import site a generated module uses —
+  a bare host number/string is never a valid term. Needed by the
+  `semantic-ir-to-typescript` SIR23 codegen this version unblocks.
+- **`unwrap(result)`** — throws a plain `Error` if a `replaceAll`/
+  `replaceRepeated` result is a `DepthLimitError`/`RewriteCycleError`
+  sentinel, otherwise returns the `IRNode` unchanged. Both rewrite
+  functions return an error *value* rather than throwing (so a caller that
+  wants to inspect the failure kind can), but a compiled `SymReplaceAll` is
+  an ordinary expression that must evaluate to a term value or fail
+  loudly — it must never silently hand a `{ kind: "depth-limit" }`
+  sentinel to code expecting an `IRNode`. Every codegen call site routes
+  through this helper rather than using the raw result directly.
+
 ## [0.1.0] - 2026-07-13
 
 ### Added

--- a/code/packages/typescript/sir-runtime-symbolic/README.md
+++ b/code/packages/typescript/sir-runtime-symbolic/README.md
@@ -40,6 +40,14 @@ things neither sibling provides:
    that gap forward — see the module doc comment in `src/index.ts` for why
    the re-exported matcher primitives *don't* need the same treatment.
 
+Also re-exported unchanged from `symbolic-ir`: the leaf-term constructors
+`sym`, `int`, `rational`, `numberNode`, `stringNode`. A compiled
+`SymSymbol`/`SymRational` node — or a bare `IntLit`/`FloatLit`/`StrLit`
+appearing as a child of a `SymApply`/`SymRule`/`SymReplaceAll` (SIR23
+"reuses [those] directly" rather than defining new leaf node kinds) — has
+nowhere else to become a real `IRNode` at the single `__SirSym` import
+site emitted code uses; a bare host number/string is never a valid term.
+
 ## How emitted code uses it
 
 ```ts
@@ -48,14 +56,14 @@ import * as __SirSym from "@coding-adventures/sir-runtime-symbolic";
 // x_ + 0 -> x_   (a rule compiled from Wolfram `x_ + 0 -> x_`)
 const xPat = __SirSym.named("x", __SirSym.blank());
 const dropAddZero = __SirSym.rule(
-  __SirSym.apply(ADD, [xPat, int(0)]),
+  __SirSym.apply(__SirSym.sym("Add"), [xPat, __SirSym.int(0)]),
   xPat,
 );
 
-const result = __SirSym.replaceAll(expr, [dropAddZero]);
-if (__SirSym.isDepthLimitError(result)) {
-  throw new Error(`expression too deep: exceeds ${result.maxDepth} levels`);
-}
+// replaceAll/replaceRepeated can return a DepthLimitError/RewriteCycleError
+// sentinel instead of a real term; `unwrap` throws on either rather than
+// letting the sentinel silently masquerade as an IRNode.
+const result = __SirSym.unwrap(__SirSym.replaceAll(expr, [dropAddZero]));
 ```
 
 ## Current scope: matching and substitution only, no evaluator

--- a/code/packages/typescript/sir-runtime-symbolic/package.json
+++ b/code/packages/typescript/sir-runtime-symbolic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coding-adventures/sir-runtime-symbolic",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Symbolic-expression + pattern/rewrite runtime for Semantic-IR-emitted TypeScript/JavaScript (SIR23)",
   "type": "module",
   "main": "src/index.ts",

--- a/code/packages/typescript/sir-runtime-symbolic/src/index.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/src/index.ts
@@ -68,6 +68,11 @@
 import {
   app,
   equals,
+  int,
+  numberNode,
+  rational,
+  stringNode,
+  sym,
   type IRApply,
   type IRNode,
 } from "@coding-adventures/symbolic-ir";
@@ -105,6 +110,43 @@ export type { IRNode, IRApply };
  */
 export function apply(head: IRNode, args: readonly IRNode[]): IRNode {
   return app(head, args);
+}
+
+/**
+ * Re-exported leaf-term constructors, unchanged, under the names a
+ * `SymSymbol`/`SymRational` node — or a literal (`IntLit`/`FloatLit`/
+ * `StrLit`, which SIR23 "reuses directly" rather than defining new node
+ * kinds for) appearing as a child of a `SymApply`/`SymRule`/
+ * `SymReplaceAll` — lowers to. A bare host number/string is never a valid
+ * `IRNode`, so a backend must wrap any such literal through `int`/
+ * `numberNode`/`stringNode` before it can appear inside a term tree; `sym`
+ * and `rational` build the two SIR23-native leaf shapes directly.
+ */
+export { int, numberNode, rational, stringNode, sym };
+
+/**
+ * Unwrap a {@link replaceAll}/{@link replaceRepeated} result, throwing a
+ * plain `Error` if the tree walk hit its depth cap or (for
+ * `replaceRepeated`) its iteration cap instead of returning a real
+ * `IRNode`. Both functions return an error *value* rather than throwing
+ * directly (see their own doc comments), because returning a value lets a
+ * caller that wants to inspect the failure kind do so without a
+ * try/catch. Semantic-IR-emitted code has no such caller today — a
+ * `SymReplaceAll` is an ordinary expression that must evaluate to a term
+ * value or fail loudly, never silently hand a `{ kind: "depth-limit" }`
+ * sentinel to code expecting an `IRNode` — so every compiled call site
+ * routes through this helper instead of using the raw result directly.
+ */
+export function unwrap(result: IRNode | DepthLimitError | RewriteCycleError): IRNode {
+  if (
+    result !== null &&
+    typeof result === "object" &&
+    "kind" in result &&
+    (result.kind === "depth-limit" || result.kind === "rewrite-cycle")
+  ) {
+    throw new Error(`sir-runtime-symbolic: ${result.kind}`);
+  }
+  return result as IRNode;
 }
 
 // ---------------------------------------------------------------------------

--- a/code/packages/typescript/sir-runtime-symbolic/tests/sir-runtime-symbolic.test.ts
+++ b/code/packages/typescript/sir-runtime-symbolic/tests/sir-runtime-symbolic.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { ADD, app, int, sym } from "@coding-adventures/symbolic-ir";
+import {
+  ADD,
+  app,
+  int as sourceInt,
+  numberNode as sourceNumberNode,
+  rational as sourceRational,
+  stringNode as sourceStringNode,
+  sym as sourceSym,
+} from "@coding-adventures/symbolic-ir";
 import {
   Bindings,
   DepthLimitError,
@@ -8,15 +16,21 @@ import {
   apply,
   applyRule,
   blank,
+  int,
   isDepthLimitError,
   isRewriteCycleError,
   matchPattern,
   named,
+  numberNode,
+  rational,
   replaceAll,
   replaceRepeated,
   rule,
   ruleDelayed,
+  stringNode,
   substitute,
+  sym,
+  unwrap,
 } from "../src/index";
 
 // Reusable "x_ + 0 -> x_" identity-elimination rule, the running example in
@@ -184,5 +198,65 @@ describe("rule vs ruleDelayed", () => {
     expect(applyRule(eager, target)).toEqual(applyRule(delayed, target));
     expect(replaceAll(target, [eager])).toEqual(replaceAll(target, [delayed]));
     expect(replaceRepeated(target, [eager], 10)).toEqual(replaceRepeated(target, [delayed], 10));
+  });
+});
+
+describe("re-exported leaf-term constructors", () => {
+  // These exist so a compiled `SymSymbol`/`SymRational` node — or a bare
+  // `IntLit`/`FloatLit`/`StrLit` appearing as a child of a `SymApply`/
+  // `SymRule`/`SymReplaceAll` — has somewhere to get wrapped into a real
+  // `IRNode` at the single `__SirSym` import site a generated module uses;
+  // see the SIR23 codegen in `semantic-ir-to-typescript`.
+  it("sym/int/rational/numberNode/stringNode produce the same nodes as symbolic-ir's own constructors", () => {
+    expect(sym("z")).toEqual(sourceSym("z"));
+    expect(int(5)).toEqual(sourceInt(5));
+    expect(rational(1, 3)).toEqual(sourceRational(1, 3));
+    expect(numberNode(1.5)).toEqual(sourceNumberNode(1.5));
+    expect(stringNode("hi")).toEqual(sourceStringNode("hi"));
+  });
+
+  it("rational reduces exactly as symbolic-ir's own rational() does", () => {
+    // 2/4 should reduce to 1/2, proving this is genuinely symbolic-ir's
+    // rational() and not a naive pass-through.
+    expect(rational(2, 4)).toEqual(rational(1, 2));
+  });
+
+  it("a leaf constructor round-trips through apply() as a SymApply arg", () => {
+    const expr = apply(sym("f"), [int(2), rational(1, 3), stringNode("x")]);
+    expect(expr).toEqual(app(sourceSym("f"), [sourceInt(2), sourceRational(1, 3), sourceStringNode("x")]));
+  });
+});
+
+describe("unwrap", () => {
+  it("returns the IRNode unchanged on a successful replaceAll/replaceRepeated", () => {
+    const expr = app(ADD, [sym("z"), int(0)]);
+    expect(unwrap(replaceAll(expr, [dropAddZero]))).toEqual(sym("z"));
+    expect(unwrap(replaceRepeated(expr, [dropAddZero], 10))).toEqual(sym("z"));
+  });
+
+  it("throws on a DepthLimitError instead of handing back the sentinel", () => {
+    const f = sym("f");
+    let node: ReturnType<typeof app> | ReturnType<typeof sym> = sym("leaf");
+    for (let i = 0; i < MAX_TERM_DEPTH * 4; i += 1) {
+      node = app(f, [node]);
+    }
+    const result = replaceAll(node, []);
+    expect(isDepthLimitError(result)).toBe(true);
+    expect(() => unwrap(result)).toThrow(/depth-limit/);
+  });
+
+  it("throws on a RewriteCycleError instead of handing back the sentinel", () => {
+    const f = sym("f");
+    const neverConverges = rule(app(f, [xPat]), app(f, [app(f, [xPat])]));
+    const result = replaceRepeated(app(f, [sym("a")]), [neverConverges], 50);
+    expect(isRewriteCycleError(result)).toBe(true);
+    expect(() => unwrap(result)).toThrow(/rewrite-cycle/);
+  });
+
+  it("never mistakes an ordinary IRNode for an error sentinel", () => {
+    // int(5) is a plain data object; unwrap must not misfire on it just
+    // because it happens to be an object.
+    expect(unwrap(int(5))).toEqual(int(5));
+    expect(unwrap(sym("z"))).toEqual(sym("z"));
   });
 });


### PR DESCRIPTION
## Summary

- Wires real codegen for the SIR23 symbolic-expression + pattern/rewrite domain into the TypeScript backend (previously a deferred panic behind a capability-rejection gate). A compiled Wolfram/Macsyma/Maxima program using pattern-matching or rewrite rules (`x /. a -> b`, `x //. rules`) now compiles to TypeScript that constructs/consumes a real term-tree value at runtime via the imported `@coding-adventures/sir-runtime-symbolic` package, bound as `__SirSym`.
- `SymApply`'s children route through a new `emit_sym_operand` helper: a literal (`IntLit`/`FloatLit`/`StrLit`, reused directly per the SIR23 spec rather than new leaf nodes) gets wrapped into the matching `__SirSym` constructor since a bare host value is never a valid `IRNode` term.
- `SymReplaceAll` routes through a new `__SirSym.unwrap` helper, since `replaceAll`/`replaceRepeated` can return a `DepthLimitError`/`RewriteCycleError` sentinel instead of a real term — a compiled `SymReplaceAll` must evaluate to a value or fail loudly, never silently propagate that sentinel.
- Required a small additive extension to `sir-runtime-symbolic` (0.1.0 → 0.2.0): re-exports of `symbolic-ir`'s leaf-term constructors (`sym`/`int`/`rational`/`numberNode`/`stringNode`, missing from the original PR) and the new `unwrap()` helper.
- Accepts `Feature::SymbolicExpr`, `Feature::PatternMatching`, `Feature::Rationals` (scoped exactly to `SymRational`); the `sir-runtime-symbolic` import is gated so a purely-numeric module never gains the dependency.
- The JavaScript backend (`semantic-ir-to-javascript`) still defers these nodes — it inlines its own runtime rather than importing packages, so SIR23 there needs a from-scratch inlined term-rewriting engine rather than a straightforward import. Tracked as follow-up work.

## Test plan

- [x] Shape-level unit tests for every new node kind: leaf constructors, literal wrapping inside `SymApply`, both pattern-blank forms, `rule` vs `ruleDelayed`, `replaceAll` vs `replaceRepeated`, the import gate, and a panic-on-invariant-violation test for a malformed `SymPatternBlank` head.
- [x] A real end-to-end test compiling actual Wolfram source (`x /. a -> b`) through `wolfram-to-semantic-ir` and this backend — not just hand-built `Module`s — confirming the codegen matches what the real frontend produces.
- [x] `sir-runtime-symbolic`'s own test suite extended (23 tests, 100% statement/branch/function/line coverage) for the new re-exports and `unwrap`.
- [x] `cargo test -p semantic-ir-to-typescript` (114 tests) and downstream consumer crates all pass unchanged.
- [x] `/security-review` passed clean (no findings) — reviewed emitted-string injection safety (`quote_ts_string` escaping), the new `unwrap()` helper's trust boundary, and confirmed the existing `MAX_IR_DEPTH` validator guard already covers the new recursive codegen paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)