### PR TITLE
feat(derive-parser): Derive grammar + parser (MA07 D-3, front2 Wave 5)

### DIFF
--- a/code/grammars/derive/derive.grammar
+++ b/code/grammars/derive/derive.grammar
@@ -1,0 +1,120 @@
+# @version 1
+
+# =============================================================================
+# derive.grammar — Parser grammar for Derive (a subset)
+# =============================================================================
+#
+# Drives the generic grammar-driven parser engine (parser::GrammarParser) over
+# the token stream from derive-lexer (D-2). Every Derive expression parses down
+# to ordinary infix/postfix operators over `head[args]`-shaped calls; the
+# D-4 runtime lowers each rule into the canonical symbolic-ir head (Plus,
+# Times, Power, Assign, Define, List, …). See
+# code/specs/MA07-derive-language.md §3 for the full surface table this
+# grammar implements.
+#
+# Token names (UPPERCASE) come from the Derive lexer (code/grammars/derive/derive.tokens):
+#   NUMBER NAME                literals and symbols
+#   ASSIGN (:=)                 the ONE assignment/definition operator
+#   EQ (=)  LE (<=)  LESS (<)  GREATER (>)  GE (>=)     comparison (`=` is
+#                                                          equation, NOT assignment)
+#   PLUS MINUS TIMES SLASH POWER      arithmetic
+#   LPAREN RPAREN               grouping AND function application F(...)
+#   LBRACKET RBRACKET           vector/matrix literal [...] / [...;...]
+#   COMMA SEMI NEWLINE          argument/list separator, matrix row separator,
+#                                statement separator
+#   KEYWORD ("AND"/"OR"/"NOT")  boolean-algebra keywords (case-sensitive; see
+#                                derive.tokens's `keywords:` block) — matched
+#                                here by their literal spelling, same
+#                                convention as macsyma.grammar's "and"/"or"/"not"
+#
+# Precedence cascade (loosest binds first -> tightest binds last), per the
+# MA07 spec §3 table:
+# ---------------------------------------------------------------
+#   assignment      :=                 (right-associative)
+#   logical_or      OR
+#   logical_and     AND
+#   logical_not     NOT                (prefix)
+#   comparison      = <= < > >=
+#   additive        + -
+#   multiplicative  * /
+#   unary           -                  (prefix)
+#   power           ^                  (right-associative)
+#   postfix         F(...)             (function/named-builtin application)
+#   atom            literals, symbols, vectors, ( ... )
+# =============================================================================
+
+program = { statement_line } ;
+
+# A line is one statement followed by a NEWLINE, or a blank/terminator-only
+# line — mirrors wolfram.grammar's statement_line exactly (Derive has no
+# other statement terminator; see derive.tokens's own header).
+statement_line = statement NEWLINE
+               | statement
+               | NEWLINE ;
+
+statement = expr ;
+
+expr = assignment ;
+
+# `:=` is Derive's ONE assignment/definition operator, used identically for
+# `x := 5` (variable assignment, LHS is a bare NAME reducing straight through
+# every tighter level down to `atom`) and `F(x) := x^2 + 1` (function
+# definition, LHS is a `postfix` application `F(x)` reducing through the same
+# path) — the D-4 lowering, not this grammar, disambiguates the two by
+# inspecting the parsed LHS shape. Right-associative, mirroring
+# wolfram.grammar's identical `assignment = replaceall [ (SET|SETDELAYED)
+# assignment ]` shape (a chained `a := b := c` is not a meaningful Derive
+# program, but the grammar shape costs nothing extra and keeps this crate's
+# parser consistent with its CAS-family siblings).
+assignment = logical_or [ ASSIGN assignment ] ;
+
+logical_or  = logical_and { "OR" logical_and } ;
+logical_and = logical_not { "AND" logical_not } ;
+logical_not = "NOT" logical_not | comparison ;
+
+# A single (non-chained) comparison, mirroring wolfram.grammar's `comparison`
+# — `=` here is Derive's equation operator (an Equal-headed Boolean-valued
+# expression), never assignment (`:=` owns that role, at the `assignment`
+# level above).
+comparison = additive [ ( EQ | LE | LESS | GREATER | GE ) additive ] ;
+
+additive       = multiplicative { ( PLUS | MINUS ) multiplicative } ;
+multiplicative = unary { ( TIMES | SLASH ) unary } ;
+
+# Prefix minus. Binds looser than Power, so `-x^2` is Times[-1, Power[x, 2]]
+# (mirrors wolfram.grammar's identical `unary`/`power` split). Derive's
+# surface table (MA07 §3) lists only unary `-` (no unary `+`), unlike
+# Wolfram's subset.
+unary = MINUS unary | power ;
+
+# Power — right-associative: `a^b^c` is Power[a, Power[b, c]]. The
+# recursive-descent shape (RHS references `unary`, which falls through to
+# `power` again absent a leading `-`) gives right-associativity for free,
+# exactly as wolfram.grammar's `power` does.
+power = postfix [ POWER unary ] ;
+
+# Postfix function/named-builtin application — Derive's defining syntactic
+# difference from Wolfram: ORDINARY parentheses, not square brackets
+# (`DIF(u, x)`, not `f[x]`). Chains left-associatively, mirroring
+# wolfram.grammar's `postfix` (`f(x)(y)` is `(f(x))(y)`), though Derive has
+# no analogue of Wolfram's `[[ ]]` Part sugar to chain alongside it.
+postfix = atom { LPAREN [ arglist ] RPAREN } ;
+
+arglist = expr { COMMA expr } ;
+
+atom = NUMBER
+     | NAME
+     | vector
+     | group ;
+
+# Vector/matrix literal (D-5): `[a, b, c]` is a vector (one row); `[a, b, c;
+# d, e, f]` is a matrix, rows separated by `;` (the ONLY use of `;` in this
+# subset — see derive.tokens's own header). A single-row `vector` (no `;`)
+# and a multi-row `vector` share this one rule; the D-4/D-5 lowering
+# distinguishes "one row" (a flat `List[...]`) from "more than one row" (a
+# `List` of row-`List`s) by counting how many `row`s were parsed, not by a
+# grammar-level distinction.
+vector = LBRACKET row { SEMI row } RBRACKET ;
+row    = expr { COMMA expr } ;
+
+group = LPAREN expr RPAREN ;

--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -244,6 +244,7 @@ members = [
     "wolfram-repl",
     "wolfram-to-semantic-ir",
     "derive-lexer",
+    "derive-parser",
     "apl-lexer",
     "apl-parser",
     "apl-runtime",

--- a/code/packages/rust/derive-parser/BUILD
+++ b/code/packages/rust/derive-parser/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-parser -- --nocapture

--- a/code/packages/rust/derive-parser/BUILD_windows
+++ b/code/packages/rust/derive-parser/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-parser -- --nocapture

--- a/code/packages/rust/derive-parser/CHANGELOG.md
+++ b/code/packages/rust/derive-parser/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial grammar-driven Rust Derive parser (MA07 §2, task D-3).
+- `derive.grammar` (compiled ahead of time into the committed
+  `src/_grammar.rs`), implementing the D-1-scoped precedence cascade from
+  MA07 §3: assignment (`:=`, right-associative, shared by both variable
+  assignment and function definition — `x := 5` and `F(x) := x^2 + 1`
+  parse through the identical rule, disambiguated only at the later D-4
+  lowering stage) → `OR` → `AND` → `NOT` → comparison (`=`/`<=`/`<`/`>`/`>=`)
+  → additive → multiplicative → unary minus → power (`^`, right-associative)
+  → postfix function/named-builtin application (`DIF(u, x)`, ordinary
+  parentheses — Derive's defining syntactic difference from Wolfram's
+  `f[x]`) → atoms, plus vector/matrix literals (`[a, b, c]` /
+  `[a, b, c; d, e, f]`, `;` as the row separator).
+- A bespoke `MAX_RULE_DEPTH = 200` recursion-depth cap, empirically measured
+  the same way `r-parser`/`s-parser`/`macsyma-parser`/`nib-parser`/
+  `oct-parser` measured their own values (the shared crate's generic
+  `DEFAULT_MAX_RULE_DEPTH` of 128 was not assumed safe, and this grammar's
+  own native-stack floor was measured independently rather than reused from
+  a sibling): parses safely to 21 real nesting levels on an uncapped,
+  default-stack worker thread, crashes at 22 (297/298 in rule-frame terms —
+  coincidentally the exact same floor `r-parser` measured). 200 sits about
+  33% below that floor and still supports 14 real nesting levels before
+  tripping.
+- 16 tests covering every construct in the D-1 surface grammar (function
+  application, the shared `:=` token across both assignment forms, `=`-vs-
+  `:=` disambiguation, vector/matrix literals, the boolean keywords,
+  arithmetic precedence and associativity, grouping, nested/multi-arg
+  builtin calls, syntax-error rejection) plus 3 depth-guard regression
+  tests mirroring the sibling crates' own (deep adversarial input on an
+  enlarged-stack thread returns a clean error, input at the measured
+  real-nesting boundary still parses one level past it doesn't, and the
+  cap trips before the native stack would overflow even on a default-stack
+  thread).

--- a/code/packages/rust/derive-parser/Cargo.toml
+++ b/code/packages/rust/derive-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coding-adventures-derive-parser"
+version = "0.1.0"
+edition = "2021"
+description = "Parser for Derive (a subset, D-3)"
+license = "MIT"
+
+[dependencies]
+grammar-tools = { path = "../grammar-tools" }
+lexer = { path = "../lexer" }
+parser = { path = "../parser" }
+coding-adventures-derive-lexer = { path = "../derive-lexer" }

--- a/code/packages/rust/derive-parser/README.md
+++ b/code/packages/rust/derive-parser/README.md
@@ -1,0 +1,80 @@
+# coding-adventures-derive-parser
+
+Derive parser backed by `code/grammars/derive/derive.grammar`, compiled to
+Rust and statically linked into the crate.
+
+The runtime path does not read grammar files from disk, which keeps it
+suitable for a future WASM facade.
+
+## Scope
+
+Covers the D-1-scoped subset fixed by
+[MA07 §3](../../../specs/MA07-derive-language.md). Every Derive expression
+parses down to ordinary infix/postfix operators over `head(args)`-shaped
+calls — there is no `f[x]`-style universal application syntax and no
+pattern/rewrite-rule vocabulary the way Wolfram has one; Derive's
+"transform this expression" operations (`DIF`, `INT`, `LIM`, `SOLVE`, …)
+are each their own named function, called with ordinary parentheses.
+
+## `:=` is genuinely one grammar rule doing two jobs
+
+Mirroring `derive-lexer`'s own README: `x := 5` (variable assignment) and
+`F(x) := x^2 + 1` (function definition) parse through the *identical*
+`assignment` rule — its left-hand side is just the next-tighter precedence
+level (`logical_or`), which naturally reduces down to a bare `NAME` or a
+`postfix` application `F(x)` depending on what's actually written. This
+parser does not (and does not need to) distinguish the two cases; a future
+`derive-runtime` (D-4) tells them apart by inspecting the parsed left-hand
+side's shape.
+
+## Precedence, loosest to tightest
+
+```
+assignment (:=, right-assoc)
+  → OR
+    → AND
+      → NOT (prefix)
+        → comparison (= <= < > >=)
+          → additive (+ -)
+            → multiplicative (* /)
+              → unary minus (prefix)
+                → power (^, right-assoc)
+                  → postfix application  F(...)
+                    → atom  (NUMBER, NAME, vector, ( ... ))
+```
+
+`=` is Derive's *equation* operator (an `Equal`-headed Boolean-valued
+expression, e.g. `SOLVE`'s first argument) — never assignment; `:=` alone
+owns that role, at the loosest level. This mirrors Macsyma's identical
+`=`-is-equation / `:`-or-`:=`-is-assignment split, minus Macsyma's separate
+bare-`:` form (Derive only ever uses `:=`, for both variables and
+functions).
+
+## Vector/matrix literals
+
+`[a, b, c]` is a one-row vector; `[a, b, c; d, e, f]` is a matrix, rows
+separated by `;` (the *only* use of `;` in this subset — Derive has no
+general statement terminator). Both parse through the same `vector` rule;
+the row count (one vs. more than one) is what a future D-4/D-5 lowering
+uses to decide between a flat `List[...]` and a `List` of row-`List`s.
+
+## Usage
+
+```rust
+use coding_adventures_derive_parser::parse_derive;
+
+let ast = parse_derive("F(x) := DIF(SIN(x), x)\nF(0)\n");
+assert_eq!(ast.rule_name, "program");
+```
+
+`parse_derive` panics on a malformed source string; use
+`try_parse_derive` for the `Result`-returning form, or
+`create_derive_parser` directly if you need the raw `GrammarParser`.
+
+## Where this fits
+
+`derive-parser` is D-3 of Derive's frontend crates, consuming the token
+stream from `derive-lexer` (D-2) against
+`code/grammars/derive/derive.grammar` to build the `GrammarASTNode` CST a
+future `derive-runtime` (D-4) will lower into `symbolic_ir::IRNode` and
+evaluate with `symbolic_vm::VM`.

--- a/code/packages/rust/derive-parser/required_capabilities.json
+++ b/code/packages/rust/derive-parser/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/derive-parser",
+  "capabilities": [],
+  "justification": "Pure computation. The Derive grammar is embedded as generated Rust code; tokenizing and parsing need no filesystem, network, or process access."
+}

--- a/code/packages/rust/derive-parser/src/_grammar.rs
+++ b/code/packages/rust/derive-parser/src/_grammar.rs
@@ -1,0 +1,220 @@
+// AUTO-GENERATED FILE — DO NOT EDIT
+// Source: derive.grammar
+// Regenerate with: grammar-tools compile-grammar derive.grammar
+//
+// This file embeds a ParserGrammar as native Rust data structures.
+// Call `parser_grammar()` instead of reading and parsing the .grammar file.
+
+use grammar_tools::parser_grammar::{GrammarElement, GrammarRule, ParserGrammar};
+
+pub fn parser_grammar() -> ParserGrammar {
+    ParserGrammar {
+        rules: vec![
+        GrammarRule {
+            name: r#"program"#.to_string(),
+            body: GrammarElement::Repetition { element: Box::new(GrammarElement::RuleReference { name: r#"statement_line"#.to_string() }) },
+            line_number: 46,
+        },
+        GrammarRule {
+            name: r#"statement_line"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                    GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"statement"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NEWLINE"#.to_string() },
+            ] },
+            line_number: 51,
+        },
+        GrammarRule {
+            name: r#"statement"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+            line_number: 55,
+        },
+        GrammarRule {
+            name: r#"expr"#.to_string(),
+            body: GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+            line_number: 57,
+        },
+        GrammarRule {
+            name: r#"assignment"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_or"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"ASSIGN"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"assignment"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 69,
+        },
+        GrammarRule {
+            name: r#"logical_or"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"OR"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_and"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 71,
+        },
+        GrammarRule {
+            name: r#"logical_and"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"AND"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 72,
+        },
+        GrammarRule {
+            name: r#"logical_not"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"NOT"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"logical_not"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"comparison"#.to_string() },
+            ] },
+            line_number: 73,
+        },
+        GrammarRule {
+            name: r#"comparison"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"EQ"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LE"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"LESS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GREATER"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"GE"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 79,
+        },
+        GrammarRule {
+            name: r#"additive"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"PLUS"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"multiplicative"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 81,
+        },
+        GrammarRule {
+            name: r#"multiplicative"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::TokenReference { name: r#"TIMES"#.to_string() },
+                                GrammarElement::TokenReference { name: r#"SLASH"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 82,
+        },
+        GrammarRule {
+            name: r#"unary"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::TokenReference { name: r#"MINUS"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                ] },
+                GrammarElement::RuleReference { name: r#"power"#.to_string() },
+            ] },
+            line_number: 88,
+        },
+        GrammarRule {
+            name: r#"power"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"postfix"#.to_string() },
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"POWER"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"unary"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 94,
+        },
+        GrammarRule {
+            name: r#"postfix"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"atom"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                        GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"arglist"#.to_string() }) },
+                        GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 101,
+        },
+        GrammarRule {
+            name: r#"arglist"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 103,
+        },
+        GrammarRule {
+            name: r#"atom"#.to_string(),
+            body: GrammarElement::Alternation { choices: vec![
+                GrammarElement::TokenReference { name: r#"NUMBER"#.to_string() },
+                GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                GrammarElement::RuleReference { name: r#"vector"#.to_string() },
+                GrammarElement::RuleReference { name: r#"group"#.to_string() },
+            ] },
+            line_number: 105,
+        },
+        GrammarRule {
+            name: r#"vector"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LBRACKET"#.to_string() },
+                GrammarElement::RuleReference { name: r#"row"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"SEMI"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"row"#.to_string() },
+                    ] }) },
+                GrammarElement::TokenReference { name: r#"RBRACKET"#.to_string() },
+            ] },
+            line_number: 117,
+        },
+        GrammarRule {
+            name: r#"row"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::TokenReference { name: r#"COMMA"#.to_string() },
+                        GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 118,
+        },
+        GrammarRule {
+            name: r#"group"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::TokenReference { name: r#"LPAREN"#.to_string() },
+                GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                GrammarElement::TokenReference { name: r#"RPAREN"#.to_string() },
+            ] },
+            line_number: 120,
+        },
+    ],
+        version: 1,
+    }
+}

--- a/code/packages/rust/derive-parser/src/lib.rs
+++ b/code/packages/rust/derive-parser/src/lib.rs
@@ -1,0 +1,280 @@
+//! # Derive Parser — building a syntax tree for Derive (a subset).
+//!
+//! Turns the token stream from [`coding_adventures_derive_lexer`] into a
+//! parse tree using the generic
+//! [`GrammarParser`](parser::grammar_parser::GrammarParser), driven by the
+//! embedded `derive.grammar` (`src/_grammar.rs`). It hand-writes no parsing
+//! logic. A sibling of `wolfram-parser` / `macsyma-parser`. See
+//! `code/specs/MA07-derive-language.md`.
+//!
+//! ## What the tree captures
+//!
+//! Every Derive expression parses down to ordinary infix/postfix operators
+//! over `head(args)`-shaped calls; this parser produces the surface tree
+//! whose rule names (`assignment`, `logical_or`, `comparison`, `additive`,
+//! `multiplicative`, `power`, `postfix`, `atom`, `vector`, …) a future
+//! `derive-runtime` (D-4) will lower into the canonical `symbolic-ir` heads
+//! (`Plus`/`Times`/`Power`/`Assign`/`Define`/`List`/…).
+//!
+//! ```text
+//! Derive source
+//!    |
+//!    v
+//! coding_adventures_derive_lexer::tokenize_derive  ->  Vec<Token>
+//!    |
+//!    v
+//! parser::GrammarParser  (driven by the embedded derive.grammar)
+//!    |
+//!    v
+//! GrammarASTNode  <- the tree D-4 lowers to symbolic-ir
+//! ```
+
+use coding_adventures_derive_lexer::{tokenize_derive, try_tokenize_derive};
+use parser::grammar_parser::{GrammarASTNode, GrammarParser};
+mod _grammar;
+
+/// Recursion-depth cap for the Derive [`GrammarParser`] — see
+/// [`GrammarParser::with_max_depth`] and
+/// [`parser::grammar_parser::DEFAULT_MAX_RULE_DEPTH`] for why the underlying
+/// guard exists at all (deep `(((…)))` grouping/application nesting recurses
+/// once per `parse_rule` call and can overflow the *native* thread stack —
+/// an uncatchable process abort — before this crate's own `Result`-returning
+/// entry points ever get a chance to report anything).
+///
+/// # Why not the shared [`DEFAULT_MAX_RULE_DEPTH`] (128)
+///
+/// One layer of `(...)` grouping/application loops back through the entire
+/// precedence cascade — `expr -> assignment -> logical_or -> logical_and ->
+/// logical_not -> comparison -> additive -> multiplicative -> unary -> power
+/// -> postfix -> atom -> group -> expr` — 12 named-rule calls per
+/// source-nesting level, per [MA07 §3](../../../specs/MA07-derive-language.md).
+/// Measured directly (binary search, parsing `(((…1…)))` at increasing
+/// depth with an *uncapped* parser on a `std::thread::spawn` worker with the
+/// default ~2 MiB stack, in a **debug** build to match this crate's own
+/// `cargo test` conditions): cap 128 already trips well below a plausible
+/// real nesting depth for hand-written Derive expressions, the same "safe
+/// but over-rejecting" problem `macsyma-parser`/`r-parser`/`s-parser`/
+/// `nib-parser`/`oct-parser` found for their own grammars.
+///
+/// Measured native-stack floor (uncapped parser, parenthesised nesting,
+/// default-stack worker thread, debug build): parses safely up to **21
+/// levels**, crashes the process at **22**. In rule-frame terms (the cap
+/// bounds recursion directly, so re-measured against candidate
+/// `with_max_depth` values on the same 5000-level adversarial input): safe
+/// through 297, crashes at 298 — coincidentally the exact same rule-frame
+/// floor `r-parser` measured for its own, similarly-shaped precedence chain.
+///
+/// `MAX_RULE_DEPTH` is set to **200** — about 33% below that 297-rule-frame
+/// floor (comparable margin to `apl-parser`'s ~26.5%, `j-parser`'s ~30%, and
+/// `r-parser`/`s-parser`'s own ~33%/~46%). Measured real-input headroom at
+/// 200 (using the *capped* parser, so no crash risk at all): a
+/// parenthesised nesting parses cleanly up to 14 levels (15 trips the cap)
+/// — comfortably past anything a hand-written Derive expression needs, and
+/// independently confirmed not to crash a default-stack thread even
+/// thousands of levels past the cap (see this crate's tests).
+const MAX_RULE_DEPTH: usize = 200;
+
+/// Create a [`GrammarParser`] wired to the Derive grammar and the tokens of
+/// `source`, with the recursion-depth guard ([`MAX_RULE_DEPTH`]) enabled so
+/// pathologically deep nesting fails cleanly instead of overflowing the
+/// native stack.
+pub fn create_derive_parser(source: &str) -> GrammarParser {
+    let tokens = tokenize_derive(source);
+    GrammarParser::new(tokens, _grammar::parser_grammar()).with_max_depth(MAX_RULE_DEPTH)
+}
+
+/// Parse Derive source text into a [`GrammarASTNode`] rooted at `program`.
+///
+/// # Panics
+///
+/// Panics on a lexical or syntax error. Use [`try_parse_derive`] to handle
+/// errors.
+///
+/// # Example
+///
+/// ```
+/// use coding_adventures_derive_parser::parse_derive;
+/// let ast = parse_derive("DIF(SIN(x), x)\n");
+/// assert_eq!(ast.rule_name, "program");
+/// ```
+pub fn parse_derive(source: &str) -> GrammarASTNode {
+    create_derive_parser(source)
+        .parse()
+        .unwrap_or_else(|e| panic!("Derive parse failed: {e}"))
+}
+
+/// Parse Derive source text, returning a `Result` instead of panicking.
+pub fn try_parse_derive(source: &str) -> Result<GrammarASTNode, String> {
+    let tokens = try_tokenize_derive(source)?;
+    GrammarParser::new(tokens, _grammar::parser_grammar())
+        .with_max_depth(MAX_RULE_DEPTH)
+        .parse()
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parser::grammar_parser::ASTNodeOrToken;
+
+    fn contains_rule(node: &GrammarASTNode, name: &str) -> bool {
+        node.rule_name == name
+            || node.children.iter().any(|c| match c {
+                ASTNodeOrToken::Node(n) => contains_rule(n, name),
+                ASTNodeOrToken::Token(_) => false,
+            })
+    }
+
+    fn parses(src: &str) -> bool {
+        try_parse_derive(src).is_ok()
+    }
+
+    #[test]
+    fn program_is_the_root() {
+        assert_eq!(parse_derive("1\n").rule_name, "program");
+    }
+
+    #[test]
+    fn function_application_uses_ordinary_parens() {
+        let ast = parse_derive("DIF(u, x)\n");
+        assert!(contains_rule(&ast, "postfix"));
+        assert!(contains_rule(&ast, "arglist"));
+    }
+
+    #[test]
+    fn assign_shared_by_variable_and_function_definition() {
+        assert!(parses("x := 5\n"));
+        let ast = parse_derive("F(x) := x^2 + 1\n");
+        assert!(contains_rule(&ast, "assignment"));
+    }
+
+    #[test]
+    fn eq_is_equation_distinct_from_assign() {
+        assert!(parses("x = 4\n"));
+        assert!(contains_rule(&parse_derive("x = 4\n"), "comparison"));
+    }
+
+    #[test]
+    fn vector_and_matrix_literals_parse() {
+        assert!(parses("[a, b, c]\n"));
+        assert!(parses("[a, b; c, d]\n"));
+        assert!(contains_rule(&parse_derive("[a, b, c]\n"), "vector"));
+    }
+
+    #[test]
+    fn boolean_keywords_parse() {
+        assert!(parses("a AND b OR NOT c\n"));
+        assert!(contains_rule(&parse_derive("a AND b\n"), "logical_and"));
+        assert!(contains_rule(&parse_derive("a OR b\n"), "logical_or"));
+        assert!(contains_rule(&parse_derive("NOT a\n"), "logical_not"));
+    }
+
+    #[test]
+    fn arithmetic_precedence() {
+        let ast = parse_derive("2 + 3 * 4 ^ 2\n");
+        assert!(contains_rule(&ast, "additive"));
+        assert!(contains_rule(&ast, "multiplicative"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn unary_minus_binds_looser_than_power() {
+        // -x^2 must parse as -(x^2): `unary` wraps `power`, not the reverse.
+        let ast = parse_derive("-x^2\n");
+        assert!(contains_rule(&ast, "unary"));
+        assert!(contains_rule(&ast, "power"));
+    }
+
+    #[test]
+    fn power_is_right_associative_by_shape() {
+        // 4^3^2 parses without error; right-associativity is exercised by
+        // the recursive-descent shape (power's RHS is `unary`, which falls
+        // back to `power`), mirroring wolfram-parser's identical contract.
+        assert!(parses("4^3^2\n"));
+    }
+
+    #[test]
+    fn grouping_parens_parse() {
+        assert!(parses("(1 + 2) * 3\n"));
+        assert!(contains_rule(&parse_derive("(1 + 2) * 3\n"), "group"));
+    }
+
+    #[test]
+    fn nested_function_calls_parse() {
+        assert!(parses("SIN(COS(x))\n"));
+    }
+
+    #[test]
+    fn multi_arg_builtin_calls_parse() {
+        assert!(parses("INT(u, x, a, b)\n"));
+        assert!(parses("SUM(expr, var, start, end)\n"));
+    }
+
+    #[test]
+    fn syntax_error_is_reported() {
+        assert!(try_parse_derive("1 +\n").is_err());
+        assert!(try_parse_derive("(1 + 2\n").is_err());
+    }
+
+    fn nested_paren_source(n: usize) -> String {
+        "(".repeat(n) + "1" + &")".repeat(n) + "\n"
+    }
+
+    /// Deeply-nested input must produce a recoverable error, not overflow
+    /// the native stack. We parse 5000 levels — far past `MAX_RULE_DEPTH` —
+    /// on a worker thread with a generous 32 MiB stack, so the *guard* is
+    /// what stops the recursion, not the stack running out.
+    #[test]
+    fn test_deeply_nested_input_returns_error_not_overflow() {
+        let handle = std::thread::Builder::new()
+            .name("derive-parser-depth-guard-regression".to_string())
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let result = try_parse_derive(&nested_paren_source(5000));
+                assert!(
+                    result.is_err(),
+                    "deeply-nested input must fail with an error, not parse or crash"
+                );
+            })
+            .expect("failed to spawn worker thread");
+        handle
+            .join()
+            .expect("depth guard must keep the worker thread from crashing");
+    }
+
+    /// Input that nests *exactly up to* `MAX_RULE_DEPTH` still parses
+    /// cleanly, and one layer deeper cleanly trips the guard. These exact
+    /// boundary counts (14 legitimate levels) were found empirically by
+    /// binary-searching against increasing nesting counts at the production
+    /// cap — see `MAX_RULE_DEPTH`'s doc comment.
+    #[test]
+    fn test_nesting_up_to_cap_still_parses() {
+        assert!(
+            try_parse_derive(&nested_paren_source(14)).is_ok(),
+            "14 levels must stay under the cap"
+        );
+        assert!(
+            try_parse_derive(&nested_paren_source(15)).is_err(),
+            "one nesting level past the cap's measured limit must fail"
+        );
+    }
+
+    /// A caller relying on `MAX_RULE_DEPTH` must have the guard trip
+    /// *before* the native stack overflows on a default-stack thread —
+    /// otherwise a production caller (or `cargo test`'s own per-test
+    /// thread) would still crash. We parse far-too-deep input on a worker
+    /// thread with **no** `stack_size` override (the same ~2 MiB a default
+    /// thread gets). A clean `Err` (not a `join()` failure from a crashed
+    /// thread) proves `MAX_RULE_DEPTH` sits safely below the native
+    /// overflow point on the default stack.
+    #[test]
+    fn test_opt_in_cap_trips_before_overflow_on_default_stack() {
+        let handle = std::thread::spawn(|| {
+            let result = try_parse_derive(&nested_paren_source(5000));
+            assert!(result.is_err(), "deeply-nested input must error, not crash");
+        });
+        handle
+            .join()
+            .expect("MAX_RULE_DEPTH must trip BEFORE native overflow on the default stack");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `derive.grammar` (grammar-tools parser grammar, compiled ahead of time into the committed `derive-parser/src/_grammar.rs`) and the `derive-parser` crate — D-3 of the Derive frontend per [MA07-derive-language.md](code/specs/MA07-derive-language.md)'s §2 item breakdown (D-2, the tokens+lexer, merged in #8195).
- Implements MA07 §3's precedence cascade over the generic `parser::GrammarParser`: assignment (`:=`, right-associative, shared by both variable assignment and function definition — the grammar doesn't distinguish `x := 5` from `F(x) := x^2 + 1`, since the LHS just reduces down through the same cascade either way; a future D-4 lowering tells them apart by inspecting the parsed shape) → `OR` → `AND` → `NOT` → comparison (`= <= < > >=`) → additive → multiplicative → unary minus → power (`^`, right-associative) → postfix application `F(...)` (ordinary parentheses, Derive's defining syntactic difference from Wolfram's `f[x]`) → atoms, plus vector/matrix literals (`[a,b,c]` / `[a,b,c;d,e,f]`, `;` as the row separator).
- A bespoke `MAX_RULE_DEPTH = 200` was empirically measured the same way `r-parser`/`s-parser`/`macsyma-parser`/`nib-parser`/`oct-parser` measured their own values, per MA06 §6's precedent (the shared crate's generic `DEFAULT_MAX_RULE_DEPTH` of 128 was not assumed safe, and this crate's own native-stack floor was measured independently): safe to 21 real nesting levels, crashes at 22 (297/298 rule-frame terms — the exact same floor `r-parser` measured for its own similarly-shaped cascade).

## Test plan

- [x] 16 functional tests covering every construct in the D-1 surface grammar: function application, the shared `:=` token across both assignment forms, `=`-vs-`:=` disambiguation, vector/matrix literals, boolean keywords, arithmetic precedence/associativity, grouping, nested/multi-arg builtin calls, syntax-error rejection.
- [x] 3 depth-guard regression tests mirroring the sibling crates' own methodology: deep adversarial input on an enlarged-stack thread returns a clean error, input at the measured real-nesting boundary still parses one level past it doesn't, and the cap trips before the native stack would overflow even on a default-stack thread.
- [x] `cargo test -p coding-adventures-derive-parser` (16 tests + 1 doctest) all pass.
- [x] `cargo clippy --all-targets` clean.
- [x] `derive.grammar` validated via `grammar_tools::validate_parser_grammar` + `cross_validate` (zero issues against `derive.tokens`) before compiling to `_grammar.rs`.
- [x] Go build-tool BUILD-file validation passes for the new package.
- [x] `/security-review` passed clean — confirmed every `GrammarParser` construction site is capped (no bypass), the test-only thread-based depth-guard idiom matches established sibling-crate convention, and no grammar production admits unbounded non-recursive resource consumption independent of the recursion-depth guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)