### PR TITLE
feat(sql): NULLS FIRST / NULLS LAST in ORDER BY

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.24 — `NULLS FIRST` / `NULLS LAST` in `ORDER BY`
+
+`SELECT … ORDER BY a NULLS FIRST` / `NULLS LAST` now parse and run. mini-sqlite
+already reproduced SQLite's *default* null ordering (NULLs first for ASC, last
+for DESC) for free — this adds the explicit clause, whose value matters most for
+the OVERRIDE cases (`ASC NULLS LAST`, `DESC NULLS FIRST`). Spans grammar
+(sql-parser 0.1.8) → `SortKey.nulls_first` (sql-planner 0.2.7) →
+`CompiledSortKey` (sql-codegen 0.6.2) → the VM sort comparator (sql-vm 0.4.13),
+with the optimizer (0.1.2) carrying the field. FIRST/LAST stay non-reserved
+(validated in the planner). Three differential-oracle cases
+(`order_by_nulls_last`, `order_by_desc_nulls_first`,
+`order_by_nulls_first_default`) diff row order against real bundled SQLite.
+COLLATE in ORDER BY (a comparator transform) remains a separate follow-up.
+
 ## 0.5.23 — `CAST(expr AS type)` — INTEGER / REAL / TEXT
 
 `SELECT CAST(x AS INTEGER)` and friends now parse and run, following SQLite's

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.23"
+version = "0.5.24"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -843,6 +843,36 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT CAST(n AS VARCHAR) AS tv, CAST('9x' AS INT) AS iv FROM t ORDER BY id",
     },
+    // `NULLS LAST` on an ASC sort OVERRIDES SQLite's default (which puts NULLs
+    // first for ASC), so the NULLs move to the end. This case is order-sensitive
+    // (the query has ORDER BY), so the oracle compares row order exactly.
+    Case {
+        id: "order_by_nulls_last",
+        setup: &[
+            "CREATE TABLE t (a INTEGER)",
+            "INSERT INTO t VALUES (2), (NULL), (1), (NULL), (3)",
+        ],
+        query: "SELECT a FROM t ORDER BY a ASC NULLS LAST",
+    },
+    // `NULLS FIRST` on a DESC sort OVERRIDES the default (NULLs last for DESC).
+    Case {
+        id: "order_by_desc_nulls_first",
+        setup: &[
+            "CREATE TABLE t (a INTEGER)",
+            "INSERT INTO t VALUES (2), (NULL), (1), (NULL), (3)",
+        ],
+        query: "SELECT a FROM t ORDER BY a DESC NULLS FIRST",
+    },
+    // The explicit clause matching the default (`ASC NULLS FIRST`) must be a
+    // no-op — same result as a bare `ORDER BY a`.
+    Case {
+        id: "order_by_nulls_first_default",
+        setup: &[
+            "CREATE TABLE t (a INTEGER)",
+            "INSERT INTO t VALUES (2), (NULL), (1), (3)",
+        ],
+        query: "SELECT a FROM t ORDER BY a NULLS FIRST",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.2] - Unreleased
+
+### Added
+
+- **`CompiledSortKey.nulls_first: Option<bool>`**, copied from the planner's
+  `SortKey`, so the VM sort comparator can honour `NULLS FIRST`/`NULLS LAST`.
+
 ## [0.6.1] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -194,6 +194,9 @@ pub struct CompiledSortKey {
     pub column: String,
     /// `true` = ascending (ASC), `false` = descending (DESC).
     pub ascending: bool,
+    /// Explicit NULL placement from `NULLS FIRST` / `NULLS LAST`. `None` = the
+    /// SQLite default (NULLs first for ASC, last for DESC).
+    pub nulls_first: Option<bool>,
 }
 
 /// The complete bytecode instruction set for the Mini-SQLite VM.
@@ -2129,6 +2132,7 @@ fn peel_post_ops(plan: &OptimizedPlan) -> (&OptimizedPlan, Vec<Instruction>) {
                             _ => "?".to_string(),
                         },
                         ascending: k.ascending,
+                        nulls_first: k.nulls_first,
                     })
                     .collect();
                 post_ops.push(Instruction::SortResult(compiled_keys));
@@ -2700,6 +2704,7 @@ mod tests {
             keys: vec![SortKey {
                 expr: col("name"),
                 ascending: true,
+                nulls_first: None,
             }],
         });
         let v = instrs(&plan);
@@ -2718,6 +2723,7 @@ mod tests {
             keys: vec![SortKey {
                 expr: col("score"),
                 ascending: true,
+                nulls_first: None,
             }],
         });
         let v = instrs(&plan);
@@ -2737,6 +2743,7 @@ mod tests {
             keys: vec![SortKey {
                 expr: col("score"),
                 ascending: false,
+                nulls_first: None,
             }],
         });
         let v = instrs(&plan);
@@ -2757,10 +2764,12 @@ mod tests {
                 SortKey {
                     expr: col("a"),
                     ascending: true,
+                    nulls_first: None,
                 },
                 SortKey {
                     expr: col("b"),
                     ascending: false,
+                    nulls_first: None,
                 },
             ],
         });
@@ -3535,6 +3544,7 @@ mod tests {
             keys: vec![SortKey {
                 expr: col("x"),
                 ascending: true,
+                nulls_first: None,
             }],
         });
         let v = instrs(&plan);

--- a/code/packages/rust/sql-optimizer/CHANGELOG.md
+++ b/code/packages/rust/sql-optimizer/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.1.2] - Unreleased
+
+### Changed
+
+- Carry the new `SortKey.nulls_first` field through constant-folding of `Sort`
+  plan nodes.
+
 ## [0.1.1] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-optimizer/Cargo.toml
+++ b/code/packages/rust/sql-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-optimizer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Logical query plan optimizer for the Mini-SQLite SQL pipeline (Level 1)"
 authors = ["Adhithya Rajasekaran <adhithyan15@gmail.com>"]

--- a/code/packages/rust/sql-optimizer/src/lib.rs
+++ b/code/packages/rust/sql-optimizer/src/lib.rs
@@ -534,6 +534,7 @@ fn fold_plan(plan: OptimizedPlan) -> OptimizedPlan {
                 .map(|k| SortKey {
                     expr: fold_expr(k.expr),
                     ascending: k.ascending,
+                    nulls_first: k.nulls_first,
                 })
                 .collect(),
         },
@@ -1787,6 +1788,7 @@ mod tests {
             keys: vec![SortKey {
                 expr: col(col_name),
                 ascending: true,
+                nulls_first: None,
             }],
         }
     }
@@ -2422,6 +2424,7 @@ mod tests {
             keys: vec![SortKey {
                 expr: col("id"),
                 ascending: true,
+                nulls_first: None,
             }],
         };
         let opt = optimize_with_passes(plan, &[&DeadCodeEliminationPass]);
@@ -2599,6 +2602,7 @@ mod tests {
                 keys: vec![SortKey {
                     expr: col("name"),
                     ascending: true,
+                    nulls_first: None,
                 }],
             }),
             count: Some(10),

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.8] - Unreleased
+
+### Added
+
+- **`NULLS FIRST` / `NULLS LAST` in `ORDER BY`.** `order_item` now accepts an
+  optional `NULLS <name>` clause after the ASC/DESC direction. `FIRST`/`LAST`
+  are NOT reserved keywords (they are common column names), so a generic NAME is
+  accepted and the planner (sql-planner 0.2.7) validates it. Omitting the clause
+  keeps SQLite's default (NULLs first for ASC, last for DESC).
+
 ## [0.1.7] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -203,6 +203,15 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Literal { value: r#"ASC"#.to_string() },
                         GrammarElement::Literal { value: r#"DESC"#.to_string() },
                     ] }) },
+                // Optional `NULLS FIRST` / `NULLS LAST`. FIRST/LAST are NOT
+                // reserved keywords (they are extremely common column names), so
+                // we accept a generic NAME here; the planner validates it is
+                // literally FIRST or LAST. Omitting the clause falls back to
+                // SQLite's defaults (NULLs first for ASC, last for DESC).
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"NULLS"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
             ] },
             line_number: 36,
         },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -266,6 +266,21 @@ mod tests {
         assert!(find_rule(&ast, "order_clause"), "Expected order_clause");
     }
 
+    /// `NULLS FIRST` / `NULLS LAST` parse in ORDER BY, alone and combined with
+    /// ASC/DESC. FIRST/LAST are ordinary NAMEs (the planner validates them).
+    #[test]
+    fn test_parse_order_by_nulls() {
+        for q in [
+            "SELECT id FROM t ORDER BY a NULLS FIRST",
+            "SELECT id FROM t ORDER BY a NULLS LAST",
+            "SELECT id FROM t ORDER BY a ASC NULLS LAST",
+            "SELECT id FROM t ORDER BY a DESC NULLS FIRST",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "order_item"), "Expected order_item for {q:?}");
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 5: SELECT with LIMIT and OFFSET
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.7] - Unreleased
+
+### Added
+
+- **`SortKey.nulls_first: Option<bool>`** — explicit NULL placement from a
+  `NULLS FIRST`/`NULLS LAST` clause (`None` = SQLite default = NULLs first for
+  ASC, last for DESC). `plan_order_item` parses the clause and rejects anything
+  other than FIRST/LAST after `NULLS`. Threaded to codegen + the VM comparator.
+
 ## [0.2.6] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -398,6 +398,10 @@ pub struct SortKey {
     pub expr: SqlExpr,
     /// `ascending = true` for ASC (default), `false` for DESC.
     pub ascending: bool,
+    /// Explicit NULL placement from a `NULLS FIRST` / `NULLS LAST` clause.
+    /// `None` = SQLite's default (NULLs sort first for ASC, last for DESC);
+    /// `Some(true)` = NULLs first; `Some(false)` = NULLs last.
+    pub nulls_first: Option<bool>,
 }
 
 /// An aggregate item inside an `Aggregate` plan node.
@@ -954,7 +958,42 @@ fn plan_order_item(item: &GrammarASTNode) -> Result<SortKey, PlanError> {
     // ASC is the default; DESC reverses.
     let ascending = !has_token(item, "DESC");
 
-    Ok(SortKey { expr, ascending })
+    // Optional `NULLS FIRST` / `NULLS LAST`. FIRST/LAST are NOT reserved
+    // keywords (they are common column names), so the grammar accepts a generic
+    // NAME after `NULLS` and we validate it here. Anything other than
+    // FIRST/LAST is a syntax error, matching SQLite.
+    let nulls_first = {
+        let children = &item.children;
+        let mut placement = None;
+        for (i, c) in children.iter().enumerate() {
+            if is_keyword_token(c, "NULLS") {
+                match children.get(i + 1) {
+                    Some(tok) => {
+                        let w = token_text_of(tok).to_uppercase();
+                        placement = Some(match w.as_str() {
+                            "FIRST" => Ok(true),
+                            "LAST" => Ok(false),
+                            other => Err(PlanError::UnsupportedStatement(format!(
+                                "expected FIRST or LAST after NULLS, got {other:?}"
+                            ))),
+                        });
+                    }
+                    None => {
+                        placement = Some(Err(PlanError::UnsupportedStatement(
+                            "NULLS clause missing FIRST/LAST".to_string(),
+                        )))
+                    }
+                }
+            }
+        }
+        placement.transpose()?
+    };
+
+    Ok(SortKey {
+        expr,
+        ascending,
+        nulls_first,
+    })
 }
 
 /// Parse the `limit_clause` and return `(count, offset)`.

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.13] - Unreleased
+
+### Added
+
+- **`NULLS FIRST`/`NULLS LAST` in the sort comparator.** `apply_sort` now places
+  NULLs explicitly per the sort key's `nulls_first` (defaulting to `ascending`,
+  which reproduces SQLite's default of NULLs-first-for-ASC / last-for-DESC).
+  NULL placement is absolute and is not flipped by the ASC/DESC reversal, so an
+  override like `ASC NULLS LAST` works.
+
 ## [0.4.12] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -2775,6 +2775,28 @@ fn apply_sort(
             let idx = output_columns.iter().position(|c| c == &key.column);
             let va = idx.and_then(|i| a.get(i)).map(|(_, v)| v).unwrap_or(&SqlValue::Null);
             let vb = idx.and_then(|i| b.get(i)).map(|(_, v)| v).unwrap_or(&SqlValue::Null);
+
+            // NULL placement is handled explicitly so it can be controlled by a
+            // `NULLS FIRST`/`NULLS LAST` clause independently of ASC/DESC. The
+            // default (no clause) is SQLite's: NULLs first for ASC, last for
+            // DESC — i.e. `nulls_first` defaults to `ascending`. Null placement
+            // is absolute and is NOT flipped by the ascending/descending
+            // reversal below (which only applies to non-NULL comparisons).
+            let a_null = matches!(va, SqlValue::Null);
+            let b_null = matches!(vb, SqlValue::Null);
+            if a_null || b_null {
+                if a_null && b_null {
+                    continue; // equal on this key; fall through to the next
+                }
+                let nulls_first = key.nulls_first.unwrap_or(key.ascending);
+                // The NULL operand sorts first iff `nulls_first`.
+                return if a_null == nulls_first {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Greater
+                };
+            }
+
             let cmp = sql_cmp(va, vb);
             if cmp != std::cmp::Ordering::Equal {
                 return if key.ascending { cmp } else { cmp.reverse() };
@@ -3722,7 +3744,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None }]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
     }
@@ -3745,7 +3767,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: false }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: false, nulls_first: None }]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(3)], vec![int(2)], vec![int(1)]]);
     }
@@ -3776,8 +3798,8 @@ mod tests {
             Instruction::CloseScan(None),
             Instruction::Halt,
             Instruction::SortResult(vec![
-                CompiledSortKey { column: "a".to_string(), ascending: true },
-                CompiledSortKey { column: "b".to_string(), ascending: true },
+                CompiledSortKey { column: "a".to_string(), ascending: true, nulls_first: None },
+                CompiledSortKey { column: "b".to_string(), ascending: true, nulls_first: None },
             ]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows[0], vec![int(1), int(1)]);
@@ -4282,7 +4304,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None }]),
             Instruction::LimitResult(Some(3), None),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
@@ -4309,7 +4331,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None }]),
             Instruction::DistinctResult,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);


### PR DESCRIPTION
## `NULLS FIRST` / `NULLS LAST` in `ORDER BY`

`SELECT … ORDER BY a NULLS FIRST` / `NULLS LAST` now parse and run. mini-sqlite
already reproduced SQLite's **default** null ordering (NULLs first for ASC, last
for DESC) for free — `sql_cmp` treats NULL as smallest and the ASC/DESC flip
does the rest. This adds the **explicit clause**, whose value matters most for
the **override** cases (`ASC NULLS LAST`, `DESC NULLS FIRST`).

### What changed (rotation lane 3)
- **sql-parser** (`_grammar.rs`): `order_item` accepts an optional `NULLS NAME`
  after the ASC/DESC direction. `FIRST`/`LAST` are **not reserved** (they're
  common column names) — the planner validates the NAME.
- **sql-planner**: `SortKey` gains `nulls_first: Option<bool>` (`None` = SQLite
  default). `plan_order_item` parses `NULLS` and rejects any non-FIRST/LAST name.
- **sql-codegen**: `CompiledSortKey` gains `nulls_first`; `peel_post_ops` copies it.
- **sql-vm** (`apply_sort`): NULL placement is now explicit — the NULL operand
  sorts first iff `key.nulls_first.unwrap_or(key.ascending)`. Placement is
  **absolute** (not flipped by the ASC/DESC reversal, which only applies to
  non-NULL comparisons), so overrides work. Default behaviour is byte-identical.
- **sql-optimizer**: carries the field through `Sort` constant-folding.

### Verification (probe → test-first)
Probed against real SQLite first — `ASC NULLS LAST`→[1,2,3,N,N], `DESC NULLS
FIRST`→[N,N,3,2,1], `NULLS FIRST` (ASC default)→[N,N,1,2,3], `DESC NULLS
LAST`→[3,2,1,N,N] — all match.
- **Differential oracle** (mini-sqlite): `order_by_nulls_last`,
  `order_by_desc_nulls_first`, `order_by_nulls_first_default` — order-sensitive,
  diffed against real bundled SQLite.
- **sql-parser**: `test_parse_order_by_nulls` (4 spellings parse).
- Full affected SQL pipeline green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — the rewritten `sort_by`
  comparator is a valid strict weak ordering (no `sort_by` panic risk):
  `nulls_first` is a per-key constant so one-NULL comparisons are antisymmetric,
  both-NULL is symmetric, NULLs partition consistently; planner is panic-free
  (`.get(i+1)` Option, `.transpose()?`); grammar has no DoS.

### Versions
sql-parser 0.1.7→0.1.8 · sql-planner 0.2.6→0.2.7 · sql-codegen 0.6.1→0.6.2 ·
sql-vm 0.4.12→0.4.13 · sql-optimizer 0.1.1→0.1.2 · mini-sqlite 0.5.23→0.5.24.

### Follow-up
`COLLATE` in `ORDER BY` (a comparator transform — NOCASE/BINARY/RTRIM) is a
separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
