### PR TITLE
feat(adj-formula-stdlib): grounded NIST temperature conversion formula library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_temperature_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_temperature_e2e.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for the `metrology/temperature.adj` library — the
+//! temperature-scale conversion formulas — driven through the built CLI binary
+//! against the SHIPPED stdlib. Each proves the same invariant as the other
+//! formula libraries: a consumer states NO arithmetic; it imports the grounded
+//! library, binds a reading with `observe`, and the engine applies the cited
+//! formula on the CPU — computing the EXACT value and rendering the applied
+//! formula's NIST citation + trust tier in the `derived` section (the auditable
+//! answer).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped temperature library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_temperature_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/metrology/temperature.adj")
+        .canonicalize()
+        .expect("shipped temperature.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_temp_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Copy the shipped library next to a consumer that imports it, so the CLI's
+/// sandbox-checked relative import resolves.
+fn place_lib(dir: &Path) {
+    let lib = std::fs::read_to_string(shipped_temperature_lib()).unwrap();
+    std::fs::write(dir.join("temperature.adj"), lib).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// fahrenheit(celsius) — Celsius → Fahrenheit, NIST's (°C * 1.8) + 32.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn imports_temperature_library_and_converts_celsius_to_fahrenheit_with_citation() {
+    let dir = scratch("c2f");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"temperature.adj\"\n\
+         observe celsius(100)\n\
+         ? fahrenheit(celsius)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries the applied formula's result: the
+    // boiling point of water, 100 °C = 212 °F, computed on the CPU.
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"fahrenheit\"") && s.contains("\"value\":212"),
+        "fahrenheit(100) = 212: {s}"
+    );
+    // … AND the NIST citation + trust tier, so the answer is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("nist.gov/pml/owm/si-units-temperature"),
+        "applied formula carries its cited NIST provenance: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// celsius(fahrenheit) — Fahrenheit → Celsius, NIST's (°F - 32) / 1.8.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn converts_fahrenheit_to_celsius_with_citation() {
+    let dir = scratch("f2c");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"temperature.adj\"\n\
+         observe fahrenheit(32)\n\
+         ? celsius(fahrenheit)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The freezing point of water, 32 °F = 0 °C, computed on the CPU.
+    assert!(
+        s.contains("\"name\":\"celsius\"") && s.contains("\"value\":0"),
+        "celsius(32) = 0: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("nist.gov/pml/owm/si-units-temperature"),
+        "conversion carries its NIST citation: {s}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// kelvin(celsius) — Celsius → Kelvin, NIST's °C + 273.15 (a distinct source
+// cell and a non-integer result the engine renders exactly).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn converts_celsius_to_kelvin_with_citation() {
+    let dir = scratch("c2k");
+    place_lib(&dir);
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"temperature.adj\"\n\
+         observe celsius(0)\n\
+         ? kelvin(celsius)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The ice point of water on the Kelvin scale, 0 °C = 273.15 K.
+    assert!(
+        s.contains("\"name\":\"kelvin\"") && s.contains("\"value\":273.15"),
+        "kelvin(0) = 273.15: {s}"
+    );
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("nist.gov/pml/owm/si-units-temperature"),
+        "conversion carries its NIST citation: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/metrology/temperature.adj
+++ b/code/specs/data/adj-formula-stdlib/metrology/temperature.adj
@@ -1,0 +1,78 @@
+% ============================================================================
+% temperature.adj — the temperature-scale conversion formula library.
+% ============================================================================
+% A METROLOGY entry of the *compute* standard library: the unit-conversion
+% formulas that turn a temperature stated on one scale into another. Like
+% `clinical/bmi.adj` and `mathematics/geometry-formulas.adj`, each is an
+% importable, byte-provenanced, PARAMETERIZED `formula`. A consumer states NO
+% arithmetic — it `import`s this file, binds the reading from its own
+% byte-provenance decomposition, and asks the engine to apply the cited formula
+% on the CPU. Zero math is performed by the model; the engine computes each
+% value EXACTLY, carrying NIST's definition as the answer's citation.
+%
+%     import "temperature.adj"
+%     observe celsius(37)              % "…a temperature of 37 °C…"  (span cited)
+%     ? fahrenheit(celsius)            % engine → 98.6, carrying NIST's (°C * 1.8) + 32
+%
+% Medically relevant: normal human body temperature is ~37 °C / 98.6 °F, and a
+% chart that records one scale must often be read on the other — a conversion a
+% clinician performs constantly. The formula (and its source) live HERE; the
+% reading (and its span) comes from the input.
+%
+% Grounding note — these are the exact NIST relations, expressed with exact
+% integer ratios rather than the decimal 1.8. NIST's "Temperature Conversion
+% (Exact)" table gives Celsius→Fahrenheit as `(°C * 1.8) + 32` and
+% Fahrenheit→Celsius as `(°F - 32) / 1.8`; since 1.8 = 9/5 (and dividing by 1.8
+% is multiplying by 5/9), `celsius * 9 / 5 + 32` and `(fahrenheit - 32) * 5 / 9`
+% are the SAME relations written with the schoolbook fraction, so the engine's
+% exact CPU arithmetic matches the cited definition character-for-value.
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each term is a temperature reading on a named scale — both an
+% input a formula ranges over and a result another formula produces. Rung-0's
+% grammar types an observable slot as `finding` (dimensional typing of formula
+% parameters is a later rung; the engine already infers + checks quantities when
+% a formula is APPLIED). The `surface` lists are the everyday names a decomposer
+% maps onto the canonical term.
+% ----------------------------------------------------------------------------
+dictionary temperature_vocab {
+    define celsius    : finding  surface "celsius", "degrees celsius", "°C", "centigrade"
+    define fahrenheit : finding  surface "fahrenheit", "degrees fahrenheit", "°F"
+    define kelvin     : finding  surface "kelvin", "kelvins", "K"
+}
+
+% ----------------------------------------------------------------------------
+% The formulas. Each is a named, importable, reusable `let` over its formal
+% parameter, bound at apply time, and each carries a VERBATIM cell of NIST's
+% "Temperature Conversion (Exact)" table (required on a shipped formula; the
+% linter rejects an unsourced one). NIST is a primary standards body (a .gov
+% metrology authority) — trust `authoritative`.
+%
+%   fahrenheit(celsius)    = celsius * 9 / 5 + 32      %  NIST: (°C * 1.8) + 32
+%   celsius(fahrenheit)    = (fahrenheit - 32) * 5 / 9 %  NIST: (°F - 32) / 1.8
+%   kelvin(celsius)        = celsius + 273.15          %  NIST: °C + 273.15
+% ----------------------------------------------------------------------------
+formulabook temperature_conversions {
+    use temperature_vocab
+
+    % Celsius → Fahrenheit. NIST states it as (°C * 1.8) + 32; 1.8 = 9/5.
+    formula fahrenheit(celsius) = celsius * 9 / 5 + 32
+        source "(°C * 1.8) + 32"
+        locator "https://www.nist.gov/pml/owm/si-units-temperature"
+        trust authoritative
+
+    % Fahrenheit → Celsius. NIST states it as (°F - 32) / 1.8; dividing by 1.8
+    % is multiplying by 5/9.
+    formula celsius(fahrenheit) = (fahrenheit - 32) * 5 / 9
+        source "(°F - 32) / 1.8"
+        locator "https://www.nist.gov/pml/owm/si-units-temperature"
+        trust authoritative
+
+    % Celsius → Kelvin. NIST states it exactly as °C + 273.15 (the ice point of
+    % water offset that fixes the two scales' shared degree size).
+    formula kelvin(celsius) = celsius + 273.15
+        source "°C + 273.15"
+        locator "https://www.nist.gov/pml/owm/si-units-temperature"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/metrology/temperature.query.adj
+++ b/code/specs/data/adj-formula-stdlib/metrology/temperature.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% temperature.query.adj — worked applications of the temperature library.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a "what is 37 °C
+% in Fahrenheit?" question: it states no arithmetic — it only `import`s the
+% grounded library, binds the reading with `observe`, and applies the cited
+% formula. The native adj-lang engine computes each value on the CPU and returns
+% it WITH NIST's source/locator/trust as the answer's proof.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli temperature.query.adj
+% ============================================================================
+
+import "temperature.adj"
+
+observe celsius(100)   ? fahrenheit(celsius)    % expect 212    (boiling point of water)
+observe celsius(37)    ? fahrenheit(celsius)    % expect 98.6   (normal body temperature)
+observe fahrenheit(32) ? celsius(fahrenheit)    % expect 0      (freezing point of water)
+observe celsius(0)     ? kelvin(celsius)        % expect 273.15 (ice point on the Kelvin scale)


### PR DESCRIPTION
## What

Adds `code/specs/data/adj-formula-stdlib/metrology/temperature.adj` — a byte-provenanced FORMULA library (new `metrology/` subject) for the ADJ compute standard library, covering the three temperature-scale conversions, plus a worked query consumer and an end-to-end test.

```
fahrenheit(celsius) = celsius * 9 / 5 + 32       % NIST: (°C * 1.8) + 32
celsius(fahrenheit) = (fahrenheit - 32) * 5 / 9  % NIST: (°F - 32) / 1.8
kelvin(celsius)     = celsius + 273.15           % NIST: °C + 273.15
```

## Grounding (rigorous provenance)

Every `formula` carries a **verbatim cell** of NIST's "Temperature Conversion (Exact)" table as its `source`, the page URL as `locator`, and `trust authoritative` (NIST is a primary `.gov` metrology standards body). `1.8 = 9/5` and dividing by `1.8` is multiplying by `5/9`, so the schoolbook integer-ratio form is the SAME relation NIST states — the engine's exact CPU arithmetic matches the cited definition.

| formula | verbatim NIST span | trust |
|---|---|---|
| `fahrenheit(celsius)` | `(°C * 1.8) + 32` | authoritative |
| `celsius(fahrenheit)` | `(°F - 32) / 1.8` | authoritative |
| `kelvin(celsius)` | `°C + 273.15` | authoritative |

Source (all three): https://www.nist.gov/pml/owm/si-units-temperature

Medically relevant: normal body temperature 37 °C / 98.6 °F.

## Files

- `metrology/temperature.adj` — the library (dictionary + 3 provenanced formulas)
- `metrology/temperature.query.adj` — worked import+bind+apply consumer
- `adj-lang-cli/tests/formula_temperature_e2e.rs` — drives the SHIPPED library through the built CLI; asserts `fahrenheit(100)=212`, `celsius(32)=0`, `kelvin(0)=273.15`, each rendering its NIST citation + trust tier

## Verification

- `cargo test -p adj-lang-cli --test formula_temperature_e2e` — 3/3 pass
- `cargo clippy -p adj-lang-cli --test formula_temperature_e2e -- -D warnings` — clean
- Security review passed (round 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)