### PR TITLE
feat(adj-formula-stdlib): ideal gas law P=nRT/V grounded to NIST CODATA R

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_idealgas_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_idealgas_e2e.rs
@@ -1,0 +1,101 @@
+//! End-to-end test for the `chemistry/ideal-gas-law.adj` library — the ideal gas
+//! law solved for pressure, P = nRT/V — driven through the built CLI binary
+//! against the SHIPPED stdlib. It proves the same invariant as the other formula
+//! libraries: a consumer states NO arithmetic; it imports the grounded library,
+//! binds the three state variables with `observe`, and the engine applies the
+//! cited law on the CPU — computing the value and rendering the applied formula's
+//! NIST CODATA citation + trust tier in the `derived` section (the auditable
+//! answer, zero math by the model).
+//!
+//! Because the molar gas constant R = 8.314462618 J mol⁻¹ K⁻¹ (NIST CODATA,
+//! exact) makes the result a real number, the assertion parses the emitted
+//! `value` and compares it to the expected pressure within a small epsilon rather
+//! than matching an exact decimal string.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped ideal-gas-law library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_idealgas_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj")
+        .canonicalize()
+        .expect("shipped chemistry/ideal-gas-law.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_idealgas_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Pull the numeric `value` for the derived `name` out of the CLI's JSON output.
+/// The output shape is `…"name":"pressure","value":101324.8623…,"dim":…`, so we
+/// slice between the `"value":` that follows this name and the next comma.
+fn derived_value(json: &str, name: &str) -> f64 {
+    let anchor = format!("\"name\":\"{name}\",\"value\":");
+    let start = json
+        .find(&anchor)
+        .map(|i| i + anchor.len())
+        .unwrap_or_else(|| panic!("derived value for {name} present: {json}"));
+    let rest = &json[start..];
+    let end = rest.find(',').expect("value terminated by a comma");
+    rest[..end]
+        .trim()
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("value for {name} parses as a real: {json}"))
+}
+
+/// Ideal gas law at STP — "one mole of an ideal gas at 273.15 K occupies the
+/// molar volume 0.022414 m³" → the model binds moles, temperature, volume; the
+/// engine applies P = nRT/V on the CPU with the NIST CODATA molar gas constant
+/// R = 8.314462618 J mol⁻¹ K⁻¹ → ~101325 Pa (one standard atmosphere), carrying
+/// the authoritative NIST citation.
+#[test]
+fn ideal_gas_law_binds_and_computes_pressure_at_stp_with_nist_citation() {
+    let dir = scratch("stp");
+    let lib = std::fs::read_to_string(shipped_idealgas_lib()).unwrap();
+    std::fs::write(dir.join("ideal-gas-law.adj"), lib).unwrap();
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"ideal-gas-law.adj\"\n\
+         observe moles(1)\n\
+         observe temperature(273.15)\n\
+         observe volume(0.022414)\n\
+         ? pressure(moles, temperature, volume)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+
+    // The pressure is a real (R makes it non-integer): parse it and compare to
+    // one standard atmosphere within a small epsilon rather than matching digits.
+    let pressure = derived_value(&s, "pressure");
+    let expected = 101_325.0_f64; // 1 atm — STP pressure for 1 mol in the molar volume
+    assert!(
+        (pressure - expected).abs() < 5.0,
+        "pressure at STP is ~101325 Pa (got {pressure}): {s}"
+    );
+
+    // … AND the applied law carries its NIST CODATA citation + trust tier, so the
+    // value of R (and thus the answer) is auditable end to end.
+    assert!(
+        s.contains("\"trust\":\"authoritative\"")
+            && s.contains("physics.nist.gov/cgi-bin/cuu/Value?r")
+            && s.contains("8.314 462 618"),
+        "applied formula carries its verbatim NIST CODATA provenance: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj
@@ -1,0 +1,98 @@
+% ============================================================================
+% ideal-gas-law.adj — the ideal gas law for the ADJ compute stdlib (chemistry).
+% ============================================================================
+% The FIRST entry of the SCIENCE track's CHEMISTRY layer, and the first
+% MULTI-VARIABLE STATE LAW in the ADJ stdlib: an equation of state relating three
+% independent quantities of a gas at once. Where `physics/mechanics-laws.adj`
+% ships two-variable products/quotients (F = m·a, ρ = m/V) and `clinical/bmi.adj`
+% ships a clinical definition, this ships a LAW OF NATURE that couples pressure,
+% amount, temperature, and volume through a single grounded constant.
+%
+% The ideal gas law is  P·V = n·R·T.  Solved for pressure:
+%
+%     P = n · R · T / V
+%
+% where  n = amount of substance (moles),  T = absolute temperature (kelvin),
+% V = volume (m³),  R = the molar gas constant, and  P = pressure (pascals).
+%
+% The crux of GROUNDING here is R. R is NOT a memorized number — it is copied
+% verbatim from the NIST CODATA reference below (2022 CODATA recommended value,
+% an EXACT constant since the 2019 SI redefinition fixed the Boltzmann constant):
+%
+%     R = 8.314462618 J mol⁻¹ K⁻¹   (NIST CODATA, exact) → trust authoritative
+%
+% Contract, unchanged from the rest of the ladder: THE MODEL DOES ZERO
+% ARITHMETIC. A consumer states no math. It `import`s this file, binds the three
+% quantities from its own byte-provenance decomposition of the input, and asks
+% the engine to APPLY the cited law on the CPU. The engine computes exactly, and
+% the answer carries the law's citation — auditable end to end:
+%
+%     import "ideal-gas-law.adj"
+%     observe moles(1)              % "…1 mole of gas…"        (span cited by the model)
+%     observe temperature(273.15)   % "…at 273.15 K…"          (span cited by the model)
+%     observe volume(0.022414)      % "…occupying 0.022414 m³…" (span cited by the model)
+%     ? pressure(moles, temperature, volume)   % engine → ~101325 Pa (1 atm at STP)
+%
+% Why a MEDICINE agent cares: gas laws are the substrate for respiratory and
+% anesthetic reasoning. Alveolar gas equations, the partial pressures that drive
+% oxygen uptake and CO₂ clearance, the behavior of anesthetic gases across
+% temperature and volume changes in a breathing circuit, gas-cylinder content
+% from pressure — all of it descends from PV = nRT. An agent that reasons about
+% "the pressure of n moles of an anesthetic vapor in a fixed reservoir at body
+% temperature" RECALLS this law and BINDS the numbers; it never re-derives the
+% relation or re-guesses R.
+%
+% Run a worked consumer (from a directory it can resolve this import from):
+%     adj-lang-cli ideal-gas-law.query.adj
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each term is an observable state variable of the gas the law ranges
+% over. rung-0's grammar types an observable slot as `finding` (dimensional
+% typing of formula parameters is a later rung — but the engine already INFERS
+% and CHECKS dimensions when a formula is APPLIED, so mol · (J/mol/K) · K / m³
+% reduces to J/m³ = Pa, and a unit mismatch is an error, not a silent coercion).
+% The intended dimension of each term is recorded in the trailing comment, and
+% the `surface` synonyms let a decomposer map everyday phrasing onto the term.
+%
+%   Term          Dimension                     Role in P = nRT/V
+%   ----          ---------                     -----------------
+%   moles         amount of substance (mol)     n  — how much gas
+%   temperature   temperature (K)               T  — absolute, kelvin
+%   volume        length³ (m³)                   V  — occupied volume
+%   pressure      mass/length/time² (Pa)        P  — the computed result
+% ----------------------------------------------------------------------------
+dictionary ideal_gas_vocab {
+    define moles       : finding  surface "moles", "amount of substance", "n", "number of moles"  % mol
+    define temperature : finding  surface "temperature", "absolute temperature", "T"              % kelvin (K)
+    define volume      : finding  surface "volume", "V"                                           % length³ (m³)
+    define pressure    : finding  surface "pressure", "P", "gas pressure"                         % pascals (Pa)
+}
+
+% ----------------------------------------------------------------------------
+% The law. A named, importable, reusable `let` over its three formal parameters —
+% the SAME expression grammar `let` uses (+ - * / and parens), with the parameter
+% leaves bound at apply time. R appears as a LITERAL in the body, copied verbatim
+% from the NIST CODATA value quoted in the `source` clause — so the constant is
+% grounded in the same provenance envelope as the relation itself, not asserted
+% by fiat.
+%
+% Two sources travel with this one formula:
+%   • the value of R — NIST CODATA (physics.nist.gov), the authoritative primary
+%     reference, quoted verbatim including its exact digits;
+%   • the relation PV = nRT — Wikipedia's clean statement of the ideal gas law,
+%     for the equation-of-state form itself.
+% The value of the constant is the load-bearing claim, and it is authoritative;
+% the trust tier for the shipped formula follows the constant → authoritative.
+% ----------------------------------------------------------------------------
+formulabook chemistry_ideal_gas {
+    use ideal_gas_vocab
+
+    % Ideal gas law solved for pressure — P = nRT/V. The molar gas constant R is
+    % the verbatim NIST CODATA value 8.314462618 J mol⁻¹ K⁻¹ (exact, 2022 CODATA).
+    % The relation PV = nRT is the standard ideal-gas equation of state.
+    formula pressure(moles, temperature, volume) = moles * 8.314462618 * temperature / volume
+        source "molar gas constant | Numerical value | 8.314 462 618 J mol^-1 K^-1 | Standard uncertainty | (exact). The ideal gas law: PV = nRT, where P is the pressure, V is the volume, n is the amount of substance, R is the ideal (universal) gas constant, and T is the absolute temperature."
+        locator "https://physics.nist.gov/cgi-bin/cuu/Value?r"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.query.adj
+++ b/code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% ideal-gas-law.query.adj — a worked application of the ideal gas law.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a gas-law word
+% problem: it states NO arithmetic. It `import`s the grounded law library, binds
+% each state variable it decomposed from the input (each `observe` is a
+% byte-provenance span the model cited), and asks the engine to APPLY the recalled
+% law. The native adj-lang engine substitutes the law's body, computes exactly on
+% the CPU, and returns the value carrying the law's NIST source/locator/trust —
+% the auditable chain.
+%
+% "One mole of an ideal gas at 273.15 K occupies 0.022414 m³. What is its
+%  pressure?"  → recall P = nRT/V, bind n = 1, T = 273.15, V = 0.022414,
+%  apply → ~101325 Pa (one standard atmosphere — this is exactly STP: 1 mol of
+%  ideal gas at the ice point occupies the molar volume 22.414 L, so the pressure
+%  comes back to 1 atm, the internal consistency check on R and the molar volume).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli ideal-gas-law.query.adj
+% ============================================================================
+
+import "ideal-gas-law.adj"
+
+% --- Ideal gas law at STP: 1 mol at 273.15 K in the molar volume 0.022414 m³. ---
+observe moles(1)                              % "…one mole of gas…"        (span cited by the model)
+observe temperature(273.15)                   % "…at 273.15 K…"            (span cited by the model)
+observe volume(0.022414)                      % "…occupying 0.022414 m³…"  (span cited by the model)
+? pressure(moles, temperature, volume)        % engine → ~101325 Pa (P = nRT/V, NIST CODATA R, authoritative)


### PR DESCRIPTION
## What

Adds the first **chemistry** entry and the first **multi-variable state law** to the ADJ compute stdlib: the ideal gas law solved for pressure.

    formula pressure(moles, temperature, volume)
        = moles * 8.314462618 * temperature / volume    % P = nRT/V

New files (data + one test):
- `code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.adj` — `dictionary ideal_gas_vocab` (moles, temperature, volume, pressure) + `formulabook chemistry_ideal_gas`. Literate header: first multi-variable state law; why a medicine agent reasons from gas laws (alveolar gas, anesthesia, cylinder content).
- `code/specs/data/adj-formula-stdlib/chemistry/ideal-gas-law.query.adj` — worked STP consumer: 1 mol at 273.15 K in the molar volume 0.022414 m³ → ~101325 Pa (1 atm), an internal consistency check on R and the molar volume.
- `code/packages/rust/adj-lang-cli/tests/formula_idealgas_e2e.rs` — e2e through the built CLI; parses the emitted real `value` and epsilon-compares to 101325 Pa, and asserts the applied formula carries its verbatim NIST citation + `authoritative` tier.

## Grounding

The molar gas constant **R** is the crux and is grounded verbatim to **NIST CODATA** (2022 recommended value, *exact* since the 2019 SI redefinition):

> molar gas constant | Numerical value | **8.314 462 618** J mol⁻¹ K⁻¹ | Standard uncertainty | (exact)

- `source`: verbatim NIST CODATA span for R + the PV = nRT relation.
- `locator`: https://physics.nist.gov/cgi-bin/cuu/Value?r
- `trust`: **authoritative** (NIST CODATA primary reference)

## Verification

- `cargo test -p adj-lang-cli --test formula_idealgas_e2e` passes — computed pressure **101324.8623229544 Pa** (within 0.14 of 1 atm).
- `cargo clippy -p adj-lang-cli --test formula_idealgas_e2e -- -D warnings` clean.
- Security review: passed (round 1, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)