### PR TITLE
feat(adj-formula-stdlib): grounded geometry area/perimeter formula library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_geometry_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_geometry_e2e.rs
@@ -1,0 +1,108 @@
+//! End-to-end tests for the `mathematics/geometry-formulas.adj` library — the
+//! foundational plane-geometry area & perimeter formulas — driven through the
+//! built CLI binary against the SHIPPED stdlib. Each proves the same invariant as
+//! the other formula libraries: a consumer states NO arithmetic; it imports the
+//! grounded library, binds side lengths with `observe`, and the engine applies the
+//! cited formula on the CPU — computing the EXACT value and rendering the applied
+//! formula's MathWorld citation + trust tier in the `derived` section (the
+//! auditable answer).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped geometry library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_geometry_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/mathematics/geometry-formulas.adj")
+        .canonicalize()
+        .expect("shipped geometry-formulas.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_geom_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_geometry_lib()).unwrap();
+    std::fs::write(dir.join("geometry-formulas.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// rectangle_area — the product of the two side lengths.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_geometry_library_and_computes_rectangle_area_with_citation() {
+    let dir = scratch("rectarea");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"geometry-formulas.adj\"\n\
+         observe length(4)\n\
+         observe width(3)\n\
+         ? rectangle_area(length, width)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: 4 * 3 = 12.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"rectangle_area\"") && s.contains("\"value\":12"),
+        "rectangle_area(4, 3) = 12: {s}"
+    );
+    // … AND the MathWorld citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("mathworld.wolfram.com/Rectangle.html"),
+        "applied formula carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// triangle_area — half the base times the height (a distinct formula & source).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_triangle_area_as_half_base_times_height_with_citation() {
+    let dir = scratch("triarea");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"geometry-formulas.adj\"\n\
+         observe base(10)\n\
+         observe height(3)\n\
+         ? triangle_area(base, height)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 10 * 3 / 2 = 15, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"triangle_area\"") && s.contains("\"value\":15"),
+        "triangle_area(10, 3) = 15: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("mathworld.wolfram.com/Triangle.html"),
+        "triangle area carries its MathWorld citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/mathematics/geometry-formulas.adj
+++ b/code/specs/data/adj-formula-stdlib/mathematics/geometry-formulas.adj
@@ -1,0 +1,92 @@
+% ============================================================================
+% geometry-formulas.adj — foundational plane-geometry area & perimeter formulas.
+% ============================================================================
+% The FIRST entry of the *mathematics* track of the compute standard library: the
+% area and perimeter formulas a grade-schooler meets, each an importable,
+% byte-provenanced, PARAMETERIZED `formula`. Like `arithmetic/arithmetic.adj` and
+% `clinical/bmi.adj`, a consumer states NO arithmetic — it `import`s this file,
+% binds the side lengths from its own byte-provenance decomposition, and asks the
+% engine to apply the cited formula on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY, carrying the formula's citation.
+%
+%     import "geometry-formulas.adj"
+%     observe length(4)     % "…a 4 m wall…"   (span cited by the model)
+%     observe width(3)      % "…3 m deep…"     (span cited by the model)
+%     ? rectangle_area(length, width)   % engine → 12, carrying MathWorld's A=ab
+%
+% Every formula here is EXACT over its parameters — an area or perimeter is a
+% product / sum of side lengths, with no cited constant (that is why circle area
+% and circumference, which need π as a *separately grounded* constant, live in a
+% different library and are deliberately absent here). The definitions come from
+% Wolfram MathWorld, the authoritative reference for mathematics; each `formula`
+% carries the same provenance envelope every shipped grounded clause carries.
+%
+% These formulas COMPOSE with the geometry *facts* elsewhere in the stdlib (a
+% recall library's polygon side counts, right-angle counts, and the like): the
+% facts say WHAT a rectangle is; these formulas say how to MEASURE one. Answer a
+% mixed question by importing both — recall the shape, then apply its measure.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable length the formulas range over, and
+% each result is the derived measure. Rung-0's grammar types an observable slot as
+% `finding` (dimensional typing of parameters is a later rung — the engine already
+% infers + checks dimensions when a formula is APPLIED: length·width reports an
+% area, 2·(length+width) reports a length). The `surface` lists are the everyday
+% names a decomposer maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary geometry_vocab {
+    define length : finding  surface "length", "long side", "l"           % a side length
+    define width  : finding  surface "width", "breadth", "short side", "w" % a side length
+    define base   : finding  surface "base", "base length", "b"           % a triangle's base
+    define height : finding  surface "height", "altitude", "h"            % a triangle's height
+    define side   : finding  surface "side", "side length", "edge", "s"   % a square's side
+
+    define rectangle_area      : finding  surface "area of the rectangle", "rectangle area"
+    define rectangle_perimeter : finding  surface "perimeter of the rectangle", "rectangle perimeter"
+    define triangle_area       : finding  surface "area of the triangle", "triangle area"
+    define square_area         : finding  surface "area of the square", "square area"
+}
+
+% ----------------------------------------------------------------------------
+% The formulas. Each is a named, importable, reusable `let` over its formal
+% parameters, bound at apply time, and each carries a definitional quote from
+% Wolfram MathWorld (required on a shipped formula; the linter rejects an
+% unsourced one). MathWorld writes each side length as `a`, `b` (rectangle),
+% `a` = base / `h` = height (triangle), and `a` = side (square) — named here with
+% the plain schoolbook words so the audit trail reads in everyday geometry terms.
+%
+%   rectangle_area(length, width)      = length * width         %  A = a b
+%   rectangle_perimeter(length, width) = 2 * (length + width)   %  P = 2(a+b)
+%   triangle_area(base, height)        = base * height / 2      %  Δ = ½ a h
+%   square_area(side)                  = side * side            %  A = a²
+% ----------------------------------------------------------------------------
+formulabook geometry_formulas {
+    use geometry_vocab
+
+    % Rectangle area — the product of its two side lengths.
+    formula rectangle_area(length, width) = length * width
+        source "The area of the rectangle is A=ab."
+        locator "https://mathworld.wolfram.com/Rectangle.html"
+        trust authoritative
+
+    % Rectangle perimeter — twice the sum of its two side lengths. MathWorld's
+    % perimeter table lists the rectangle (lamina) perimeter as 2(a+b).
+    formula rectangle_perimeter(length, width) = 2 * (length + width)
+        source "rectangle | 2(a+b)"
+        locator "https://mathworld.wolfram.com/Perimeter.html"
+        trust authoritative
+
+    % Triangle area — half the base times the height. MathWorld: let a be the
+    % base length and h be the height; then Delta = (1/2) a h.
+    formula triangle_area(base, height) = base * height / 2
+        source "Let a be the base length and h be the height."
+        locator "https://mathworld.wolfram.com/Triangle.html"
+        trust authoritative
+
+    % Square area — the side length squared.
+    formula square_area(side) = side * side
+        source "and the area is A=a^2."
+        locator "https://mathworld.wolfram.com/Square.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/mathematics/geometry-formulas.query.adj
+++ b/code/specs/data/adj-formula-stdlib/mathematics/geometry-formulas.query.adj
@@ -1,0 +1,30 @@
+% ============================================================================
+% geometry-formulas.query.adj — worked examples over the geometry formula library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a mensuration
+% question: it states NO arithmetic and NO formula — it only `import`s the
+% grounded library, `observe`s the side lengths it decomposed from the prompt
+% (each a byte-provenanced span, elided here), and asks the engine to APPLY the
+% cited formula. The native adj-lang engine binds the parameters, computes each
+% value EXACTLY on the CPU, and returns it with the formula's source/locator/trust.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli geometry-formulas.query.adj
+% ============================================================================
+
+import "geometry-formulas.adj"
+
+% A 4 by 3 rectangle: area = 4 * 3, perimeter = 2 * (4 + 3).
+observe length(4)
+observe width(3)
+? rectangle_area(length, width)        % expect 12  (MathWorld: A = ab)
+? rectangle_perimeter(length, width)   % expect 14  (MathWorld: P = 2(a+b))
+
+% A triangle with base 10 and height 3: area = 10 * 3 / 2.
+observe base(10)
+observe height(3)
+? triangle_area(base, height)          % expect 15  (MathWorld: Δ = ½ a h)
+
+% A square with side 5: area = 5 * 5.
+observe side(5)
+? square_area(side)                    % expect 25  (MathWorld: A = a²)


### PR DESCRIPTION
## What

Adds the first entry of the **mathematics** track of the ADJ compute standard library: `code/specs/data/adj-formula-stdlib/mathematics/geometry-formulas.adj`, a `formulabook` of four foundational plane-geometry formulas — each a byte-provenanced, importable, parameterized `formula` the engine applies on the CPU (zero math performed by the model).

| formula | expression | MathWorld |
|---|---|---|
| `rectangle_area(length, width)` | `length * width` | A = ab |
| `rectangle_perimeter(length, width)` | `2 * (length + width)` | 2(a+b) |
| `triangle_area(base, height)` | `base * height / 2` | Δ = ½ a h |
| `square_area(side)` | `side * side` | A = a² |

## Grounding

Every formula carries a **verbatim** definitional span from Wolfram MathWorld (the authoritative mathematics reference), a real `locator` URL, and `trust authoritative`:

- rectangle_area — `https://mathworld.wolfram.com/Rectangle.html` — "The area of the rectangle is A=ab."
- rectangle_perimeter — `https://mathworld.wolfram.com/Perimeter.html` — perimeter table: "rectangle | 2(a+b)"
- triangle_area — `https://mathworld.wolfram.com/Triangle.html` — "Let a be the base length and h be the height."
- square_area — `https://mathworld.wolfram.com/Square.html` — "and the area is A=a^2."

Circle area/circumference are **deliberately excluded** — they require π as a *separately grounded* constant, which belongs to a different library.

## Also ships

- `geometry-formulas.query.adj` — worked example: import + `observe` side lengths + `?` each formula (all four values checked: 12, 14, 15, 25).
- `code/packages/rust/adj-lang-cli/tests/formula_geometry_e2e.rs` — CLI e2e test asserting `rectangle_area(4,3)=12` and `triangle_area(10,3)=15`, each computed on the CPU and carrying its MathWorld citation + `authoritative` trust tier.

Data + one test only. `cargo test -p adj-lang-cli --test formula_geometry_e2e` passes (2/2); the query file runs green through the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)