### PR TITLE
feat(semantic-ir-to-javascript): SIR23 symbolic-expression + pattern/rewrite codegen (HML01 Stream B, item 7 JS half)

### DIFF
--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 0.35.0 — SIR23 symbolic-expression + pattern/rewrite codegen (HML01 Stream B, item 7 JS half)
+
+Real codegen for the SIR23 symbolic/pattern domain, replacing the deferred
+`panic!` placeholder these seven `Expr` nodes had (`SymSymbol`, `SymRational`,
+`SymApply`, `SymPatternBlank`, `SymPatternNamed`, `SymRule`,
+`SymReplaceAll`). Mirrors the TypeScript backend's SIR23 codegen (already
+shipped) exactly at the `emit.rs` call-site shape, but targets an *inlined*
+runtime rather than an imported npm package — the same "port it inline so the
+JavaScript artifact stays self-contained" treatment the exception runtime
+(`sir-runtime-exceptions`) already got.
+
+- `runtime.rs` gains `__Sir.Symbolic`, a plain-JS port of the published
+  `@coding-adventures/symbolic-ir` (term-tree type + constructors),
+  `@coding-adventures/cas-pattern-matching` (the five-case structural
+  matcher/substitution algorithm), and `@coding-adventures/sir-runtime-symbolic`
+  (`replaceAll`/`replaceRepeated`/`unwrap`) TypeScript packages. Deliberate
+  divergence from the TS packages: terms use plain JS `number` for
+  `integer`/`rational` values rather than `bigint`, matching how every other
+  numeric value in this backend already works (`IntLit` emits a bare JS number
+  literal) — there is no `bigint` anywhere else in this runtime.
+  `replaceRepeated` carries forward the TS package's own
+  `/security-review`-found fix: a rule firing loops at the *same* call frame
+  (not a recursive call), so a caller-supplied `maxIterations` bounds CPU time
+  only, never native stack depth. `MAX_TERM_DEPTH = 512` caps the tree walk
+  itself against unbounded runtime data (CWE-674).
+- `emit.rs`: all seven `Expr::Sym*` arms now emit real `__Sir.Symbolic.*` calls
+  instead of panicking; `emit_sym_operand` wraps a bare `IntLit`/`FloatLit`/
+  `StrLit` operand through the matching leaf-term constructor before it can
+  sit inside a term tree.
+- `lib.rs`: `Feature::SymbolicExpr`, `Feature::PatternMatching`, and
+  `Feature::Rationals` (shared with the still-deferred SIR22 array/matrix
+  domain) join `ACCEPTED_FEATURES`.
+- `formatSeen` (the `print`/`puts` display path) now recognizes a Symbolic
+  term (a plain object carrying a `.kind` tag) and renders it via a new
+  `Symbolic.toDisplayString` — so `print`ing a `SymReplaceAll` result reads as
+  `f(x, 1/3)` rather than `[object Object]`.
+- New `tests/sir23_symbolic.rs`: three real `node`-execution tests (not just
+  string-shape assertions) proving the ported algorithm is actually correct —
+  `replaceRepeated` reduces `Add(Add(z, 0), 0)` to the bare symbol `z` via
+  `x_ + 0 -> x_`, `replaceAll`'s single-pass contract, and a head-typed blank
+  (`x_Integer`) matching selectively. `lib.rs` gains the TypeScript backend's
+  own shape-assertion test suite (leaf constructors, literal wrapping,
+  blank/blankTyped, the non-`SymSymbol`-head panic guard, `rule` vs.
+  `ruleDelayed`, and `replaceAll`/`replaceRepeated` both routing through
+  `unwrap`), plus an end-to-end `wolfram-to-semantic-ir` compile test (new dev
+  dependency).
+
 ## 0.34.0 — Array `cycle(n)`
 
 Mirrors the Python reference (PR #8117), Go (PR #8123), and Rust (PR #8131) into

--- a/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
+++ b/code/packages/rust/semantic-ir-to-javascript/CHANGELOG.md
@@ -36,16 +36,30 @@ JavaScript artifact stays self-contained" treatment the exception runtime
   term (a plain object carrying a `.kind` tag) and renders it via a new
   `Symbolic.toDisplayString` — so `print`ing a `SymReplaceAll` result reads as
   `f(x, 1/3)` rather than `[object Object]`.
-- New `tests/sir23_symbolic.rs`: three real `node`-execution tests (not just
+- New `tests/sir23_symbolic.rs`: four real `node`-execution tests (not just
   string-shape assertions) proving the ported algorithm is actually correct —
   `replaceRepeated` reduces `Add(Add(z, 0), 0)` to the bare symbol `z` via
-  `x_ + 0 -> x_`, `replaceAll`'s single-pass contract, and a head-typed blank
-  (`x_Integer`) matching selectively. `lib.rs` gains the TypeScript backend's
-  own shape-assertion test suite (leaf constructors, literal wrapping,
-  blank/blankTyped, the non-`SymSymbol`-head panic guard, `rule` vs.
-  `ruleDelayed`, and `replaceAll`/`replaceRepeated` both routing through
-  `unwrap`), plus an end-to-end `wolfram-to-semantic-ir` compile test (new dev
-  dependency).
+  `x_ + 0 -> x_`, `replaceAll`'s single-pass contract, a head-typed blank
+  (`x_Integer`) matching selectively, and a DoS regression test (below).
+  `lib.rs` gains the TypeScript backend's own shape-assertion test suite
+  (leaf constructors, literal wrapping, blank/blankTyped, the
+  non-`SymSymbol`-head panic guard, `rule` vs. `ruleDelayed`, and
+  `replaceAll`/`replaceRepeated` both routing through `unwrap`), plus an
+  end-to-end `wolfram-to-semantic-ir` compile test (new dev dependency).
+- **Security fix (found by this PR's own `/security-review`, CWE-674):**
+  `Symbolic.toDisplayString` — reached from `print`/`puts` via the
+  `formatSeen` branch above — recursed over a term's *entire* tree with no
+  depth cap of its own; only `replaceAll`/`replaceRepeated`'s walk enforced
+  `MAX_TERM_DEPTH`. A term built via a small, ordinary compiled `for`-loop
+  (not a huge static AST — a handful of source-level nodes executed many
+  times at runtime) can grow arbitrarily deep, so `print`ing one could crash
+  the process with a raw `RangeError: Maximum call stack size exceeded`.
+  `toDisplayString` now threads a `depth` parameter and truncates to `"..."`
+  past `MAX_TERM_DEPTH`, matching how `formatSeen` already renders
+  `"[...]"`/`"{...}"` for an Array/Map cycle instead of crashing. New
+  regression test in `tests/sir23_symbolic.rs` builds depth via a real
+  `Stmt::ForRange` loop (2000 runtime firings of `Symbolic.apply`), proving
+  `node` now exits cleanly with a truncated result.
 
 ## 0.34.0 — Array `cycle(n)`
 

--- a/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
+++ b/code/packages/rust/semantic-ir-to-javascript/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semantic-ir-to-javascript"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 description = "Semantic IR → self-contained JavaScript source code (SIR18). Fifth backend for the SIR10 narrow-waist IR. Includes __method__ dispatch execution (C3), exception handling (try/catch/raise) with user-class ancestry (E1), user-defined-class OOP — instantiation, method dispatch, super, self, and @ivar/@@cvar access (O3) — and Ruby mixins (module include/extend with MRO method resolution, MX4)."
 
@@ -9,3 +9,4 @@ semantic-ir = { path = "../semantic-ir" }
 
 [dev-dependencies]
 twig-to-semantic-ir = { path = "../twig-to-semantic-ir" }
+wolfram-to-semantic-ir = { path = "../wolfram-to-semantic-ir" }

--- a/code/packages/rust/semantic-ir-to-javascript/README.md
+++ b/code/packages/rust/semantic-ir-to-javascript/README.md
@@ -89,6 +89,9 @@ lowering is direct.
 | `ClassVars` (O3)                |                                          |
 | `Modules` (MX4 mixins)          |                                          |
 | `Constants`                     |                                          |
+| `SymbolicExpr` (SIR23)          | `NDArrays` / `MatrixOps` (SIR22)         |
+| `PatternMatching` (SIR23)       |                                          |
+| `Rationals` (shared w/ SIR22)   |                                          |
 
 `accepts_intrinsics()` is empty. The accept-set is deliberately matched
 to what `emit` handles, so a module using a deferred node is turned away
@@ -337,6 +340,55 @@ are treated strictly as data. The mutable map is `Object.create(null)`
 (prototype-less), so a user class named `constructor`/`__proto__` cannot
 poison the lookup, and a cyclic user map terminates via a `seen` guard.
 
+### Symbolic expressions + pattern/rewrite (SIR23)
+
+The inlined `__Sir` also carries `Symbolic` — a plain-JS port of the
+published `@coding-adventures/symbolic-ir` (term-tree type + constructors),
+`@coding-adventures/cas-pattern-matching` (the structural matcher/
+substitution algorithm), and `@coding-adventures/sir-runtime-symbolic`
+(`replaceAll`/`replaceRepeated`/`unwrap`) TypeScript packages, so the
+artifact stays self-contained:
+
+| SIR                               | JavaScript emitted                              |
+|------------------------------------|-------------------------------------------------|
+| `SymSymbol("f")`                   | `__Sir.Symbolic.sym("f")`                       |
+| `SymRational(1, 3)`                 | `__Sir.Symbolic.rational(1, 3)`                 |
+| `SymApply(f, [x])`                  | `__Sir.Symbolic.apply(sym(f), [x])`             |
+| `SymPatternBlank(None)`             | `__Sir.Symbolic.blank()`                        |
+| `SymPatternBlank(Some(Integer))`    | `__Sir.Symbolic.blankTyped("Integer")`          |
+| `SymPatternNamed("x", pat)`         | `__Sir.Symbolic.named("x", pat)`                |
+| `SymRule(lhs, rhs, delayed: false)` | `__Sir.Symbolic.rule(lhs, rhs)`                 |
+| `SymRule(lhs, rhs, delayed: true)`  | `__Sir.Symbolic.ruleDelayed(lhs, rhs)`          |
+| `SymReplaceAll(e, r, repeated: false)` | `unwrap(replaceAll(e, r))`                   |
+| `SymReplaceAll(e, r, repeated: true)`  | `unwrap(replaceRepeated(e, r))`              |
+
+A term is a plain, frozen `{ kind, … }` object (`"symbol"` / `"integer"` /
+`"rational"` / `"float"` / `"string"` / `"apply"`) — never a class instance,
+so it never collides with `Sym`/`Pair`/`Closure`/`SirInstance` above. A bare
+`IntLit`/`FloatLit`/`StrLit` operand is wrapped through `int`/`numberNode`/
+`stringNode` (`emit_sym_operand`) before it can sit inside a term tree, since
+a raw JS number/string is never a valid term.
+
+**Deliberate divergence from the TypeScript sibling:** terms use plain JS
+`number` for `integer`/`rational` values rather than `bigint` — matching how
+every other numeric value in this backend already works (`IntLit` emits a
+bare JS number literal; there is no `bigint` anywhere else in this runtime).
+
+**Security.** `matchPattern`/`substitute`/`applyRule` recurse only as deep as
+a single rule's own (author-written) pattern/RHS shape, never the target
+expression's depth, so they need no cap. `replaceAll`/`replaceRepeated` walk
+the *entire* target expression, which ordinary program data can build
+unboundedly deep — `MAX_TERM_DEPTH = 512` caps that walk (CWE-674). A rule
+firing inside `replaceRepeated` loops at the *same* call frame rather than
+recursing on the fresh replacement, so a caller-supplied `maxIterations`
+(default 100) bounds only CPU time, never native stack depth — carrying
+forward the fix the TypeScript sibling package's own `/security-review`
+found.
+
+`print`/`puts` render a Symbolic term via `Symbolic.toDisplayString`
+(`f(x, 1/3)`-style), reached from `formatSeen` by checking for a plain
+object carrying a `.kind` tag.
+
 ## Output format
 
 - 2-space indentation, semicolons always (no ASI reliance).
@@ -386,3 +438,7 @@ cargo test -p semantic-ir-to-javascript
   counter, a for-range accumulator (and a descending step), for-each, and
   mutable reassignment (`42`). When `node` is not on PATH the execution is
   skipped and the syntactic checks still run.
+- `tests/sir23_symbolic.rs`: real `node`-execution tests for the SIR23
+  symbolic domain — `replaceRepeated` reduces `Add(Add(z, 0), 0)` to the bare
+  symbol `z` via `x_ + 0 -> x_`, `replaceAll`'s single-pass (no-retry)
+  contract, and a head-typed blank (`x_Integer`) matching selectively.

--- a/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/emit.rs
@@ -56,16 +56,28 @@
 //! StandardError` catches a `raise MyErr` when `class MyErr < StandardError`
 //! (E2's JS half); the class body's non-`def` statements are emitted inline.
 //!
+//! ## Symbolic expressions + pattern/rewrite (SIR23)
+//!
+//! A `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+//! `SymPatternNamed`/`SymRule`/`SymReplaceAll` node lowers to a call into
+//! `__Sir.Symbolic.*` — a plain-JS port of the published
+//! `sir-runtime-symbolic`/`symbolic-ir`/`cas-pattern-matching` TypeScript
+//! packages (see `runtime.rs`), so the artifact stays self-contained.
+//! `emit_sym_operand` wraps a bare `IntLit`/`FloatLit`/`StrLit` child
+//! through the matching leaf-term constructor before it can sit inside a
+//! term tree. Mirrors the TypeScript backend's SIR23 arms exactly, minus
+//! the `import`.
+//!
 //! ## Deferred nodes (still rejected at the capability check)
 //!
 //! String interpolation (`StrConcat`), the remaining SIR17 OOP scopes
 //! (`ModuleDef`, `SingletonClassDef` dispatch, the `Instance`/`ClassVar`
-//! scopes), and `Intrinsic` are **not emitted**.  Their `Feature`s are
-//! absent from the backend's `accepts_features()` list, so a module that
-//! uses them is rejected at the capability check *before* lowering — the
-//! `panic!` arms below are defence-in-depth that fire only on a backend bug
-//! (the accept-set drifting out of sync with what `emit` handles), never on
-//! user input.
+//! scopes), the SIR22 array/matrix domain, and `Intrinsic` are **not
+//! emitted**.  Their `Feature`s are absent from the backend's
+//! `accepts_features()` list, so a module that uses them is rejected at
+//! the capability check *before* lowering — the `panic!` arms below are
+//! defence-in-depth that fire only on a backend bug (the accept-set
+//! drifting out of sync with what `emit` handles), never on user input.
 
 use std::cell::Cell;
 use std::fmt::Write;
@@ -859,28 +871,117 @@ fn emit_expr(out: &mut String, e: &Expr, indent: usize) {
                 e.kind_name()
             );
         }
-        // ── SIR23: symbolic expression + pattern/rewrite nodes (deferred) ──
-        // Neither `Feature::SymbolicExpr` nor `Feature::PatternMatching` is
-        // in `ACCEPTED_FEATURES` (see lib.rs), so `check_module` rejects any
-        // module using these nodes before lowering reaches this emitter —
-        // per the SIR23 spec's "Backend impact": real codegen (a tagged
-        // term-tree value built/consumed via `sir-runtime-symbolic`'s
-        // `__SirSym.apply`/`replaceAll`/`replaceRepeated`) is a follow-up PR
-        // once that runtime package exists, not required for this spec to
-        // land safely. These panics only guard against the capability check
-        // ever drifting, exactly like the SIR22/SIR26 arm above.
-        Expr::SymSymbol { span, .. }
-        | Expr::SymRational { span, .. }
-        | Expr::SymApply { span, .. }
-        | Expr::SymPatternBlank { span, .. }
-        | Expr::SymPatternNamed { span, .. }
-        | Expr::SymRule { span, .. }
-        | Expr::SymReplaceAll { span, .. } => {
-            panic!(
-                "javascript backend reached a deferred SIR23 expression ({}) at {span} — not accepted yet",
-                e.kind_name()
-            );
+        // ── SIR23: symbolic expression + pattern/rewrite nodes ────────
+        // Mirrors the TypeScript backend's SIR23 arms exactly, but calls
+        // into the INLINED `__Sir.Symbolic.*` runtime (runtime.rs) rather
+        // than an imported `@coding-adventures/sir-runtime-symbolic`.
+        Expr::SymSymbol { name, .. } => {
+            out.push_str("__Sir.Symbolic.sym(");
+            out.push_str(&quote_js_string(name));
+            out.push(')');
         }
+        Expr::SymRational { numer, denom, .. } => {
+            let _ = write!(out, "__Sir.Symbolic.rational({numer}, {denom})");
+        }
+        Expr::SymApply { head, args, .. } => {
+            out.push_str("__Sir.Symbolic.apply(");
+            emit_sym_operand(out, head, indent);
+            out.push_str(", [");
+            for (i, a) in args.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_sym_operand(out, a, indent);
+            }
+            out.push_str("])");
+        }
+        Expr::SymPatternBlank { head: None, .. } => {
+            out.push_str("__Sir.Symbolic.blank()");
+        }
+        Expr::SymPatternBlank {
+            head: Some(head), ..
+        } => match head.as_ref() {
+            Expr::SymSymbol { name, .. } => {
+                out.push_str("__Sir.Symbolic.blankTyped(");
+                out.push_str(&quote_js_string(name));
+                out.push(')');
+            }
+            _ => panic!(
+                "javascript backend: SymPatternBlank's head-constraint must be a SymSymbol, got {} at {}",
+                head.kind_name(),
+                head.span()
+            ),
+        },
+        Expr::SymPatternNamed { name, pattern, .. } => {
+            out.push_str("__Sir.Symbolic.named(");
+            out.push_str(&quote_js_string(name));
+            out.push_str(", ");
+            emit_sym_operand(out, pattern, indent);
+            out.push(')');
+        }
+        Expr::SymRule {
+            lhs, rhs, delayed, ..
+        } => {
+            out.push_str(if *delayed {
+                "__Sir.Symbolic.ruleDelayed("
+            } else {
+                "__Sir.Symbolic.rule("
+            });
+            emit_sym_operand(out, lhs, indent);
+            out.push_str(", ");
+            emit_sym_operand(out, rhs, indent);
+            out.push(')');
+        }
+        Expr::SymReplaceAll {
+            expr,
+            rules,
+            repeated,
+            ..
+        } => {
+            out.push_str("__Sir.Symbolic.unwrap(");
+            out.push_str(if *repeated {
+                "__Sir.Symbolic.replaceRepeated("
+            } else {
+                "__Sir.Symbolic.replaceAll("
+            });
+            emit_sym_operand(out, expr, indent);
+            out.push_str(", [");
+            for (i, r) in rules.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                emit_sym_operand(out, r, indent);
+            }
+            out.push_str("]))");
+        }
+    }
+}
+
+/// Wrap a `SymApply`/`SymRule`/`SymReplaceAll` operand that is a bare
+/// literal (`IntLit`/`FloatLit`/`StrLit`) through the matching
+/// `__Sir.Symbolic.*` leaf-term constructor — a raw JS number/string is
+/// never a valid Symbolic term, so it must become one before it can sit
+/// inside a term tree. Any other operand (already a Symbolic-producing
+/// expression, e.g. a nested `SymApply` or a `VarRef`) emits unchanged.
+/// Mirrors the TypeScript backend's identically-named helper exactly.
+fn emit_sym_operand(out: &mut String, e: &Expr, indent: usize) {
+    match e {
+        Expr::IntLit { .. } => {
+            out.push_str("__Sir.Symbolic.int(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::FloatLit { .. } => {
+            out.push_str("__Sir.Symbolic.numberNode(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        Expr::StrLit { .. } => {
+            out.push_str("__Sir.Symbolic.stringNode(");
+            emit_expr(out, e, indent);
+            out.push(')');
+        }
+        _ => emit_expr(out, e, indent),
     }
 }
 

--- a/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/lib.rs
@@ -47,10 +47,18 @@
 //! method dispatch, `super`, `self`, and `@ivar`/`@@cvar` access lower
 //! to the inlined `__Sir` OOP runtime.
 //!
+//! It also accepts the SIR23 symbolic-expression + pattern/rewrite domain
+//! (`SymbolicExpr`, `PatternMatching`, `Rationals`): a `SymApply`/
+//! `SymPatternBlank`/`SymRule`/`SymReplaceAll` node lowers to a call into
+//! the inlined `__Sir.Symbolic.*` runtime — a plain-JS port of the
+//! published `sir-runtime-symbolic`/`symbolic-ir`/`cas-pattern-matching`
+//! TypeScript packages, so the artifact stays self-contained.
+//!
 //! It **rejects** everything else at the capability check — the
-//! remaining SIR18 features (e.g. string interpolation), `TailCalls` (V8
-//! does not reliably tail-call optimise), and `Intrinsics` (empty
-//! whitelist).  The accept-set is deliberately matched to exactly what
+//! remaining SIR18 features (e.g. string interpolation), the SIR22
+//! array/matrix domain (`NDArrays`, `MatrixOps`), `TailCalls` (V8 does not
+//! reliably tail-call optimise), and `Intrinsics` (empty whitelist).  The
+//! accept-set is deliberately matched to exactly what
 //! [`emit`](crate::emit) lowers, so a module that uses a deferred node is
 //! turned away *before* lowering rather than producing wrong code.
 //!
@@ -174,6 +182,18 @@ const ACCEPTED_FEATURES: &[Feature] = &[
     // or on the class itself (`extend`).  See `emit`'s `__include__` /
     // `__extend__` / `__class_method__` arms and `runtime::resolveMethod`.
     Feature::Modules,
+    // SIR23: the symbolic-expression + pattern/rewrite domain.  A
+    // `SymApply`/`SymPatternBlank`/`SymRule`/`SymReplaceAll` node lowers to
+    // a call into the inlined `__Sir.Symbolic.*` runtime (a plain-JS port
+    // of the published `sir-runtime-symbolic`/`symbolic-ir`/
+    // `cas-pattern-matching` TypeScript packages).  See `emit`'s SIR23
+    // section and `runtime.rs`'s "Symbolic expressions" section.
+    Feature::SymbolicExpr,
+    Feature::PatternMatching,
+    // A `SymRational` node sets this (shared with the still-deferred SIR22
+    // array/matrix domain rather than a flag of its own — mirroring the
+    // TypeScript backend's identical choice).
+    Feature::Rationals,
 ];
 
 impl Backend for JavaScriptBackend {
@@ -437,6 +457,255 @@ mod tests {
         };
         let err = compile(&m).expect_err("array/matmul body rejected");
         assert_eq!(err.kind, BackendErrorKind::UnsupportedFeature);
+    }
+
+    // ── SIR23: symbolic-expression/pattern codegen ─────────────────────
+
+    #[test]
+    fn accepts_sir23_symbolic_features() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::SymbolicExpr,
+            Feature::PatternMatching,
+            Feature::Rationals,
+        ]);
+        compile(&m).expect("SIR23 features accepted");
+    }
+
+    #[test]
+    fn sym_symbol_and_sym_rational_emit_leaf_constructors() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::SymbolicExpr, Feature::Rationals]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::SymApply {
+            head: Box::new(Expr::SymSymbol {
+                name: "f".into(),
+                span: s(),
+            }),
+            args: vec![Expr::SymRational {
+                numer: 1,
+                denom: 3,
+                span: s(),
+            }],
+            span: s(),
+        };
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(
+                r#"__Sir.Symbolic.apply(__Sir.Symbolic.sym("f"), [__Sir.Symbolic.rational(1, 3)])"#
+            ),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn literal_children_of_sym_apply_are_wrapped_as_terms() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[
+            Feature::SymbolicExpr,
+            Feature::Floats,
+            Feature::Strings,
+        ]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::SymApply {
+            head: Box::new(Expr::SymSymbol {
+                name: "g".into(),
+                span: s(),
+            }),
+            args: vec![
+                Expr::IntLit {
+                    value: 2,
+                    span: s(),
+                },
+                Expr::FloatLit {
+                    value: 1.5,
+                    span: s(),
+                },
+                Expr::StrLit {
+                    value: "hi".into(),
+                    span: s(),
+                },
+            ],
+            span: s(),
+        };
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains("__Sir.Symbolic.int(2)"),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains("__Sir.Symbolic.numberNode(1.5)"),
+            "got:\n{}",
+            a.source
+        );
+        assert!(
+            a.source.contains(r#"__Sir.Symbolic.stringNode("hi")"#),
+            "got:\n{}",
+            a.source
+        );
+    }
+
+    #[test]
+    fn untyped_and_typed_pattern_blanks_emit_blank_and_blank_typed() {
+        let mut m = minimal_module();
+        m.manifest =
+            FeatureManifest::from_features(&[Feature::PatternMatching, Feature::SymbolicExpr]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::SymPatternNamed {
+            name: "x".into(),
+            pattern: Box::new(Expr::SymPatternBlank {
+                head: Some(Box::new(Expr::SymSymbol {
+                    name: "Integer".into(),
+                    span: s(),
+                })),
+                span: s(),
+            }),
+            span: s(),
+        };
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source
+                .contains(r#"__Sir.Symbolic.named("x", __Sir.Symbolic.blankTyped("Integer"))"#),
+            "got:\n{}",
+            a.source
+        );
+
+        let mut bare = minimal_module();
+        bare.manifest = FeatureManifest::from_features(&[Feature::PatternMatching]);
+        let main = bare
+            .functions
+            .iter_mut()
+            .find(|f| f.name == "main")
+            .unwrap();
+        main.body.value = Expr::SymPatternBlank {
+            head: None,
+            span: s(),
+        };
+        let a2 = compile(&bare).expect("compile");
+        assert!(
+            a2.source.contains("__Sir.Symbolic.blank()"),
+            "got:\n{}",
+            a2.source
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "SymPatternBlank's head-constraint must be a SymSymbol")]
+    fn pattern_blank_with_non_symbol_head_panics_rather_than_miscompiling() {
+        let mut m = minimal_module();
+        m.manifest = FeatureManifest::from_features(&[Feature::PatternMatching]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::SymPatternBlank {
+            head: Some(Box::new(Expr::IntLit {
+                value: 1,
+                span: s(),
+            })),
+            span: s(),
+        };
+        let _ = compile(&m);
+    }
+
+    #[test]
+    fn rule_vs_rule_delayed_emit_distinct_constructors() {
+        let mut m = minimal_module();
+        m.manifest =
+            FeatureManifest::from_features(&[Feature::SymbolicExpr, Feature::PatternMatching]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "a".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::SymSymbol {
+                name: "b".into(),
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source.contains(
+                r#"__Sir.Symbolic.rule(__Sir.Symbolic.sym("a"), __Sir.Symbolic.sym("b"))"#
+            ),
+            "got:\n{}",
+            a.source
+        );
+
+        let mut d = m.clone();
+        let main = d.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        if let Expr::SymRule { delayed, .. } = &mut main.body.value {
+            *delayed = true;
+        }
+        let ad = compile(&d).expect("compile");
+        assert!(
+            ad.source.contains("__Sir.Symbolic.ruleDelayed("),
+            "got:\n{}",
+            ad.source
+        );
+    }
+
+    #[test]
+    fn replace_all_and_replace_repeated_both_route_through_unwrap() {
+        let rule = || Expr::SymRule {
+            lhs: Box::new(Expr::SymSymbol {
+                name: "a".into(),
+                span: s(),
+            }),
+            rhs: Box::new(Expr::SymSymbol {
+                name: "b".into(),
+                span: s(),
+            }),
+            delayed: false,
+            span: s(),
+        };
+        let mut m = minimal_module();
+        m.manifest =
+            FeatureManifest::from_features(&[Feature::SymbolicExpr, Feature::PatternMatching]);
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        main.body.value = Expr::SymReplaceAll {
+            expr: Box::new(Expr::SymSymbol {
+                name: "a".into(),
+                span: s(),
+            }),
+            rules: vec![rule()],
+            repeated: false,
+            span: s(),
+        };
+        let a = compile(&m).expect("compile");
+        assert!(
+            a.source
+                .contains("__Sir.Symbolic.unwrap(__Sir.Symbolic.replaceAll("),
+            "got:\n{}",
+            a.source
+        );
+
+        let main = m.functions.iter_mut().find(|f| f.name == "main").unwrap();
+        if let Expr::SymReplaceAll { repeated, .. } = &mut main.body.value {
+            *repeated = true;
+        }
+        let ar = compile(&m).expect("compile");
+        assert!(
+            ar.source
+                .contains("__Sir.Symbolic.unwrap(__Sir.Symbolic.replaceRepeated("),
+            "got:\n{}",
+            ar.source
+        );
+    }
+
+    #[test]
+    fn end_to_end_wolfram_replace_all_compiles() {
+        let module =
+            wolfram_to_semantic_ir::compile_source("x /. a -> b\n", "demo").expect("lower wolfram");
+        let a = compile(&module).expect("compile");
+        assert!(
+            a.source
+                .contains("__Sir.Symbolic.unwrap(__Sir.Symbolic.replaceAll("),
+            "got:\n{}",
+            a.source
+        );
     }
 
     #[test]

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -35,6 +35,17 @@
 //!
 //! The constant is fixed text — byte-identical in every artifact — so
 //! two compilations of the same module produce the same output.
+//!
+//! ## Symbolic expressions + pattern/rewrite (SIR23)
+//!
+//! `__Sir.Symbolic` is a plain-JS port of the published
+//! `@coding-adventures/symbolic-ir` / `@coding-adventures/
+//! cas-pattern-matching` / `@coding-adventures/sir-runtime-symbolic`
+//! TypeScript packages — the same "port it inline" treatment the
+//! exception runtime gives `@coding-adventures/sir-runtime-exceptions`
+//! (see that section's own comment). A `SymApply`/`SymPatternBlank`/
+//! `SymRule`/`SymReplaceAll` node lowers to a call into
+//! `__Sir.Symbolic.*`; see that section for the full algorithm.
 
 /// The full inlined runtime.  Always emitted verbatim, exactly once,
 /// near the top of every artifact (after the banner, before the user's
@@ -142,6 +153,16 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         .join(", ");
       seen.delete(v);
       return "{" + body + "}";
+    }
+    // A SIR23 symbolic-expression term (see the "symbolic expressions"
+    // section far below) — a plain frozen `{ kind: "symbol"|"integer"|…
+    // }` object, never a class instance. Unlike Array/Map, a term is
+    // built exclusively through `Symbolic.*`'s constructors, which only
+    // ever wrap ALREADY-frozen children, so a term can never reference
+    // itself; no cycle guard is needed here the way Array/Map need `seen`.
+    if (v !== null && typeof v === "object" && typeof v.kind === "string") {
+      const s = Symbolic.toDisplayString(v);
+      if (s !== undefined) { return s; }
     }
     return String(v);
   }
@@ -2264,6 +2285,373 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     return val;
   }
 
+  // ── symbolic expressions + pattern/rewrite (SIR23) ─────────────
+  //
+  // A `SymSymbol`/`SymRational`/`SymApply`/`SymPatternBlank`/
+  // `SymPatternNamed`/`SymRule`/`SymReplaceAll` node lowers to a call
+  // into `Symbolic.*` below — the same treatment the exceptions
+  // section above gave `@coding-adventures/sir-runtime-exceptions`: a
+  // plain-JS port of the published TypeScript packages
+  // (`@coding-adventures/symbolic-ir`, `@coding-adventures/
+  // cas-pattern-matching`, `@coding-adventures/sir-runtime-symbolic`)
+  // this backend's TypeScript sibling *imports*, so the JavaScript
+  // artifact stays self-contained (no `require`/`import`).
+  //
+  // ## Value model
+  //
+  // A term is a plain, `Object.freeze`d object — never a class
+  // instance, so it never collides with `Sym`/`Pair`/`Closure`/
+  // `SirInstance` above:
+  //
+  //   { kind: "symbol",   name }
+  //   { kind: "integer",  value }          -- a JS `number`, NOT bigint.
+  //   { kind: "rational", numer, denom }   -- reduced; denom > 0.
+  //   { kind: "float",    value }
+  //   { kind: "string",   value }
+  //   { kind: "apply",    head, args }
+  //
+  // The TypeScript sibling package uses `bigint` for `integer`/
+  // `rational` (arbitrary precision); this port deliberately uses
+  // `number` instead, matching how every OTHER numeric value in this
+  // backend already works (`IntLit` emits a bare JS number literal —
+  // see `emit.rs`'s `Expr::IntLit` arm — there is no bigint anywhere
+  // else in this runtime). A `Symbolic.int`/`Symbolic.rational` value
+  // therefore shares the same `Number.isSafeInteger` ceiling ordinary
+  // SIR integers already have on this backend; this is a pre-existing
+  // backend-wide limitation, not a new one this port introduces.
+  const Symbolic = (() => {
+    function frozen(obj) { return Object.freeze(obj); }
+
+    function symTerm(name) { return frozen({ kind: "symbol", name }); }
+    function intTerm(value) {
+      if (!Number.isSafeInteger(value)) {
+        throw new RangeError("Symbolic.int: value must be a safe integer");
+      }
+      return frozen({ kind: "integer", value });
+    }
+    function gcdAbs(a, b) {
+      a = Math.abs(a);
+      b = Math.abs(b);
+      while (b !== 0) {
+        const t = b;
+        b = a % b;
+        a = t;
+      }
+      return a === 0 ? 1 : a;
+    }
+    function rationalTerm(numer, denom) {
+      if (denom === 0) {
+        throw new RangeError("Symbolic.rational: denominator cannot be zero");
+      }
+      if (denom < 0) {
+        numer = -numer;
+        denom = -denom;
+      }
+      const g = gcdAbs(numer, denom);
+      return frozen({ kind: "rational", numer: numer / g, denom: denom / g });
+    }
+    function floatTerm(value) {
+      if (!Number.isFinite(value)) {
+        throw new RangeError("Symbolic.numberNode: value must be finite");
+      }
+      return frozen({ kind: "float", value });
+    }
+    function stringTerm(value) { return frozen({ kind: "string", value }); }
+    function applyTerm(head, args) {
+      return frozen({ kind: "apply", head, args: Object.freeze([...args]) });
+    }
+
+    // Structural equality — used by the matcher (a repeated pattern
+    // variable must bind to the SAME term every occurrence) and by
+    // `replaceRepeated`'s "did this firing actually change anything"
+    // fixed-point check.
+    function termEquals(a, b) {
+      if (a.kind !== b.kind) { return false; }
+      switch (a.kind) {
+        case "symbol": return a.name === b.name;
+        case "integer": return a.value === b.value;
+        case "rational": return a.numer === b.numer && a.denom === b.denom;
+        case "float": return Object.is(a.value, b.value);
+        case "string": return a.value === b.value;
+        case "apply":
+          return termEquals(a.head, b.head)
+            && a.args.length === b.args.length
+            && a.args.every((arg, i) => termEquals(arg, b.args[i]));
+        default: return false;
+      }
+    }
+
+    function headName(node) { return node.kind === "symbol" ? node.name : ""; }
+
+    // A minimal, non-recursive-through-the-whole-tree display: enough
+    // to make `print`/`puts` on a Symbolic term readable in tests and
+    // REPL output (`f(x, 1/3)`), mirroring `symbolic-ir`'s own
+    // `toDisplayString`. Not part of the SIR23 spec's own contract —
+    // an internal convenience `formatSeen` (above) reaches for.
+    function toDisplayString(node) {
+      switch (node.kind) {
+        case "symbol": return node.name;
+        case "integer": return String(node.value);
+        case "rational": return node.numer + "/" + node.denom;
+        case "float": return String(node.value);
+        case "string": return JSON.stringify(node.value);
+        case "apply":
+          return toDisplayString(node.head) + "("
+            + node.args.map(toDisplayString).join(", ") + ")";
+        default: return undefined;
+      }
+    }
+
+    // ── pattern/rule vocabulary (cas-pattern-matching) ─────────────
+    const BLANK = "Blank";
+    const PATTERN = "Pattern";
+    const RULE = "Rule";
+    const RULE_DELAYED = "RuleDelayed";
+
+    function isHead(node, name) {
+      return node.kind === "apply" && node.head.kind === "symbol" && node.head.name === name;
+    }
+    function isBlank(node) { return isHead(node, BLANK); }
+    function isPattern(node) { return isHead(node, PATTERN); }
+    function isRule(node) {
+      return node.kind === "apply" && node.head.kind === "symbol"
+        && (node.head.name === RULE || node.head.name === RULE_DELAYED)
+        && node.args.length === 2;
+    }
+
+    function blankTerm() { return applyTerm(symTerm(BLANK), []); }
+    function blankTypedTerm(head) { return applyTerm(symTerm(BLANK), [symTerm(head)]); }
+    function namedTerm(name, inner) { return applyTerm(symTerm(PATTERN), [symTerm(name), inner]); }
+    function ruleTerm(lhs, rhs) { return applyTerm(symTerm(RULE), [lhs, rhs]); }
+    function ruleDelayedTerm(lhs, rhs) { return applyTerm(symTerm(RULE_DELAYED), [lhs, rhs]); }
+
+    // Bindings: a name -> term map. Persistent / copy-on-write (mirrors
+    // `cas-pattern-matching`'s `Bindings` class) so a failed match
+    // attempt never mutates a binding set an earlier attempt still
+    // holds a reference to.
+    function bindingsEmpty() { return new Map(); }
+    function bindingsBind(bindings, name, value) {
+      const existing = bindings.get(name);
+      if (existing !== undefined && termEquals(existing, value)) { return bindings; }
+      const next = new Map(bindings);
+      next.set(name, value);
+      return next;
+    }
+
+    function blankHeadConstraint(node) {
+      if (node.args.length === 0) { return null; }
+      const first = node.args[0];
+      return first.kind === "symbol" ? first.name : null;
+    }
+    function patternName(node) {
+      const first = node.args[0];
+      if (first === undefined || first.kind !== "symbol") {
+        throw new TypeError("Symbolic: Pattern name must be a Symbol");
+      }
+      return first.name;
+    }
+    function patternInner(node) {
+      if (node.args.length < 2) {
+        throw new TypeError("Symbolic: Pattern requires an inner expression");
+      }
+      return node.args[1];
+    }
+    function effectiveHeadName(node) {
+      if (node.kind === "apply") { return headName(node.head) || "Apply"; }
+      if (node.kind === "integer") { return "Integer"; }
+      if (node.kind === "rational") { return "Rational"; }
+      if (node.kind === "float") { return "Float"; }
+      if (node.kind === "string") { return "String"; }
+      return "Symbol";
+    }
+
+    // Five-case structural matcher: `Blank()`, `Blank(T)`,
+    // `Pattern(name, inner)`, compound-vs-compound (recurse head +
+    // every arg, same arity required), and plain structural equality —
+    // a direct port of `cas-pattern-matching::matchPattern`.
+    function matchPattern(pattern, target, bindings) {
+      if (bindings === undefined) { bindings = bindingsEmpty(); }
+      if (isBlank(pattern)) {
+        const constraint = blankHeadConstraint(pattern);
+        if (constraint === null) { return bindings; }
+        return effectiveHeadName(target) === constraint ? bindings : null;
+      }
+      if (isPattern(pattern)) {
+        const name = patternName(pattern);
+        const inner = patternInner(pattern);
+        const matched = matchPattern(inner, target, bindings);
+        if (matched === null) { return null; }
+        const existing = matched.get(name);
+        if (existing !== undefined) { return termEquals(existing, target) ? matched : null; }
+        return bindingsBind(matched, name, target);
+      }
+      if (pattern.kind === "apply") {
+        if (target.kind !== "apply") { return null; }
+        let current = matchPattern(pattern.head, target.head, bindings);
+        if (current === null) { return null; }
+        if (pattern.args.length !== target.args.length) { return null; }
+        for (let i = 0; i < pattern.args.length; i++) {
+          current = matchPattern(pattern.args[i], target.args[i], current);
+          if (current === null) { return null; }
+        }
+        return current;
+      }
+      return termEquals(pattern, target) ? bindings : null;
+    }
+
+    function substituteTerm(template, bindings) {
+      if (isPattern(template)) {
+        const captured = bindings.get(patternName(template));
+        return captured !== undefined ? captured : template;
+      }
+      if (template.kind === "apply") {
+        return applyTerm(
+          substituteTerm(template.head, bindings),
+          template.args.map((a) => substituteTerm(a, bindings)),
+        );
+      }
+      return template;
+    }
+
+    function applyRuleTerm(rewriteRule, expr) {
+      if (!isRule(rewriteRule)) {
+        throw new TypeError("Symbolic.applyRule: expected Rule/RuleDelayed");
+      }
+      const lhs = rewriteRule.args[0];
+      const rhs = rewriteRule.args[1];
+      const bindings = matchPattern(lhs, expr, bindingsEmpty());
+      return bindings === null ? null : substituteTerm(rhs, bindings);
+    }
+
+    // ── replaceAll / replaceRepeated (`/.` / `//.`) + depth guard ──
+    //
+    // `matchPattern`/`substituteTerm`/`applyRuleTerm` recurse, but only
+    // as deep as a single RULE's own (author-written, not runtime-
+    // controlled) pattern/RHS shape — always shallow regardless of how
+    // deep the *target* expression is. `replaceAllTerm`/
+    // `replaceRepeatedTerm`, by contrast, walk the ENTIRE target
+    // expression tree, which ordinary compiled-program data can build
+    // up to unbounded depth — so these two need an explicit cap
+    // (CWE-674 stack-overflow DoS guard), mirroring
+    // `semantic_ir::limits::MAX_IR_DEPTH`'s rationale.
+    const MAX_TERM_DEPTH = 512;
+
+    function isDepthLimitError(v) {
+      return v !== null && typeof v === "object" && v.kind === "depth-limit";
+    }
+    function isRewriteCycleErrorTerm(v) {
+      return v !== null && typeof v === "object" && v.kind === "rewrite-cycle";
+    }
+
+    // `expr /. rules` — one pass, bottom-up: a node's head/args are
+    // walked (and possibly replaced) before the node itself is tried
+    // against `rules`; the first matching rule wins and the freshly
+    // substituted replacement is NOT re-walked or retried at that same
+    // position (Wolfram's single-pass `/.` contract, distinct from
+    // {@link replaceRepeatedTerm}'s fixed point below).
+    function walkOnce(node, rules, depth) {
+      if (depth > MAX_TERM_DEPTH) {
+        return { kind: "depth-limit", maxDepth: MAX_TERM_DEPTH };
+      }
+      let current = node;
+      if (node.kind === "apply") {
+        const newHead = walkOnce(node.head, rules, depth + 1);
+        if (isDepthLimitError(newHead)) { return newHead; }
+        const newArgs = [];
+        for (const arg of node.args) {
+          const nextArg = walkOnce(arg, rules, depth + 1);
+          if (isDepthLimitError(nextArg)) { return nextArg; }
+          newArgs.push(nextArg);
+        }
+        current = applyTerm(newHead, newArgs);
+      }
+      for (const candidateRule of rules) {
+        const replacement = applyRuleTerm(candidateRule, current);
+        if (replacement !== null) { return replacement; }
+      }
+      return current;
+    }
+
+    function replaceAllTerm(expr, rules) {
+      return walkOnce(expr, rules, 0);
+    }
+
+    // `expr //. rules` — a fixed point: at each subtree, keep retrying
+    // `rules` until none fire (re-walking any fresh replacement so its
+    // own sub-parts also converge) before moving up to the parent.
+    // `maxIterations` (default 100) is a GLOBAL cap shared across the
+    // whole walk, guarding against a non-terminating rule set (SIR23
+    // spec "Matcher semantics" point 6). A firing loops LOCALLY at the
+    // current call frame (never a recursive call on the replacement),
+    // so however many times a rule fires at one tree position costs
+    // O(1) native stack frames, not O(firings) — `depth` only
+    // increases on a genuine descent into `head`/`args`, so
+    // `maxIterations` bounds iteration COUNT (CPU time) only, never
+    // native recursion depth.
+    function replaceRepeatedTerm(expr, rules, maxIterations) {
+      if (maxIterations === undefined) { maxIterations = 100; }
+      let counter = 0;
+      function walk(node, depth) {
+        if (depth > MAX_TERM_DEPTH) {
+          return { kind: "depth-limit", maxDepth: MAX_TERM_DEPTH };
+        }
+        let current = node;
+        while (true) {
+          if (current.kind === "apply") {
+            const newHead = walk(current.head, depth + 1);
+            if (isDepthLimitError(newHead) || isRewriteCycleErrorTerm(newHead)) { return newHead; }
+            const newArgs = [];
+            for (const arg of current.args) {
+              const nextArg = walk(arg, depth + 1);
+              if (isDepthLimitError(nextArg) || isRewriteCycleErrorTerm(nextArg)) { return nextArg; }
+              newArgs.push(nextArg);
+            }
+            current = applyTerm(newHead, newArgs);
+          }
+          let fired = false;
+          for (const candidateRule of rules) {
+            const replacement = applyRuleTerm(candidateRule, current);
+            if (replacement !== null && !termEquals(replacement, current)) {
+              counter += 1;
+              if (counter > maxIterations) {
+                return { kind: "rewrite-cycle", maxIterations };
+              }
+              current = replacement;
+              fired = true;
+              break;
+            }
+          }
+          if (!fired) { return current; }
+        }
+      }
+      return walk(expr, 0);
+    }
+
+    // Unwrap a `replaceAll`/`replaceRepeated` result, throwing a plain
+    // `Error` if the walk hit its depth cap or (for `replaceRepeated`)
+    // its iteration cap instead of returning a real term. Every
+    // compiled `SymReplaceAll` call site routes through this — a
+    // `SymReplaceAll` is an ordinary expression that must evaluate to a
+    // term or fail loudly, never silently hand a sentinel to code
+    // expecting a term.
+    function unwrapTerm(result) {
+      if (isDepthLimitError(result) || isRewriteCycleErrorTerm(result)) {
+        throw new Error("sir-runtime-symbolic: " + result.kind);
+      }
+      return result;
+    }
+
+    return {
+      sym: symTerm, int: intTerm, rational: rationalTerm,
+      numberNode: floatTerm, stringNode: stringTerm, apply: applyTerm,
+      blank: blankTerm, blankTyped: blankTypedTerm, named: namedTerm,
+      rule: ruleTerm, ruleDelayed: ruleDelayedTerm,
+      matchPattern, applyRule: applyRuleTerm, substitute: substituteTerm,
+      replaceAll: replaceAllTerm, replaceRepeated: replaceRepeatedTerm,
+      unwrap: unwrapTerm, toDisplayString, equals: termEquals,
+    };
+  })();
+
   return {
     Sym, Pair, Closure,
     intern, applyClosure, truthy, format, print, puts,
@@ -2277,6 +2665,10 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
     ivarGet, ivarSet, cvarGet, cvarSet,
     // Mixins (MX4): include/extend registration + class-method dispatch.
     includeModule, extendModule, callClassMethod,
+    // SIR23: symbolic expression + pattern/rewrite domain, ported from
+    // the published sir-runtime-symbolic/symbolic-ir/cas-pattern-matching
+    // TypeScript packages so this backend stays self-contained.
+    Symbolic,
   };
 })();
 "##;
@@ -2303,19 +2695,39 @@ mod tests {
     #[test]
     fn runtime_exports_the_helpers_the_emitter_calls() {
         for needed in [
-            "intern", "applyClosure", "truthy", "format",
-            "builtins", "builtinClosure", "callBuiltin", "callMethod",
-            "class Sym", "class Pair", "class Closure",
+            "intern",
+            "applyClosure",
+            "truthy",
+            "format",
+            "builtins",
+            "builtinClosure",
+            "callBuiltin",
+            "callMethod",
+            "class Sym",
+            "class Pair",
+            "class Closure",
             // Exception runtime (SIR17): the four helpers the emitter
             // references from its TryCatch / raise / ClassDef arms.
-            "class SirError", "raiseError", "rescueMatches", "registerAncestry",
+            "class SirError",
+            "raiseError",
+            "rescueMatches",
+            "registerAncestry",
             // OOP runtime (O3): the helpers the emitter references from
             // its __new__ / __super__ / __def_method__ / @ivar arms.
-            "class SirInstance", "callNew", "callSuper",
-            "defMethod", "defClassMethod", "currentSelf",
-            "ivarGet", "ivarSet", "cvarGet", "cvarSet",
+            "class SirInstance",
+            "callNew",
+            "callSuper",
+            "defMethod",
+            "defClassMethod",
+            "currentSelf",
+            "ivarGet",
+            "ivarSet",
+            "cvarGet",
+            "cvarSet",
             // Mixins (MX4): include/extend + class-method dispatch.
-            "includeModule", "extendModule", "callClassMethod",
+            "includeModule",
+            "extendModule",
+            "callClassMethod",
         ] {
             assert!(RUNTIME.contains(needed), "runtime missing `{needed}`");
         }
@@ -2422,7 +2834,10 @@ mod tests {
         // adds the check native JS `/` lacks (it yields Infinity).
         assert!(RUNTIME.contains("function divide(a, b)"));
         assert!(RUNTIME.contains(r#"raiseError("ZeroDivisionError", "divided by 0")"#));
-        assert!(RUNTIME.contains("plus, times, divide,"), "divide must be exported");
+        assert!(
+            RUNTIME.contains("plus, times, divide,"),
+            "divide must be exported"
+        );
 
         // `.fetch` raises typed errors: IndexError for a sequence OOB,
         // KeyError for a missing hash key (no default).
@@ -2432,7 +2847,9 @@ mod tests {
 
         // An unknown method raises NoMethodError (not a JS-native TypeError).
         assert!(RUNTIME.contains(r#"raiseError("NoMethodError","#));
-        assert!(RUNTIME.contains(r#""undefined method `" + name + "` for " + classDescription(recv)"#));
+        assert!(
+            RUNTIME.contains(r#""undefined method `" + name + "` for " + classDescription(recv)"#)
+        );
         assert!(RUNTIME.contains("function classDescription(recv)"));
         // The old JS-native TypeError floor for the allowlist miss is gone.
         assert!(!RUNTIME.contains("is not an allowed collection method"));
@@ -2442,25 +2859,32 @@ mod tests {
     fn runtime_defines_m6_universal_metaprogramming_surface() {
         // M6: send/tap/then/yield_self/respond_to? + boolean &/|/^ are mixed
         // into EVERY receiver, ported to match the Python/TS references.
-        assert!(RUNTIME.contains(r#"const SEND_METHODS = new Set(["send", "__send__", "public_send"]);"#));
-        assert!(RUNTIME.contains(r#"const OBJECT_BLOCK_METHODS = new Set(["tap", "then", "yield_self"]);"#));
+        assert!(RUNTIME
+            .contains(r#"const SEND_METHODS = new Set(["send", "__send__", "public_send"]);"#));
+        assert!(RUNTIME
+            .contains(r#"const OBJECT_BLOCK_METHODS = new Set(["tap", "then", "yield_self"]);"#));
         assert!(RUNTIME.contains(r#"const BOOL_METHODS = new Set(["&", "|", "^"]);"#));
         assert!(RUNTIME.contains("function objectMetaMethod("));
         assert!(RUNTIME.contains("function respondsTo("));
         assert!(RUNTIME.contains("function boolMethod("));
         // `tap` returns the receiver; `then`/`yield_self` return the block result.
-        assert!(RUNTIME.contains(r#"if (name === "tap") { applyClosure(last, [recv]); return recv; }"#));
+        assert!(
+            RUNTIME.contains(r#"if (name === "tap") { applyClosure(last, [recv]); return recv; }"#)
+        );
         assert!(RUNTIME.contains("return applyClosure(last, [recv]); // then / yield_self"));
 
         // SECURITY (the C3 RCE lesson): `send` routes the DYNAMIC name back
         // through `callMethod` — the SAME allowlist / method-table gate a direct
         // call uses — NEVER `recv[name]` / `eval` / `new Function` on the name.
-        assert!(RUNTIME.contains("return callMethod(recv, methodNameArg(rawArgs[0]), ...rawArgs.slice(1));"));
+        assert!(RUNTIME
+            .contains("return callMethod(recv, methodNameArg(rawArgs[0]), ...rawArgs.slice(1));"));
         assert!(!RUNTIME.contains("new Function("));
         assert!(!RUNTIME.contains("eval("));
         // `respond_to?` checks the same tables dispatch uses (method table for a
         // SirInstance, the allowlist for a primitive) — not a probe of recv[name].
-        assert!(RUNTIME.contains("resolveMethod(methodTable, recv.sirClass, name, includedModules) !== undefined"));
+        assert!(RUNTIME.contains(
+            "resolveMethod(methodTable, recv.sirClass, name, includedModules) !== undefined"
+        ));
         assert!(RUNTIME.contains("METHOD_ALLOWLIST.has(native)"));
     }
 
@@ -2472,5 +2896,75 @@ mod tests {
         assert!(RUNTIME.contains("ancestry[cur]"));
         assert!(RUNTIME.contains("Object.create(null)"));
         assert!(!RUNTIME.contains("eval("));
+    }
+
+    #[test]
+    fn runtime_defines_symbolic_expression_domain() {
+        // SIR23: the emitter's Sym* arms all call into `Symbolic.*` — this
+        // must stay inlined (no import/require), matching every other
+        // domain in this file.
+        assert!(RUNTIME.contains("const Symbolic = (() => {"));
+        assert!(RUNTIME.contains("Symbolic,"), "Symbolic must be exported");
+        for needed in [
+            "function symTerm(",
+            "function intTerm(",
+            "function rationalTerm(",
+            "function floatTerm(",
+            "function stringTerm(",
+            "function applyTerm(",
+            "function blankTerm(",
+            "function blankTypedTerm(",
+            "function namedTerm(",
+            "function ruleTerm(",
+            "function ruleDelayedTerm(",
+            "function matchPattern(",
+            "function applyRuleTerm(",
+            "function substituteTerm(",
+            "function replaceAllTerm(",
+            "function replaceRepeatedTerm(",
+            "function unwrapTerm(",
+            "function toDisplayString(",
+        ] {
+            assert!(
+                RUNTIME.contains(needed),
+                "Symbolic runtime missing `{needed}`"
+            );
+        }
+        assert!(!RUNTIME.contains("import "));
+        assert!(!RUNTIME.contains("require("));
+    }
+
+    #[test]
+    fn symbolic_uses_plain_numbers_not_bigint() {
+        // Deliberate divergence from the TypeScript sibling package (which
+        // uses `bigint` for arbitrary precision): this backend's numeric
+        // model is `number` everywhere (see `Expr::IntLit`'s emit arm), so
+        // the symbolic-term port follows suit rather than introducing the
+        // only `bigint` anywhere in this runtime.
+        assert!(!RUNTIME.contains("BigInt"));
+        assert!(!RUNTIME.contains("0n"));
+    }
+
+    #[test]
+    fn symbolic_replace_repeated_loops_locally_not_recursively() {
+        // SECURITY: a rule firing must loop at the SAME call frame (the
+        // `while (true)` body), never recurse on the fresh replacement —
+        // otherwise a caller-supplied `maxIterations` bounds only CPU time
+        // in theory while still exhausting the native stack in practice
+        // (the exact gap `sir-runtime-symbolic`'s own /security-review
+        // found and fixed in the TypeScript sibling; this port carries the
+        // fix forward rather than reintroducing the gap).
+        assert!(RUNTIME.contains("while (true) {"));
+        assert!(RUNTIME.contains("const MAX_TERM_DEPTH = 512;"));
+    }
+
+    #[test]
+    fn symbolic_terms_render_through_format() {
+        // `print`/`puts` on a Symbolic term must not fall through to the
+        // useless `[object Object]` default — formatSeen dispatches to
+        // `Symbolic.toDisplayString` for any plain object carrying a
+        // `.kind` tag.
+        assert!(RUNTIME.contains("typeof v.kind === \"string\""));
+        assert!(RUNTIME.contains("Symbolic.toDisplayString(v)"));
     }
 }

--- a/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/src/runtime.rs
@@ -2383,12 +2383,25 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
 
     function headName(node) { return node.kind === "symbol" ? node.name : ""; }
 
-    // A minimal, non-recursive-through-the-whole-tree display: enough
-    // to make `print`/`puts` on a Symbolic term readable in tests and
-    // REPL output (`f(x, 1/3)`), mirroring `symbolic-ir`'s own
-    // `toDisplayString`. Not part of the SIR23 spec's own contract —
-    // an internal convenience `formatSeen` (above) reaches for.
-    function toDisplayString(node) {
+    // A display helper `print`/`puts`/`formatSeen` (above) reach for,
+    // mirroring `symbolic-ir`'s own `toDisplayString`. Not part of the
+    // SIR23 spec's own contract.
+    //
+    // SECURITY (CWE-674): a term built via `Symbolic.apply`/`applyTerm`
+    // is NOT depth-capped at construction time (only `replaceAll`/
+    // `replaceRepeated`'s tree WALK enforces `MAX_TERM_DEPTH` above) — a
+    // compiled program can build one arbitrarily deep directly, e.g. a
+    // loop lowered to repeated `SymApply` nesting with an
+    // attacker-influenced iteration count. Without its own cap, this
+    // recursive walk would `RangeError: Maximum call stack size
+    // exceeded` well before 512 levels (this walk's per-frame cost is
+    // heavier than `walkOnce`'s). `depth` mirrors the SAME
+    // `MAX_TERM_DEPTH` cap and truncates rather than crashing, matching
+    // how `formatSeen` already renders `"[...]"`/`"{...}"` for an
+    // Array/Map cycle instead of recursing forever.
+    function toDisplayString(node, depth) {
+      if (depth === undefined) { depth = 0; }
+      if (depth > MAX_TERM_DEPTH) { return "..."; }
       switch (node.kind) {
         case "symbol": return node.name;
         case "integer": return String(node.value);
@@ -2396,8 +2409,8 @@ pub const RUNTIME: &str = r##"const __Sir = (() => {
         case "float": return String(node.value);
         case "string": return JSON.stringify(node.value);
         case "apply":
-          return toDisplayString(node.head) + "("
-            + node.args.map(toDisplayString).join(", ") + ")";
+          return toDisplayString(node.head, depth + 1) + "("
+            + node.args.map((a) => toDisplayString(a, depth + 1)).join(", ") + ")";
         default: return undefined;
       }
     }

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
@@ -264,15 +264,20 @@ fn print_on_deeply_nested_term_truncates_instead_of_crashing_node() {
     // — reached from `print`/`puts` via `formatSeen` — recursed over the
     // FULL term tree with no depth cap of its own (only `replaceAll`/
     // `replaceRepeated`'s walk enforced `MAX_TERM_DEPTH`). A term built via
-    // 2000 real *runtime* firings of `Symbolic.apply` (an ordinary
-    // compiled `for`-loop, NOT a hand-built 2000-node static AST — the
+    // 20,000 real *runtime* firings of `Symbolic.apply` (an ordinary
+    // compiled `for`-loop, NOT a hand-built 20,000-node static AST — the
     // whole point being that a tiny, shallow compiled program can build an
     // arbitrarily deep runtime VALUE) bypassed that cap entirely, so
-    // `toDisplayString` needed its own guard. `node` must exit cleanly
-    // with a truncated `...` rather than crashing with "Maximum call
-    // stack size exceeded".
+    // `toDisplayString` needed its own guard. Comfortably above the
+    // empirically-measured ~5000-level pre-fix crash threshold for this
+    // walk (a smaller count wouldn't actually exercise the crash this
+    // test guards against), so reverting the fix makes this test fail via
+    // a genuine `node` crash (`run_module`'s `output.status.success()`),
+    // not just the truncation-string assertion below. `node` must exit
+    // cleanly with a truncated `...` rather than crashing with "Maximum
+    // call stack size exceeded".
     //
-    // for i in range(0, 2000, 1) { acc = Symbolic-apply(f, [acc]) }
+    // for i in range(0, 20000, 1) { acc = Symbolic-apply(f, [acc]) }
     // print(acc)
     let stmts = vec![
         Stmt::LetBinding {
@@ -288,7 +293,7 @@ fn print_on_deeply_nested_term_truncates_instead_of_crashing_node() {
                 span: sp(),
             },
             stop: Expr::IntLit {
-                value: 2000,
+                value: 20000,
                 span: sp(),
             },
             step: Expr::IntLit {

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
@@ -1,0 +1,251 @@
+//! End-to-end integration test: hand-built SIR23 nodes → JavaScript →
+//! `node`.
+//!
+//! `src/lib.rs`'s own test module proves the emitted *shape* (exact
+//! substring assertions on generated source, mirroring the TypeScript
+//! backend's SIR23 tests). This file proves the emitted *behaviour*: a
+//! `SymReplaceAll { repeated: true }` node, run for real under Node.js,
+//! must actually reduce `Add(Add(z, 0), 0)` to the bare symbol `z` via
+//! the `x_ + 0 -> x_` rule — not just produce plausible-looking source.
+//!
+//! Node is optional at test time; when unavailable the test degrades to
+//! a no-op rather than failing (mirroring `run_with_node.rs`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use semantic_ir::{
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+};
+use semantic_ir_to_javascript::compile;
+
+fn node_available() -> bool {
+    Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn sp() -> Span {
+    Span::synthetic()
+}
+
+fn sym(name: &str) -> Expr {
+    Expr::SymSymbol {
+        name: name.into(),
+        span: sp(),
+    }
+}
+
+fn sym_apply(head: Expr, args: Vec<Expr>) -> Expr {
+    Expr::SymApply {
+        head: Box::new(head),
+        args,
+        span: sp(),
+    }
+}
+
+fn blank() -> Expr {
+    Expr::SymPatternBlank {
+        head: None,
+        span: sp(),
+    }
+}
+
+fn named(name: &str, pattern: Expr) -> Expr {
+    Expr::SymPatternNamed {
+        name: name.into(),
+        pattern: Box::new(pattern),
+        span: sp(),
+    }
+}
+
+fn rule(lhs: Expr, rhs: Expr, delayed: bool) -> Expr {
+    Expr::SymRule {
+        lhs: Box::new(lhs),
+        rhs: Box::new(rhs),
+        delayed,
+        span: sp(),
+    }
+}
+
+fn bc(name: &str, args: Vec<Expr>) -> Expr {
+    Expr::BuiltinCall {
+        name: name.into(),
+        args,
+        effects: EffectSet::PURE,
+        span: sp(),
+    }
+}
+
+fn print(arg: Expr) -> Stmt {
+    Stmt::ExprStmt {
+        expr: bc("print", vec![arg]),
+        span: sp(),
+    }
+}
+
+fn module_with_main(stmts: Vec<Stmt>, value: Expr, features: &[Feature]) -> Module {
+    Module {
+        name: "sir23".into(),
+        manifest: FeatureManifest::from_features(features),
+        imports: vec![],
+        exports: vec![],
+        functions: vec![Function {
+            name: "main".into(),
+            params: vec![],
+            return_type: None,
+            captures: vec![],
+            body: Block {
+                stmts,
+                value,
+                span: sp(),
+            },
+            effects: EffectSet::PURE,
+            metadata: Metadata::new(),
+            span: sp(),
+        }],
+        globals: vec![],
+        metadata: Metadata::new()
+            .with_source_language("handbuilt")
+            .with_sir_version(semantic_ir::CURRENT_SIR_VERSION),
+        span: sp(),
+    }
+}
+
+fn run_module(module: &Module, tag: &str) -> Option<String> {
+    let artifact = compile(module).expect("compile to javascript");
+    if !node_available() {
+        eprintln!("note: `node` unavailable — skipping execution for `{tag}`");
+        return None;
+    }
+    let mut path: PathBuf = std::env::temp_dir();
+    path.push(format!("sir_js_{}_{}.js", tag, std::process::id()));
+    std::fs::write(&path, &artifact.source).expect("write temp js");
+    let output = Command::new("node")
+        .arg(&path)
+        .output()
+        .expect("spawn node");
+    let _ = std::fs::remove_file(&path);
+    assert!(
+        output.status.success(),
+        "node exited non-zero for `{tag}`:\nstdout: {}\nstderr: {}\nsource:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        artifact.source,
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+    Some(stdout.trim_end_matches(['\n', '\r']).to_string())
+}
+
+#[test]
+fn replace_repeated_reduces_nested_add_zero_to_bare_symbol() {
+    // Rule: x_ + 0 -> x_ (Wolfram `x_ + 0 :> x_`, held as `RuleDelayed`
+    // here so the RHS is exactly the same pattern-bound `x_` node).
+    let x_pat = named("x", blank());
+    let zero = || Expr::IntLit {
+        value: 0,
+        span: sp(),
+    };
+    let r = rule(
+        sym_apply(sym("Add"), vec![x_pat.clone(), zero()]),
+        x_pat,
+        true,
+    );
+
+    // expr: Add(Add(z, 0), 0)  —  both `+ 0`s should fire, to a fixed point.
+    let inner = sym_apply(sym("Add"), vec![sym("z"), zero()]);
+    let expr = sym_apply(sym("Add"), vec![inner, zero()]);
+
+    let replace_repeated = Expr::SymReplaceAll {
+        expr: Box::new(expr),
+        rules: vec![r],
+        repeated: true,
+        span: sp(),
+    };
+
+    let module = module_with_main(
+        vec![print(replace_repeated)],
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr, Feature::PatternMatching],
+    );
+
+    if let Some(stdout) = run_module(&module, "sym_replace_repeated") {
+        assert_eq!(stdout, "z");
+    }
+}
+
+#[test]
+fn replace_all_single_pass_does_not_retry_at_same_position() {
+    // `/.` (single pass): a -> b applied to Add(a, a) fires once at EACH
+    // occurrence of `a` (bottom-up, one visit per node), not repeatedly —
+    // there is nothing to retry here since `a`'s replacement `b` doesn't
+    // itself match the rule, so replaceAll and replaceRepeated agree on
+    // this particular input; the real single-pass-vs-fixed-point contrast
+    // is `replace_repeated_reduces_nested_add_zero_to_bare_symbol` above
+    // (repeated=true fires at TWO nested positions in one call).
+    let r = rule(sym("a"), sym("b"), false);
+    let expr = sym_apply(sym("Pair"), vec![sym("a"), sym("a")]);
+    let replace_all = Expr::SymReplaceAll {
+        expr: Box::new(expr),
+        rules: vec![r],
+        repeated: false,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![print(replace_all)],
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr, Feature::PatternMatching],
+    );
+    if let Some(stdout) = run_module(&module, "sym_replace_all") {
+        assert_eq!(stdout, "Pair(b, b)");
+    }
+}
+
+#[test]
+fn typed_blank_matches_only_constrained_head() {
+    // f(x_Integer) -> x_ matched against f(5) and f(z) (a bare Symbol):
+    // only the Integer-headed argument matches; the Symbol one is left
+    // unchanged by replaceAll's "no match, no rewrite" fallthrough.
+    let x_pat = named(
+        "x",
+        Expr::SymPatternBlank {
+            head: Some(Box::new(sym("Integer"))),
+            span: sp(),
+        },
+    );
+    let r = rule(sym_apply(sym("f"), vec![x_pat.clone()]), x_pat, false);
+    let matching = sym_apply(
+        sym("f"),
+        vec![Expr::IntLit {
+            value: 5,
+            span: sp(),
+        }],
+    );
+    let non_matching = sym_apply(sym("f"), vec![sym("z")]);
+    let expr = sym_apply(sym("Pair"), vec![matching, non_matching]);
+    let replace_all = Expr::SymReplaceAll {
+        expr: Box::new(expr),
+        rules: vec![r],
+        repeated: false,
+        span: sp(),
+    };
+    let module = module_with_main(
+        vec![print(replace_all)],
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[Feature::SymbolicExpr, Feature::PatternMatching],
+    );
+    if let Some(stdout) = run_module(&module, "sym_typed_blank") {
+        assert_eq!(stdout, "Pair(5, f(z))");
+    }
+}

--- a/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
+++ b/code/packages/rust/semantic-ir-to-javascript/tests/sir23_symbolic.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use semantic_ir::{
-    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Span, Stmt,
+    Block, EffectSet, Expr, Feature, FeatureManifest, Function, Metadata, Module, Scope, Span, Stmt,
 };
 use semantic_ir_to_javascript::compile;
 
@@ -34,6 +34,14 @@ fn sp() -> Span {
 fn sym(name: &str) -> Expr {
     Expr::SymSymbol {
         name: name.into(),
+        span: sp(),
+    }
+}
+
+fn local(name: &str) -> Expr {
+    Expr::VarRef {
+        name: name.into(),
+        scope: Scope::Local,
         span: sp(),
     }
 }
@@ -247,5 +255,73 @@ fn typed_blank_matches_only_constrained_head() {
     );
     if let Some(stdout) = run_module(&module, "sym_typed_blank") {
         assert_eq!(stdout, "Pair(5, f(z))");
+    }
+}
+
+#[test]
+fn print_on_deeply_nested_term_truncates_instead_of_crashing_node() {
+    // Regression test (/security-review finding): `Symbolic.toDisplayString`
+    // — reached from `print`/`puts` via `formatSeen` — recursed over the
+    // FULL term tree with no depth cap of its own (only `replaceAll`/
+    // `replaceRepeated`'s walk enforced `MAX_TERM_DEPTH`). A term built via
+    // 2000 real *runtime* firings of `Symbolic.apply` (an ordinary
+    // compiled `for`-loop, NOT a hand-built 2000-node static AST — the
+    // whole point being that a tiny, shallow compiled program can build an
+    // arbitrarily deep runtime VALUE) bypassed that cap entirely, so
+    // `toDisplayString` needed its own guard. `node` must exit cleanly
+    // with a truncated `...` rather than crashing with "Maximum call
+    // stack size exceeded".
+    //
+    // for i in range(0, 2000, 1) { acc = Symbolic-apply(f, [acc]) }
+    // print(acc)
+    let stmts = vec![
+        Stmt::LetBinding {
+            name: "acc".into(),
+            sir_type: None,
+            value: sym("leaf"),
+            span: sp(),
+        },
+        Stmt::ForRange {
+            var: "i".into(),
+            start: Expr::IntLit {
+                value: 0,
+                span: sp(),
+            },
+            stop: Expr::IntLit {
+                value: 2000,
+                span: sp(),
+            },
+            step: Expr::IntLit {
+                value: 1,
+                span: sp(),
+            },
+            body: Block {
+                stmts: vec![Stmt::Assign {
+                    name: "acc".into(),
+                    scope: Scope::Local,
+                    value: sym_apply(sym("f"), vec![local("acc")]),
+                    span: sp(),
+                }],
+                value: Expr::NilLit { span: sp() },
+                span: sp(),
+            },
+            span: sp(),
+        },
+        print(local("acc")),
+    ];
+    let module = module_with_main(
+        stmts,
+        Expr::IntLit {
+            value: 0,
+            span: sp(),
+        },
+        &[
+            Feature::SymbolicExpr,
+            Feature::Loops,
+            Feature::MutableBindings,
+        ],
+    );
+    if let Some(stdout) = run_module(&module, "sym_deep_display") {
+        assert!(stdout.contains("..."), "got: {stdout}");
     }
 }


### PR DESCRIPTION
## Summary
- Real codegen for SIR23's symbolic-expression/pattern-matching domain in the JS backend, replacing the deferred `panic!` placeholder for all seven `Expr::Sym*` nodes (`SymSymbol`, `SymRational`, `SymApply`, `SymPatternBlank`, `SymPatternNamed`, `SymRule`, `SymReplaceAll`) — the JS half of item 7, mirroring the TypeScript backend's SIR23 codegen already shipped in #8190.
- New `__Sir.Symbolic` runtime: a plain-JS port of the published `symbolic-ir`/`cas-pattern-matching`/`sir-runtime-symbolic` TypeScript packages, **inlined** (not imported) so the JS artifact stays self-contained — the same treatment the exception runtime already got. Deliberately uses plain JS `number` (not `bigint`) for integers/rationals, matching this backend's existing numeric model.
- `Feature::SymbolicExpr`, `Feature::PatternMatching`, `Feature::Rationals` join `ACCEPTED_FEATURES`.
- **Security fix included** (found by this PR's own `/security-review`, CWE-674): `Symbolic.toDisplayString` (reached via `print`/`puts`) recursed with no depth cap of its own — a term built by an ordinary compiled `for`-loop could grow arbitrarily deep at runtime and crash `node`. Fixed by threading a `depth` parameter capped at the existing `MAX_TERM_DEPTH`, with a regression test that builds depth via a real `Stmt::ForRange` loop (not a hand-built static AST, which would overflow the Rust test process's own recursion/drop instead of testing the actual runtime behavior).

## Test plan
- [x] `cargo test -p semantic-ir-to-javascript` — 121 lib tests + 79 `run_with_node` execution tests + 4 new `sir23_symbolic` execution tests, all passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean (scoped to touched files only)
- [x] New string-shape unit tests mirroring the TypeScript backend's SIR23 suite (leaf constructors, literal wrapping, blank/blankTyped, non-`SymSymbol`-head panic guard, `rule` vs `ruleDelayed`, `replaceAll`/`replaceRepeated` unwrap routing)
- [x] New genuine `node`-execution tests (not just string assertions): `replaceRepeated` reduces `Add(Add(z,0),0)` to `z` via `x_ + 0 -> x_`, `replaceAll`'s single-pass contract, a head-typed blank matching selectively, and the depth-cap DoS regression test
- [x] End-to-end `wolfram-to-semantic-ir` → JS compile test (new dev dependency)
- [x] `/security-review`: found and fixed one HIGH finding (CWE-674 recursion cap gap), confirmed via follow-up review, plus a LOW test-robustness nit also applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)