### PR TITLE
feat(adj-facts-stdlib): biology/amino-acids — amino acid → one-letter code

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_aminoacids_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_aminoacids_e2e.rs
@@ -1,0 +1,62 @@
+//! End-to-end test for the biology FACTS library
+//! (`adj-facts-stdlib/biology/amino-acids.adj`) driven through the built CLI:
+//! a native `table` of amino acid -> one-letter code resolves binding-query
+//! recall in BOTH directions with the source's (DDBJ) citation, and abstains on
+//! a non-standard amino acid — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsaa_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_amino_acid_code_recall_binds_both_directions_with_citation() {
+    let dir = scratch("aminoacids");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/amino-acids.adj");
+    std::fs::copy(&src, dir.join("amino-acids.adj")).expect("copy shipped amino-acids.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"amino-acids.adj\"\n\
+         ? amino_acid_code(glycine, $C)\n\
+         ? amino_acid_code($A, a)\n\
+         ? amino_acid_code(selenocysteine, $C)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Forward recall: glycine -> g (the name binds the one-letter code).
+    assert!(out.contains("\"C\":\"g\""), "glycine -> g: {out}");
+    // Reverse recall: the code a binds the amino-acid name alanine.
+    assert!(out.contains("\"A\":\"alanine\""), "a -> alanine: {out}");
+    // The answer carries the DDBJ citation as its proof.
+    assert!(
+        out.contains("ddbj.nig.ac.jp") && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // Selenocysteine (Sec/U) is the 21st amino acid, not one of the standard
+    // twenty — honest abstention, never a fabricated code.
+    assert!(out.contains("\"abstained\":true"), "selenocysteine abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/amino-acids.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/amino-acids.adj
@@ -1,0 +1,77 @@
+% ============================================================================
+% amino-acids — each standard amino acid and its one-letter code
+% (adj-facts-stdlib, BIOLOGY). A biochemistry fact a medicine or molecular-
+% biology agent reasons from, foundational to reading protein sequences.
+% ============================================================================
+% Proteins are chains of amino acids, and every sequence database, alignment,
+% and clinical variant report writes those chains in the standard ONE-LETTER
+% code: the haemoglobin beta chain begins "MVHLTPEEK…", the sickle-cell variant
+% swaps a single letter (E6V). Knowing that "glycine is G, serine is S" is the
+% alphabet an agent needs before it can read any protein. Recall is a binding
+% query in either direction:
+%
+%     ? amino_acid_code(glycine, $C)      % g   (name -> code)
+%     ? amino_acid_code($A, a)            % alanine  (code -> name)
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `amino_acid_code(amino_acid, code)` carrying the table's citation, so
+% both lookups above are ordinary SLD binding queries — the engine returns the
+% answer WITH its source, on the CPU, with zero model calls, and abstains on
+% anything not in the table (never inventing a code). Keys AND code values are
+% lowercase ADJ atoms (glycine -> g, serine -> s, …); the human-facing capital
+% form (G, S, …) is the same one-letter string upper-cased for display. The two
+% acidic residues keep the source's own names, `aspartic_acid` (D) and
+% `glutamic_acid` (E), spelled as single atoms.
+%
+% Only the 20 STANDARD (proteinogenic, genetically encoded via the universal
+% codon table) amino acids are shipped. The DDBJ page also lists Sec/U
+% (selenocysteine) and Pyl/O (pyrrolysine) — the 21st and 22nd amino acids,
+% incorporated by special recoding — and these are deliberately OMITTED so that
+% a recall over "the standard twenty" abstains on them rather than conflating
+% the canonical alphabet with its rare extensions.
+%
+% Provenance: every amino-acid name and its one-letter code below is copied from
+% the DNA Data Bank of Japan (DDBJ) "Codes" reference page — DDBJ is a primary
+% national sequence database and a member of the International Nucleotide
+% Sequence Database Collaboration (INSDC, with NCBI/GenBank and EMBL-EBI/ENA),
+% so its amino-acid code table is an official standard. On that page the three
+% columns are, in order, `Abbreviation` (3-letter), `1 letter abbreviation`, and
+% `Amino acid name`; the `source` span below is the VERBATIM cell triple for
+% glycine — the 3-letter code "Gly", the one-letter code "G", and the name
+% "Glycine", each its own table cell — pairing the name with its one-letter
+% code. The full 20-row table this covers is served at the `locator` URL, and
+% every name->code pair below was confirmed against it. `trust authoritative`.
+% Nothing here is asserted from memory; any pair that could not be verified on
+% the fetched page would have been dropped. (See ../README.md;
+% feedback_nothing_human_authored, feedback_adj_only_shipped_artifacts,
+% feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table amino_acid_code {
+    columns amino_acid, code
+
+    row (alanine, a)
+    row (arginine, r)
+    row (asparagine, n)
+    row (aspartic_acid, d)
+    row (cysteine, c)
+    row (glutamine, q)
+    row (glutamic_acid, e)
+    row (glycine, g)
+    row (histidine, h)
+    row (isoleucine, i)
+    row (leucine, l)
+    row (lysine, k)
+    row (methionine, m)
+    row (phenylalanine, f)
+    row (proline, p)
+    row (serine, s)
+    row (threonine, t)
+    row (tryptophan, w)
+    row (tyrosine, y)
+    row (valine, v)
+
+    source "Gly\nG\nGlycine"
+    locator "https://www.ddbj.nig.ac.jp/ddbj/code-e.html"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/amino-acids.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/amino-acids.query.adj
@@ -1,0 +1,24 @@
+% ============================================================================
+% amino-acids.query.adj — a worked recall over the amino-acid one-letter codes.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is glycine's
+% one-letter code?": it states no biochemistry fact — it only `import`s the
+% grounded table and asks binding queries. The engine resolves each `?` against
+% the `amino_acid_code` rows and returns the code (or the name) plus the table's
+% source/locator/trust. An amino acid not among the standard twenty abstains
+% honestly — the engine never invents a code.
+%
+% The query runs in BOTH directions: bind the name to recall the code (forward),
+% or bind the code to recall the name (reverse) — the same ground relation
+% resolves either way.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli amino-acids.query.adj
+% ============================================================================
+
+import "amino-acids.adj"
+
+? amino_acid_code(glycine, $C)         % forward — expect g
+? amino_acid_code($A, g)               % reverse — expect glycine (code g -> name)
+? amino_acid_code(alanine, $C)         % forward — expect a
+? amino_acid_code(selenocysteine, $C)  % expect abstain — not one of the standard 20


### PR DESCRIPTION
## Summary

Adds a grounded ADJ facts library `biology/amino-acids.adj` mapping each of the **20 standard (proteinogenic) amino acids** to its IUPAC/IUBMB **one-letter code** — the alphabet an agent needs to read any protein sequence (glycine→g, serine→s, alanine→a, …). Foundational biochemistry a medicine or molecular-biology agent reasons from.

Subject-organized under `biology/` (no grade levels), following the `name→value` `table` pattern (ADJ-TABLES RS-5). Each row lowers to a ground relation carrying the citation, so recall is an ordinary SLD binding query resolvable in **both directions** (name→code and code→name), on the CPU, **zero model calls**, abstaining on anything not in the table.

## Files
- `biology/amino-acids.adj` — the `table amino_acid_code { columns amino_acid, code … }` with all 20 standard residues + literate provenance comment.
- `biology/amino-acids.query.adj` — worked forward + reverse recall and an honest abstention on selenocysteine.
- `adj-lang-cli/tests/facts_aminoacids_e2e.rs` — drives the built CLI end-to-end: asserts glycine→g, reverse a→alanine, the DDBJ citation + `authoritative` trust, and abstention on selenocysteine.

## Grounding / provenance
Every name→code pair is copied from the **DNA Data Bank of Japan (DDBJ) "Codes" reference page** — a primary national sequence database and INSDC member (alongside NCBI/GenBank and EMBL-EBI/ENA), so its amino-acid code table is an official standard.

- **source** (verbatim span): the glycine cell triple `Gly` / `G` / `Glycine` (columns on the page are 3-letter, 1-letter, name).
- **locator**: https://www.ddbj.nig.ac.jp/ddbj/code-e.html
- **trust**: `authoritative`

Sec/U (selenocysteine, 21st) and Pyl/O (pyrrolysine, 22nd) are deliberately **omitted** so recall over the standard twenty abstains on them. Nothing asserted from memory.

## Verification
- `cargo test -p adj-lang-cli --test facts_aminoacids_e2e` — passes.
- `cargo clippy -p adj-lang-cli --test facts_aminoacids_e2e -- -D warnings` — clean.
- Security review: passed (static fact data + deterministic test, no runtime attack surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)