### PR TITLE
feat(adj-facts-stdlib): chemistry atomic-weights table (CIAAW, H–Ca)

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/facts_atomicweights_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/facts_atomicweights_e2e.rs
@@ -1,0 +1,62 @@
+//! End-to-end test for the chemistry FACTS library
+//! (`adj-facts-stdlib/chemistry/atomic-weights.adj`) driven through the built CLI:
+//! a native `table` of element → standard atomic weight resolves a binding-query
+//! recall with the source's citation, and abstains on a non-element — 0 model calls.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn facts_stdlib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-facts-stdlib")
+        .canonicalize()
+        .expect("shipped adj-facts-stdlib must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_factsw_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+#[test]
+fn chemistry_atomic_weight_recall_binds_weight_with_citation() {
+    let dir = scratch("atomicweights");
+    // Copy the shipped chemistry table beside the entry program and import it.
+    let src = facts_stdlib().join("chemistry/atomic-weights.adj");
+    std::fs::copy(&src, dir.join("atomic-weights.adj")).expect("copy shipped atomic-weights.adj");
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"atomic-weights.adj\"\n\
+         ? atomic_weight(carbon, $W)\n\
+         ? atomic_weight(oxygen, $W)\n\
+         ? atomic_weight(adamantium, $W)\n",
+    )
+    .unwrap();
+
+    let (ok, out) = run(&dir.join("case.adj"));
+    assert!(ok, "cli should succeed: {out}");
+    assert!(out.contains("\"recall\""), "has a recall section: {out}");
+    // Carbon's standard atomic weight is the abridged conventional value 12.011,
+    // the leading number of CIAAW's verbatim "12.011 ± 0.002"; oxygen is 15.999.
+    assert!(out.contains("\"W\":\"12.011\""), "carbon -> 12.011: {out}");
+    assert!(out.contains("\"W\":\"15.999\""), "oxygen -> 15.999: {out}");
+    // The answer carries the CIAAW citation as its proof, at authoritative trust.
+    assert!(
+        out.contains("ciaaw.org/abridged-atomic-weights.htm")
+            && out.contains("\"trust\":\"authoritative\""),
+        "carries the source citation: {out}"
+    );
+    // "adamantium" is not a chemical element — honest abstention, never a
+    // fabricated weight.
+    assert!(out.contains("\"abstained\":true"), "adamantium abstains: {out}");
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/atomic-weights.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/atomic-weights.adj
@@ -1,0 +1,76 @@
+% ============================================================================
+% atomic_weight — the standard atomic weight (relative atomic mass) of the
+% first twenty chemical elements (adj-facts-stdlib, CHEMISTRY).
+% ============================================================================
+% The SIBLING of `elements.adj`. Where `elements.adj` recalls an element's
+% atomic NUMBER (its proton count, an integer that ORDERS the periodic table),
+% this library recalls its standard atomic WEIGHT — the relative atomic mass,
+% a dimensionless decimal averaged over the isotopes found in normal terrestrial
+% material. Recall is a binding query:
+%
+%     ? atomic_weight(carbon, $W)          % 12.011
+%
+% Like every FACTS library this is a native `table` (ADJ-TABLES RS-5): each
+% `row` lowers to a ground relation `atomic_weight(element, weight)` carrying the
+% table's citation, so the lookup is the ordinary SLD binding query — the engine
+% returns the weight WITH its source, on the CPU, with zero model calls, and
+% abstains on a name not in the table. It also runs BACKWARD (bind a weight,
+% recall the element).
+%
+% WHY a weight and not just a number — recall feeding COMPUTE. A molecule's molar
+% mass is the sum of the standard atomic weights of its atoms (in grams per mole):
+% water H2O is 2 * weight(hydrogen) + weight(oxygen) ~= 2 * 1.008 + 15.999
+% = 18.015 g/mol. Because each `weight` cell is a NUMBER (not a label), a recalled
+% weight composes straight into that arithmetic — this is the concrete bridge from
+% chemistry RECALL to molar-mass COMPUTE, the reason a facts library and a formula
+% library belong in one standard library.
+%
+% Provenance. Every weight below is copied verbatim from the CIAAW (Commission on
+% Isotopic Abundances and Atomic Weights of IUPAC) "Abridged standard atomic
+% weights" table — the primary international authority that publishes the standard
+% atomic weights. The abridged table gives, for each element, a single CONVENTIONAL
+% value with an uncertainty (e.g. carbon "12.011 ± 0.002"); the `weight` cell holds
+% exactly that conventional value (the number before the "±"). The `source` span is
+% the verbatim carbon and oxygen rows as they render on that page; the `locator` is
+% its real URL; `trust authoritative` because CIAAW/IUPAC is the standards body that
+% defines these values. Nothing here is asserted from memory — the twenty weights
+% were read out of the fetched CIAAW page, and any element whose value could not be
+% copied verbatim would have been dropped.
+%
+% Note on keys: element atoms use the same lowercase names as `elements.adj` (so a
+% weight joins its atomic number), including the US spelling `aluminum` for CIAAW's
+% "Aluminium". Note on rendering: a decimal is stored as its exact numeric value, so
+% a trailing-zero form in the source (e.g. neon "20.180") recalls as the equal value
+% "20.18"; carbon and oxygen have no trailing zero and recall exactly as written.
+% (See ../README.md; feedback_nothing_human_authored,
+% feedback_adj_only_shipped_artifacts, feedback_no_byte_arithmetic_for_llm.)
+% ============================================================================
+
+table atomic_weight {
+    columns element, weight
+
+    row (hydrogen, 1.0080)
+    row (helium, 4.0026)
+    row (lithium, 6.94)
+    row (beryllium, 9.0122)
+    row (boron, 10.81)
+    row (carbon, 12.011)
+    row (nitrogen, 14.007)
+    row (oxygen, 15.999)
+    row (fluorine, 18.998)
+    row (neon, 20.180)
+    row (sodium, 22.990)
+    row (magnesium, 24.305)
+    row (aluminum, 26.982)
+    row (silicon, 28.085)
+    row (phosphorus, 30.974)
+    row (sulfur, 32.06)
+    row (chlorine, 35.45)
+    row (argon, 39.95)
+    row (potassium, 39.098)
+    row (calcium, 40.078)
+
+    source "6\tC\tcarbon\t 12.011 ± 0.002    8\tO\toxygen\t 15.999 ± 0.001"
+    locator "https://ciaaw.org/abridged-atomic-weights.htm"
+    trust authoritative
+}

--- a/code/specs/data/adj-facts-stdlib/chemistry/atomic-weights.query.adj
+++ b/code/specs/data/adj-facts-stdlib/chemistry/atomic-weights.query.adj
@@ -1,0 +1,21 @@
+% ============================================================================
+% atomic-weights.query.adj — a worked recall over the atomic-weight library.
+% ============================================================================
+% The shape a learner (or an LLM) produces to ANSWER "what is carbon's standard
+% atomic weight?": it states no chemistry fact — it only `import`s the grounded
+% table and asks binding queries. The engine resolves each `?` against the
+% `atomic_weight` rows and returns the weight + the table's source/locator/trust.
+% The third query runs the relation BACKWARD (bind the weight, recall the
+% element). A name that is not an element abstains honestly — the engine never
+% invents an atomic weight.
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli atomic-weights.query.adj
+% ============================================================================
+
+import "atomic-weights.adj"
+
+? atomic_weight(carbon, $W)            % expect 12.011
+? atomic_weight(oxygen, $W)            % expect 15.999
+? atomic_weight($E, 12.011)            % expect carbon — the reverse recall
+? atomic_weight(adamantium, $W)        % expect abstain — not a chemical element


### PR DESCRIPTION
## What

Adds one grounded ADJ facts library to the chemistry stdlib: `chemistry/atomic-weights.adj`, a native `table atomic_weight(element, weight)` for the first twenty elements (hydrogen → calcium) → standard atomic weight (relative atomic mass).

Sibling of the existing `elements.adj` (element → atomic NUMBER). Where that recalls proton count, this recalls relative atomic mass. Because `weight` is a decimal number, a recalled weight **composes into molar-mass compute** (e.g. water H2O ≈ 2·1.008 + 15.999 = 18.015 g/mol) — the bridge from RECALL to COMPUTE.

## Grounding (rigorous provenance)

- Source: **CIAAW / IUPAC "Abridged standard atomic weights"** — the standards body that defines these values.
- Locator: `https://ciaaw.org/abridged-atomic-weights.htm`
- Each `weight` is the **conventional value** (the number before the "±"), copied verbatim. Examples from the page: carbon `12.011 ± 0.002`, oxygen `15.999 ± 0.001`.
- `trust authoritative`. Nothing asserted from memory; all 20 elements grounded (none dropped).
- Element keys reuse `elements.adj` spellings (incl. US `aluminum`) so a weight joins its atomic number.

## Files

- `code/specs/data/adj-facts-stdlib/chemistry/atomic-weights.adj` — the table + literate provenance.
- `code/specs/data/adj-facts-stdlib/chemistry/atomic-weights.query.adj` — forward + reverse recall, abstain on a non-element.
- `code/packages/rust/adj-lang-cli/tests/facts_atomicweights_e2e.rs` — asserts carbon 12.011, oxygen 15.999, CIAAW locator + authoritative trust, abstention on a fabricated element.

## Verification

- `cargo test -p adj-lang-cli --test facts_atomicweights_e2e` — passes.
- `cargo clippy -p adj-lang-cli --test facts_atomicweights_e2e -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)