### PR TITLE
feat(javascript-parser): CLOC12.190 PR2 — bridge rest parameters to FunctionParam::RestElement

### DIFF
--- a/code/packages/rust/javascript-parser/CHANGELOG.md
+++ b/code/packages/rust/javascript-parser/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `coding-adventures-javascript-parser` crate will be documented in this file.
 
+## [0.55.0] - 2026-07-14
+
+### Added — bridge rest parameters (`function f(...args){}`) — CLOC12.190 PR2
+
+`convert_formal_parameter` now bridges a trailing rest parameter to the (PR1) `FunctionParam::RestElement`
+instead of declining: on an `ELLIPSIS` it takes the sole non-`...` NAME token as the gathered
+identifier. A destructuring rest target (`...[a,b]`, `...{x}`) still declines (Phase 3), and a rest
+`binding_pattern` is guarded. A file whose only unmodelled construct was a rest parameter now flows
+through the typed pipeline rather than falling back to WHITESPACE_ONLY. 3 new bridge tests
+(`rest_parameter_bridges`, `fixed_then_rest_parameter_bridges`, `rest_destructuring_param_declines_gracefully`).
+Picks up javascript-ast 0.41.0. MINOR.
+
 ## [0.54.1] - 2026-07-14
 
 ### Fixed — test compiles against `FunctionParam::RestElement` — CLOC12.190 PR1

--- a/code/packages/rust/javascript-parser/Cargo.toml
+++ b/code/packages/rust/javascript-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-javascript-parser"
-version = "0.54.1"
+version = "0.55.0"
 edition = "2021"
 description = "JavaScript parser — parses JavaScript source code against any ECMAScript edition (es1 through es2025) using the grammar-driven parser. Includes correlation-vector plumbing per CLOC03 and a typed-AST bridge (GrammarASTNode → javascript_ast::Program) per CLOC12.136."
 

--- a/code/packages/rust/javascript-parser/src/bridge.rs
+++ b/code/packages/rust/javascript-parser/src/bridge.rs
@@ -51,8 +51,8 @@ use coding_adventures_javascript_ast::{
     declaration::{
         BindingTarget, ClassDeclaration, Declaration, ExportAllDeclaration,
         ExportDefaultDeclaration, ExportDefaultKind, ExportNamedDeclaration, ExportSpecifier,
-        FunctionDeclaration, FunctionParam, ImportDeclaration, ImportSpecifier, VarKind,
-        VariableDeclaration, VariableDeclarator,
+        FunctionDeclaration, FunctionParam, ImportDeclaration, ImportSpecifier, RestElement,
+        VarKind, VariableDeclaration, VariableDeclarator,
     },
     expression::{
         ArrayExpression, ArrowBody, ArrowFunctionExpression, AssignmentExpression,
@@ -2206,9 +2206,32 @@ fn convert_formal_parameters(node: &GrammarASTNode) -> Result<Vec<FunctionParam>
 fn convert_formal_parameter(node: &GrammarASTNode) -> Result<FunctionParam, BridgeError> {
     // formal_parameter = ( NAME | binding_pattern ) [ EQUALS assignment_expression ]
     //                  | ELLIPSIS ( NAME | binding_pattern )
-    // In Phase 1: only simple NAME identifiers.
+    // Simple NAME identifiers and (CLOC12.190) trailing rest parameters
+    // (`...name`) are modelled; a destructuring target is declined.
     if has_token(node, "...") {
-        return Err(unsupported(node)); // rest params are Phase 3
+        // Rest parameter `...target`. A destructuring rest (`...[a,b]`, `...{x}`)
+        // reuses the Phase-3 binding-pattern machinery — decline it rather than
+        // mis-model. A simple `...name` bridges to a `FunctionParam::RestElement`.
+        for c in &node.children {
+            if let ASTNodeOrToken::Node(n) = c {
+                if n.rule_name == "binding_pattern" {
+                    return Err(unsupported(n));
+                }
+            }
+        }
+        // The gathered name is the sole non-`...` token in the node.
+        let name = node
+            .children
+            .iter()
+            .find_map(|c| match c {
+                ASTNodeOrToken::Token(t) if t.value != "..." => Some(t.value.clone()),
+                _ => None,
+            })
+            .ok_or_else(|| internal(node, "rest parameter: missing name"))?;
+        return Ok(FunctionParam::RestElement(RestElement {
+            cv: None,
+            argument: Identifier { cv: None, name },
+        }));
     }
     for c in &node.children {
         if let ASTNodeOrToken::Node(n) = c {
@@ -4148,6 +4171,55 @@ mod tests {
             Some(ProgramItem::Declaration(Declaration::ImportDeclaration(i))) => i.clone(),
             other => panic!("expected an ImportDeclaration for {src}, got {other:?}"),
         }
+    }
+
+    /// Pull the sole `FunctionDeclaration` out of a single-item program.
+    fn fn_of(src: &str) -> FunctionDeclaration {
+        let p = bridge_ok(src);
+        match p.body.first() {
+            Some(ProgramItem::Declaration(Declaration::FunctionDeclaration(f))) => f.clone(),
+            other => panic!("expected a FunctionDeclaration for {src}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rest_parameter_bridges() {
+        // `function f(...args){}` — CLOC12.190 PR2. The lone `...args` bridges to
+        // a `FunctionParam::RestElement` binding the name `args`, instead of the
+        // whole file declining to WHITESPACE_ONLY.
+        let f = fn_of("function f(...args){}");
+        assert_eq!(f.params.len(), 1);
+        match &f.params[0] {
+            FunctionParam::RestElement(re) => assert_eq!(re.argument.name, "args"),
+            other => panic!("expected a RestElement param, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fixed_then_rest_parameter_bridges() {
+        // `function f(a, ...rest){}` — the fixed `a` stays an Identifier param and
+        // the trailing `...rest` bridges to a RestElement, in order.
+        let f = fn_of("function f(a, ...rest){}");
+        assert_eq!(f.params.len(), 2);
+        match &f.params[0] {
+            FunctionParam::Identifier(id) => assert_eq!(id.name, "a"),
+            other => panic!("expected Identifier for param 0, got {other:?}"),
+        }
+        match &f.params[1] {
+            FunctionParam::RestElement(re) => assert_eq!(re.argument.name, "rest"),
+            other => panic!("expected RestElement for param 1, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rest_destructuring_param_declines_gracefully() {
+        // `function f(...[a, b]){}` — a destructuring rest target is Phase 3, so
+        // the bridge declines (the whole program falls back to WHITESPACE_ONLY)
+        // rather than mis-modelling it. A decline is an Err, never a panic.
+        assert!(
+            bridge("function f(...[a, b]){}").is_err(),
+            "destructuring rest param should decline, not bridge"
+        );
     }
 
     #[test]


### PR DESCRIPTION
PR2 of the rest-parameters arc — the parser-bridge flip. PR1 (#8233, merged) landed the `FunctionParam::RestElement` AST node + emitter + pass arms; this makes the bridge actually *produce* it.

## Change
`convert_formal_parameter` previously declined any parameter list containing `...`, dropping the whole file to WHITESPACE_ONLY. Now:
- On an `ELLIPSIS`, the sole non-`...` NAME token becomes the gathered identifier → `FunctionParam::RestElement { argument: Identifier { name } }`.
- A **destructuring** rest target (`...[a,b]`, `...{x}`) still declines — it reuses the Phase-3 binding-pattern machinery — and a rest `binding_pattern` child is guarded, so an unrepresentable shape falls back to WHITESPACE_ONLY rather than mis-modelling.

## Tests
3 new bridge roundtrip tests:
- `rest_parameter_bridges` — `function f(...args){}` → `params[0]` is `RestElement("args")`.
- `fixed_then_rest_parameter_bridges` — `function f(a, ...rest){}` → `[Identifier("a"), RestElement("rest")]` in order.
- `rest_destructuring_param_declines_gracefully` — `function f(...[a,b]){}` → `Err`, not a panic.

## Verification
`RUSTFLAGS="-D warnings" cargo test -p coding-adventures-javascript-parser`: **248 passed, zero warnings** (matches CI's deny-warnings build). Security review **passed** (bounded, panic-free, in-memory transform; no unsafe/I/O/new deps).

Follow-up: **PR3** = the closurec e2e fixture proving a rest-param file now optimizes (arg folds) instead of WHITESPACE_ONLY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)