### PR TITLE
refactor(adj-facts-stdlib): subject-organized ADJ standard library (retire grade levels)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_shapes_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_shapes_e2e.rs
@@ -1,5 +1,5 @@
-//! End-to-end test for the first kindergarten FACTS library
-//! (`adj-facts-stdlib/kindergarten/shapes.adj`) driven through the built CLI:
+//! End-to-end test for the geometry FACTS library
+//! (`adj-facts-stdlib/geometry/shapes.adj`) driven through the built CLI:
 //! a native `table` of polygon → number-of-sides resolves a binding-query recall
 //! with the source's citation, and abstains on a non-polygon — 0 model calls.
 
@@ -29,10 +29,10 @@ fn run(program: &Path) -> (bool, String) {
 }
 
 #[test]
-fn kindergarten_shapes_recall_binds_side_count_with_citation() {
+fn geometry_shapes_recall_binds_side_count_with_citation() {
     let dir = scratch("shapes");
-    // Copy the shipped kindergarten table beside the entry program and import it.
-    let src = facts_stdlib().join("kindergarten/shapes.adj");
+    // Copy the shipped geometry table beside the entry program and import it.
+    let src = facts_stdlib().join("geometry/shapes.adj");
     std::fs::copy(&src, dir.join("shapes.adj")).expect("copy shipped shapes.adj");
     std::fs::write(
         dir.join("case.adj"),

--- a/code/specs/data/adj-facts-stdlib/README.md
+++ b/code/specs/data/adj-facts-stdlib/README.md
@@ -1,39 +1,51 @@
-# adj-facts-stdlib — the graded, byte-provenanced *facts* standard library (K → med)
+# adj-facts-stdlib — the ADJ standard library of grounded facts (organized by subject)
 
-A curriculum of **recallable facts**, climbing from **what every kindergartener
-learns → medical school**, as importable, grounded ADJ libraries. The sibling of
-[`adj-formula-stdlib`](../adj-formula-stdlib/) (graded *formulas*) and the
-[medical recall domains](../mycin-2026/recall/) (single-hop clinical recall): where
-those hold computation and clinical edges, this holds the **elementary facts a
-learner memorizes first** — shapes, colors, counting, the calendar, the planets —
-and grows upward toward the science facts a clinician recalls.
+A growing **standard library of recallable facts** that any ADJ program can `import` and
+query. Together with [`adj-formula-stdlib`](../adj-formula-stdlib/) (grounded **formulas and
+laws**) and the [medical recall domains](../mycin-2026/recall/), it forms the **ADJ standard
+library**: the facts, formulas, and laws of the sciences — chemistry, physics, biology,
+mathematics, and beyond — encoded once, provenanced, and reusable.
 
-## Why facts are first-class
+## Why a standard library of facts (and formulas, and laws)
 
-The ADJ language natively supports facts (`relate`, `dictionary`) and now native
-tabular data ([`table`](../../ADJ-TABLES.md)). A fact library is *imported* and
-*recalled* — the model performs no lookup from memory; the engine resolves a
-binding query against the grounded rows and returns the answer **with its
-citation**, on the CPU, with zero answer-time model calls. Every shipped fact is
-byte-provenanced from a citable source (see
-[feedback: nothing human-authored]) — nothing is asserted "from memory."
+The goal is that an AI agent working in a domain can **reason through this library** the way a
+student reasons up from foundations — e.g. a medicine agent draws on chemistry, physics,
+biology, and math the way a medical student builds on them from the start. Recall costs
+**zero answer-time model calls**: the engine resolves a binding query against the grounded
+rows and returns the answer **with its citation**, on the CPU. Every value is byte-provenanced
+from a citable source (see [feedback: nothing human-authored]); nothing is asserted "from
+memory," and the trust tier honestly reflects the source (`authoritative` for a primary/official
+source — NIST, NASA, IUPAC, PubChem, a standards body; `consensus` for a secondary reference).
 
-## Layout (by grade level)
+## Organized by subject, not by level
 
-| level | what | examples |
-|-------|------|----------|
-| `kindergarten/` | the first facts a child learns | shapes → sides (this PR) |
-| … | grade-school, middle, high-school, undergrad … | *(grown one small library per rotation)* |
-| → medical school | the science facts a clinician recalls | (already: `mycin-2026/recall/`, 63 domains) |
+Files live under `code/specs/data/adj-facts-stdlib/<subject>/<name>.adj`. There is **no
+grade/age categorization** — just subjects. Current subjects (grown one small, grounded library
+per rotation, in parallel):
 
-## Consuming a fact library
+| subject | example library | source |
+|---|---|---|
+| `geometry/` | polygon → number of sides | Wolfram MathWorld |
+| `astronomy/` | planet → order from the Sun | NASA |
+| `chemistry/` | element → atomic number | PubChem / NIH |
+| `metrology/` | SI prefix → power of ten | NIST |
+| `mathematics/` | Roman numeral → value | (consensus) |
+| `calendar/` | day / month → number | ISO 8601 |
+| `money/` | US coin → cents | US Mint |
+| … | *physics, biology, geography, anatomy, physical constants, …* | *(expanding)* |
+
+Formulas and laws (Newton's `F = ma`, the ideal gas law `PV = nRT`, area/volume, …) are grown
+in `adj-formula-stdlib/<subject>/` using the `formula` construct — simple ones first, growing
+more complex — and are consumed the same way.
+
+## Consuming a library
 
 ```adj
-import "kindergarten/shapes.adj"
-? polygon_sides(hexagon, $Sides)     % 6, cited to the source
+import "chemistry/elements.adj"
+? atomic_number(oxygen, $Z)          % 8, cited to its source
 ```
 
-Because a `table` row lowers to a relation whose value is a number, a recalled
-fact **composes into a formula**: e.g. a looked-up side count feeds a
-perimeter/area formula from `adj-formula-stdlib` — the concrete K-math bridge from
-*recall* to *compute*.
+Because a `table` row lowers to a relation whose value is a number ([`ADJ-TABLES`](../../ADJ-TABLES.md)),
+a recalled fact **composes into a formula** — a looked-up atomic number, side count, or
+conversion factor flows straight into arithmetic. That is the bridge from **recall** to
+**compute**, and the reason facts and formulas belong in one standard library.

--- a/code/specs/data/adj-facts-stdlib/geometry/shapes.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/shapes.adj
@@ -1,7 +1,7 @@
 % ============================================================================
-% shapes — how many sides each polygon has (adj-facts-stdlib, KINDERGARTEN).
+% shapes — how many sides each polygon has (adj-facts-stdlib, GEOMETRY).
 % ============================================================================
-% The very first rung of the facts ladder: a fact every kindergartener learns —
+% A geometry facts library: how many sides each polygon has —
 % "a triangle has three sides, a square has four." Recall is a binding query:
 %
 %     ? polygon_sides(hexagon, $Sides)      % 6
@@ -12,7 +12,7 @@
 % WITH its source, on the CPU, with zero model calls, and abstains on a shape not
 % in the table. Because the `sides` value is a NUMBER, a recalled count composes
 % straight into a formula (a regular polygon's perimeter is sides × side-length):
-% the concrete bridge from kindergarten RECALL to kindergarten COMPUTE.
+% the concrete bridge from RECALL to COMPUTE.
 %
 % Provenance: the polygon names and their side counts are copied verbatim from
 % the Wolfram MathWorld "Polygon" names table (the citable artifact is that table

--- a/code/specs/data/adj-facts-stdlib/geometry/shapes.query.adj
+++ b/code/specs/data/adj-facts-stdlib/geometry/shapes.query.adj
@@ -1,5 +1,5 @@
 % ============================================================================
-% shapes.query.adj — a worked recall over the kindergarten shapes library.
+% shapes.query.adj — a worked recall over the geometry shapes library.
 % ============================================================================
 % The shape a learner (or an LLM) produces to ANSWER "how many sides does a
 % hexagon have?": it states no geometry fact — it only `import`s the grounded


### PR DESCRIPTION
## What

Reorganizes the facts standard library **by subject** and reframes it as **one ADJ standard library** of grounded facts (with formulas/laws in `adj-formula-stdlib`) that any program imports — **no grade/age categorization**.

- Moves the merged **shapes** library `kindergarten/` → **`geometry/`** (+ query), renames its test to `facts_shapes_e2e`, strips all "kindergarten" wording. Test passes.
- Rewrites the README as a subject-organized standard library: facts + formulas + laws across the sciences (chemistry, physics, biology, math…), byte-provenanced, trust tier honestly reflecting the source, with the **recall→compute** bridge — so a domain agent (e.g. medicine) can reason up from foundational science like a student.

## Why

Per direction: don't categorize facts by grade; put them all in a subject-organized standard library any ADJ program can import and reason through. Companion moves: planets → `astronomy/` (#8217), and the wave-1 libraries → `calendar/`, `chemistry/`, `mathematics/`, `metrology/`, `money/`. Once all land, `kindergarten/`/`gradeschool/` are gone.

Data + doc + one test rename only — no engine changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)