### PR TITLE
test(closurec): CLOC12.190 PR3 — ES rest parameters end-to-end fixture

### DIFF
--- a/code/programs/rust/closurec/CHANGELOG.md
+++ b/code/programs/rust/closurec/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `coding-adventures-closurec` binary will be documented in this file.
 
+## [0.234.29] - 2026-07-14
+
+### Added — CLOC12.190 PR3: ES rest parameters end-to-end
+
+Picks up javascript-parser 0.55.0 (the `convert_formal_parameter` bridge flip, PR2) on top of the PR1
+`FunctionParam::RestElement` node + emitter + pass arms. A file with a rest parameter no longer declines
+to WHITESPACE_ONLY — it flows through the full optimization pipeline. New `tests/diff/rest-params/`
+fixture + `diff_rest_params.rs`:
+  - **SIMPLE**: `function f(...a){return a.length} g(f(1 + 2, 3));` →
+    `function f(...a){return a.length};g(f(3,3));` — the rest parameter round-trips (`...a` survives,
+    proving the bridge modelled it) AND the call argument folds `1+2`→`3` (the pipeline optimized the
+    rest of the module, not a WHITESPACE_ONLY fallback which would leave `1+2` intact). The `g(...)`
+    wrapper retains the single-use `f` so its `...a` parameter stays visible.
+
+Version-synced cli.spec.json + tests/diff/help-markdown/expected.stdout. PATCH.
+
 ## [0.234.28] - 2026-07-13
 
 ### Added — CLOC12.189 PR3: ES-module `export` end-to-end

--- a/code/programs/rust/closurec/Cargo.toml
+++ b/code/programs/rust/closurec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coding-adventures-closurec"
-version = "0.234.28"
+version = "0.234.29"
 edition = "2021"
 description = "closurec — CLI driver for the Closure Compiler clone. Mirrors the upstream Java Closure Compiler's command-line flag surface (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility. Per CLOC08."
 

--- a/code/programs/rust/closurec/cli.spec.json
+++ b/code/programs/rust/closurec/cli.spec.json
@@ -2,7 +2,7 @@
   "cli_builder_spec_version": "1.0",
   "name": "closurec",
   "description": "closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.",
-  "version": "0.234.28",
+  "version": "0.234.29",
   "parsing_mode": "gnu",
   "flags": [
     { "id": "browser_featureset_year", "long": "browser_featureset_year", "type": "integer", "default": 0, "description": "Shortcut for defining goog.FEATURESET_YEAR=YYYY (minimum 2012)." },

--- a/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/help-markdown/expected.stdout
@@ -2,7 +2,7 @@
 
 closurec — Closure Compiler clone CLI driver. Mirrors the flag surface of the upstream Java Closure Compiler (google/closure-compiler @ CommandLineRunner.java) for drop-in compatibility.
 
-Version: 0.234.28
+Version: 0.234.29
 
 ## Flags
 

--- a/code/programs/rust/closurec/tests/diff/rest-params/expected.stdout
+++ b/code/programs/rust/closurec/tests/diff/rest-params/expected.stdout
@@ -1,0 +1,1 @@
+function f(...a){return a.length};g(f(3,3));

--- a/code/programs/rust/closurec/tests/diff/rest-params/flags.txt
+++ b/code/programs/rust/closurec/tests/diff/rest-params/flags.txt
@@ -1,0 +1,4 @@
+--js
+tests/diff/rest-params/input/a.js
+--compilation_level
+SIMPLE

--- a/code/programs/rust/closurec/tests/diff/rest-params/input/a.js
+++ b/code/programs/rust/closurec/tests/diff/rest-params/input/a.js
@@ -1,0 +1,1 @@
+function f(...a){return a.length} g(f(1 + 2, 3));

--- a/code/programs/rust/closurec/tests/diff_rest_params.rs
+++ b/code/programs/rust/closurec/tests/diff_rest_params.rs
@@ -65,7 +65,7 @@ fn rest_params_round_trip_and_fold() {
         "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
     );
 
-    let flat = actual.replace(' ', "").replace('\n', "");
+    let flat = actual.replace([' ', '\n'], "");
     // (1) the rest parameter round-tripped — the bridge modelled it (not
     // WHITESPACE_ONLY). The `...a` prefix must survive on the emitted function.
     // (Checked on space-stripped output, so no space between `function` and `f`.)

--- a/code/programs/rust/closurec/tests/diff_rest_params.rs
+++ b/code/programs/rust/closurec/tests/diff_rest_params.rs
@@ -1,0 +1,85 @@
+//! Integration test for the `tests/diff/rest-params/` fixture.
+//!
+//! Exercises ES rest parameters (`function f(...args){}`) end-to-end — the
+//! CLOC12.190 arc. Before it, a rest parameter landed in the parser bridge's
+//! *unsupported* bucket (`convert_formal_parameter` declined any `...`), so any
+//! file with a rest parameter DECLINED to WHITESPACE_ONLY (no optimization at
+//! all). The arc landed in three PRs:
+//!   - PR1 (#8233): the `FunctionParam::RestElement` AST variant + emitter arm
+//!     (`...name`) + the pass-traversal arms across scope-analyzer / rename /
+//!     inline (atomic; the variant was unreachable);
+//!   - PR2 (#8241): the parser-bridge flip (`convert_formal_parameter` maps an
+//!     `ELLIPSIS` parameter to a `RestElement`, while a destructuring rest
+//!     target `...[a,b]` still declines);
+//!   - PR3 (this test): the closurec end-to-end proof.
+//!
+//! ## Fact — SIMPLE: the rest parameter survives and the pipeline optimizes
+//!
+//! `function f(...a){return a.length} g(f(1 + 2, 3));` at SIMPLE emits
+//! `function f(...a){return a.length};g(f(3,3));`. Two things prove the whole
+//! pipeline ran:
+//!   1. the rest parameter round-trips (`function f(...a){…}`), proving the
+//!      bridge modelled it — not a WHITESPACE_ONLY fallback; and
+//!   2. the call argument folds — `1 + 2` → `3` (`f(3,3)`) — proving the SIMPLE
+//!      pipeline ran the rest of the module. A WHITESPACE_ONLY fallback would
+//!      leave `1+2` intact (it would emit the source verbatim, only stripping
+//!      whitespace).
+//!
+//! The call is wrapped in `g(...)` so the single-use function `f` is *retained*
+//! (an unknown `g` consumes its result), keeping the `...a` parameter visible in
+//! the output rather than being inlined away.
+
+use std::process::Command;
+
+const BINARY: &str = env!("CARGO_BIN_EXE_closurec");
+
+fn read_flags() -> Vec<String> {
+    let raw = std::fs::read_to_string("tests/diff/rest-params/flags.txt").expect("read flags.txt");
+    raw.lines()
+        .filter(|l| !l.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[test]
+fn rest_params_round_trip_and_fold() {
+    let flags = read_flags();
+    let out = Command::new(BINARY)
+        .args(&flags)
+        .output()
+        .expect("run closurec");
+
+    assert!(
+        out.status.success(),
+        "exit: {:?}, stderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let actual = String::from_utf8_lossy(&out.stdout);
+    let expected = std::fs::read_to_string("tests/diff/rest-params/expected.stdout")
+        .expect("read expected.stdout");
+    assert_eq!(
+        actual.trim_end_matches('\n'),
+        expected.trim_end_matches('\n'),
+        "mismatch.\nactual:\n{actual}\nexpected:\n{expected}",
+    );
+
+    let flat = actual.replace(' ', "").replace('\n', "");
+    // (1) the rest parameter round-tripped — the bridge modelled it (not
+    // WHITESPACE_ONLY). The `...a` prefix must survive on the emitted function.
+    // (Checked on space-stripped output, so no space between `function` and `f`.)
+    assert!(
+        flat.contains("f(...a){"),
+        "rest parameter did not round-trip: {actual}"
+    );
+    // (2) the pipeline optimized the rest of the module: `1+2` folded to `3`.
+    assert!(
+        flat.contains("f(3,3)"),
+        "argument did not fold to `f(3,3)`: {actual}"
+    );
+    assert!(
+        !flat.contains("1+2"),
+        "unfolded arithmetic present — pipeline fell back to WHITESPACE_ONLY: {actual}"
+    );
+}


### PR DESCRIPTION
Completes the **CLOC12.190 rest-parameters arc** with the closurec end-to-end proof.

## Arc recap
Before the arc, a rest parameter (`function f(...args){}`) declined to WHITESPACE_ONLY — no optimization at all.
- **PR1** (#8233, merged): `FunctionParam::RestElement` AST node + emitter (`...name`) + pass-traversal arms.
- **PR2** (#8241, merged): the parser-bridge flip (`convert_formal_parameter` ELLIPSIS → `RestElement`; destructuring rest `...[a,b]` still declines).
- **PR3** (this): the closurec end-to-end proof.

## The fact proven
**SIMPLE** — `function f(...a){return a.length} g(f(1 + 2, 3));` → `function f(...a){return a.length};g(f(3,3));`
1. the rest parameter round-trips (`...a` survives on the emitted function — the bridge modelled it, not a WHITESPACE_ONLY fallback); and
2. the call argument folds `1 + 2` → `3` (`f(3,3)`), proving the SIMPLE pipeline ran the rest of the module (a WHITESPACE_ONLY passthrough would leave `1+2` verbatim).

The `g(...)` wrapper retains the single-use `f` so its `...a` parameter stays visible in the output.

## Housekeeping
- closurec PATCH bump `0.234.28` → `0.234.29`, with `cli.spec.json` version synced and `tests/diff/help-markdown/expected.stdout` regenerated.
- Full closurec suite green, incl. `version_string_matches_crate_version` and `help_markdown_fixture_matches_expected_dump`.

## Security review
Test-only PR (fixtures + version-sync); **no runtime or library code changed**, so a security review is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)