### PR TITLE
feat(adj-formula-stdlib): grounded physics work + kinetic-energy formula library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_energy_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_energy_e2e.rs
@@ -1,0 +1,107 @@
+//! End-to-end tests for the `physics/energy-work.adj` library — the foundational
+//! mechanics laws (work and kinetic energy) — driven through the built CLI binary
+//! against the SHIPPED stdlib. Each proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library,
+//! binds the physical quantities with `observe`, and the engine applies the cited
+//! law on the CPU — computing the EXACT value and rendering the applied law's
+//! citation + trust tier in the `derived` section (the auditable answer).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped physics library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_energy_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/energy-work.adj")
+        .canonicalize()
+        .expect("shipped energy-work.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_energy_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_energy_lib()).unwrap();
+    std::fs::write(dir.join("energy-work.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// work — the product of a force and the distance through which it acts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_energy_library_and_computes_work_with_citation() {
+    let dir = scratch("work");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"energy-work.adj\"\n\
+         observe force(10)\n\
+         observe distance(3)\n\
+         ? work(force, distance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied law's result: 10 * 3 = 30.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"work\"") && s.contains("\"value\":30"),
+        "work(10, 3) = 30: {s}"
+    );
+    // … AND the NASA citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("grc.nasa.gov/www/k-12/airplane/work.html"),
+        "applied law carries its cited provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// kinetic_energy — half the mass times the square of the speed (a distinct law
+// and a distinct source).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computes_kinetic_energy_as_half_mass_velocity_squared_with_citation() {
+    let dir = scratch("ke");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"energy-work.adj\"\n\
+         observe mass(2)\n\
+         observe velocity(3)\n\
+         ? kinetic_energy(mass, velocity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // 0.5 * 2 * 3 * 3 = 9, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"kinetic_energy\"") && s.contains("\"value\":9"),
+        "kinetic_energy(2, 3) = 9: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("hyperphysics.gsu.edu/hbase/ke.html"),
+        "kinetic energy carries its HyperPhysics citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/energy-work.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/energy-work.adj
@@ -1,0 +1,80 @@
+% ============================================================================
+% energy-work.adj — foundational physics laws in the ADJ standard library.
+% ============================================================================
+% The FIRST entry of the *physics* track of the compute standard library: two of
+% the laws a first mechanics course opens with — the definition of WORK and the
+% KINETIC ENERGY of a moving mass — each an importable, byte-provenanced,
+% PARAMETERIZED `formula`. Like `mathematics/geometry-formulas.adj` and
+% `clinical/bmi.adj`, a consumer states NO arithmetic: it `import`s this file,
+% binds the physical quantities from its own byte-provenance decomposition, and
+% asks the engine to APPLY the cited law on the CPU. Zero math is performed by the
+% model; the engine computes each value EXACTLY, carrying the law's citation.
+%
+%     import "energy-work.adj"
+%     observe force(10)     % "…a 10 N push…"      (span cited by the model)
+%     observe distance(3)   % "…over 3 m…"         (span cited by the model)
+%     ? work(force, distance)          % engine → 30, carrying NASA's W = F·d
+%
+% Both laws are EXACT over their parameters — work is a product of two quantities,
+% kinetic energy the product of the (exact, dimensionless) constant ½ with a mass
+% and the square of a speed. There is no *separately grounded* physical constant
+% here (no G, no c), so every value the engine returns is exact; laws that need a
+% measured constant belong in a different, constant-carrying library.
+%
+%   work(force, distance)          = force · distance          %  W = F d
+%   kinetic_energy(mass, velocity) = ½ · mass · velocity²       %  KE = ½ m v²
+%
+% The definitions are quoted from primary references — NASA Glenn Research Center
+% (a .gov primary source) for work, and Georgia State University's HyperPhysics (a
+% university .edu physics reference) for kinetic energy — so each `formula` carries
+% the same provenance envelope every shipped grounded clause carries; the linter
+% rejects an unsourced one.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each parameter is an observable physical quantity the laws range
+% over, and each result is the derived quantity. Rung-0's grammar types an
+% observable slot as `finding` (dimensional typing of parameters is a later rung —
+% the engine already infers + checks dimensions when a law is APPLIED: force·
+% distance reports an energy, ½·mass·speed² reports an energy too, which is exactly
+% why the two answers share a unit). The `surface` lists are the everyday names a
+% decomposer maps onto the canonical term; the trailing comment records the
+% intended SI dimension.
+% ----------------------------------------------------------------------------
+dictionary physics_vocab {
+    define force          : finding  surface "force", "applied force", "F"          % force, e.g. N
+    define distance       : finding  surface "distance", "displacement", "d", "s"   % length, e.g. m
+    define mass           : finding  surface "mass", "m"                            % mass, e.g. kg
+    define velocity       : finding  surface "velocity", "speed", "v"              % length/time, e.g. m/s
+
+    define work           : finding  surface "work", "work done", "W"              % energy, e.g. J
+    define kinetic_energy : finding  surface "kinetic energy", "KE"                % energy, e.g. J
+}
+
+% ----------------------------------------------------------------------------
+% The laws. Each is a named, importable, reusable `let` over its formal parameters,
+% bound at apply time, and each carries a definitional quote from a primary source
+% (required on a shipped formula). Kinetic energy is written with the ½ folded to
+% its decimal literal `0.5` and the square spelled `velocity * velocity` — the
+% surface expression grammar supports + - * / and parentheses, and a parameter may
+% recur, so v² is exactly `velocity * velocity`.
+% ----------------------------------------------------------------------------
+formulabook physics_energy {
+    use physics_vocab
+
+    % Work — the product of a force and the distance through which it acts.
+    % NASA Glenn Research Center (Beginner's Guide to Aeronautics) defines work
+    % this way and gives the formula W = F * s.
+    formula work(force, distance) = force * distance
+        source "For scientists, work is the product of a force acting through a distance."
+        locator "https://www.grc.nasa.gov/www/k-12/airplane/work.html"
+        trust authoritative
+
+    % Kinetic energy — one half the mass times the square of the speed. Georgia
+    % State University's HyperPhysics states "The kinetic energy of a point mass m
+    % is given by" the equation KE = (1/2) m v².
+    formula kinetic_energy(mass, velocity) = 0.5 * mass * velocity * velocity
+        source "The kinetic energy of a point mass m is given by"
+        locator "https://hyperphysics.gsu.edu/hbase/ke.html"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/energy-work.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/energy-work.query.adj
@@ -1,0 +1,25 @@
+% ============================================================================
+% energy-work.query.adj — worked examples over the physics energy/work library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a mechanics
+% question: it states NO arithmetic and NO law — it only `import`s the grounded
+% library, `observe`s the physical quantities it decomposed from the prompt (each
+% a byte-provenanced span, elided here), and asks the engine to APPLY the cited
+% law. The native adj-lang engine binds the parameters, computes each value
+% EXACTLY on the CPU, and returns it with the law's source/locator/trust.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli energy-work.query.adj
+% ============================================================================
+
+import "energy-work.adj"
+
+% A 10 N force acting through 3 m: work = 10 * 3.
+observe force(10)
+observe distance(3)
+? work(force, distance)               % expect 30  (NASA: W = F d)
+
+% A 2 kg mass moving at 3 m/s: KE = ½ * 2 * 3².
+observe mass(2)
+observe velocity(3)
+? kinetic_energy(mass, velocity)      % expect 9   (HyperPhysics: KE = ½ m v²)


### PR DESCRIPTION
## What

Adds the first **physics** track entry of the ADJ compute standard library: `code/specs/data/adj-formula-stdlib/physics/energy-work.adj` (`formulabook physics_energy`), encoding two foundational mechanics laws as importable, byte-provenanced, parameterized formulas that the native adj-lang engine applies **exactly on the CPU**:

| formula | expression | law |
| --- | --- | --- |
| `work(force, distance)` | `force * distance` | W = F·d |
| `kinetic_energy(mass, velocity)` | `0.5 * mass * velocity * velocity` | KE = ½mv² |

A consumer states **no arithmetic**: it `import`s the grounded library, binds quantities with `observe`, and the engine returns each exact value with its citation + trust tier in the `derived` section.

## Grounding (rigorous provenance)

Each formula carries a verbatim definitional quote and a real locator; nothing from memory.

- **work** — NASA Glenn Research Center (`grc.nasa.gov`, .gov primary source), **trust `authoritative`**
  - verbatim: *"For scientists, work is the product of a force acting through a distance."*
  - locator: https://www.grc.nasa.gov/www/k-12/airplane/work.html
- **kinetic_energy** — Georgia State University HyperPhysics (`hyperphysics.gsu.edu`, university .edu physics reference), **trust `authoritative`**
  - verbatim: *"The kinetic energy of a point mass m is given by"* (KE = ½ m v²)
  - locator: https://hyperphysics.gsu.edu/hbase/ke.html

## Files

- `physics/energy-work.adj` — the grounded formula library (literate).
- `physics/energy-work.query.adj` — worked consumer: `work(10,3)=30`, `kinetic_energy(2,3)=9`.
- `adj-lang-cli/tests/formula_energy_e2e.rs` — e2e test mirroring the geometry library test; asserts both values and both citations through the built CLI against the shipped stdlib.

## Verification

- `cargo test -p adj-lang-cli --test formula_energy_e2e` — 2 passed.
- `cargo clippy -p adj-lang-cli --test formula_energy_e2e -- -D warnings` — clean.
- Query file runs end-to-end: `work=30`, `kinetic_energy=9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)