### PR TITLE
feat(sql): bitwise operators & | ~ << >>

### DIFF
--- a/code/packages/rust/mini-sqlite/CHANGELOG.md
+++ b/code/packages/rust/mini-sqlite/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.5.29 — Bitwise operators `& | ~ << >>`
+
+`SELECT 5 & 3`, `5 | 2`, `~0`, `1 << 4`, `256 >> 2` now parse and run with
+SQLite's exact semantics: operands are coerced to integer (integer affinity —
+reals truncate toward zero, `2.9 & 1` → 0; text prefix-parses), NULL propagates,
+and the four binary operators share one left-associative precedence level between
+additive and comparison (`5 | 3 & 2` = `(5|3)&2` = 2; `3 + 1 << 2` = 16). Shifts
+follow SQLite's rules precisely — a negative count flips direction (`1 << -1` =
+`1 >> 1` = 0), a count ≥ 64 saturates (left → 0; right → 0 for non-negative, −1
+for negative), and right shift is arithmetic (`-1 >> 1` = -1) — implemented
+without Rust's shift-overflow UB. Full pipeline: lexer tokens (sql-lexer 0.1.2),
+grammar `bitwise` level + `~` prefix (sql-parser 0.1.13), `BitAnd`/`BitOr`/
+`ShiftLeft`/`ShiftRight`/`BitNot` (sql-planner 0.2.12, sql-codegen 0.6.5), and VM
+execution with `sql_shift` (sql-vm 0.4.15). Seven differential-oracle cases diff
+each operator, precedence, real truncation, NULL, shift edges, and a table column
+against real bundled SQLite.
+
 ## 0.5.28 — Simple (operand) `CASE x WHEN v THEN …`
 
 `SELECT CASE x WHEN 1 THEN 'a' WHEN 2 THEN 'b' ELSE 'c' END` now parses and runs

--- a/code/packages/rust/mini-sqlite/Cargo.toml
+++ b/code/packages/rust/mini-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-mini-sqlite"
-version = "0.5.28"
+version = "0.5.29"
 edition = "2021"
 description = "Mini SQLite facade for Rust — Level 1 full pipeline (parser → planner → optimizer → codegen → VM), over in-memory or real .sqlite-file backends"
 

--- a/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
+++ b/code/packages/rust/mini-sqlite/tests/differential_oracle.rs
@@ -1004,6 +1004,54 @@ const CASES: &[Case] = &[
         setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
         query: "SELECT CASE NULL WHEN 1 THEN 'a' ELSE 'z' END AS r FROM t",
     },
+    // ---- Lane 2: bitwise operators `& | ~ << >>` -------------------------
+    // Each operator's basic result. Aliased so the diff is on the value, not
+    // the (orthogonal) unaliased-expression column name.
+    Case {
+        id: "bitwise_and_or",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (5 & 3) AS a, (5 | 2) AS o FROM t",
+    },
+    Case {
+        id: "bitwise_not_and_shifts",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (~0) AS n, (1 << 4) AS sl, (256 >> 2) AS sr FROM t",
+    },
+    // Precedence: `& | << >>` share one left-associative level, so
+    // `5 | 3 & 2` = `(5 | 3) & 2` = 2, and `3 + 1 << 2` = `(3+1) << 2` = 16.
+    Case {
+        id: "bitwise_precedence",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (5 | 3 & 2) AS p, (3 + 1 << 2) AS q FROM t",
+    },
+    // Integer affinity: a real operand truncates toward zero (2.9 → 2).
+    Case {
+        id: "bitwise_real_truncation",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (2.9 & 1) AS a FROM t",
+    },
+    // NULL propagates through every bitwise operator (binary and unary).
+    Case {
+        id: "bitwise_null_propagates",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (NULL & 1) AS a, (1 | NULL) AS o, (~NULL) AS n, (NULL << 2) AS s FROM t",
+    },
+    // Shift edge cases: count ≥ 64 saturates to 0; a negative count flips the
+    // shift direction (`1 << -1` = `1 >> 1` = 0); right shift is arithmetic.
+    Case {
+        id: "bitwise_shift_edges",
+        setup: &["CREATE TABLE t (id INTEGER)", "INSERT INTO t VALUES (1)"],
+        query: "SELECT (1 << 64) AS big, (8 >> 100) AS huge, (1 << -1) AS neg, (-1 >> 1) AS ar FROM t",
+    },
+    // Bitwise over a real table column (integer-affinity coercion per row).
+    Case {
+        id: "bitwise_column",
+        setup: &[
+            "CREATE TABLE t (id INTEGER, x INTEGER)",
+            "INSERT INTO t VALUES (1,12),(2,7),(3,255)",
+        ],
+        query: "SELECT id, (x & 6) AS m, (x | 1) AS o FROM t ORDER BY id",
+    },
 ];
 
 /// Documented divergences: `(case id, reason)`. Ledger cases are executed but

--- a/code/packages/rust/sql-codegen/CHANGELOG.md
+++ b/code/packages/rust/sql-codegen/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.5] - Unreleased
+
+### Added
+
+- **Emit bitwise ops.** `BinaryOp`/`UnaryOp` gain the bitwise variants and
+  `map_binary_op`/`map_unary_op` forward them to the VM instruction stream.
+
 ## [0.6.4] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-codegen/Cargo.toml
+++ b/code/packages/rust/sql-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-codegen"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 description = "Bytecode code generator for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-codegen/src/lib.rs
+++ b/code/packages/rust/sql-codegen/src/lib.rs
@@ -135,6 +135,14 @@ pub enum BinaryOp {
     Or,
     /// `left || right` (string concatenation)
     Concat,
+    /// `left & right` (bitwise AND; operands coerced to integer)
+    BitAnd,
+    /// `left | right` (bitwise OR; operands coerced to integer)
+    BitOr,
+    /// `left << right` (bitwise left shift; SQLite saturation/negation rules)
+    ShiftLeft,
+    /// `left >> right` (bitwise arithmetic right shift; SQLite rules)
+    ShiftRight,
 }
 
 /// A unary operator for the VM's evaluation stack.
@@ -148,6 +156,8 @@ pub enum UnaryOp {
     Neg,
     /// Logical negation: `NOT x`
     Not,
+    /// Bitwise complement: `~x` (operand coerced to integer)
+    BitNot,
 }
 
 /// An aggregate function tag.
@@ -2378,6 +2388,10 @@ fn map_binary_op(op: &PlanBinaryOp) -> BinaryOp {
         PlanBinaryOp::And => BinaryOp::And,
         PlanBinaryOp::Or => BinaryOp::Or,
         PlanBinaryOp::Concat => BinaryOp::Concat,
+        PlanBinaryOp::BitAnd => BinaryOp::BitAnd,
+        PlanBinaryOp::BitOr => BinaryOp::BitOr,
+        PlanBinaryOp::ShiftLeft => BinaryOp::ShiftLeft,
+        PlanBinaryOp::ShiftRight => BinaryOp::ShiftRight,
     }
 }
 
@@ -2386,6 +2400,7 @@ fn map_unary_op(op: &PlanUnaryOp) -> UnaryOp {
     match op {
         PlanUnaryOp::Neg => UnaryOp::Neg,
         PlanUnaryOp::Not => UnaryOp::Not,
+        PlanUnaryOp::BitNot => UnaryOp::BitNot,
     }
 }
 

--- a/code/packages/rust/sql-lexer/CHANGELOG.md
+++ b/code/packages/rust/sql-lexer/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - Unreleased
+
+### Added
+
+- **Bitwise operator tokens `& | ~ << >>`.** New literal tokens for bitwise AND,
+  OR, NOT, and the two shifts. `<<`/`>>` are declared before the single `<`/`>`
+  and `|` after `||`, so first-match-in-order scanning preserves maximal munch
+  (`<<` is one token, `||` still beats a single `|`).
+
 ## [0.1.1] - Unreleased
 
 ### Fixed

--- a/code/packages/rust/sql-lexer/Cargo.toml
+++ b/code/packages/rust/sql-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-lexer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "SQL lexer — tokenizes SQL source text using the grammar-driven lexer and the sql.tokens grammar file"
 

--- a/code/packages/rust/sql-lexer/src/_grammar.rs
+++ b/code/packages/rust/sql-lexer/src/_grammar.rs
@@ -75,11 +75,53 @@ pub fn token_grammar() -> TokenGrammar {
                 alias: Some(r#"NOT_EQUALS"#.to_string()),
             },
             TokenDefinition {
+                // Bitwise left shift.  Must precede the single-character `<`
+                // (LESS_THAN) below so the lexer prefers the two-character match
+                // (first-match-in-order scanning, like `<=`/`<>`).
+                name: r#"SHIFT_LEFT"#.to_string(),
+                pattern: r#"<<"#.to_string(),
+                is_regex: false,
+                line_number: 25,
+                alias: None,
+            },
+            TokenDefinition {
+                // Bitwise right shift.  Must precede the single-character `>`
+                // (GREATER_THAN) below for the same maximal-munch reason.
+                name: r#"SHIFT_RIGHT"#.to_string(),
+                pattern: r#">>"#.to_string(),
+                is_regex: false,
+                line_number: 25,
+                alias: None,
+            },
+            TokenDefinition {
                 // SQL string concatenation operator.  Must be declared BEFORE
                 // any single-pipe (|) token so the lexer always prefers the
                 // longer two-character match.
                 name: r#"CONCAT_OP"#.to_string(),
                 pattern: r#"||"#.to_string(),
+                is_regex: false,
+                line_number: 26,
+                alias: None,
+            },
+            TokenDefinition {
+                // Bitwise OR.  Declared AFTER CONCAT_OP (`||`) so the
+                // two-character concat always wins over the single pipe.
+                name: r#"BIT_OR"#.to_string(),
+                pattern: r#"|"#.to_string(),
+                is_regex: false,
+                line_number: 26,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"BIT_AND"#.to_string(),
+                pattern: r#"&"#.to_string(),
+                is_regex: false,
+                line_number: 26,
+                alias: None,
+            },
+            TokenDefinition {
+                name: r#"BIT_NOT"#.to_string(),
+                pattern: r#"~"#.to_string(),
                 is_regex: false,
                 line_number: 26,
                 alias: None,

--- a/code/packages/rust/sql-lexer/src/lib.rs
+++ b/code/packages/rust/sql-lexer/src/lib.rs
@@ -753,4 +753,23 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].0, TokenType::Star);
     }
+
+    /// The bitwise operators `& | ~ << >>` each lex to a single token with the
+    /// expected value, and — crucially — maximal munch holds: `<<`/`>>` win over
+    /// `<`/`>`, and `||` (concat) still wins over a single `|`.
+    #[test]
+    fn test_bitwise_operator_tokens() {
+        for op in ["&", "|", "~", "<<", ">>"] {
+            let pairs = lex(op);
+            assert_eq!(pairs.len(), 1, "expected one token for {op:?}");
+            assert_eq!(pairs[0].1, op, "token value mismatch for {op:?}");
+        }
+        // Maximal munch: `<<`/`>>` are one token each, not two `<`/`>`.
+        assert_eq!(lex("<<").len(), 1);
+        assert_eq!(lex(">>").len(), 1);
+        // `||` still lexes as a single concat token, not two `|` bit-ors.
+        let concat = lex("||");
+        assert_eq!(concat.len(), 1, "|| must remain one token");
+        assert_eq!(concat[0].1, "||");
+    }
 }

--- a/code/packages/rust/sql-parser/CHANGELOG.md
+++ b/code/packages/rust/sql-parser/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.13] - Unreleased
+
+### Added
+
+- **Bitwise operators in the expression grammar.** Wired the generated grammar's
+  `bitwise` precedence level (`bitwise = additive {{ ("&"|"|"|"<<"|">>") additive }}`)
+  between `additive` and `comparison` — all four are one left-associative level,
+  so `5 | 3 & 2` = `(5|3)&2`. Added the `~` (and `+`) prefix to `unary`. Both were
+  present in the grammar source but stale in the generated parser.
+
 ## [0.1.12] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-parser/Cargo.toml
+++ b/code/packages/rust/sql-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-parser"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "SQL parser — parses SQL source text into an AST using the grammar-driven parser and the sql.grammar file"
 

--- a/code/packages/rust/sql-parser/src/_grammar.rs
+++ b/code/packages/rust/sql-parser/src/_grammar.rs
@@ -431,24 +431,24 @@ pub fn parser_grammar() -> ParserGrammar {
         GrammarRule {
             name: r#"comparison"#.to_string(),
             body: GrammarElement::Sequence { elements: vec![
-                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                 GrammarElement::Optional { element: Box::new(GrammarElement::Alternation { choices: vec![
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::RuleReference { name: r#"cmp_op"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"BETWEEN"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                             GrammarElement::Literal { value: r#"AND"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"NOT"#.to_string() },
                             GrammarElement::Literal { value: r#"BETWEEN"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                             GrammarElement::Literal { value: r#"AND"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"IN"#.to_string() },
@@ -465,12 +465,12 @@ pub fn parser_grammar() -> ParserGrammar {
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"LIKE"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"NOT"#.to_string() },
                             GrammarElement::Literal { value: r#"LIKE"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         // `x GLOB pattern` — case-sensitive Unix-glob matching.
                         // SQLite defines `X GLOB Y` as `glob(Y, X)`, so the
@@ -478,12 +478,12 @@ pub fn parser_grammar() -> ParserGrammar {
                         // (args swapped); `NOT GLOB` wraps it in a logical NOT.
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"GLOB"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"NOT"#.to_string() },
                             GrammarElement::Literal { value: r#"GLOB"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"IS"#.to_string() },
@@ -502,11 +502,11 @@ pub fn parser_grammar() -> ParserGrammar {
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"IS"#.to_string() },
                             GrammarElement::Literal { value: r#"NOT"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                         GrammarElement::Sequence { elements: vec![
                             GrammarElement::Literal { value: r#"IS"#.to_string() },
-                            GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                            GrammarElement::RuleReference { name: r#"bitwise"#.to_string() },
                         ] },
                     ] }) },
             ] },
@@ -523,6 +523,27 @@ pub fn parser_grammar() -> ParserGrammar {
                 GrammarElement::Literal { value: r#">="#.to_string() },
             ] },
             line_number: 78,
+        },
+        GrammarRule {
+            // Bitwise operators `& | << >>` — one precedence level, left-
+            // associative, sitting BETWEEN additive and comparison (SQLite
+            // groups all four here). `5 | 3 & 2` = `(5|3)&2` = 2; `3+1<<2` =
+            // `(3+1)<<2` = 16. The generated rule mirrors the grammar source
+            // `bitwise = additive { ("&"|"|"|"<<"|">>") additive }`.
+            name: r#"bitwise"#.to_string(),
+            body: GrammarElement::Sequence { elements: vec![
+                GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                GrammarElement::Repetition { element: Box::new(GrammarElement::Sequence { elements: vec![
+                        GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                                GrammarElement::Literal { value: r#"&"#.to_string() },
+                                GrammarElement::Literal { value: r#"|"#.to_string() },
+                                GrammarElement::Literal { value: r#"<<"#.to_string() },
+                                GrammarElement::Literal { value: r#">>"#.to_string() },
+                            ] }) },
+                        GrammarElement::RuleReference { name: r#"additive"#.to_string() },
+                    ] }) },
+            ] },
+            line_number: 79,
         },
         GrammarRule {
             name: r#"additive"#.to_string(),
@@ -556,9 +577,17 @@ pub fn parser_grammar() -> ParserGrammar {
         },
         GrammarRule {
             name: r#"unary"#.to_string(),
+            // Prefix operators, per the grammar source `( "-" | "~" | "+" ) unary`:
+            // arithmetic negation `-`, bitwise complement `~`, and the no-op
+            // unary plus `+`. The planner maps `-`→Neg, `~`→BitNot, and treats
+            // `+x` as `x`.
             body: GrammarElement::Alternation { choices: vec![
                 GrammarElement::Sequence { elements: vec![
-                    GrammarElement::Literal { value: r#"-"#.to_string() },
+                    GrammarElement::Group { element: Box::new(GrammarElement::Alternation { choices: vec![
+                            GrammarElement::Literal { value: r#"-"#.to_string() },
+                            GrammarElement::Literal { value: r#"~"#.to_string() },
+                            GrammarElement::Literal { value: r#"+"#.to_string() },
+                        ] }) },
                     GrammarElement::RuleReference { name: r#"unary"#.to_string() },
                 ] },
                 GrammarElement::RuleReference { name: r#"primary"#.to_string() },

--- a/code/packages/rust/sql-parser/src/lib.rs
+++ b/code/packages/rust/sql-parser/src/lib.rs
@@ -639,6 +639,26 @@ mod tests {
         }
     }
 
+    /// Bitwise operators parse through the new `bitwise` precedence level and
+    /// the `~` prefix in `unary`: each operator alone, mixed precedence with
+    /// additive, and the unary complement.
+    #[test]
+    fn test_parse_bitwise() {
+        for q in [
+            "SELECT a & b FROM t",
+            "SELECT a | b FROM t",
+            "SELECT a << 2 FROM t",
+            "SELECT a >> 2 FROM t",
+            "SELECT ~a FROM t",
+            "SELECT 5 | 3 & 2 FROM t",
+            "SELECT 3 + 1 << 2 FROM t",
+            "SELECT x FROM t WHERE (a & 1) = 0",
+        ] {
+            let ast = assert_program_root(q);
+            assert!(find_rule(&ast, "bitwise"), "Expected bitwise for {q:?}");
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Test 20: BETWEEN expression
     // -----------------------------------------------------------------------

--- a/code/packages/rust/sql-planner/CHANGELOG.md
+++ b/code/packages/rust/sql-planner/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.12] - Unreleased
+
+### Added
+
+- **Bitwise `BinaryOp`/`UnaryOp` variants.** `BitAnd`/`BitOr`/`ShiftLeft`/
+  `ShiftRight` and `BitNot`; `plan_bitwise` maps the `bitwise` rule's operators
+  and `plan_unary` maps `~`. Operands are coerced to integer in the VM.
+
 ## [0.2.11] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-planner/Cargo.toml
+++ b/code/packages/rust/sql-planner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-planner"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 description = "Rust logical query planner for the mini-sqlite Level 1 pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-planner/src/lib.rs
+++ b/code/packages/rust/sql-planner/src/lib.rs
@@ -200,6 +200,11 @@ pub enum BinaryOp {
     Or,
     // String concatenation
     Concat,
+    // Bitwise — operands coerced to integer, NULL-propagating
+    BitAnd,
+    BitOr,
+    ShiftLeft,
+    ShiftRight,
 }
 
 /// A unary operator.
@@ -209,6 +214,8 @@ pub enum UnaryOp {
     Neg,
     /// Logical negation: `NOT x`
     Not,
+    /// Bitwise complement: `~x` (operand coerced to integer, NULL-propagating).
+    BitNot,
 }
 
 /// The target type of a `CAST(expr AS type)` conversion.
@@ -1777,6 +1784,7 @@ fn plan_expression(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
         "and_expr" => plan_and_expr(node),
         "not_expr" => plan_not_expr(node),
         "comparison" => plan_comparison(node),
+        "bitwise" => plan_bitwise(node),
         "additive" => plan_additive(node),
         "multiplicative" => plan_multiplicative(node),
         "unary" => plan_unary(node),
@@ -2109,6 +2117,23 @@ fn plan_additive(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
     })
 }
 
+/// Plan a `bitwise` node.
+///
+/// Grammar: `bitwise = additive { ("&" | "|" | "<<" | ">>") additive }`
+///
+/// All four operators share one precedence level and are left-associative, so
+/// `5 | 3 & 2` parses as `(5 | 3) & 2`. The VM coerces both operands to integer
+/// and propagates NULL; see `apply_binary`/`apply_shift` in sql-vm.
+fn plan_bitwise(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
+    plan_left_assoc_binary(node, |tok| match tok {
+        "&" => Some(BinaryOp::BitAnd),
+        "|" => Some(BinaryOp::BitOr),
+        "<<" => Some(BinaryOp::ShiftLeft),
+        ">>" => Some(BinaryOp::ShiftRight),
+        _ => None,
+    })
+}
+
 /// Plan a `multiplicative` node.
 ///
 /// Grammar: `multiplicative = unary { (* | / | %) unary }`
@@ -2125,7 +2150,17 @@ fn plan_multiplicative(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
 ///
 /// Grammar: `unary = "-" unary | "+" unary | primary`
 fn plan_unary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
-    if has_token(node, "-") {
+    // `-x` (arithmetic negation) and `~x` (bitwise complement) both wrap the
+    // inner operand; `+x` is a no-op handled by the fall-through below. `~`
+    // coerces its operand to integer and propagates NULL (see the VM).
+    let unary_op = if has_token(node, "-") {
+        Some(UnaryOp::Neg)
+    } else if has_token(node, "~") {
+        Some(UnaryOp::BitNot)
+    } else {
+        None
+    };
+    if let Some(op) = unary_op {
         let inner = node
             .children
             .iter()
@@ -2136,9 +2171,9 @@ fn plan_unary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
                     None
                 }
             })
-            .ok_or_else(|| PlanError::UnsupportedStatement("unary minus without operand".to_string()))?;
+            .ok_or_else(|| PlanError::UnsupportedStatement("unary operator without operand".to_string()))?;
         return Ok(SqlExpr::UnaryOp {
-            op: UnaryOp::Neg,
+            op,
             expr: Box::new(plan_expression(inner)?),
         });
     }
@@ -2191,8 +2226,8 @@ fn plan_primary(node: &GrammarASTNode) -> Result<SqlExpr, PlanError> {
                 "column_ref" => return plan_column_ref(n),
                 "function_call" => return plan_function_call(n),
                 "expr" => return plan_expression(n),
-                "or_expr" | "and_expr" | "not_expr" | "comparison" | "additive"
-                | "multiplicative" | "unary" | "primary" => return plan_expression(n),
+                "or_expr" | "and_expr" | "not_expr" | "comparison" | "bitwise"
+                | "additive" | "multiplicative" | "unary" | "primary" => return plan_expression(n),
                 _ => return plan_expression(n),
             },
             ASTNodeOrToken::Token(tok) => {

--- a/code/packages/rust/sql-vm/CHANGELOG.md
+++ b/code/packages/rust/sql-vm/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.15] - Unreleased
+
+### Added
+
+- **Execute bitwise ops.** `&`/`|`/`~` coerce operands to integer (reusing the
+  CAST slice's integer affinity), propagate NULL, and complement/AND/OR as i64.
+  Shifts go through new `sql_shift`, which implements SQLite's exact rules —
+  negative count flips direction, count ≥ 64 saturates (left → 0; right → 0/−1
+  by sign), right shift is arithmetic — avoiding Rust's shift-overflow UB via
+  `wrapping_shl` and width-checked branches.
+
 ## [0.4.14] - Unreleased
 
 ### Added

--- a/code/packages/rust/sql-vm/Cargo.toml
+++ b/code/packages/rust/sql-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-sql-vm"
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 description = "Stack-machine bytecode VM for the Mini-SQLite SQL processing pipeline"
 license = "MIT"

--- a/code/packages/rust/sql-vm/src/lib.rs
+++ b/code/packages/rust/sql-vm/src/lib.rs
@@ -1925,8 +1925,69 @@ fn eval_binary(op: &BinaryOp, l: SqlValue, r: SqlValue) -> Result<SqlValue, VmEr
             Ok(SqlValue::Text(ls + &rs))
         }
 
+        // ── Bitwise ───────────────────────────────────────────────────────────
+        //
+        // Both operands are coerced to integer (SQLite integer affinity: reals
+        // truncate toward zero, text prefix-parses). NULL was already handled
+        // above, so these never see NULL. `&`/`|` are plain i64 bit ops; shifts
+        // follow SQLite's saturate-and-negate rules in `sql_shift`.
+        BinaryOp::BitAnd => Ok(SqlValue::Int(cast_to_i64(&l) & cast_to_i64(&r))),
+        BinaryOp::BitOr => Ok(SqlValue::Int(cast_to_i64(&l) | cast_to_i64(&r))),
+        BinaryOp::ShiftLeft => {
+            Ok(SqlValue::Int(sql_shift(cast_to_i64(&l), cast_to_i64(&r), true)))
+        }
+        BinaryOp::ShiftRight => {
+            Ok(SqlValue::Int(sql_shift(cast_to_i64(&l), cast_to_i64(&r), false)))
+        }
+
         // AND/OR already handled above.
         BinaryOp::And | BinaryOp::Or => unreachable!(),
+    }
+}
+
+/// SQLite's bit-shift semantics for `value << count` / `value >> count`.
+///
+/// Rust's own `<<`/`>>` are Undefined Behaviour (they panic in debug) once the
+/// shift amount reaches the type width, so we cannot use them directly on
+/// attacker-controlled counts. SQLite instead defines every count precisely
+/// (verified against the C library):
+///
+/// | input        | result | why                                        |
+/// |--------------|--------|--------------------------------------------|
+/// | `1 << 64`    | 0      | count ≥ 64 on a left shift → 0             |
+/// | `8 >> 100`   | 0      | count ≥ 64, value ≥ 0 → 0                  |
+/// | `-1 >> 1`    | -1     | right shift is arithmetic (sign-extending) |
+/// | `-4 >> 100`  | -1     | count ≥ 64, value < 0 → -1                 |
+/// | `1 << -1`    | 0      | negative count flips direction: `1 >> 1`   |
+///
+/// The rules: a negative count shifts the *other* direction by its magnitude; a
+/// count ≥ 64 saturates (left → 0; right → 0 for a non-negative value, −1 for a
+/// negative one because the sign bit fills); otherwise a normal shift, using an
+/// unsigned left shift so it can never overflow and an `i64` (arithmetic) right
+/// shift so negatives sign-extend — exactly matching SQLite's implementation.
+fn sql_shift(value: i64, count: i64, left: bool) -> i64 {
+    let mut do_left = left;
+    // Magnitude of the shift; a negative count means shift the other way.
+    // `i64::MIN.unsigned_abs()` is 2^63, well past 64, so it saturates below.
+    let amount: u64 = if count < 0 {
+        do_left = !do_left;
+        count.unsigned_abs()
+    } else {
+        count as u64
+    };
+
+    if amount >= 64 {
+        // Saturated: a left shift (or any shift of a non-negative value) yields
+        // 0; a right shift of a negative value fills with sign bits → -1.
+        return if value >= 0 || do_left { 0 } else { -1 };
+    }
+    let amount = amount as u32;
+    if do_left {
+        // Unsigned shift cannot be UB and matches SQLite's `(i64)((u64)iA<<iB)`.
+        (value as u64).wrapping_shl(amount) as i64
+    } else {
+        // i64 `>>` is arithmetic in Rust, sign-extending like SQLite.
+        value >> amount
     }
 }
 
@@ -2012,6 +2073,9 @@ fn eval_unary(op: &UnaryOp, v: SqlValue) -> Result<SqlValue, VmError> {
                 other => Ok(other), // non-numeric: leave unchanged
             },
             UnaryOp::Not => Ok(SqlValue::Bool(!is_truthy(&v))),
+            // `~x` — coerce to integer (SQLite integer affinity) then complement.
+            // `~0` = -1, `~-1` = 0. NULL was handled above.
+            UnaryOp::BitNot => Ok(SqlValue::Int(!cast_to_i64(&v))),
         },
     }
 }


### PR DESCRIPTION
## Bitwise operators `& | ~ << >>`

Adds SQLite's bitwise operators **end-to-end** — lexer → grammar → planner →
codegen → VM. **Rotation lane 2 (operators).** The largest slice this rotation:
it needed all five pipeline layers because the lexer didn't tokenize `& | ~ << >>`
and the generated parser's `bitwise` level + `~` prefix were stale.

### Behaviour (probed against real SQLite first)
| Expr | Result | Note |
|---|---|---|
| `5 & 3` / `5 \| 2` / `~0` | 1 / 7 / -1 | basic |
| `1 << 4` / `256 >> 2` | 16 / 64 | shifts |
| `2.9 & 1` | 0 | real → int (truncate toward 0) |
| `NULL & 1`, `~NULL` | NULL | NULL propagates |
| `5 \| 3 & 2` | 2 | `(5\|3)&2` — one left-assoc level |
| `3 + 1 << 2` | 16 | `+` binds tighter than `<<` |
| `1 << 64` / `8 >> 100` | 0 | count ≥ 64 saturates |
| `1 << -1` | 0 | negative count flips → `1 >> 1` |
| `-1 >> 1` | -1 | right shift is arithmetic |

### Layers
- **sql-lexer 0.1.2** — tokens `& | ~ << >>`. Maximal munch preserved: `<<`/`>>`
  before single `<`/`>`, `|` after `||`.
- **sql-parser 0.1.13** — wired the generated grammar's `bitwise` level between
  `additive` and `comparison`, and the `~`/`+` prefix in `unary` (both were in the
  grammar source but stale in the generated parser).
- **sql-planner 0.2.12** — `BitAnd`/`BitOr`/`ShiftLeft`/`ShiftRight` + `BitNot`;
  `plan_bitwise` and `~` in `plan_unary`.
- **sql-codegen 0.6.5** — emit via `map_binary_op`/`map_unary_op`.
- **sql-vm 0.4.15** — integer-affinity coercion (reused from the CAST slice),
  NULL propagation, and a new `sql_shift` implementing SQLite's exact shift rules
  **without Rust's shift-overflow UB** (`wrapping_shl` + width-checked branches).
- **mini-sqlite 0.5.29** — 7 differential-oracle cases.

`sql-optimizer` was **not** bumped — its constant-fold has a catch-all, so the new
variants pass through unfolded (correct) with no source change.

### Tests
Lexer token + maximal-munch test, parser bitwise + precedence test, and 7
differential-oracle cases (each operator, precedence, real truncation, NULL, shift
edges incl. `1<<64`/`1<<-1`/`-1>>1`, and a table column) diffed against real
bundled SQLite. Full affected set green; clippy clean.

### Security
Inline adversarial review **PASSED** — reviewer traced `sql_shift` for every
`(value, count)` including `i64::MIN`/`i64::MAX`/negative/≥64 counts and confirmed
**no shift-overflow UB and no panic** on any attacker input; `cast_to_i64`'s
float→int cast is saturating (NaN→0, ±inf→i64::MIN/MAX), so coercion is panic-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
