### PR TITLE
feat(adj-lang): RS-2 multi-step formula bodies (in-formula let-steps)

### DIFF
--- a/code/grammars/adj_lang/adj_lang.grammar
+++ b/code/grammars/adj_lang/adj_lang.grammar
@@ -346,9 +346,24 @@ formulabook_decl = "formulabook" IDENT LBRACE { formulabook_item } RBRACE ;
 
 formulabook_item = use_decl | formula_decl ;
 
-formula_decl     = "formula" IDENT LPAREN [ formula_params ] RPAREN EQUALS expr { annotation } ;
+formula_decl     = "formula" IDENT LPAREN [ formula_params ] RPAREN formula_body { annotation } ;
 
 formula_params   = IDENT { COMMA IDENT } ;
+
+# The formula body is EITHER the single-expression sugar (`= <expr>`, the
+# rung-0 form every shipped library uses) OR a MULTI-STEP block
+# (ADJ-RULE-SUBSTRATE RS-2): `{ let s1 = e1  let s2 = e2  … <final-expr> }`.
+# Each `let`-step names an intermediate value (a conjunction of sub-goals); a
+# later step and the final expression may reference an earlier step's name in
+# addition to the formula parameters. The `let`-literal that opens a step and
+# the `factor` that opens the final expression have DISJOINT first-sets (no
+# expression begins with the `let` literal), so `{ formula_step } expr` is
+# unambiguous. The lowerer desugars the steps into the final expression by
+# in-order substitution, so a multi-step body reuses the RS-1 apply/expand
+# pipeline verbatim (worked example: `cockcroft_gault` with named steps).
+formula_body     = EQUALS expr | LBRACE { formula_step } expr RBRACE ;
+
+formula_step     = "let" IDENT EQUALS expr ;
 
 # ----------------------------------------------------------------
 # Import (MYCIN-2026 M3 — composition across files). `import "<path>"`

--- a/code/packages/rust/adj-lang-cli/tests/rs2_multistep_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/rs2_multistep_e2e.rs
@@ -1,0 +1,181 @@
+//! End-to-end tests for ADJ-RULE-SUBSTRATE RS-2 — MULTI-STEP formula bodies
+//! (in-formula `let`-steps), driven through the built CLI binary. Four things
+//! are proven:
+//!
+//!   (a) WORKED COMPOSITE: the shipped `cockcroft_gault.adj` — a four-`let`-step
+//!       formula composing `difference`/`product`/`quotient` — computes the
+//!       creatinine-clearance estimate (80 mL/min for the canonical case) on the
+//!       CPU, carrying its citation.
+//!   (b) STEP-REFERENCES-STEP: a self-contained inline multi-step formula whose
+//!       later steps reference earlier ones, and whose final expression combines
+//!       them, computes the right value — the core RS-2 semantics with no imports.
+//!   (c) UNDECLARED / FORWARD reference is a clean `FormulaFreeVariable` scoping
+//!       error (scope grows strictly left-to-right), never a silent 0 or a panic.
+//!   (d) BACK-COMPAT: the single-expression sugar (`formula f(...) = <expr>`) is
+//!       unchanged — the block form is purely additive.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib")
+        .canonicalize()
+        .expect("shipped adj-formula-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_rs2_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy a shipped `.adj` file into `dir` at the given relative destination
+/// (creating parent dirs), preserving the directory layout so relative imports
+/// (`../arithmetic/...`) resolve from an entry program at the scratch root.
+fn place_at(dir: &Path, src_rel: &str, dst_rel: &str) {
+    let src = stdlib().join(src_rel);
+    let dst = dir.join(dst_rel);
+    std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    std::fs::copy(&src, &dst).unwrap_or_else(|e| panic!("copy {src_rel} -> {dst_rel}: {e}"));
+}
+
+// ---------------------------------------------------------------------------
+// (a) Worked composite — cockcroft_gault, a 4-step formula, computes 80.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cockcroft_gault_multistep_computes_creatinine_clearance() {
+    let dir = scratch("cg");
+    // Preserve the two-subdir layout so cockcroft_gault's `../arithmetic/…`
+    // import stays inside the (scratch-root) import root.
+    place_at(&dir, "arithmetic/arithmetic.adj", "arithmetic/arithmetic.adj");
+    place_at(&dir, "clinical/cockcroft_gault.adj", "clinical/cockcroft_gault.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"clinical/cockcroft_gault.adj\"\n\
+         observe age(60)\n\
+         observe weight(72)\n\
+         observe creatinine(1)\n\
+         observe sex_factor(1)\n\
+         ? cockcroft_gault(age, weight, creatinine, sex_factor)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // ((140 - 60) * 72 * 1) / (72 * 1) = 80, via the four named let-steps.
+    assert!(
+        s.contains("\"name\":\"cockcroft_gault\"") && s.contains("\"value\":80"),
+        "cockcroft_gault(60, 72, 1, 1) = 80: {s}"
+    );
+    // The formula's own citation rides on the answer.
+    assert!(
+        s.contains("NBK555956") && s.contains("\"trust\":\"authoritative\""),
+        "carries the Cockcroft-Gault citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Step-references-step — self-contained inline multi-step formula.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inline_multistep_body_references_earlier_steps() {
+    let dir = scratch("inline");
+    // (a + b) then (a - b), combined as their product — each step names an
+    // intermediate the final expression reuses. No imports: pure RS-2 substrate.
+    std::fs::write(
+        dir.join("case.adj"),
+        "formulabook demo {\n\
+             formula span_product(a, b) {\n\
+                 let total = a + b\n\
+                 let gap = a - b\n\
+                 total * gap\n\
+             }\n\
+                 source \"test: (a+b)*(a-b) via two named let-steps\" trust inferred\n\
+         }\n\
+         observe a(5)\n\
+         observe b(3)\n\
+         ? span_product(a, b)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // (5 + 3) * (5 - 3) = 8 * 2 = 16.
+    assert!(
+        s.contains("\"name\":\"span_product\"") && s.contains("\"value\":16"),
+        "span_product(5, 3) = 16: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) Scoping — an undeclared / forward step reference is a clean error.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn step_referencing_an_undeclared_name_is_a_clean_scoping_error() {
+    let dir = scratch("scope");
+    // `later` is defined AFTER the step that uses it; scope grows left-to-right,
+    // so this is a free variable, not a forward reference.
+    std::fs::write(
+        dir.join("case.adj"),
+        "formulabook bad {\n\
+             formula oops(a) {\n\
+                 let early = later + a\n\
+                 let later = a\n\
+                 early\n\
+             }\n\
+                 source \"test: forward reference must be rejected\" trust inferred\n\
+         }\n\
+         observe a(1)\n\
+         ? oops(a)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(!ok, "a forward/undeclared step reference must fail: {s}");
+    assert!(
+        s.contains("FormulaFreeVariable"),
+        "the scoping check returns a clean typed error: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) Back-compat — the single-expression sugar is unchanged.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_expression_formula_still_works_alongside_the_block_form() {
+    let dir = scratch("sugar");
+    std::fs::write(
+        dir.join("case.adj"),
+        "formulabook demo {\n\
+             formula twice(a) = a + a\n\
+                 source \"test: doubling, single-expression form\" trust inferred\n\
+         }\n\
+         observe a(21)\n\
+         ? twice(a)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(
+        s.contains("\"name\":\"twice\"") && s.contains("\"value\":42"),
+        "the single-expression sugar still computes: {s}"
+    );
+}

--- a/code/packages/rust/adj-lang/CHANGELOG.md
+++ b/code/packages/rust/adj-lang/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.50.0] — multi-step formula bodies (ADJ-RULE-SUBSTRATE RS-2)
+
+### Added
+
+- **Multi-step `formula` bodies** — a formula may now be written as a block of named `let`-steps
+  followed by a final expression: `formula f(p…) { let s1 = e1  let s2 = e2  <body> }`. Each step
+  names an intermediate value; a later step and the final body may reference the parameters plus any
+  **earlier** step. Grammar: new `formula_body` (either the existing `= <expr>` sugar or the block form)
+  and `formula_step` rules; AST: `FormulaStep` + `FormulaDef.steps`. The lowerer folds the steps into a
+  single **effective body** by in-order substitution, so the RS-1 param-substitution and
+  formula-calls-formula expansion consume it unchanged (a multi-step body is surface sugar for the
+  equivalent nested single expression). Scope is validated strictly left-to-right — an undeclared or
+  forward step reference is a clean `LowerError::FormulaFreeVariable`. The size budget bounds an
+  adversarial step chain to `FormulaExpansionTooLarge`. The single-expression form is unchanged (purely
+  additive). Worked example: the shipped `clinical/cockcroft_gault.adj` (four named steps composing
+  `difference`/`product`/`quotient`). *(Per-step `DerivedRef` trace nodes — each step as its own audit
+  entry — are deferred to the RS-4 execution-trace renderer; RS-2 delivers the expressible, correct,
+  composing construct.)*
+
 ## [Unreleased] — `formulabook` / `formula` — importable, provenanced, parameterized formulas (ADJ-FORMULA-LIBRARIES rung-0)
 
 ### Added

--- a/code/packages/rust/adj-lang/Cargo.toml
+++ b/code/packages/rust/adj-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adj-lang"
-version = "0.49.0"
+version = "0.50.0"
 edition = "2021"
 description = "Surface-syntax frontend for the adjudication framework's probabilistic-logic rulebooks. Lexes, parses, and lowers a domain-expert-readable DSL into a `logic-engine` KnowledgeBase. Dissolves ADJ46 awkwardness items A10 (rulebook syntax) and A4 (joint contributions syntactically distinct)."
 

--- a/code/packages/rust/adj-lang/src/_parser_grammar.rs
+++ b/code/packages/rust/adj-lang/src/_parser_grammar.rs
@@ -548,8 +548,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"formula_params"#.to_string() }) },
                 GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
-                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
-                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::RuleReference { name: r#"formula_body"#.to_string() },
                 GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"annotation"#.to_string() }) },
             ] },
             line_number: 349,
@@ -566,12 +565,38 @@ pub fn parser_grammar() -> ParserGrammar {
             line_number: 351,
         },
         GrammarRule {
+            name: r#"formula_body"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                ] },
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"LBRACE"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"formula_step"#.to_string() }) },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"RBRACE"#.to_string() },
+                ] },
+            ] },
+            line_number: 364,
+        },
+        GrammarRule {
+            name: r#"formula_step"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::Literal { value: r#"let"#.to_string() },
+                GrammarElement::TokenReference { name: r#"IDENT"#.to_string() },
+                GrammarElement::TokenReference { name: r#"EQUALS"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            ] },
+            line_number: 366,
+        },
+        GrammarRule {
             name: r#"import_decl"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::Literal { value: r#"import"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 367,
+            line_number: 382,
         },
         GrammarRule {
             name: r#"annotation"#.to_string(),
@@ -581,7 +606,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::RuleReference { name: r#"trust_annotation"#.to_string() },
                 GrammarElement::RuleReference { name: r#"cites_annotation"#.to_string() },
             ] },
-            line_number: 379,
+            line_number: 394,
         },
         GrammarRule {
             name: r#"source_annotation"#.to_string(),
@@ -589,7 +614,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"source"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 385,
+            line_number: 400,
         },
         GrammarRule {
             name: r#"locator_annotation"#.to_string(),
@@ -597,7 +622,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 386,
+            line_number: 401,
         },
         GrammarRule {
             name: r#"trust_annotation"#.to_string(),
@@ -605,7 +630,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"trust"#.to_string() },
                 GrammarElement::RuleReference { name: r#"trust_tier"#.to_string() },
             ] },
-            line_number: 387,
+            line_number: 402,
         },
         GrammarRule {
             name: r#"cites_annotation"#.to_string(),
@@ -615,7 +640,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"locator"#.to_string() },
                 GrammarElement::TokenReference { name: r#"STRING"#.to_string() },
             ] },
-            line_number: 388,
+            line_number: 403,
         },
         GrammarRule {
             name: r#"trust_tier"#.to_string(),
@@ -626,7 +651,7 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"inferred"#.to_string() },
                 GrammarElement::Literal { value: r#"unattributed"#.to_string() },
             ] },
-            line_number: 390,
+            line_number: 405,
         },
         GrammarRule {
             name: r#"term"#.to_string(),
@@ -650,7 +675,7 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
                     ] }) },
             ] },
-            line_number: 412,
+            line_number: 427,
         },
     ],
         version: 1,

--- a/code/packages/rust/adj-lang/src/adapter.rs
+++ b/code/packages/rust/adj-lang/src/adapter.rs
@@ -864,8 +864,43 @@ fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    // The body reuses the EXISTING `let` expression grammar/adapter verbatim.
-    let expr_node = first_named_child(node, "expr").ok_or(AdapterError::MissingChild {
+    // formula_body = EQUALS expr | LBRACE { formula_step } expr RBRACE
+    // Both forms wrap the body in a `formula_body` node. The single-expression
+    // sugar leaves `steps` empty and `body` = the sole expr; the block form
+    // collects each `let`-step (in source order) and takes the FINAL expr (the
+    // direct `expr` child of `formula_body` — a step's own expr is nested one
+    // level deeper, inside its `formula_step` node, so it is not mistaken for
+    // the body). RS-2.
+    let body_node = first_named_child(node, "formula_body").ok_or(AdapterError::MissingChild {
+        rule: "formula_decl".into(),
+        position: "formula_body",
+    })?;
+    let mut steps = Vec::new();
+    for child in &body_node.children {
+        if let ASTNodeOrToken::Node(step_node) = child {
+            if step_node.rule_name == "formula_step" {
+                // formula_step = "let" IDENT EQUALS expr
+                let step_name = first_name_not(step_node, "let")
+                    .ok_or(AdapterError::MissingChild {
+                        rule: "formula_step".into(),
+                        position: "step name",
+                    })?
+                    .to_string();
+                let step_expr_node =
+                    first_named_child(step_node, "expr").ok_or(AdapterError::MissingChild {
+                        rule: "formula_step".into(),
+                        position: "step expr",
+                    })?;
+                steps.push(crate::ast::FormulaStep {
+                    name: step_name,
+                    expr: adapt_expr(step_expr_node)?,
+                });
+            }
+        }
+    }
+    // The FINAL body expr reuses the EXISTING `let` expression grammar/adapter
+    // verbatim; it is the direct `expr` child of `formula_body`.
+    let expr_node = first_named_child(body_node, "expr").ok_or(AdapterError::MissingChild {
         rule: "formula_decl".into(),
         position: "body expr",
     })?;
@@ -875,6 +910,7 @@ fn adapt_formula(node: &GrammarASTNode) -> Result<FormulaDef, AdapterError> {
     Ok(FormulaDef {
         name,
         params,
+        steps,
         body,
         annotations,
     })

--- a/code/packages/rust/adj-lang/src/ast.rs
+++ b/code/packages/rust/adj-lang/src/ast.rs
@@ -441,13 +441,35 @@ pub struct FormulaDef {
     /// (or [`ExprAst::Agg`] slot) naming one of these is a parameter reference;
     /// any other free identifier is a compile error (parameter-scoping).
     pub params: Vec<String>,
+    /// The multi-step `let`-bindings that precede the final body, in source
+    /// order (ADJ-RULE-SUBSTRATE RS-2). Empty for the single-expression sugar
+    /// (`formula f(...) = <expr>`, the rung-0 form). For the block form
+    /// (`formula f(...) { let s1 = e1  let s2 = e2  <body> }`) each entry names
+    /// an intermediate value; a later step and the [`body`](Self::body) may
+    /// reference an earlier step's name in addition to the [`params`](Self::params).
+    /// The lowerer desugars these into `body` by in-order substitution, so the
+    /// RS-1 apply/expand pipeline consumes a single effective expression.
+    pub steps: Vec<FormulaStep>,
     /// The formula body — the EXISTING `let` expression AST, reused verbatim.
+    /// In the block form this is the final expression after the `let`-steps.
     pub body: ExprAst,
     /// The provenance envelope (`source` / `locator` / `trust`, plus any
     /// corroborating `cites`), reusing the shared [`Annotation`] set every
     /// grounded clause carries. Lowered via `annotations_to_provenance`; a
     /// shipped formula must carry a non-empty `source`.
     pub annotations: Vec<Annotation>,
+}
+
+/// A single `let`-step inside a multi-step formula body (ADJ-RULE-SUBSTRATE
+/// RS-2). `let <name> = <expr>` names an intermediate value; the `expr` may
+/// reference the formula's parameters and any earlier step's name. The lowerer
+/// folds the steps into the final body by in-order substitution.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FormulaStep {
+    /// The step's binding name (the intermediate value's identifier).
+    pub name: String,
+    /// The step's defining expression (over params + earlier step names).
+    pub expr: ExprAst,
 }
 
 /// A single dictionary entry (MYCIN-2026).

--- a/code/packages/rust/adj-lang/src/lower.rs
+++ b/code/packages/rust/adj-lang/src/lower.rs
@@ -1099,18 +1099,32 @@ fn annotations_to_provenance(annotations: &[Annotation]) -> Result<Provenance, L
 /// time; and (2) the **provenance-required lint** — a shipped formula must carry
 /// a non-empty `source`, mirroring the recall-library adversarial write gate.
 fn validate_formula(fd: &FormulaDef) -> Result<(), LowerError> {
-    let params: std::collections::HashSet<&str> =
-        fd.params.iter().map(String::as_str).collect();
-    let mut refs = Vec::new();
-    collect_refs(&fd.body, &mut refs);
-    for r in refs {
-        if !params.contains(r.as_str()) {
-            return Err(LowerError::FormulaFreeVariable {
-                formula: fd.name.clone(),
-                variable: r,
-            });
+    // Scope grows LEFT-TO-RIGHT (RS-2): the parameters are in scope everywhere;
+    // each `let`-step may reference the parameters plus any EARLIER step's name,
+    // and after a step it binds its own name; the final body may reference the
+    // parameters plus ALL step names. An identifier that resolves to none of
+    // these is a clean free-variable error.
+    let mut in_scope: std::collections::HashSet<String> = fd.params.iter().cloned().collect();
+    let check = |expr: &ExprAst,
+                 scope: &std::collections::HashSet<String>|
+     -> Result<(), LowerError> {
+        let mut refs = Vec::new();
+        collect_refs(expr, &mut refs);
+        for r in refs {
+            if !scope.contains(&r) {
+                return Err(LowerError::FormulaFreeVariable {
+                    formula: fd.name.clone(),
+                    variable: r,
+                });
+            }
         }
+        Ok(())
+    };
+    for step in &fd.steps {
+        check(&step.expr, &in_scope)?;
+        in_scope.insert(step.name.clone());
     }
+    check(&fd.body, &in_scope)?;
     // Reuse the shared provenance path (the same relate/rule/prior use), then
     // enforce that the primary `source` span is non-empty.
     let prov = annotations_to_provenance(&fd.annotations)?;
@@ -1421,7 +1435,11 @@ fn expand_rec(
             // (formula-calls-formula) at depth + 1. The callee is pushed onto the
             // active path for the duration of its body expansion and popped after, so
             // a later SIBLING application of the same formula is not seen as a cycle.
-            let substituted = substitute_expr(&fd.body, &subst, budget, d)?;
+            // Fold the callee's `let`-steps (RS-2) into its effective body FIRST
+            // so a multi-step callee composes correctly when called from another
+            // formula, then substitute the caller's args into it.
+            let callee_body = effective_body(fd, budget, d)?;
+            let substituted = substitute_expr(&callee_body, &subst, budget, d)?;
             active.push(name.clone());
             let expanded = expand_rec(&substituted, formulas, depth + 1, chain, active, budget, d);
             active.pop();
@@ -1530,9 +1548,40 @@ fn apply_formula(fd: &FormulaDef, goal: &AstTerm) -> Result<ExprAst, LowerError>
     // A shallow, one-level substitution of leaf bindings (a query's args are atoms
     // or numbers) — its own local budget guards a body that reuses a parameter; the
     // deeper formula-calls-formula expansion of the resulting body runs later, in
-    // `expand_applies`, under that call's own shared budget.
+    // `expand_applies`, under that call's own shared budget. The `let`-steps
+    // (RS-2) are folded into a single effective body FIRST (so the param
+    // substitution below reaches into the inlined steps), then param-substituted.
     let mut budget: usize = 0;
-    substitute_expr(&fd.body, &subst, &mut budget, 0)
+    let effective = effective_body(fd, &mut budget, 0)?;
+    substitute_expr(&effective, &subst, &mut budget, 0)
+}
+
+/// Fold a formula's multi-step `let`-bindings (RS-2) into a SINGLE effective
+/// body by in-order substitution: each step's expression is expanded against
+/// the already-expanded earlier steps, then the final body is expanded against
+/// all of them. The result names only the formula's parameters (plus numbers
+/// and nested formula applications), so the RS-1 param-substitution and
+/// formula-calls-formula expansion consume it unchanged — a multi-step body is
+/// surface sugar for the equivalent nested single expression. A formula with no
+/// steps returns its body verbatim. Every emitted node is charged against the
+/// shared `budget`, so an adversarial step chain (each step doubling the last)
+/// trips [`LowerError::FormulaExpansionTooLarge`] instead of exploding.
+fn effective_body(
+    fd: &FormulaDef,
+    budget: &mut usize,
+    node_depth: usize,
+) -> Result<ExprAst, LowerError> {
+    if fd.steps.is_empty() {
+        return Ok(fd.body.clone());
+    }
+    let mut step_subst: HashMap<String, ExprAst> = HashMap::new();
+    for step in &fd.steps {
+        // Expand this step against the already-inlined earlier steps, then bind
+        // its (now step-free) value under its name for the steps/body that follow.
+        let expanded = substitute_expr(&step.expr, &step_subst, budget, node_depth)?;
+        step_subst.insert(step.name.clone(), expanded);
+    }
+    substitute_expr(&fd.body, &step_subst, budget, node_depth)
 }
 
 /// Substitute parameter references in a formula body with their bound argument

--- a/code/specs/data/adj-formula-stdlib/clinical/cockcroft_gault.adj
+++ b/code/specs/data/adj-formula-stdlib/clinical/cockcroft_gault.adj
@@ -1,0 +1,86 @@
+% ============================================================================
+% cockcroft_gault.adj — creatinine-clearance estimate (ADJ-RULE-SUBSTRATE RS-2).
+% ============================================================================
+% The first MULTI-STEP formula in the compute standard library: a formula whose
+% body is a sequence of named `let`-steps, not a single expression. Where the
+% rung-0 form writes one nested expression (`formula f(...) = <expr>`), RS-2 lets
+% a formula read like the worked calculation it models —
+%
+%     formula cockcroft_gault(age, weight, creatinine, sex_factor) {
+%         let age_factor = difference(140, age)          % 140 − age
+%         let lean_term  = product(age_factor, weight)    % (140 − age) · weight
+%         let numerator  = product(lean_term, sex_factor) % · sex factor
+%         let denominator = product(72, creatinine)       % 72 · Scr
+%         quotient(numerator, denominator)                % CrCl
+%     }
+%
+% Each `let`-step names an intermediate value and may reference the parameters
+% AND any earlier step; the final expression combines them. The engine folds the
+% steps into the effective body and computes on the CPU, exactly composing the
+% cited `arithmetic.adj` primitives (difference / product / quotient) — the model
+% performs zero arithmetic, and every primitive it builds on rides in the
+% provenance chain.
+%
+% Cockcroft-Gault estimates creatinine clearance (mL/min) from age (years),
+% lean/total body weight (kg), serum creatinine (mg/dL), and a sex factor
+% (1 for men; the female estimate multiplies by 0.85, supplied as sex_factor):
+%
+%     CrCl = ((140 − age) × weight × sex_factor) / (72 × serum_creatinine)
+%
+%     % run from the stdlib root so the cross-directory import resolves:
+%     import "clinical/cockcroft_gault.adj" % transitively imports arithmetic.adj
+%     observe age(60)                       % "…60-year-old…"   (span cited by the model)
+%     observe weight(72)                    % "…72 kg…"         (span cited by the model)
+%     observe creatinine(1)                 % "…Cr 1.0…"        (span cited by the model)
+%     observe sex_factor(1)                 % male              (span cited by the model)
+%     ? cockcroft_gault(age, weight, creatinine, sex_factor)   % engine → 80 mL/min
+%
+% (The import root is the entry program's directory; because this clinical
+% formula composes the elementary `arithmetic/` primitives, the entry program is
+% placed at the stdlib root and imports `clinical/cockcroft_gault.adj`, so the
+% relative `../arithmetic/arithmetic.adj` stays inside the root.)
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Depends on the elementary primitives — `difference`, `product`, `quotient`.
+% The import is RELATIVE to this file, so a consumer that imports
+% `cockcroft_gault.adj` gets those primitives transitively and the step bodies
+% below resolve.
+% ----------------------------------------------------------------------------
+import "../arithmetic/arithmetic.adj"
+
+% ----------------------------------------------------------------------------
+% Vocabulary. The four inputs and the estimated clearance. Rung-0 types an
+% observable slot as `finding`; the `surface` synonyms let a decomposer map
+% everyday phrasing ("years old", "body weight", "serum creatinine") onto the
+% canonical terms.
+% ----------------------------------------------------------------------------
+dictionary cockcroft_gault_vocab {
+    define age             : finding  surface "age", "years old", "age in years"
+    define weight          : finding  surface "weight", "body weight", "lean body weight", "mass"
+    define creatinine      : finding  surface "creatinine", "serum creatinine", "Scr", "Cr"
+    define sex_factor      : finding  surface "sex factor", "sex coefficient", "gender factor"
+    define cockcroft_gault : finding  surface "creatinine clearance", "CrCl", "Cockcroft-Gault", "estimated clearance"
+}
+
+% ----------------------------------------------------------------------------
+% The multi-step formula. Its body is four named `let`-steps followed by the
+% final quotient; each step APPLIES a cited primitive from arithmetic.adj (no
+% bare − × /), so the estimate is provenance-complete and reads as the worked
+% calculation. The constants 140 and 72 are the formula's own defining
+% constants, carried by its authoritative source.
+% ----------------------------------------------------------------------------
+formulabook renal_clearance {
+    use cockcroft_gault_vocab
+
+    formula cockcroft_gault(age, weight, creatinine, sex_factor) {
+        let age_factor = difference(140, age)
+        let lean_term = product(age_factor, weight)
+        let numerator = product(lean_term, sex_factor)
+        let denominator = product(72, creatinine)
+        quotient(numerator, denominator)
+    }
+        source "Cockcroft-Gault estimates creatinine clearance as ((140 − age) × weight × [0.85 if female]) / (72 × serum creatinine), with weight in kg and creatinine in mg/dL."
+        locator "https://www.ncbi.nlm.nih.gov/books/NBK555956/"
+        trust authoritative
+}


### PR DESCRIPTION
## ADJ-RULE-SUBSTRATE RS-2 — multi-step formula bodies

Resumes the substrate arc the user flagged (multi-step + branching + probabilistic rulebooks) after a detour into eval-scoreboard fixtures. **RS-2 is the multi-step piece.** A formula may now be a block of named `let`-steps then a final expression, so it reads as the worked calculation it models:

```adj
formula cockcroft_gault(age, weight, creatinine, sex_factor) {
    let age_factor  = difference(140, age)
    let lean_term   = product(age_factor, weight)
    let numerator   = product(lean_term, sex_factor)
    let denominator = product(72, creatinine)
    quotient(numerator, denominator)
}
```

Each step names an intermediate value; a later step and the final body may reference the parameters **plus any earlier step** (scope grows strictly left-to-right).

### How it's built (small, layered, reuses RS-1)
- **Grammar**: new `formula_body` (the existing `= <expr>` sugar **or** the block form) + `formula_step` rules; regenerated via `regen_grammars`.
- **AST**: `FormulaStep` + `FormulaDef.steps` (empty ⇒ the sugar form; purely additive).
- **adapter**: `adapt_formula` descends into `formula_body`, collecting the steps and final expr.
- **lower**: `validate_formula` checks scope left-to-right (undeclared/forward step ref ⇒ clean `FormulaFreeVariable`); `effective_body()` folds the steps into a single expression by in-order substitution, so the **RS-1** param-substitution + formula-calls-formula expansion consume it unchanged (both compute sites routed through it). The shared size budget bounds an adversarial step chain to `FormulaExpansionTooLarge`; the depth guard prevents stack overflow.

### Verification
- Worked library `clinical/cockcroft_gault.adj` (4 steps composing `difference`/`product`/`quotient`). Engine-verified: **`cockcroft_gault(60,72,1,1) = 80`** exact.
- **e2e** (`rs2_multistep_e2e.rs`, 4 tests): worked composite; step-references-step; forward-ref ⇒ error; single-expression back-compat.
- **156 adj-lang unit tests + all cli test binaries green**; clippy clean; `adj-lang` 0.49.0 → 0.50.0 + CHANGELOG.
- Security review passed (DoS bound via the shared node budget; no panic path on malformed `.adj`; recursion guarded).

Per-step `DerivedRef` trace nodes (each step as its own audit entry) are deferred to the **RS-4** execution-trace renderer — RS-2 delivers the expressible, correct, composing construct. Next rotation: a facts/recall library, then RS-3 (the branching state-machine driver), then FL-5 clinical libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)