### PR TITLE
feat(adj-formula-stdlib): grounded Newton's law of universal gravitation

### DIFF
--- a/code/packages/rust/adj-lang-cli/tests/formula_gravitation_e2e.rs
+++ b/code/packages/rust/adj-lang-cli/tests/formula_gravitation_e2e.rs
@@ -1,0 +1,117 @@
+//! End-to-end test for Newton's law of universal gravitation through the built
+//! CLI binary: a consumer `import`s the SHIPPED `physics/gravitation.adj` formula
+//! library, binds the three quantities from its own `observe`d facts, and applies
+//! the cited law F = G·m₁·m₂/r². The CLI must compute the force on the CPU and
+//! render the applied formula's NIST citation in the `derived` section — the
+//! auditable answer, zero math by the model.
+//!
+//! The Newtonian constant of gravitation baked into the shipped law is grounded
+//! VERBATIM to the NIST CODATA 2022 recommended value,
+//! "6.674 30 x 10-11 m3 kg-1 s-2" (https://physics.nist.gov/cgi-bin/cuu/Value?bg),
+//! at `authoritative` trust — so the magnitude, not just the inverse-square form,
+//! carries primary-source provenance.
+//!
+//! Because the law multiplies an irrational-looking real constant through three
+//! large real inputs, the result is a REAL: the assertion is an APPROXIMATE
+//! (relative-epsilon) compare, the honest contract for floating-point physics.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Absolute path to the shipped gravitation library, resolved from this crate's
+/// manifest dir so the test is location-independent.
+fn shipped_gravitation_lib() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../specs/data/adj-formula-stdlib/physics/gravitation.adj")
+        .canonicalize()
+        .expect("shipped physics/gravitation.adj must exist")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("adjcli_grav_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run(program: &Path) -> (bool, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_adj-lang-cli"))
+        .arg(program)
+        .output()
+        .expect("run adj-lang-cli");
+    (out.status.success(), String::from_utf8(out.stdout).unwrap())
+}
+
+/// Pull the numeric `"value":<num>` immediately following the FIRST occurrence of
+/// `marker` out of the CLI's JSON, parsed as `f64`. Tiny purpose-built extractor
+/// (the crate ships no JSON dependency) so the test can do a real approximate
+/// compare on the derived force rather than a brittle exact-string match.
+fn derived_value_after(json: &str, marker: &str) -> f64 {
+    let at = json.find(marker).expect("marker present in output");
+    let vkey = "\"value\":";
+    let vstart = json[at..].find(vkey).expect("value key after marker") + at + vkey.len();
+    let rest = &json[vstart..];
+    let end = rest
+        .find(|c: char| c != '-' && c != '+' && c != '.' && c != 'e' && c != 'E' && !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    rest[..end].parse::<f64>().expect("value parses as f64")
+}
+
+/// Newton's law of universal gravitation — the Earth (m₁ = 5.972×10²⁴ kg) and the
+/// Moon (m₂ = 7.348×10²² kg) separated by r = 3.844×10⁸ m. The model binds the
+/// three quantities; the engine applies F = G·m₁·m₂/r² on the CPU → ≈1.982×10²⁰ N,
+/// carrying NIST's CODATA value of G. Approximate (relative-epsilon) compare.
+#[test]
+fn universal_gravitation_binds_and_computes_with_nist_citation() {
+    let dir = scratch("earthmoon");
+    let lib = std::fs::read_to_string(shipped_gravitation_lib()).unwrap();
+    std::fs::write(dir.join("gravitation.adj"), lib).unwrap();
+    std::fs::write(
+        dir.join("case.adj"),
+        "import \"gravitation.adj\"\n\
+         observe mass_one(5.972e24)\n\
+         observe mass_two(7.348e22)\n\
+         observe distance(3.844e8)\n\
+         ? gravitational_force(mass_one, mass_two, distance)\n",
+    )
+    .unwrap();
+
+    let (ok, s) = run(&dir.join("case.adj"));
+    assert!(ok, "CLI exited non-zero: {s}");
+    assert!(!s.contains("\"error\""), "no compile error: {s}");
+    assert!(s.contains("\"derived\":["), "derived section present: {s}");
+    assert!(
+        s.contains("\"name\":\"gravitational_force\""),
+        "applied law named in derived section: {s}"
+    );
+
+    // The Earth–Moon attraction is ≈1.982×10²⁰ N. Assert with a relative epsilon
+    // (reals): F = 6.67430e-11 · 5.972e24 · 7.348e22 / (3.844e8)² = 1.9821…×10²⁰.
+    let f = derived_value_after(&s, "\"name\":\"gravitational_force\"");
+    let expected = 1.982110729079252e20;
+    let rel_err = (f - expected).abs() / expected;
+    assert!(
+        rel_err < 1e-9,
+        "gravitational force ≈ {expected:e} N (got {f:e}, rel_err {rel_err:e}): {s}"
+    );
+    // Sanity: the order of magnitude alone is the headline answer (~10²⁰ N).
+    assert!(
+        (1.0e20..1.0e21).contains(&f),
+        "force is on the order of 10²⁰ N: {f:e}"
+    );
+
+    // The applied law carries its cited NIST provenance — verbatim G value,
+    // authoritative trust, and the NIST value-page locator — so it is auditable.
+    assert!(
+        s.contains("\"trust\":\"authoritative\""),
+        "applied formula is authoritative-tier: {s}"
+    );
+    assert!(
+        s.contains("physics.nist.gov"),
+        "applied formula cites the NIST locator: {s}"
+    );
+    assert!(
+        s.contains("6.674 30 x 10-11"),
+        "source quotes NIST's verbatim value of G: {s}"
+    );
+}

--- a/code/specs/data/adj-formula-stdlib/physics/gravitation.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/gravitation.adj
@@ -1,0 +1,90 @@
+% ============================================================================
+% gravitation.adj — Newton's law of universal gravitation for the ADJ compute
+% stdlib (ADJ-FORMULA-LIBRARIES §4, SCIENCE track / physics layer).
+% ============================================================================
+% A companion to `physics/mechanics-laws.adj`: where that file ships the leaf
+% laws a student memorizes (F = m·a, V = I·R, ρ = m/V, v = d/t), this ships the
+% single most-cited *inverse-square* law of classical physics — Newton's law of
+% universal gravitation:
+%
+%       G · m₁ · m₂
+%   F = ───────────          (the attractive force between two point masses)
+%           r²
+%
+% The contract is the whole point of the ladder: THE MODEL DOES ZERO ARITHMETIC.
+% A consumer states no math. It `import`s this file, binds the three quantities
+% from its own byte-provenance decomposition of the input, and asks the engine
+% to APPLY the cited law on the CPU. The engine computes exactly, and the answer
+% carries the law's citation — so the derivation is auditable end to end:
+%
+%     import "gravitation.adj"
+%     observe mass_one(5.972e24)                 % "…Earth's mass 5.972×10²⁴ kg…" (span cited)
+%     observe mass_two(7.348e22)                 % "…the Moon's 7.348×10²² kg…"    (span cited)
+%     observe distance(3.844e8)                  % "…384 400 km apart…"            (span cited)
+%     ? gravitational_force(mass_one, mass_two, distance)   % engine → ≈1.98×10²⁰ N
+%
+% The law (and its source) live HERE; the numbers (and their spans) come from
+% the input. A science/medicine agent that needs "the gravitational force
+% between two bodies" RECALLS which law applies and BINDS the numbers — it never
+% re-derives F = G·m₁·m₂/r².
+%
+% Why the constant is the crux. The relationship F ∝ m₁m₂/r² is the *structure*;
+% the Newtonian constant of gravitation G is the *magnitude*, and getting G wrong
+% by a decimal place is the whole answer wrong. So G is grounded to the primary
+% metrological authority — the NIST CODATA 2022 recommended value,
+% 6.674 30 × 10⁻¹¹ m³ kg⁻¹ s⁻² — copied VERBATIM into the formula's `source`, with
+% the NIST value page as the `locator`, at `authoritative` trust. The
+% inverse-square *form* composes from the arithmetic primitives already in the
+% stdlib (multiply, divide) applied to the parameter leaves; only the constant
+% needs external grounding, and it is grounded to the definitive source.
+%
+% Run a worked consumer (from a directory it can resolve this import from):
+%     adj-lang-cli gravitation.query.adj
+% ============================================================================
+
+% ----------------------------------------------------------------------------
+% Vocabulary. Each term is an observable physical quantity the law ranges over.
+% rung-0's grammar types an observable slot as `finding` (dimensional typing of
+% formula parameters is a later rung — but the engine already INFERS and CHECKS
+% dimensions when a formula is APPLIED, so kg × kg / m² carries through and a
+% unit mismatch is an error, not a silent coercion). The intended dimension of
+% each term is recorded in the trailing comment, and the `surface` synonyms let a
+% decomposer map everyday phrasing onto the canonical term.
+%
+%   Term                Dimension                  Role in F = G·m₁·m₂/r²
+%   ----                ---------                  ----------------------
+%   mass_one            mass (kg)                  first body's mass, m₁
+%   mass_two            mass (kg)                  second body's mass, m₂
+%   distance            length (m)                 centre-to-centre separation, r
+%   gravitational_force mass·length/time² (N)      attractive force, F
+% ----------------------------------------------------------------------------
+dictionary gravitation_vocab {
+    define mass_one            : finding  surface "first mass", "m1", "mass of the first body", "M"    % mass, e.g. kg
+    define mass_two            : finding  surface "second mass", "m2", "mass of the second body"       % mass, e.g. kg
+    define distance            : finding  surface "distance", "separation", "r", "distance between centres" % length, e.g. m
+    define gravitational_force : finding  surface "gravitational force", "force of gravity", "F"       % mass · length / time² (newtons)
+}
+
+% ----------------------------------------------------------------------------
+% The law. A named, importable, reusable `let` over its formal parameters — the
+% SAME expression grammar `let` uses, with the parameter leaves bound at apply
+% time. The provenance clause is the envelope every grounded clause carries: the
+% constant G is quoted VERBATIM from the NIST CODATA value page (the definitive
+% metrological source), the `locator` resolves to that page, and the trust tier
+% is `authoritative`. The inverse-square denominator `distance * distance` is r²
+% composed from the multiply primitive; the whole body composes G·m₁·m₂ / r².
+% ----------------------------------------------------------------------------
+formulabook physics_gravitation {
+    use gravitation_vocab
+
+    % Newton's law of universal gravitation — every point mass attracts every
+    % other with a force proportional to the product of their masses and
+    % inversely proportional to the square of the distance between them.
+    % F = G · m₁ · m₂ / r², with G = 6.674 30 × 10⁻¹¹ m³ kg⁻¹ s⁻² (NIST CODATA
+    % 2022, the exact recommended value → authoritative).
+    formula gravitational_force(mass_one, mass_two, distance) =
+        6.67430e-11 * mass_one * mass_two / (distance * distance)
+        source "Newtonian constant of gravitation: Numerical value 6.674 30 x 10-11 m3 kg-1 s-2 (Standard uncertainty 0.000 15 x 10-11 m3 kg-1 s-2), CODATA 2022 recommended value."
+        locator "https://physics.nist.gov/cgi-bin/cuu/Value?bg"
+        trust authoritative
+}

--- a/code/specs/data/adj-formula-stdlib/physics/gravitation.query.adj
+++ b/code/specs/data/adj-formula-stdlib/physics/gravitation.query.adj
@@ -1,0 +1,28 @@
+% ============================================================================
+% gravitation.query.adj — a worked application of Newton's law of universal
+% gravitation from the ADJ compute stdlib.
+% ============================================================================
+% The shape a consumer (an LLM, or a person) produces to ANSWER a gravitation
+% word-problem: it states NO arithmetic. It `import`s the grounded law library,
+% binds each quantity it decomposed from the input (each `observe` is a
+% byte-provenance span the model cited), and asks the engine to APPLY the
+% recalled law. The native adj-lang engine substitutes the law's body, computes
+% exactly on the CPU, and returns the value carrying the law's source/locator/
+% trust — the auditable chain.
+%
+% "What gravitational force does the Earth (5.972×10²⁴ kg) exert on the Moon
+%  (7.348×10²² kg), given a centre-to-centre distance of 3.844×10⁸ m?"
+%   → recall F = G·m₁·m₂/r², bind the three quantities, apply → ≈1.98×10²⁰ N,
+%     carrying NIST's value of G (authoritative).
+%
+% Run (from this directory so the relative import resolves):
+%     ../../../../packages/rust/target/debug/adj-lang-cli gravitation.query.adj
+% ============================================================================
+
+import "gravitation.adj"
+
+% --- Earth–Moon: the ~1.98×10²⁰ N attraction that keeps the Moon in orbit. ---
+observe mass_one(5.972e24)     % "…Earth's mass, 5.972×10²⁴ kg…"          (span cited by the model)
+observe mass_two(7.348e22)     % "…the Moon's mass, 7.348×10²² kg…"        (span cited by the model)
+observe distance(3.844e8)      % "…a centre-to-centre distance of 3.844×10⁸ m…" (span cited)
+? gravitational_force(mass_one, mass_two, distance)  % engine → ≈1.98e20 N (F = G·m₁·m₂/r², NIST, authoritative)


### PR DESCRIPTION
## What

Ships **Newton's law of universal gravitation** as an importable, byte-provenanced, parameterized ADJ formula in the compute stdlib's physics layer (`code/specs/data/adj-formula-stdlib/physics/gravitation.adj`):

```
gravitational_force(mass_one, mass_two, distance)
    = 6.67430e-11 * mass_one * mass_two / (distance * distance)   % F = G·m₁·m₂/r²
```

A companion to `physics/mechanics-laws.adj`: where that ships the leaf laws (F=ma, V=IR, ρ=m/V, v=d/t), this ships the canonical **inverse-square** law. The `formulabook` name `physics_gravitation` is distinct from the existing `physics_laws`/`physics_energy` books — no collision.

## Grounding (the crux: G)

The Newtonian constant of gravitation G is the magnitude that makes or breaks the answer, so it is grounded **verbatim** to the primary metrological authority:

- **Source (verbatim):** "Newtonian constant of gravitation: Numerical value 6.674 30 x 10-11 m3 kg-1 s-2 (Standard uncertainty 0.000 15 x 10-11 m3 kg-1 s-2), CODATA 2022 recommended value."
- **Locator:** https://physics.nist.gov/cgi-bin/cuu/Value?bg
- **Trust tier:** `authoritative` (NIST CODATA 2022)

ADJ number literals accept scientific notation (verified — `physical-constants.adj` already uses `6.62607015e-34`), so G is written in NIST's exact digits `6.67430e-11`. The inverse-square form composes from the arithmetic multiply/divide primitives applied to the parameter leaves.

## Contract

The model does **zero arithmetic**. A consumer `import`s the library, binds the three quantities from its own byte-provenance decomposition, and asks the engine to apply the cited law on the CPU. The answer carries the NIST citation — auditable end to end.

## Files

- `physics/gravitation.adj` — the grounded law + literate commentary
- `physics/gravitation.query.adj` — a worked **Earth–Moon** consumer (m₁=5.972e24, m₂=7.348e22, r=3.844e8) → **≈1.982×10²⁰ N**
- `adj-lang-cli/tests/formula_gravitation_e2e.rs` — one CLI e2e test: imports the shipped library, binds the quantities, asserts the derived force `1.982110729079252e20` N with a **relative epsilon** (reals) plus the NIST trust/locator/verbatim-value.

## Verification

- `cargo test -p adj-lang-cli --test formula_gravitation_e2e` — passes
- `cargo clippy -p adj-lang-cli --test formula_gravitation_e2e -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)