### PR TITLE
feat(sql): searched CASE WHEN ... THEN ... ELSE ... END

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.25 — Searched `CASE WHEN … THEN … [ELSE …] END`
+
+`SELECT CASE WHEN cond THEN val … [ELSE val] END` now parses and runs with
+SQLite's exact semantics: branches are evaluated top-to-bottom, the first
+truthy `WHEN` yields its `THEN`; no match with an `ELSE` yields the `ELSE`,
+otherwise `NULL`; a `NULL` condition is not truthy (its branch is skipped); and
+evaluation short-circuits (later branches' values are not computed once one
+matches). Spans grammar (sql-parser 0.1.9) → `SqlExpr::Case` (sql-planner
+0.2.8) → a jump-chain in codegen (sql-codegen 0.6.3, reusing the existing
+`JumpIfTrue`/`Jump`/`Label` opcodes — no VM change), with the optimizer (0.1.3)
+folding through the node. Three differential-oracle cases (`case_first_match_and_else`,
+`case_no_else_is_null_and_null_cond_skipped`, `case_in_where_and_arithmetic`)
+diff against real bundled SQLite, including CASE nested in a WHERE predicate and
+in arithmetic. (The *simple* form `CASE x WHEN v THEN …` — equality against a
+base expression — is a separate follow-up slice.)
+
 ## 0.5.24 — `NULLS FIRST` / `NULLS LAST` in `ORDER BY`
 
 `SELECT … ORDER BY a NULLS FIRST` / `NULLS LAST` now parse and run. mini-sqlite

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.24"
+version = "0.5.25"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -873,6 +873,36 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT a FROM t ORDER BY a NULLS FIRST",
     },
+    // Searched CASE: the value of the first branch whose WHEN is truthy wins;
+    // no match with an ELSE yields the ELSE. Aliased so the check is on values.
+    Case {
+        id: "case_first_match_and_else",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER)",
+            "INSERT INTO t VALUES (1,1),(2,2),(3,3)",
+        ],
+        query: "SELECT CASE WHEN a=1 THEN 'one' WHEN a=2 THEN 'two' ELSE 'other' END AS c FROM t ORDER BY id",
+    },
+    // No matching WHEN and NO ELSE → NULL; and a NULL condition is not truthy so
+    // its branch is skipped (the `WHEN NULL THEN 'x'` never fires).
+    Case {
+        id: "case_no_else_is_null_and_null_cond_skipped",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER)",
+            "INSERT INTO t VALUES (1,1),(2,5)",
+        ],
+        query: "SELECT CASE WHEN NULL THEN 'x' WHEN a=1 THEN 'one' END AS c FROM t ORDER BY id",
+    },
+    // CASE nests as an ordinary expression — usable in a WHERE predicate and in
+    // arithmetic — proving it composes through the whole expression grammar.
+    Case {
+        id: "case_in_where_and_arithmetic",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER)",
+            "INSERT INTO t VALUES (1,1),(2,2),(3,NULL),(4,4)",
+        ],
+        query: "SELECT id, CASE WHEN a=2 THEN 10 ELSE 20 END + 5 AS v FROM t WHERE CASE WHEN a IS NULL THEN 0 ELSE 1 END ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.3] - Unreleased
+
+### Added
+
+- **`SqlExpr::Case` codegen** as a short-circuiting jump chain: each condition
+  is compiled followed by `JumpIfTrue(body_i)`; if none match, the ELSE (or a
+  `LoadConst(Null)`) is compiled; each body pushes its THEN value and jumps to a
+  shared end label. No new VM opcode — reuses `JumpIfTrue`/`Jump`/`Label`. Later
+  branches' THENs are never evaluated once one matches.
+
 ## [0.6.2] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -2026,6 +2026,40 @@ impl Compiler {
                 self.emit(Instruction::Cast(ty.clone()));
             }
 
+            // ── CASE ─────────────────────────────────────────────────────────
+
+            SqlExpr::Case { branches, else_val } => {
+                // Short-circuit via a jump chain (no branch's THEN is evaluated
+                // unless its WHEN matched, and no later WHEN is evaluated once
+                // one matches). Exactly one value is left on the stack.
+                //
+                //     for each branch:  <compile cond>; JumpIfTrue(body_i)
+                //     <compile ELSE or LoadConst Null>; Jump(end)
+                //     body_i: <compile then_i>; Jump(end)
+                //     end:
+                let end = self.fresh_label("case_end");
+                let body_labels: Vec<String> =
+                    branches.iter().map(|_| self.fresh_label("case_body")).collect();
+
+                for ((cond, _), body) in branches.iter().zip(body_labels.iter()) {
+                    self.compile_expr(cond);
+                    self.emit(Instruction::JumpIfTrue(body.clone()));
+                }
+                // Fell through every WHEN → the ELSE value, or NULL.
+                match else_val {
+                    Some(e) => self.compile_expr(e),
+                    None => self.emit(Instruction::LoadConst(SqlValue::Null)),
+                }
+                self.emit(Instruction::Jump(end.clone()));
+
+                for ((_, then_val), body) in branches.iter().zip(body_labels.iter()) {
+                    self.emit(Instruction::Label(body.clone()));
+                    self.compile_expr(then_val);
+                    self.emit(Instruction::Jump(end.clone()));
+                }
+                self.emit(Instruction::Label(end));
+            }
+
             // ── IN list ──────────────────────────────────────────────────────
 
             SqlExpr::InList {

--- a/code/packages/rust/sql-optimizer/CHANGELOG.md
+++ b/code/packages/rust/sql-optimizer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.1.3] - Unreleased
+
+### Added
+
+- Handle `SqlExpr::Case`: `fold_expr` folds each condition/value and the ELSE
+  while keeping the branch structure (short-circuiting stays the VM's job), and
+  `collect_columns_in_expr` recurses into every branch and the ELSE.
+
 ## [0.1.2] - Unreleased
 
 ### Changed

--- a/code/packages/rust/sql-optimizer/Cargo.toml
+++ b/code/packages/rust/sql-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-optimizer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Logical query plan optimizer for the Mini-SQLite SQL pipeline (Level 1)"
 authors = ["Adhithya Rajasekaran <adhithyan15@gmail.com>"]

--- a/code/packages/rust/sql-optimizer/src/lib.rs
+++ b/code/packages/rust/sql-optimizer/src/lib.rs
@@ -612,6 +612,16 @@ fn fold_expr(expr: SqlExpr) -> SqlExpr {
             ty,
         },
 
+        // CASE: fold each condition/value and the ELSE, but keep the branch
+        // structure (short-circuit semantics are the VM's job, not the folder's).
+        Case { branches, else_val } => Case {
+            branches: branches
+                .into_iter()
+                .map(|(cond, val)| (fold_expr(cond), fold_expr(val)))
+                .collect(),
+            else_val: else_val.map(|e| Box::new(fold_expr(*e))),
+        },
+
         IsNull(inner) => {
             let inner = fold_expr(*inner);
             match &inner {
@@ -1289,6 +1299,15 @@ fn collect_columns_in_expr(expr: &SqlExpr, out: &mut HashSet<String>) {
         }
         SqlExpr::UnaryOp { expr, .. } => collect_columns_in_expr(expr, out),
         SqlExpr::Cast { expr, .. } => collect_columns_in_expr(expr, out),
+        SqlExpr::Case { branches, else_val } => {
+            for (cond, val) in branches {
+                collect_columns_in_expr(cond, out);
+                collect_columns_in_expr(val, out);
+            }
+            if let Some(e) = else_val {
+                collect_columns_in_expr(e, out);
+            }
+        }
         SqlExpr::IsNull(inner) | SqlExpr::IsNotNull(inner) => {
             collect_columns_in_expr(inner, out)
         }

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.9] - Unreleased
+
+### Added
+
+- **Searched `CASE WHEN … THEN … [ELSE …] END`.** Added to the `primary` rule
+  (before `function_call`): one `WHEN/THEN` is mandatory, further ones repeat,
+  and `ELSE` is optional. Conditions and values are full `expr`s. The planner
+  (sql-planner 0.2.8) turns it into `SqlExpr::Case`.
+
 ## [0.1.8] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -560,6 +560,28 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     GrammarElement::Literal { value: r#")"#.to_string() },
                 ] },
+                // Searched `CASE WHEN cond THEN val … [ELSE val] END`. One
+                // WHEN/THEN is mandatory; further ones repeat; ELSE is optional.
+                // The condition/value slots are full `expr`s. Placed before
+                // function_call so the leading `CASE` literal is matched here.
+                GrammarElement::Sequence { elements: vec![
+                    GrammarElement::Literal { value: r#"CASE"#.to_string() },
+                    GrammarElement::Literal { value: r#"WHEN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::Literal { value: r#"THEN"#.to_string() },
+                    GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                    GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"WHEN"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                            GrammarElement::Literal { value: r#"THEN"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                        ] }) },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"ELSE"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                        ] }) },
+                    GrammarElement::Literal { value: r#"END"#.to_string() },
+                ] },
                 GrammarElement::RuleReference { name: r#"function_call"#.to_string() },
                 GrammarElement::RuleReference { name: r#"column_ref"#.to_string() },
                 GrammarElement::Sequence { elements: vec![

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -578,6 +578,20 @@ mod tests {
         assert!(find_rule(&ast2, "comparison"), "Expected comparison");
     }
 
+    /// Searched `CASE WHEN … THEN … [ELSE …] END` parses as a primary: a single
+    /// WHEN, multiple WHENs, with and without ELSE, and nested in a WHERE.
+    #[test]
+    fn test_parse_case() {
+        for q in [
+            "SELECT CASE WHEN a=1 THEN 'x' END FROM t",
+            "SELECT CASE WHEN a=1 THEN 'x' WHEN a=2 THEN 'y' ELSE 'z' END FROM t",
+            "SELECT x FROM t WHERE CASE WHEN a IS NULL THEN 0 ELSE 1 END",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "primary"), "Expected primary for {q:?}");
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.8] - Unreleased
+
+### Added
+
+- **`SqlExpr::Case { branches, else_val }`** for searched CASE, plus `plan_case`
+  which walks the `CASE`/`WHEN`/`THEN`/`ELSE`/`END` keyword tokens and their
+  interleaved expression nodes into `(cond, value)` branch pairs and an optional
+  ELSE. Rejects a CASE with no `WHEN` branch.
+
 ## [0.2.7] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -151,6 +151,17 @@ pub enum SqlExpr {
         ty: CastType,
     },
 
+    /// A searched `CASE WHEN cond THEN val … [ELSE val] END` expression.
+    ///
+    /// The `branches` are evaluated top-to-bottom; the value of the first branch
+    /// whose condition is truthy (non-zero, non-NULL) is the result. If none
+    /// match, the result is `else_val` if present, otherwise `NULL`. Later
+    /// branches are NOT evaluated once one matches (short-circuit).
+    Case {
+        branches: Vec<(SqlExpr, SqlExpr)>,
+        else_val: Option<Box<SqlExpr>>,
+    },
+
     /// An aggregate function applied within GROUP BY context.
     ///
     /// Aggregates are separated from regular function calls because they
@@ -2125,6 +2136,9 @@ fn plan_primary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         if t.value.eq_ignore_ascii_case("CAST") {
             return plan_cast(node);
         }
+        if t.value.eq_ignore_ascii_case("CASE") {
+            return plan_case(node);
+        }
     }
 
     // Check child nodes first (column_ref, function_call, or parenthesized expr).
@@ -2215,6 +2229,57 @@ fn plan_cast(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         expr: Box::new(inner),
         ty,
     })
+}
+
+/// Plan a searched `CASE WHEN … THEN … [ELSE …] END` primary node into
+/// [`SqlExpr::Case`].
+///
+/// Grammar: `CASE ("WHEN" expr "THEN" expr)+ ["ELSE" expr] "END"`. The node's
+/// children are the `CASE`/`WHEN`/`THEN`/`ELSE`/`END` keyword tokens interleaved
+/// with the condition and value expression nodes. We walk them in order: each
+/// keyword tags the expression node that follows it, so `WHEN`→condition,
+/// `THEN`→pairs with the last condition into a branch, `ELSE`→the fallback.
+fn plan_case(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
+    let mut branches: Vec<(SqlExpr, SqlExpr)> = Vec::new();
+    let mut else_val: Option<Box<SqlExpr>> = None;
+    let mut pending_cond: Option<SqlExpr> = None;
+    // What the next expression node is filling (set by the preceding keyword).
+    let mut slot: Option<&'static str> = None;
+
+    for child in &node.children {
+        match child {
+            ASTNodeOrToken::Token(t) => {
+                slot = match t.value.to_uppercase().as_str() {
+                    "WHEN" => Some("when"),
+                    "THEN" => Some("then"),
+                    "ELSE" => Some("else"),
+                    _ => None, // CASE / END and any punctuation
+                };
+            }
+            ASTNodeOrToken::Node(n) => {
+                let expr = plan_expression(n)?;
+                match slot {
+                    Some("when") => pending_cond = Some(expr),
+                    Some("then") => {
+                        let cond = pending_cond.take().ok_or_else(|| {
+                            PlanError::UnsupportedStatement("CASE THEN without WHEN".to_string())
+                        })?;
+                        branches.push((cond, expr));
+                    }
+                    Some("else") => else_val = Some(Box::new(expr)),
+                    _ => {}
+                }
+                slot = None;
+            }
+        }
+    }
+
+    if branches.is_empty() {
+        return Err(PlanError::UnsupportedStatement(
+            "CASE requires at least one WHEN … THEN … branch".to_string(),
+        ));
+    }
+    Ok(SqlExpr::Case { branches, else_val })
 }
 
 /// Plan a single token from a primary node into a literal or column reference.


### PR DESCRIPTION
## Searched `CASE WHEN … THEN … [ELSE …] END`

`SELECT CASE WHEN cond THEN val … [ELSE val] END` now parses and runs with
SQLite's exact semantics: branches evaluate top-to-bottom, the first truthy
`WHEN` yields its `THEN`; no match + `ELSE` → the `ELSE`; no match + no `ELSE` →
`NULL`; a `NULL` condition is not truthy (its branch is skipped); and evaluation
**short-circuits** (later branches' values are never computed once one matches).

Notably this needed **no new VM opcode** — the codegen is a jump chain over the
existing `JumpIfTrue`/`Jump`/`Label`/`LoadConst` instructions, so short-circuit
falls out for free.

### What changed (rotation lane 1, CASE)
- **sql-parser** (`_grammar.rs`): a `CASE` alternative in `primary` (before
  `function_call`): mandatory `WHEN/THEN`, repeated `WHEN/THEN`, optional
  `ELSE`, `END`.
- **sql-planner**: `SqlExpr::Case { branches, else_val }` + `plan_case` (walks
  the keyword tokens + interleaved expr nodes into `(cond, value)` pairs;
  rejects a `CASE` with no `WHEN`).
- **sql-codegen**: `compile_expr` Case arm — each cond compiled + `JumpIfTrue(body_i)`;
  else the `ELSE` (or `LoadConst(Null)`); each body pushes its `THEN` and jumps
  to a shared `end` label.
- **sql-optimizer**: `fold_expr` folds conds/values/`ELSE` keeping branch
  structure; `collect_columns_in_expr` recurses into all of them.

### Verification (probe → test-first)
Probed against real SQLite first — first-match+else, no-else→NULL,
NULL-cond-skipped, CASE in a WHERE predicate, CASE in arithmetic (`+5`) — all
match.
- **Differential oracle** (mini-sqlite): `case_first_match_and_else`,
  `case_no_else_is_null_and_null_cond_skipped`, `case_in_where_and_arithmetic`.
- **sql-parser**: `test_parse_case` (single/multi `WHEN`, with/without `ELSE`,
  in a WHERE).
- Full affected SQL pipeline green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — grammar has no zero-width
  repetition; the codegen jump-chain is **stack-balanced on every path** (the
  ELSE/NULL block's `Jump(end)` sits before the first body label, so fall-through
  into a body is impossible; each body ends with `Jump(end)`); every referenced
  label is emitted; the planner is panic-free.

### Versions
sql-parser 0.1.8→0.1.9 · sql-planner 0.2.7→0.2.8 · sql-codegen 0.6.2→0.6.3 ·
sql-optimizer 0.1.2→0.1.3 · mini-sqlite 0.5.24→0.5.25.

### Follow-up
Simple CASE (`CASE x WHEN v THEN …` — equality against a base expression) is a
separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
