### PR TITLE
feat(adj-facts-stdlib): chemistry element→symbol recall (PubChem-grounded)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_elemsym_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_elemsym_e2e.rs
@@ -1,0 +1,61 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/element-symbols.adj`) driven through the built
+//! CLI: a native `table` of element -> chemical symbol resolves binding-query
+//! recall in BOTH directions with the source's citation, and abstains on a
+//! non-element — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsym_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_element_symbol_recall_binds_both_directions_with_citation() {
+    let dir = scratch("elemsym");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/element-symbols.adj");
+    std::fs::copy(&src, dir.join("element-symbols.adj")).expect("copy shipped element-symbols.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"element-symbols.adj\"\n\
+         ? element_symbol(oxygen, $S)\n\
+         ? element_symbol($E, na)\n\
+         ? element_symbol(unobtainium, $S)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward recall: oxygen -> o (name binds the symbol).
+    assert!(out.contains("\"S\":\"o\""), "oxygen -> o: {out}");
+    // Reverse recall: the symbol na binds the element name sodium.
+    assert!(out.contains("\"E\":\"sodium\""), "na -> sodium: {out}");
+    // The answer carries the PubChem citation as its proof.
+    assert!(
+        out.contains("pubchem.ncbi.nlm.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // unobtainium is not a real element in the table — honest abstention.
+    assert!(out.contains("\"abstained\":true"), "unobtainium abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/element-symbols.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/element-symbols.adj
@@ -1,0 +1,58 @@
+% ============================================================================
+% element-symbols — each chemical element's one/two-letter SYMBOL
+% (adj-facts-stdlib, CHEMISTRY). Complements chemistry/elements.adj (atomic
+% numbers) with the OTHER half of what a chemistry student memorizes first.
+% ============================================================================
+% A subject-organized (no grade level) facts library: the chemical symbol every
+% chemistry learner recalls — "hydrogen is H, sodium is Na." Recall is a binding
+% query in either direction:
+%
+%     ? element_symbol(oxygen, $S)      % o   (name  -> symbol)
+%     ? element_symbol($E, na)          % sodium  (symbol -> name)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `element_symbol(element, symbol)` carrying the table's citation, so
+% both lookups above are ordinary SLD binding queries — the engine returns the
+% answer WITH its source, on the CPU, with zero model calls, and abstains on an
+% element not in the table (never inventing a symbol). Keys AND symbol values are
+% lowercase ADJ atoms (hydrogen -> h, helium -> he, …); the human-facing capital
+% form (H, He, Na, …) is the same string title-cased for display.
+%
+% Provenance: every element name and its symbol below is copied from PubChem's
+% (NIH/NLM) periodic-table REST resource — a primary chemistry authority. The
+% `source` span is the VERBATIM JSON `Cell` triple for atomic number 8
+% (AtomicNumber "8", Symbol "O", Name "Oxygen") as it appears in that response;
+% the full 20-row table this covers is served at the `locator` URL, and each
+% name->symbol pair below was confirmed against it. `trust authoritative`.
+% Nothing here is asserted from memory. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table element_symbol {
+    columns element, symbol
+
+    row (hydrogen, h)
+    row (helium, he)
+    row (lithium, li)
+    row (beryllium, be)
+    row (boron, b)
+    row (carbon, c)
+    row (nitrogen, n)
+    row (oxygen, o)
+    row (fluorine, f)
+    row (neon, ne)
+    row (sodium, na)
+    row (magnesium, mg)
+    row (aluminum, al)
+    row (silicon, si)
+    row (phosphorus, p)
+    row (sulfur, s)
+    row (chlorine, cl)
+    row (argon, ar)
+    row (potassium, k)
+    row (calcium, ca)
+
+    source "\"8\",\n          \"O\",\n          \"Oxygen\""
+    locator "https://pubchem.ncbi.nlm.nih.gov/rest/pug/periodictable/JSON"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/element-symbols.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/element-symbols.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% element-symbols.query.adj — a worked recall over the chemistry symbols library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is oxygen's symbol?"
+% or "which element is Na?": it states no chemistry fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `element_symbol` rows and returns the answer + the table's
+% source/locator/trust. Recall runs in BOTH directions because the row is a plain
+% relation: bind the symbol from the name, or the name from the symbol. An
+% element not in the table abstains honestly — the engine never invents a symbol.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli element-symbols.query.adj
+% ============================================================================
+
+import "element-symbols.adj"
+
+? element_symbol(oxygen, $S)        % expect o        (name  -> symbol)
+? element_symbol(sodium, $S)        % expect na
+? element_symbol($E, na)            % expect sodium   (symbol -> name, reverse)
+? element_symbol($E, k)             % expect potassium
+? element_symbol(unobtainium, $S)   % expect abstain — not a real element in the table


### PR DESCRIPTION
## What

Adds a subject-organized **chemistry** facts library mapping each of the first 20 elements to its **chemical symbol**, complementing the existing `chemistry/elements.adj` (atomic numbers) with the other half of what a chemistry student memorizes first.

A native `table element_symbol { columns element, symbol }` lowers each `row` to a ground relation carrying the table's citation, so recall is an ordinary SLD binding query in **both directions**:

- `? element_symbol(oxygen, $S)` → `o` (name → symbol)
- `? element_symbol($E, na)` → `sodium` (symbol → name, reverse)
- `? element_symbol(unobtainium, $S)` → **abstains** honestly (never invents a symbol)

The engine returns the answer **with its source** on the CPU with zero model calls. Keys and symbol values are lowercase ADJ atoms (`hydrogen→h`, `sodium→na`, …).

## Provenance (rigorous)

Element names and symbols are copied from **PubChem's (NIH/NLM) periodic-table REST resource** — a primary chemistry authority.

- **`source`** (verbatim JSON `Cell` triple for atomic number 8): `"8", "O", "Oxygen"` (byte-exact, whitespace preserved via escapes)
- **`locator`**: `https://pubchem.ncbi.nlm.nih.gov/rest/pug/periodictable/JSON`
- **`trust`**: `authoritative`

All 20 name→symbol pairs (H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca) were confirmed against the fetched endpoint. Nothing asserted from memory.

## Files

- `chemistry/element-symbols.adj` — the grounded table + literate comment
- `chemistry/element-symbols.query.adj` — worked bidirectional recall
- `adj-lang-cli tests/facts_elemsym_e2e.rs` — asserts oxygen→o, na→sodium, PubChem locator + `authoritative` trust, and abstention on a fake element

## Verification

`cargo test -p adj-lang-cli --test facts_elemsym_e2e` passes; also driven through the built CLI binary against the query file (forward, reverse, and abstain all cite PubChem). Security review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)