### PR TITLE
feat(sql): simple (operand) CASE — CASE x WHEN v THEN ... END

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.28 — Simple (operand) `CASE x WHEN v THEN …`
+
+`SELECT CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END` now parses and runs
+with SQLite's semantics: the operand is compared to each `WHEN` value for
+equality, the first match's result is returned (ELSE, or NULL if no ELSE and no
+match). A NULL operand matches nothing (`x = NULL` is never true) and falls
+through to ELSE. It is lowered entirely in the planner (sql-parser 0.1.12 adds
+the optional operand to the CASE grammar; sql-planner 0.2.11 desugars each
+`WHEN v THEN r` into a `(x = v, r)` branch of the searched-CASE node added in
+0.5.25) — so **no codegen or VM opcode**; it reuses the searched `CASE`
+machinery. Four differential-oracle cases (with/without ELSE, text operand +
+first-match, NULL-operand → ELSE) diff against real bundled SQLite.
+
 ## 0.5.27 — `COLLATE` in `ORDER BY` (NOCASE / RTRIM / BINARY)
 
 `ORDER BY col COLLATE name` now sorts through a collating sequence, matching

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.27"
+version = "0.5.28"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -966,6 +966,44 @@ const CASES: &[Case] = &[
         ],
         query: "SELECT name FROM t ORDER BY name COLLATE BINARY",
     },
+    // ---- Lane 1: simple (operand) CASE ----------------------------------
+    // `CASE x WHEN v THEN r … ELSE d END` compares the operand to each value
+    // for equality; a NULL operand matches nothing (x = NULL is never true)
+    // and falls through to ELSE, exactly as the searched form would.
+    Case {
+        id: "simple_case_with_else",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, x INTEGER)",
+            "INSERT INTO t VALUES (1,1),(2,2),(3,3),(4,NULL)",
+        ],
+        query: "SELECT id, CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END AS r FROM t ORDER BY id",
+    },
+    // No ELSE: an unmatched operand (including NULL) yields NULL.
+    Case {
+        id: "simple_case_no_else_yields_null",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, x INTEGER)",
+            "INSERT INTO t VALUES (1,1),(2,9),(3,NULL)",
+        ],
+        query: "SELECT id, CASE x WHEN 1 THEN 'one' END AS r FROM t ORDER BY id",
+    },
+    // Text operand, and the first matching branch wins.
+    Case {
+        id: "simple_case_text_first_match",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, s TEXT)",
+            "INSERT INTO t VALUES (1,'x'),(2,'y'),(3,'z')",
+        ],
+        query: "SELECT id, CASE s WHEN 'x' THEN 10 WHEN 'y' THEN 20 ELSE 30 END AS r FROM t ORDER BY id",
+    },
+    // Constant simple CASE with a NULL operand hits ELSE (x = NULL is not true).
+    // Aliased so the diff is on the value, not the column name (unaliased
+    // expression column naming is a separate, orthogonal gap).
+    Case {
+        id: "simple_case_null_operand_hits_else",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT CASE NULL WHEN 1 THEN 'a' ELSE 'z' END AS r FROM t",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.12] - Unreleased
+
+### Added
+
+- **Simple (operand) `CASE` form.** The `case_expr` grammar gains an optional
+  operand expression between `CASE` and the first `WHEN`, so
+  `CASE x WHEN v THEN r … END` parses alongside the searched
+  `CASE WHEN cond THEN r … END`. `WHEN` is a keyword (not a NAME), so the
+  optional operand never swallows the searched form's `WHEN`. The planner tells
+  the two forms apart and desugars the simple form.
+
 ## [0.1.11] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -585,12 +585,19 @@ pub fn parser_grammar() -> ParserGrammar {
                     GrammarElement::TokenReference { name: r#"NAME"#.to_string() },
                     GrammarElement::Literal { value: r#")"#.to_string() },
                 ] },
-                // Searched `CASE WHEN cond THEN val … [ELSE val] END`. One
-                // WHEN/THEN is mandatory; further ones repeat; ELSE is optional.
-                // The condition/value slots are full `expr`s. Placed before
-                // function_call so the leading `CASE` literal is matched here.
+                // `CASE [operand] WHEN cond THEN val … [ELSE val] END`. Two
+                // forms share one rule: the *searched* form (`CASE WHEN cond …`)
+                // and the *simple* form (`CASE operand WHEN value …`), told apart
+                // by the optional `operand` expr between `CASE` and the first
+                // `WHEN`. Because `WHEN` is a keyword and cannot start an `expr`,
+                // the optional operand never swallows the searched form's `WHEN`.
+                // One WHEN/THEN is mandatory; further ones repeat; ELSE is
+                // optional. All slots are full `expr`s. The planner desugars the
+                // simple form to the searched form (`operand = value`). Placed
+                // before function_call so the leading `CASE` literal matches here.
                 GrammarElement::Sequence { elements: vec![
                     GrammarElement::Literal { value: r#"CASE"#.to_string() },
+                    GrammarElement::Optional { element: Box::new(GrammarElement::RuleReference { name: r#"expr"#.to_string() }) },
                     GrammarElement::Literal { value: r#"WHEN"#.to_string() },
                     GrammarElement::RuleReference { name: r#"expr"#.to_string() },
                     GrammarElement::Literal { value: r#"THEN"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -624,6 +624,21 @@ mod tests {
         }
     }
 
+    /// Simple `CASE operand WHEN value THEN … END` parses (the operand form): a
+    /// column operand, a literal operand, with and without ELSE. The optional
+    /// operand must not disturb the searched form (covered by `test_parse_case`).
+    #[test]
+    fn test_parse_simple_case() {
+        for q in [
+            "SELECT CASE x WHEN 1 THEN 'a' END FROM t",
+            "SELECT CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END FROM t",
+            "SELECT CASE 5 WHEN 5 THEN 'five' ELSE 'no' END FROM t",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "primary"), "Expected primary for {q:?}");
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.11] - Unreleased
+
+### Added
+
+- **Simple `CASE` desugars to searched `CASE`.** `plan_case` now captures the
+  optional operand (the expression node before the first `WHEN`) and lowers each
+  `WHEN value THEN result` into a `(operand = value, result)` branch of the
+  existing `SqlExpr::Case` — **no new codegen or VM opcode**. A NULL operand
+  makes every `operand = value` NULL (never true), so it falls through to ELSE,
+  matching SQLite. Exact because mini-sqlite expressions are pure (SQLite
+  evaluates the operand once; a pure operand is unchanged by re-evaluation).
+
 ## [0.2.10] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -2339,6 +2339,10 @@ fn plan_case(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
     let mut pending_cond: Option<SqlExpr> = None;
     // What the next expression node is filling (set by the preceding keyword).
     let mut slot: Option<&'static str> = None;
+    // The *simple* form carries an operand expr between `CASE` and the first
+    // `WHEN` — the one expression node that appears while no WHEN/THEN/ELSE
+    // keyword is active. `None` = the searched form (`CASE WHEN cond …`).
+    let mut operand: Option<SqlExpr> = None;
 
     for child in &node.children {
         match child {
@@ -2355,13 +2359,32 @@ fn plan_case(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
                 match slot {
                     Some("when") => pending_cond = Some(expr),
                     Some("then") => {
-                        let cond = pending_cond.take().ok_or_else(|| {
+                        let value = pending_cond.take().ok_or_else(|| {
                             PlanError::UnsupportedStatement("CASE THEN without WHEN".to_string())
                         })?;
+                        // Simple form: the WHEN expression is a *value* compared
+                        // to the operand for equality (`operand = value`); the
+                        // searched form uses the WHEN expression as the condition
+                        // verbatim. Cloning the operand per branch is exact
+                        // because mini-sqlite expressions are pure (SQLite
+                        // evaluates the operand once, but a pure operand yields
+                        // the same result each time). A NULL operand makes every
+                        // `operand = value` NULL — never true — so a NULL operand
+                        // falls through to ELSE, matching SQLite.
+                        let cond = match &operand {
+                            Some(op) => SqlExpr::BinaryOp {
+                                op: BinaryOp::Eq,
+                                left: Box::new(op.clone()),
+                                right: Box::new(value),
+                            },
+                            None => value,
+                        };
                         branches.push((cond, expr));
                     }
                     Some("else") => else_val = Some(Box::new(expr)),
-                    _ => {}
+                    // A node with no active slot, before any WHEN, is the simple
+                    // form's operand.
+                    _ => operand = Some(expr),
                 }
                 slot = None;
             }


### PR DESCRIPTION
## Simple (operand) `CASE x WHEN v THEN … END`

Adds SQLite's **simple** `CASE` form alongside the searched form: the operand is
compared to each `WHEN` value for equality, returning the first match's result
(`ELSE`, or `NULL` if no `ELSE` and no match). A `NULL` operand matches nothing
(`x = NULL` is never true) and falls through to `ELSE`. **Rotation lane 1
(CAST/CASE/subqueries).**

### Grammar + planner only — no new codegen/VM opcode
- **sql-parser 0.1.12** — `case_expr` grammar gains an optional operand `expr`
  between `CASE` and the first `WHEN`. `WHEN` is a keyword (cannot start an
  `expr`), so the optional operand never swallows the searched form's `WHEN` —
  searched `CASE WHEN …` parsing is unchanged (regression-tested).
- **sql-planner 0.2.11** — `plan_case` captures the operand (the node before any
  `WHEN`) and desugars each `WHEN v THEN r` into a `(operand = v, r)` branch of
  the **existing** searched-`CASE` `SqlExpr::Case`. Exact because mini-sqlite
  expressions are pure (SQLite evaluates the operand once; a pure operand is
  unchanged by re-evaluation).

### Behaviour (probed against real SQLite before implementing)
`NULL` operand → `ELSE` · no match, no `ELSE` → `NULL` · first match wins ·
numeric `1.0 = 1` matches (via the existing `=`).

### Tests
Parser test (3 operand spellings) + four differential-oracle cases (with/without
`ELSE`, text operand + first-match, `NULL`-operand → `ELSE`) diffing against real
bundled SQLite. Full affected set green; clippy clean.

### Security
Inline adversarial review **PASSED** — no panics, no OOB, grammar stays
linear-time (memoized packrat; `WHEN`/`THEN`/`ELSE`/`END` keywords can't start an
`expr`), desugar semantically exact. **One LOW/INFO note:** the per-branch
`operand.clone()` makes the plan tree O(statement-length²) for a pathologically
long single `CASE` — bounded, gated behind linear parse cost, **not a blocking
defect**. The clean fix (evaluate the operand once into a VM register) needs a
new `CASE`-with-operand codegen/VM path and is **deferred to its own slice** to
keep this PR planner-only.

### Known-orthogonal gap (not in scope)
An *unaliased* simple-`CASE` expression is still named `?` rather than its source
text (SQLite echoes the expression). That expression-column-naming gap is
pre-existing and affects searched `CASE` too; the `NULL`-operand oracle case is
aliased to isolate semantics from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
