### PR TITLE
feat(adj-facts-stdlib): grounded standard genetic code (NCBI table 1) biology library

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_geneticcode_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_geneticcode_e2e.rs
@@ -1,0 +1,67 @@
+//! End-to-end test for the BIOLOGY FACTS library
+//! (`adj-facts-stdlib/biology/genetic-code.adj`) driven through the built CLI:
+//! a native `table` of the STANDARD GENETIC CODE (NCBI translation table 1) maps
+//! each mRNA codon to its amino acid. A binding-query recall returns the amino
+//! acid with the NCBI citation, and abstains on a triplet that is not a real
+//! codon (`xyz`) — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsgc_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn biology_genetic_code_recall_binds_amino_acid_with_citation() {
+    let dir = scratch("gc");
+    // Copy the shipped biology table beside the entry program and import it.
+    let src = facts_stdlib().join("biology/genetic-code.adj");
+    std::fs::copy(&src, dir.join("genetic-code.adj")).expect("copy shipped genetic-code.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"genetic-code.adj\"\n\
+         ? codon_amino_acid(atg, $A)\n\
+         ? codon_amino_acid(taa, $A)\n\
+         ? codon_amino_acid(gag, $A)\n\
+         ? codon_amino_acid(xyz, $A)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Standard genetic code: AUG (atg) codes methionine (also START);
+    // a third-base wobble / sense-vs-stop decode is what a mutation reasoner reads.
+    assert!(out.contains("\"A\":\"m\""), "atg → m (methionine): {out}");
+    // A STOP codon terminates translation — maps to the atom `stop`.
+    assert!(out.contains("\"A\":\"stop\""), "taa → stop: {out}");
+    // Glutamate — the sickle-cell wild-type codon (gag e → gtg v is the mutation).
+    assert!(out.contains("\"A\":\"e\""), "gag → e (glutamate): {out}");
+    // The answer carries the NCBI translation-table citation as its proof.
+    assert!(
+        out.contains("ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the NCBI source citation: {out}"
+    );
+    // `xyz` is not a codon — honest abstention, never a fabricated amino acid.
+    assert!(out.contains("\"abstained\":true"), "xyz abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/biology/genetic-code.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/genetic-code.adj
@@ -1,0 +1,149 @@
+% ============================================================================
+% genetic-code — the STANDARD GENETIC CODE: every mRNA codon and the amino acid
+% it specifies (adj-facts-stdlib, BIOLOGY).
+% ============================================================================
+% The single most foundational fact-table in molecular biology, and one a
+% medicine agent reasons from constantly: the ribosome reads messenger RNA three
+% nucleotides at a time, and each of the 64 possible triplets (a "codon") maps to
+% exactly one of the 20 amino acids — or to a STOP signal that ends translation.
+% Recall is a binding query:
+%
+%     ? codon_amino_acid(atg, $A)      % m  (methionine — also the START codon)
+%     ? codon_amino_acid(taa, $A)      % stop
+%
+% This is a native `table` (ADJ-TABLES RS-5): each `row` lowers to a ground
+% relation `codon_amino_acid(codon, amino_acid)` carrying the table's citation, so
+% the lookup above is the ordinary SLD binding query — the engine returns the
+% amino acid WITH its source, on the CPU, with zero model calls, and abstains on
+% any triplet that is not a real codon (e.g. a typo like `xyz`).
+%
+% WHY A CLINICAL REASONER NEEDS THIS
+% ----------------------------------
+% The genetic code is where genotype becomes phenotype, so it is the substrate
+% for reasoning about mutations:
+%
+%   * A POINT MUTATION swaps one base of a codon. Whether that is silent,
+%     missense, or nonsense is read straight off this table. Example: the sickle-
+%     cell mutation changes codon `gag` (e = glutamate) to `gtg` (v = valine) in
+%     beta-globin — two rows of this table are the entire molecular story.
+%       ? codon_amino_acid(gag, $A)   % e   (wild-type)
+%       ? codon_amino_acid(gtg, $A)   % v   (mutant)  → missense
+%   * A NONSENSE mutation turns a sense codon into a STOP (e.g. `caa` q → `taa`
+%     stop), truncating the protein.
+%   * DEGENERACY: 61 sense codons encode only 20 amino acids, so many codons are
+%     synonymous (e.g. all four of `ggt ggc gga ggg` → g, glycine). A mutation
+%     landing on the third "wobble" base is often SILENT — visible here as two
+%     rows sharing the same amino acid.
+%
+% TRANSLATION-TABLE NOTATION (matches the cited NCBI artifact)
+% ------------------------------------------------------------
+% NCBI publishes the code in the canonical 5-line block reproduced VERBATIM in
+% `source` below. Column i of that block names one codon and its product:
+%
+%     codon(i)      = Base1[i] Base2[i] Base3[i]      (read top-to-bottom)
+%     amino_acid(i) = AAs[i]                          ('*' = STOP)
+%
+% Following the artifact, codons are written with T (thymine) as they appear in
+% the table; in transcribed mRNA the corresponding base is U (uracil), so e.g.
+% row `atg` is the mRNA start codon AUG. Amino acids use the standard single
+% letter, LOWERCASED (`f` = Phe, `m` = Met, …); every STOP codon maps to the atom
+% `stop`. All 64 codons are shipped so that every triplet resolves.
+%
+% Amino-acid single-letter legend (for the reader):
+%   a Ala  c Cys  d Asp  e Glu  f Phe  g Gly  h His  i Ile  k Lys  l Leu
+%   m Met  n Asn  p Pro  q Gln  r Arg  s Ser  t Thr  v Val  w Trp  y Tyr
+%   stop = translation terminator (the '*' in the AAs line)
+%
+% PROVENANCE
+% ----------
+% Nothing here is from memory. The whole NCBI "Genetic Codes" page — translation
+% table 1, "The Standard Code" (SGC0) — is the citable artifact: its exact AAs /
+% Starts / Base1 / Base2 / Base3 lines are copied VERBATIM into `source`, and the
+% 64 rows below are a faithful column-by-column decode of those lines. `locator`
+% is the live NCBI URL. `trust authoritative` — ncbi.nlm.nih.gov is NIH/NLM, a
+% primary source. (See ../README.md; feedback_nothing_human_authored,
+% feedback_no_byte_arithmetic_for_llm, feedback_adj_only_shipped_artifacts.)
+% ============================================================================
+
+table codon_amino_acid {
+    columns codon, amino_acid
+
+    % --- Base1 = T (mRNA U…) : the "U" block ---------------------------------
+    row (ttt, f)     % Phe
+    row (ttc, f)     % Phe
+    row (tta, l)     % Leu
+    row (ttg, l)     % Leu
+    row (tct, s)     % Ser
+    row (tcc, s)     % Ser
+    row (tca, s)     % Ser
+    row (tcg, s)     % Ser
+    row (tat, y)     % Tyr
+    row (tac, y)     % Tyr
+    row (taa, stop)  % STOP (ochre)
+    row (tag, stop)  % STOP (amber)
+    row (tgt, c)     % Cys
+    row (tgc, c)     % Cys
+    row (tga, stop)  % STOP (opal)
+    row (tgg, w)     % Trp
+
+    % --- Base1 = C -----------------------------------------------------------
+    row (ctt, l)     % Leu
+    row (ctc, l)     % Leu
+    row (cta, l)     % Leu
+    row (ctg, l)     % Leu
+    row (cct, p)     % Pro
+    row (ccc, p)     % Pro
+    row (cca, p)     % Pro
+    row (ccg, p)     % Pro
+    row (cat, h)     % His
+    row (cac, h)     % His
+    row (caa, q)     % Gln
+    row (cag, q)     % Gln
+    row (cgt, r)     % Arg
+    row (cgc, r)     % Arg
+    row (cga, r)     % Arg
+    row (cgg, r)     % Arg
+
+    % --- Base1 = A -----------------------------------------------------------
+    row (att, i)     % Ile
+    row (atc, i)     % Ile
+    row (ata, i)     % Ile
+    row (atg, m)     % Met — the START codon
+    row (act, t)     % Thr
+    row (acc, t)     % Thr
+    row (aca, t)     % Thr
+    row (acg, t)     % Thr
+    row (aat, n)     % Asn
+    row (aac, n)     % Asn
+    row (aaa, k)     % Lys
+    row (aag, k)     % Lys
+    row (agt, s)     % Ser
+    row (agc, s)     % Ser
+    row (aga, r)     % Arg
+    row (agg, r)     % Arg
+
+    % --- Base1 = G -----------------------------------------------------------
+    row (gtt, v)     % Val
+    row (gtc, v)     % Val
+    row (gta, v)     % Val
+    row (gtg, v)     % Val
+    row (gct, a)     % Ala
+    row (gcc, a)     % Ala
+    row (gca, a)     % Ala
+    row (gcg, a)     % Ala
+    row (gat, d)     % Asp
+    row (gac, d)     % Asp
+    row (gaa, e)     % Glu
+    row (gag, e)     % Glu
+    row (ggt, g)     % Gly
+    row (ggc, g)     % Gly
+    row (gga, g)     % Gly
+    row (ggg, g)     % Gly
+
+    % The citable artifact: NCBI translation table 1, "The Standard Code" (SGC0),
+    % 5-line block copied VERBATIM. Column i => codon Base1[i]Base2[i]Base3[i]
+    % maps to amino acid AAs[i] ('*' = stop); the 64 rows above decode it.
+    source "AAs  = FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG\nStarts = ---M------**--*----M---------------M----------------------------\nBase1  = TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG\nBase2  = TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG\nBase3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG"
+    locator "https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/biology/genetic-code.query.adj
+++ b/code/specs/data/adj-facts-stdlib/biology/genetic-code.query.adj
@@ -1,0 +1,19 @@
+% ============================================================================
+% genetic-code.query.adj — a worked recall over the standard-genetic-code library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what does codon AUG code
+% for?": it states no biology fact — it only `import`s the grounded table and asks
+% binding queries. The engine resolves each `?` against the `codon_amino_acid`
+% rows and returns the amino acid + the table's source/locator/trust. A triplet
+% that is not a real codon abstains honestly — the engine never invents a product.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli genetic-code.query.adj
+% ============================================================================
+
+import "genetic-code.adj"
+
+? codon_amino_acid(atg, $A)      % expect m    — methionine, also the START codon
+? codon_amino_acid(taa, $A)      % expect stop — a STOP codon terminates translation
+? codon_amino_acid(gag, $A)      % expect e    — glutamate (sickle-cell wild-type)
+? codon_amino_acid(xyz, $A)      % expect abstain — `xyz` is not a codon


### PR DESCRIPTION
## What

Adds the **STANDARD GENETIC CODE** (NCBI translation table 1, "The Standard Code" / SGC0) as a grounded ADJ facts library under `biology/`: a native `table codon_amino_acid` with **all 64 mRNA codons** mapped to their amino acid (single-letter, lowercased; the three stop codons map to the atom `stop`).

This is the foundational molecular-biology table a medicine agent reasons from — point mutations (silent / missense / nonsense), start/stop, and codon degeneracy (wobble). Recall is a binding query with zero answer-time model calls:

```adj
? codon_amino_acid(atg, $A)   % m    (methionine — also the START codon)
? codon_amino_acid(taa, $A)   % stop (terminates translation)
? codon_amino_acid(gag, $A)   % e    (glutamate; gag e -> gtg v is the sickle-cell mutation)
? codon_amino_acid(xyz, $A)   % abstain — not a real codon
```

## Grounding (nothing from memory)

The whole NCBI "Genetic Codes" page is the citable artifact. Its exact 5-line block is copied **VERBATIM** into `source`:

```
  AAs  = FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG
  Starts = ---M------**--*----M---------------M----------------------------
  Base1  = TTTTTTTTTTTTTTTTCCCCCCCCCCCCCCCCAAAAAAAAAAAAAAAAGGGGGGGGGGGGGGGG
  Base2  = TTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGGTTTTCCCCAAAAGGGG
  Base3  = TCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAGTCAG
```

The 64 rows are a faithful column-by-column decode: codon `i` = `Base1[i]Base2[i]Base3[i]` -> amino acid `AAs[i]` (`*` = stop).

- **locator**: `https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi`
- **trust**: `authoritative` (ncbi.nlm.nih.gov — NIH/NLM, primary source)

## Files

- `code/specs/data/adj-facts-stdlib/biology/genetic-code.adj` — the 64-row table + literate commentary
- `code/specs/data/adj-facts-stdlib/biology/genetic-code.query.adj` — worked recall
- `code/packages/rust/adj-lang-cli/tests/facts_geneticcode_e2e.rs` — e2e: asserts `atg->m`, `taa->stop`, `gag->e`, the NCBI locator + authoritative trust, and honest abstention on `xyz`

## Verification

- `cargo test -p adj-lang-cli --test facts_geneticcode_e2e` ✅
- `cargo clippy -p adj-lang-cli --test facts_geneticcode_e2e -- -D warnings` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)