### PR TITLE
feat(adj-facts-stdlib): kindergarten shapes — first rung of the K→med facts ladder

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_k_shapes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_k_shapes_e2e.rs
@@ -1,0 +1,59 @@
+//! End-to-end test for the first kindergarten FACTS library
+//! (`adj-facts-stdlib/kindergarten/shapes.adj`) driven through the built CLI:
+//! a native `table` of polygon → number-of-sides resolves a binding-query recall
+//! with the source's citation, and abstains on a non-polygon — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn kindergarten_shapes_recall_binds_side_count_with_citation() {
+    let dir = scratch("shapes");
+    // Copy the shipped kindergarten table beside the entry program and import it.
+    let src = facts_stdlib().join("kindergarten/shapes.adj");
+    std::fs::copy(&src, dir.join("shapes.adj")).expect("copy shipped shapes.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"shapes.adj\"\n\
+         ? polygon_sides(hexagon, $Sides)\n\
+         ? polygon_sides(triangle, $Sides)\n\
+         ? polygon_sides(circle, $Sides)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A hexagon has six sides; a triangle has three — the recalled counts.
+    assert!(out.contains("\"Sides\":\"6\""), "hexagon → 6: {out}");
+    assert!(out.contains("\"Sides\":\"3\""), "triangle → 3: {out}");
+    // The answer carries the MathWorld citation as its proof.
+    assert!(
+        out.contains("mathworld.wolfram.com") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // A circle is not a polygon — honest abstention, never a fabricated count.
+    assert!(out.contains("\"abstained\":true"), "circle abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -1,0 +1,39 @@
+# adj-facts-stdlib — the graded, byte-provenanced *facts* standard library (K → med)
+
+A curriculum of **recallable facts**, climbing from **what every kindergartener
+learns → medical school**, as importable, grounded ADJ libraries. The sibling of
+[`adj-formula-stdlib`](../adj-formula-stdlib/) (graded *formulas*) and the
+[medical recall domains](../mycin-2026/recall/) (single-hop clinical recall): where
+those hold computation and clinical edges, this holds the **elementary facts a
+learner memorizes first** — shapes, colors, counting, the calendar, the planets —
+and grows upward toward the science facts a clinician recalls.
+
+## Why facts are first-class
+
+The ADJ language natively supports facts (`relate`, `dictionary`) and now native
+tabular data ([`table`](../../ADJ-TABLES.md)). A fact library is *imported* and
+*recalled* — the model performs no lookup from memory; the engine resolves a
+binding query against the grounded rows and returns the answer **with its
+citation**, on the CPU, with zero answer-time model calls. Every shipped fact is
+byte-provenanced from a citable source (see
+[feedback: nothing human-authored]) — nothing is asserted "from memory."
+
+## Layout (by grade level)
+
+| level | what | examples |
+|-------|------|----------|
+| `kindergarten/` | the first facts a child learns | shapes → sides (this PR) |
+| … | grade-school, middle, high-school, undergrad … | *(grown one small library per rotation)* |
+| → medical school | the science facts a clinician recalls | (already: `mycin-2026/recall/`, 63 domains) |
+
+## Consuming a fact library
+
+```adj
+import "kindergarten/shapes.adj"
+? polygon_sides(hexagon, $Sides)     % 6, cited to the source
+```
+
+Because a `table` row lowers to a relation whose value is a number, a recalled
+fact **composes into a formula**: e.g. a looked-up side count feeds a
+perimeter/area formula from `adj-formula-stdlib` — the concrete K-math bridge from
+*recall* to *compute*.

--- a/code/specs/data/adj-facts-stdlib/kindergarten/shapes.adj
+++ b/code/specs/data/adj-facts-stdlib/kindergarten/shapes.adj
@@ -1,0 +1,42 @@
+% ============================================================================
+% shapes — how many sides each polygon has (adj-facts-stdlib, KINDERGARTEN).
+% ============================================================================
+% The very first rung of the facts ladder: a fact every kindergartener learns —
+% "a triangle has three sides, a square has four." Recall is a binding query:
+%
+%     ? polygon_sides(hexagon, $Sides)      % 6
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `polygon_sides(shape, sides)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the count
+% WITH its source, on the CPU, with zero model calls, and abstains on a shape not
+% in the table. Because the `sides` value is a NUMBER, a recalled count composes
+% straight into a formula (a regular polygon's perimeter is sides × side-length):
+% the concrete bridge from kindergarten RECALL to kindergarten COMPUTE.
+%
+% Provenance: the polygon names and their side counts are copied verbatim from
+% the Wolfram MathWorld "Polygon" names table (the citable artifact is that table
+% at the `locator`; each name→count pair below appears in it). `trust
+% authoritative` — a primary mathematics reference. Nothing here is asserted from
+% memory. The names are the FORMAL polygon names as the source gives them
+% (`quadrilateral` is the 4-sided polygon — the family that includes the square
+% and rectangle a child names first). (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table polygon_sides {
+    columns shape, sides
+
+    row (triangle, 3)
+    row (quadrilateral, 4)
+    row (pentagon, 5)
+    row (hexagon, 6)
+    row (heptagon, 7)
+    row (octagon, 8)
+    row (nonagon, 9)
+    row (decagon, 10)
+
+    source "3 | triangle (trigon)"
+    locator "https://mathworld.wolfram.com/Polygon.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/kindergarten/shapes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/kindergarten/shapes.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% shapes.query.adj — a worked recall over the kindergarten shapes library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many sides does a
+% hexagon have?": it states no geometry fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `polygon_sides` rows and returns the count + the table's source/locator/trust.
+% A shape not in the table abstains honestly — the engine never invents a count.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli shapes.query.adj
+% ============================================================================
+
+import "shapes.adj"
+
+? polygon_sides(triangle, $Sides)      % expect 3
+? polygon_sides(hexagon, $Sides)       % expect 6
+? polygon_sides(octagon, $Sides)       % expect 8
+? polygon_sides(circle, $Sides)        % expect abstain — a circle is not a polygon


### PR DESCRIPTION
## What

Starts the **facts standard library** — a graded, byte-provenanced ladder of *recallable facts* climbing from **what every kindergartener learns → medical school**. First rung: **polygon → number of sides** (the archetypal kindergarten fact — "a triangle has three sides").

```adj
import "kindergarten/shapes.adj"
? polygon_sides(hexagon, $Sides)     % → 6, cited to Wolfram MathWorld
? polygon_sides(circle, $Sides)      % → abstains (a circle is not a polygon)
```

## Why this is the right first rung

- **Genuinely kindergarten** — shapes are among the first things a child learns.
- **Dogfoods the just-merged `table` construct** (ADJ-TABLES RS-5, #8206): each row lowers to a ground relation, so recall is the ordinary SLD binding query — the engine returns the count **with its citation**, on the CPU, **0 answer-time model calls**, and **abstains** honestly on a non-polygon.
- **Numeric → composable**: because `sides` is a number, a recalled count feeds straight into a formula (a regular polygon's perimeter = sides × side-length) — the concrete **kindergarten bridge from RECALL to COMPUTE**, mirroring the K→med *formula* ladder.
- **Climbs** — shapes → geometry → clinical geometry, toward the 63 medical recall domains already shipped under `mycin-2026/recall/`.

## Grounding

Polygon names + side counts copied **verbatim** from the Wolfram MathWorld "Polygon" names table (`trust authoritative`). Nothing asserted from memory.

## Ships
- `code/specs/data/adj-facts-stdlib/README.md` — the K→med facts ladder, organized by grade level.
- `kindergarten/shapes.adj` (+ `shapes.query.adj`) — the grounded table + a worked recall.
- `adj-lang-cli/tests/facts_k_shapes_e2e.rs` — e2e: hexagon→6, triangle→3, citation carried, circle abstains. (Passes; security review clean.)

Data + one test only — no parser/engine changes. Next rotation rungs (one small library each): more kindergarten facts (colors, counting, calendar, planets), climbing upward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)