### PR TITLE
test(closurec): CLOC12.189 PR3 — ES-module `export` end-to-end fixture

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.28] - 2026-07-13
+
+### Added — CLOC12.189 PR3: ES-module `export` end-to-end
+
+Picks up javascript-parser 0.54.0 (the `export_declaration` bridge flip,
+`convert_export_declaration`) and its renaming-soundness gate. A file with a
+top-level `export` no longer declines to WHITESPACE_ONLY — it flows through the
+full optimization pipeline. New `tests/diff/simple-export/` fixture +
+`diff_simple_export.rs` with two facts:
+  - **SIMPLE**: `export { a, b as c } from "y"; d(4 + 5);` →
+    `export{a,b as c}from"y";d(9);` — the re-`export` round-trips (bridge
+    modelled it, `b as c` alias space preserved) and the trailing argument folds
+    `4+5`→`9` (the pipeline optimized the rest of the module, not a
+    WHITESPACE_ONLY fallback).
+  - **ADVANCED**: `export { a } from "y"; function longFn(longParam){…}
+    longFn(1);longFn(2);longFn(3);` keeps `longFn`/`longParam` verbatim — the
+    CLOC12.189 PR2 renaming-soundness gate fires end-to-end. (The identical
+    program without the `export` renames down to `function b(a){…}`, so the
+    surviving long names are a direct observation of the gate: an `export`ed
+    name is part of the module's public interface and must not be renamed.)
+
+Version-synced cli.spec.json + tests/diff/help-markdown/expected.stdout. PATCH.
+
 ## [0.234.27] - 2026-07-12
 
 ### Added — CLOC12.188 PR3: ES-module `import` end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.27"
+version = "0.234.28"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.27",
+  "version": "0.234.28",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.27
+Version: 0.234.28
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/simple-export/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/simple-export/expected.stdout
@@ -1,0 +1,1 @@
+export{a,b as c}from"y";d(9);

--- a/code/programs/rust/closurec/tests/diff/simple-export/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/simple-export/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/simple-export/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/simple-export/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/simple-export/input/a.js
@@ -1,0 +1,1 @@
+export { a, b as c } from "y"; d(4 + 5);

--- a/code/programs/rust/closurec/tests/diff/simple-export/input/adv.js
+++ b/code/programs/rust/closurec/tests/diff/simple-export/input/adv.js
@@ -1,0 +1,1 @@
+export { a } from "y"; function longFn(longParam){return longParam+longParam+g(longParam);} longFn(1); longFn(2); longFn(3);

--- a/code/programs/rust/closurec/tests/diff_simple_export.rs
+++ b/code/programs/rust/closurec/tests/diff_simple_export.rs
@@ -1,0 +1,131 @@
+//! Integration test for the `tests/diff/simple-export/` fixture.
+//!
+//! Exercises ES-module `export` declarations end-to-end — the CLOC12.189 arc.
+//! Before it, `export` landed in the parser bridge's *unsupported* bucket, so
+//! any file with a top-level `export` DECLINED to WHITESPACE_ONLY (no
+//! optimization at all). The arc landed in three PRs:
+//!   - PR1: the `ExportNamedDeclaration` / `ExportDefaultDeclaration` /
+//!     `ExportAllDeclaration` AST nodes + emitter (`emit_export_named` /
+//!     `emit_export_default` / `emit_export_all`) + pass traversal (atomic; the
+//!     nodes were unreachable);
+//!   - PR2: the parser-bridge flip (`convert_export_declaration`) that makes an
+//!     `export` reach the AST, together with the renaming-soundness gate — an
+//!     `export`ed name is part of the module's *public* interface, so renaming
+//!     it would break a foreign importer; the rename / rename-globals /
+//!     rename-properties passes therefore *decline to rename* when a module
+//!     `export` is present (`program_contains_export_declaration`);
+//!   - PR3 (this test): the closurec end-to-end proof.
+//!
+//! ## Fact 1 — SIMPLE: the `export` survives and the pipeline optimizes past it
+//!
+//! `export { a, b as c } from "y"; d(4 + 5);` at SIMPLE emits
+//! `export{a,b as c}from"y";d(9);`. Two things prove the whole pipeline ran:
+//!   1. the re-`export` round-trips (`export{a,b as c}from"y";`), proving the
+//!      bridge modelled it — not a WHITESPACE_ONLY fallback; and
+//!   2. the trailing call argument folds — `4 + 5` → `9` — proving the SIMPLE
+//!      pipeline ran the rest of the module. A WHITESPACE_ONLY fallback would
+//!      leave `4+5` intact (it would emit the source verbatim).
+//!
+//! ## Fact 2 — ADVANCED: the soundness gate leaves an `export` program un-renamed
+//!
+//! `export { a } from "y"; function longFn(longParam){…} longFn(1);longFn(2);longFn(3);`
+//! at ADVANCED keeps `longFn` and `longParam` verbatim, because the PR2 gate
+//! disables the renaming passes whenever a module `export` is present. The
+//! identical program WITHOUT the `export` renames all the way down to
+//! `function b(a){…}` (the retained multi-use function and its param both get
+//! short names), so the surviving long names are a direct, end-to-end
+//! observation of the gate firing — not merely "nothing to rename".
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw =
+        std::fs::read_to_string("tests/diff/simple-export/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn simple_export_round_trips_and_folds() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/simple-export/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    // (1) the re-`export` round-tripped — the bridge modelled it (not
+    // WHITESPACE_ONLY). Checked on the raw output: the `b as c` alias carries a
+    // required space, so we must NOT strip spaces here.
+    let flat = actual.replace('\n', "");
+    assert!(
+        flat.contains("export{a,b as c}from\"y\";"),
+        "`export` did not round-trip: {actual}"
+    );
+    // (2) the pipeline optimized the rest of the module: `4+5` folded to `9`.
+    let a = actual.replace(' ', "");
+    assert!(
+        a.contains("d(9)"),
+        "argument did not fold to `d(9)`: {actual}"
+    );
+    assert!(
+        !a.contains("4+5"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+}
+
+#[test]
+fn advanced_export_disables_renaming() {
+    // ADVANCED on a program that contains a renameable multi-use function AND a
+    // module `export`. The PR2 soundness gate must fire, leaving `longFn` and
+    // `longParam` un-renamed.
+    let out = Command::new(BINARY)
+        .args([
+            "--js",
+            "tests/diff/simple-export/input/adv.js",
+            "--compilation_level",
+            "ADVANCED",
+        ])
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let a = actual.replace(' ', "");
+    // The `export` bridged (not WHITESPACE_ONLY)…
+    assert!(
+        a.contains("export{a}from\"y\""),
+        "`export` did not round-trip: {actual}"
+    );
+    // …and the gate left the otherwise-renameable names intact. (The identical
+    // program without the `export` renames down to `function b(a){…}`.)
+    assert!(
+        a.contains("longFn") && a.contains("longParam"),
+        "gate did not fire — names were renamed under an `export`: {actual}"
+    );
+}


### PR DESCRIPTION
Closes the **CLOC12.189 export arc** with the closurec end-to-end proof, mirroring the CLOC12.188 `simple-import` fixture.

## Arc recap
Before the arc, any file with a top-level `export` declined to WHITESPACE_ONLY (no optimization at all).
- **PR1** (#8109, merged): the three export AST nodes (`ExportNamed`/`ExportDefault`/`ExportAll`) + emitter + pass traversal.
- **PR2** (#8197, merged): the parser-bridge flip (`convert_export_declaration`) + the renaming-soundness gate (`program_contains_export_declaration` — the 3 rename passes bail when a module `export` is present).
- **PR3** (this): the closurec end-to-end proof.

## Two facts proven
**SIMPLE** — `export { a, b as c } from "y"; d(4 + 5);` → `export{a,b as c}from"y";d(9);`
1. the re-`export` round-trips (bridge modelled it — the `b as c` alias space is preserved), not a WHITESPACE_ONLY fallback; and
2. the trailing argument folds `4+5`→`9`, proving the SIMPLE pipeline ran the rest of the module (a WHITESPACE_ONLY fallback would leave `4+5` verbatim).

**ADVANCED** — `export { a } from "y"; function longFn(longParam){…} longFn(1);longFn(2);longFn(3);` keeps `longFn`/`longParam` verbatim — the PR2 soundness gate fires end-to-end. The identical program **without** the `export` renames down to `function b(a){…}`, so the surviving long names are a direct observation of the gate (an `export`ed name is part of the module's public interface and must not be renamed).

## Housekeeping
- closurec PATCH bump `0.234.27` → `0.234.28`, with `cli.spec.json` version synced and `tests/diff/help-markdown/expected.stdout` regenerated (version string).
- Full closurec suite green (**685 passed, 0 failed**), incl. `version_string_matches_crate_version` and `help_markdown_fixture_matches_expected_dump`.

## Security review
Test-only PR (fixtures + version-sync); **no runtime or library code changed**, so a security review is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)