### PR TITLE
feat(sql): IS / IS NOT null-safe (in)equality

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.26 — `IS` / `IS NOT` null-safe (in)equality
+
+`SELECT a IS b` / `a IS NOT b` now parse and run as SQLite's null-safe
+comparison: `a IS b` is 1 when both operands are equal OR both NULL, 0 when
+exactly one is NULL (unlike `=`, which yields NULL if either side is NULL);
+`a IS NOT b` is the negation. It is lowered entirely in the planner onto the
+CASE node (added in 0.5.25) — `CASE WHEN a IS NULL AND b IS NULL THEN 1 WHEN a
+IS NULL OR b IS NULL THEN 0 ELSE a=b END` — so grammar (sql-parser 0.1.10) +
+planner (sql-planner 0.2.9) are the only changes; **no codegen or VM opcode**.
+`IS NULL` / `IS NOT NULL` still work (matched first). Two differential-oracle
+cases (`is_null_safe_equality`, `is_operator_in_where`) diff against real
+bundled SQLite, including `IS` as a WHERE predicate. (`IS [NOT] DISTINCT FROM`
+— the standard-SQL spelling — is a separate follow-up.)
+
 ## 0.5.25 — Searched `CASE WHEN … THEN … [ELSE …] END`
 
 `SELECT CASE WHEN cond THEN val … [ELSE val] END` now parses and runs with

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.25"
+version = "0.5.26"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -903,6 +903,27 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id, CASE WHEN a=2 THEN 10 ELSE 20 END + 5 AS v FROM t WHERE CASE WHEN a IS NULL THEN 0 ELSE 1 END ORDER BY id",
     },
+    // `a IS b` is null-SAFE equality: 1 when both equal OR both NULL, 0 when
+    // exactly one is NULL — unlike `=`, which yields NULL if either side is NULL.
+    // Aliased so the check is on the 1/0 result value per row.
+    Case {
+        id: "is_null_safe_equality",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER, b INTEGER)",
+            "INSERT INTO t VALUES (1,1,1),(2,1,2),(3,NULL,NULL),(4,1,NULL),(5,NULL,1)",
+        ],
+        query: "SELECT id, (a IS b) AS e, (a IS NOT b) AS ne FROM t ORDER BY id",
+    },
+    // `IS`/`IS NOT` used as a WHERE predicate — the null-safe match includes the
+    // both-NULL row, which a plain `a = b` would exclude (NULL is not true).
+    Case {
+        id: "is_operator_in_where",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, a INTEGER, b INTEGER)",
+            "INSERT INTO t VALUES (1,1,1),(2,1,2),(3,NULL,NULL),(4,2,NULL)",
+        ],
+        query: "SELECT id FROM t WHERE a IS b ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.10] - Unreleased
+
+### Added
+
+- **`IS <expr>` / `IS NOT <expr>` (null-safe (in)equality).** Two `comparison`
+  alternatives added AFTER the `IS NULL` / `IS NOT NULL` sequences (so those
+  still match first) and with `IS NOT <expr>` before `IS <expr>`. The planner
+  (sql-planner 0.2.9) lowers them onto a CASE, so no codegen/VM change.
+
 ## [0.1.9] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -483,6 +483,20 @@ pub fn parser_grammar() -> ParserGrammar {
                             GrammarElement::Literal { value: r#"NOT"#.to_string() },
                             GrammarElement::Literal { value: r#"NULL"#.to_string() },
                         ] },
+                        // `x IS NOT <expr>` / `x IS <expr>` — null-safe (in)equality.
+                        // These come AFTER the IS NULL / IS NOT NULL sequences so
+                        // ordered-choice matches the NULL forms first (NULL is
+                        // itself a valid `additive`); and `IS NOT <expr>` before
+                        // `IS <expr>` so the NOT form is tried first.
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"IS"#.to_string() },
+                            GrammarElement::Literal { value: r#"NOT"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                        ] },
+                        GrammarElement::Sequence { elements: vec![
+                            GrammarElement::Literal { value: r#"IS"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                        ] },
                     ] }) },
             ] },
             line_number: 68,

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -556,6 +556,22 @@ mod tests {
         assert!(find_rule(&ast, "comparison"), "Expected comparison");
     }
 
+    /// `IS <expr>` / `IS NOT <expr>` (null-safe (in)equality) parse as comparison
+    /// forms, without disturbing `IS NULL` / `IS NOT NULL` (which must still
+    /// match their dedicated sequences first).
+    #[test]
+    fn test_parse_is_operator() {
+        for q in [
+            "SELECT x FROM t WHERE a IS b",
+            "SELECT x FROM t WHERE a IS NOT b",
+            "SELECT x FROM t WHERE a IS NULL",
+            "SELECT x FROM t WHERE a IS NOT NULL",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "comparison"), "Expected comparison for {q:?}");
+        }
+    }
+
     /// The `GLOB` and `NOT GLOB` infix operators parse as comparison forms
     /// (the planner lowers them onto the `glob` builtin).
     #[test]

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.9] - Unreleased
+
+### Added
+
+- **`a IS b` / `a IS NOT b` null-safe (in)equality.** The IS handler now
+  distinguishes `IS [NOT] NULL` (no right operand) from `IS [NOT] <expr>` (a
+  right operand node) and lowers the latter via new `plan_is_distinct` onto
+  `CASE WHEN a IS NULL AND b IS NULL THEN 1 WHEN a IS NULL OR b IS NULL THEN 0
+  ELSE a = b END` (negated → wrapped in `NOT`). Reuses the CASE node added in
+  0.2.8 plus existing `IsNull`/`BinaryOp`/`UnaryOp` — **no codegen or VM opcode
+  needed**. (The naive `(a=b) OR (a IS NULL AND b IS NULL)` is wrong — it yields
+  NULL, not 0, for `1 IS NULL`.)
+
 ## [0.2.8] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -1907,10 +1907,16 @@ fn plan_comparison(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         return Ok(left);
     }
 
-    // IS NULL / IS NOT NULL
-    // Grammar: `IS NULL` or `IS NOT NULL` — these arrive as direct keyword tokens.
+    // IS [NOT] NULL   and   IS [NOT] <expr>  (null-safe (in)equality)
+    // Grammar: `IS NULL` / `IS NOT NULL` produce only keyword tokens (no right
+    // operand node), whereas `IS <expr>` / `IS NOT <expr>` produce a second
+    // expression node — that is how we tell the two apart.
     if direct_tok_uppers.contains(&"IS".to_string()) {
         let negated = direct_tok_uppers.contains(&"NOT".to_string());
+        if let Some(right_node) = child_nodes_ordered.get(1) {
+            let right = plan_expression(right_node)?;
+            return Ok(plan_is_distinct(left, right, negated));
+        }
         return Ok(if negated {
             SqlExpr::IsNotNull(Box::new(left))
         } else {
@@ -2229,6 +2235,57 @@ fn plan_cast(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         expr: Box::new(inner),
         ty,
     })
+}
+
+/// Lower `a IS b` (and `a IS NOT b`) — SQLite's **null-safe** (in)equality —
+/// onto a `CASE`, reusing existing nodes so no new codegen or VM opcode is
+/// needed.
+///
+/// Semantics: `a IS b` is 1 when both operands are NULL, 0 when exactly one is
+/// NULL, and `a = b` otherwise (in that last case neither is NULL, so `a = b` is
+/// a clean boolean, never NULL). This differs from `a = b`, which yields NULL
+/// whenever either side is NULL. `a IS NOT b` is the logical negation.
+///
+/// Expressed as:
+/// ```text
+/// CASE WHEN a IS NULL AND b IS NULL THEN 1
+///      WHEN a IS NULL OR  b IS NULL THEN 0
+///      ELSE a = b END
+/// ```
+/// Both operands are pure, so re-evaluating them across the CASE branches is
+/// sound. (The tempting `(a = b) OR (a IS NULL AND b IS NULL)` is WRONG — it
+/// yields NULL, not 0, for `1 IS NULL`.)
+fn plan_is_distinct(left: SqlExpr, right: SqlExpr, negated: bool) -> SqlExpr {
+    let both_null = SqlExpr::BinaryOp {
+        op: BinaryOp::And,
+        left: Box::new(SqlExpr::IsNull(Box::new(left.clone()))),
+        right: Box::new(SqlExpr::IsNull(Box::new(right.clone()))),
+    };
+    let either_null = SqlExpr::BinaryOp {
+        op: BinaryOp::Or,
+        left: Box::new(SqlExpr::IsNull(Box::new(left.clone()))),
+        right: Box::new(SqlExpr::IsNull(Box::new(right.clone()))),
+    };
+    let eq = SqlExpr::BinaryOp {
+        op: BinaryOp::Eq,
+        left: Box::new(left),
+        right: Box::new(right),
+    };
+    let case = SqlExpr::Case {
+        branches: vec![
+            (both_null, SqlExpr::Literal(SqlValue::Int(1))),
+            (either_null, SqlExpr::Literal(SqlValue::Int(0))),
+        ],
+        else_val: Some(Box::new(eq)),
+    };
+    if negated {
+        SqlExpr::UnaryOp {
+            op: UnaryOp::Not,
+            expr: Box::new(case),
+        }
+    } else {
+        case
+    }
 }
 
 /// Plan a searched `CASE WHEN … THEN … [ELSE …] END` primary node into


### PR DESCRIPTION
## `IS` / `IS NOT` null-safe (in)equality

`SELECT a IS b` / `a IS NOT b` now parse and run as SQLite's null-safe
comparison: `a IS b` is **1** when both operands are equal OR both `NULL`, **0**
when exactly one is `NULL` — unlike `=`, which yields `NULL` if either side is
`NULL`. `a IS NOT b` is the negation.

### Elegant lowering — no new opcode
Now that `CASE` exists (merged just before this), the planner lowers `a IS b`
**entirely** onto:
```
CASE WHEN a IS NULL AND b IS NULL THEN 1
     WHEN a IS NULL OR  b IS NULL THEN 0
     ELSE a = b END
```
(negated → wrapped in `NOT`), reusing the `CASE` node plus existing
`IsNull`/`BinaryOp`/`UnaryOp`. So this is a **grammar + planner change only** —
no codegen or VM opcode. (The tempting `(a=b) OR (a IS NULL AND b IS NULL)` is
*wrong* — it yields `NULL`, not `0`, for `1 IS NULL`.)

### What changed (rotation lane 2)
- **sql-parser** (`_grammar.rs`): `comparison` gains `IS NOT additive` and
  `IS additive`, placed **after** the `IS NULL` / `IS NOT NULL` sequences
  (`NULL` is itself a valid `additive`, so those must match first via ordered
  choice) and with the `NOT` form first.
- **sql-planner**: the IS handler distinguishes `IS [NOT] NULL` (no right
  operand node) from `IS [NOT] <expr>` (right operand present) and lowers the
  latter via new `plan_is_distinct`.

### Verification
Probed against real SQLite — `a IS b` over {equal, unequal, both-NULL,
one-NULL}, `a IS NOT b`, `IS` in a WHERE predicate, and `IS NULL` (regression) —
all match.
- **Differential oracle** (mini-sqlite): `is_null_safe_equality`,
  `is_operator_in_where`.
- **sql-parser**: `test_parse_is_operator` (`IS`/`IS NOT <expr>` and
  `IS [NOT] NULL` all parse).
- Full affected SQL pipeline green; clippy clean.
- Security review (Rust, inline diff): **PASSED** — grammar ordering verified
  (NULL forms never mis-parsed as `IS <additive=NULL>`, `IS NOT b` not swallowed),
  no zero-width repetition, planner `.get(1)` bounds-safe, `plan_is_distinct`
  builds a fixed-shape tree, no unsafe/injection.

### Versions
sql-parser 0.1.9→0.1.10 · sql-planner 0.2.8→0.2.9 · mini-sqlite 0.5.25→0.5.26.

### Follow-up
`IS [NOT] DISTINCT FROM` (the standard-SQL spelling of the same operator) is a
separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
