### PR TITLE
feat(derive-lexer): Derive tokens + lexer (MA07 D-2, front2 Wave 5)

### DIFF
--- a/code/grammars/derive/derive.tokens
+++ b/code/grammars/derive/derive.tokens
@@ -1,0 +1,112 @@
+# Derive Token Grammar
+# ============================================================================
+#
+# Tokenizes the D-1-scoped subset of Derive (Soft Warehouse, 1988; successor
+# to muMATH, later Texas Instruments, discontinued 2007 at v6.1). Derive is
+# expression-oriented — a worksheet is a flat sequence of expressions and
+# `:=` definitions, much closer in spirit to Macsyma/Wolfram than to the
+# array languages (APL/J) — but its surface syntax is genuinely its own:
+# ordinary parentheses for function application (`DIF(u, x)`, not `f[x]`),
+# `:=` for both variable and function definition, and `[...]`/`[...;...]`
+# for vector/matrix literals. See code/specs/MA07-derive-language.md.
+#
+# Derive is treated as CASE-SENSITIVE here (case_sensitive left at its
+# default), mirroring Wolfram: built-ins are conventionally, but not
+# enforced, uppercase (SIN, DIF) — an ordinary lowercase `sin` lexes as a
+# distinct NAME, exactly like Wolfram's `Sin` vs `sin`. The boolean-algebra
+# keywords `AND`/`OR`/`NOT` (spec's own wording: "Derive's boolean-algebra
+# keywords, not symbols") ARE genuine reserved words, matched by exact case
+# via the `keywords:` block below — `and`/`or`/`not` in lowercase lex as
+# ordinary NAMEs, not keywords.
+#
+# @version 1
+
+# Strings are out of this subset's scope entirely (no STRING token) — the
+# D-1 surface grammar (MA07 spec §3) never uses a string literal.
+escapes: none
+
+# ============================================================================
+# SECTION 1: Multi-character operators
+#
+# Longest-match-first: every multi-character operator is listed before the
+# shorter operator(s) it begins with, so `:=` wins over there being no bare
+# `:` at all in this subset, and `<=`/`>=` win over `<`/`>`.
+# ============================================================================
+
+# `:=` is Derive's ONE assignment/definition operator — used for BOTH
+# `x := 5` (variable assignment) and `F(x) := x^2 + 1` (function
+# definition); the parser (D-3), not the lexer, disambiguates the two by
+# what shape precedes it (a bare NAME vs a `NAME(...)` call). There is no
+# bare `:` anywhere else in this subset, so declaring `:=` first is a
+# defensive longest-match convention (matching wolfram.tokens's own
+# `SETDELAYED = ":="` precedent) rather than resolving a real ambiguity.
+ASSIGN    = ":="
+
+LE        = "<="
+GE        = ">="
+
+# ============================================================================
+# SECTION 2: Single-character operators and delimiters
+# ============================================================================
+
+PLUS      = "+"
+MINUS     = "-"
+TIMES     = "*"
+SLASH     = "/"
+POWER     = "^"
+
+# `=` is Derive's equation operator (a Boolean-valued expression, e.g.
+# `SOLVE`'s first argument) — NOT assignment; `:=` (above) owns that role.
+# Mirrors Macsyma's identical `=`-is-equation / `:`-or-`:=`-is-assignment
+# split (macsyma.tokens), just without Macsyma's separate `:` variable-set
+# form (Derive only ever uses `:=`, for both variables and functions).
+EQ        = "="
+LESS      = "<"
+GREATER   = ">"
+
+LPAREN    = "("
+RPAREN    = ")"
+LBRACKET  = "["
+RBRACKET  = "]"
+
+COMMA     = ","
+
+# The ONLY use of `;` in this subset is as the matrix row separator inside
+# `[...]` (`[a, b, c; d, e, f]`, MA07 spec §3/D-5) — Derive has no general
+# statement terminator (a NEWLINE ends a top-level expression; see SECTION 4).
+SEMI      = ";"
+
+# ============================================================================
+# SECTION 3: Literal value tokens
+#
+# NUMBER requires a leading digit, so a bare `.5` is not a number (matches
+# every sibling symbolic-family lexer's convention — wolfram.tokens,
+# macsyma.tokens). NAME is a case-sensitive identifier; builtin heads (SIN,
+# DIF, IF) are ordinary NAMEs resolved by the runtime (D-4), so — aside
+# from the `keywords:` block below for AND/OR/NOT — there is no reserved-word
+# list here.
+# ============================================================================
+
+NUMBER = /[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?/
+NAME   = /[a-zA-Z][a-zA-Z0-9]*/
+
+# ============================================================================
+# SECTION 4: Significant newlines + skip patterns
+#
+# A worksheet is a flat sequence of expressions/definitions, each its own
+# line at Derive's own numbered `#n:` prompt (MA07 spec §5) — so NEWLINE is
+# a real, significant token at bracket-depth 0, exactly like Wolfram. Inside
+# an open `(` or `[`, a newline is insignificant (the D-2 lexer drops it,
+# mirroring wolfram-lexer's `drop_bracketed_newlines` hook), so a call or a
+# vector/matrix literal may span several physical lines.
+# ============================================================================
+
+NEWLINE = /\r?\n/
+
+skip:
+  WHITESPACE = /[ \t]+/
+
+keywords:
+  AND
+  OR
+  NOT

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -243,6 +243,7 @@ members = [
     "wolfram-runtime",
     "wolfram-repl",
     "wolfram-to-semantic-ir",
+    "derive-lexer",
     "apl-lexer",
     "apl-parser",
     "apl-runtime",

--- a/code/packages/rust/derive-lexer/BUILD
+++ b/code/packages/rust/derive-lexer/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-lexer -- --nocapture

--- a/code/packages/rust/derive-lexer/BUILD_windows
+++ b/code/packages/rust/derive-lexer/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-lexer -- --nocapture

--- a/code/packages/rust/derive-lexer/CHANGELOG.md
+++ b/code/packages/rust/derive-lexer/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial grammar-driven Rust Derive tokenizer (MA07 §2, task D-2).
+- Statically linked compiled token grammar (`code/grammars/derive/derive.tokens`),
+  covering the D-1-scoped surface (MA07 §3): ordinary-parenthesis function
+  application (`DIF(u, x)`, not `f[x]`), the single `:=` assign/define
+  operator (shared by both variable assignment and function definition —
+  the D-3 parser disambiguates by what precedes it), `=` as the *equation*
+  operator (never assignment — Derive/Macsyma's shared convention),
+  comparison (`<=`/`<`/`>`/`>=`), the three boolean-algebra keywords
+  `AND`/`OR`/`NOT` (case-sensitive reserved words — lowercase `and`/`or`/`not`
+  lex as ordinary `NAME`s), `[...]`/`[...;...]` vector/matrix literal
+  delimiters (`;` as the row separator, no other use of `;` in this subset),
+  and arithmetic (`+ - * / ^`).
+- Bracket-interior newline hook (`drop_bracketed_newlines`), mirroring
+  `wolfram-lexer`'s: a top-level `NEWLINE` ends a worksheet expression (each
+  its own line at Derive's numbered `#n:` prompt), but one inside an open
+  `(` or `[` is dropped so a call or a vector/matrix literal may span
+  several physical lines. Derive has no `{ }` and no `[[ ]]` part-sugar
+  (unlike Wolfram), so only `(`/`[` depth is tracked.
+- 13 tests covering function application, the shared `:=` token, `=` vs
+  `:=` disambiguation, vector/matrix literal delimiters, the case-sensitive
+  `AND`/`OR`/`NOT` keywords (and that lowercase spellings are NOT promoted),
+  comparison/arithmetic operators, longest-match precedence, and
+  bracket-interior newline dropping.

--- a/code/packages/rust/derive-lexer/Cargo.toml
+++ b/code/packages/rust/derive-lexer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "coding-adventures-derive-lexer"
+version = "0.1.0"
+edition = "2021"
+description = "Tokenizer for the Derive symbolic-CAS frontend (D-2)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/derive-lexer/README.md
+++ b/code/packages/rust/derive-lexer/README.md
@@ -1,0 +1,68 @@
+# coding-adventures-derive-lexer
+
+Derive tokenizer backed by `code/grammars/derive/derive.tokens`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the D-1-scoped subset fixed by
+[MA07 §3](../../../specs/MA07-derive-language.md): ordinary-parenthesis
+function application (`DIF(u, x)`, not Wolfram's `f[x]`), the single `:=`
+assign/define operator (used identically for `x := 5` and
+`F(x) := x^2 + 1`; the D-3 parser, not this lexer, disambiguates variable
+assignment from function definition by what shape precedes it), `=` as the
+*equation* operator (never assignment), comparison (`<= < > >=`), the
+boolean-algebra keywords `AND`/`OR`/`NOT`, `[a, b, c]`/`[a, b, c; d, e, f]`
+vector/matrix literal delimiters, and arithmetic `+ - * / ^`.
+
+## `:=` is genuinely one token doing two jobs
+
+Unlike most languages, Derive spells variable assignment and function
+definition with the exact same operator — `x := 5` and `F(x) := x^2 + 1`
+both use `:=`. This crate does not attempt to distinguish them (there is
+nothing for a *lexer* to distinguish — both are the identical two-character
+`:=` token); the D-3 parser tells them apart by whether the thing to the
+left of `:=` is a bare `NAME` or a `NAME(...)` call.
+
+## Boolean keywords are case-sensitive reserved words, not conventionally-cased symbols
+
+Derive's built-in function names (`SIN`, `DIF`, `INT`) are conventionally,
+but not enforced, uppercase — an ordinary `NAME` either way, exactly like
+Wolfram's `Sin` vs. `sin` distinction. `AND`/`OR`/`NOT`, however, are the
+one place this subset's grammar (MA07 §3's own wording: "Derive's
+boolean-algebra keywords, not symbols") promotes specific spellings to a
+dedicated `KEYWORD` token type via `derive.tokens`'s `keywords:` block —
+matched case-sensitively, so lowercase `and`/`or`/`not` lex as ordinary
+`NAME`s, never as the keyword.
+
+## No `{ }`, no `[[ ]]` — only `(`/`[` need bracket-depth tracking
+
+Unlike Wolfram (which needs `(`, `[`, `{`, and the two-level `[[` part-sugar
+opener all tracked for its bracket-interior-newline hook), Derive's surface
+has only two bracket pairs: `( )` for grouping/application and `[ ]` for
+vector/matrix literals. `drop_bracketed_newlines` here tracks just those
+two.
+
+## Usage
+
+```rust
+use coding_adventures_derive_lexer::tokenize_derive;
+
+let tokens = tokenize_derive("F(x) := x^2 + 1\nF(3)\n");
+```
+
+`tokenize_derive` panics on a malformed source string; use
+`create_derive_lexer` directly if you need the `Result`-returning
+`GrammarLexer::tokenize` instead, or the crate-level `try_tokenize_derive`
+convenience wrapper.
+
+## Where this fits
+
+`derive-lexer` is the first of Derive's frontend crates (D-2); the sibling
+`derive-parser` crate (D-3) will consume this crate's token stream against
+`code/grammars/derive/derive.grammar` to build the `GrammarASTNode` CST a
+future `derive-runtime` (D-4) will lower into `symbolic_ir::IRNode` and
+evaluate with `symbolic_vm::VM`.

--- a/code/packages/rust/derive-lexer/required_capabilities.json
+++ b/code/packages/rust/derive-lexer/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/derive-lexer",
+  "capabilities": [],
+  "justification": "Pure computation over statically linked grammar data. No filesystem, network, process, DOM, or environment access needed."
+}

--- a/code/packages/rust/derive-lexer/src/_grammar.rs
+++ b/code/packages/rust/derive-lexer/src/_grammar.rs
@@ -1,0 +1,181 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: derive.tokens
+// Regenerate with: grammar-tools compile-tokens derive.tokens
+//
+// This file embeds a TokenGrammar as native Rust data structures.
+// Call `token_grammar()` instead of reading and parsing the .tokens file.
+
+#[allow(unused_imports)]
+use grammar_tools::token_grammar::{ModeTransition, PatternGroup, TokenDefinition, TokenGrammar, TransitionAction};
+#[allow(unused_imports)]
+use std::collections::HashMap;
+
+pub fn token_grammar() -> TokenGrammar {
+    TokenGrammar {
+        definitions: vec![
+            TokenDefinition {
+                name: r#"ASSIGN"#.to_string(),
+                pattern: r#":="#.to_string(),
+                is_regex: false,
+                line_number: 43,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LE"#.to_string(),
+                pattern: r#"<="#.to_string(),
+                is_regex: false,
+                line_number: 45,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GE"#.to_string(),
+                pattern: r#">="#.to_string(),
+                is_regex: false,
+                line_number: 46,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"PLUS"#.to_string(),
+                pattern: r#"+"#.to_string(),
+                is_regex: false,
+                line_number: 52,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"MINUS"#.to_string(),
+                pattern: r#"-"#.to_string(),
+                is_regex: false,
+                line_number: 53,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"TIMES"#.to_string(),
+                pattern: r#"*"#.to_string(),
+                is_regex: false,
+                line_number: 54,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SLASH"#.to_string(),
+                pattern: r#"/"#.to_string(),
+                is_regex: false,
+                line_number: 55,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"POWER"#.to_string(),
+                pattern: r#"^"#.to_string(),
+                is_regex: false,
+                line_number: 56,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"EQ"#.to_string(),
+                pattern: r#"="#.to_string(),
+                is_regex: false,
+                line_number: 63,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LESS"#.to_string(),
+                pattern: r#"<"#.to_string(),
+                is_regex: false,
+                line_number: 64,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"GREATER"#.to_string(),
+                pattern: r#">"#.to_string(),
+                is_regex: false,
+                line_number: 65,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LPAREN"#.to_string(),
+                pattern: r#"("#.to_string(),
+                is_regex: false,
+                line_number: 67,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RPAREN"#.to_string(),
+                pattern: r#")"#.to_string(),
+                is_regex: false,
+                line_number: 68,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"LBRACKET"#.to_string(),
+                pattern: r#"["#.to_string(),
+                is_regex: false,
+                line_number: 69,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"RBRACKET"#.to_string(),
+                pattern: r#"]"#.to_string(),
+                is_regex: false,
+                line_number: 70,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"COMMA"#.to_string(),
+                pattern: r#","#.to_string(),
+                is_regex: false,
+                line_number: 72,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"SEMI"#.to_string(),
+                pattern: r#";"#.to_string(),
+                is_regex: false,
+                line_number: 77,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NUMBER"#.to_string(),
+                pattern: r#"[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?"#.to_string(),
+                is_regex: true,
+                line_number: 90,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NAME"#.to_string(),
+                pattern: r#"[a-zA-Z][a-zA-Z0-9]*"#.to_string(),
+                is_regex: true,
+                line_number: 91,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"NEWLINE"#.to_string(),
+                pattern: r#"\r?\n"#.to_string(),
+                is_regex: true,
+                line_number: 104,
+                alias: None,
+            },
+        ],
+        keywords: vec![r#"AND"#.to_string(), r#"OR"#.to_string(), r#"NOT"#.to_string()],
+        mode: None,
+        skip_definitions: vec![
+            TokenDefinition {
+                name: r#"WHITESPACE"#.to_string(),
+                pattern: r#"[ \t]+"#.to_string(),
+                is_regex: true,
+                line_number: 107,
+                alias: None,
+            },
+        ],
+        reserved_keywords: vec![],
+        escapes: Some(r#"none"#.to_string()),
+        error_definitions: vec![],
+        groups: HashMap::new(),
+        case_sensitive: true,
+        version: 1,
+        case_insensitive: false,
+        context_keywords: vec![],
+        soft_keywords: vec![],
+        layout_keywords: vec![],
+        start_mode: None,
+        transitions: vec![],
+    }
+}

--- a/code/packages/rust/derive-lexer/src/lib.rs
+++ b/code/packages/rust/derive-lexer/src/lib.rs
@@ -1,0 +1,276 @@
+//! # Derive Lexer — tokenizing the Derive symbolic-CAS subset (D-2).
+//!
+//! Derive (Soft Warehouse, 1988; successor to muMATH, later Texas
+//! Instruments, discontinued 2007 at v6.1) is expression-oriented — a
+//! worksheet is a flat sequence of expressions and `:=` definitions, much
+//! closer in spirit to Macsyma/Wolfram than to the array languages
+//! (APL/J) — but its surface syntax is genuinely its own: ordinary
+//! parentheses for function application (`DIF(u, x)`, not `f[x]`), `:=` for
+//! both variable and function definition, and `[...]`/`[...;...]` for
+//! vector/matrix literals. This crate is a thin wrapper over the generic
+//! [`GrammarLexer`] (a sibling of `wolfram-lexer`/`macsyma-lexer`), adding
+//! only the bracket-interior newline hook. See
+//! `code/specs/MA07-derive-language.md`.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! derive.tokens       (grammar file — declares every token pattern)
+//!     |  (compiled ahead of time into src/_grammar.rs)
+//!     v
+//! lexer::GrammarLexer (tokenizes source using the embedded TokenGrammar)
+//!     |
+//!     v
+//! derive-lexer        (this crate — adds the bracket-interior newline hook)
+//! ```
+//!
+//! ## The post-tokenize hook: bracket-interior newlines
+//!
+//! A worksheet is a flat sequence of expressions, each its own line at
+//! Derive's own numbered `#n:` prompt, so a NEWLINE at bracket-depth 0 ends
+//! a top-level expression — but the contents of a `( … )` grouping/call or a
+//! `[ … ]` vector/matrix literal may legally span several physical lines, so
+//! those interior newlines must not terminate the expression.
+//! [`drop_bracketed_newlines`] tracks the combined `(`/`[` depth (Derive has
+//! no `{ }` and no `[[ ]]` part-sugar, unlike Wolfram) and drops `NEWLINE`
+//! tokens whenever depth is positive.
+
+use lexer::grammar_lexer::GrammarLexer;
+use lexer::token::{Token, TokenType};
+mod _grammar;
+
+/// Drop `NEWLINE` tokens that occur inside an open `(` or `[`.
+fn drop_bracketed_newlines(tokens: Vec<Token>) -> Vec<Token> {
+    let mut result = Vec::with_capacity(tokens.len());
+    let mut depth: i32 = 0;
+
+    for tok in tokens {
+        if tok.type_ == TokenType::Newline && depth > 0 {
+            continue;
+        }
+        match tok.type_ {
+            TokenType::LParen | TokenType::LBracket => depth += 1,
+            TokenType::RParen | TokenType::RBracket => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+        result.push(tok);
+    }
+
+    result
+}
+
+/// Create a [`GrammarLexer`] configured for Derive source text, with the
+/// bracket-interior newline hook registered.
+pub fn create_derive_lexer(source: &str) -> GrammarLexer<'_> {
+    let grammar = _grammar::token_grammar();
+    let mut lexer = GrammarLexer::new(source, &grammar);
+    lexer.add_post_tokenize(Box::new(drop_bracketed_newlines));
+    lexer
+}
+
+/// Tokenize Derive source text into a vector of tokens (ending in an `EOF`).
+///
+/// # Panics
+///
+/// Panics on an unrecognized character. Use [`try_tokenize_derive`] for a
+/// `Result`.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_derive_lexer::tokenize_derive;
+/// let tokens = tokenize_derive("DIF(SIN(x), x)\n");
+/// assert_eq!(tokens[0].value, "DIF");
+/// assert_eq!(tokens[1].effective_type_name(), "LPAREN");
+/// ```
+pub fn tokenize_derive(source: &str) -> Vec<Token> {
+    create_derive_lexer(source)
+        .tokenize()
+        .unwrap_or_else(|e| panic!("Derive tokenization failed: {e}"))
+}
+
+/// Tokenize Derive source text, returning a `Result` instead of panicking.
+pub fn try_tokenize_derive(source: &str) -> Result<Vec<Token>, String> {
+    create_derive_lexer(source)
+        .tokenize()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Lex, dropping the trailing EOF and any NEWLINE tokens, into
+    /// `(effective_type_name, value)` pairs.
+    fn lex(source: &str) -> Vec<(String, String)> {
+        tokenize_derive(source)
+            .iter()
+            .filter(|t| t.type_ != TokenType::Eof && t.type_ != TokenType::Newline)
+            .map(|t| (t.effective_type_name().to_string(), t.value.clone()))
+            .collect()
+    }
+
+    fn pair(p: &[(String, String)], i: usize, ty: &str, val: &str) {
+        assert_eq!(
+            (p[i].0.as_str(), p[i].1.as_str()),
+            (ty, val),
+            "tok {i} in {p:?}"
+        );
+    }
+
+    fn types(p: &[(String, String)]) -> Vec<&str> {
+        p.iter().map(|t| t.0.as_str()).collect()
+    }
+
+    // --- Function application uses ordinary parens, unlike Wolfram -------
+
+    #[test]
+    fn function_application_uses_ordinary_parens() {
+        let p = lex("DIF(u, x)\n");
+        pair(&p, 0, "NAME", "DIF");
+        pair(&p, 1, "LPAREN", "(");
+        pair(&p, 2, "NAME", "u");
+        pair(&p, 3, "COMMA", ",");
+        pair(&p, 4, "NAME", "x");
+        pair(&p, 5, "RPAREN", ")");
+    }
+
+    // --- `:=` is the ONE assign/define operator ---------------------------
+
+    #[test]
+    fn assign_token_is_shared_by_variable_and_function_definition() {
+        pair(&lex("x := 5\n"), 1, "ASSIGN", ":=");
+        pair(&lex("F(x) := x^2 + 1\n"), 4, "ASSIGN", ":=");
+    }
+
+    // --- `=` is equation, NOT assignment (Derive/Macsyma convention) -----
+
+    #[test]
+    fn eq_is_equation_distinct_from_assign() {
+        let p = lex("x = 4\n");
+        pair(&p, 1, "EQ", "=");
+        assert!(!types(&p).contains(&"ASSIGN"));
+    }
+
+    // --- Vector/matrix literals: `[...]` / `[...;...]` --------------------
+
+    #[test]
+    fn vector_literal_lexes_with_brackets_and_commas() {
+        let p = lex("[a, b, c]\n");
+        assert_eq!(
+            types(&p),
+            vec!["LBRACKET", "NAME", "COMMA", "NAME", "COMMA", "NAME", "RBRACKET"]
+        );
+    }
+
+    #[test]
+    fn matrix_literal_row_separator_is_semi() {
+        let p = lex("[a, b; c, d]\n");
+        assert_eq!(
+            types(&p),
+            vec![
+                "LBRACKET", "NAME", "COMMA", "NAME", "SEMI", "NAME", "COMMA", "NAME", "RBRACKET"
+            ]
+        );
+    }
+
+    // --- Boolean-algebra keywords AND/OR/NOT, case-sensitive --------------
+
+    #[test]
+    fn boolean_keywords_promote_to_keyword_token_type() {
+        let p = lex("a AND b OR NOT c\n");
+        assert_eq!(
+            p,
+            vec![
+                ("NAME".to_string(), "a".to_string()),
+                ("KEYWORD".to_string(), "AND".to_string()),
+                ("NAME".to_string(), "b".to_string()),
+                ("KEYWORD".to_string(), "OR".to_string()),
+                ("KEYWORD".to_string(), "NOT".to_string()),
+                ("NAME".to_string(), "c".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn lowercase_boolean_words_are_ordinary_names_not_keywords() {
+        // Derive is case-sensitive: `and`/`or`/`not` in lowercase are NOT the
+        // reserved boolean keywords — only the exact-case AND/OR/NOT are.
+        let p = lex("and or not\n");
+        assert_eq!(types(&p), vec!["NAME", "NAME", "NAME"]);
+    }
+
+    // --- Comparison and arithmetic operators ------------------------------
+
+    #[test]
+    fn comparison_and_arithmetic_operators() {
+        for (src, ty) in [
+            ("a <= b\n", "LE"),
+            ("a >= b\n", "GE"),
+            ("a < b\n", "LESS"),
+            ("a > b\n", "GREATER"),
+            ("a ^ b\n", "POWER"),
+            ("a * b\n", "TIMES"),
+            ("a / b\n", "SLASH"),
+        ] {
+            assert!(
+                types(&lex(src)).contains(&ty),
+                "expected {ty} in {src:?}: {:?}",
+                types(&lex(src))
+            );
+        }
+    }
+
+    // --- Longest-match: `:=` never lexes as two tokens --------------------
+
+    #[test]
+    fn assign_wins_over_any_shorter_prefix() {
+        assert!(types(&lex("x:=5\n")).contains(&"ASSIGN"));
+        assert!(!types(&lex("x:=5\n")).contains(&"EQ"));
+    }
+
+    // --- Case sensitivity of ordinary symbols (SIN vs sin) ----------------
+
+    #[test]
+    fn names_are_case_sensitive() {
+        pair(&lex("SIN\n"), 0, "NAME", "SIN");
+        pair(&lex("sin\n"), 0, "NAME", "sin");
+    }
+
+    // --- Significant newlines, dropped inside `(` / `[` -------------------
+
+    #[test]
+    fn newline_inside_parens_or_brackets_is_dropped_top_level_kept() {
+        let in_paren = tokenize_derive("F(\n a,\n b\n)\n")
+            .iter()
+            .filter(|t| t.type_ == TokenType::Newline)
+            .count();
+        assert_eq!(in_paren, 1, "only the trailing top-level newline remains");
+
+        let in_bracket = tokenize_derive("[\n1,\n2\n]\n")
+            .iter()
+            .filter(|t| t.type_ == TokenType::Newline)
+            .count();
+        assert_eq!(in_bracket, 1);
+
+        let top = tokenize_derive("a\nb\n")
+            .iter()
+            .filter(|t| t.type_ == TokenType::Newline)
+            .count();
+        assert_eq!(top, 2, "two top-level statements keep their separating newline");
+    }
+
+    // --- Literals and errors ----------------------------------------------
+
+    #[test]
+    fn numbers_and_symbols() {
+        pair(&lex("3.14\n"), 0, "NUMBER", "3.14");
+        pair(&lex("42\n"), 0, "NUMBER", "42");
+        pair(&lex("x\n"), 0, "NAME", "x");
+    }
+
+    #[test]
+    fn unknown_char_is_an_error() {
+        assert!(try_tokenize_derive("x ~ y\n").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `derive.tokens` (grammar-tools token grammar, compiled ahead of time into the committed `derive-lexer/src/_grammar.rs`) and the `derive-lexer` crate — D-2 of the Derive frontend per [MA07-derive-language.md](code/specs/MA07-derive-language.md)'s §2 item breakdown (D-1, the kickoff spec, merged in #8180).
- Derive's surface (Soft Warehouse, 1988) is closer in spirit to Macsyma/Wolfram than the array languages (APL/J): ordinary parentheses for function application (`DIF(u, x)`, not `f[x]`), a single `:=` operator shared by both variable assignment and function definition, `=` as the equation operator (never assignment), the case-sensitive boolean keywords `AND`/`OR`/`NOT`, and `[...]`/`[...;...]` vector/matrix literal delimiters.
- Mirrors `wolfram-lexer`'s thin-wrapper-over-`GrammarLexer` shape, including the bracket-interior-newline hook (a worksheet's numbered `#n:` prompt means each top-level `NEWLINE` ends an expression, but one inside an open `(` or `[` must not) — simplified relative to Wolfram's version since Derive has no `{ }` and no `[[ ]]` part-sugar, so only `(`/`[` need depth tracking.

## Test plan

- [x] 13 tests covering every token kind in the D-1 surface grammar (MA07 §3), the shared `:=` token across both assignment forms, `=`-vs-`:=` disambiguation, vector/matrix literal delimiters, case-sensitive keyword promotion (confirming lowercase `and`/`or`/`not` stay ordinary `NAME`s, only exact-case `AND`/`OR`/`NOT` promote to `KEYWORD`), comparison/arithmetic operators, longest-match precedence, and bracket-interior newline dropping.
- [x] `cargo test -p coding-adventures-derive-lexer` (13 tests + 1 doctest) all pass.
- [x] `cargo clippy --all-targets` clean.
- [x] `derive.tokens` validated via `grammar_tools::validate_token_grammar` (zero issues) before compiling to `_grammar.rs`.
- [x] Go build-tool BUILD-file validation passes for the new package.
- [x] `/security-review` passed clean — confirmed no unsafe code, no panics beyond the documented unrecognized-character path, safe bracket-depth tracking against unbalanced input, and no ReDoS risk in the new regex patterns (the shared `regex` crate guarantees linear-time matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)