### PR TITLE
feat(sql): COLLATE NOCASE / RTRIM / BINARY in ORDER BY

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.27 — `COLLATE` in `ORDER BY` (NOCASE / RTRIM / BINARY)
+
+`ORDER BY col COLLATE name` now sorts through a collating sequence, matching
+SQLite: `NOCASE` compares ASCII case-insensitively (`'Apple'` = `'apple'`),
+`RTRIM` ignores trailing spaces (`'a  '` = `'a'`), and `BINARY` (the default)
+keeps raw byte order (uppercase before lowercase). The `COLLATE` name parses
+between the sort expression and `ASC`/`DESC` (sql-parser 0.1.11), is validated
+in the planner into a new `SortKey.collation` field (sql-planner 0.2.10),
+threaded through `CompiledSortKey` (sql-codegen 0.6.4) and constant folding
+(sql-optimizer 0.1.4), and applied by the VM sort comparator to text values
+only (sql-vm 0.4.14). Equal keys keep insertion order (the sort is stable),
+matching SQLite. Four differential-oracle cases diff NOCASE (asc + desc), RTRIM,
+and BINARY against real bundled SQLite. Unknown collations are a planning error.
+
 ## 0.5.26 — `IS` / `IS NOT` null-safe (in)equality
 
 `SELECT a IS b` / `a IS NOT b` now parse and run as SQLite's null-safe

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.26"
+version = "0.5.27"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -924,6 +924,48 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT id FROM t WHERE a IS b ORDER BY id",
     },
+    // ---- Lane 3: COLLATE in ORDER BY -------------------------------------
+    // NOCASE folds case, so mixed-case names sort case-insensitively. Equal
+    // keys ('Apple'/'apple', 'banana'/'BANANA') keep insertion order — a
+    // secondary `id` key pins that so the oracle diff is deterministic.
+    Case {
+        id: "order_by_collate_nocase",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'cherry'),(4,'BANANA'),(5,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY name COLLATE NOCASE, id",
+    },
+    // NOCASE with DESC — the key comparison flips but the collation still folds
+    // case, and equal-key ties are unaffected by direction.
+    Case {
+        id: "order_by_collate_nocase_desc",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'cherry'),(4,'BANANA'),(5,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY name COLLATE NOCASE DESC, id",
+    },
+    // RTRIM ignores trailing spaces, so 'a  ' and 'a' compare equal (broken by
+    // the id tiebreak). Contrast with default BINARY, where 'a' < 'a  '.
+    Case {
+        id: "order_by_collate_rtrim",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'b'),(2,'a  '),(3,'a'),(4,'b '),(5,'c')",
+        ],
+        query: "SELECT name FROM t ORDER BY name COLLATE RTRIM, id",
+    },
+    // Explicit COLLATE BINARY is the default byte order — uppercase sorts
+    // before lowercase (ASCII 'A'=65 < 'a'=97).
+    Case {
+        id: "order_by_collate_binary",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, name TEXT)",
+            "INSERT INTO t VALUES (1,'banana'),(2,'Apple'),(3,'apple')",
+        ],
+        query: "SELECT name FROM t ORDER BY name COLLATE BINARY",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.4] - Unreleased
+
+### Added
+
+- **Thread `collation` through `CompiledSortKey`.** The compiled sort key gains
+  a `collation: Option<String>` field, copied from the planner's `SortKey`, so
+  the VM can apply the collating sequence when comparing text values.
+
 ## [0.6.3] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -197,6 +197,10 @@ pub struct CompiledSortKey {
     /// Explicit NULL placement from `NULLS FIRST` / `NULLS LAST`. `None` = the
     /// SQLite default (NULLs first for ASC, last for DESC).
     pub nulls_first: Option<bool>,
+    /// Collating sequence from `COLLATE name`, applied to text values before
+    /// comparison. `None` = default byte order (BINARY). `Some("NOCASE")` =
+    /// ASCII case-insensitive; `Some("RTRIM")` = ignore trailing spaces.
+    pub collation: Option<String>,
 }
 
 /// The complete bytecode instruction set for the Mini-SQLite VM.
@@ -2167,6 +2171,7 @@ fn peel_post_ops(plan: &OptimizedPlan) -> (&OptimizedPlan, Vec<Instruction>) {
                         },
                         ascending: k.ascending,
                         nulls_first: k.nulls_first,
+                        collation: k.collation.clone(),
                     })
                     .collect();
                 post_ops.push(Instruction::SortResult(compiled_keys));
@@ -2739,6 +2744,7 @@ mod tests {
                 expr: col("name"),
                 ascending: true,
                 nulls_first: None,
+                collation: None,
             }],
         });
         let v = instrs(&plan);
@@ -2758,6 +2764,7 @@ mod tests {
                 expr: col("score"),
                 ascending: true,
                 nulls_first: None,
+                collation: None,
             }],
         });
         let v = instrs(&plan);
@@ -2778,6 +2785,7 @@ mod tests {
                 expr: col("score"),
                 ascending: false,
                 nulls_first: None,
+                collation: None,
             }],
         });
         let v = instrs(&plan);
@@ -2799,11 +2807,13 @@ mod tests {
                     expr: col("a"),
                     ascending: true,
                     nulls_first: None,
+                    collation: None,
                 },
                 SortKey {
                     expr: col("b"),
                     ascending: false,
                     nulls_first: None,
+                    collation: None,
                 },
             ],
         });
@@ -3579,6 +3589,7 @@ mod tests {
                 expr: col("x"),
                 ascending: true,
                 nulls_first: None,
+                collation: None,
             }],
         });
         let v = instrs(&plan);

--- a/code/packages/rust/sql-optimizer/CHANGELOG.md
+++ b/code/packages/rust/sql-optimizer/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this crate will be documented here.
 
+## [0.1.4] - Unreleased
+
+### Changed
+
+- **Preserve `SortKey.collation` through constant folding.** `fold_plan` now
+  carries the new `collation` field on `Sort` keys so a `COLLATE` clause
+  survives optimization.
+
 ## [0.1.3] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-optimizer/Cargo.toml
+++ b/code/packages/rust/sql-optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-optimizer"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Logical query plan optimizer for the Mini-SQLite SQL pipeline (Level 1)"
 authors = ["Adhithya Rajasekaran <adhithyan15@gmail.com>"]

--- a/code/packages/rust/sql-optimizer/src/lib.rs
+++ b/code/packages/rust/sql-optimizer/src/lib.rs
@@ -535,6 +535,7 @@ fn fold_plan(plan: OptimizedPlan) -> OptimizedPlan {
                     expr: fold_expr(k.expr),
                     ascending: k.ascending,
                     nulls_first: k.nulls_first,
+                    collation: k.collation,
                 })
                 .collect(),
         },
@@ -1808,6 +1809,7 @@ mod tests {
                 expr: col(col_name),
                 ascending: true,
                 nulls_first: None,
+                collation: None,
             }],
         }
     }
@@ -2444,6 +2446,7 @@ mod tests {
                 expr: col("id"),
                 ascending: true,
                 nulls_first: None,
+                collation: None,
             }],
         };
         let opt = optimize_with_passes(plan, &[&DeadCodeEliminationPass]);
@@ -2622,6 +2625,7 @@ mod tests {
                     expr: col("name"),
                     ascending: true,
                     nulls_first: None,
+                    collation: None,
                 }],
             }),
             count: Some(10),

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.11] - Unreleased
+
+### Added
+
+- **`COLLATE name` clause in `ORDER BY`.** The `order_item` grammar rule gains
+  an optional `[ "COLLATE" NAME ]` between the sort expression and the `ASC` /
+  `DESC` direction (`expr COLLATE name [ASC|DESC] [NULLS ...]`), matching
+  SQLite's grammar. `COLLATE` is matched by literal text and the collation name
+  is an ordinary NAME token (validated in the planner), so no lexer keyword was
+  added. Existing `ASC`/`DESC`/`NULLS` ordering is unaffected.
+
 ## [0.1.10] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -199,6 +199,17 @@ pub fn parser_grammar() -> ParserGrammar {
             name: r#"order_item"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
                 GrammarElement::RuleReference { name: r#"expr"#.to_string() },
+                // Optional `COLLATE name` clause, BEFORE the ASC/DESC direction
+                // (per SQLite grammar: `expr COLLATE name ASC`). `COLLATE` is
+                // matched by literal text (it is not in the lexer keyword list,
+                // so it arrives as a NAME token that the literal matcher accepts
+                // case-insensitively); the name that follows (BINARY / NOCASE /
+                // RTRIM, or a user collation) is accepted as a generic NAME and
+                // validated in the planner. Absent → BINARY (byte order).
+                GrammarElement::Optional { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Literal { value: r#"COLLATE"#.to_string() },
+                        GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
+                    ] }) },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::Literal { value: r#"ASC"#.to_string() },
                         GrammarElement::Literal { value: r#"DESC"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -281,6 +281,22 @@ mod tests {
         }
     }
 
+    /// `COLLATE name` parses in ORDER BY — standalone, and composed with the
+    /// ASC/DESC direction and a NULLS clause (COLLATE comes first, per SQLite).
+    /// The collation name is an ordinary NAME; the planner validates it.
+    #[test]
+    fn test_parse_order_by_collate() {
+        for q in [
+            "SELECT id FROM t ORDER BY name COLLATE NOCASE",
+            "SELECT id FROM t ORDER BY name COLLATE BINARY",
+            "SELECT id FROM t ORDER BY name COLLATE RTRIM DESC",
+            "SELECT id FROM t ORDER BY name COLLATE NOCASE ASC NULLS LAST",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "order_item"), "Expected order_item for {q:?}");
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 5: SELECT with LIMIT and OFFSET
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.10] - Unreleased
+
+### Added
+
+- **`COLLATE name` read into `SortKey.collation`.** `plan_order_item` now scans
+  for a `COLLATE` token and validates the following name against the three
+  built-in sequences: `BINARY` (folded to `None`, the default byte order),
+  `NOCASE`, and `RTRIM`. An unknown collation is a planning error
+  (`no such collating sequence: X`), matching SQLite. New `collation:
+  Option<String>` field on `SortKey` (stored uppercased).
+
 ## [0.2.9] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -413,6 +413,12 @@ pub struct SortKey {
     /// `None` = SQLite's default (NULLs sort first for ASC, last for DESC);
     /// `Some(true)` = NULLs first; `Some(false)` = NULLs last.
     pub nulls_first: Option<bool>,
+    /// Collating sequence from a `COLLATE name` clause, applied to **text**
+    /// values before comparison. `None` (or an explicit `COLLATE BINARY`) means
+    /// the default byte-order comparison. `Some("NOCASE")` compares ASCII
+    /// case-insensitively; `Some("RTRIM")` ignores trailing spaces. Non-text
+    /// values are unaffected by collation. Stored uppercased.
+    pub collation: Option<String>,
 }
 
 /// An aggregate item inside an `Aggregate` plan node.
@@ -1000,10 +1006,41 @@ fn plan_order_item(item: &GrammarASTNode) -> Result<SortKey, PlanError> {
         placement.transpose()?
     };
 
+    // Optional `COLLATE name` clause. `COLLATE` is followed by the collation
+    // name (BINARY / NOCASE / RTRIM). We validate against the three built-in
+    // sequences and store the name uppercased; `BINARY` (the default) collapses
+    // to `None` so the VM takes the plain byte-order path. An unknown collation
+    // is a planning error, matching SQLite's "no such collating sequence".
+    let collation = {
+        let children = &item.children;
+        let mut coll: Option<Result<Option<String>, PlanError>> = None;
+        for (i, c) in children.iter().enumerate() {
+            if is_keyword_token(c, "COLLATE") {
+                coll = Some(match children.get(i + 1) {
+                    Some(tok) => {
+                        let name = token_text_of(tok).to_uppercase();
+                        match name.as_str() {
+                            "BINARY" => Ok(None),
+                            "NOCASE" | "RTRIM" => Ok(Some(name)),
+                            other => Err(PlanError::UnsupportedStatement(format!(
+                                "no such collating sequence: {other}"
+                            ))),
+                        }
+                    }
+                    None => Err(PlanError::UnsupportedStatement(
+                        "COLLATE clause missing collation name".to_string(),
+                    )),
+                });
+            }
+        }
+        coll.transpose()?.flatten()
+    };
+
     Ok(SortKey {
         expr,
         ascending,
         nulls_first,
+        collation,
     })
 }
 

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.14] - Unreleased
+
+### Added
+
+- **Collation-aware `ORDER BY` comparator.** `apply_sort` now compares text
+  values through the sort key's collating sequence: `NOCASE` folds ASCII case
+  on both operands, `RTRIM` strips trailing spaces, and `BINARY`/absent keeps
+  raw byte order. Collation applies only to text-vs-text comparisons; every
+  other type pairing uses the existing `sql_cmp` type ordering. The stable sort
+  already preserves insertion order for equal keys, matching SQLite. New helpers
+  `sql_cmp_collated` and `collate_text`.
+
 ## [0.4.13] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -2797,13 +2797,53 @@ fn apply_sort(
                 };
             }
 
-            let cmp = sql_cmp(va, vb);
+            let cmp = sql_cmp_collated(va, vb, key.collation.as_deref());
             if cmp != std::cmp::Ordering::Equal {
                 return if key.ascending { cmp } else { cmp.reverse() };
             }
         }
         std::cmp::Ordering::Equal
     });
+}
+
+/// Compare two values honouring an optional `COLLATE` sequence.
+///
+/// Collation only affects **text-vs-text** comparisons; for every other type
+/// pairing SQLite's normal type-ordering (`sql_cmp`) applies unchanged. The two
+/// built-in text collations we transform:
+///
+/// | Collation | Transform before byte comparison        | Example equal pair |
+/// |-----------|------------------------------------------|--------------------|
+/// | `NOCASE`  | ASCII-lowercase both operands            | `'Apple'` = `'apple'` |
+/// | `RTRIM`   | strip trailing spaces from both operands | `'a  '` = `'a'`       |
+///
+/// `None` or `BINARY` (folded to `None` in the planner) keeps raw byte order.
+/// The transform is applied to *copies*; the underlying values are untouched, so
+/// the sort is a pure reordering. NOCASE is ASCII-only, matching SQLite's
+/// built-in NOCASE (it lowercases A–Z exclusively, leaving non-ASCII bytes as
+/// is) — we mirror that with `to_ascii_lowercase` rather than Unicode folding.
+fn sql_cmp_collated(
+    a: &SqlValue,
+    b: &SqlValue,
+    collation: Option<&str>,
+) -> std::cmp::Ordering {
+    if let (Some(coll), SqlValue::Text(sa), SqlValue::Text(sb)) = (collation, a, b) {
+        let ta = collate_text(sa, coll);
+        let tb = collate_text(sb, coll);
+        return ta.cmp(&tb);
+    }
+    sql_cmp(a, b)
+}
+
+/// Produce the collation-normalised form of a text value for comparison.
+/// Unknown collation names fall through to the raw string (defensive — the
+/// planner already rejects anything other than NOCASE/RTRIM/BINARY).
+fn collate_text(s: &str, collation: &str) -> String {
+    match collation {
+        "NOCASE" => s.to_ascii_lowercase(),
+        "RTRIM" => s.trim_end_matches(' ').to_string(),
+        _ => s.to_string(),
+    }
 }
 
 /// Remove duplicate rows from `rows` (preserving first occurrence).
@@ -3744,7 +3784,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None }]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
     }
@@ -3767,7 +3807,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: false, nulls_first: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: false, nulls_first: None, collation: None }]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(3)], vec![int(2)], vec![int(1)]]);
     }
@@ -3798,8 +3838,8 @@ mod tests {
             Instruction::CloseScan(None),
             Instruction::Halt,
             Instruction::SortResult(vec![
-                CompiledSortKey { column: "a".to_string(), ascending: true, nulls_first: None },
-                CompiledSortKey { column: "b".to_string(), ascending: true, nulls_first: None },
+                CompiledSortKey { column: "a".to_string(), ascending: true, nulls_first: None, collation: None },
+                CompiledSortKey { column: "b".to_string(), ascending: true, nulls_first: None, collation: None },
             ]),
         ]), &mut b).unwrap();
         assert_eq!(r.rows[0], vec![int(1), int(1)]);
@@ -4304,7 +4344,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None }]),
             Instruction::LimitResult(Some(3), None),
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);
@@ -4331,7 +4371,7 @@ mod tests {
             Instruction::Label("end".to_string()),
             Instruction::CloseScan(None),
             Instruction::Halt,
-            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None }]),
+            Instruction::SortResult(vec![CompiledSortKey { column: "x".to_string(), ascending: true, nulls_first: None, collation: None }]),
             Instruction::DistinctResult,
         ]), &mut b).unwrap();
         assert_eq!(r.rows, vec![vec![int(1)], vec![int(2)], vec![int(3)]]);


### PR DESCRIPTION
## COLLATE NOCASE / RTRIM / BINARY in `ORDER BY`

Adds SQLite's three built-in collating sequences to `ORDER BY`, so text sorts
case-insensitively (`NOCASE`), ignoring trailing spaces (`RTRIM`), or by raw
byte order (`BINARY`, the default). **Rotation lane 3 (NULLS/COLLATE)**,
mirroring the merged NULLS FIRST/LAST slice — one `SortKey` field threaded to
the VM comparator.

### Behaviour (verified against real bundled SQLite)
| Collation | Rule | `banana,Apple,cherry,BANANA,apple` → |
|---|---|---|
| `BINARY` (default) | byte order, `A`<`a` | `Apple, BANANA, apple, banana, cherry` |
| `NOCASE` | ASCII case-fold | `Apple, apple, banana, BANANA, cherry` |
| `NOCASE DESC` | fold + reverse key | `cherry, banana, BANANA, Apple, apple` |
| `RTRIM` (`b,a␣␣,a,b␣,c`) | ignore trailing spaces | `a␣␣, a, b, b␣, c` |

Equal keys keep insertion order (the sort is stable), matching SQLite.

### Pipeline
- **sql-parser 0.1.11** — `order_item` grammar gains optional `[COLLATE NAME]`
  between the sort expr and `ASC`/`DESC`, per SQLite's grammar. `COLLATE` is
  matched by literal text (not a lexer keyword); the name is a generic NAME
  validated downstream.
- **sql-planner 0.2.10** — `plan_order_item` reads the name into a new
  `SortKey.collation: Option<String>`. `BINARY` folds to `None`; `NOCASE`/`RTRIM`
  stored uppercased; unknown names → planning error (`no such collating
  sequence`), matching SQLite.
- **sql-codegen 0.6.4** — `CompiledSortKey` carries `collation` through.
- **sql-optimizer 0.1.4** — `fold_plan` preserves it.
- **sql-vm 0.4.14** — `apply_sort` compares text via new
  `sql_cmp_collated`/`collate_text`. Collation applies to **text-vs-text only**;
  every other pairing uses the existing `sql_cmp`.

### Tests
Parser test (4 spellings incl. composition with ASC/DESC + NULLS); four
differential-oracle cases (`order_by_collate_nocase`, `..._nocase_desc`,
`..._rtrim`, `..._binary`) diffing against real bundled SQLite, with a secondary
`id` key pinning equal-key stability. Full affected set green; clippy clean.

### Security
Inline adversarial review **PASSED**: `children.get(i+1)` is Option-safe (no
OOB), unknown collations error cleanly (no panic), the comparator stays a
consistent strict-weak-ordering so `sort_by` cannot panic, and all new `String`
allocations are bounded by input size (no DoS amplification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
