### PR TITLE
feat(adj-facts-stdlib): grounded ABO blood type → antigen(s) biology library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_bloodgroups_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_bloodgroups_e2e.rs
@@ -1,0 +1,69 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/blood-groups.adj`) driven through the built CLI:
+//! a native `table` of ABO blood type → antigen(s) on the red cells resolves a
+//! binding-query recall with the source's citation, and abstains on a label that
+//! is not an ABO phenotype — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsk_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_blood_groups_recall_binds_antigen_with_citation() {
+    let dir = scratch("bloodgroups");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/blood-groups.adj");
+    std::fs::copy(&src, dir.join("blood-groups.adj")).expect("copy shipped blood-groups.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"blood-groups.adj\"\n\
+         ? blood_type_antigen(a, $Antigen)\n\
+         ? blood_type_antigen(ab, $Antigen)\n\
+         ? blood_type_antigen(o, $Antigen)\n\
+         ? blood_type_antigen(rh_positive, $Antigen)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Type A carries the A antigen; type AB carries both — the recalled atoms.
+    assert!(out.contains("\"Antigen\":\"a_antigen\""), "type a → a_antigen: {out}");
+    assert!(
+        out.contains("\"Antigen\":\"a_and_b_antigens\""),
+        "type ab → a_and_b_antigens: {out}"
+    );
+    // Type O positively carries NO ABO antigen (why O cells are universal donors).
+    assert!(
+        out.contains("\"Antigen\":\"no_antigens\""),
+        "type o → no_antigens: {out}"
+    );
+    // The answer carries the NCBI Bookshelf citation as its proof.
+    assert!(
+        out.contains("ncbi.nlm.nih.gov") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // An Rh label is not an ABO phenotype — honest abstention, never a fabricated antigen.
+    assert!(out.contains("\"abstained\":true"), "rh_positive abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/blood-groups.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/blood-groups.adj
@@ -1,0 +1,64 @@
+% ============================================================================
+% blood-groups — each ABO blood type and the antigen(s) present on the red
+% cells (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% An immunohematology fact a medicine agent reasons from: the ABO blood group
+% is defined by which of the A and B antigens sit on the surface of a person's
+% red blood cells (RBCs). This single fact is what makes ABO the most important
+% system in transfusion medicine — transfusing ABO-incompatible blood is the
+% most common cause of a fatal transfusion reaction, because the recipient's
+% naturally-occurring anti-A / anti-B antibodies bind the mismatched antigen and
+% lyse the donor cells. So the recall "which antigen(s) does type X carry?" is a
+% load-bearing clinical primitive, not trivia. Recall is a binding query:
+%
+%     ? blood_type_antigen(a, $Antigen)     % a_antigen
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `blood_type_antigen(blood_type, antigen)` carrying the table's
+% citation, so the lookup above is the ordinary SLD binding query — the engine
+% returns the antigen WITH its source, on the CPU, with zero model calls, and
+% abstains on anything not in the table.
+%
+% The ABO antigen table, as a truth table:
+%
+%     blood_type   antigen(s) on the RBC        atom
+%     ----------   -------------------------    -----------------
+%     a            A antigen only               a_antigen
+%     b            B antigen only               b_antigen
+%     ab           both the A and the B         a_and_b_antigens
+%     o            neither A nor B              no_antigens
+%
+% Note that `ab` maps to the compound atom `a_and_b_antigens` (both present) and
+% `o` maps to `no_antigens` (both absent). Keeping `o` an explicit row — rather
+% than letting it fall through to abstention — is deliberate: "type O carries no
+% ABO antigen" is itself a grounded, citable fact (it is *why* O red cells are
+% the universal-donor cells), so the table asserts it positively. A query for a
+% blood type that is not one of the four ABO phenotypes (e.g. an Rh label, or a
+% typo) is not in the table and ABSTAINS honestly — the engine never invents an
+% antigen. That honest-abstention property is what makes the table safe for a
+% clinical reasoner to trust.
+%
+% Provenance: the antigen assignment is copied verbatim from the NCBI Bookshelf
+% chapter "The ABO blood group" (Blood Groups and Red Cell Antigens, Laura
+% Dean), whose History section states, in one continuous passage (see `source`),
+% that the RBC expressing the A antigen "belonged to blood group A", the one
+% expressing the B antigen to "blood group B", that group O RBCs "lacked the
+% properties of A and B", and that the AB group "RBCs expressed both A and B
+% antigens." The citable artifact is that chapter at the `locator`. `trust
+% authoritative` — NCBI Bookshelf / ncbi.nlm.nih.gov is a primary U.S. National
+% Library of Medicine reference. Nothing here is asserted from memory. (See
+% ../README.md; feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table blood_type_antigen {
+    columns blood_type, antigen
+
+    row (a, a_antigen)
+    row (b, b_antigen)
+    row (ab, a_and_b_antigens)
+    row (o, no_antigens)
+
+    source "He called the antigens A and B, and depending upon which antigen the RBC expressed, blood either belonged to blood group A or blood group B. A third blood group contained RBCs that reacted as if they lacked the properties of A and B, and this group was later called \"O\" after the German word \"Ohne\", which means \"without\". The following year the fourth blood group, AB, was added to the ABO blood group system. These RBCs expressed both A and B antigens."
+    locator "https://www.ncbi.nlm.nih.gov/books/NBK2267/"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/blood-groups.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/blood-groups.query.adj
@@ -1,0 +1,20 @@
+% ============================================================================
+% blood-groups.query.adj — a worked recall over the ABO antigen library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "which antigen does type A
+% carry?": it states no biology fact — it only `import`s the grounded table and
+% asks binding queries. The engine resolves each `?` against the
+% `blood_type_antigen` rows and returns the antigen + the table's
+% source/locator/trust. A label that is not one of the four ABO phenotypes
+% abstains honestly — the engine never invents an antigen.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli blood-groups.query.adj
+% ============================================================================
+
+import "blood-groups.adj"
+
+? blood_type_antigen(a, $Antigen)        % expect a_antigen
+? blood_type_antigen(ab, $Antigen)       % expect a_and_b_antigens
+? blood_type_antigen(o, $Antigen)        % expect no_antigens (universal donor cells)
+? blood_type_antigen(rh_positive, $Antigen)   % expect abstain — not an ABO phenotype


### PR DESCRIPTION
## What

Adds a **biology** facts library to the ADJ standard library mapping each ABO blood type to the antigen(s) present on its red blood cells — a load-bearing immunohematology primitive for transfusion reasoning.

| blood_type | antigen |
|---|---|
| `a` | `a_antigen` |
| `b` | `b_antigen` |
| `ab` | `a_and_b_antigens` |
| `o` | `no_antigens` |

Implemented as a native ADJ `table` (ADJ-TABLES): each row lowers to a ground relation `blood_type_antigen(blood_type, antigen)` carrying the table's citation, so recall is an ordinary SLD binding query resolved on the CPU with **zero model calls**, and **abstains honestly** on any non-ABO label.

## Grounding (rigorous provenance)

Every row is byte-grounded in **one continuous verbatim span** from an authoritative source — nothing from memory:

- **Source (verbatim):** "He called the antigens A and B, and depending upon which antigen the RBC expressed, blood either belonged to blood group A or blood group B. A third blood group contained RBCs that reacted as if they lacked the properties of A and B, and this group was later called \"O\" after the German word \"Ohne\", which means \"without\". The following year the fourth blood group, AB, was added to the ABO blood group system. These RBCs expressed both A and B antigens."
- **Locator:** https://www.ncbi.nlm.nih.gov/books/NBK2267/ — NCBI Bookshelf, *The ABO blood group* (Blood Groups and Red Cell Antigens, Laura Dean)
- **Trust tier:** `authoritative` (ncbi.nlm.nih.gov / U.S. National Library of Medicine primary reference)

The span faithfully supports every object atom: A antigen → group A, B antigen → group B, group O "lacked the properties of A and B" → `no_antigens`, AB "expressed both A and B antigens" → `a_and_b_antigens`.

## Files (DATA + one test)

- `code/specs/data/adj-facts-stdlib/biology/blood-groups.adj` — the grounded table (literate).
- `code/specs/data/adj-facts-stdlib/biology/blood-groups.query.adj` — worked recall: 3 binds + 1 abstain.
- `code/packages/rust/adj-lang-cli/tests/facts_bloodgroups_e2e.rs` — asserts the binds, the locator substring + trust tier, and the abstain.

## Verification

- `cargo test -p adj-lang-cli --test facts_bloodgroups_e2e` — passes.
- `cargo clippy -p adj-lang-cli --test facts_bloodgroups_e2e -- -D warnings` — clean.
- CLI run of `blood-groups.query.adj` binds `a→a_antigen`, `ab→a_and_b_antigens`, `o→no_antigens` (each with the NCBI citation, `trust: authoritative`) and abstains on `rh_positive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)