### PR TITLE
feat(human-languages): beginner audience + Arabic reading course

### DIFF
--- a/code/learning/human-languages/arabic/CHANGELOG.md
+++ b/code/learning/human-languages/arabic/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 
-## Chapter 1 — Greetings (track bootstrapped)
+## Reading course: Chapter 1 = learn to read, greetings → Chapter 2
+
+Reworked after feedback that the first draft "dropped a bunch of words but
+never taught how to actually read any of it" — a vocabulary list, not
+reading, and a break from the atom-first playbook.
+
+- **Chapter 1 is now an incremental reading course** (`lessons/AR-C01-read-*`):
+  a few letters per lesson, each cashing out in a real, decodable word —
+  ل+ا → **لا** ("no"), then م/س → **سلام**, ب/ر/ح → **مرحبا**, ص/خ/ي → **صباح
+  الخير**, ش/ك → **شكرا**, ع/ء → **السلام عليكم**/**مساء الخير**, then a reading
+  recap. ~15 letters, half the alphabet, each welded to a word. RTL, letter
+  connection, dots-on-shared-skeletons, one-way letters — all taught inline as
+  the words need them.
+- **The greeting lessons moved to Chapter 2** (`lessons/AR-C02-*`) — same
+  content (root system, salām family, al-/sun-moon letters, the greetings and
+  replies), now that the learner can read the words. The book's chapters were
+  restructured to match (ch01-reading + ch02-greetings; LaTeX auto-renumbers).
+- `HL00` updated to codify: **for any non-Latin script, Chapter 1 is a reading
+  course** (letters → words, incremental), not a gated alphabet chart and not
+  word-first.
+
+## Chapter 1 — Greetings (initial draft, superseded by the reading course)
 
 - New Arabic track on the HL00 framework: one word per lesson, slug ids,
   atom-first, derivations shown, LaTeX book. First **right-to-left** track and

--- a/code/learning/human-languages/arabic/README.md
+++ b/code/learning/human-languages/arabic/README.md
@@ -15,9 +15,11 @@ the **root system** itself as the organizing engine.
 
 Two more things:
 
-- **Script inline, RTL.** The learner reads Arabic but is rusty, so letters
-  are reintroduced *inside real words*, right-to-left — no up-front alphabet
-  drill (per `HL00`).
+- **Chapter 1 is a reading course**, written for someone who cannot read a
+  single letter. It teaches *reading* incrementally — a few letters per
+  lesson, each cashing out in a real, decodable word (ل + ا → **لا**, "no"),
+  building up until the greeting set is readable. Vocabulary depth begins in
+  Chapter 2. (Per `HL00`'s reading-course rule for non-Latin scripts.)
 - **Grounded against English + Spanish.** Arabic's long shadow over Spanish is
   a recurring thread: the article **al-** smuggled into English *algebra*/
   *alcohol*, and the sun-letter assimilation you can still hear in Spanish
@@ -26,11 +28,14 @@ Two more things:
 
 ## Progress
 
-- **Chapter 1 — Greetings** ([`lessons/AR-C01-*`](./lessons/)): the root
+- **Chapter 1 — Learning to Read** ([`lessons/AR-C01-read-*`](./lessons/)):
+  la → salam → marhaba → sabah/khayr → shukran → alaykum → practice; ~15
+  letters, each learned by reading a real word, reaching the full greeting set.
+- **Chapter 2 — Greetings** ([`lessons/AR-C02-*`](./lessons/)): the root
   system, marḥaban, salām, al-, as-salāmu ʿalaykum, ṣabāḥ, khayr, ṣabāḥ
-  al-khayr, masāʾ, masāʾ al-khayr, shukran, practice. In the book.
-- **Chapter 2 — Introducing Yourself** (planned): ismī ("my name is"), the
-  gendered "you" (anta/anti), root system deepened.
+  al-khayr, masāʾ, masāʾ al-khayr, shukran, practice — now that you can read
+  them. In the book.
+- **Chapter 3 — Introducing Yourself** (planned): ismī, the gendered "you".
 
 ## Book / fonts
 

--- a/code/learning/human-languages/arabic/book/book.tex
+++ b/code/learning/human-languages/arabic/book/book.tex
@@ -61,6 +61,7 @@ just the rule. Released under CC~BY-SA~4.0.
 
 \input{chapters/appendix-pronunciation}
 
-\input{chapters/ch01-greetings}
+\input{chapters/ch01-reading}
+\input{chapters/ch02-greetings}
 
 \end{document}

--- a/code/learning/human-languages/arabic/book/chapters/ch01-reading.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch01-reading.tex
@@ -1,0 +1,106 @@
+\chapter{Learning to Read}
+\label{ch:reading}
+
+Chapter~1 teaches you to read Arabic from the ground up --- assuming you
+cannot read a single letter --- the same way the rest of the series builds
+everything: one atom at a time. The atoms here are \textbf{letters}, and every
+lesson cashes a few of them out in a \emph{real, decodable word}. By the end you can read the whole greeting set --- and
+Chapter~2 finally tells you what it means. \emph{Practice lessons:
+\texttt{lessons/AR-C01-read-*.md}.}
+
+\section*{Three facts about the script}
+
+\begin{enumerate}
+  \item \textbf{Right to left.} The first letter of a word is on the
+    \emph{right}.
+  \item \textbf{Letters connect} (cursive-style), so a letter's shape shifts
+    by position; a few are ``one-way'' --- they join the letter before but not
+    the one after.
+  \item \textbf{Short vowels are usually invisible}; long vowels
+    (\emph{\=a \=\i\ \=u}) are full letters.
+\end{enumerate}
+
+\section{\ar{لا} --- two letters, one word (\emph{l\=a}, ``no'')}
+\label{lesson:read-la}
+
+\textbf{ا} (\emph{alif}, long ``aa,'' \emph{one-way}) $+$ \textbf{ل}
+(\emph{l\=am}, ``l,'' both sides). Right to left, \emph{l\=am} then
+\emph{alif}, fusing into the ligature:
+\begin{center}\ar{لا} \quad=\quad \emph{l\=a} \quad=\quad ``no.''\end{center}
+Your first Arabic word, read letter by letter.
+
+\section{\ar{سلام} --- read ``sal\=am'' (peace)}
+\label{lesson:read-salam}
+
+Add \textbf{م} (\emph{m\=\i m}, ``m'') and \textbf{س} (\emph{s\=\i n}, ``s'').
+Now four letters --- \ar{ا ل م س} --- read right to left:
+\ar{ما} (\emph{m\=a}, ``what''), \ar{ماما} (\emph{m\=am\=a}, ``mom''), and:
+\begin{center}\ar{سلام} \quad=\quad \emph{sal\=am} \quad=\quad ``peace.''\end{center}
+
+\section{\ar{مرحبا} --- read ``mar\d{h}aban'' (welcome/hi)}
+\label{lesson:read-marhaba}
+
+Add \textbf{ب} (\emph{b\=aʾ}, ``b,'' one dot below), \textbf{ر} (\emph{r\=aʾ},
+tapped ``r,'' one-way), \textbf{ح} (\emph{\d{h}\=aʾ}, heavy throaty ``h'').
+Read \ar{باب} (\emph{b\=ab}, ``door''), \ar{حب} (\emph{\d{h}ubb}, ``love''),
+and:
+\begin{center}\ar{مرحبا} \quad=\quad \emph{mar\d{h}aban} \quad=\quad ``welcome / hi.''\end{center}
+
+\begin{cousinweb}
+\textbf{Dots on a shared skeleton} distinguish letters: \ar{ب}/\ar{ت}/\ar{ث}
+(b/t/th) are the same shape with one dot below / two above / three above.
+Learn one skeleton and you often get three letters.
+\end{cousinweb}
+
+\section{\ar{صباح الخير} --- read ``morning'' and ``good''}
+\label{lesson:read-sabah}
+
+Add \textbf{ص} (\emph{\d{s}\=ad}, an \emph{emphatic}/heavy ``s'' --- a
+different letter from \ar{س}), \textbf{خ} (\emph{kh\=aʾ}, a throat-scrape =
+\textbf{Spanish \emph{j}}), \textbf{ي} (\emph{y\=aʾ}, ``y''). Read:
+\ar{صباح} (\emph{\d{s}ab\=a\d{h}}, ``morning''), \ar{خير} (\emph{khayr},
+``good''), together \ar{صباح الخير} (\emph{\d{s}ab\=a\d{h} al-khayr}, ``good
+morning'').
+
+\section{\ar{شكرا} --- read ``shukran'' (thanks)}
+\label{lesson:read-shukran}
+
+Add \textbf{ش} (\emph{sh\=\i n}, ``sh'' --- \ar{س} \emph{plus three dots}) and
+\textbf{ك} (\emph{k\=af}, ``k''):
+\begin{center}\ar{شكرا} \quad=\quad \emph{shukran} \quad=\quad ``thank you.''\end{center}
+
+\section{\ar{عليكم} --- the last two letters, and the full greeting}
+\label{lesson:read-alaykum}
+
+Add the two hardest: \textbf{ع} (\emph{`ayn}, a voiced throat-tightening with
+no English equivalent) and \textbf{ء} (\emph{hamza}, a glottal stop --- the
+catch in ``uh-oh''). Read \ar{عليكم} (\emph{`alaykum}, ``upon you''), \ar{مساء}
+(\emph{mas\=aʾ}, ``evening''), and now the greetings assemble:
+\ar{السلام عليكم} (\emph{as-sal\=amu `alaykum}), \ar{مساء الخير} (\emph{mas\=aʾ
+al-khayr}).
+
+\section{Reading practice}
+\label{lesson:read-practice}
+
+About fifteen letters, half the alphabet, each learned by reading a real word.
+Sound each out, right to left, before checking:
+
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+Read & \\
+\midrule
+\ar{لا} & \emph{l\=a} --- no \\
+\ar{سلام} & \emph{sal\=am} --- peace \\
+\ar{مرحبا} & \emph{mar\d{h}aban} --- welcome/hi \\
+\ar{صباح الخير} & \emph{\d{s}ab\=a\d{h} al-khayr} --- good morning \\
+\ar{مساء الخير} & \emph{mas\=aʾ al-khayr} --- good evening \\
+\ar{السلام عليكم} & \emph{as-sal\=amu `alaykum} --- peace be upon you \\
+\ar{شكرا} & \emph{shukran} --- thanks \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+That was the hard part. Chapter~2 keeps these exact words and finally opens
+them --- the root behind \emph{sal\=am}, the \emph{al-} hiding in
+\emph{algebra}, why \emph{al-sal\=am} is said \emph{as-sal\=am}.

--- a/code/learning/human-languages/arabic/book/chapters/ch02-greetings.tex
+++ b/code/learning/human-languages/arabic/book/chapters/ch02-greetings.tex
@@ -1,10 +1,11 @@
 \chapter{Greetings}
 \label{ch:greetings}
 
-The Arabic greetings, built from three-consonant roots and the attached
-article \emph{al-}. Because the reader knows Spanish, Arabic's shadow over
-Spanish (the \emph{al-} words, the sun-letter assimilation in \emph{az\'{u}car})
-runs throughout. \emph{Practice lessons: \texttt{lessons/AR-C01-*.md}.}
+Now that you can \emph{read} the greetings (Chapter~\ref{ch:reading}), here is
+what they mean --- built from three-consonant roots and the attached article
+\emph{al-}. Because the reader knows Spanish, Arabic's shadow over Spanish (the
+\emph{al-} words, the sun-letter assimilation in \emph{az\'{u}car}) runs
+throughout. \emph{Practice lessons: \texttt{lessons/AR-C02-*.md}.}
 
 \section{The root system --- this whole book, but literal}
 \label{lesson:root-system}
@@ -21,9 +22,8 @@ of ---.''
 This is the Latin/Greek root idea from the earlier books, but \emph{more
 regular and more visible}: where English hides \emph{scribe/describe/script}
 inside \emph{scrib-}, Arabic wears the root on the surface of every derived
-word. Every greeting below is a root plus a pattern. (And: Arabic reads
-\textbf{right to left}, letters connecting --- reintroduced inside real words,
-not drilled up front.)
+word. Every greeting below is a root plus a pattern --- and you can already
+\emph{read} each of them from Chapter~\ref{ch:reading}.
 \end{cousinweb}
 
 \section{\ar{مرحبا} \emph{(mar\d{h}aban)} --- ``hello,'' i.e. ``there's room for you''}

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-alaykum.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-alaykum.md
@@ -1,0 +1,64 @@
+---
+id: AR-C01-read-alaykum
+chapter: 1
+type: word
+headword: عليكم
+gloss: two letters → read "ʿalaykum" and "masāʾ"
+concept_tag: READ-ALAYKUM
+prerequisites: [AR-C01-read-shukran]
+sounds: [rtl, ayn, hamza]
+roots: []
+est_minutes: 4
+reviews_of: [AR-C01-read-salam, AR-C01-read-shukran]
+---
+
+# Reading lesson 6 — the last two letters, and the full peace greeting
+
+## Warm-up
+
+[PAUSE 2s] Two more letters — the two hardest sounds — and you can read the
+whole set: the peace greeting and "good evening."
+
+## You'll want to know first
+
+- [reading lesson 5 (شكرا)](./AR-C01-read-shukran.md)
+
+## Two new letters (the tricky ones)
+
+- **ع** — *ʿayn*. A sound English simply doesn't have: a **voiced tightening
+  deep in the throat**. Approximate it (a strained "ah" from the throat); a
+  native ear forgives. We write it *ʿ*. Connects both sides. Do not confuse
+  it with **غ** *ghayn* (same shape + one dot = a gargled "gh").
+- **ء** — *hamza*. A **glottal stop** — the little catch in the middle of
+  "uh-oh." It doesn't connect; it perches on a carrier or sits alone. Written
+  *ʾ*.
+
+## Read
+
+Read right to left:
+
+- **عليكم** = ع + ل + ي + ك + م = *ʿalaykum* = **"upon you (all)."**
+- **مساء** = م + س + ا + ء = *masāʾ* = **"evening."**
+
+And now the greetings assemble fully:
+
+> **السلام عليكم**  =  *as-salāmu ʿalaykum*  =  **"peace be upon you"**
+> **مساء الخير**  =  *masāʾ al-khayr*  =  **"good evening"**
+
+You can now *read* every greeting in the next chapter — where we finally open
+what they *mean* and how their roots work.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the two hard letters — "*ʿayn*" (throat), "*hamza*" (glottal
+  catch)]
+- [YOU SAY: read "عليكم" (ʿalaykum), "مساء" (masāʾ)]
+- [YOU SAY: read the whole line "السلام عليكم" — as-salāmu ʿalaykum]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What is **ع** (*ʿayn*)? (A throat-tightening with no English
+equivalent.) What is **ء** (*hamza*)? (A glottal stop — the catch in
+"uh-oh.") You can now read the greetings — the next chapter tells you what
+they mean.

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-la.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-la.md
@@ -1,0 +1,63 @@
+---
+id: AR-C01-read-la
+chapter: 1
+type: word
+headword: لا
+gloss: your first two letters → your first word (lā, "no")
+concept_tag: READ-LA
+prerequisites: []
+sounds: [rtl, connect, alif, lam]
+roots: []
+est_minutes: 4
+reviews_of: []
+---
+
+# Reading Arabic, lesson 1 — two letters, one real word
+
+## Warm-up
+
+[PAUSE 2s] We are going to *read*, not memorize. By the end of this lesson —
+two letters in — you will read an actual Arabic word off the page. Everything
+after builds on it.
+
+## Three facts about the script
+
+1. **Right to left.** Your eyes (and the writing) move right → left. The
+   *first* letter of a word sits on the **right**.
+2. **Letters hold hands.** Most letters *connect* to the next one, cursive-
+   style, so a letter's shape changes a little depending on where it sits
+   (start / middle / end). A few letters are "one-way" — they join to the
+   letter before them but refuse to join the one after.
+3. **Short vowels are often invisible.** *a, i, u* are usually not written
+   out; long vowels (*ā, ī, ū*) are full letters. (More on this as we go.)
+
+## Your first two letters
+
+- **ا** — *alif*. Sound: a long **"aa"** (or just a carrier/post for other
+  vowels). *alif* is **one-way**: it connects to the letter on its right, but
+  never joins the letter after it.
+- **ل** — *lām*. Sound: **"l"**. It connects on **both** sides.
+
+## Read your first word
+
+Put them together, right to left — *lām* first (on the right), then *alif*:
+
+> **لا**  =  ل + ا  =  **lā**  =  **"no."**
+
+(When *lām* meets *alif* they fuse into one springy shape, **لا** — a
+ligature you'll see constantly.) That's it: you just read Arabic. *lā* is one
+of the most common words in the language — "no."
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the two letters — "*alif*" (aa), "*lām*" (l)]
+- [YOU SAY: read it right-to-left — "lā" — and its meaning, "no"]
+- [YOU SAY: which of the two letters refuses to connect to what follows?
+  (*alif*.)]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Which direction do you read? (Right to left.) Read **لا** — what is
+it? (*lā*, "no.") Next lesson: two more letters, and you'll read *salām*,
+"peace."

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-marhaba.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-marhaba.md
@@ -1,0 +1,60 @@
+---
+id: AR-C01-read-marhaba
+chapter: 1
+type: word
+headword: مرحبا
+gloss: three letters → read "marḥaban" (welcome/hello)
+concept_tag: READ-MARHABA
+prerequisites: [AR-C01-read-salam]
+sounds: [rtl, connect, ra, ha-heavy, ba]
+roots: []
+est_minutes: 4
+reviews_of: [AR-C01-read-la, AR-C01-read-salam]
+---
+
+# Reading lesson 3 — three letters, and you read "marḥaban"
+
+## Warm-up
+
+[PAUSE 2s] You can read *lā* and *salām*. Three more letters and you'll read
+the everyday "hi."
+
+## You'll want to know first
+
+- [reading lesson 2 (سلام)](./AR-C01-read-salam.md) — you now know ا ل م س.
+
+## Three new letters
+
+- **ب** — *bāʾ*. Sound: **"b"**. Connects both sides. A single dot **below**
+  the shape. (Its cousins differ only by dots: **ت** *tāʾ* = "t," two dots
+  *above*; **ث** *thāʾ* = "th," three dots above. Same skeleton, different
+  dots — a pattern worth banking.)
+- **ر** — *rāʾ*. Sound: a tapped **"r"** (like Spanish *r*). **One-way**:
+  joins the letter before it, not the one after — like *alif*.
+- **ح** — *ḥāʾ*. Sound: a **heavy, throaty "h"** (breathed hard from deep in
+  the throat — not the light English *h*). Connects both sides.
+
+## Read
+
+Known letters now: ا ل م س ب ر ح. Read right to left:
+
+- **باب** = ب + ا + ب = *bāb* = **"door."**
+- **حب** = ح + ب = *ḥubb* = **"love."**
+- and the greeting — *mīm · rāʾ · ḥāʾ · bāʾ · alif*:
+
+> **مرحبا**  =  م + ر + ح + ب + ا  =  **marḥaban**  =  **"welcome / hi."**
+
+Two greetings now readable: *salām* and *marḥaban*.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the new letters — "*bāʾ*" (b), "*rāʾ*" (r), "*ḥāʾ*" (heavy h)]
+- [YOU SAY: read "باب" (door), "حب" (love)]
+- [YOU SAY: read "مرحبا" right to left — m, r, ḥ, b, ā]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Read **مرحبا** — sound and meaning. (*marḥaban*, "welcome/hi.")
+Which two letters you now know are "one-way" (don't join the next letter)?
+(*alif* and *rāʾ*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-practice.md
@@ -1,0 +1,50 @@
+---
+id: AR-C01-read-practice
+chapter: 1
+type: practice-mix
+headword: (reading practice)
+gloss: read all the greeting words you've unlocked
+concept_tag: READ-PRACTICE
+prerequisites: [AR-C01-read-la, AR-C01-read-salam, AR-C01-read-marhaba, AR-C01-read-sabah-khayr, AR-C01-read-shukran, AR-C01-read-alaykum]
+sounds: [rtl]
+roots: []
+est_minutes: 4
+reviews_of: [AR-C01-read-la, AR-C01-read-salam, AR-C01-read-marhaba, AR-C01-read-sabah-khayr, AR-C01-read-shukran, AR-C01-read-alaykum]
+---
+
+# Reading practice — decode, don't recall
+
+## Warm-up
+
+[PAUSE 2s] No new letters. Prove to yourself you can *read* — sound each one
+out, right to left, before you check the answer.
+
+## The letters you now know
+
+ا ل م س ب ر ح ص خ ي ش ك ع ء — about fifteen letters, roughly half the
+alphabet, each learned by reading a real word with it.
+
+Two patterns you picked up along the way:
+- **Dots on a shared skeleton** distinguish letters: **ب/ت/ث** (b/t/th),
+  **س/ش** (s/sh), **ع/غ** (ʿ/gh).
+- **One-way letters** (*alif* ا, *rāʾ* ر) join the letter before them but not
+  the one after.
+
+## Guided Practice — read each aloud, then check
+
+[PAUSE 1s]
+- [YOU SAY: **لا** → *(lā, "no")*]
+- [YOU SAY: **سلام** → *(salām, "peace")*]
+- [YOU SAY: **مرحبا** → *(marḥaban, "welcome/hi")*]
+- [YOU SAY: **صباح الخير** → *(ṣabāḥ al-khayr, "good morning")*]
+- [YOU SAY: **مساء الخير** → *(masāʾ al-khayr, "good evening")*]
+- [YOU SAY: **السلام عليكم** → *(as-salāmu ʿalaykum, "peace be upon you")*]
+- [YOU SAY: **شكرا** → *(shukran, "thanks")*]
+
+## Wrap-up Recall
+
+[PAUSE 3s] You can now read the whole greeting set letter by letter. That was
+the hard part. **Chapter 2** keeps these exact words but finally opens them
+up — the three-consonant root behind *salām*, the article *al-* hiding in
+English *algebra*, why *al-salām* is said *as-salām*. You'll understand what
+you can already read.

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-sabah-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-sabah-khayr.md
@@ -1,0 +1,61 @@
+---
+id: AR-C01-read-sabah-khayr
+chapter: 1
+type: word
+headword: صباح الخير
+gloss: three letters → read "morning" and "good"
+concept_tag: READ-SABAH-KHAYR
+prerequisites: [AR-C01-read-marhaba]
+sounds: [rtl, emphatic-sad, kha, ya]
+roots: []
+est_minutes: 4
+reviews_of: [AR-C01-read-salam, AR-C01-read-marhaba]
+---
+
+# Reading lesson 4 — three letters, and you read "good morning"
+
+## Warm-up
+
+[PAUSE 2s] Three new letters unlock the morning greeting — and one of them
+teaches an important idea about Arabic: "heavy" (emphatic) consonants.
+
+## You'll want to know first
+
+- [reading lesson 3 (مرحبا)](./AR-C01-read-marhaba.md) — you now know
+  ا ل م س ب ر ح.
+
+## Three new letters
+
+- **ص** — *ṣād*. An **emphatic** "s": a heavier, deeper *s*, made with the
+  tongue low and the mouth full. Arabic has several such "heavy" consonants,
+  and they genuinely change the word — **ص** *ṣ* is a different letter from
+  **س** *s*. We mark it with a dot underneath in transliteration: *ṣ*.
+- **خ** — *khāʾ*. A **throat-scrape**, like the *ch* in Scottish *loch* — and
+  exactly the sound of **Spanish *j*** (as in *jueves*). Connects both sides.
+- **ي** — *yāʾ*. Sound: **"y"** (or a long *ī*). Connects both sides. Two
+  dots below.
+
+## Read
+
+Known letters now include ص خ ي. Read right to left:
+
+- **صباح** = ص + ب + ا + ح = *ṣabāḥ* = **"morning."**
+- **خير** = خ + ي + ر = *khayr* = **"good, goodness."**
+
+Put them together (with **ال**, "the," which you'll formally meet next
+chapter): **صباح الخير** = *ṣabāḥ al-khayr* = literally **"morning of the
+goodness"** — "good morning." Your third greeting, decoded.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the new letters — "*ṣād*" (heavy s), "*khāʾ*" (throat-scrape),
+  "*yāʾ*" (y)]
+- [YOU SAY: read "صباح" (ṣabāḥ) and "خير" (khayr)]
+- [YOU SAY: "خير" then Spanish "jueves" — same خ / *j* throat sound]
+
+## Wrap-up Recall
+
+[PAUSE 3s] What makes **ص** different from **س**? (It's *emphatic* — heavier,
+deeper.) Read **صباح الخير** — meaning? ("Good morning," lit. "morning of the
+goodness.")

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-salam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-salam.md
@@ -1,0 +1,58 @@
+---
+id: AR-C01-read-salam
+chapter: 1
+type: word
+headword: سلام
+gloss: two more letters → read "salām" (peace)
+concept_tag: READ-SALAM
+prerequisites: [AR-C01-read-la]
+sounds: [rtl, connect, mim, sin]
+roots: []
+est_minutes: 4
+reviews_of: [AR-C01-read-la]
+---
+
+# Reading lesson 2 — two more letters, and you read "peace"
+
+## Warm-up
+
+[PAUSE 2s] You can read **لا** (*lā*). Add two letters and you'll read one of
+the most important words in the language.
+
+## You'll want to know first
+
+- [reading lesson 1 (لا)](./AR-C01-read-la.md) — *alif* (ا) and *lām* (ل).
+
+## Two new letters
+
+- **م** — *mīm*. Sound: **"m"**. Connects on both sides. Look for the little
+  circle with a tail.
+- **س** — *sīn*. Sound: **"s"**. Connects on both sides. Look for the row of
+  three little teeth.
+
+## Read some words
+
+You now know four letters: ا ل م س. Read right to left:
+
+- **ما** = م + ا = *mā* = **"what."**
+- **ماما** = م + ا + م + ا = *māmā* = **"mama, mom."**
+
+And now the big one — four letters you all know, *sīn · lām · alif · mīm*:
+
+> **سلام**  =  س + ل + ا + م  =  **salām**  =  **"peace."**
+
+You just *read* the word at the heart of the most common Arabic greeting. We
+won't unpack its huge root family yet — that's the next chapter, once you can
+read the whole greeting. For now, savor that you decoded it letter by letter.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the new letters — "*mīm*" (m), "*sīn*" (s)]
+- [YOU SAY: read "ما" (what), "ماما" (mom)]
+- [YOU SAY: read "سلام" letter by letter, right to left — s, l, ā, m → salām]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Read **سلام** — sound it out and give the meaning. (*salām*,
+"peace.") Which four letters build it? (*sīn, lām, alif, mīm*.)

--- a/code/learning/human-languages/arabic/lessons/AR-C01-read-shukran.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C01-read-shukran.md
@@ -1,0 +1,53 @@
+---
+id: AR-C01-read-shukran
+chapter: 1
+type: word
+headword: شكرا
+gloss: two letters → read "shukran" (thanks)
+concept_tag: READ-SHUKRAN
+prerequisites: [AR-C01-read-sabah-khayr]
+sounds: [rtl, shin, kaf]
+roots: []
+est_minutes: 3
+reviews_of: [AR-C01-read-marhaba, AR-C01-read-sabah-khayr]
+---
+
+# Reading lesson 5 — two letters, and you read "thanks"
+
+## Warm-up
+
+[PAUSE 2s] Two more letters unlock the word you'll say constantly: *shukran*.
+
+## You'll want to know first
+
+- [reading lesson 4 (صباح الخير)](./AR-C01-read-sabah-khayr.md)
+
+## Two new letters
+
+- **ش** — *shīn*. Sound: **"sh"** (English *sh*). Connects both sides. It's
+  *sīn* (س) with **three dots** added on top — same skeleton, dots change the
+  sound, exactly like the *bāʾ / tāʾ / thāʾ* family from lesson 3.
+- **ك** — *kāf*. Sound: **"k"**. Connects both sides.
+
+## Read
+
+Read right to left (the final *-an* is a grammatical ending; just read
+*shukran*):
+
+> **شكرا**  =  ش + ك + ر + ا  =  **shukran**  =  **"thank you."**
+
+Notice how the dots do the work: **س** *s* → add three dots → **ش** *sh*.
+Arabic reuses a handful of skeletons and distinguishes them by dots — learn
+one skeleton and you often get two or three letters.
+
+## Guided Practice
+
+[PAUSE 1s]
+- [YOU SAY: the new letters — "*shīn*" (sh), "*kāf*" (k)]
+- [YOU SAY: read "شكرا" — sh, k, r, a → shukran]
+- [YOU SAY: "س" (s) vs "ش" (sh) — three dots is the only difference]
+
+## Wrap-up Recall
+
+[PAUSE 3s] Read **شكرا** — sound and meaning. (*shukran*, "thanks.") How does
+*sīn* (س) become *shīn* (ش)? (Add three dots on top.)

--- a/code/learning/human-languages/arabic/lessons/AR-C02-al.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-al.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-al
-chapter: 1
+id: AR-C02-al
+chapter: 2
 type: word
 headword: ال
 gloss: "the" (al-)
 concept_tag: ARTICLE-AL
-prerequisites: [AR-C01-salam]
+prerequisites: [AR-C02-salam]
 sounds: [rtl, sun-moon]
 roots: []
 est_minutes: 5
-reviews_of: [AR-C01-salam]
+reviews_of: [AR-C02-salam]
 ---
 
 # ال (al-) — "the," the one Arabic word hiding in English *algebra*
@@ -22,7 +22,7 @@ smuggled piece of Arabic.
 
 ## You'll want to know first
 
-- [سلام (salām)](./AR-C01-salam.md) — you'll attach *al-* to it next lesson.
+- [سلام (salām)](./AR-C02-salam.md) — you'll attach *al-* to it next lesson.
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-as-salamu-alaykum.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-as-salamu-alaykum.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-as-salamu-alaykum
-chapter: 1
+id: AR-C02-as-salamu-alaykum
+chapter: 2
 type: word
 headword: السلام عليكم
 gloss: peace be upon you (as-salāmu ʿalaykum)
 concept_tag: GREETING-PEACE
-prerequisites: [AR-C01-salam, AR-C01-al]
+prerequisites: [AR-C02-salam, AR-C02-al]
 sounds: [rtl, ayn]
 roots: [s-l-m]
 est_minutes: 4
-reviews_of: [AR-C01-salam, AR-C01-al]
+reviews_of: [AR-C02-salam, AR-C02-al]
 ---
 
 # السلام عليكم (as-salāmu ʿalaykum) — "peace be upon you"
@@ -21,7 +21,7 @@ the most-spoken sentences on Earth.
 
 ## You'll want to know first
 
-- [سلام (salām)](./AR-C01-salam.md) · [ال (al-)](./AR-C01-al.md)
+- [سلام (salām)](./AR-C02-salam.md) · [ال (al-)](./AR-C02-al.md)
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-khayr.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-khayr
-chapter: 1
+id: AR-C02-khayr
+chapter: 2
 type: word
 headword: خير
 gloss: good, goodness (khayr)
 concept_tag: KHAYR
-prerequisites: [AR-C01-root-system]
+prerequisites: [AR-C02-root-system]
 sounds: [rtl, kha]
 roots: [kh-y-r]
 est_minutes: 3
-reviews_of: [AR-C01-sabah]
+reviews_of: [AR-C02-sabah]
 ---
 
 # خير (khayr) — "good, goodness"

--- a/code/learning/human-languages/arabic/lessons/AR-C02-marhaba.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-marhaba.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-marhaba
-chapter: 1
+id: AR-C02-marhaba
+chapter: 2
 type: word
 headword: مرحبا
 gloss: hello / welcome (marḥaban)
 concept_tag: GREETING-HELLO
-prerequisites: [AR-C01-root-system]
+prerequisites: [AR-C02-root-system]
 sounds: [rtl, ha-heavy]
 roots: [r-h-b]
 est_minutes: 4
-reviews_of: [AR-C01-root-system]
+reviews_of: [AR-C02-root-system]
 ---
 
 # مرحبا (marḥaban) — "hello," literally "welcome, there's room for you"
@@ -21,7 +21,7 @@ do its work. This one is built on the idea of *spaciousness*.
 
 ## You'll want to know first
 
-- [the root system](./AR-C01-root-system.md) — three consonants, one meaning.
+- [the root system](./AR-C02-root-system.md) — three consonants, one meaning.
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-masa-al-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-masa-al-khayr.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-masa-al-khayr
-chapter: 1
+id: AR-C02-masa-al-khayr
+chapter: 2
 type: word
 headword: مساء الخير
 gloss: good evening (masāʾ al-khayr)
 concept_tag: GREETING-EVENING
-prerequisites: [AR-C01-masa, AR-C01-khayr]
+prerequisites: [AR-C02-masa, AR-C02-khayr]
 sounds: [rtl]
 roots: [m-s-w, kh-y-r]
 est_minutes: 2
-reviews_of: [AR-C01-masa, AR-C01-sabah-al-khayr]
+reviews_of: [AR-C02-masa, AR-C02-sabah-al-khayr]
 ---
 
 # مساء الخير (masāʾ al-khayr) — "evening of goodness"
@@ -21,7 +21,7 @@ evening.
 
 ## You'll want to know first
 
-- [مساء (masāʾ)](./AR-C01-masa.md) · [خير (khayr)](./AR-C01-khayr.md)
+- [مساء (masāʾ)](./AR-C02-masa.md) · [خير (khayr)](./AR-C02-khayr.md)
 
 ## The word, taken apart — by assembling it
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-masa.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-masa.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-masa
-chapter: 1
+id: AR-C02-masa
+chapter: 2
 type: word
 headword: مساء
 gloss: evening (masāʾ)
 concept_tag: MASA
-prerequisites: [AR-C01-sabah]
+prerequisites: [AR-C02-sabah]
 sounds: [rtl, hamza]
 roots: [m-s-w]
 est_minutes: 3
-reviews_of: [AR-C01-sabah-al-khayr]
+reviews_of: [AR-C02-sabah-al-khayr]
 ---
 
 # مساء (masāʾ) — "evening"
@@ -20,7 +20,7 @@ reviews_of: [AR-C01-sabah-al-khayr]
 
 ## You'll want to know first
 
-- [صباح (ṣabāḥ)](./AR-C01-sabah.md) — its morning counterpart.
+- [صباح (ṣabāḥ)](./AR-C02-sabah.md) — its morning counterpart.
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-practice.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-practice.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-practice
-chapter: 1
+id: AR-C02-practice
+chapter: 2
 type: practice-mix
 headword: (practice)
 gloss: the Arabic greetings, all together
 concept_tag: CH1-PRACTICE
-prerequisites: [AR-C01-marhaba, AR-C01-as-salamu-alaykum, AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C01-shukran]
+prerequisites: [AR-C02-marhaba, AR-C02-as-salamu-alaykum, AR-C02-sabah-al-khayr, AR-C02-masa-al-khayr, AR-C02-shukran]
 sounds: [rtl]
 roots: []
 est_minutes: 4
-reviews_of: [AR-C01-marhaba, AR-C01-as-salamu-alaykum, AR-C01-sabah-al-khayr, AR-C01-masa-al-khayr, AR-C01-shukran]
+reviews_of: [AR-C02-marhaba, AR-C02-as-salamu-alaykum, AR-C02-sabah-al-khayr, AR-C02-masa-al-khayr, AR-C02-shukran]
 ---
 
 # Practice — the Arabic greetings

--- a/code/learning/human-languages/arabic/lessons/AR-C02-root-system.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-root-system.md
@@ -1,6 +1,6 @@
 ---
-id: AR-C01-root-system
-chapter: 1
+id: AR-C02-root-system
+chapter: 2
 type: word
 headword: (the root system)
 gloss: how Arabic builds words from three-consonant roots
@@ -16,19 +16,17 @@ reviews_of: []
 
 ## Warm-up
 
-[PAUSE 2s] Every book in this series is obsessed with *roots*. Arabic is the
-language where roots aren't a historical curiosity — they're the *living
-machine* that builds almost every word. Understand this one idea and Arabic
-stops looking like memorization and starts looking like arithmetic.
+[PAUSE 2s] You can now *read* the greeting words (Chapter 1). This chapter
+opens them up — and it starts with the single idea that runs all of Arabic:
+the root. Every book in this series is obsessed with *roots*; Arabic is the
+language where roots aren't a historical curiosity but the *living machine*
+that builds almost every word. Understand this and Arabic stops looking like
+memorization and starts looking like arithmetic.
 
-## Two things about the script first
+## You'll want to know first
 
-Arabic is written **right to left**. And its letters **connect** into each
-other like cursive, so a letter changes shape depending on whether it's at the
-start, middle, or end of a word. Don't try to master the alphabet up front —
-you already read Arabic (if rusty), and this book reintroduces letters *inside
-real words* as they come. For now, just re-set two habits: eyes move
-right-to-left, and letters join up.
+- The [Chapter 1 reading lessons](./AR-C01-read-practice.md) — you can decode
+  every word below; now you'll learn what it means.
 
 ## The big idea: three consonants = one meaning-family
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-sabah-al-khayr.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-sabah-al-khayr.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-sabah-al-khayr
-chapter: 1
+id: AR-C02-sabah-al-khayr
+chapter: 2
 type: word
 headword: صباح الخير
 gloss: good morning (ṣabāḥ al-khayr)
 concept_tag: GREETING-MORNING
-prerequisites: [AR-C01-sabah, AR-C01-khayr, AR-C01-al]
+prerequisites: [AR-C02-sabah, AR-C02-khayr, AR-C02-al]
 sounds: [rtl]
 roots: [s-b-h, kh-y-r]
 est_minutes: 3
-reviews_of: [AR-C01-sabah, AR-C01-khayr]
+reviews_of: [AR-C02-sabah, AR-C02-khayr]
 ---
 
 # صباح الخير (ṣabāḥ al-khayr) — "morning of goodness"
@@ -21,8 +21,8 @@ standard "good morning."
 
 ## You'll want to know first
 
-- [صباح (ṣabāḥ)](./AR-C01-sabah.md) · [خير (khayr)](./AR-C01-khayr.md) ·
-  [ال (al-)](./AR-C01-al.md)
+- [صباح (ṣabāḥ)](./AR-C02-sabah.md) · [خير (khayr)](./AR-C02-khayr.md) ·
+  [ال (al-)](./AR-C02-al.md)
 
 ## The word, taken apart — by assembling it
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-sabah.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-sabah.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-sabah
-chapter: 1
+id: AR-C02-sabah
+chapter: 2
 type: word
 headword: صباح
 gloss: morning (ṣabāḥ)
 concept_tag: SABAH
-prerequisites: [AR-C01-root-system]
+prerequisites: [AR-C02-root-system]
 sounds: [rtl, emphatic-sad, ha-heavy]
 roots: [s-b-h]
 est_minutes: 3
-reviews_of: [AR-C01-as-salamu-alaykum]
+reviews_of: [AR-C02-as-salamu-alaykum]
 ---
 
 # صباح (ṣabāḥ) — "morning"

--- a/code/learning/human-languages/arabic/lessons/AR-C02-salam.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-salam.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-salam
-chapter: 1
+id: AR-C02-salam
+chapter: 2
 type: word
 headword: سلام
 gloss: peace (salām)
 concept_tag: SALAM
-prerequisites: [AR-C01-root-system]
+prerequisites: [AR-C02-root-system]
 sounds: [rtl, emphatic-none]
 roots: [s-l-m]
 est_minutes: 5
-reviews_of: [AR-C01-marhaba]
+reviews_of: [AR-C02-marhaba]
 ---
 
 # سلام (salām) — "peace," and the most famous root in the language
@@ -22,7 +22,7 @@ Hebrew *shalom*. It is the root under the whole culture's word for hello.
 
 ## You'll want to know first
 
-- [the root system](./AR-C01-root-system.md)
+- [the root system](./AR-C02-root-system.md)
 
 ## Sounds you'll need
 

--- a/code/learning/human-languages/arabic/lessons/AR-C02-shukran.md
+++ b/code/learning/human-languages/arabic/lessons/AR-C02-shukran.md
@@ -1,15 +1,15 @@
 ---
-id: AR-C01-shukran
-chapter: 1
+id: AR-C02-shukran
+chapter: 2
 type: word
 headword: شكرا
 gloss: thank you (shukran)
 concept_tag: THANKS
-prerequisites: [AR-C01-root-system]
+prerequisites: [AR-C02-root-system]
 sounds: [rtl, shin]
 roots: [sh-k-r]
 est_minutes: 3
-reviews_of: [AR-C01-masa-al-khayr]
+reviews_of: [AR-C02-masa-al-khayr]
 ---
 
 # شكرا (shukran) — "thank you"

--- a/code/learning/human-languages/arabic/pronunciation-reference.md
+++ b/code/learning/human-languages/arabic/pronunciation-reference.md
@@ -1,8 +1,9 @@
 # Arabic Pronunciation & Script — Reference
 
-A **reference**, not a chapter. You already read Arabic (if rusty), so this is
-a refresher you dip into — never a wall to climb first. Lessons name the
-sounds they need and link here.
+A **reference**, not a chapter — a place to look things up as you go, never a
+wall to climb first. Chapter 1 (the reading course) teaches you to decode the
+script from zero, letter by letter; this page just collects the sound-and-
+script facts in one spot. Lessons name the sounds they need and link here.
 
 Transliteration note: this curriculum writes Arabic in both the **script**
 (مرحبا) and a **Latin transliteration** (*marḥaban*), with a dot under a

--- a/code/learning/human-languages/arabic/roadmap.md
+++ b/code/learning/human-languages/arabic/roadmap.md
@@ -11,9 +11,12 @@ organizing engine. Script is reintroduced inline, RTL.
 
 ## Authored
 
-- **Ch. 1 — Greetings**: the root system → marḥaban → salām → **al-** → as-salāmu
-  ʿalaykum → ṣabāḥ → khayr → ṣabāḥ al-khayr → masāʾ → masāʾ al-khayr → shukran
-  → practice.
+- **Ch. 1 — Learning to Read** (reading course): la → salam → marhaba →
+  sabah/khayr → shukran → alaykum → practice. A few letters per lesson, each
+  cashing out in a real word, reaching the full greeting set (~15 letters).
+- **Ch. 2 — Greetings** (what they mean): the root system → marḥaban → salām →
+  **al-** → as-salāmu ʿalaykum → ṣabāḥ → khayr → ṣabāḥ al-khayr → masāʾ → masāʾ
+  al-khayr → shukran → practice.
 
 ## Planned
 

--- a/code/learning/human-languages/arabic/session-map.md
+++ b/code/learning/human-languages/arabic/session-map.md
@@ -1,26 +1,37 @@
-# Session Map — Arabic Chapter 1 (Greetings)
+# Session Map — Arabic Chapters 1-2
 
-How Chapter 1's lessons compose into commute sessions. Same spaced-repetition
-schedule as the other tracks (a word from session *N* resurfaces at *N+1, N+3,
-N+7, N+15*). Lessons named by slug; this map is the authoritative order.
+Same spaced-repetition schedule as the other tracks (a word from session *N*
+resurfaces at *N+1, N+3, N+7, N+15*). Lessons named by slug; this map is the
+authoritative order.
 
-## Session-by-session
+**Chapter 1 is a reading course** — you learn to *decode* Arabic from zero, a
+few letters per lesson, each cashing out in a real word — before Chapter 2
+opens what the words mean.
 
-| Session | New lesson(s) | Introduces |
+## Chapter 1 — Learning to read
+
+| Session | Lesson | New letters → word you can now read |
 |---|---|---|
-| 1 | the root system | three-consonant roots + patterns; RTL/script refresher |
-| 2 | marḥaban | casual "hi" (root r-ḥ-b) |
-| 3 | salām | "peace" (root s-l-m — the big family) |
-| 4 | al- | "the"; sun/moon letters; Al-Andalus loanword web |
-| 5 | as-salāmu ʿalaykum | assembled; the ʿayn sound; the fixed reply |
-| 6 | ṣabāḥ · khayr | morning + "goodness" (emphatic ṣ; throaty kh) |
-| 7 | ṣabāḥ al-khayr | assembled "good morning" (reply ṣabāḥ an-nūr) |
-| 8 | masāʾ · masāʾ al-khayr | evening (hamza); "good evening" |
-| 9 | shukran · practice | "thanks" (root sh-k-r reusing the kātib pattern); recap |
+| 1 | read-la | ا ل → **لا** (*lā*, "no") |
+| 2 | read-salam | م س → **سلام** (*salām*, "peace") |
+| 3 | read-marhaba | ب ر ح → **مرحبا** (*marḥaban*, "welcome/hi") |
+| 4 | read-sabah-khayr | ص خ ي → **صباح الخير** (good morning) |
+| 5 | read-shukran | ش ك → **شكرا** (*shukran*, "thanks") |
+| 6 | read-alaykum | ع ء → **السلام عليكم**, **مساء الخير** |
+| 7 | read-practice | (decode the whole greeting set) |
 
-Reviews of earlier words fold into each session per the interval schedule.
+## Chapter 2 — Greetings (what they mean)
+
+| Session | Lesson | Introduces |
+|---|---|---|
+| 8 | root-system | the three-consonant root engine (k-t-b → kitāb/kātib/maktab) |
+| 9 | marhaba · salam | roots r-ḥ-b and s-l-m (the big family; Hebrew *shalom*) |
+| 10 | al- · as-salamu-alaykum | "the"; sun/moon letters; Al-Andalus loanwords (algebra, azúcar) |
+| 11 | sabah · khayr · sabah-al-khayr | morning + goodness; reply ṣabāḥ an-nūr |
+| 12 | masa · masa-al-khayr | evening; "good evening" |
+| 13 | shukran · practice | thanks (sh-k-r); recap |
 
 ## Next
 
-Chapter 2 — introducing yourself (*ismī…*, "my name is") and Arabic's
-**gendered** "you" (*anta* / *anti*).
+Chapter 3 — introducing yourself (*ismī…*) and Arabic's **gendered** "you"
+(*anta* / *anti*).

--- a/code/learning/human-languages/french/lessons/FR-C01-bien.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-bien.md
@@ -16,9 +16,8 @@ reviews_of: [FR-C01-salut]
 
 ## Warm-up
 
-[PAUSE 2s] If you're learning Spanish too, this word will feel like déjà vu —
-it's *spelled the same and means the same*: **bien**, "well." That's not a
-coincidence, and this lesson shows why.
+[PAUSE 2s] A tiny, essential word: **bien**, "well." It carries a good chunk
+of everyday conversation, and its root reaches straight into English.
 
 ## Sounds you'll need
 
@@ -33,12 +32,13 @@ is yours already:
 - **bene**fit ("do well"), **bene**volent ("wish well"), **bene**diction
   ("speak well"), be**nign**.
 
-> Spanish twin: Spanish also has **bien**, also from *bene*, also meaning
-> "well." French and Spanish inherited the *same* Latin adverb independently
-> and it barely changed in either. When two Romance languages agree this
-> exactly, you're looking straight at the shared Latin parent.
+> A cross-language aside: Spanish, another daughter of Latin, has the very
+> same word — *bien*, also from *bene*, also "well." French and Spanish each
+> inherited the Latin adverb independently and it barely changed in either;
+> when two Romance languages agree this exactly, you're looking straight at
+> the shared Latin parent.
 
-**Using it alone**, just like Spanish: "*Comment ça va?*" → "**Bien.**"
+**Using it alone**: "*Comment ça va?*" (how's it going?) → "**Bien.**"
 ("Well / good.") Intensified: "**très bien**" ("very well").
 
 ## Grammar Lens: the "good" it pairs with

--- a/code/learning/human-languages/french/lessons/FR-C01-practice.md
+++ b/code/learning/human-languages/french/lessons/FR-C01-practice.md
@@ -22,7 +22,7 @@ agreement are automatic.
 ## What you've built
 
 - **salut** — casual "hi/bye" (← *salus*, "health").
-- **bien** — "well," a one-word answer (← *bene*; the Spanish twin).
+- **bien** — "well," a one-word answer (← *bene*; Spanish kept the same word).
 - **bon / bonne** — "good," the adjective (← *bonus*), and its agreement.
 - **le / la / les** — "the," carrying gender (← *ille/illa/illos*).
 - **bonjour** = bon + jour (masc.) — polite daytime "hello," *singular*

--- a/code/learning/human-languages/german/lessons/GE-C01-hallo.md
+++ b/code/learning/human-languages/german/lessons/GE-C01-hallo.md
@@ -16,9 +16,9 @@ reviews_of: []
 
 ## Warm-up
 
-[PAUSE 2s] Your first German word — and a reassuring one. German is the
-learner's home turf in a way Spanish and French aren't: German and English
-are *both Germanic languages*, close siblings. *hallo* is the first proof.
+[PAUSE 2s] Your first German word — and a reassuring one, because German and
+English are close cousins: *both are Germanic languages*. That kinship will
+help you all through this book, and *hallo* is the first proof.
 
 ## Sounds you'll need
 
@@ -36,8 +36,8 @@ even shaped partly by German *hallo*.
 
 > The pattern to carry through this whole book: because English is a Germanic
 > language, German words are often **direct cousins** of English words — same
-> family, no Latin middleman. Where Spanish sent you through Rome, German
-> sends you straight home.
+> family, no Latin middleman. (The Romance languages like Spanish and French
+> reach English mostly *through* Latin; German reaches it directly.)
 
 ## Why it's said this way
 

--- a/code/specs/HL00-human-language-curriculum-framework.md
+++ b/code/specs/HL00-human-language-curriculum-framework.md
@@ -34,6 +34,41 @@ both were removed on learner feedback in favor of this finer, gate-free
 model. Some legacy `ES-P0-U##` files from that scheme may still exist mid-
 migration.)
 
+## Audience — who the books are for
+
+**The books are written for a motivated *true beginner* — someone with no
+prior knowledge of the target language (or of any of the others), who wants
+to learn it in depth.** They are *not* written for the curriculum's
+originator or any particular person. This is a load-bearing rule, because it
+constrains what the text may assume:
+
+- **The only language the reader is assumed to know is English** (the books
+  are written in English). Every explanation grounds in English + the
+  language's own deep roots (Latin, Sanskrit, Semitic roots, etc.), because
+  those are universally available to the reader.
+- **No lesson may assume the reader knows another *target* language.** Phrases
+  like "you already know this from Spanish," "the Spanish twin you know,"
+  "if you're also learning Spanish," or "skim this, it's already yours" are
+  forbidden — they address a specific reader, not the beginner the book is
+  for.
+- **Cross-language comparisons are still welcome — as self-contained
+  enrichment.** Showing that Spanish *día* and French *jour* both descend from
+  Latin *dies* is wonderful depth, and a beginner learns *both* facts fresh
+  from it. State such comparisons as information the text supplies ("Spanish,
+  another daughter of Latin, kept *día*…"), never as knowledge the reader is
+  presumed to arrive with.
+- **For non-Latin scripts, the reading course (below) is written for someone
+  who cannot read a single letter** — not "a refresher you can skim." Someone
+  who happens to read the script will move fast on their own; the text does
+  not tell them to.
+
+The curriculum's *methodology* (etymology-first, atom-first, gender-early,
+grammar-from-zero) was shaped by one person's learning preferences — the
+"Motivation" below records that origin — but the *output* serves the beginner
+defined here. Where this spec below says "the learner" as design rationale,
+read it as "why the method is shaped this way"; the reader of the books is
+always the beginner above.
+
 ## Motivation
 
 Off-the-shelf apps (Duolingo et al.) optimize for screen-tap engagement, not
@@ -372,16 +407,45 @@ Instead:
   not a gate to pass through. Every inline "Sounds you'll need" note links
   into it (via `sounds:` ids in the frontmatter), so the curious learner
   can go deep on demand and everyone else keeps moving.
-- The same applies to **new or rusty scripts** (Arabic, Hindi, and the
-  Dravidian scripts when those tracks are built): letters are introduced
-  inside the lesson whose headword first uses them, and collected in the
-  track's pronunciation/script reference — never as a wall of alphabet
-  before any real words.
-
 The payoff is cumulative: by the time a learner has done the first several
-lessons, they've absorbed the sounds (or letters) they've actually needed,
-each one welded to a real word, rather than having memorized an abstract
-chart they can't yet attach to anything.
+lessons, they've absorbed the sounds they've actually needed, each one welded
+to a real word, rather than having memorized an abstract chart they can't yet
+attach to anything.
+
+### Non-Latin scripts: Chapter 1 IS a reading course
+
+The rules above assume the learner can already *read* the script (true for
+the Latin-alphabet tracks — Spanish, French, German). For any track whose
+script the learner does **not** fluently read — **Arabic, Hindi, Tamil,
+Kannada, Telugu, Malayalam** (i.e. everything not written in the Latin
+alphabet) — **Chapter 1 is an incremental reading course**, and vocabulary
+(greetings, etc.) begins in Chapter 2, once the letters exist to decode it.
+
+This was a correction after the first Arabic draft dropped whole words
+(*مرحبا*, *صباح الخير*) with only a gloss of the hard sounds — which teaches
+a vocabulary list, not *reading*. The fix is the atom-first playbook applied
+to the **script**: the atoms are **letters**, and words are built from letters
+the learner has just learned, exactly as Spanish built *buenos días* from
+*bueno* + *días*.
+
+The reading course is **not** the "gated alphabet chart" this section warns
+against. The difference:
+
+- A gated chart teaches all ~28-50 letters in the abstract before any word.
+- A reading course introduces **a few letters per lesson** and **immediately
+  cashes them out in a real, decodable word** — so the learner *reads
+  something true* in lesson 1 (e.g. Arabic ل + ا → **لا**, "no"), and every
+  lesson after adds letters that unlock the next word. Letters change shape
+  by position (Arabic) or combine into conjuncts (Indic scripts); those facts
+  are taught as the words that use them arrive, cumulatively.
+
+Sequence the letters so real words — and soon the greeting set — become
+readable as fast as possible (Frequency-Driven Content Selection, below,
+applied to letters). The reading course is authored for someone who cannot
+read a single letter of the script (per Audience, above) — it never tells the
+reader to skim. Once Chapter 1's reading course is done, later chapters
+proceed word-first like the Latin tracks, with new letters still introduced
+inline as rarer ones appear.
 
 Grammar follows the identical principle — introduced in context, on the
 first word that needs it (the Grammar Lens section), never front-loaded.


### PR DESCRIPTION
## Beginner audience + landing the Arabic reading course

Two corrections in one PR (both touch Arabic + HL00, so they're bundled).

### 1. The books are for a true beginner (not the curriculum's author)

Added an explicit **Audience** section to [`HL00`](code/specs/HL00-human-language-curriculum-framework.md): the books target a motivated beginner with **no prior knowledge of any target language**, who wants depth. The only assumed shared language is **English**. Scrubbed reader-background assumptions from the content:

- Removed "skim if the script is already yours" / "you already read Arabic (rusty)" (Arabic reading course, README, pronunciation ref, and the HL00 rule).
- Reframed "if you're learning Spanish too / déjà vu" (French *bien*) and "German is your home turf" (German *hallo*) into **self-contained** cross-language comparisons — a beginner learns the Spanish/Latin fact fresh from the text, rather than being assumed to already know it.

### 2. Lands the Arabic reading course on `main`

The reading-course rebuild (Chapter 1 = *learn to read*, greetings → Chapter 2) was pushed **after** PR #8198 had already merged the greetings-first version, so it never reached `main`. This PR lands it: `AR-C01-read-*` reading lessons (ل + ا → لا, building to the full greeting set), `AR-C02-*` greetings, the restructured book, and the HL00 reading-course rule for non-Latin scripts.

Arabic book compiles clean locally (17 pages); CI builds all book PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
