### PR TITLE
feat(derive-runtime,derive-repl): lower Derive to symbolic-ir, evaluate via symbolic-vm (MA07 D-4, front2 Wave 5)

### DIFF
--- a/code/packages/rust/Cargo.toml
+++ b/code/packages/rust/Cargo.toml
@@ -245,6 +245,8 @@ members = [
     "wolfram-to-semantic-ir",
     "derive-lexer",
     "derive-parser",
+    "derive-runtime",
+    "derive-repl",
     "apl-lexer",
     "apl-parser",
     "apl-runtime",

--- a/code/packages/rust/derive-repl/BUILD
+++ b/code/packages/rust/derive-repl/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-repl -- --nocapture

--- a/code/packages/rust/derive-repl/BUILD_windows
+++ b/code/packages/rust/derive-repl/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-repl -- --nocapture

--- a/code/packages/rust/derive-repl/CHANGELOG.md
+++ b/code/packages/rust/derive-repl/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial `derive-repl` crate (MA07 D-4, front2 Wave 5): an interactive
+  Read-Eval-Print loop and the `derive` binary, wrapping a persistent
+  `DeriveSession` (`derive-runtime`).
+- `#n: ` numbered-worksheet prompt (MA07 §5), `(`/`[`-bracket-depth line
+  continuation (no string/comment state to track — this subset has
+  neither), and case-insensitive `QUIT`/`EXIT` to end the session.
+- Bounded single-physical-line reads (`read_bounded_line`, 64 KiB cap),
+  carrying forward the `j-repl`/`apl-repl` `/security-review` fix ("cap
+  unbounded single-line read before continuation-buffer check") rather than
+  reintroducing the same gap in a new REPL: `BufRead::read_line` alone has
+  no length bound, so a single arbitrarily-long line would fully buffer in
+  memory before any of this crate's own size checks ran.
+- 18 tests: prompt/continuation behaviour, quit words, error recovery,
+  persistent bindings, an end-to-end worksheet program, and the full
+  `read_bounded_line` regression suite (oversized line, exact-cap boundary,
+  multi-chunk overflow drain, multibyte-character straddle).

--- a/code/packages/rust/derive-repl/Cargo.toml
+++ b/code/packages/rust/derive-repl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "coding-adventures-derive-repl"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive REPL and `derive` binary for Derive (a subset)"
+license = "MIT"
+
+[dependencies]
+coding-adventures-derive-runtime = { path = "../derive-runtime" }
+
+[[bin]]
+name = "derive"
+path = "src/main.rs"

--- a/code/packages/rust/derive-repl/README.md
+++ b/code/packages/rust/derive-repl/README.md
@@ -1,0 +1,57 @@
+# coding-adventures-derive-repl
+
+An interactive Read-Eval-Print loop and the `derive` binary for Derive (a
+subset). Wraps a persistent
+[`coding_adventures_derive_runtime::DeriveSession`](../derive-runtime) and
+adds the console behaviours a Derive worksheet user expects. See
+[`code/specs/MA07-derive-language.md`](../../../specs/MA07-derive-language.md).
+
+## Usage
+
+```sh
+cargo run -p coding-adventures-derive-repl --bin derive
+```
+
+```text
+Derive (on the shared symbolic stack) — one statement per line, type QUIT to exit.
+#1: x := 5
+#1: 5
+#2: x + 1
+#2: 6
+#3: DIF(x^2, x)
+#3: 2*x
+#4: QUIT
+```
+
+## Behaviour
+
+- **`#n: ` prompts** — Derive's own numbered expression-history convention
+  (MA07 §5), not Wolfram's `In[n]:=`/`Out[n]=` split.
+- **Line continuation** — a statement is complete once `(`/`[` bracket depth
+  returns to zero; unlike `wolfram-repl` there is no string/comment state to
+  track (this subset has neither — MA07 §4).
+- **`QUIT`/`EXIT`** (case-insensitive) or Ctrl-D ends the session.
+- **Non-fatal errors** — a surface error (parse failure, a deferred D-5
+  vector literal, …) prints and the session keeps working.
+
+## Security: bounded line reads
+
+`run` reads each physical line through a byte-oriented, cap-bounded
+`read_bounded_line` (64 KiB) rather than `BufRead::read_line` directly —
+carrying forward the exact fix `j-repl`/`apl-repl` needed after their own
+`/security-review`: `read_line` has no length bound of its own, so a single,
+arbitrarily long line (no embedded newline) would be fully buffered in
+memory before `DeriveRepl::feed`'s own size check ever ran. See the module
+doc comment for the full rationale (including the multibyte-character/
+cap-boundary edge case this fix also closes).
+
+## Tests
+
+```sh
+cargo test -p coding-adventures-derive-repl
+```
+
+Prompt/continuation behaviour, quit words, error recovery, persistent
+bindings, an end-to-end worksheet program, and the full `read_bounded_line`
+regression suite (oversized single line, exact-cap boundary, multi-chunk
+overflow drain, multibyte-character straddle).

--- a/code/packages/rust/derive-repl/required_capabilities.json
+++ b/code/packages/rust/derive-repl/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/derive-repl",
+  "capabilities": ["stdio"],
+  "justification": "An interactive console: the `derive` binary reads Derive source from stdin and writes results to stdout. No filesystem, network, or process access beyond standard streams."
+}

--- a/code/packages/rust/derive-repl/src/lib.rs
+++ b/code/packages/rust/derive-repl/src/lib.rs
@@ -1,0 +1,449 @@
+//! # Derive REPL — an interactive Read-Eval-Print loop for Derive (a subset).
+//!
+//! [`DeriveRepl`] wraps a persistent [`DeriveSession`] (which reuses the
+//! entire shared symbolic stack) and adds the console behaviours a Derive
+//! worksheet user expects:
+//!
+//! * **`#n: ` prompts** — mirroring Derive's own numbered expression history
+//!   (MA07 §5); the continuation prompt is shown while a statement spans
+//!   physical lines.
+//! * **Line continuation** — a statement is terminated by a newline once
+//!   `(`/`[` brackets are balanced (Derive has no strings or comments in
+//!   this subset — MA07 §4 — so, unlike `wolfram-repl`, there is no
+//!   string/comment state to track). The accumulation buffer is size-capped
+//!   so an input that never balances cannot grow memory without bound.
+//! * **Quit / EOF** — `QUIT`, `EXIT` (case-insensitive convenience: also
+//!   `quit`/`exit`), or Ctrl-D end the session.
+//! * **Non-fatal errors** — a surface error prints and the session continues.
+//!
+//! This mirrors `wolfram-repl`/`maxima-repl`'s single-threaded driver, with
+//! one difference carried forward from `j-repl`/`apl-repl`'s own
+//! `/security-review` fix (task tracked as "cap unbounded single-line read
+//! before continuation-buffer check"): [`run`] reads each physical line
+//! through [`read_bounded_line`] (capped at [`MAX_LINE_LEN`]) rather than
+//! `BufRead::read_line` directly. `read_line` has no length bound of its
+//! own — a single, arbitrarily long physical line with no embedded newline
+//! is fully buffered in memory before [`DeriveRepl::feed`]'s own
+//! `MAX_INPUT_LEN` check ever gets a chance to reject anything.
+
+use coding_adventures_derive_runtime::{DeriveSession, MAX_INPUT_LEN};
+use std::io::{BufRead, Write};
+
+/// What the REPL should do after being fed one physical line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplResponse {
+    /// A complete statement (or batch) was evaluated; here is its echo.
+    Output(String),
+    /// The buffer is not yet a complete statement — read another line.
+    NeedMore,
+    /// The user asked to leave.
+    Quit,
+}
+
+/// A persistent interactive Derive session.
+pub struct DeriveRepl {
+    session: DeriveSession,
+    buffer: String,
+    /// The 1-based index shown in the `#n:` prompt. Advances once per
+    /// *submitted* batch, mirroring Derive's own numbered worksheet lines.
+    input_index: usize,
+}
+
+impl Default for DeriveRepl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeriveRepl {
+    pub fn new() -> Self {
+        DeriveRepl {
+            session: DeriveSession::new(),
+            buffer: String::new(),
+            input_index: 1,
+        }
+    }
+
+    /// The prompt to print before reading the next physical line.
+    pub fn prompt(&self) -> String {
+        if self.buffer.is_empty() {
+            format!("#{}: ", self.input_index)
+        } else {
+            "... ".to_string()
+        }
+    }
+
+    /// Feed one physical input line (without its trailing newline).
+    pub fn feed(&mut self, line: &str) -> ReplResponse {
+        // Quit words are only recognised at the start of a fresh statement,
+        // so an identifier named `QUIT`/`EXIT` mid-expression is never
+        // hijacked.
+        if self.buffer.is_empty() {
+            match line.trim() {
+                "QUIT" | "quit" | "Quit" | "EXIT" | "exit" | "Exit" => return ReplResponse::Quit,
+                _ => {}
+            }
+        }
+        self.buffer.push_str(line);
+        self.buffer.push('\n');
+
+        // Bound the accumulation buffer: a stream that never balances (an
+        // endless run of open brackets) must not buffer unbounded memory.
+        // Once over the size the session would reject anyway, submit so
+        // `feed` returns the clean "too large" error and resets.
+        if self.buffer.len() <= MAX_INPUT_LEN && is_incomplete(&self.buffer) {
+            return ReplResponse::NeedMore;
+        }
+
+        let src = std::mem::take(&mut self.buffer);
+        if src.trim().is_empty() {
+            return ReplResponse::Output(String::new());
+        }
+        self.input_index += 1;
+        match self.session.feed(&src) {
+            Ok(text) => ReplResponse::Output(text),
+            Err(e) => ReplResponse::Output(format!("Error: {e}\n")),
+        }
+    }
+
+    /// Is a statement currently spanning multiple lines?
+    pub fn is_continuing(&self) -> bool {
+        !self.buffer.is_empty()
+    }
+}
+
+/// Upper bound on a single *physical* line read from the input stream,
+/// applied in [`read_bounded_line`] before [`DeriveRepl::feed`]'s own
+/// `MAX_INPUT_LEN` check ever runs. `BufRead::read_line` has no length bound
+/// of its own — it grows its buffer until it sees a `\n` or EOF — so without
+/// this, a single, arbitrarily long physical line (no embedded newline at
+/// all) is fully buffered in memory before `feed` ever gets a chance to
+/// reject anything. Mirrors `j-repl`/`apl-repl`'s own `MAX_LINE_LEN` fix
+/// exactly (same value, same rationale).
+const MAX_LINE_LEN: u64 = 64 * 1024;
+
+/// Read one physical line, bounded to [`MAX_LINE_LEN`] bytes.
+///
+/// - `Ok(None)` — genuine end of input.
+/// - `Ok(Some(Ok(line)))` — an ordinary line. Includes a final, newline-less
+///   line at genuine EOF (same as `BufRead::read_line`'s own contract).
+/// - `Ok(Some(Err(())))` — a single physical line's true length exceeds the
+///   cap; the oversized remainder is fully drained and discarded so the next
+///   read always starts at a genuine line boundary.
+///
+/// Reads raw **bytes** (`read_until(b'\n', ..)`), not `BufRead::read_line`
+/// directly, deciding "oversized?" on the byte run *before* attempting UTF-8
+/// decoding — `Take` stops at an arbitrary byte offset with no notion of a
+/// character boundary, so a valid UTF-8 line whose true length only slightly
+/// exceeds the cap could have a multi-byte character straddle that exact
+/// offset, and validating on the byte run through `read_line` alone would
+/// misreport that as a decoding failure rather than an oversized line.
+/// Mirrors `j-repl::read_bounded_line`/`apl-repl::read_bounded_line` exactly.
+fn read_bounded_line<R: BufRead>(reader: &mut R) -> std::io::Result<Option<Result<String, ()>>> {
+    let mut buf: Vec<u8> = Vec::new();
+    // Explicit UFCS + an explicit reborrow (`&mut *reader`): `Read`/`BufRead`
+    // are implemented both for `R` itself and for `&mut R`, and ordinary
+    // autoref method resolution prefers the by-value `R` candidate even when
+    // the receiver is already a reference — silently trying to MOVE
+    // `*reader` instead of taking a bounded view of it. Naming the trait and
+    // the exact `&mut R` receiver explicitly removes that ambiguity.
+    let mut limited: std::io::Take<&mut R> = std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+    let read = limited.read_until(b'\n', &mut buf)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    let hit_cap = buf.len() as u64 == MAX_LINE_LEN && buf.last() != Some(&b'\n');
+    if hit_cap {
+        // The initial capped read filled up with no newline in sight — keep
+        // reading further capped chunks (discarding them) until either a
+        // real `\n` is found (genuinely oversized) or a chunk comes back
+        // empty (a maximal-but-not-oversized line at genuine EOF).
+        let mut saw_more_data = false;
+        loop {
+            let mut chunk: Vec<u8> = Vec::new();
+            let mut limited: std::io::Take<&mut R> =
+                std::io::Read::take(&mut *reader, MAX_LINE_LEN);
+            let n = limited.read_until(b'\n', &mut chunk)?;
+            if n == 0 {
+                if !saw_more_data {
+                    return match String::from_utf8(buf) {
+                        Ok(line) => Ok(Some(Ok(line))),
+                        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+                    };
+                }
+                break; // true EOF reached while draining real overflow
+            }
+            saw_more_data = true;
+            if chunk.last() == Some(&b'\n') {
+                break; // found the oversized line's real end
+            }
+        }
+        return Ok(Some(Err(())));
+    }
+    match String::from_utf8(buf) {
+        Ok(line) => Ok(Some(Ok(line))),
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+    }
+}
+
+/// Is the accumulated source *incomplete* — i.e. should the REPL keep
+/// reading?
+///
+/// A Derive statement is complete at a newline once `(`/`[` bracket depth is
+/// zero — this subset has no strings or comments (MA07 §4), so unlike
+/// `wolfram-repl` there is no quote/comment state to track. This is only a
+/// continuation *heuristic*: whatever is submitted still passes through
+/// [`DeriveSession::feed`], which re-lexes with the real lexer and applies
+/// the size/complexity guards, so a mismatch can never crash — at worst it
+/// submits early or asks for one more line.
+fn is_incomplete(src: &str) -> bool {
+    let mut depth: i32 = 0;
+    for ch in src.chars() {
+        match ch {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth -= 1,
+            _ => {}
+        }
+    }
+    depth > 0
+}
+
+/// Drive a full interactive Derive session over the given reader and writer.
+pub fn run<R: BufRead, W: Write>(mut reader: R, mut writer: W) -> std::io::Result<()> {
+    let mut repl = DeriveRepl::new();
+    writeln!(
+        writer,
+        "Derive (on the shared symbolic stack) — one statement per line, type QUIT to exit."
+    )?;
+
+    loop {
+        write!(writer, "{}", repl.prompt())?;
+        writer.flush()?;
+
+        let line = match read_bounded_line(&mut reader)? {
+            None => {
+                writeln!(writer)?;
+                break;
+            }
+            Some(Err(())) => {
+                writeln!(
+                    writer,
+                    "Error: line exceeds the {MAX_LINE_LEN}-byte limit; discarded"
+                )?;
+                writer.flush()?;
+                continue;
+            }
+            Some(Ok(line)) => line,
+        };
+        let line = line.strip_suffix('\n').unwrap_or(&line);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+
+        match repl.feed(line) {
+            ReplResponse::Output(text) => {
+                write!(writer, "{text}")?;
+                writer.flush()?;
+            }
+            ReplResponse::NeedMore => {}
+            ReplResponse::Quit => break,
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_single_line_statement_evaluates_immediately() {
+        let mut r = DeriveRepl::new();
+        assert!(matches!(r.feed("1 + 2*3"), ReplResponse::Output(t) if t.contains('7')));
+    }
+
+    #[test]
+    fn continues_while_a_paren_is_open() {
+        let mut r = DeriveRepl::new();
+        assert_eq!(r.feed("SIN(1,"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("2)"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn continues_while_a_bracket_is_open() {
+        // A matrix/vector literal spanning lines — this crate doesn't
+        // evaluate it (D-5), but the REPL still buffers correctly and the
+        // session surfaces the deferral as a clean error.
+        let mut r = DeriveRepl::new();
+        assert_eq!(r.feed("[1,"), ReplResponse::NeedMore);
+        assert!(matches!(r.feed("2, 3]"), ReplResponse::Output(_)));
+    }
+
+    #[test]
+    fn prompts_switch_between_input_and_continuation() {
+        let mut r = DeriveRepl::new();
+        assert_eq!(r.prompt(), "#1: ");
+        assert_eq!(r.feed("SIN("), ReplResponse::NeedMore);
+        assert_eq!(r.prompt(), "... ", "continuation prompt while open");
+        assert!(r.is_continuing());
+        assert!(matches!(r.feed("0)"), ReplResponse::Output(_)));
+        assert_eq!(r.prompt(), "#2: ", "input index advanced");
+    }
+
+    #[test]
+    fn quit_words_leave_the_session() {
+        assert_eq!(DeriveRepl::new().feed("QUIT"), ReplResponse::Quit);
+        assert_eq!(DeriveRepl::new().feed("quit"), ReplResponse::Quit);
+        assert_eq!(DeriveRepl::new().feed("EXIT"), ReplResponse::Quit);
+        assert_eq!(DeriveRepl::new().feed("exit"), ReplResponse::Quit);
+    }
+
+    #[test]
+    fn an_error_is_printed_and_the_session_survives() {
+        let mut r = DeriveRepl::new();
+        assert!(matches!(r.feed("1 +"), ReplResponse::Output(t) if t.contains("Error")));
+        assert!(matches!(r.feed("1 + 1"), ReplResponse::Output(t) if t.contains('2')));
+    }
+
+    #[test]
+    fn bindings_persist_across_lines() {
+        let mut r = DeriveRepl::new();
+        assert!(matches!(r.feed("x := 5"), ReplResponse::Output(_)));
+        assert!(matches!(r.feed("x + 1"), ReplResponse::Output(t) if t.contains('6')));
+    }
+
+    #[test]
+    fn an_unterminated_buffer_is_submitted_once_over_the_size_cap() {
+        let mut r = DeriveRepl::new();
+        let big = "(".repeat(MAX_INPUT_LEN + 16);
+        match r.feed(&big) {
+            ReplResponse::Output(t) => assert!(t.contains("too large"), "got {t:?}"),
+            other => panic!("expected an over-size submission, got {other:?}"),
+        }
+        assert_eq!(r.prompt(), "#2: ");
+    }
+
+    #[test]
+    fn run_drives_a_session_to_eof() {
+        let input = b"1 + 2*3\nQUIT\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains('7'), "expected 7 in session: {text:?}");
+        assert!(text.contains("#1:"), "expected the input prompt: {text:?}");
+    }
+
+    #[test]
+    fn run_handles_bare_eof_without_quit() {
+        let input = b"2 + 2\n" as &[u8];
+        let mut output = Vec::new();
+        run(input, &mut output).unwrap();
+        assert!(String::from_utf8(output).unwrap().contains('4'));
+    }
+
+    #[test]
+    fn blank_lines_are_harmless() {
+        let mut r = DeriveRepl::new();
+        assert_eq!(r.feed(""), ReplResponse::Output(String::new()));
+        assert_eq!(
+            r.prompt(),
+            "#1: ",
+            "a blank line does not advance the counter"
+        );
+    }
+
+    #[test]
+    fn a_derive_worksheet_program_evaluates_end_to_end() {
+        let mut r = DeriveRepl::new();
+        assert!(matches!(
+            r.feed("F(x) := DIF(SIN(x), x)"),
+            ReplResponse::Output(_)
+        ));
+        assert!(matches!(r.feed("F(0)"), ReplResponse::Output(_)));
+    }
+
+    // --- read_bounded_line: the /security-review fix carried forward from
+    //     j-repl/apl-repl (task #32) ---------------------------------------
+
+    #[test]
+    fn read_bounded_line_rejects_a_line_exceeding_the_cap_without_buffering_it_whole() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 3);
+        let mut input = oversized.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        let _ = read_bounded_line(&mut input);
+    }
+
+    #[test]
+    fn read_bounded_line_at_exactly_the_cap_with_a_trailing_newline_is_not_oversized() {
+        let mut line = "+".repeat(MAX_LINE_LEN as usize - 1);
+        line.push('\n');
+        assert_eq!(line.len() as u64, MAX_LINE_LEN);
+        let mut input = line.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Ok(line)));
+    }
+
+    #[test]
+    fn read_bounded_line_treats_an_exactly_cap_sized_final_line_as_ordinary_not_oversized() {
+        let line = "+".repeat(MAX_LINE_LEN as usize);
+        let mut input = line.as_bytes();
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok(line.clone()))
+        );
+        assert_eq!(read_bounded_line(&mut input).unwrap(), None);
+    }
+
+    #[test]
+    fn read_bounded_line_fully_drains_a_line_spanning_multiple_cap_chunks() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1\n");
+        let mut input = input.as_bytes();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+        assert_eq!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(Ok("1+1\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn read_bounded_line_handles_a_multibyte_char_straddling_the_cap_boundary() {
+        let mut oversized: Vec<u8> = vec![b'a'; MAX_LINE_LEN as usize - 1];
+        oversized.extend_from_slice("é".as_bytes()); // 2-byte char, straddles the cap
+        oversized.push(b'\n');
+        let mut input = oversized.as_slice();
+        assert_eq!(read_bounded_line(&mut input).unwrap(), Some(Err(())));
+    }
+
+    #[test]
+    fn run_reports_an_oversized_line_cleanly_and_keeps_the_session_alive() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 2);
+        let input = format!("{oversized}\n1+1\nQUIT\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("exceeds"),
+            "expected an oversized-line error, got: {text}"
+        );
+        assert!(
+            text.contains('2'),
+            "session must keep working after an oversized line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn run_executes_the_correct_follow_up_statement_after_a_multi_chunk_oversized_line() {
+        let oversized = "+".repeat(MAX_LINE_LEN as usize * 5 / 2);
+        let input = format!("{oversized}\n1+1\nQUIT\n");
+        let mut output = Vec::new();
+        run(input.as_bytes(), &mut output).unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(
+            text.contains("exceeds"),
+            "expected an oversized-line error, got: {text}"
+        );
+        assert!(
+            text.contains('2'),
+            "the real follow-up statement (1+1), not a fragment of the \
+             discarded line, must be what gets evaluated, got: {text}"
+        );
+    }
+}

--- a/code/packages/rust/derive-repl/src/main.rs
+++ b/code/packages/rust/derive-repl/src/main.rs
@@ -1,0 +1,18 @@
+//! The `derive` binary — an interactive prompt for Derive (a subset).
+//!
+//! Reads one physical line at a time (continuing across an open `(`/`[`
+//! until balanced), evaluates over the reused shared symbolic stack, and
+//! echoes each result as `#n: «value»` — Derive's own numbered-worksheet
+//! convention (MA07 §5). Type `QUIT`/`EXIT` (or Ctrl-D) to leave. All logic
+//! lives in [`coding_adventures_derive_repl::run`].
+
+use std::io;
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if let Err(e) = coding_adventures_derive_repl::run(stdin.lock(), stdout.lock()) {
+        eprintln!("derive: I/O error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/code/packages/rust/derive-runtime/BUILD
+++ b/code/packages/rust/derive-runtime/BUILD
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-runtime -- --nocapture

--- a/code/packages/rust/derive-runtime/BUILD_windows
+++ b/code/packages/rust/derive-runtime/BUILD_windows
@@ -1,0 +1,1 @@
+cargo test -p coding-adventures-derive-runtime -- --nocapture

--- a/code/packages/rust/derive-runtime/CHANGELOG.md
+++ b/code/packages/rust/derive-runtime/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+## [0.1.0] - 2026-07-13
+
+### Added
+
+- Initial `derive-runtime` crate (MA07 D-4, front2 Wave 5): lowers the
+  `derive-parser` (D-3) `GrammarASTNode` CST into `symbolic_ir::IRNode` and
+  evaluates it via `symbolic_vm::VM` over the shared `SymbolicBackend` —
+  unchanged, no custom `Backend` — since D-4's scope (arithmetic,
+  comparison, logic, `Assign`/`Define`/`If`, base `DIF`→`D`/`INT`→`Integrate`)
+  is already fully covered by the existing handler table.
+- `lower` module: the full precedence-cascade lowering (`assignment` through
+  `atom`), the uppercase-surface→canonical head bridge (`SIN`→`Sin`,
+  `DIF`→`D`, `INT`→`Integrate`, `IF`→`If`, plus the hyperbolic/inverse-trig
+  catalogue), and `:=` assignment-vs-function-definition disambiguation by
+  LHS shape (Derive has only one assignment token, unlike Wolfram's
+  `=`/`:=` or Macsyma's `:`/`::=`, so there is no operator to branch on).
+  Vector/matrix literals (`[a, b, c]`) return a clean `LowerError` — deferred
+  to D-5 per MA07 §2, not silently mis-lowered.
+- `printer` module: the inverse — canonical heads back to Derive surface
+  notation (infix arithmetic/comparison/logic, `F(…)` calls), with its own
+  precedence ladder mirroring MA07 §3's table.
+- `DeriveSession`/`eval`: a string-in/string-out facade mirroring
+  `wolfram-runtime`/`maxima-runtime`'s session pattern, with a `#n:`
+  numbered-worksheet display convention (MA07 §5) — no `;`-suppression
+  syntax exists in this subset, so every statement always displays.
+- Robustness: `MAX_INPUT_LEN` (64 KiB) bounds total input;
+  `MAX_STATEMENT_TOKENS` (2000, measured against the real `derive-lexer`
+  token stream) closes the "long flat chain folds into a deep lowered tree"
+  vector that `derive-parser`'s own `MAX_RULE_DEPTH` cannot cover (grammar
+  repetitions, not recursive rule calls, aren't bounded by that cap — a
+  genuinely separate vector, per the "depth caps don't compose across
+  boundaries" lesson). Evaluation runs on a 512 MiB-stack worker thread
+  inside `catch_unwind`, rebuilding the session after any caught panic.
+- 19 unit tests in `lower`/`printer` covering every lowering/printing
+  construct, plus 22 end-to-end session tests (arithmetic, persistent
+  bindings/functions, `DIF`/`INT`/`IF` through the shared handler table, both
+  robustness guards, panic recovery, and the D-5 deferral).

--- a/code/packages/rust/derive-runtime/Cargo.toml
+++ b/code/packages/rust/derive-runtime/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "coding-adventures-derive-runtime"
+version = "0.1.0"
+edition = "2021"
+description = "Derive runtime — lowers Derive syntax to symbolic-ir and evaluates via symbolic-vm"
+license = "MIT"
+
+[dependencies]
+# The D-3 frontend: parses Derive source into a generic GrammarASTNode that
+# this crate lowers to symbolic-ir.
+coding-adventures-derive-parser = { path = "../derive-parser" }
+# The D-2 lexer. Tokenized once up front (the lexer is iterative, so unlike
+# the parser it cannot stack-overflow) to measure per-statement token counts
+# from the *real* token stream, mirroring wolfram-runtime/maxima-runtime's
+# identical guard against a long flat operator chain folding into a deeply
+# nested lowered tree (see MAX_STATEMENT_TOKENS's doc comment).
+coding-adventures-derive-lexer = { path = "../derive-lexer" }
+# The shared symbolic substrate: the term IR everything lowers to and the VM
+# that rewrites it.
+symbolic-ir = { path = "../symbolic-ir" }
+symbolic-vm = { path = "../symbolic-vm" }
+# The generic parser AST types (GrammarASTNode / ASTNodeOrToken) and the lexer
+# Token type the lowering walks.
+parser = { path = "../parser" }
+lexer = { path = "../lexer" }

--- a/code/packages/rust/derive-runtime/README.md
+++ b/code/packages/rust/derive-runtime/README.md
@@ -1,0 +1,88 @@
+# coding-adventures-derive-runtime
+
+Evaluates Derive (a subset) by lowering the `derive-parser` (D-3) CST into
+[`symbolic-ir`](../symbolic-ir) and running it through
+[`symbolic-vm`](../symbolic-vm)'s shared `SymbolicBackend` — the *same*
+rewrite engine Wolfram and Macsyma already drive, unchanged. See
+[`code/specs/MA07-derive-language.md`](../../../specs/MA07-derive-language.md).
+
+## Where this fits
+
+`derive-runtime` is D-4 of the Derive frontend/runtime pipeline:
+
+```
+derive.tokens + derive-lexer   (D-2)
+        │
+derive.grammar + derive-parser (D-3)
+        │
+derive-runtime                 (D-4, this crate) ── crate::lower ──► symbolic_ir::IRNode
+        │                                              │
+        │                                       symbolic_vm::VM (SymbolicBackend)
+        │                                              │
+derive-repl                    (D-4)  ◄── crate::printer ─┘
+```
+
+## No custom `Backend`
+
+`SymbolicBackend` (built with `simplify: true`) already provides every
+operation MA07 §3/§4 scopes for D-4 — arithmetic, comparison, logic, the
+held `Assign`/`Define`/`If` forms, and the base `D`/`Integrate` calculus
+handlers — so this crate adds **no new evaluation code**, only:
+
+- **`lower`** — Derive's surface `GrammarASTNode` (assignment, additive,
+  multiplicative, power, postfix, atom, …) → the canonical `IRNode` heads
+  the VM dispatches, including the uppercase-surface→canonical head bridge
+  (`SIN`→`Sin`, `DIF`→`D`, `INT`→`Integrate`, `IF`→`If`, …) and the `:=`
+  assignment-vs-definition disambiguation by LHS shape (see the module doc
+  comment — Derive, unlike Wolfram/Macsyma, has only one assignment
+  operator token, so there is no operator to branch on).
+- **`printer`** — the inverse: canonical `IRNode` → Derive surface notation
+  (infix `+`/`-`/`*`/`/`/`^`, `AND`/`OR`/`NOT`, `F(…)` calls), bridging
+  builtin heads back to their uppercase spelling.
+
+`LIM`/`SOLVE`/`SUM`/`PRODUCT`/`TAYLOR` are **not** wired — MA07 §4 ("Honest
+scope") defers them to their own follow-on items, since the shared VM has
+no existing handler for any of them (unlike `D`/`Integrate`, which are
+already fully implemented and used unchanged).
+
+## Usage
+
+```rust
+use coding_adventures_derive_runtime::DeriveSession;
+
+let mut s = DeriveSession::new();
+assert_eq!(s.feed("x := 5\n").unwrap(), "#1: 5\n");
+assert_eq!(s.feed("x + 1\n").unwrap(), "#2: 6\n");
+assert_eq!(s.feed("DIF(x^2, x)\n").unwrap(), "#3: 2*x\n");
+```
+
+`coding_adventures_derive_runtime::eval(src)` is a one-shot convenience for
+callers that don't need a persistent session.
+
+## Robustness
+
+`feed`/`eval_to_outputs` are the trust boundary for arbitrary Derive source.
+Two independent deep-recursion vectors are closed (see the crate doc
+comment for the full rationale):
+
+1. **Deeply nested source** (`((((…))))`) — already rejected by
+   `derive-parser`'s own `MAX_RULE_DEPTH`.
+2. **A long flat chain** (`1+1+1+…`) that folds into a deeply *nested*
+   lowered tree — grammar repetitions aren't bounded by `MAX_RULE_DEPTH`, so
+   `MAX_STATEMENT_TOKENS` (measured against the real lexer token stream)
+   closes this separately.
+
+Evaluation itself runs on a worker thread with a large bounded stack inside
+`catch_unwind`, so a reused-handler panic (e.g. a malformed `Assign` LHS)
+becomes a clean `Err` and the session is rebuilt rather than left corrupted.
+
+## Tests
+
+```sh
+cargo test -p coding-adventures-derive-runtime
+```
+
+Unit tests for every `lower`/`printer` construct, plus end-to-end session
+tests: arithmetic, persistent assignment/user-defined functions, `DIF`/`INT`/`IF`
+wiring through the shared handler table, the two robustness guards, and
+panic recovery.

--- a/code/packages/rust/derive-runtime/required_capabilities.json
+++ b/code/packages/rust/derive-runtime/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "rust/derive-runtime",
+  "capabilities": [],
+  "justification": "Pure computation: parses Derive source, lowers it to symbolic-ir, evaluates with symbolic-vm, and formats the result string. No filesystem, network, or process access. (A bounded worker thread with a large stack is spawned per evaluation to contain deep-recursion stack overflows; this is in-process compute, not OS-level process spawning.)"
+}

--- a/code/packages/rust/derive-runtime/src/lib.rs
+++ b/code/packages/rust/derive-runtime/src/lib.rs
@@ -1,0 +1,484 @@
+//! # Derive runtime — lower Derive syntax to `symbolic-ir`, evaluate via `symbolic-vm`.
+//!
+//! This is the **D-4** deliverable of the Derive-language lane (MA07 §2). D-1
+//! through D-3 gave us a spec, a lexer, and a parser; this crate is the
+//! *runtime* that finally **evaluates** Derive source — by **reusing the
+//! shared symbolic substrate** rather than writing a bespoke interpreter:
+//!
+//! ```text
+//!   Derive source
+//!        │
+//!        ▼  coding_adventures_derive_parser::parse_derive  (D-3)
+//!   GrammarASTNode  (surface tree: assignment, additive, power, postfix, …)
+//!        │
+//!        ▼  crate::lower                                   (this crate)
+//!   symbolic_ir::IRNode   (Add, Mul, Pow, Assign, Define, D, Integrate, If, …)
+//!        │
+//!        ▼  symbolic_vm::VM over SymbolicBackend, UNCHANGED
+//!   symbolic_ir::IRNode   (evaluated)
+//!        │
+//!        ▼  crate::printer
+//!   Derive surface string  (infix, F(…), AND/OR/NOT)
+//! ```
+//!
+//! ## No custom `Backend` needed
+//!
+//! Unlike `wolfram-runtime`/`macsyma-runtime` (each of which layers list,
+//! string, or CAS-specific built-ins onto a bespoke `Backend` impl), D-4's
+//! scope (MA07 §3/§4) needs *nothing* beyond what
+//! [`symbolic_vm::SymbolicBackend`] already provides out of the box:
+//! arithmetic, comparison, logic, `Assign`/`Define`/`If` (held, per
+//! [`symbolic_vm::backend::BaseBackend`]), and — because `SymbolicBackend`
+//! builds its handler table with `simplify: true` — the base `D`/`Integrate`
+//! calculus handlers. So this crate's entire Derive-specific contribution is
+//! the **lowering** (surface syntax → canonical heads, `crate::lower`) and
+//! the **printer** (canonical heads → surface syntax, `crate::printer`); the
+//! evaluation engine itself is reused completely unchanged, exactly the
+//! "one function, three languages agreeing on its result" reuse MA07 §5
+//! promises. `LIM`/`SOLVE`/`SUM`/`PRODUCT`/`TAYLOR` are deliberately not
+//! wired here — MA07 §4 defers them (the shared VM has no existing handler
+//! for any of them, so wiring them would be new engine code, not reuse).
+//!
+//! ## Public contract
+//!
+//! [`DeriveSession::feed`] is string-in / string-out, like the
+//! Wolfram/Maxima/Octave facades. It evaluates a chunk of source (one or
+//! more statements) and returns the surface rendering of each result, one
+//! per line as `#n: «value»` — mirroring Derive's own numbered-worksheet
+//! convention (MA07 §5). Unlike Wolfram, this subset has **no**
+//! statement-suppression syntax (Derive's only `;` use is the matrix
+//! row-separator, at non-zero bracket depth — MA07 §3/§4), so every
+//! statement always displays. Bindings persist across calls, so an
+//! interactive `x := 5` then `x + 1` works.
+//!
+//! ## Robustness at the trust boundary
+//!
+//! `feed` takes arbitrary user text, so — exactly as in
+//! `wolfram-runtime`/`maxima-runtime` — it is the trust boundary for the
+//! whole reused stack. Two layered guards close the two independent
+//! deep-recursion vectors (per the "depth caps don't compose across
+//! boundaries" lesson: a cap on one recursive walk does not protect a
+//! *different* recursive walk over the same or a derived tree):
+//!
+//! 1. **Deeply *nested* source** (`((((…))))`, `F(F(F(…)))`). This vector is
+//!    already closed by `derive-parser`'s own `MAX_RULE_DEPTH` — parsing
+//!    itself rejects it with a clean `Err` before a deep tree is ever built,
+//!    so this crate's lowering/printing recursion (which walks the *same*
+//!    already-shallow tree the parser handed back) can never overflow on
+//!    this vector. (Unlike Wolfram's parser, which has no depth cap of its
+//!    own — hence `wolfram-runtime` needing a token-count gate to close
+//!    *this same* vector itself.)
+//! 2. **A long *flat* chain that folds into a deeply *nested* lowered tree**
+//!    (`1+1+1+…` with thousands of terms). `additive`/`multiplicative` are
+//!    grammar *repetitions*, not recursive rule calls, so `MAX_RULE_DEPTH`
+//!    does not bound chain length at all — but [`lower_binary_chain`]
+//!    left-folds an N-term chain into N-1 *nested* `Apply` applications, and
+//!    the VM's own evaluation recurses through that nesting. [`MAX_STATEMENT_TOKENS`],
+//!    measured against the **real** lexer token stream (so there is no
+//!    separately-maintained lexical model to diverge from and bypass), closes
+//!    this vector — a statement's resulting tree depth is bounded above by
+//!    its token count, since every node consumes at least one token.
+//! 3. **Unwinding panics** (a malformed `Assign`/`Define` LHS, or any other
+//!    reused-handler panic on a surprising shape). Evaluation runs inside
+//!    [`catch_unwind`] on a worker thread with a large bounded stack, and any
+//!    panic becomes a clean `Err(String)`; the session is rebuilt afterward
+//!    (trading lost bindings for a guaranteed-usable session next call), so
+//!    one crafted statement can never abort the process or wedge a session.
+//!
+//! [`lower_binary_chain`]: lower
+
+mod lower;
+mod printer;
+
+pub use lower::LowerError;
+pub use printer::print_derive;
+
+use coding_adventures_derive_lexer::try_tokenize_derive;
+use coding_adventures_derive_parser::try_parse_derive;
+use lower::lower_program;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use symbolic_vm::{SymbolicBackend, VM};
+
+/// Maximum length, in bytes, of a single source chunk handed to
+/// [`DeriveSession::feed`].
+///
+/// A cheap first gate bounding per-call memory/time. 64 KiB is far beyond
+/// any realistic interactive submission.
+pub const MAX_INPUT_LEN: usize = 64 * 1024;
+
+/// Maximum number of lexer tokens allowed in any single top-level statement.
+///
+/// See the module doc comment's "Robustness" point 2 — this closes the
+/// long-flat-chain vector `derive-parser`'s own `MAX_RULE_DEPTH` does not
+/// (and cannot) cover. 2000 tokens in one statement is already absurd for a
+/// hand-written Derive worksheet line.
+pub const MAX_STATEMENT_TOKENS: usize = 2000;
+
+/// Stack size of the worker thread that runs evaluation and printing.
+///
+/// With the per-statement complexity cap bounding tree depth, this is
+/// generous headroom so the bounded-but-still-deep trees are built,
+/// evaluated, printed, and dropped well clear of any overflow, regardless of
+/// the caller's own stack.
+const EVAL_STACK_SIZE: usize = 512 * 1024 * 1024;
+
+/// A persistent Derive session.
+///
+/// Owns the [`VM`] (and through it the [`SymbolicBackend`] environment), so
+/// variable bindings (`x := 5`) and user-defined functions (`F(x) := x^2`)
+/// persist across calls to [`feed`](DeriveSession::feed), exactly as in an
+/// interactive Derive worksheet. The `#n` counter likewise persists.
+pub struct DeriveSession {
+    vm: VM,
+    /// 1-based counter of displayed results so far — the `#n` worksheet
+    /// index (MA07 §5).
+    output_index: usize,
+}
+
+impl Default for DeriveSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One displayed result line from a [`DeriveSession::feed`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Output {
+    /// The 1-based `#n` index.
+    pub index: usize,
+    /// The result rendered in Derive surface notation.
+    pub text: String,
+}
+
+impl DeriveSession {
+    /// Create a fresh session with an empty environment and `#n` counter.
+    pub fn new() -> Self {
+        DeriveSession {
+            vm: VM::new(Box::new(SymbolicBackend::new())),
+            output_index: 0,
+        }
+    }
+
+    /// Evaluate a chunk of Derive source and return the concatenated echo.
+    ///
+    /// Every statement produces one `#n: «value»` line (this subset has no
+    /// statement-suppression syntax); the lines are concatenated in
+    /// evaluation order, each ending in a newline. A parse or lowering error
+    /// is returned as `Err` with the message.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use coding_adventures_derive_runtime::DeriveSession;
+    /// let mut s = DeriveSession::new();
+    /// assert_eq!(s.feed("1 + 2*3\n").unwrap(), "#1: 7\n");
+    /// ```
+    pub fn feed(&mut self, src: &str) -> Result<String, String> {
+        let outputs = self.eval_to_outputs(src)?;
+        let mut out = String::new();
+        for o in outputs {
+            out.push_str(&format!("#{}: {}\n", o.index, o.text));
+        }
+        Ok(out)
+    }
+
+    /// Evaluate `src` and return the structured list of displayed [`Output`]s.
+    ///
+    /// The lower-level cousin of [`feed`](DeriveSession::feed) — a REPL that
+    /// wants to format the prompt itself uses this and renders each `Output`.
+    pub fn eval_to_outputs(&mut self, src: &str) -> Result<Vec<Output>, String> {
+        // Guard 1: bound total input size (cheap memory/time gate).
+        if src.len() > MAX_INPUT_LEN {
+            return Err(format!(
+                "input too large: {} bytes exceeds the {}-byte limit",
+                src.len(),
+                MAX_INPUT_LEN
+            ));
+        }
+        // Guard 2: reject a long flat chain before it can fold into a
+        // stack-overflowing lowered tree (see the module "Robustness" note,
+        // point 2 — deeply *nested* source is already rejected by
+        // `derive-parser`'s own `MAX_RULE_DEPTH`, a *different* vector this
+        // guard does not need to re-cover).
+        check_statement_token_counts(src)?;
+
+        // Guard 3 + panics: the lowering, the VM evaluation, and the printer
+        // all run on a worker thread with a large bounded stack, and any
+        // unwinding panic from the reused symbolic stack is caught.
+        let vm = &mut self.vm;
+        let start_index = self.output_index;
+        let src_owned = src.to_string();
+        let outcome = std::thread::scope(|scope| {
+            std::thread::Builder::new()
+                .stack_size(EVAL_STACK_SIZE)
+                .spawn_scoped(scope, || {
+                    catch_unwind(AssertUnwindSafe(|| {
+                        eval_source(vm, &src_owned, start_index)
+                    }))
+                })
+                .expect("failed to spawn derive evaluation thread")
+                .join()
+        });
+
+        match outcome {
+            // Normal path: the worker produced the outputs (or a surface error).
+            Ok(Ok(Ok((outputs, next_index)))) => {
+                self.output_index = next_index;
+                Ok(outputs)
+            }
+            Ok(Ok(Err(message))) => Err(message),
+            // A panic the worker caught, or one that escaped and unwound the
+            // join. Either way the env may be inconsistent, so rebuild.
+            Ok(Err(payload)) | Err(payload) => {
+                self.vm = VM::new(Box::new(SymbolicBackend::new()));
+                self.output_index = 0;
+                Err(panic_message(payload))
+            }
+        }
+    }
+}
+
+/// Evaluate every statement in `src`, returning the displayed outputs and the
+/// new `#n` counter. Runs on the worker thread.
+fn eval_source(vm: &mut VM, src: &str, start_index: usize) -> Result<(Vec<Output>, usize), String> {
+    // The parser's error string already carries a user-readable message, so
+    // we forward it as-is.
+    let ast = try_parse_derive(src)?;
+    let statements = lower_program(&ast).map_err(|e| e.to_string())?;
+
+    let mut outputs = Vec::new();
+    let mut index = start_index;
+    for stmt in statements {
+        let result = vm.eval(stmt);
+        index += 1;
+        outputs.push(Output {
+            index,
+            text: print_derive(&result),
+        });
+    }
+    Ok((outputs, index))
+}
+
+/// Reject input where any single statement lexes to too many tokens.
+///
+/// The count is taken from the **real** Derive lexer, the very one the
+/// parser consumes, so there is no separately-maintained lexical model to
+/// diverge from: comments (none in this subset) and whitespace are skip
+/// patterns (absent from the token stream), and a top-level `NEWLINE` token
+/// marks a statement boundary (the lexer drops bracketed newlines, so a
+/// call or vector/matrix literal spanning several physical lines is
+/// correctly counted as one statement). Unlike `wolfram-runtime`'s identical
+/// guard, there is no `SEMI` reset case — Derive's only `;` use is the
+/// matrix row separator, which never appears at bracket depth 0.
+///
+/// If the lexer itself errors (an untokenizable character), we return
+/// `Ok(())` and let the parser surface the error uniformly — we never
+/// reject solely because the *checker* could not lex something.
+fn check_statement_token_counts(src: &str) -> Result<(), String> {
+    let tokens = match try_tokenize_derive(src) {
+        Ok(tokens) => tokens,
+        Err(_) => return Ok(()), // unlexable — let the parser surface it
+    };
+
+    let mut count: usize = 0;
+    for token in &tokens {
+        if token.effective_type_name() == "NEWLINE" {
+            count = 0;
+            continue;
+        }
+        count += 1;
+        if count > MAX_STATEMENT_TOKENS {
+            return Err(format!(
+                "statement too complex: more than {MAX_STATEMENT_TOKENS} tokens in one statement"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Evaluate `src` once on a fresh [`DeriveSession`] and return its echo.
+///
+/// Convenience for callers that do not need persistent state.
+pub fn eval(src: &str) -> Result<String, String> {
+    DeriveSession::new().feed(src)
+}
+
+/// Recover a human-readable message from a caught panic payload.
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "Derive could not evaluate that input".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arithmetic_folds_to_an_integer() {
+        assert_eq!(eval("1 + 2*3\n").unwrap(), "#1: 7\n");
+    }
+
+    #[test]
+    fn power_and_division() {
+        assert_eq!(eval("2^10\n").unwrap(), "#1: 1024\n");
+        assert_eq!(eval("10 / 2\n").unwrap(), "#1: 5\n");
+    }
+
+    #[test]
+    fn free_symbols_stay_symbolic() {
+        assert_eq!(eval("x + 0\n").unwrap(), "#1: x\n");
+    }
+
+    #[test]
+    fn assignment_persists_across_calls() {
+        let mut s = DeriveSession::new();
+        assert_eq!(s.feed("x := 5\n").unwrap(), "#1: 5\n");
+        assert_eq!(s.feed("x + 1\n").unwrap(), "#2: 6\n");
+    }
+
+    #[test]
+    fn user_defined_function_end_to_end() {
+        let mut s = DeriveSession::new();
+        s.feed("SQUARE(x) := x*x\n").unwrap();
+        assert_eq!(s.feed("SQUARE(5)\n").unwrap(), "#2: 25\n");
+    }
+
+    #[test]
+    fn dif_differentiates_via_the_shared_handler() {
+        // DIF(x^2, x) -> 2*x
+        assert_eq!(eval("DIF(x^2, x)\n").unwrap(), "#1: 2*x\n");
+    }
+
+    #[test]
+    fn int_integrates_via_the_shared_handler() {
+        // INT(x, x) -> x^2/2
+        let out = eval("INT(x, x)\n").unwrap();
+        assert!(out.starts_with("#1: "), "got {out:?}");
+    }
+
+    #[test]
+    fn if_selects_a_branch_via_the_held_handler() {
+        assert_eq!(eval("IF(1 > 0, 42, 0)\n").unwrap(), "#1: 42\n");
+    }
+
+    #[test]
+    fn sin_of_zero_folds_to_zero() {
+        assert_eq!(eval("SIN(0)\n").unwrap(), "#1: 0\n");
+    }
+
+    #[test]
+    fn equation_stays_unevaluated_not_assignment() {
+        // `x = 4` is Equal, not Assign — it does not bind x.
+        let mut s = DeriveSession::new();
+        assert_eq!(s.feed("x = 4\n").unwrap(), "#1: x = 4\n");
+        assert_eq!(s.feed("x + 1\n").unwrap(), "#2: x + 1\n");
+    }
+
+    #[test]
+    fn multiple_statements_in_one_feed() {
+        let out = eval("1 + 1\n2 + 2\n3 + 3\n").unwrap();
+        assert_eq!(out, "#1: 2\n#2: 4\n#3: 6\n");
+    }
+
+    #[test]
+    fn a_parse_error_is_returned_not_panicked() {
+        let err = eval("1 +\n");
+        assert!(err.is_err(), "expected a clean Err, got {err:?}");
+    }
+
+    #[test]
+    fn session_recovers_after_a_parse_error() {
+        let mut s = DeriveSession::new();
+        let _ = s.feed("1 +\n");
+        assert_eq!(s.feed("3 + 4\n").unwrap(), "#1: 7\n");
+    }
+
+    #[test]
+    fn oversized_input_is_rejected_before_evaluation() {
+        let huge = format!("{}1\n", "1+".repeat(MAX_INPUT_LEN));
+        assert!(huge.len() > MAX_INPUT_LEN);
+        let err = eval(&huge).unwrap_err();
+        assert!(err.contains("too large"), "got {err:?}");
+    }
+
+    #[test]
+    fn deeply_nested_parens_are_rejected_by_the_parsers_own_cap() {
+        // derive-parser's own MAX_RULE_DEPTH rejects this before the runtime
+        // ever sees a tree — this test proves the session surfaces that as a
+        // clean Err (not a crash), not that this crate re-implements the cap.
+        let depth = 5000;
+        let src = format!("{}1{}\n", "(".repeat(depth), ")".repeat(depth));
+        assert!(src.len() <= MAX_INPUT_LEN, "stays under the length cap");
+        assert!(eval(&src).is_err());
+    }
+
+    #[test]
+    fn long_flat_chain_is_rejected_by_the_statement_token_cap() {
+        // additive/multiplicative are grammar REPETITIONS, not recursive
+        // rule calls, so derive-parser's MAX_RULE_DEPTH does not bound chain
+        // length — this is the vector MAX_STATEMENT_TOKENS closes instead.
+        let src = format!("{}1\n", "1+".repeat(5_000));
+        assert!(src.len() <= MAX_INPUT_LEN);
+        assert!(eval(&src).unwrap_err().contains("too complex"));
+    }
+
+    #[test]
+    fn moderate_chain_still_evaluates() {
+        let src = format!("{}1\n", "1+".repeat(50));
+        assert_eq!(eval(&src).unwrap(), "#1: 51\n");
+    }
+
+    #[test]
+    fn a_malformed_assign_lhs_is_caught_not_aborted() {
+        // `5 := 3` lowers to Assign(5, 3). The reused VM's assign_handler
+        // *panics* when the lhs is not a symbol — the worker-thread
+        // `catch_unwind` must convert that panic into a clean `Err`, and the
+        // session must remain usable afterward (the env is rebuilt).
+        let mut s = DeriveSession::new();
+        assert!(
+            s.feed("5 := 3\n").is_err(),
+            "a non-symbol Assign lhs must return Err, never abort"
+        );
+        assert_eq!(s.feed("2 + 2\n").unwrap(), "#1: 4\n");
+    }
+
+    #[test]
+    fn vector_literal_is_a_clean_error_not_a_panic() {
+        // Deferred to D-5 (see crate::lower) — must surface as Err, not crash.
+        assert!(eval("[1, 2, 3]\n").is_err());
+    }
+
+    #[test]
+    fn the_one_shot_eval_helper_matches_a_session() {
+        let one = eval("2 + 3\n").unwrap();
+        let two = DeriveSession::new().feed("2 + 3\n").unwrap();
+        assert_eq!(one, two);
+    }
+
+    #[test]
+    fn empty_and_whitespace_input_yields_nothing() {
+        assert_eq!(eval("\n").unwrap(), "");
+    }
+
+    #[test]
+    fn a_small_derive_program_evaluates_end_to_end() {
+        // A bound variable distinct from the DIF variable (`t`, not the
+        // function's own parameter `y`) — `y` never appears in the body, so
+        // substituting it at call time changes nothing, and `DIF(SIN(t), t)`
+        // evaluates via the shared handler to `COS(t)` regardless of the
+        // argument `H` is called with. (`F(x) := DIF(SIN(x), x); F(0)` would
+        // NOT simplify to `cos(0)`: substituting `x` -> `0` also replaces
+        // DIF's *variable* argument, leaving the well-defined-but-unevaluable
+        // `DIF(0, 0)` — the same substitution-collision a Wolfram/Macsyma
+        // user-defined function hits identically, not a Derive-specific bug.)
+        let mut s = DeriveSession::new();
+        s.feed("H(y) := DIF(SIN(t), t)\n").unwrap();
+        let out = s.feed("H(0)\n").unwrap();
+        assert_eq!(out, "#2: COS(t)\n");
+    }
+}

--- a/code/packages/rust/derive-runtime/src/lower.rs
+++ b/code/packages/rust/derive-runtime/src/lower.rs
@@ -1,0 +1,824 @@
+//! # Lowering — Derive syntax tree → `symbolic-ir`
+//!
+//! The D-3 [`derive-parser`](coding_adventures_derive_parser) hands us a
+//! *generic* [`GrammarASTNode`] tree whose `rule_name`s mirror the grammar
+//! (`assignment`, `additive`, `multiplicative`, `power`, `postfix`, `atom`,
+//! …). The parser deliberately does **no** semantic work — it just records
+//! which rule matched. This module is where Derive's *meaning* is assigned:
+//! every surface construct is **desugared** into the canonical
+//! [`symbolic_ir::IRNode`] head [`symbolic-vm`](symbolic_vm) already knows
+//! how to evaluate.
+//!
+//! ## Much thinner than Wolfram's/Macsyma's lowering
+//!
+//! Derive (MA07 §1) has no `f[x]`-universal-application syntax and no
+//! pattern/rewrite-rule vocabulary (`_`, `->`, `/.`) — every "transform this
+//! expression" operation (`DIF`, `INT`, `IF`, …) is an ordinary named
+//! function call with ordinary parentheses, ambiguity-free with the infix
+//! operators. So this module needs none of the pattern-lowering,
+//! `ReplaceAll`/`ReplaceRepeated` interception, or ordinary-vs-pure-function
+//! machinery `wolfram-runtime::lower` carries — just arithmetic, comparison,
+//! logic, assignment/definition, and function application.
+//!
+//! ## The head-name bridge — and why Derive needs a BIGGER one than Wolfram
+//!
+//! Wolfram already spells its canonical heads in the IR's own casing
+//! (`Sin`, `Plus`, …), so its bridge only covers the handful of operators
+//! with a *different* long-form name (`Plus` → `Add`, `Set` → `Assign`, …).
+//! Derive's built-ins are conventionally **UPPERCASE** (`SIN`, `DIF`, `INT`,
+//! `IF` — MA07 §3), and `IRNode::Symbol` equality is case-sensitive, so
+//! *every* elementary/hyperbolic function and every renamed calculus/control
+//! head needs an explicit surface→IR entry here — not just the handful that
+//! differ semantically. An unrecognised head (a user-defined function name,
+//! or a builtin not spelled in the exact uppercase convention) passes
+//! through unchanged, exactly like Wolfram's unknown-head fallthrough.
+//!
+//! ## `:=` disambiguation has no operator to branch on
+//!
+//! Wolfram (`=`/`:=`) and Macsyma (`:`/`::=`) each have TWO distinct
+//! assignment operators, so their lowering picks `Assign` vs `Define` by
+//! *which token fired*. Derive's grammar has exactly ONE token, `ASSIGN`
+//! (`:=`), reaching the `assignment` rule (derive-lexer/derive-parser's own
+//! READMEs) — `x := 5` and `F(x) := x^2 + 1` are syntactically identical
+//! until this lowering step. So [`lower_assignment`] disambiguates purely by
+//! the *lowered LHS's shape*: `Apply(Symbol(_), _)` → `Define`, anything
+//! else → `Assign`. Derive also has no pattern syntax, so (unlike Wolfram's
+//! `param_binding_symbol`) a function's parameters need no unwrapping — a
+//! bare `NAME` in `F(x, y) := …`'s argument position already lowers straight
+//! to a plain `Symbol`, the exact shape `define_handler` binds against.
+//!
+//! ## Vectors/matrices are deferred to D-5
+//!
+//! `derive-parser` already parses `[a, b, c]` / `[a, b; c, d]` (D-3 syntax
+//! scope), but MA07 §2 scopes their `List`-lowering to a separate D-5 item.
+//! `vector`/`row` nodes therefore return a [`LowerError`] here rather than
+//! silently mis-lowering — the same "reject, don't guess" discipline
+//! `lower_node`'s catch-all arm already applies to any other unhandled rule.
+
+use lexer::token::Token;
+use parser::grammar_parser::{ASTNodeOrToken, GrammarASTNode};
+use symbolic_ir::{
+    apply, flt, int, sym, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ATAN, ATANH, COS, COSH, COTH,
+    CSCH, D, DEFINE, DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, LESS, LESS_EQUAL,
+    LIST, LOG, MUL, NEG, NOT, OR, POW, SECH, SIN, SINH, SQRT, SUB, TAN, TANH,
+};
+
+/// A failure while lowering the surface tree to IR. These are *structural*
+/// errors — a node shape the lowering did not expect, or a construct
+/// deliberately deferred to a later item — not user syntax errors (those are
+/// caught earlier by the parser).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LowerError {
+    message: String,
+}
+
+impl LowerError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    /// The human-readable message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for LowerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for LowerError {}
+
+/// Lower a parsed `program` node into one IR statement per source statement.
+///
+/// The D-3 grammar's root is `program = { statement_line }`, where each
+/// `statement_line` wraps a `statement` plus a `NEWLINE` terminator, or is
+/// terminator-only (a blank line). We keep only the lines that actually
+/// carry a `statement` and lower each one; blank lines contribute nothing.
+pub fn lower_program(root: &GrammarASTNode) -> Result<Vec<IRNode>, LowerError> {
+    if root.rule_name != "program" {
+        return Err(LowerError::new(format!(
+            "expected `program` root, got `{}`",
+            root.rule_name
+        )));
+    }
+    let mut statements = Vec::new();
+    for line in child_nodes(root) {
+        if line.rule_name != "statement_line" {
+            continue;
+        }
+        if let Some(statement) = child_nodes(line).find(|n| n.rule_name == "statement") {
+            statements.push(lower_node(statement)?);
+        }
+    }
+    Ok(statements)
+}
+
+/// Lower a single arbitrary node.
+///
+/// Most grammar rules are "transparent wrappers" — a `statement` is just an
+/// `expr`, an `expr` is just an `assignment`, and when a precedence level did
+/// not actually apply its operator the parser still emits the level's node
+/// with a single child. [`unwrap_single`] peels those away so we dispatch on
+/// the first rule that genuinely shapes the tree.
+fn lower_node(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    match unwrap_single(node) {
+        Unwrapped::Token(token) => lower_token(token),
+        Unwrapped::Node(node) => match node.rule_name.as_str() {
+            "program" => Err(LowerError::new("nested program node is not an expression")),
+            "statement_line" | "statement" | "expr" => lower_first_node(node),
+            "assignment" => lower_assignment(node),
+            "logical_or" => lower_logical_chain(node, OR),
+            "logical_and" => lower_logical_chain(node, AND),
+            "logical_not" => lower_logical_not(node),
+            "comparison" => lower_comparison(node),
+            "additive" | "multiplicative" => lower_binary_chain(node),
+            "unary" => lower_unary(node),
+            "power" => lower_power(node),
+            "postfix" => lower_postfix(node),
+            "atom" => lower_atom(node),
+            "vector" | "row" => Err(LowerError::new(format!(
+                "`{}` literals are not lowered until D-5 (MA07 §2) — vectors/matrices \
+                 parse (D-3) but do not yet evaluate",
+                node.rule_name
+            ))),
+            "group" => lower_group(node),
+            "arglist" => Err(LowerError::new(
+                "an arglist cannot be lowered as a scalar expression",
+            )),
+            other => Err(LowerError::new(format!("no lowering for rule `{other}`"))),
+        },
+    }
+}
+
+/// Lower a raw token (a literal or a bare symbol).
+fn lower_token(token: &Token) -> Result<IRNode, LowerError> {
+    match token_type(token) {
+        "NUMBER" => lower_number(&token.value),
+        "NAME" => Ok(sym(&token.value)),
+        other => Err(LowerError::new(format!(
+            "unexpected token `{other}` = {:?}",
+            token.value
+        ))),
+    }
+}
+
+/// Parse a `NUMBER` lexeme into an `Integer` or `Float` IR literal.
+///
+/// The D-2 lexer's `NUMBER` regex is `[0-9]+\.?[0-9]*([eE][+-]?[0-9]+)?`, so
+/// a `.`, `e`, or `E` means it is a real; otherwise it is an integer. We
+/// reject an integer that overflows `i64` (the IR's integer width) rather
+/// than silently wrapping.
+fn lower_number(text: &str) -> Result<IRNode, LowerError> {
+    if text.contains('.') || text.contains('e') || text.contains('E') {
+        text.parse::<f64>()
+            .map(flt)
+            .map_err(|e| LowerError::new(format!("invalid real literal {text:?}: {e}")))
+    } else {
+        text.parse::<i64>()
+            .map(int)
+            .map_err(|e| LowerError::new(format!("invalid integer literal {text:?}: {e}")))
+    }
+}
+
+/// `assignment = logical_or [ ASSIGN assignment ]` — right-associative.
+///
+/// See the module doc comment's "`:=` disambiguation" section: there is only
+/// one operator token, so the LHS's own *lowered shape* decides `Assign` vs
+/// `Define`. `F(x, y) := body` (LHS lowers to `Apply(Symbol(F), [x, y])`)
+/// becomes `Define(F, List(x, y), body)`; a bare `x := body` (LHS is a plain
+/// symbol) becomes a zero-parameter `Define` — no, becomes `Assign(x,
+/// body)`, an ordinary variable binding.
+fn lower_assignment(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let Some(op_index) = node
+        .children
+        .iter()
+        .position(|c| as_token(c).is_some_and(|t| token_type(t) == "ASSIGN"))
+    else {
+        return lower_first_node(node);
+    };
+    if op_index == 0 || op_index + 1 >= node.children.len() {
+        return Err(LowerError::new("malformed assignment node"));
+    }
+    let lhs = lower_child(&node.children[op_index - 1])?;
+    let rhs = lower_child(&node.children[op_index + 1])?;
+
+    if let IRNode::Apply(app) = &lhs {
+        if matches!(&app.head, IRNode::Symbol(_)) {
+            // F(x, y) := body — a function definition. Derive has no pattern
+            // syntax, so each parameter already lowered to a plain `Symbol`
+            // (or, for a malformed definition like `F(1) := …`, whatever the
+            // caller wrote — `define_handler` and the VM's parameter binder
+            // own validating that, not this lowering, mirroring how
+            // Wolfram's own lowering does not validate parameter shapes
+            // either).
+            return Ok(apply(
+                sym(DEFINE),
+                vec![app.head.clone(), apply(sym(LIST), app.args.clone()), rhs],
+            ));
+        }
+    }
+    // x := e — variable assignment.
+    Ok(apply(sym(symbolic_ir::ASSIGN), vec![lhs, rhs]))
+}
+
+/// `logical_or`/`logical_and` — fold the operands into an n-ary `Or`/`And`.
+/// Safe to fold n-ary (unlike `additive`/`multiplicative`) because every
+/// step in one chain shares the SAME operator (`logical_or = logical_and {
+/// "OR" logical_and }` never mixes `OR` and `AND`). A single operand (no
+/// operator present) is a transparent wrapper.
+fn lower_logical_chain(node: &GrammarASTNode, head: &str) -> Result<IRNode, LowerError> {
+    let operands = child_nodes(node)
+        .map(lower_node)
+        .collect::<Result<Vec<_>, _>>()?;
+    match operands.len() {
+        0 => Err(LowerError::new("empty logical chain")),
+        1 => Ok(operands.into_iter().next().unwrap()),
+        _ => Ok(apply(sym(head), operands)),
+    }
+}
+
+/// `logical_not = NOT logical_not | comparison`. A leading `NOT` wraps the
+/// operand; otherwise it is the inner comparison.
+///
+/// `NOT` is matched in the grammar as a `Literal` (a keyword the D-2 lexer
+/// promotes from a plain `NAME`, not a distinct regex-declared token type
+/// like `PLUS`/`EQ`), so — mirroring `macsyma-compiler::compile_logical_not`'s
+/// identical check for its own `Literal`-matched `"not"` — this checks the
+/// token's literal *value*, not `effective_type_name()` (which stays
+/// whatever the lexer classified the underlying lexeme as).
+fn lower_logical_not(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let has_not = node
+        .children
+        .iter()
+        .any(|c| as_token(c).is_some_and(|t| t.value == "NOT"));
+    if !has_not {
+        return lower_first_node(node);
+    }
+    let inner = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new("`NOT` with no operand"))?;
+    Ok(apply(sym(NOT), vec![lower_node(inner)?]))
+}
+
+/// `comparison = additive [ (EQ|LE|LESS|GREATER|GE) additive ]` — a single
+/// (non-chained) comparison. `=` is Derive's *equation* operator (`Equal`),
+/// never assignment — `:=` alone owns that role (MA07 §3).
+fn lower_comparison(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let Some(op_index) = node
+        .children
+        .iter()
+        .position(|c| as_token(c).is_some_and(|t| comparison_head(token_type(t)).is_some()))
+    else {
+        return lower_first_node(node);
+    };
+    if op_index == 0 || op_index + 1 >= node.children.len() {
+        return Err(LowerError::new("malformed comparison node"));
+    }
+    let head = comparison_head(token_type(as_token(&node.children[op_index]).unwrap())).unwrap();
+    Ok(apply(
+        sym(head),
+        vec![
+            lower_child(&node.children[op_index - 1])?,
+            lower_child(&node.children[op_index + 1])?,
+        ],
+    ))
+}
+
+/// `additive`/`multiplicative` — a left-associative chain of `+`/`-` or
+/// `*`/`/`. Must fold pairwise (not n-ary, unlike the logical chains) since a
+/// single chain can mix operators: `a - b - c` folds left into
+/// `Sub(Sub(a, b), c)`; `a + b - c` into `Sub(Add(a, b), c)`.
+fn lower_binary_chain(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let mut children = node.children.iter();
+    let first = children
+        .next()
+        .ok_or_else(|| LowerError::new("empty binary chain"))?;
+    let mut result = lower_child(first)?;
+    while let Some(op_child) = children.next() {
+        let head = as_token(op_child)
+            .and_then(|t| binary_head(token_type(t)))
+            .ok_or_else(|| LowerError::new("expected a binary operator"))?;
+        let rhs = children
+            .next()
+            .ok_or_else(|| LowerError::new("binary operator with no right operand"))?;
+        result = apply(sym(head), vec![result, lower_child(rhs)?]);
+    }
+    Ok(result)
+}
+
+/// `unary = MINUS unary | power`. Derive's grammar (unlike Wolfram's) has no
+/// unary-plus alternative — a leading `-` is `Neg`; otherwise it is the
+/// inner `power`.
+fn lower_unary(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if node.children.len() == 1 {
+        return lower_child(&node.children[0]);
+    }
+    let operand = lower_child(
+        node.children
+            .get(1)
+            .ok_or_else(|| LowerError::new("unary `-` with no operand"))?,
+    )?;
+    Ok(apply(sym(NEG), vec![operand]))
+}
+
+/// `power = postfix [ POWER unary ]` — right-associative `^`.
+fn lower_power(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    match node.children.len() {
+        1 => lower_child(&node.children[0]),
+        3 => Ok(apply(
+            sym(POW),
+            vec![
+                lower_child(&node.children[0])?,
+                lower_child(&node.children[2])?,
+            ],
+        )),
+        _ => Err(LowerError::new("malformed power node")),
+    }
+}
+
+/// `postfix = atom { LPAREN [arglist] RPAREN }` — function application,
+/// left-associative and chainable (`F(x)(y)` is `(F(x))(y)`, though Derive
+/// has no idiom that actually produces one — included for grammar fidelity).
+///
+/// The head runs through [`canonical_head`] so a builtin surface name like
+/// `SIN`/`DIF`/`IF` becomes the IR head (`Sin`/`D`/`If`) the VM dispatches;
+/// an unrecognised head (a user-defined function) passes through unchanged.
+fn lower_postfix(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let mut result = lower_child(
+        node.children
+            .first()
+            .ok_or_else(|| LowerError::new("postfix has no base"))?,
+    )?;
+
+    let mut i = 1;
+    while i < node.children.len() {
+        let Some(token) = as_token(&node.children[i]) else {
+            i += 1;
+            continue;
+        };
+        if token_type(token) == "LPAREN" {
+            let args = node
+                .children
+                .get(i + 1)
+                .and_then(as_node)
+                .filter(|n| n.rule_name == "arglist")
+                .map(lower_arglist)
+                .transpose()?
+                .unwrap_or_default();
+            result = apply(canonical_head(result), args);
+        }
+        i += 1;
+    }
+    Ok(result)
+}
+
+/// `arglist = expr { COMMA expr }` — lower each comma-separated argument.
+fn lower_arglist(node: &GrammarASTNode) -> Result<Vec<IRNode>, LowerError> {
+    child_nodes(node).map(lower_node).collect()
+}
+
+/// `atom = NUMBER | NAME | vector | group`.
+fn lower_atom(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    if let Some(child) = child_nodes(node).next() {
+        if matches!(child.rule_name.as_str(), "vector" | "group") {
+            return lower_node(child);
+        }
+    }
+    let tokens: Vec<&Token> = node.children.iter().filter_map(as_token).collect();
+    match tokens.as_slice() {
+        [single] => lower_token(single),
+        _ => Err(LowerError::new(format!(
+            "unrecognised atom token shape: {:?}",
+            tokens.iter().map(|t| &t.value).collect::<Vec<_>>()
+        ))),
+    }
+}
+
+/// `group = LPAREN expr RPAREN` — grouping only; lower the inner expression.
+fn lower_group(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let inner = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new("empty group `( )`"))?;
+    lower_node(inner)
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+fn lower_child(child: &ASTNodeOrToken) -> Result<IRNode, LowerError> {
+    match child {
+        ASTNodeOrToken::Node(node) => lower_node(node),
+        ASTNodeOrToken::Token(token) => lower_token(token),
+    }
+}
+
+/// Lower the first *node* child (ignoring tokens). Used by transparent-
+/// wrapper rules whose only meaningful content is a nested expression node.
+fn lower_first_node(node: &GrammarASTNode) -> Result<IRNode, LowerError> {
+    let child = child_nodes(node)
+        .next()
+        .ok_or_else(|| LowerError::new(format!("`{}` has no expression child", node.rule_name)))?;
+    lower_node(child)
+}
+
+/// Map an arithmetic token type to its IR head.
+fn binary_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "PLUS" => Some(ADD),
+        "MINUS" => Some(SUB),
+        "TIMES" => Some(MUL),
+        "SLASH" => Some(DIV),
+        _ => None,
+    }
+}
+
+/// Map a comparison token type to its IR head.
+fn comparison_head(token_type: &str) -> Option<&'static str> {
+    match token_type {
+        "EQ" => Some(EQUAL),
+        "LE" => Some(LESS_EQUAL),
+        "LESS" => Some(LESS),
+        "GREATER" => Some(GREATER),
+        "GE" => Some(GREATER_EQUAL),
+        _ => None,
+    }
+}
+
+/// Bridge a Derive *surface* head (conventionally uppercase — MA07 §3) to the
+/// canonical IR head. `Symbol` equality is case-sensitive, so every builtin
+/// this D-4 milestone wires needs an explicit entry — not just the ones that
+/// differ semantically (unlike Wolfram's bridge, which only needs to rename
+/// the few operators whose long-form name isn't already the IR's own). A
+/// head not in this table (a user-defined function, or a builtin not spelled
+/// in the exact uppercase convention) is returned unchanged, so `F(x)`
+/// evaluates through the VM's ordinary user-function path and an unrecognised
+/// spelling stays a harmless unevaluated symbolic call.
+fn canonical_head(head: IRNode) -> IRNode {
+    if let IRNode::Symbol(name) = &head {
+        if let Some(canonical) = surface_head_to_ir(name) {
+            return sym(canonical);
+        }
+    }
+    head
+}
+
+/// The surface→IR head dictionary for D-4's scope: the base calculus forms
+/// (`DIF`→`D`, `INT`→`Integrate` — both already fully implemented in
+/// `symbolic_vm::handlers::build_handler_table`, so this milestone adds no
+/// new engine code, per MA07 §5's reuse strategy), `IF`→`If`, and the
+/// elementary/hyperbolic functions (case-bridged only — `symbolic-ir`
+/// already names these `Sin`/`Cos`/…, so no other transformation is needed).
+/// `LIM`/`SOLVE`/`SUM`/`PRODUCT`/`TAYLOR` are deliberately absent — MA07 §4
+/// ("Honest scope") defers them to their own follow-on items, since (unlike
+/// `DIF`/`INT`) the shared VM has no existing handler for them; wiring them
+/// here would be new engine code, not reuse.
+fn surface_head_to_ir(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "DIF" => D,
+        "INT" => INTEGRATE,
+        "IF" => IF,
+        "SIN" => SIN,
+        "COS" => COS,
+        "TAN" => TAN,
+        "SQRT" => SQRT,
+        "EXP" => EXP,
+        "LOG" => LOG,
+        "ATAN" => ATAN,
+        "ASIN" => ASIN,
+        "ACOS" => ACOS,
+        "SINH" => SINH,
+        "COSH" => COSH,
+        "TANH" => TANH,
+        "ASINH" => ASINH,
+        "ACOSH" => ACOSH,
+        "ATANH" => ATANH,
+        "COTH" => COTH,
+        "SECH" => SECH,
+        "CSCH" => CSCH,
+        _ => return None,
+    })
+}
+
+fn token_type(token: &Token) -> &str {
+    token.effective_type_name()
+}
+
+fn as_node(child: &ASTNodeOrToken) -> Option<&GrammarASTNode> {
+    match child {
+        ASTNodeOrToken::Node(node) => Some(node),
+        ASTNodeOrToken::Token(_) => None,
+    }
+}
+
+fn as_token(child: &ASTNodeOrToken) -> Option<&Token> {
+    match child {
+        ASTNodeOrToken::Token(token) => Some(token),
+        ASTNodeOrToken::Node(_) => None,
+    }
+}
+
+/// Iterate a node's direct *node* children (skipping tokens).
+fn child_nodes(node: &GrammarASTNode) -> impl Iterator<Item = &GrammarASTNode> {
+    node.children.iter().filter_map(as_node)
+}
+
+enum Unwrapped<'a> {
+    Node(&'a GrammarASTNode),
+    Token(&'a Token),
+}
+
+/// Peel away single-child wrapper nodes until we reach a node with structure
+/// (or a leaf token). A precedence-cascade rule that did not apply its
+/// operator still emits its own node with exactly one child —
+/// `unwrap_single` skips straight to the rule that actually matters.
+fn unwrap_single(mut node: &GrammarASTNode) -> Unwrapped<'_> {
+    loop {
+        if node.children.len() != 1 {
+            return Unwrapped::Node(node);
+        }
+        match &node.children[0] {
+            ASTNodeOrToken::Node(child) => node = child,
+            ASTNodeOrToken::Token(token) => return Unwrapped::Token(token),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coding_adventures_derive_parser::parse_derive;
+
+    /// Lower a single-statement source to its one IR node.
+    fn lower_one(src: &str) -> IRNode {
+        let ast = parse_derive(src);
+        let mut stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 1, "expected exactly one statement for {src:?}");
+        stmts.pop().unwrap()
+    }
+
+    #[test]
+    fn integer_and_real_literals() {
+        assert_eq!(lower_one("42\n"), int(42));
+        assert_eq!(lower_one("1.5\n"), flt(1.5));
+    }
+
+    #[test]
+    fn bare_symbol() {
+        assert_eq!(lower_one("foo\n"), sym("foo"));
+    }
+
+    #[test]
+    fn additive_lowers_to_add() {
+        assert_eq!(lower_one("1 + 2\n"), apply(sym(ADD), vec![int(1), int(2)]));
+    }
+
+    #[test]
+    fn subtraction_lowers_to_sub_left_assoc() {
+        // a - b - c  ->  Sub(Sub(a, b), c)
+        assert_eq!(
+            lower_one("a - b - c\n"),
+            apply(
+                sym(SUB),
+                vec![apply(sym(SUB), vec![sym("a"), sym("b")]), sym("c")]
+            )
+        );
+    }
+
+    #[test]
+    fn mixed_additive_chain_folds_left_by_operator() {
+        // a + b - c  ->  Sub(Add(a, b), c)
+        assert_eq!(
+            lower_one("a + b - c\n"),
+            apply(
+                sym(SUB),
+                vec![apply(sym(ADD), vec![sym("a"), sym("b")]), sym("c")]
+            )
+        );
+    }
+
+    #[test]
+    fn multiplication_and_division() {
+        assert_eq!(
+            lower_one("a * b\n"),
+            apply(sym(MUL), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a / b\n"),
+            apply(sym(DIV), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn power_is_right_associative() {
+        // a ^ b ^ c  ->  Pow(a, Pow(b, c))
+        assert_eq!(
+            lower_one("a ^ b ^ c\n"),
+            apply(
+                sym(POW),
+                vec![sym("a"), apply(sym(POW), vec![sym("b"), sym("c")])]
+            )
+        );
+    }
+
+    #[test]
+    fn unary_minus_binds_looser_than_power() {
+        // -x^2  ->  Neg(Pow(x, 2))  (unary wraps power, not the reverse)
+        assert_eq!(
+            lower_one("-x^2\n"),
+            apply(sym(NEG), vec![apply(sym(POW), vec![sym("x"), int(2)])])
+        );
+    }
+
+    #[test]
+    fn eq_lowers_to_equal_not_assign() {
+        // `=` is Derive's equation operator, never assignment.
+        assert_eq!(
+            lower_one("x = 4\n"),
+            apply(sym(EQUAL), vec![sym("x"), int(4)])
+        );
+    }
+
+    #[test]
+    fn comparisons_lower_to_their_heads() {
+        assert_eq!(
+            lower_one("a <= b\n"),
+            apply(sym(LESS_EQUAL), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a < b\n"),
+            apply(sym(LESS), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a > b\n"),
+            apply(sym(GREATER), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a >= b\n"),
+            apply(sym(GREATER_EQUAL), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn boolean_keywords_lower_to_and_or_not() {
+        assert_eq!(
+            lower_one("a AND b\n"),
+            apply(sym(AND), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("a OR b\n"),
+            apply(sym(OR), vec![sym("a"), sym("b")])
+        );
+        assert_eq!(lower_one("NOT a\n"), apply(sym(NOT), vec![sym("a")]));
+    }
+
+    #[test]
+    fn logical_or_chain_folds_n_ary() {
+        // a OR b OR c  ->  Or(a, b, c) — homogeneous chain, safe to fold flat.
+        assert_eq!(
+            lower_one("a OR b OR c\n"),
+            apply(sym(OR), vec![sym("a"), sym("b"), sym("c")])
+        );
+    }
+
+    #[test]
+    fn grouping_parens_lower_transparently() {
+        assert_eq!(
+            lower_one("(1 + 2) * 3\n"),
+            apply(
+                sym(MUL),
+                vec![apply(sym(ADD), vec![int(1), int(2)]), int(3)]
+            )
+        );
+    }
+
+    #[test]
+    fn function_application_of_unknown_head_passes_through() {
+        // F(a, b)  ->  F(a, b) — a user-defined function, no bridging.
+        assert_eq!(
+            lower_one("F(a, b)\n"),
+            apply(sym("F"), vec![sym("a"), sym("b")])
+        );
+    }
+
+    #[test]
+    fn builtin_uppercase_calls_are_bridged_to_canonical_ir_heads() {
+        assert_eq!(
+            lower_one("DIF(u, x)\n"),
+            apply(sym(D), vec![sym("u"), sym("x")])
+        );
+        assert_eq!(
+            lower_one("INT(u, x)\n"),
+            apply(sym(INTEGRATE), vec![sym("u"), sym("x")])
+        );
+        assert_eq!(
+            lower_one("INT(u, x, a, b)\n"),
+            apply(sym(INTEGRATE), vec![sym("u"), sym("x"), sym("a"), sym("b")])
+        );
+        assert_eq!(
+            lower_one("IF(a, b, c)\n"),
+            apply(sym(IF), vec![sym("a"), sym("b"), sym("c")])
+        );
+        assert_eq!(lower_one("SIN(x)\n"), apply(sym(SIN), vec![sym("x")]));
+        assert_eq!(lower_one("SQRT(x)\n"), apply(sym(SQRT), vec![sym("x")]));
+    }
+
+    #[test]
+    fn lowercase_spelling_is_not_bridged() {
+        // Only the exact uppercase convention is bridged (case-sensitive,
+        // matching IRNode::Symbol equality) — a different casing is just an
+        // ordinary user symbol/call, not the builtin.
+        assert_eq!(lower_one("sin(x)\n"), apply(sym("sin"), vec![sym("x")]));
+    }
+
+    #[test]
+    fn variable_assignment_lowers_to_assign() {
+        assert_eq!(
+            lower_one("x := 5\n"),
+            apply(sym(symbolic_ir::ASSIGN), vec![sym("x"), int(5)])
+        );
+    }
+
+    #[test]
+    fn function_definition_lowers_to_define() {
+        // F(x) := x^2 + 1  ->  Define(F, List(x), Add(Pow(x, 2), 1))
+        assert_eq!(
+            lower_one("F(x) := x^2 + 1\n"),
+            apply(
+                sym(DEFINE),
+                vec![
+                    sym("F"),
+                    apply(sym(LIST), vec![sym("x")]),
+                    apply(
+                        sym(ADD),
+                        vec![apply(sym(POW), vec![sym("x"), int(2)]), int(1)]
+                    ),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn multi_param_function_definition() {
+        // F(x, y) := x + y  ->  Define(F, List(x, y), Add(x, y))
+        assert_eq!(
+            lower_one("F(x, y) := x + y\n"),
+            apply(
+                sym(DEFINE),
+                vec![
+                    sym("F"),
+                    apply(sym(LIST), vec![sym("x"), sym("y")]),
+                    apply(sym(ADD), vec![sym("x"), sym("y")]),
+                ]
+            )
+        );
+    }
+
+    #[test]
+    fn assign_vs_define_disambiguated_by_lhs_shape_not_operator() {
+        // Both use the identical `:=` token; only the parsed LHS shape
+        // decides Assign vs Define (there is no SET/SETDELAYED distinction
+        // in this grammar, unlike Wolfram/Macsyma).
+        assert!(matches!(
+            lower_one("x := 5\n"),
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == symbolic_ir::ASSIGN)
+        ));
+        assert!(matches!(
+            lower_one("F(x) := x\n"),
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == DEFINE)
+        ));
+    }
+
+    #[test]
+    fn vector_and_matrix_literals_are_deferred_to_d5() {
+        let ast = parse_derive("[a, b, c]\n");
+        let err = lower_program(&ast).expect_err("vector lowering must be deferred");
+        assert!(err.message().contains("D-5"), "got {err:?}");
+    }
+
+    #[test]
+    fn nested_function_calls_lower_correctly() {
+        // SIN(COS(x))  ->  Sin(Cos(x))
+        assert_eq!(
+            lower_one("SIN(COS(x))\n"),
+            apply(sym(SIN), vec![apply(sym(COS), vec![sym("x")])])
+        );
+    }
+
+    #[test]
+    fn multi_statement_program_lowers_each_line() {
+        let ast = parse_derive("F(x) := DIF(SIN(x), x)\nF(0)\n");
+        let stmts = lower_program(&ast).expect("lowering failed");
+        assert_eq!(stmts.len(), 2);
+        assert!(matches!(
+            &stmts[0],
+            IRNode::Apply(a) if matches!(&a.head, IRNode::Symbol(s) if s == DEFINE)
+        ));
+        assert_eq!(stmts[1], apply(sym("F"), vec![int(0)]));
+    }
+}

--- a/code/packages/rust/derive-runtime/src/printer.rs
+++ b/code/packages/rust/derive-runtime/src/printer.rs
@@ -1,0 +1,275 @@
+//! # Pretty-printing — `symbolic-ir` → Derive surface notation
+//!
+//! After evaluation the result is a [`symbolic_ir::IRNode`] whose heads are
+//! the IR's canonical names (`Add`, `Sin`, `D`, …). A Derive user expects to
+//! read it back in Derive's own notation — infix `+`/`*`/`^`, `AND`/`OR`,
+//! `F(…)` application — not the IR's default `Add(2, 3)` debug form. This
+//! module is the inverse of [`crate::lower`]: it walks the result tree and
+//! renders the surface string, reversing the same uppercase head-name bridge
+//! [`crate::lower`] applies going in.
+//!
+//! It is deliberately a **presentation** layer, not a re-parse: the output
+//! only needs to be readable and round-trippable for the heads this subset
+//! actually produces. Precedence is handled by parenthesising a child
+//! whenever its operator binds *looser* than the parent's.
+//!
+//! ## Precedence ladder (loosest → tightest, mirrors MA07 §3 exactly)
+//!
+//! | Level | Constructs |
+//! |-------|------------|
+//! | 0 | (unevaluated `Assign`/`Define` — printed via the generic call form) |
+//! | 1 | `Or` |
+//! | 2 | `And` |
+//! | 3 | `Not` (prefix) / comparisons `=` `<=` `<` `>` `>=` |
+//! | 4 | `Add` `Sub` |
+//! | 5 | `Mul` `Div` |
+//! | 6 | unary `Neg` |
+//! | 7 | `Pow` |
+//! | 8 | atoms, `F(…)` |
+
+use symbolic_ir::{
+    IRApply, IRNode, ACOS, ACOSH, ADD, AND, ASIN, ASINH, ATAN, ATANH, COS, COSH, COTH, CSCH, D,
+    DIV, EQUAL, EXP, GREATER, GREATER_EQUAL, IF, INTEGRATE, LESS, LESS_EQUAL, LOG, MUL, NEG, NOT,
+    OR, POW, SECH, SIN, SINH, SQRT, SUB, TAN, TANH,
+};
+
+const PREC_LOWEST: u8 = 0;
+const PREC_OR: u8 = 1;
+const PREC_AND: u8 = 2;
+const PREC_NOT_CMP: u8 = 3;
+const PREC_ADD: u8 = 4;
+const PREC_MUL: u8 = 5;
+const PREC_NEG: u8 = 6;
+const PREC_POW: u8 = 7;
+const PREC_ATOM: u8 = 8;
+
+/// Render `node` as a Derive surface string.
+pub fn print_derive(node: &IRNode) -> String {
+    print_at(node, PREC_LOWEST)
+}
+
+/// Render `node`, wrapping it in parentheses if its own precedence is looser
+/// than `parent_prec` (so the surface string re-parses to the same tree).
+fn print_at(node: &IRNode, parent_prec: u8) -> String {
+    let (text, prec) = render(node);
+    if prec < parent_prec {
+        format!("({text})")
+    } else {
+        text
+    }
+}
+
+/// Render a node, returning its surface text and its own precedence level.
+fn render(node: &IRNode) -> (String, u8) {
+    match node {
+        IRNode::Integer(n) => (n.to_string(), PREC_ATOM),
+        IRNode::Float(v) => (format!("{v:?}"), PREC_ATOM),
+        IRNode::Rational(n, d) => (format!("{n}/{d}"), PREC_MUL),
+        IRNode::Str(s) => (format!("\"{s}\""), PREC_ATOM),
+        IRNode::Symbol(s) => (s.clone(), PREC_ATOM),
+        IRNode::Apply(app) => render_apply(app),
+    }
+}
+
+/// Render a compound `head(args)` node.
+fn render_apply(app: &IRApply) -> (String, u8) {
+    let head_name = match &app.head {
+        IRNode::Symbol(s) => Some(s.as_str()),
+        _ => None,
+    };
+    let args = &app.args;
+
+    if let Some(name) = head_name {
+        if let Some((op, prec)) = infix_binary(name) {
+            if args.len() == 2 {
+                let l = print_at(&args[0], prec);
+                let r = print_at(&args[1], prec);
+                return (format!("{l}{op}{r}"), prec);
+            }
+        }
+        // n-ary associative logic: And/Or flatten to a chain (mirrors how
+        // `lower_logical_chain` folds a homogeneous run flat rather than
+        // pairwise).
+        if let Some((op, prec)) = nary_logic(name) {
+            if args.len() >= 2 {
+                let parts: Vec<String> = args.iter().map(|a| print_at(a, prec)).collect();
+                return (parts.join(op), prec);
+            }
+            if args.len() == 1 {
+                return render(&args[0]);
+            }
+        }
+        match name {
+            POW if args.len() == 2 => {
+                // Right-associative and tighter than unary minus.
+                let base = print_at(&args[0], PREC_POW + 1);
+                let exp = print_at(&args[1], PREC_NEG);
+                return (format!("{base}^{exp}"), PREC_POW);
+            }
+            NEG if args.len() == 1 => {
+                let inner = print_at(&args[0], PREC_NEG);
+                return (format!("-{inner}"), PREC_NEG);
+            }
+            NOT if args.len() == 1 => {
+                let inner = print_at(&args[0], PREC_NOT_CMP);
+                return (format!("NOT {inner}"), PREC_NOT_CMP);
+            }
+            _ => {}
+        }
+
+        // Ordinary function application: `head(args…)`, bridging the
+        // canonical IR head back to Derive's uppercase surface spelling
+        // (the reverse of `crate::lower::canonical_head`); an unrecognised
+        // head (a user-defined function) is rendered as-typed.
+        let surface = ir_head_to_surface(name).unwrap_or(name);
+        let parts: Vec<String> = args.iter().map(print_derive).collect();
+        return (format!("{surface}({})", parts.join(", ")), PREC_ATOM);
+    }
+
+    // A computed (non-symbol) head — render generically as `(head)(args…)`.
+    let head_text = print_at(&app.head, PREC_ATOM);
+    let parts: Vec<String> = args.iter().map(print_derive).collect();
+    (format!("{head_text}({})", parts.join(", ")), PREC_ATOM)
+}
+
+/// Binary infix arithmetic/comparison operators — `(surface, precedence)`.
+fn infix_binary(name: &str) -> Option<(&'static str, u8)> {
+    Some(match name {
+        ADD => (" + ", PREC_ADD),
+        SUB => (" - ", PREC_ADD),
+        MUL => ("*", PREC_MUL),
+        DIV => ("/", PREC_MUL),
+        EQUAL => (" = ", PREC_NOT_CMP),
+        LESS => (" < ", PREC_NOT_CMP),
+        GREATER => (" > ", PREC_NOT_CMP),
+        LESS_EQUAL => (" <= ", PREC_NOT_CMP),
+        GREATER_EQUAL => (" >= ", PREC_NOT_CMP),
+        _ => return None,
+    })
+}
+
+/// n-ary logic operators — `(join-text, precedence)`.
+fn nary_logic(name: &str) -> Option<(&'static str, u8)> {
+    Some(match name {
+        AND => (" AND ", PREC_AND),
+        OR => (" OR ", PREC_OR),
+        _ => return None,
+    })
+}
+
+/// The IR→surface head dictionary — the exact reverse of
+/// [`crate::lower`]'s `surface_head_to_ir`, kept as its own table (rather
+/// than derived at runtime) so each direction reads as a simple, directly
+/// checkable list.
+fn ir_head_to_surface(name: &str) -> Option<&'static str> {
+    Some(match name {
+        D => "DIF",
+        INTEGRATE => "INT",
+        IF => "IF",
+        SIN => "SIN",
+        COS => "COS",
+        TAN => "TAN",
+        SQRT => "SQRT",
+        EXP => "EXP",
+        LOG => "LOG",
+        ATAN => "ATAN",
+        ASIN => "ASIN",
+        ACOS => "ACOS",
+        SINH => "SINH",
+        COSH => "COSH",
+        TANH => "TANH",
+        ASINH => "ASINH",
+        ACOSH => "ACOSH",
+        ATANH => "ATANH",
+        COTH => "COTH",
+        SECH => "SECH",
+        CSCH => "CSCH",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use symbolic_ir::{apply, flt, int, rat, sym};
+
+    #[test]
+    fn atoms_print_bare() {
+        assert_eq!(print_derive(&int(42)), "42");
+        assert_eq!(print_derive(&flt(1.5)), "1.5");
+        assert_eq!(print_derive(&rat(1, 3)), "1/3");
+        assert_eq!(print_derive(&sym("x")), "x");
+    }
+
+    #[test]
+    fn arithmetic_prints_infix() {
+        assert_eq!(
+            print_derive(&apply(sym(ADD), vec![sym("x"), int(1)])),
+            "x + 1"
+        );
+        assert_eq!(
+            print_derive(&apply(sym(MUL), vec![sym("x"), int(2)])),
+            "x*2"
+        );
+    }
+
+    #[test]
+    fn precedence_forces_parens_on_the_looser_child() {
+        // Mul(Add(a, b), c)  ->  "(a + b)*c" — never the ambiguous "a + b*c".
+        let e = apply(
+            sym(MUL),
+            vec![apply(sym(ADD), vec![sym("a"), sym("b")]), sym("c")],
+        );
+        assert_eq!(print_derive(&e), "(a + b)*c");
+    }
+
+    #[test]
+    fn power_prints_caret_right_associative() {
+        let e = apply(
+            sym(POW),
+            vec![sym("a"), apply(sym(POW), vec![sym("b"), sym("c")])],
+        );
+        assert_eq!(print_derive(&e), "a^b^c");
+    }
+
+    #[test]
+    fn negation_and_not_print_prefix() {
+        assert_eq!(print_derive(&apply(sym(NEG), vec![sym("x")])), "-x");
+        assert_eq!(print_derive(&apply(sym(NOT), vec![sym("a")])), "NOT a");
+    }
+
+    #[test]
+    fn logic_chain_prints_flat() {
+        let e = apply(sym(OR), vec![sym("a"), sym("b"), sym("c")]);
+        assert_eq!(print_derive(&e), "a OR b OR c");
+    }
+
+    #[test]
+    fn comparisons_print_derive_spelling() {
+        assert_eq!(
+            print_derive(&apply(sym(EQUAL), vec![sym("x"), int(4)])),
+            "x = 4"
+        );
+        assert_eq!(
+            print_derive(&apply(sym(LESS_EQUAL), vec![sym("a"), sym("b")])),
+            "a <= b"
+        );
+    }
+
+    #[test]
+    fn builtin_calls_print_bridged_back_to_uppercase() {
+        assert_eq!(
+            print_derive(&apply(sym(D), vec![sym("u"), sym("x")])),
+            "DIF(u, x)"
+        );
+        assert_eq!(print_derive(&apply(sym(SIN), vec![sym("x")])), "SIN(x)");
+    }
+
+    #[test]
+    fn user_function_call_prints_as_typed() {
+        assert_eq!(
+            print_derive(&apply(sym("F"), vec![sym("x"), sym("y")])),
+            "F(x, y)"
+        );
+    }
+}

--- a/code/specs/MA07-derive-language.md
+++ b/code/specs/MA07-derive-language.md
@@ -65,16 +65,19 @@ no grammar files yet:
   precedent) rather than assumed.
 - **D-4 — `derive-runtime` + `derive-repl`.** Lowers the parsed
   `GrammarASTNode` into `symbolic-ir`, evaluates with `symbolic-vm`'s shared
-  `SymbolicBackend`, and wires the §3-specified named built-ins (`DIF`, `INT`, `LIM`,
-  `SUM`, `SOLVE`, `IF`, …) as thin calls into the same handler-table pattern
-  Wolfram's W-4/W-5/W-22 already use — each one, where the semantics match,
-  calling the *exact same* `cas-*` function its Macsyma/Wolfram counterpart
-  calls (`DIF` → the same differentiation `cas-*` already implements for
-  `D`/`DIF`-under-Macsyma-names, `INT` → the same integration engine, `SOLVE`
-  → the same solver), so all three languages agree on every result these
-  crates can produce. Plus the interactive `derive-repl` (`#n: ` numbered
-  input, mirroring Derive's own numbered expression history, and the
-  `derive` binary).
+  `SymbolicBackend` — reused *unchanged*, with no custom `Backend` at all,
+  since D-4's scope needs nothing the shared handler table doesn't already
+  provide (arithmetic, comparison, logic, the held `Assign`/`Define`/`If`
+  forms, and the base `DIF`→`D`/`INT`→`Integrate` calculus handlers, both
+  already implemented — the *exact same* functions Macsyma/Wolfram call
+  under their own names, so all three languages agree on every result these
+  handlers can produce). Per §4, `LIM`/`SUM`/`PRODUCT`/`TAYLOR`/`SOLVE` are
+  **not** in D-4's scope — the shared VM has no existing handler for any of
+  them, so wiring them would be new engine code, not reuse; they land in
+  their own follow-on item(s), matching how Wolfram's W-6 through W-22 items
+  landed incrementally rather than all at once. Plus the interactive
+  `derive-repl` (`#n: ` numbered input, mirroring Derive's own numbered
+  expression history, and the `derive` binary).
 - **D-5 — vectors/matrices as structural `List` data.** `[a, b, c]` and
   `[a, b, c; d, e, f]` lower to nested `List` heads (mirroring Wolfram's
   `{a, b}` → `List[a, b]`), giving programs a way to *hold* vector/matrix


### PR DESCRIPTION
## Summary
- Adds `derive-runtime` and `derive-repl` — MA07 D-4, the last item before D-5's vector/matrix literal support — completing the frontend/runtime pipeline started by D-2 (`derive-lexer`) and D-3 (`derive-parser`, #8200).
- `derive-runtime`: lowers the `derive-parser` CST into `symbolic_ir::IRNode` and evaluates it via `symbolic_vm::VM` over the **unchanged** shared `SymbolicBackend` — no custom `Backend` needed, since D-4's scope (arithmetic, comparison, logic, `Assign`/`Define`/`If`, base `DIF`→`D`/`INT`→`Integrate`) is already fully covered by the existing handler table.
  - The lowering bridges Derive's uppercase builtin convention (`SIN`, `DIF`, `INT`, `IF`, …) to the IR's TitleCase heads, and disambiguates `:=` assignment vs. function definition purely by the parsed LHS's shape — Derive, unlike Wolfram/Macsyma, has only one assignment token, so there's no operator to branch on.
  - Vector/matrix literals return a clean deferred-to-D-5 error rather than silently mis-lowering.
  - A printer module reverses the bridge for display.
  - Two independent deep-recursion vectors are guarded: `derive-parser`'s own `MAX_RULE_DEPTH` already closes deeply-nested source; a new `MAX_STATEMENT_TOKENS` (mirroring `wolfram-runtime`) separately closes a long flat chain folding into a deep lowered tree, which grammar repetitions aren't bounded by the parser's cap.
- `derive-repl`: an interactive REPL and `derive` binary with Derive's own `#n:` numbered-worksheet prompt convention, bracket-depth line continuation, and a bounded `read_bounded_line` carrying forward the `j-repl`/`apl-repl` `/security-review` fix (task #32) rather than reintroducing the same unbounded-single-line-read gap in a new REPL.
- Resolves an internal MA07 spec contradiction found while implementing: §2 listed `LIM`/`SUM`/`SOLVE` under D-4's scope while §4 ("Honest scope") deferred them — followed §4 (the shared VM has no existing handler for any of them, so wiring them would be new engine code, not reuse) and updated §2 to match.

## Test plan
- [x] 73 tests across both crates (54 in `derive-runtime`, 19 in `derive-repl`), all passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean on both crates
- [x] `cargo fmt --check` — clean (scoped to touched files only)
- [x] Manually smoke-tested the `derive` binary end-to-end (`SQUARE(x):=x*x; SQUARE(5)` → 25, `DIF(x^2,x)` → `2*x`, `INT(x,x)` → `1/2*x^2`, `IF(1>0,42,0)` → 42)
- [x] `/security-review`: one round, one LOW-severity informational finding (a main-thread `.expect()` on thread-spawn failure, byte-for-byte identical to the same accepted pattern already shipped in `wolfram-runtime`/`maxima-runtime` — not introduced by this diff, not triggerable by a single crafted statement, needs external OS resource exhaustion) — does not block per the skill's LOW/INFO handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)