### PR TITLE
feat(sql): CAST(expr AS type) — INTEGER / REAL / TEXT

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.23 — `CAST(expr AS type)` — INTEGER / REAL / TEXT
+
+`SELECT CAST(x AS INTEGER)` and friends now parse and run, following SQLite's
+documented cast rules: text yields its leading integer prefix (`'12abc'`→12,
+`'3.9'`→3), reals truncate toward zero (`-4.9`→-4), text→REAL reads the leading
+real prefix incl. exponent (`'1e3'`→1000.0), and integers render to their
+decimal string for TEXT. The declared type name resolves through SQLite's
+substring **affinity** rule, so synonyms like `INT`, `VARCHAR`, and `FLOAT`
+work. This spans all layers: grammar (sql-parser 0.1.7) → `SqlExpr::Cast`
+(sql-planner 0.2.6) → `Instruction::Cast` (sql-codegen 0.6.1) → `apply_cast`
+(sql-vm 0.4.12), with the optimizer (0.1.1) recursing through the new node.
+Three differential-oracle cases (`cast_to_integer`, `cast_to_real`,
+`cast_to_text_and_synonyms`) diff against real bundled SQLite. `BLOB` and
+`NUMERIC` target types, and `real→TEXT` formatting (the approximate-`dtoa`
+rabbit hole), remain follow-ups.
+
 ## 0.5.22 — `GLOB` / `NOT GLOB` infix operators
 
 `SELECT … WHERE s GLOB 'x*'` now parses and runs — case-sensitive Unix-glob

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.22"
+version = "0.5.23"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -810,6 +810,39 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE s NOT GLOB 'c?t' ORDER BY id",
     },
+    // `CAST(x AS INTEGER)` — text yields its leading integer prefix (`'12abc'`
+    // → 12, `'3.9'` → 3 since it stops at the `.`), and a real truncates toward
+    // zero (`4.9` → 4, `-4.9` → -4). Aliased so the check is on values, not the
+    // (engine-specific) auto-generated CAST column name.
+    Case {
+        id: "cast_to_integer",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT, r REAL)",
+            "INSERT INTO t VALUES (1,'12abc',4.9),(2,'3.9',-4.9),(3,'abc',7.2)",
+        ],
+        query: "SELECT CAST(s AS INTEGER) AS si, CAST(r AS INTEGER) AS ri FROM t ORDER BY id",
+    },
+    // `CAST(x AS REAL)` — text yields its leading real prefix (`'1e3'` → 1000.0,
+    // `'12.5abc'` → 12.5), and an integer widens (`42` → 42.0). REAL cells are
+    // compared within the oracle's numeric epsilon.
+    Case {
+        id: "cast_to_real",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT, n INTEGER)",
+            "INSERT INTO t VALUES (1,'1e3',42),(2,'12.5abc',7)",
+        ],
+        query: "SELECT CAST(s AS REAL) AS sr, CAST(n AS REAL) AS nr FROM t ORDER BY id",
+    },
+    // `CAST(int AS TEXT)` renders the decimal string; the affinity substring
+    // rule resolves the synonym `VARCHAR` to TEXT and `INT` to INTEGER.
+    Case {
+        id: "cast_to_text_and_synonyms",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, n INTEGER)",
+            "INSERT INTO t VALUES (1,65),(2,-7)",
+        ],
+        query: "SELECT CAST(n AS VARCHAR) AS tv, CAST('9x' AS INT) AS iv FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.6.1] - Unreleased
+
+### Added
+
+- **`Instruction::Cast(CastType)`** and a `compile_expr` arm for
+  `SqlExpr::Cast`: compile the operand, then emit a single `Cast` opcode that
+  the VM applies. `CastType` is re-exported from the planner so the codegen
+  and VM name the same enum.
+
 ## [0.6.0] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -76,6 +76,11 @@ use coding_adventures_sql_planner::{
     OutputColumn, SqlExpr, UnaryOp as PlanUnaryOp,
 };
 
+/// The CAST target type, re-exported from the planner so `Instruction::Cast`
+/// and the VM can name it without a parallel enum (it is a plain data enum
+/// with identical meaning across all three layers).
+pub use coding_adventures_sql_planner::CastType;
+
 // ---------------------------------------------------------------------------
 // Maximum recursion depth for compile_expr.
 //
@@ -277,6 +282,11 @@ pub enum Instruction {
     ///
     /// ## Stack effect: `[..., value, pattern] → [..., Bool]`
     Like,
+
+    /// SQL `CAST(value AS type)` — pop one value, push its conversion.
+    ///
+    /// ## Stack effect: `[..., value] → [..., converted]`
+    Cast(CastType),
 
     /// SQL `IN (v1, v2, ...)` list membership test.
     ///
@@ -2003,6 +2013,14 @@ impl Compiler {
                 self.compile_expr(value);
                 self.compile_expr(pattern);
                 self.emit(Instruction::Like);
+            }
+
+            // ── CAST ─────────────────────────────────────────────────────────
+
+            SqlExpr::Cast { expr, ty } => {
+                // Evaluate the operand, then convert it in place.
+                self.compile_expr(expr);
+                self.emit(Instruction::Cast(ty.clone()));
             }
 
             // ── IN list ──────────────────────────────────────────────────────

--- a/code/packages/rust/sql-optimizer/CHANGELOG.md
+++ b/code/packages/rust/sql-optimizer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.1.1] - Unreleased
+
+### Added
+
+- Handle the new `SqlExpr::Cast` variant: `fold_expr` folds the cast's operand
+  but keeps the conversion (a cast of a constant is still evaluated by the VM),
+  and `collect_columns_in_expr` recurses into the operand.
+
 ## [0.1.0] — 2026-06-30
 
 ### Added

--- a/code/packages/rust/sql-optimizer/Cargo.toml
+++ b/code/packages/rust/sql-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-optimizer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Logical query plan optimizer for the Mini-SQLite SQL pipeline (Level 1)"
 authors = ["Adhithya Rajasekaran <adhithyan15@gmail.com>"]

--- a/code/packages/rust/sql-optimizer/src/lib.rs
+++ b/code/packages/rust/sql-optimizer/src/lib.rs
@@ -604,6 +604,13 @@ fn fold_expr(expr: SqlExpr) -> SqlExpr {
             fold_unary(op, inner)
         }
 
+        // CAST: fold the operand, but keep the conversion (a cast of a constant
+        // is still evaluated by the VM — we don't constant-fold the coercion).
+        Cast { expr: inner, ty } => Cast {
+            expr: Box::new(fold_expr(*inner)),
+            ty,
+        },
+
         IsNull(inner) => {
             let inner = fold_expr(*inner);
             match &inner {
@@ -1280,6 +1287,7 @@ fn collect_columns_in_expr(expr: &SqlExpr, out: &mut HashSet<String>) {
             collect_columns_in_expr(right, out);
         }
         SqlExpr::UnaryOp { expr, .. } => collect_columns_in_expr(expr, out),
+        SqlExpr::Cast { expr, .. } => collect_columns_in_expr(expr, out),
         SqlExpr::IsNull(inner) | SqlExpr::IsNotNull(inner) => {
             collect_columns_in_expr(inner, out)
         }

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.7] - Unreleased
+
+### Added
+
+- **`CAST(expr AS type)` expressions.** A `CAST` alternative was added to the
+  `primary` rule, before `function_call` so the ordered-choice parser matches
+  the AS-typed form first. The type is a `NAME` token (INTEGER/REAL/TEXT and
+  their affinity synonyms). The planner (sql-planner 0.2.6) turns it into a
+  `SqlExpr::Cast`.
+
 ## [0.1.6] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -539,6 +539,18 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#"NULL"#.to_string() },
                 GrammarElement::Literal { value: r#"TRUE"#.to_string() },
                 GrammarElement::Literal { value: r#"FALSE"#.to_string() },
+                // `CAST(expr AS type)` — placed before `function_call` so the
+                // ordered-choice parser matches the AS-typed form first (a bare
+                // `foo(...)` fails the leading `CAST` literal and falls through
+                // to function_call). The type is a NAME token (INTEGER/REAL/…).
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"CAST"#.to_string() },
+                    GrammarElement::Literal { value: r#"("#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::Literal { value: r#"AS"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    GrammarElement::Literal { value: r#")"#.to_string() },
+                ] },
                 GrammarElement::RuleReference { name: r#"function_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"column_ref"#.to_string() },
                 GrammarElement::Sequence { elements: vec![

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -551,6 +551,18 @@ mod tests {
         assert!(find_rule(&ast2, "comparison"), "Expected comparison for NOT GLOB");
     }
 
+    /// `CAST(expr AS type)` parses as a primary. The `CAST` alternative sits
+    /// before `function_call`, so `CAST(a AS INTEGER)` is not mistaken for a
+    /// function call named CAST.
+    #[test]
+    fn test_parse_cast() {
+        let ast = assert_program_root("SELECT CAST(a AS INTEGER) FROM t");
+        assert!(find_rule(&ast, "primary"), "Expected primary");
+        // A CAST expression can also appear in a WHERE predicate.
+        let ast2 = assert_program_root("SELECT x FROM t WHERE CAST(s AS REAL) > 1.5");
+        assert!(find_rule(&ast2, "comparison"), "Expected comparison");
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.6] - Unreleased
+
+### Added
+
+- **`CAST(expr AS type)` planning.** New `SqlExpr::Cast { expr, ty }` variant
+  and `CastType { Integer, Real, Text }` enum. `plan_cast` extracts the inner
+  expression and resolves the declared type name to a `CastType` using SQLite's
+  substring **affinity** rule (so `INT`/`VARCHAR`/`FLOAT` synonyms resolve
+  correctly). `BLOB` and `NUMERIC` are not yet supported and return an
+  `UnsupportedStatement` error (a later increment). Codegen/VM apply the
+  conversion (sql-codegen 0.6.1, sql-vm 0.4.12).
+
 ## [0.2.5] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -143,6 +143,14 @@ pub enum SqlExpr {
         star: bool,
     },
 
+    /// `CAST(expr AS type)` — an explicit type conversion.
+    ///
+    /// Example: `CAST('12' AS INTEGER)` → the integer `12`.
+    Cast {
+        expr: Box<SqlExpr>,
+        ty: CastType,
+    },
+
     /// An aggregate function applied within GROUP BY context.
     ///
     /// Aggregates are separated from regular function calls because they
@@ -190,6 +198,23 @@ pub enum UnaryOp {
     Neg,
     /// Logical negation: `NOT x`
     Not,
+}
+
+/// The target type of a `CAST(expr AS type)` conversion.
+///
+/// SQLite resolves any declared type name to one of five "affinities"; this
+/// enum covers the three whose CAST results compare exactly or within the
+/// oracle's numeric epsilon (INTEGER, REAL, TEXT). BLOB and NUMERIC are not
+/// yet supported (a later increment) — see the planner's cast parser.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CastType {
+    /// `CAST(x AS INTEGER)` — truncate reals toward zero; parse a leading
+    /// numeric prefix of text (`'12abc'` → 12, `'abc'` → 0).
+    Integer,
+    /// `CAST(x AS REAL)` — parse a leading numeric prefix of text as f64.
+    Real,
+    /// `CAST(x AS TEXT)` — render the value as its text representation.
+    Text,
 }
 
 /// An aggregate function name.
@@ -2054,6 +2079,15 @@ fn plan_unary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
 /// | `TRUE`               | KEYWORD      | `Bool(true)`          |
 /// | `FALSE`              | KEYWORD      | `Bool(false)`         |
 fn plan_primary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
+    // `CAST(expr AS type)` — recognised by a leading `CAST` keyword token.
+    // Handled before the generic loop so the `CAST` token isn't mistaken for a
+    // bare column name.
+    if let Some(ASTNodeOrToken::Token(t)) = node.children.first() {
+        if t.value.eq_ignore_ascii_case("CAST") {
+            return plan_cast(node);
+        }
+    }
+
     // Check child nodes first (column_ref, function_call, or parenthesized expr).
     for child in &node.children {
         match child {
@@ -2086,6 +2120,62 @@ fn plan_primary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
     Err(PlanError::UnsupportedStatement(
         "empty primary node".to_string(),
     ))
+}
+
+/// Plan a `CAST(expr AS type)` primary node into [`SqlExpr::Cast`].
+///
+/// Grammar: `primary = "CAST" "(" expr "AS" NAME ")"` (among other choices).
+/// The node's children are the `CAST` / `(` / `AS` / `)` tokens, the inner
+/// expression node, and the type-name token.
+///
+/// The declared type name is mapped to a [`CastType`] using SQLite's
+/// substring affinity rule (so synonyms like `INT`, `VARCHAR`, `FLOAT` resolve
+/// correctly): a name containing `INT` → INTEGER; `CHAR`/`CLOB`/`TEXT` → TEXT;
+/// `REAL`/`FLOA`/`DOUB` → REAL. `BLOB` and `NUMERIC`/other names are not yet
+/// supported and yield an `UnsupportedStatement` error (a later increment).
+fn plan_cast(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
+    // The inner expression is the sole nested Node child.
+    let expr_node = node
+        .children
+        .iter()
+        .find_map(|c| match c {
+            ASTNodeOrToken::Node(n) => Some(n),
+            _ => None,
+        })
+        .ok_or_else(|| PlanError::UnsupportedStatement("CAST missing expression".to_string()))?;
+    let inner = plan_expression(expr_node)?;
+
+    // The type name is the token following `AS`.
+    let type_name = {
+        let children = &node.children;
+        let mut found = None;
+        for (i, c) in children.iter().enumerate() {
+            if is_keyword_token(c, "AS") {
+                if let Some(ASTNodeOrToken::Token(t)) = children.get(i + 1) {
+                    found = Some(t.value.to_uppercase());
+                }
+            }
+        }
+        found.ok_or_else(|| PlanError::UnsupportedStatement("CAST missing type name".to_string()))?
+    };
+
+    // SQLite's type-affinity substring rule, restricted to the supported types.
+    let ty = if type_name.contains("INT") {
+        CastType::Integer
+    } else if type_name.contains("CHAR") || type_name.contains("CLOB") || type_name.contains("TEXT") {
+        CastType::Text
+    } else if type_name.contains("REAL") || type_name.contains("FLOA") || type_name.contains("DOUB") {
+        CastType::Real
+    } else {
+        return Err(PlanError::UnsupportedStatement(format!(
+            "CAST to unsupported type: {type_name}"
+        )));
+    };
+
+    Ok(SqlExpr::Cast {
+        expr: Box::new(inner),
+        ty,
+    })
 }
 
 /// Plan a single token from a primary node into a literal or column reference.

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.12] - Unreleased
+
+### Added
+
+- **`Instruction::Cast` execution** (`apply_cast`) with SQLite's documented
+  rules for the three supported target types: INTEGER (reals truncate toward
+  zero; text yields its leading integer prefix), REAL (text yields its leading
+  real prefix, exponent-aware), and TEXT (decimal string; a boolean renders as
+  `1`/`0`). NULL always casts to NULL. Helpers `parse_int_prefix` /
+  `parse_real_prefix` do the byte-scan prefix parsing.
+
 ## [0.4.11] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -33,7 +33,9 @@
 use std::collections::HashMap;
 
 use coding_adventures_sql_backend::{Backend, Cursor, Row, RowIterator, SqlValue};
-use coding_adventures_sql_codegen::{AggFn, BinaryOp, CompiledSortKey, Instruction, Program, UnaryOp};
+use coding_adventures_sql_codegen::{
+    AggFn, BinaryOp, CastType, CompiledSortKey, Instruction, Program, UnaryOp,
+};
 
 // ===========================================================================
 // Public API types
@@ -364,6 +366,11 @@ pub fn execute(program: &Program, backend: &mut dyn Backend) -> Result<QueryResu
                     _ => SqlValue::Bool(like_match(&sql_to_str(&val), &sql_to_str(&pat))),
                 };
                 stack.push(result);
+            }
+
+            Instruction::Cast(ty) => {
+                let val = pop(&mut stack)?;
+                stack.push(apply_cast(&val, &ty));
             }
 
             // ─────────────── BETWEEN ───────────────────────────────────────
@@ -2432,6 +2439,137 @@ fn sql_to_str(v: &SqlValue) -> String {
         }
         SqlValue::Null => String::new(),
     }
+}
+
+/// Apply a `CAST(value AS type)` conversion, following SQLite's documented
+/// rules for the three supported target types. NULL always casts to NULL.
+///
+/// - **INTEGER**: reals truncate toward zero; text yields the longest leading
+///   *integer* prefix (`'3.9'` → 3 because it stops at the `.`, `'12abc'` → 12,
+///   `'abc'` → 0), leading whitespace ignored.
+/// - **REAL**: text yields the longest leading *real* prefix (`'1e3'` → 1000.0,
+///   `'12.5abc'` → 12.5, `'abc'` → 0.0).
+/// - **TEXT**: the value's text representation (integers become their decimal
+///   string; a boolean — which SQLite has no type for — renders as `1`/`0`).
+fn apply_cast(val: &SqlValue, ty: &CastType) -> SqlValue {
+    if matches!(val, SqlValue::Null) {
+        return SqlValue::Null;
+    }
+    match ty {
+        CastType::Integer => SqlValue::Int(cast_to_i64(val)),
+        CastType::Real => SqlValue::Float(cast_to_f64(val)),
+        CastType::Text => SqlValue::Text(match val {
+            // SQLite has no boolean type; a stored bool casts like the integer
+            // 1/0 it stands in for, not the words "true"/"false".
+            SqlValue::Bool(b) => (*b as i64).to_string(),
+            _ => sql_to_str(val),
+        }),
+    }
+}
+
+/// Value → i64 for `CAST(… AS INTEGER)`. Float truncates toward zero (and
+/// saturates on overflow, matching Rust's `as i64`); text parses a leading
+/// integer prefix.
+fn cast_to_i64(val: &SqlValue) -> i64 {
+    match val {
+        SqlValue::Int(i) => *i,
+        SqlValue::Bool(b) => *b as i64,
+        SqlValue::Float(f) => *f as i64,
+        SqlValue::Text(s) => parse_int_prefix(s),
+        SqlValue::Blob(b) => parse_int_prefix(&String::from_utf8_lossy(b)),
+        SqlValue::Null => 0,
+    }
+}
+
+/// Value → f64 for `CAST(… AS REAL)`. Text parses a leading real prefix.
+fn cast_to_f64(val: &SqlValue) -> f64 {
+    match val {
+        SqlValue::Int(i) => *i as f64,
+        SqlValue::Bool(b) => *b as i64 as f64,
+        SqlValue::Float(f) => *f,
+        SqlValue::Text(s) => parse_real_prefix(s),
+        SqlValue::Blob(b) => parse_real_prefix(&String::from_utf8_lossy(b)),
+        SqlValue::Null => 0.0,
+    }
+}
+
+/// The longest leading substring of `s` that is a well-formed integer
+/// (optional sign + digits, after skipping leading whitespace), parsed to
+/// i64. No such prefix → 0; digit overflow saturates to i64::MIN/MAX.
+fn parse_int_prefix(s: &str) -> i64 {
+    let t = s.trim_start();
+    let bytes = t.as_bytes();
+    let mut i = 0;
+    let mut neg = false;
+    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+        neg = bytes[i] == b'-';
+        i += 1;
+    }
+    let start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == start {
+        return 0;
+    }
+    match t[start..i].parse::<i64>() {
+        Ok(n) => {
+            if neg {
+                -n
+            } else {
+                n
+            }
+        }
+        Err(_) => {
+            if neg {
+                i64::MIN
+            } else {
+                i64::MAX
+            }
+        }
+    }
+}
+
+/// The longest leading substring of `s` that is a well-formed real number
+/// (optional sign, digits, fractional part, and exponent — after skipping
+/// leading whitespace), parsed to f64. No such prefix → 0.0.
+fn parse_real_prefix(s: &str) -> f64 {
+    let t = s.trim_start();
+    let bytes = t.as_bytes();
+    let mut i = 0;
+    if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
+        i += 1;
+    }
+    let mut saw_digit = false;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+        saw_digit = true;
+    }
+    if i < bytes.len() && bytes[i] == b'.' {
+        i += 1;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+            saw_digit = true;
+        }
+    }
+    if !saw_digit {
+        return 0.0;
+    }
+    // Optional exponent — only consumed if it actually has digits.
+    if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
+        let mut j = i + 1;
+        if j < bytes.len() && (bytes[j] == b'+' || bytes[j] == b'-') {
+            j += 1;
+        }
+        let exp_start = j;
+        while j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j > exp_start {
+            i = j;
+        }
+    }
+    t[..i].parse::<f64>().unwrap_or(0.0)
 }
 
 // ===========================================================================


### PR DESCRIPTION
## `CAST(expr AS type)` — INTEGER / REAL / TEXT

`SELECT CAST(x AS INTEGER)` (and `REAL` / `TEXT`) now parse and run, following
SQLite's documented cast semantics. This is the **first multi-layer feature**
of the conformance rotation — a new expression node threaded through every
stage of the pipeline.

### What changed
- **sql-parser** (`_grammar.rs`): `primary` gains a `CAST "(" expr "AS" NAME ")"`
  alternative, placed before `function_call` so ordered choice matches it first.
- **sql-planner**: new `SqlExpr::Cast { expr, ty }` + `CastType { Integer, Real,
  Text }`. `plan_cast` resolves the declared type name via SQLite's **substring
  affinity rule**, so synonyms like `INT`, `VARCHAR`, `FLOAT` map correctly.
  `BLOB`/`NUMERIC` return `UnsupportedStatement` (follow-up).
- **sql-codegen**: `Instruction::Cast(CastType)` (re-exported from the planner)
  + a `compile_expr` arm (compile operand, emit `Cast`).
- **sql-vm**: `apply_cast` + `parse_int_prefix` / `parse_real_prefix`. INTEGER
  truncates reals toward zero and reads a text integer prefix; REAL reads a text
  real prefix (exponent-aware); TEXT renders the decimal string (bool → `1`/`0`).
  NULL casts to NULL.
- **sql-optimizer**: `fold_expr` folds the operand but keeps the cast;
  `collect_columns_in_expr` recurses into it.

### Verification (probe → test-first)
Every rule was probed against real SQLite first — `CAST('12abc' AS INTEGER)`=12,
`CAST('3.9' AS INTEGER)`=3, `CAST(-3.9 AS INTEGER)`=-3, `CAST('1e3' AS REAL)`=1000.0,
`typeof(CAST(42 AS REAL))`='real' — then locked in:
- **Differential oracle** (mini-sqlite): `cast_to_integer`, `cast_to_real`,
  `cast_to_text_and_synonyms`, all diffing against real bundled SQLite (aliased
  so the check is on values, not the auto-generated column name).
- **sql-parser**: `test_parse_cast` (CAST in select list and WHERE predicate).
- Full affected SQL pipeline (parser/planner/codegen/vm/optimizer/mini-sqlite/
  storage-sqlite) green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — UTF-8-boundary-safe prefix
  parsers (only ASCII bytes consumed), `-n` can't overflow, `f as i64`
  saturates, planner/grammar paths panic-free with no unbounded loops.

### Scope
Deliberately limited to **INTEGER / REAL / TEXT**: REAL cells compare within the
oracle's numeric epsilon and integers are exact, so this subset sidesteps the
approximate-`dtoa` `real→TEXT` formatting rabbit hole. `BLOB`, `NUMERIC`, and
`real→TEXT` are follow-ups; the infrastructure (Cast node + opcode) makes them
small.

### Versions
sql-parser 0.1.6→0.1.7 · sql-planner 0.2.5→0.2.6 · sql-codegen 0.6.0→0.6.1 ·
sql-vm 0.4.11→0.4.12 · sql-optimizer 0.1.0→0.1.1 · mini-sqlite 0.5.22→0.5.23.

Rotation lane 1 (CAST/CASE/subqueries), slice 1. Next lanes: NULLS/COLLATE
ordering → sqlite-file writer → CASE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
