### PR TITLE
feat(adj-facts-stdlib): physics library — exact SI defining constants (NIST)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_constants_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_constants_e2e.rs
@@ -1,0 +1,76 @@
+//! End-to-end test for the physics FACTS library
+//! (`adj-facts-stdlib/physics/physical-constants.adj`) driven through the built
+//! CLI: a native `table` of physical-constant → exact value resolves a
+//! binding-query recall with the source's NIST citation, resolves the reverse
+//! (value → constant name), and abstains on a constant not in the table —
+//! 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn physics_constants_recall_binds_exact_values_with_nist_citation() {
+    let dir = scratch("constants");
+    // Copy the shipped physics table beside the entry program and import it.
+    let src = facts_stdlib().join("physics/physical-constants.adj");
+    std::fs::copy(&src, dir.join("physical-constants.adj")).expect("copy shipped constants table");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"physical-constants.adj\"\n\
+         ? physical_constant(speed_of_light, $V)\n\
+         ? physical_constant(avogadro_constant, $V)\n\
+         ? physical_constant($C, 299792458)\n\
+         ? physical_constant(gravitational_constant, $V)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+
+    // Forward recall: the speed of light in vacuum is exactly 299792458 m/s.
+    assert!(out.contains("\"V\":\"299792458\""), "speed_of_light -> 299792458: {out}");
+    // A scientific-notation literal is kept as its EXACT decimal expansion:
+    // Avogadro's number 6.02214076e23 -> 602214076 followed by fifteen zeros.
+    assert!(
+        out.contains("\"V\":\"602214076000000000000000\""),
+        "avogadro_constant -> exact expansion of 6.02214076e23: {out}"
+    );
+    // Reverse recall: the value 299792458 binds back to the constant's name.
+    assert!(
+        out.contains("\"C\":\"speed_of_light\""),
+        "reverse recall 299792458 -> speed_of_light: {out}"
+    );
+    // The answer carries the NIST citation as its proof.
+    assert!(
+        out.contains("nist.gov/si-redefinition")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the NIST source citation at authoritative trust: {out}"
+    );
+    // The Newtonian gravitational constant is NOT one of the exact defining SI
+    // constants and is absent from the table — honest abstention, never a
+    // fabricated value.
+    assert!(out.contains("\"abstained\":true"), "unknown constant abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/physics/physical-constants.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/physical-constants.adj
@@ -1,0 +1,53 @@
+% ============================================================================
+% physical-constants — the exact defining constants of the SI (adj-facts-stdlib,
+% SUBJECT: physics). Subject-organized, NOT graded by school level.
+% ============================================================================
+% A physics fact library for the ADJ standard library: each row maps a physical
+% constant to its EXACT value. Recall is a binding query — the model asserts no
+% number from memory; the engine resolves the `?` against the grounded rows and
+% returns the value WITH its citation, on the CPU, with zero answer-time model
+% calls, and abstains on a constant that is not in the table:
+%
+%     ? physical_constant(speed_of_light, $V)    % 299792458 (m/s), cited to NIST
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `physical_constant(name, value)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query. A science- or medicine-facing
+% agent `import`s this library to recall a constant and get its source in one hop,
+% and — because each `value` is a NUMBER — feeds the recalled constant straight
+% into a formula from `adj-formula-stdlib` (e.g. E = h·ν uses the recalled Planck
+% constant): the concrete bridge from physics RECALL to physics COMPUTE.
+%
+% WHY THESE FIVE, AND WHY THEY ARE EXACT. Since the 2019 revision of the SI, seven
+% "defining constants" are fixed by DEFINITION — they have exact numerical values
+% with zero uncertainty, and the base units are derived FROM them (the metre, for
+% instance, is now defined by fixing c). Five of those defining constants are the
+% ones a physics or chemistry learner recalls most: the speed of light c, the
+% Planck constant h, the elementary charge e, the Boltzmann constant k, and the
+% Avogadro constant N_A. Each value below is exact.
+%
+% PROVENANCE. Every value is copied verbatim from NIST's "Definitions of the SI
+% base units" page (the `source` span and `locator` below). NIST — the U.S.
+% National Institute of Standards and Technology, which with CODATA is a PRIMARY
+% metrology authority — is the citable artifact; hence `trust authoritative`.
+% Nothing here is asserted from memory. Note how ADJ stores each value: a literal
+% written in scientific notation (`6.62607015e-34`) is kept as its EXACT decimal
+% expansion, so no precision is lost — `? physical_constant(planck_constant, $V)`
+% binds the full exact decimal, not a rounded float. Keys are lowercase atoms.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table physical_constant {
+    columns constant, value
+
+    row (speed_of_light, 299792458)          % c   — metres per second (m s^-1)
+    row (planck_constant, 6.62607015e-34)    % h   — joule seconds     (J s)
+    row (elementary_charge, 1.602176634e-19) % e   — coulombs          (C)
+    row (boltzmann_constant, 1.380649e-23)   % k   — joules per kelvin (J K^-1)
+    row (avogadro_constant, 6.02214076e23)   % N_A — per mole          (mol^-1)
+
+    source "The meter is defined by taking the fixed numerical value of the speed of light in vacuum c to be 299,792,458 when expressed in the unit m s−1, where the second is defined in terms of ∆νCs."
+    locator "https://www.nist.gov/si-redefinition/definitions-si-base-units"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/physics/physical-constants.query.adj
+++ b/code/specs/data/adj-facts-stdlib/physics/physical-constants.query.adj
@@ -1,0 +1,26 @@
+% ============================================================================
+% physical-constants.query.adj — a worked recall over the physics constants
+% library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is the speed of
+% light?" or "which constant equals 299792458?": it states no physics fact — it
+% only `import`s the grounded table and asks binding queries. The engine resolves
+% each `?` against the `physical_constant` rows and returns the value + the
+% table's source/locator/trust. A constant not in the table abstains honestly —
+% the engine never invents a value.
+%
+% Note the two directions of recall a `table` gives for free:
+%   - forward  `? physical_constant(planck_constant, $V)`   name  → value
+%   - reverse  `? physical_constant($C, 299792458)`         value → name
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli physical-constants.query.adj
+% ============================================================================
+
+import "physical-constants.adj"
+
+? physical_constant(speed_of_light, $V)     % expect 299792458
+? physical_constant(planck_constant, $V)    % expect exact expansion of 6.62607015e-34
+? physical_constant(elementary_charge, $V)  % expect exact expansion of 1.602176634e-19
+? physical_constant($C, 299792458)          % reverse recall — expect C = speed_of_light
+? physical_constant(gravitational_constant, $V) % expect abstain — not a DEFINING SI constant


### PR DESCRIPTION
## What

Adds the first **SUBJECT-organized** library to `adj-facts-stdlib`: `physics/`, holding the exact **SI defining constants** as a native ADJ `table` (`physical_constant(name, value)`).

| constant (key) | exact value | unit |
|---|---|---|
| `speed_of_light` (c) | 299792458 | m s⁻¹ |
| `planck_constant` (h) | 6.62607015e-34 | J s |
| `elementary_charge` (e) | 1.602176634e-19 | C |
| `boltzmann_constant` (k) | 1.380649e-23 | J K⁻¹ |
| `avogadro_constant` (N_A) | 6.02214076e23 | mol⁻¹ |

## How it recalls

`? physical_constant(speed_of_light, $V)` returns `299792458` **with its citation**, on the CPU, zero answer-time model calls, and abstains on a constant not in the table. A `table` gives both directions for free (forward name→value, reverse value→name). Scientific-notation literals are kept as their **exact decimal expansion** — no precision lost.

## Provenance

Every value is copied verbatim from NIST's *Definitions of the SI base units* page. The `source` span quotes the metre definition (which fixes c = 299,792,458 m/s); `locator` is the real NIST URL: https://www.nist.gov/si-redefinition/definitions-si-base-units . NIST/CODATA is a primary metrology authority → **`trust authoritative`**. Nothing from memory.

## Files

- `physics/physical-constants.adj` — grounded table + literate top comment
- `physics/physical-constants.query.adj` — worked forward/reverse/abstain recall
- `adj-lang-cli/tests/facts_constants_e2e.rs` — asserts `speed_of_light`→299792458, Avogadro's exact expansion, reverse recall, the NIST locator substring + authoritative trust, and abstention on a non-defining constant

DATA + one e2e test only; **no engine code changed**. Test passes; query file also verified through the built binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)