### PR TITLE
feat(adj-facts-stdlib): grounded anatomy body-counts facts library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_anatomy_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_anatomy_e2e.rs
@@ -1,0 +1,70 @@
+//! End-to-end test for the anatomy FACTS library
+//! (`adj-facts-stdlib/anatomy/body-counts.adj`) driven through the built CLI:
+//! a native `table` of structure → count resolves a binding-query recall with
+//! the source's citation, runs the relation backward (count → structure), and
+//! abstains on a structure not in the table — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsanat_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn anatomy_body_counts_recall_binds_count_with_citation() {
+    let dir = scratch("bodycounts");
+    // Copy the shipped anatomy table beside the entry program and import it.
+    let src = facts_stdlib().join("anatomy/body-counts.adj");
+    std::fs::copy(&src, dir.join("body-counts.adj")).expect("copy shipped body-counts.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"body-counts.adj\"\n\
+         ? body_count(chromosomes, $N)\n\
+         ? body_count(heart_chambers, $N)\n\
+         ? body_count(pairs_of_ribs, $N)\n\
+         ? body_count($S, 206)\n\
+         ? body_count(spleens, $N)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // A human cell carries 46 chromosomes; the heart has 4 chambers; there are
+    // twelve pairs of ribs — the recalled counts, each a plain number.
+    assert!(out.contains("\"N\":\"46\""), "chromosomes → 46: {out}");
+    assert!(out.contains("\"N\":\"4\""), "heart_chambers → 4: {out}");
+    assert!(out.contains("\"N\":\"12\""), "pairs_of_ribs → 12: {out}");
+    // The relation runs backward: the count 206 recalls the adult bone total.
+    assert!(
+        out.contains("\"S\":\"bones_in_adult_body\""),
+        "206 → bones_in_adult_body (reverse recall): {out}"
+    );
+    // The answer carries the NHGRI genome.gov citation as its proof.
+    assert!(
+        out.contains("genome.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // "spleens" is not a structure in the table — honest abstention, never a
+    // fabricated count.
+    assert!(out.contains("\"abstained\":true"), "unknown structure abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/body-counts.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/body-counts.adj
@@ -1,0 +1,87 @@
+% ============================================================================
+% body-counts — how many of each major structure the human body has
+% (adj-facts-stdlib, ANATOMY).
+% ============================================================================
+% An anatomy facts library in the ADJ standard library — the kind a MEDICINE
+% agent `import`s when it needs a grounded, citable structural fact about the
+% human body: "an adult skeleton has 206 bones," "the heart has 4 chambers," "a
+% human cell carries 46 chromosomes." These are the counts a clinician reasons
+% FROM — a rib-fracture note that reads "fracture of the 13th rib" is suspect
+% because there are only twelve pairs; a karyotype with 47 chromosomes is a
+% trisomy precisely because the normal count is 46. Recall is a binding query:
+%
+%     ? body_count(heart_chambers, $N)      % 4
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `body_count(structure, count)` carrying the table's citation, so the
+% lookup above is the ordinary SLD binding query — the engine returns the number
+% WITH its source, on the CPU, with zero model calls, and abstains on a
+% structure not in the table (it never invents a count). The query also runs
+% BACKWARD — bind a count and recall the structure(s) that have it:
+%
+%     ? body_count($S, 206)                 % bones_in_adult_body
+%
+% Because each `count` value is a NUMBER (not a label), a recalled count
+% composes straight into arithmetic and constraint checks: `pairs_of_ribs` (12)
+% doubles to 24 individual ribs; an observed chromosome count can be compared to
+% 46 to flag aneuploidy — the concrete bridge from anatomy RECALL to COMPUTE.
+%
+% ---------------------------------------------------------------------------
+% Provenance (nothing here is asserted from memory — every count below was read
+% out of a fetched authoritative page, and any count that could not be verified
+% there would have been dropped). Each structure→count pair, with the primary
+% U.S. government / NIH source it was copied from and the verbatim span that
+% states it:
+%
+%   chromosomes → 46
+%     https://www.genome.gov/genetics-glossary/Chromosome  (NIH / NHGRI)
+%     "Humans have 22 pairs of numbered chromosomes (autosomes) and one pair
+%      of sex chromosomes (XX or XY), for a total of 46."
+%
+%   bones_in_adult_body → 206
+%     https://www.ncbi.nlm.nih.gov/books/NBK537199/  (NIH / NLM, StatPearls)
+%     "Human infants typically have 270 bones, fusing into around 206 in the
+%      human adult."
+%
+%   heart_chambers → 4
+%     https://www.nhlbi.nih.gov/health/heart/anatomy  (NIH / NHLBI)
+%     "It has four hollow chambers surrounded by muscle and other heart tissue."
+%
+%   lungs → 2
+%     https://www.nhlbi.nih.gov/health/lungs  (NIH / NHLBI)
+%     "the pair of spongy, pinkish-gray organs in your chest"
+%
+%   pairs_of_ribs → 12
+%     https://www.ncbi.nlm.nih.gov/books/NBK538328/  (NIH / NLM, StatPearls)
+%     "Generally, there are twelve pairs of ribs."
+%
+%   kidneys → 2
+%     https://training.seer.cancer.gov/anatomy/urinary/components/kidney.html
+%     (NIH / NCI SEER Training)
+%     "The paired kidneys are located between the twelfth thoracic and third
+%      lumbar vertebrae, one on each side of the vertebral column."
+%
+% An ADJ `table` carries ONE provenance envelope, so the `source`/`locator`/
+% `trust` below hold the single strongest span: the explicitly numeric NHGRI
+% statement that fixes the first row (chromosomes → 46). Every OTHER row's
+% per-fact source and verbatim span is listed above, so each count remains
+% independently checkable. All six sources are primary U.S. government / NIH
+% references, so `trust authoritative`.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table body_count {
+    columns structure, count
+
+    row (chromosomes, 46)
+    row (bones_in_adult_body, 206)
+    row (heart_chambers, 4)
+    row (lungs, 2)
+    row (pairs_of_ribs, 12)
+    row (kidneys, 2)
+
+    source "Humans have 22 pairs of numbered chromosomes (autosomes) and one pair of sex chromosomes (XX or XY), for a total of 46."
+    locator "https://www.genome.gov/genetics-glossary/Chromosome"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/anatomy/body-counts.query.adj
+++ b/code/specs/data/adj-facts-stdlib/anatomy/body-counts.query.adj
@@ -1,0 +1,22 @@
+% ============================================================================
+% body-counts.query.adj — a worked recall over the anatomy body-counts library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "how many chambers does
+% the heart have?": it states no anatomy fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `body_count` rows and returns the number + the table's source/locator/trust.
+% The fourth query runs the relation BACKWARD (bind the count, recall the
+% structure). A structure not in the table abstains honestly — the engine never
+% invents a count.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli body-counts.query.adj
+% ============================================================================
+
+import "body-counts.adj"
+
+? body_count(chromosomes, $N)          % expect 46
+? body_count(heart_chambers, $N)       % expect 4
+? body_count(pairs_of_ribs, $N)        % expect 12
+? body_count($S, 206)                  % expect bones_in_adult_body — reverse recall
+? body_count(spleens, $N)              % expect abstain — not in the table


### PR DESCRIPTION
## What

Adds an **ANATOMY** subject library to `adj-facts-stdlib`: a native ADJ `table` mapping human-body structures to their counts, so a medicine agent can `import` it and recall a grounded, citable structural fact with zero answer-time model calls.

| structure | count |
|---|---|
| chromosomes | 46 |
| bones_in_adult_body | 206 |
| heart_chambers | 4 |
| lungs | 2 |
| pairs_of_ribs | 12 |
| kidneys | 2 |

Each `row` lowers to a ground `body_count(structure, count)` relation, so recall is an ordinary SLD binding query: it returns the number **with its citation**, runs **backward** (count → structure), and **abstains** on an unknown structure (never invents a count). Because each count is a NUMBER, it composes straight into arithmetic/constraint checks (e.g. 47 chromosomes flags aneuploidy vs. the normal 46).

## Grounding (nothing from memory)

Every count was copied verbatim from a fetched **primary U.S. government / NIH** page; per-fact source URLs + verbatim spans are recorded in the literate header. The table's single provenance envelope carries the strongest explicitly-numeric span (chromosomes → 46, NHGRI genome.gov). `trust authoritative`.

- **chromosomes → 46** — NHGRI [genome.gov](https://www.genome.gov/genetics-glossary/Chromosome): "Humans have 22 pairs of numbered chromosomes (autosomes) and one pair of sex chromosomes (XX or XY), for a total of 46."
- **bones_in_adult_body → 206** — NLM/NCBI StatPearls [NBK537199](https://www.ncbi.nlm.nih.gov/books/NBK537199/): "Human infants typically have 270 bones, fusing into around 206 in the human adult."
- **heart_chambers → 4** — NHLBI [heart/anatomy](https://www.nhlbi.nih.gov/health/heart/anatomy): "It has four hollow chambers surrounded by muscle and other heart tissue."
- **lungs → 2** — NHLBI [health/lungs](https://www.nhlbi.nih.gov/health/lungs): "the pair of spongy, pinkish-gray organs in your chest"
- **pairs_of_ribs → 12** — NLM/NCBI StatPearls [NBK538328](https://www.ncbi.nlm.nih.gov/books/NBK538328/): "Generally, there are twelve pairs of ribs."
- **kidneys → 2** — NCI SEER Training [urinary/kidney](https://training.seer.cancer.gov/anatomy/urinary/components/kidney.html): "The paired kidneys are located between the twelfth thoracic and third lumbar vertebrae, one on each side of the vertebral column."

## Files

- `code/specs/data/adj-facts-stdlib/anatomy/body-counts.adj` — the grounded table + literate provenance
- `code/specs/data/adj-facts-stdlib/anatomy/body-counts.query.adj` — worked recall example (forward, reverse, abstain)
- `code/packages/rust/adj-lang-cli/tests/facts_anatomy_e2e.rs` — one e2e test (chromosomes→46, heart→4, ribs→12, 206→bones reverse, genome.gov locator + authoritative trust, abstain on unknown)

## Verification

- `cargo test -p adj-lang-cli --test facts_anatomy_e2e` — passes
- `cargo clippy -p adj-lang-cli --test facts_anatomy_e2e -- -D warnings` — clean
- Security review (sub-agent) — passed, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)