### PR TITLE
feat(adj-formula-stdlib): grounded physics-law formula library (F=ma, V=IR, ρ=m/V, v=d/t)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_physics_laws_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_physics_laws_e2e.rs
@@ -36,6 +36,7 @@ fn run(program: &Path) -> (bool, String) {
 /// Run one law: copy the shipped library next to a consumer that binds the two
 /// quantities and applies `call`, then assert the derived value AND that the
 /// applied formula carries its cited provenance (trust tier + locator host).
+#[allow(clippy::too_many_arguments)]
 fn check_law(
     tag: &str,
     obs_one: &str,

--- a/code/packages/rust/adj-lang-cli/tests/formula_physics_laws_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_physics_laws_e2e.rs
@@ -1,0 +1,137 @@
+//! End-to-end test for the foundational physics-law library through the built
+//! CLI binary: a consumer `import`s the SHIPPED `physics/mechanics-laws.adj`
+//! formula library, binds the quantities from its own `observe`d facts, and
+//! applies one of the cited laws (F = ma, V = IR, ρ = m/V, v = d/t). For each,
+//! the CLI must compute the value on the CPU and render the applied formula's
+//! citation in the `derived` section — the auditable answer, zero math by the
+//! model.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped physics-law library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_physics_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/mechanics-laws.adj")
+        .canonicalize()
+        .expect("shipped physics/mechanics-laws.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_physlaw_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Run one law: copy the shipped library next to a consumer that binds the two
+/// quantities and applies `call`, then assert the derived value AND that the
+/// applied formula carries its cited provenance (trust tier + locator host).
+fn check_law(
+    tag: &str,
+    obs_one: &str,
+    obs_two: &str,
+    call: &str,
+    name: &str,
+    value: &str,
+    trust: &str,
+    locator_host: &str,
+) {
+    let dir = scratch(tag);
+    let lib = std::fs::read_to_string(shipped_physics_lib()).unwrap();
+    std::fs::write(dir.join("mechanics-laws.adj"), lib).unwrap();
+    let consumer = format!(
+        "import \"mechanics-laws.adj\"\n\
+         observe {obs_one}\n\
+         observe {obs_two}\n\
+         ? {call}\n"
+    );
+    std::fs::write(dir.join("case.adj"), consumer).unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains(&format!("\"name\":\"{name}\"")) && s.contains(&format!("\"value\":{value}")),
+        "{name} computed to {value}: {s}"
+    );
+    // The applied law carries its cited definition + trust tier + locator — auditable.
+    assert!(
+        s.contains(&format!("\"trust\":\"{trust}\"")) && s.contains(locator_host),
+        "{name} carries its cited provenance ({trust} @ {locator_host}): {s}"
+    );
+}
+
+/// Newton's second law — "a 2 kg block accelerates at 3 m/s²" → the model binds
+/// mass and acceleration; the engine multiplies them → 6 N, carrying NASA's F=ma.
+#[test]
+fn newtons_second_law_binds_and_computes_with_citation() {
+    check_law(
+        "force",
+        "mass(2)",
+        "acceleration(3)",
+        "force(mass, acceleration)",
+        "force",
+        "6",
+        "authoritative",
+        "grc.nasa.gov",
+    );
+}
+
+/// Ohm's law — 4 A through a 5 Ω resistor → the engine multiplies → 20 V. The
+/// clean V=IR product form is quoted from an encyclopedia, so this law is
+/// `consensus`-tier and cites the Wikipedia locator.
+#[test]
+fn ohms_law_binds_and_computes_with_citation() {
+    check_law(
+        "voltage",
+        "current(4)",
+        "resistance(5)",
+        "voltage(current, resistance)",
+        "voltage",
+        "20",
+        "consensus",
+        "en.wikipedia.org",
+    );
+}
+
+/// Density — 12 kg in 4 m³ → the engine divides → 3 kg/m³, carrying NASA Glenn.
+#[test]
+fn density_binds_and_computes_with_citation() {
+    check_law(
+        "density",
+        "mass(12)",
+        "volume(4)",
+        "density(mass, volume)",
+        "density",
+        "3",
+        "authoritative",
+        "grc.nasa.gov",
+    );
+}
+
+/// Average speed — 150 m in 3 s → the engine divides → 50 m/s, carrying the
+/// Alabama State Department of Education physical-science course.
+#[test]
+fn average_speed_binds_and_computes_with_citation() {
+    check_law(
+        "speed",
+        "distance(150)",
+        "time(3)",
+        "speed(distance, time)",
+        "speed",
+        "50",
+        "authoritative",
+        "accessdl.state.al.us",
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.adj
@@ -1,0 +1,125 @@
+% ============================================================================
+% mechanics-laws.adj — foundational physics laws for the ADJ compute stdlib.
+% ============================================================================
+% The FIRST entry of the SCIENCE track's physics layer (ADJ-FORMULA-LIBRARIES
+% §4): a handful of the laws every physics student memorizes, each shipped as an
+% importable, byte-provenanced, PARAMETERIZED `formula`. Where `clinical/bmi.adj`
+% ships a clinical definition and `arithmetic/*.adj` ship the four leaf
+% primitives, this ships the elementary LAWS OF NATURE a science/medicine agent
+% reasons from — F = ma, V = IR, ρ = m/V, v = d/t.
+%
+% The contract is the whole point of the ladder: THE MODEL DOES ZERO ARITHMETIC.
+% A consumer states no math. It `import`s this file, binds the variables from its
+% own byte-provenance decomposition of the input, and asks the engine to APPLY
+% the cited law on the CPU. The engine computes exactly, and the answer carries
+% the law's citation — so the derivation is auditable end to end:
+%
+%     import "mechanics-laws.adj"
+%     observe mass(2)                     % "…a 2 kg block…"   (span cited by the model)
+%     observe acceleration(3)             % "…accelerates at 3 m/s²…" (span cited)
+%     ? force(mass, acceleration)         % engine → 6 N, carrying NASA's F = m·a
+%
+% The laws (and their sources) live HERE; the numbers (and their spans) come from
+% the input. A science/medicine agent that needs "the net force on a 2 kg mass"
+% RECALLS which law applies and BINDS the numbers — it never re-derives F = ma.
+%
+% Each law is its OWN sourced formula: a shipped formula must carry a non-empty
+% `source` (the linter rejects an unsourced one), a real `locator`, and a `trust`
+% tier. Three of these four are grounded in primary .gov / state-education physics
+% references (NASA Glenn's Beginners' Guide to Aeronautics; the Alabama State
+% Department of Education physical-science course) → `authoritative`; Ohm's law
+% falls back to an encyclopedia (Wikipedia) for the clean V = IR product form →
+% `consensus`. Provenance travels per-formula, so the tiers differ by law.
+%
+% Run a worked consumer (from a directory it can resolve this import from):
+%     adj-lang-cli mechanics-laws.query.adj
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each term is an observable physical quantity a law ranges over.
+% rung-0's grammar types an observable slot as `finding` (dimensional typing of
+% formula parameters is a later rung — but the engine already INFERS and CHECKS
+% dimensions when a formula is APPLIED, so 2 kg × 3 m/s² reports newtons and a
+% unit mismatch is an error, not a silent coercion). The intended dimension of
+% each term is recorded in the trailing comment, and the `surface` synonyms let a
+% decomposer map everyday phrasing onto the canonical term.
+%
+%   Term          Dimension            Appears in
+%   ----          ---------            ----------
+%   mass          mass (kg)            force (F=ma), density (ρ=m/V)
+%   acceleration  length/time² (m/s²)  force (F=ma)
+%   force         mass·length/time² N  force  = mass × acceleration
+%   current       electric current A   voltage (V=IR)
+%   resistance    ohm  Ω               voltage (V=IR)
+%   voltage       volt V               voltage = current × resistance
+%   volume        length³ (m³)         density (ρ=m/V)
+%   density       mass/length³ kg/m³   density = mass / volume
+%   distance      length (m)           speed  (v=d/t)
+%   time          time (s)             speed  (v=d/t)
+%   speed         length/time (m/s)    speed  = distance / time
+% ----------------------------------------------------------------------------
+dictionary physics_vocab {
+    % --- mechanics: Newton's second law, F = m·a ---
+    define mass         : finding  surface "mass", "m"                                         % mass, e.g. kg
+    define acceleration : finding  surface "acceleration", "a", "rate of change of velocity"   % length / time²
+    define force        : finding  surface "force", "net force", "F"                           % mass · length / time² (newtons)
+
+    % --- electricity: Ohm's law, V = I·R ---
+    define current      : finding  surface "current", "electric current", "I"                  % electric current (amperes)
+    define resistance   : finding  surface "resistance", "R"                                   % ohms
+    define voltage      : finding  surface "voltage", "potential difference", "V", "EMF"       % volts
+
+    % --- matter: density, ρ = m/V ---
+    define volume       : finding  surface "volume", "V"                                       % length³
+    define density      : finding  surface "density", "mass density", "rho"                    % mass / length³
+
+    % --- kinematics: average speed, v = d/t ---
+    define distance     : finding  surface "distance", "displacement", "d", "path length"      % length
+    define time         : finding  surface "time", "elapsed time", "duration", "t"             % time
+    define speed        : finding  surface "speed", "average speed", "velocity", "v"           % length / time
+}
+
+% ----------------------------------------------------------------------------
+% The laws. Each `formula` is a named, importable, reusable `let` over its formal
+% parameters — the SAME expression grammar `let` uses, with the parameter leaves
+% bound at apply time. Every one carries the provenance envelope a grounded clause
+% requires: a verbatim definitional span from a citable reference, a resolvable
+% locator, and a trust tier. These are CLAIMS ABOUT THE WORLD ("force is the
+% product of mass and acceleration"), grounded exactly like a `relate` edge — not
+% asserted by fiat.
+% ----------------------------------------------------------------------------
+formulabook physics_laws {
+    use physics_vocab
+
+    % Newton's second law — the net force on a body is its mass times its
+    % acceleration.  F = m · a.  Source: NASA Glenn Research Center, Beginners'
+    % Guide to Aeronautics (primary .gov physics reference) → authoritative.
+    formula force(mass, acceleration) = mass * acceleration
+        source "The second law then reduces to the more familiar product of a mass and an acceleration: F = m · a"
+        locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/newtons-laws-of-motion/"
+        trust authoritative
+
+    % Ohm's law — the voltage across a conductor is the current through it times
+    % its resistance.  V = I · R.  The clean product form is quoted from an
+    % encyclopedia (Wikipedia), so this law falls back one tier → consensus.
+    formula voltage(current, resistance) = current * resistance
+        source "Ohm's law states that the electric current through a conductor between two points is directly proportional to the voltage across the two points ... one arrives at the three mathematical equations used to describe this relationship: V = IR or I = V/R or R = V/I"
+        locator "https://en.wikipedia.org/wiki/Ohm%27s_law"
+        trust consensus
+
+    % Density — the mass of a substance divided by the volume it occupies.
+    % ρ = m / V.  Source: NASA Glenn Research Center, Beginners' Guide to
+    % Aeronautics, Air Properties Definitions (primary .gov) → authoritative.
+    formula density(mass, volume) = mass / volume
+        source "When a gas is moving, it is convenient to use the density of a gas, which is the mass divided by the volume the gas occupies."
+        locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/air-properties-definitions/"
+        trust authoritative
+
+    % Average speed — the total distance travelled divided by the total time.
+    % v = d / t.  Source: Alabama State Department of Education, ACCESS physical
+    % science course (primary state-education .gov reference) → authoritative.
+    formula speed(distance, time) = distance / time
+        source "Average speed is the total distance traveled divided by the total time of travel."
+        locator "https://accessdl.state.al.us/AventaCourses/access_courses/physci_ua_v17/05_unit/05-02/05-02_learn_alt_speed.htm"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/mechanics-laws.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% mechanics-laws.query.adj — worked applications of the foundational physics laws.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a physics-word
+% problem: it states NO arithmetic. It `import`s the grounded law library, binds
+% each quantity it decomposed from the input (each `observe` is a byte-provenance
+% span the model cited), and asks the engine to APPLY the recalled law. The native
+% adj-lang engine substitutes the law's body, computes exactly on the CPU, and
+% returns the value carrying the law's source/locator/trust — the auditable chain.
+%
+% "A 2 kg block accelerates at 3 m/s². What net force acts on it?"
+%   → recall F = ma, bind mass = 2, acceleration = 3, apply → 6 N (Newton, NASA).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli mechanics-laws.query.adj
+% ============================================================================
+
+import "mechanics-laws.adj"
+
+% --- Newton's second law: a 2 kg mass accelerating at 3 m/s² feels 6 N. ---
+observe mass(2)                        % "…a 2 kg block…"          (span cited by the model)
+observe acceleration(3)                % "…accelerates at 3 m/s²…" (span cited by the model)
+? force(mass, acceleration)            % engine → 6  (F = m·a, NASA Glenn, authoritative)
+
+% --- Ohm's law: 4 A through a 5 Ω resistor drops 20 V. ---
+observe current(4)                     % "…a current of 4 amperes…"   (span cited)
+observe resistance(5)                  % "…a 5 ohm resistor…"         (span cited)
+? voltage(current, resistance)         % engine → 20 (V = I·R, Wikipedia, consensus)


### PR DESCRIPTION
## What

Adds the **physics layer** of the ADJ compute standard library (ADJ-FORMULA-LIBRARIES §4): four foundational laws of nature shipped as importable, byte-provenanced, parameterized `formula`s in a new `physics/mechanics-laws.adj` `formulabook`. Mirrors the shipped `clinical/bmi.adj` and `arithmetic/*.adj` pattern — **the model does zero arithmetic**; a consumer imports the library, binds the quantities from its own byte-provenance decomposition, and the engine applies the cited law on the CPU, returning the value carrying the law's citation.

This is **DATA + one test only** — no engine code.

## Laws + grounding

Each law is its own sourced `formula` carrying a verbatim definitional span, a real locator, and a per-formula trust tier:

| Law | Formula | Source (verbatim span) | Locator | Trust |
|-----|---------|------------------------|---------|-------|
| Newton's 2nd | `force = mass * acceleration` | "The second law then reduces to the more familiar product of a mass and an acceleration: F = m · a" | NASA Glenn Beginners' Guide to Aeronautics | `authoritative` (.gov) |
| Ohm's | `voltage = current * resistance` | "Ohm's law states that the electric current through a conductor … V = IR or I = V/R or R = V/I" | en.wikipedia.org/wiki/Ohm's_law | `consensus` (encyclopedia) |
| Density | `density = mass / volume` | "…the density of a gas, which is the mass divided by the volume the gas occupies." | NASA Glenn, Air Properties Definitions | `authoritative` (.gov) |
| Avg speed | `speed = distance / time` | "Average speed is the total distance traveled divided by the total time of travel." | Alabama State Dept. of Education ACCESS physical science | `authoritative` (state .gov) |

Ohm's law falls back one tier to an encyclopedia (`consensus`) for the clean V=IR product form; the other three are grounded in primary `.gov` / state-education physics references (`authoritative`).

## Files
- `code/specs/data/adj-formula-stdlib/physics/mechanics-laws.adj` — the `formulabook physics_laws` with the four sourced formulas + a literate top comment.
- `code/specs/data/adj-formula-stdlib/physics/mechanics-laws.query.adj` — a worked consumer (F=ma → 6 N; V=IR → 20 V).
- `code/packages/rust/adj-lang-cli/tests/formula_physics_laws_e2e.rs` — e2e test driving the built CLI over the shipped library, asserting each law's computed value **and** its citation chain (trust tier + locator host).

## Verification
Run via the binary: `force(2,3)=6`, `voltage(4,5)=20`, `density(12,4)=3`, `speed(150,3)=50`, each carrying its source/locator/trust. All 4 e2e tests pass (`cargo test -p adj-lang-cli --test formula_physics_laws_e2e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)