### PR TITLE
feat(sql-parser): GLOB / NOT GLOB infix operators

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.22 — `GLOB` / `NOT GLOB` infix operators
+
+`SELECT … WHERE s GLOB 'x*'` now parses and runs — case-sensitive Unix-glob
+matching (`*` any run, `?` one char, `[…]` classes). SQLite defines the
+operator `X GLOB Y` as the function `glob(Y, X)`, and mini-sqlite lowers it
+exactly that way: the grammar accepts `GLOB`/`NOT GLOB` as comparison forms
+(sql-parser 0.1.6) and the planner rewrites them onto the existing `glob`
+builtin (sql-planner 0.2.5, args swapped; `NOT GLOB` = `NOT glob(...)`). No new
+codegen or VM opcode was needed — it reuses the scalar-function path. Two new
+differential-oracle cases (`glob_operator`, `not_glob_and_question`) diff
+against real bundled SQLite, including case-sensitivity and the `?`
+single-char wildcard. (The `glob()` function form has been available since
+0.4.x; this adds the infix operator spelling.)
+
 ## 0.5.21 — `LIMIT off, count` MySQL shorthand
 
 `SELECT … LIMIT 1, 2` now parses and runs, returning the same rows as

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.21"
+version = "0.5.22"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -789,6 +789,27 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT n FROM t ORDER BY n LIMIT 2, 3",
     },
+    // The `GLOB` infix operator: case-sensitive Unix-glob matching (`*` = any
+    // run, `?` = one char). `X GLOB Y` is SQLite's `glob(Y, X)`. Case matters —
+    // `x*` matches `xyz` but not `Xyz` (unlike LIKE, which is case-insensitive
+    // for ASCII). Exercises the operator lowering to the glob builtin.
+    Case {
+        id: "glob_operator",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1,'xyz'),(2,'abc'),(3,'xen'),(4,'Xyz')",
+        ],
+        query: "SELECT id FROM t WHERE s GLOB 'x*' ORDER BY id",
+    },
+    // `NOT GLOB` is the logical negation, and `?` matches exactly one char.
+    Case {
+        id: "not_glob_and_question",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1,'cat'),(2,'cot'),(3,'coat'),(4,'cut')",
+        ],
+        query: "SELECT id FROM t WHERE s NOT GLOB 'c?t' ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - Unreleased
+
+### Added
+
+- **`GLOB` and `NOT GLOB` infix operators.** `WHERE s GLOB 'x*'` now parses —
+  case-sensitive Unix-glob matching (`*` any run, `?` one char, `[…]` classes).
+  Added as `comparison` alternatives mirroring `LIKE`/`NOT LIKE`. The planner
+  (0.2.5) lowers `X GLOB Y` onto the existing `glob(Y, X)` builtin, so no new
+  codegen/VM opcode was needed.
+
 ## [0.1.5] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -452,6 +452,19 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::Literal { value: r#"LIKE"#.to_string() },
                             GrammarElement::RuleReference { name: r#"additive"#.to_string() },
                         ] },
+                        // `x GLOB pattern` — case-sensitive Unix-glob matching.
+                        // SQLite defines `X GLOB Y` as `glob(Y, X)`, so the
+                        // planner lowers this to the existing `glob` builtin
+                        // (args swapped); `NOT GLOB` wraps it in a logical NOT.
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"GLOB"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"NOT"#.to_string() },
+                            GrammarElement::Literal { value: r#"GLOB"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                        ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"IS"#.to_string() },
                             GrammarElement::Literal { value: r#"NULL"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -541,6 +541,16 @@ mod tests {
         assert!(find_rule(&ast, "comparison"), "Expected comparison");
     }
 
+    /// The `GLOB` and `NOT GLOB` infix operators parse as comparison forms
+    /// (the planner lowers them onto the `glob` builtin).
+    #[test]
+    fn test_parse_glob_operator() {
+        let ast = assert_program_root("SELECT x FROM t WHERE name GLOB 'A*'");
+        assert!(find_rule(&ast, "comparison"), "Expected comparison");
+        let ast2 = assert_program_root("SELECT x FROM t WHERE name NOT GLOB 'A*'");
+        assert!(find_rule(&ast2, "comparison"), "Expected comparison for NOT GLOB");
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.5] - Unreleased
+
+### Added
+
+- **`GLOB` / `NOT GLOB` operator lowering.** `plan_comparison` now recognises
+  the `GLOB` token (sql-parser 0.1.6) and lowers `X GLOB Y` onto the existing
+  `glob` builtin as `FunctionCall { name: "glob", args: [Y, X] }` — SQLite
+  defines the operator exactly as `glob(Y, X)` (pattern first). `NOT GLOB`
+  wraps the call in `UnaryOp::Not`. No dedicated `Glob` expr node, codegen, or
+  VM opcode was added — it reuses the function-call path end to end.
+
 ## [0.2.4] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1878,6 +1878,32 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         });
     }
 
+    // GLOB / NOT GLOB
+    // Grammar: `[NOT] GLOB additive`
+    //
+    // SQLite defines the operator `X GLOB Y` as the function `glob(Y, X)` —
+    // note the argument order: the PATTERN is the first argument. Rather than
+    // add a dedicated `Glob` expr node + codegen + VM opcode, we lower the
+    // operator onto the `glob` builtin the VM already implements, exactly as
+    // SQLite does. `NOT GLOB` wraps the call in a logical NOT.
+    if direct_tok_uppers.contains(&"GLOB".to_string()) {
+        let negated = direct_tok_uppers.contains(&"NOT".to_string());
+        let pattern_node = child_nodes_ordered
+            .get(1)
+            .ok_or_else(|| PlanError::UnsupportedStatement("GLOB missing pattern".to_string()))?;
+        let pattern = plan_expression(pattern_node)?;
+        let call = SqlExpr::FunctionCall {
+            name: "glob".to_string(),
+            args: vec![pattern, left], // glob(pattern, value)
+            star: false,
+        };
+        return Ok(if negated {
+            SqlExpr::UnaryOp { op: UnaryOp::Not, expr: Box::new(call) }
+        } else {
+            call
+        });
+    }
+
     // IN / NOT IN
     // Grammar: `[NOT] IN ( value_list )`
     // The value_list is a child node.


### PR DESCRIPTION
## `GLOB` / `NOT GLOB` infix operators

`WHERE s GLOB 'x*'` now parses and runs — case-sensitive Unix-glob matching
(`*` any run, `?` one char, `[…]` classes). SQLite defines the operator
`X GLOB Y` as the function `glob(Y, X)`, so mini-sqlite lowers it exactly that
way rather than adding a dedicated expr node / codegen / VM opcode. (The
`glob()` **function** spelling has worked since 0.4.x; this adds the infix
**operator**.)

### What changed
- **sql-parser** (`_grammar.rs`): `comparison` gains `GLOB additive` and
  `NOT GLOB additive` alternatives, mirroring `LIKE` / `NOT LIKE`.
- **sql-planner** (`plan_comparison`): detects the `GLOB` token and builds
  `FunctionCall { name: "glob", args: [pattern, value] }` (pattern first, per
  SQLite); `NOT GLOB` wraps it in `UnaryOp::Not`. Reuses the existing `glob`
  builtin end to end — no new codegen or VM opcode.

### Tests
- **Differential oracle** (mini-sqlite): `glob_operator` (case-sensitivity —
  `x*` matches `xyz` not `Xyz`) and `not_glob_and_question` (`NOT GLOB` + the
  `?` single-char wildcard), both diffing against real bundled SQLite.
- **sql-parser**: `test_parse_glob_operator` (GLOB and NOT GLOB parse).
- Full affected SQL pipeline green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — structural mirror of the
  shipped LIKE branch; no zero-width grammar match, `.get(1)` bounds-safe, and
  it reuses the already-reviewed O(n·m) glob matcher with no new reachability.

### Versions
sql-parser 0.1.5→0.1.6 · sql-planner 0.2.4→0.2.5 · mini-sqlite 0.5.21→0.5.22.

### Context
First increment of a multi-lane conformance **rotation** (operators lane), per
the maintainer's direction to keep advancing all fronts autonomously. Upcoming
rotations: CAST → NULLS/COLLATE ordering → sqlite-file writer groundwork → back
to CASE, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
