### PR TITLE
feat(adj-formula-stdlib): grounded physics_kinematics formula library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_kinematics_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_kinematics_e2e.rs
@@ -1,0 +1,79 @@
+//! End-to-end test for the shipped physics/kinematics.adj formula library through
+//! the built CLI binary. A consumer `import`s the SHIPPED library, binds the
+//! quantities from its own `observe`d facts, and applies each cited law. The CLI
+//! must compute the value on the CPU and render the applied formula's citation in
+//! the `derived` section — the auditable answer, with zero math done by the model.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped kinematics library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_kinematics_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/kinematics.adj")
+        .canonicalize()
+        .expect("shipped kinematics.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_formula_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn imports_kinematics_library_binds_and_computes_with_its_citation() {
+    // Copy the shipped library next to a consumer that imports it, so the CLI's
+    // sandbox-checked relative import resolves. The consumer states NO arithmetic
+    // — it binds the numbers and applies the recalled laws.
+    let dir = scratch("kinematics");
+    let lib = std::fs::read_to_string(shipped_kinematics_lib()).unwrap();
+    std::fs::write(dir.join("kinematics.adj"), lib).unwrap();
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"kinematics.adj\"\n\
+         observe initial_velocity(5)\n\
+         observe acceleration(2)\n\
+         observe time(3)\n\
+         ? final_velocity(initial_velocity, acceleration, time)\n\
+         observe mass(4)\n\
+         observe velocity(5)\n\
+         ? momentum(mass, velocity)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    // The derived value section carries each applied law's result …
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    // v = u + a·t  →  5 + 2·3 = 11
+    assert!(
+        s.contains("\"name\":\"final_velocity\"") && s.contains("\"value\":11"),
+        "computed final velocity = 11 m/s (v = u + a·t): {s}"
+    );
+    // p = m·v  →  4·5 = 20
+    assert!(
+        s.contains("\"name\":\"momentum\"") && s.contains("\"value\":20"),
+        "computed momentum = 20 kg·m/s (p = m·v): {s}"
+    );
+    // … AND each answer carries its authoritative citation, so the chain audits.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"") && s.contains("openstax.org"),
+        "final velocity carries its OpenStax provenance: {s}"
+    );
+    assert!(
+        s.contains("grc.nasa.gov"),
+        "momentum carries its NASA Glenn provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/kinematics.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/kinematics.adj
@@ -1,0 +1,78 @@
+% ============================================================================
+% kinematics.adj — foundational kinematics laws in the ADJ standard library.
+% ============================================================================
+% Two more worked entries of the *compute* standard library, alongside
+% physics/mechanics-laws.adj and physics/energy-work.adj: importable,
+% byte-provenanced, PARAMETERIZED formulas for one-dimensional motion. Where the
+% recall libraries ship grounded `relate` edges (facts a model recalls), this
+% ships grounded `formula`s (arithmetic a model recalls) — the same contract, the
+% other half of the stdlib. The engine computes each law EXACTLY on the CPU, and
+% the answer carries the law's own citation, so the chain is auditable end to end.
+%
+% A consumer states NO arithmetic. It `import`s this file, binds the quantities it
+% decomposed from the input (each `observe` is a byte-provenance span the model
+% cited), and asks the engine to APPLY the recalled law:
+%
+%     import "kinematics.adj"
+%     observe initial_velocity(5)  % "…starting at 5 m/s…"          (span cited)
+%     observe acceleration(2)      % "…accelerating at 2 m/s²…"     (span cited)
+%     observe time(3)              % "…for 3 seconds…"              (span cited)
+%     ? final_velocity(initial_velocity, acceleration, time)  % engine → 11 (v = u + at)
+%
+% The laws (and their sources) live HERE; the numbers (and their spans) come from
+% the input. Zero math is performed by the model.
+%
+% Run the worked consumer (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli kinematics.query.adj
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each term is an observable quantity the laws range over. Rung-0's
+% grammar types an observable slot as `finding`, so we register each quantity as a
+% finding and record its intended physical dimension in the surface synonyms +
+% comments. (Dimensional typing of formula parameters is a later rung — but the
+% engine already INFERS and CHECKS dimensions when a formula is APPLIED, so
+% 5 m/s + 2 m/s² · 3 s reports m/s and mismatched units are caught regardless.)
+% ----------------------------------------------------------------------------
+dictionary kinematics_vocab {
+    % --- final velocity under constant acceleration: v = u + a·t ---
+    define initial_velocity : finding  surface "initial velocity", "starting velocity", "u", "v0"   % length / time (e.g. m/s)
+    define acceleration     : finding  surface "acceleration", "a", "rate of change of velocity"     % length / time² (e.g. m/s²)
+    define time             : finding  surface "time", "elapsed time", "duration", "t"               % time (e.g. s)
+    define final_velocity   : finding  surface "final velocity", "velocity", "v"                     % length / time (e.g. m/s)
+
+    % --- linear momentum: p = m·v ---
+    define mass             : finding  surface "mass", "m"                                            % mass (e.g. kg)
+    define velocity         : finding  surface "velocity", "speed", "v"                               % length / time (e.g. m/s)
+    define momentum         : finding  surface "momentum", "linear momentum", "p"                     % mass · length / time (e.g. kg·m/s)
+}
+
+% ----------------------------------------------------------------------------
+% The laws. Each `formula` is a named, importable, reusable `let` over its formal
+% parameters — the SAME expression grammar `let` uses, with the parameter leaves
+% bound at apply time. Every one carries the provenance envelope a grounded clause
+% requires: a verbatim definitional span from a citable reference, a resolvable
+% locator, and a trust tier. These are CLAIMS ABOUT THE WORLD ("final velocity is
+% the initial velocity plus acceleration times time"), grounded exactly like a
+% `relate` edge — not asserted by fiat.
+% ----------------------------------------------------------------------------
+formulabook physics_kinematics {
+    use kinematics_vocab
+
+    % Final velocity under constant acceleration — a body's velocity after time t
+    % is its initial velocity plus the velocity its acceleration has added.
+    % v = u + a·t.  Source: OpenStax College Physics 2e (a peer-reviewed, primary
+    % physics textbook reference) → authoritative.
+    formula final_velocity(initial_velocity, acceleration, time) = initial_velocity + (acceleration * time)
+        source "Solving for v yields v = v0 + at (constant a)."
+        locator "https://openstax.org/books/college-physics-2e/pages/2-5-motion-equations-for-constant-acceleration-in-one-dimension"
+        trust authoritative
+
+    % Linear momentum — the quantity of motion of a body is its mass times its
+    % velocity.  p = m·v.  Source: NASA Glenn Research Center, Beginners' Guide to
+    % Aeronautics (a primary .gov physics reference) → authoritative.
+    formula momentum(mass, velocity) = mass * velocity
+        source "Momentum is defined to be the mass of an object multiplied by the velocity of the object."
+        locator "https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/conservation-of-momentum-2/"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/kinematics.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/kinematics.query.adj
@@ -1,0 +1,31 @@
+% ============================================================================
+% kinematics.query.adj — worked applications of the foundational kinematics laws.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a motion word
+% problem: it states NO arithmetic. It `import`s the grounded law library, binds
+% each quantity it decomposed from the input (each `observe` is a byte-provenance
+% span the model cited), and asks the engine to APPLY the recalled law. The native
+% adj-lang engine substitutes the law's body, computes exactly on the CPU, and
+% returns the value carrying the law's source/locator/trust — the auditable chain.
+%
+% "A car starting at 5 m/s accelerates at 2 m/s² for 3 s. What is its velocity?"
+%   → recall v = u + at, bind u = 5, a = 2, t = 3, apply → 11 m/s (OpenStax).
+% "A 4 kg cart moves at 5 m/s. What is its momentum?"
+%   → recall p = mv, bind mass = 4, velocity = 5, apply → 20 kg·m/s (NASA Glenn).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli kinematics.query.adj
+% ============================================================================
+
+import "kinematics.adj"
+
+% --- Final velocity: 5 m/s + 2 m/s² · 3 s = 11 m/s. ---
+observe initial_velocity(5)                          % "…starting at 5 m/s…"       (span cited by the model)
+observe acceleration(2)                              % "…accelerates at 2 m/s²…"   (span cited by the model)
+observe time(3)                                      % "…for 3 seconds…"           (span cited by the model)
+? final_velocity(initial_velocity, acceleration, time)  % engine → 11 (v = u + a·t, OpenStax, authoritative)
+
+% --- Linear momentum: 4 kg · 5 m/s = 20 kg·m/s. ---
+observe mass(4)                                      % "…a 4 kg cart…"             (span cited)
+observe velocity(5)                                  % "…moving at 5 m/s…"         (span cited)
+? momentum(mass, velocity)                           % engine → 20 (p = m·v, NASA Glenn, authoritative)


### PR DESCRIPTION
## What

Adds a grounded, byte-provenanced **`physics_kinematics`** formula library to the ADJ compute standard library, alongside the existing `physics/mechanics-laws.adj` and `physics/energy-work.adj`.

Two foundational one-dimensional-motion laws, each an importable, parameterized `formula`:

| Formula | Body | Law |
|---|---|---|
| `final_velocity(initial_velocity, acceleration, time)` | `u + (a * t)` | v = u + at |
| `momentum(mass, velocity)` | `m * v` | p = mv |

## Grounding (rigorous provenance)

Each formula carries the provenance envelope a shipped clause requires — a **verbatim** definitional span, a resolvable `locator`, and a `trust` tier. Both are grounded in primary physics references → **`authoritative`**:

- **final_velocity** — OpenStax *College Physics 2e* (peer-reviewed physics textbook)
  - span: `"Solving for v yields v = v0 + at (constant a)."`
  - locator: https://openstax.org/books/college-physics-2e/pages/2-5-motion-equations-for-constant-acceleration-in-one-dimension
- **momentum** — NASA Glenn Research Center, *Beginners' Guide to Aeronautics* (primary .gov reference)
  - span: `"Momentum is defined to be the mass of an object multiplied by the velocity of the object."`
  - locator: https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/conservation-of-momentum-2/

## Files

- `code/specs/data/adj-formula-stdlib/physics/kinematics.adj` — the `formulabook physics_kinematics` (distinct name; no collision with the existing physics books)
- `code/specs/data/adj-formula-stdlib/physics/kinematics.query.adj` — worked consumer: `observe` inputs, `? f(...)`; the engine computes on the CPU
- `code/packages/rust/adj-lang-cli/tests/formula_kinematics_e2e.rs` — drives the shipped library through the built CLI

## Verification

- `cargo test -p adj-lang-cli --test formula_kinematics_e2e` → passes (final_velocity(5,2,3) = **11**, momentum(4,5) = **20**, each carrying its authoritative citation)
- `cargo clippy -p adj-lang-cli --test formula_kinematics_e2e -- -D warnings` → clean

DATA + one test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)