### PR TITLE
feat(adj-facts-stdlib): DNA base-pairing biology recall library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_dna_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_dna_e2e.rs
@@ -1,0 +1,62 @@
+//! End-to-end test for the BIOLOGY FACTS library
+//! (`adj-facts-stdlib/biology/dna-base-pairs.adj`) driven through the built CLI:
+//! a native `table` of DNA base → Watson–Crick complement resolves a binding
+//! query recall with the source's citation, and abstains on `uracil` (an RNA
+//! base, deliberately not a DNA row) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsdna_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_dna_complement_recall_binds_pair_with_citation() {
+    let dir = scratch("dna");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/dna-base-pairs.adj");
+    std::fs::copy(&src, dir.join("dna-base-pairs.adj")).expect("copy shipped dna-base-pairs.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"dna-base-pairs.adj\"\n\
+         ? dna_complement(adenine, $Base)\n\
+         ? dna_complement(guanine, $Base)\n\
+         ? dna_complement(uracil, $Base)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Watson–Crick pairing: adenine binds thymine; guanine binds cytosine.
+    assert!(out.contains("\"Base\":\"thymine\""), "adenine → thymine: {out}");
+    assert!(out.contains("\"Base\":\"cytosine\""), "guanine → cytosine: {out}");
+    // The answer carries the NHGRI genome.gov citation as its proof.
+    assert!(
+        out.contains("genome.gov/genetics-glossary/Base-Pair")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Uracil is an RNA base, not a DNA row — honest abstention, never a
+    // fabricated partner.
+    assert!(out.contains("\"abstained\":true"), "uracil abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/dna-base-pairs.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/dna-base-pairs.adj
@@ -1,0 +1,55 @@
+% ============================================================================
+% dna-base-pairs — each DNA base and its Watson–Crick complement
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A molecular-biology fact a medicine agent reasons from: in double-stranded
+% DNA the two strands are complementary, and each base pairs with exactly one
+% partner across the helix. Recall is a binding query:
+%
+%     ? dna_complement(adenine, $Base)      % thymine
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `dna_complement(base, complement)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% complementary base WITH its source, on the CPU, with zero model calls, and
+% abstains on anything not in the table.
+%
+% Watson–Crick base pairing, as a truth table:
+%
+%     base       complement    bond
+%     ---------  ----------    ------------------
+%     adenine    thymine       2 hydrogen bonds (A–T)
+%     thymine    adenine       2 hydrogen bonds (T–A)
+%     guanine    cytosine      3 hydrogen bonds (G–C)
+%     cytosine   guanine       3 hydrogen bonds (C–G)
+%
+% All FOUR directed rows are shipped so that BOTH forward directions resolve:
+% asking for adenine's partner and asking for thymine's partner each bind
+% directly, without the query needing to know the pairing is symmetric.
+%
+% Note that `uracil` is deliberately NOT a row: uracil replaces thymine in RNA,
+% not DNA, so a DNA-complement recall must ABSTAIN on it rather than invent a
+% partner — the honest-abstention property is what makes the table safe for a
+% clinical reasoner to trust.
+%
+% Provenance: the pairing is copied from the NHGRI (National Human Genome
+% Research Institute) Genetics Glossary "Base Pair" entry, whose definition
+% states verbatim (see `source`) that "adenine pairs with thymine, and cytosine
+% pairs with guanine." The citable artifact is that glossary page at the
+% `locator`. `trust authoritative` — NHGRI/genome.gov is a primary genetics
+% reference. Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table dna_complement {
+    columns base, complement
+
+    row (adenine, thymine)
+    row (thymine, adenine)
+    row (guanine, cytosine)
+    row (cytosine, guanine)
+
+    source "adenine pairs with thymine, and cytosine pairs with guanine"
+    locator "https://www.genome.gov/genetics-glossary/Base-Pair"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/dna-base-pairs.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/dna-base-pairs.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% dna-base-pairs.query.adj — a worked recall over the DNA base-pairing library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what base pairs with
+% adenine in DNA?": it states no biology fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `dna_complement` rows and returns the complement + the table's source/locator/
+% trust. A molecule not in the table abstains honestly — the engine never
+% invents a partner.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli dna-base-pairs.query.adj
+% ============================================================================
+
+import "dna-base-pairs.adj"
+
+? dna_complement(adenine, $Base)       % expect thymine
+? dna_complement(guanine, $Base)       % expect cytosine
+? dna_complement(uracil, $Base)        % expect abstain — uracil is RNA, not DNA


### PR DESCRIPTION
## What

Adds the first **BIOLOGY** rung of `adj-facts-stdlib`: a native `table` `dna_complement(base, complement)` shipping all **four directed** Watson–Crick rows so both forward binding directions resolve:

| base | complement |
|------|-----------|
| adenine | thymine |
| thymine | adenine |
| guanine | cytosine |
| cytosine | guanine |

Recall is an ordinary SLD binding query — the engine returns the complement **with its citation**, on the CPU, with **zero model calls**. Anything not in the table (e.g. `uracil`, an RNA base deliberately excluded) **abstains honestly** rather than fabricating a partner.

## Grounding / provenance

- **Source (verbatim):** `adenine pairs with thymine, and cytosine pairs with guanine`
- **Locator:** https://www.genome.gov/genetics-glossary/Base-Pair (NHGRI Genetics Glossary, "Base Pair")
- **Trust tier:** `authoritative` (NHGRI / genome.gov is a primary genetics reference)
- Nothing asserted from memory.

## Files

- `code/specs/data/adj-facts-stdlib/biology/dna-base-pairs.adj` — the grounded `table`
- `code/specs/data/adj-facts-stdlib/biology/dna-base-pairs.query.adj` — a worked recall
- `code/packages/rust/adj-lang-cli/tests/facts_dna_e2e.rs` — one e2e test (adenine→thymine, guanine→cytosine, locator citation carried, uracil abstains), driven through the built CLI

## Verification

`cargo test -p adj-lang-cli --test facts_dna_e2e` passes; also verified by running the query file through the built binary (adenine→thymine, guanine→cytosine, uracil abstains, citation present). Security review passed (round 1).

DATA + one test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)