### PR TITLE
feat(adj-facts-stdlib): biology cell-organelle → primary-function library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_organelles_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_organelles_e2e.rs
@@ -1,0 +1,68 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/cell-organelles.adj`) driven through the built CLI:
+//! a native `table` of organelle → primary-function resolves a binding-query
+//! recall with the source's citation, runs the relation backward
+//! (function → organelle), and abstains on a non-organelle — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsbio_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_organelles_recall_binds_function_with_citation() {
+    let dir = scratch("organelles");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/cell-organelles.adj");
+    std::fs::copy(&src, dir.join("cell-organelles.adj")).expect("copy shipped cell-organelles.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"cell-organelles.adj\"\n\
+         ? organelle_function(mitochondrion, $F)\n\
+         ? organelle_function(ribosome, $F)\n\
+         ? organelle_function($O, photosynthesis)\n\
+         ? organelle_function(smartphone, $F)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // The mitochondrion produces energy; the ribosome makes protein — the
+    // recalled primary-function atoms.
+    assert!(out.contains("\"F\":\"produces_energy\""), "mitochondrion → produces_energy: {out}");
+    assert!(out.contains("\"F\":\"makes_protein\""), "ribosome → makes_protein: {out}");
+    // The relation runs backward: the function photosynthesis recalls chloroplast.
+    assert!(
+        out.contains("\"O\":\"chloroplast\""),
+        "photosynthesis → chloroplast (reverse recall): {out}"
+    );
+    // The answer carries the Wikipedia citation as its proof.
+    assert!(
+        out.contains("en.wikipedia.org/wiki/Organelle") && out.contains("\"trust\":\"consensus\""),
+        "carries the source citation: {out}"
+    );
+    // "smartphone" is not a cell organelle — honest abstention, never a
+    // fabricated function.
+    assert!(out.contains("\"abstained\":true"), "non-organelle abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/cell-organelles.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/cell-organelles.adj
@@ -1,0 +1,70 @@
+% ============================================================================
+% cell-organelles — each eukaryotic cell organelle and its primary function
+% (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% A biology facts library in the ADJ standard library — the kind a medicine or
+% science agent `import`s when it needs a grounded cell-biology fact: "the
+% mitochondrion produces energy; the nucleus maintains the DNA; the ribosome
+% makes protein." A cell is built from membrane-bound compartments called
+% organelles, and each organelle carries out one primary job. Recall is a
+% binding query:
+%
+%     ? organelle_function(mitochondrion, $F)   % produces_energy
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `organelle_function(organelle, function)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the function atom WITH its source, on the CPU, with zero model calls,
+% and abstains on an organelle (or non-organelle) not in the table. The query
+% also runs BACKWARD — bind the function and recall the organelle:
+%
+%     ? organelle_function($O, photosynthesis)  % chloroplast
+%
+% The `function` value of every row is a SINGLE lowercase atom, chosen to be a
+% faithful one-word paraphrase of the primary-function text the source states —
+% never an interpretation the source does not support. A recalled function atom
+% therefore composes straight into downstream reasoning (a medicine agent asking
+% "which organelle produces_energy?" gets the grounded answer, not a guess) —
+% the concrete bridge from biology RECALL to reasoning.
+%
+% Provenance: every organelle name and its `function` atom is grounded in the
+% "Main function" column of the organelle tables on the Wikipedia "Organelle"
+% article (the citable artifact at the `locator`, which lists all rows below).
+% The `source` span is the VERBATIM "Main function" cell for the first data row
+% (mitochondrion), copied character-for-character from that page. The remaining
+% rows' atoms are each a faithful one-word paraphrase of that same column's cell
+% for their organelle:
+%
+%     nucleus                → "DNA maintenance, controls all activities …"    → maintains_dna
+%     ribosome               → "translation of RNA into proteins"              → makes_protein
+%     chloroplast            → "photosynthesis, traps energy from sunlight"     → photosynthesis
+%     endoplasmic_reticulum  → "translation and folding of new proteins …"     → folds_proteins
+%     golgi_apparatus        → "sorting, packaging, processing … of proteins"   → packages_proteins
+%     vacuole                → "storage, transportation, helps maintain …"     → storage
+%     lysosome               → "breakdown of large molecules …"                → breaks_down_molecules
+%
+% `trust consensus` — an encyclopedia (collaboratively edited reference), the
+% honest tier for a Wikipedia source (contrast the `authoritative` tier reserved
+% for a primary government reference such as NIH/NHGRI). Nothing here is asserted
+% from memory; each pair was read out of the fetched article and any organelle
+% whose function the article did not state would have been dropped.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_adjudication_no_interpretive_gating.)
+% ============================================================================
+
+table organelle_function {
+    columns organelle, function
+
+    row (mitochondrion, produces_energy)
+    row (nucleus, maintains_dna)
+    row (ribosome, makes_protein)
+    row (chloroplast, photosynthesis)
+    row (endoplasmic_reticulum, folds_proteins)
+    row (golgi_apparatus, packages_proteins)
+    row (vacuole, storage)
+    row (lysosome, breaks_down_molecules)
+
+    source "energy production from the oxidation of glucose substances and the release of adenosine triphosphate"
+    locator "https://en.wikipedia.org/wiki/Organelle"
+    trust consensus
+}

--- a/code/specs/data/adj-facts-stdlib/biology/cell-organelles.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/cell-organelles.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% cell-organelles.query.adj — a worked recall over the biology organelles library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does the mitochondrion
+% do?": it states no biology fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `organelle_function`
+% rows and returns the function atom + the table's source/locator/trust. The
+% fourth query runs the relation BACKWARD (bind the function, recall the
+% organelle). An organelle (or non-organelle) not in the table abstains honestly —
+% the engine never invents a function.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli cell-organelles.query.adj
+% ============================================================================
+
+import "cell-organelles.adj"
+
+? organelle_function(mitochondrion, $F)   % expect produces_energy
+? organelle_function(ribosome, $F)        % expect makes_protein
+? organelle_function(nucleus, $F)         % expect maintains_dna
+? organelle_function($O, photosynthesis)  % expect chloroplast — the reverse recall
+? organelle_function(smartphone, $F)      % expect abstain — not a cell organelle


### PR DESCRIPTION
## What

Adds a grounded **BIOLOGY** facts library to the ADJ standard library: a native `table organelle_function` mapping each eukaryotic cell organelle to its primary function.

| organelle | function |
|-----------|----------|
| mitochondrion | produces_energy |
| nucleus | maintains_dna |
| ribosome | makes_protein |
| chloroplast | photosynthesis |
| endoplasmic_reticulum | folds_proteins |
| golgi_apparatus | packages_proteins |
| vacuole | storage |
| lysosome | breaks_down_molecules |

A binding query `? organelle_function(mitochondrion, $F)` recalls the function atom **with its citation** on the CPU, zero model calls; it runs backward (`? organelle_function($O, photosynthesis)` → chloroplast) and abstains honestly on a non-organelle.

## Grounding / provenance

Every organelle/function pair is grounded in the **"Main function"** column of the organelle tables on the Wikipedia **"Organelle"** article (`https://en.wikipedia.org/wiki/Organelle`). The `source` span is the **verbatim** mitochondrion cell — *"energy production from the oxidation of glucose substances and the release of adenosine triphosphate"* — and each function atom is a faithful one-word paraphrase of that column's cell for its organelle (documented row-by-row in the literate comment). **`trust consensus`** (encyclopedia; `authoritative` is reserved for primary government references). Nothing asserted from memory.

## Files (data + one test only)

- `code/specs/data/adj-facts-stdlib/biology/cell-organelles.adj` — grounded table + literate provenance comment
- `code/specs/data/adj-facts-stdlib/biology/cell-organelles.query.adj` — worked recall (forward, reverse, abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_organelles_e2e.rs` — e2e: two bindings, reverse recall, locator substring + `trust:consensus`, abstain

## Verification

- `cargo test -p adj-lang-cli --test facts_organelles_e2e` — passes
- `cargo clippy -p adj-lang-cli --test facts_organelles_e2e -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)