### PR TITLE
feat(dart): port B-tree and B+ tree

### DIFF
--- a/code/packages/dart/b-plus-tree/.gitignore
+++ b/code/packages/dart/b-plus-tree/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/b-plus-tree/BUILD
+++ b/code/packages/dart/b-plus-tree/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/b-plus-tree/BUILD_windows
+++ b/code/packages/dart/b-plus-tree/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/b-plus-tree/CHANGELOG.md
+++ b/code/packages/dart/b-plus-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure Dart B+ tree with linked leaves, point lookup, upsert, deletion,
+  inclusive range scans, full scans, height reporting, and validation.

--- a/code/packages/dart/b-plus-tree/README.md
+++ b/code/packages/dart/b-plus-tree/README.md
@@ -1,0 +1,28 @@
+# coding-adventures-b-plus-tree
+
+Pure Dart implementation of the DT12 B+ tree. All values live in sorted leaf
+nodes, while internal nodes contain routing separators. The leaves form a
+linked list, so an inclusive range scan pays one tree lookup and then walks
+adjacent leaves sequentially.
+
+```dart
+import 'package:coding_adventures_b_plus_tree/coding_adventures_b_plus_tree.dart';
+
+void main() {
+  final tree = BPlusTree<int, String>(3)
+    ..insert(10, 'ten')
+    ..insert(5, 'five')
+    ..insert(20, 'twenty');
+
+  print(tree.search(10)); // ten
+  print(tree.rangeScan(5, 20));
+  // [(5, five), (10, ten), (20, twenty)]
+}
+```
+
+The first optional constructor argument is the minimum degree `t` (`t >= 2`).
+Keys use their natural `Comparable` order by default; pass a comparator as the
+second argument for custom key types. Values may be any Dart type, including
+nullable types. Mutations rebuild balanced levels from the sorted in-memory
+entries, which keeps the implementation deterministic and every non-root node
+within the DT12 degree bounds.

--- a/code/packages/dart/b-plus-tree/lib/coding_adventures_b_plus_tree.dart
+++ b/code/packages/dart/b-plus-tree/lib/coding_adventures_b_plus_tree.dart
@@ -1,0 +1,7 @@
+/// A pure Dart B+ tree (DT12).
+///
+/// The library exports [BPlusTree], a balanced sorted map whose linked leaves
+/// support efficient ordered and inclusive range scans.
+library coding_adventures_b_plus_tree;
+
+export 'src/b_plus_tree.dart';

--- a/code/packages/dart/b-plus-tree/lib/src/b_plus_tree.dart
+++ b/code/packages/dart/b-plus-tree/lib/src/b_plus_tree.dart
@@ -1,0 +1,367 @@
+import 'dart:collection';
+
+/// A sorted key-value entry returned by B+ tree scans.
+typedef BPlusTreeEntry<K, V> = (K, V);
+
+Comparator<T> _naturalOrder<T>() => (left, right) =>
+    Comparable.compare(left as Comparable, right as Comparable);
+
+sealed class _BPlusNode<K, V> {
+  final List<K> keys = <K>[];
+}
+
+final class _BPlusInternalNode<K, V> extends _BPlusNode<K, V> {
+  final List<_BPlusNode<K, V>> children = <_BPlusNode<K, V>>[];
+}
+
+final class _BPlusLeafNode<K, V> extends _BPlusNode<K, V> {
+  final List<V> values = <V>[];
+  _BPlusLeafNode<K, V>? next;
+
+  int findKeyIndex(K key, Comparator<K> compare) {
+    var low = 0;
+    var high = keys.length;
+    while (low < high) {
+      final middle = (low + high) >> 1;
+      if (compare(keys[middle], key) < 0) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  }
+}
+
+/// A generic B+ tree mapping ordered keys to values.
+///
+/// Data lives only in linked leaf nodes. Internal nodes contain the minimum key
+/// of each right child as a routing separator. Inserting an existing key
+/// updates its value, and deleting a missing key is a no-op that returns false.
+final class BPlusTree<K, V> {
+  /// Create an empty B+ tree with minimum degree [minimumDegree].
+  ///
+  /// Natural [Comparable] order is used unless [compare] is supplied.
+  BPlusTree([this.minimumDegree = 2, Comparator<K>? compare])
+      : _compare = compare ?? _naturalOrder<K>() {
+    if (minimumDegree < 2) {
+      throw ArgumentError.value(
+        minimumDegree,
+        'minimumDegree',
+        'must be at least 2',
+      );
+    }
+    _entries = SplayTreeMap<K, V>(_compare);
+    final leaf = _BPlusLeafNode<K, V>();
+    _root = leaf;
+    _firstLeaf = leaf;
+  }
+
+  /// The minimum number of children in a non-root internal node.
+  final int minimumDegree;
+  final Comparator<K> _compare;
+  late final SplayTreeMap<K, V> _entries;
+  late _BPlusNode<K, V> _root;
+  late _BPlusLeafNode<K, V> _firstLeaf;
+
+  int get _maxKeys => 2 * minimumDegree - 1;
+  int get _maxChildren => 2 * minimumDegree;
+
+  /// Number of key-value pairs stored in the tree.
+  int get count => _entries.length;
+
+  /// Alias for [count], matching the DT12 vocabulary.
+  int get size => count;
+
+  /// Whether the tree contains no keys.
+  bool get isEmpty => _entries.isEmpty;
+
+  /// Number of edges from the root to any leaf.
+  int get height {
+    var node = _root;
+    var result = 0;
+    while (node is _BPlusInternalNode<K, V>) {
+      result++;
+      node = node.children.first;
+    }
+    return result;
+  }
+
+  /// Insert [key] with [value], updating an existing mapping in place.
+  void insert(K key, V value) {
+    _entries[key] = value;
+    _rebuild();
+  }
+
+  /// Remove [key], returning whether it was present.
+  bool delete(K key) {
+    if (!_entries.containsKey(key)) return false;
+    _entries.remove(key);
+    _rebuild();
+    return true;
+  }
+
+  /// Return the value associated with [key], or `null` when absent.
+  V? search(K key) {
+    final leaf = _findLeaf(key);
+    final index = leaf.findKeyIndex(key, _compare);
+    return index < leaf.keys.length && _compare(leaf.keys[index], key) == 0
+        ? leaf.values[index]
+        : null;
+  }
+
+  /// Whether [key] is present, including when its value is `null`.
+  bool contains(K key) {
+    final leaf = _findLeaf(key);
+    final index = leaf.findKeyIndex(key, _compare);
+    return index < leaf.keys.length && _compare(leaf.keys[index], key) == 0;
+  }
+
+  /// Return the smallest key, throwing [StateError] when empty.
+  K minKey() {
+    if (isEmpty) throw StateError('Tree is empty.');
+    return _firstLeaf.keys.first;
+  }
+
+  /// Return the largest key, throwing [StateError] when empty.
+  K maxKey() {
+    if (isEmpty) throw StateError('Tree is empty.');
+    var node = _root;
+    while (node is _BPlusInternalNode<K, V>) {
+      node = node.children.last;
+    }
+    return (node as _BPlusLeafNode<K, V>).keys.last;
+  }
+
+  /// Return entries in the inclusive key range [low] through [high].
+  ///
+  /// The first leaf costs O(log n) to find; the remainder follows linked leaves.
+  List<BPlusTreeEntry<K, V>> rangeScan(K low, K high) {
+    if (_compare(low, high) > 0) {
+      throw ArgumentError('Low key must be less than or equal to high key.');
+    }
+
+    final result = <BPlusTreeEntry<K, V>>[];
+    _BPlusLeafNode<K, V>? leaf = _findLeaf(low);
+    while (leaf != null) {
+      for (var index = 0; index < leaf.keys.length; index++) {
+        final key = leaf.keys[index];
+        if (_compare(key, high) > 0) return result;
+        if (_compare(key, low) >= 0) {
+          result.add((key, leaf.values[index]));
+        }
+      }
+      leaf = leaf.next;
+    }
+    return result;
+  }
+
+  /// Alias for [rangeScan], shared with the DT11 B-tree API.
+  List<BPlusTreeEntry<K, V>> rangeQuery(K low, K high) => rangeScan(low, high);
+
+  /// Return every entry in ascending order by walking the linked leaves.
+  List<BPlusTreeEntry<K, V>> fullScan() {
+    final result = <BPlusTreeEntry<K, V>>[];
+    _BPlusLeafNode<K, V>? leaf = _firstLeaf;
+    while (leaf != null) {
+      for (var index = 0; index < leaf.keys.length; index++) {
+        result.add((leaf.keys[index], leaf.values[index]));
+      }
+      leaf = leaf.next;
+    }
+    return result;
+  }
+
+  /// Alias for [fullScan], shared with the DT11 B-tree API.
+  List<BPlusTreeEntry<K, V>> inorder() => fullScan();
+
+  /// A snapshot iterable of all entries in sorted order.
+  Iterable<BPlusTreeEntry<K, V>> get entries => fullScan();
+
+  /// Verify degree bounds, separators, leaf depth, links, and stored entries.
+  bool isValid() {
+    if (isEmpty) {
+      return _root is _BPlusLeafNode<K, V> &&
+          identical(_root, _firstLeaf) &&
+          _firstLeaf.keys.isEmpty &&
+          _firstLeaf.values.isEmpty &&
+          _firstLeaf.next == null;
+    }
+
+    final leafDepth = <int?>[null];
+    if (!_validateNode(_root, isRoot: true, depth: 0, leafDepth: leafDepth)) {
+      return false;
+    }
+
+    final scan = <BPlusTreeEntry<K, V>>[];
+    final visited = <_BPlusLeafNode<K, V>>{};
+    _BPlusLeafNode<K, V>? leaf = _firstLeaf;
+    K? previousKey;
+    var hasPrevious = false;
+    while (leaf != null) {
+      if (!visited.add(leaf)) return false;
+      for (var index = 0; index < leaf.keys.length; index++) {
+        final key = leaf.keys[index];
+        if (hasPrevious && _compare(key, previousKey as K) <= 0) return false;
+        scan.add((key, leaf.values[index]));
+        previousKey = key;
+        hasPrevious = true;
+      }
+      leaf = leaf.next;
+    }
+    if (scan.length != count) return false;
+
+    final expected = _entries.entries.toList(growable: false);
+    for (var index = 0; index < expected.length; index++) {
+      final actual = scan[index];
+      if (_compare(actual.$1, expected[index].key) != 0 ||
+          actual.$2 != expected[index].value ||
+          !contains(actual.$1) ||
+          search(actual.$1) != actual.$2) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void _rebuild() {
+    if (_entries.isEmpty) {
+      final leaf = _BPlusLeafNode<K, V>();
+      _root = leaf;
+      _firstLeaf = leaf;
+      return;
+    }
+
+    final pairs = _entries.entries.toList(growable: false);
+    final leaves = <_BPlusNode<K, V>>[];
+    _BPlusLeafNode<K, V>? previous;
+    var offset = 0;
+    for (final groupSize in _partitionSizes(
+      pairs.length,
+      minimumDegree - 1,
+      _maxKeys,
+    )) {
+      final leaf = _BPlusLeafNode<K, V>();
+      for (var index = offset; index < offset + groupSize; index++) {
+        leaf.keys.add(pairs[index].key);
+        leaf.values.add(pairs[index].value);
+      }
+      if (previous == null) {
+        _firstLeaf = leaf;
+      } else {
+        previous.next = leaf;
+      }
+      previous = leaf;
+      leaves.add(leaf);
+      offset += groupSize;
+    }
+    _root = _buildLevel(leaves);
+  }
+
+  _BPlusNode<K, V> _buildLevel(List<_BPlusNode<K, V>> children) {
+    if (children.length == 1) return children.first;
+    if (children.length <= _maxChildren) return _buildInternal(children);
+
+    final parents = <_BPlusNode<K, V>>[];
+    var offset = 0;
+    for (final groupSize in _partitionSizes(
+      children.length,
+      minimumDegree,
+      _maxChildren,
+    )) {
+      parents.add(_buildInternal(children.sublist(offset, offset + groupSize)));
+      offset += groupSize;
+    }
+    return _buildLevel(parents);
+  }
+
+  _BPlusInternalNode<K, V> _buildInternal(List<_BPlusNode<K, V>> children) {
+    final node = _BPlusInternalNode<K, V>()..children.addAll(children);
+    for (var index = 1; index < children.length; index++) {
+      node.keys.add(_firstKey(children[index]));
+    }
+    return node;
+  }
+
+  _BPlusLeafNode<K, V> _findLeaf(K key) {
+    var node = _root;
+    while (node is _BPlusInternalNode<K, V>) {
+      var index = 0;
+      while (index < node.keys.length && _compare(key, node.keys[index]) >= 0) {
+        index++;
+      }
+      node = node.children[index];
+    }
+    return node as _BPlusLeafNode<K, V>;
+  }
+
+  K _firstKey(_BPlusNode<K, V> node) {
+    while (node is _BPlusInternalNode<K, V>) {
+      node = node.children.first;
+    }
+    return (node as _BPlusLeafNode<K, V>).keys.first;
+  }
+
+  List<int> _partitionSizes(int itemCount, int minSize, int maxSize) {
+    if (itemCount <= maxSize) return <int>[itemCount];
+    final groupCount = (itemCount + maxSize - 1) ~/ maxSize;
+    final baseSize = itemCount ~/ groupCount;
+    final remainder = itemCount % groupCount;
+    final sizes = <int>[];
+    for (var index = 0; index < groupCount; index++) {
+      final size = baseSize + (index < remainder ? 1 : 0);
+      if (size < minSize || size > maxSize) {
+        throw StateError('Unable to partition B+ tree nodes.');
+      }
+      sizes.add(size);
+    }
+    return sizes;
+  }
+
+  bool _validateNode(
+    _BPlusNode<K, V> node, {
+    required bool isRoot,
+    required int depth,
+    required List<int?> leafDepth,
+  }) {
+    if (node.keys.length > _maxKeys) return false;
+    if (!isRoot && node.keys.length < minimumDegree - 1) return false;
+    for (var index = 1; index < node.keys.length; index++) {
+      if (_compare(node.keys[index], node.keys[index - 1]) <= 0) return false;
+    }
+
+    if (node is _BPlusLeafNode<K, V>) {
+      if (node.values.length != node.keys.length) return false;
+      leafDepth[0] ??= depth;
+      return leafDepth[0] == depth;
+    }
+
+    final internal = node as _BPlusInternalNode<K, V>;
+    if (internal.children.length != internal.keys.length + 1) return false;
+    if (isRoot && internal.keys.isEmpty) return false;
+    for (var index = 0; index < internal.keys.length; index++) {
+      if (_compare(
+            internal.keys[index],
+            _firstKey(internal.children[index + 1]),
+          ) !=
+          0) {
+        return false;
+      }
+    }
+    for (final child in internal.children) {
+      if (!_validateNode(
+        child,
+        isRoot: false,
+        depth: depth + 1,
+        leafDepth: leafDepth,
+      )) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  String toString() =>
+      'BPlusTree(t=$minimumDegree, size=$count, height=$height)';
+}

--- a/code/packages/dart/b-plus-tree/pubspec.yaml
+++ b/code/packages/dart/b-plus-tree/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_b_plus_tree
+description: >
+  Pure Dart DT12 B+ tree with linked leaves, lookup, mutation, range scans,
+  balanced levels, and invariant validation.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/b-plus-tree/required_capabilities.json
+++ b/code/packages/dart/b-plus-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/b-plus-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/b-plus-tree/test/b_plus_tree_test.dart
+++ b/code/packages/dart/b-plus-tree/test/b_plus_tree_test.dart
@@ -1,0 +1,205 @@
+import 'dart:math';
+
+import 'package:coding_adventures_b_plus_tree/coding_adventures_b_plus_tree.dart';
+import 'package:test/test.dart';
+
+final class _Key {
+  const _Key(this.value);
+
+  final int value;
+}
+
+void main() {
+  group('construction and metadata', () {
+    test('rejects a minimum degree below two', () {
+      expect(() => BPlusTree<int, String>(1), throwsArgumentError);
+
+      final tree = BPlusTree<int, String>();
+      expect(tree.minimumDegree, 2);
+      expect(tree.count, 0);
+      expect(tree.size, 0);
+      expect(tree.isEmpty, isTrue);
+      expect(tree.height, 0);
+      expect(tree.isValid(), isTrue);
+      expect(tree.toString(), 'BPlusTree(t=2, size=0, height=0)');
+    });
+  });
+
+  group('insert and lookup', () {
+    test('upserts values without changing count', () {
+      final tree = BPlusTree<int, String>(3);
+      for (final key in [10, 5, 20, 1, 15, 30]) {
+        tree.insert(key, 'v$key');
+      }
+      tree.insert(15, 'updated');
+
+      expect(tree.count, 6);
+      expect(tree.contains(20), isTrue);
+      expect(tree.contains(99), isFalse);
+      expect(tree.search(15), 'updated');
+      expect(tree.search(99), isNull);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('contains distinguishes a nullable value from a missing key', () {
+      final tree = BPlusTree<int, String?>()..insert(42, null);
+
+      expect(tree.contains(42), isTrue);
+      expect(tree.search(42), isNull);
+      expect(tree.contains(7), isFalse);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('accepts a custom comparator for non-Comparable keys', () {
+      final tree = BPlusTree<_Key, String>(
+        2,
+        (left, right) => left.value.compareTo(right.value),
+      )
+        ..insert(const _Key(2), 'two')
+        ..insert(const _Key(1), 'one');
+
+      expect(tree.search(const _Key(2)), 'two');
+      expect(tree.fullScan().map((entry) => entry.$1.value), [1, 2]);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('sequential inserts create linked leaves and sorted scans', () {
+      final tree = BPlusTree<int, String>();
+      for (var key = 1; key <= 3; key++) {
+        tree.insert(key, 'v$key');
+      }
+      expect(tree.height, 0);
+
+      for (var key = 4; key <= 50; key++) {
+        tree.insert(key, 'v$key');
+        expect(tree.isValid(), isTrue, reason: 'invalid after inserting $key');
+      }
+
+      final expected = List<int>.generate(50, (index) => index + 1);
+      expect(tree.height, greaterThanOrEqualTo(2));
+      expect(tree.fullScan().map((entry) => entry.$1), orderedEquals(expected));
+      expect(tree.entries.map((entry) => entry.$1), orderedEquals(expected));
+    });
+  });
+
+  group('range and ordered scans', () {
+    test('range scans are inclusive and reject inverted bounds', () {
+      final tree = BPlusTree<int, String>();
+      for (final key in [9, 3, 7, 1, 5, 2, 8, 4, 6, 10]) {
+        tree.insert(key, 'v$key');
+      }
+
+      expect(
+        tree.rangeScan(3, 7).map((entry) => entry.$1),
+        orderedEquals([3, 4, 5, 6, 7]),
+      );
+      expect(
+        tree.rangeQuery(3, 7).map((entry) => entry.$1),
+        orderedEquals([3, 4, 5, 6, 7]),
+      );
+      expect(tree.rangeScan(11, 20), isEmpty);
+      expect(() => tree.rangeScan(7, 3), throwsArgumentError);
+    });
+
+    test('min, max, and empty edges are predictable', () {
+      final tree = BPlusTree<int, String>();
+
+      expect(() => tree.minKey(), throwsStateError);
+      expect(() => tree.maxKey(), throwsStateError);
+      expect(tree.fullScan(), isEmpty);
+      expect(tree.inorder(), isEmpty);
+      expect(tree.rangeScan(1, 10), isEmpty);
+
+      tree
+        ..insert(20, 'twenty')
+        ..insert(10, 'ten')
+        ..insert(30, 'thirty');
+      expect(tree.minKey(), 10);
+      expect(tree.maxKey(), 30);
+      expect(tree.toString(), 'BPlusTree(t=2, size=3, height=0)');
+    });
+  });
+
+  group('deletion and balancing', () {
+    test('removes keys and treats missing deletion as a no-op', () {
+      final tree = BPlusTree<int, String>();
+      for (var key = 1; key <= 25; key++) {
+        tree.insert(key, 'v$key');
+      }
+
+      for (final key in [7, 12, 1, 25, 13, 14, 15, 16, 17, 18]) {
+        expect(tree.delete(key), isTrue);
+        expect(tree.contains(key), isFalse);
+        expect(tree.isValid(), isTrue, reason: 'invalid after deleting $key');
+      }
+      expect(tree.delete(99), isFalse);
+
+      expect(tree.count, 15);
+      expect(tree.minKey(), 2);
+      expect(tree.maxKey(), 24);
+      expect(tree.height, greaterThan(0));
+    });
+
+    test('all supported minimum degrees remain valid', () {
+      for (final degree in [2, 3, 5, 8]) {
+        final tree = BPlusTree<int, String>(degree);
+        for (var key = 100; key >= 1; key--) {
+          tree.insert(key, 'v$key');
+        }
+        expect(tree.isValid(), isTrue, reason: 'degree $degree');
+        expect(
+          tree.fullScan().map((entry) => entry.$1),
+          orderedEquals(List<int>.generate(100, (index) => index + 1)),
+        );
+      }
+    });
+
+    test('deleting every key returns to the canonical empty tree', () {
+      final tree = BPlusTree<int, String>(3);
+      for (var key = 0; key < 80; key++) {
+        tree.insert(key, 'v$key');
+      }
+      final keys = List<int>.generate(80, (index) => index)
+        ..shuffle(Random(99));
+      for (final key in keys) {
+        expect(tree.delete(key), isTrue);
+        expect(tree.isValid(), isTrue, reason: 'invalid after deleting $key');
+      }
+
+      expect(tree.isEmpty, isTrue);
+      expect(tree.height, 0);
+      expect(tree.fullScan(), isEmpty);
+    });
+  });
+
+  test('randomized operations match a sorted reference map', () {
+    final tree = BPlusTree<int, String?>(3);
+    final reference = <int, String?>{};
+    final random = Random(1234);
+
+    for (var step = 0; step < 500; step++) {
+      final key = random.nextInt(200);
+      if (random.nextInt(4) == 0) {
+        final wasPresent = reference.containsKey(key);
+        reference.remove(key);
+        expect(tree.delete(key), wasPresent);
+      } else {
+        final value = random.nextInt(5) == 0 ? null : 'v$step';
+        tree.insert(key, value);
+        reference[key] = value;
+      }
+
+      final expectedKeys = reference.keys.toList()..sort();
+      expect(tree.count, reference.length);
+      expect(tree.isValid(), isTrue, reason: 'invalid at step $step');
+      expect(
+        tree.fullScan().map((entry) => entry.$1),
+        orderedEquals(expectedKeys),
+      );
+      for (final entry in reference.entries) {
+        expect(tree.contains(entry.key), isTrue);
+        expect(tree.search(entry.key), entry.value);
+      }
+    }
+  });
+}

--- a/code/packages/dart/b-tree/.gitignore
+++ b/code/packages/dart/b-tree/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/code/packages/dart/b-tree/BUILD
+++ b/code/packages/dart/b-tree/BUILD
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/b-tree/BUILD_windows
+++ b/code/packages/dart/b-tree/BUILD_windows
@@ -1,0 +1,2 @@
+dart pub get
+dart test

--- a/code/packages/dart/b-tree/CHANGELOG.md
+++ b/code/packages/dart/b-tree/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Add a pure Dart minimum-degree B-tree with upsert, lookup, deletion,
+  ordered/range traversal, height reporting, and invariant validation.

--- a/code/packages/dart/b-tree/README.md
+++ b/code/packages/dart/b-tree/README.md
@@ -1,0 +1,29 @@
+# coding-adventures-b-tree
+
+Pure Dart implementation of the DT11 minimum-degree B-tree. A B-tree stores
+sorted key-value pairs in wide, balanced nodes, making it useful for indexes
+that minimize storage-page reads.
+
+The package supports upsert, point lookup, deletion with borrow/merge repair,
+inclusive range queries, ordered traversal, min/max queries, height reporting,
+and structural invariant validation.
+
+```dart
+import 'package:coding_adventures_b_tree/coding_adventures_b_tree.dart';
+
+void main() {
+  final tree = BTree<int, String>(3)
+    ..insert(10, 'ten')
+    ..insert(5, 'five')
+    ..insert(20, 'twenty');
+
+  print(tree.search(10)); // ten
+  print(tree.rangeQuery(5, 10)); // [(5, five), (10, ten)]
+}
+```
+
+The optional constructor argument is the minimum degree `t` (`t >= 2`). Each
+non-root node holds between `t - 1` and `2t - 1` keys. Keys use their natural
+`Comparable` order by default; pass a comparator as the second constructor
+argument for custom key types. Values may be any Dart type, including nullable
+types.

--- a/code/packages/dart/b-tree/lib/coding_adventures_b_tree.dart
+++ b/code/packages/dart/b-tree/lib/coding_adventures_b_tree.dart
@@ -1,0 +1,7 @@
+/// A pure Dart minimum-degree B-tree (DT11).
+///
+/// The library exports [BTree], a balanced sorted map with point lookup,
+/// upsert, deletion, range queries, ordered traversal, and invariant checks.
+library coding_adventures_b_tree;
+
+export 'src/b_tree.dart';

--- a/code/packages/dart/b-tree/lib/src/b_tree.dart
+++ b/code/packages/dart/b-tree/lib/src/b_tree.dart
@@ -1,0 +1,433 @@
+/// A self-balancing, multi-way search tree (DT11) in pure Dart.
+///
+/// A B-tree node stores several sorted key-value pairs and, for internal
+/// nodes, one more child than key. The [minimumDegree] controls node width:
+/// every non-root node has between `t - 1` and `2t - 1` keys. Splitting full
+/// children on descent and repairing minimally-filled children before deletion
+/// keep every leaf at the same depth.
+library b_tree;
+
+/// A sorted key-value entry returned by traversal and range operations.
+typedef BTreeEntry<K, V> = (K, V);
+
+Comparator<T> _naturalOrder<T>() => (left, right) =>
+    Comparable.compare(left as Comparable, right as Comparable);
+
+final class _BTreeNode<K, V> {
+  _BTreeNode({required this.isLeaf});
+
+  final bool isLeaf;
+  final List<K> keys = <K>[];
+  final List<V> values = <V>[];
+  final List<_BTreeNode<K, V>> children = <_BTreeNode<K, V>>[];
+
+  bool isFull(int minimumDegree) => keys.length == 2 * minimumDegree - 1;
+
+  /// Return the first index whose key is greater than or equal to [key].
+  int findKeyIndex(K key, Comparator<K> compare) {
+    var low = 0;
+    var high = keys.length;
+    while (low < high) {
+      final middle = (low + high) >> 1;
+      if (compare(keys[middle], key) < 0) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  }
+}
+
+/// A generic minimum-degree B-tree mapping ordered keys to values.
+///
+/// Inserting an existing key updates its value without changing [count].
+/// [delete] is a no-op that returns `false` when the key is absent. Traversal
+/// methods return Dart 3 records in ascending key order.
+final class BTree<K, V> {
+  /// Create an empty B-tree with minimum degree [minimumDegree].
+  ///
+  /// The classic 2-3-4 tree uses the default degree of 2. Natural [Comparable]
+  /// order is used unless [compare] is supplied.
+  BTree([this.minimumDegree = 2, Comparator<K>? compare])
+      : _compare = compare ?? _naturalOrder<K>() {
+    if (minimumDegree < 2) {
+      throw ArgumentError.value(
+        minimumDegree,
+        'minimumDegree',
+        'must be at least 2',
+      );
+    }
+  }
+
+  /// The minimum number of children in a non-root internal node.
+  final int minimumDegree;
+  final Comparator<K> _compare;
+
+  _BTreeNode<K, V> _root = _BTreeNode<K, V>(isLeaf: true);
+  int _count = 0;
+
+  /// Number of key-value pairs stored in the tree.
+  int get count => _count;
+
+  /// Whether the tree contains no keys.
+  bool get isEmpty => _count == 0;
+
+  /// Number of edges from the root to any leaf.
+  int get height {
+    var node = _root;
+    var result = 0;
+    while (!node.isLeaf) {
+      node = node.children.first;
+      result++;
+    }
+    return result;
+  }
+
+  /// Insert [key] with [value], updating the value when [key] already exists.
+  void insert(K key, V value) {
+    if (_root.isFull(minimumDegree)) {
+      final newRoot = _BTreeNode<K, V>(isLeaf: false)..children.add(_root);
+      _splitChild(newRoot, 0);
+      _root = newRoot;
+    }
+
+    if (_insertNonFull(_root, key, value)) {
+      _count++;
+    }
+  }
+
+  /// Return the value associated with [key], or `null` when it is absent.
+  V? search(K key) => _search(_root, key);
+
+  /// Whether [key] is present, including when its stored value is `null`.
+  bool contains(K key) => _contains(_root, key);
+
+  /// Remove [key], returning whether it was present.
+  ///
+  /// This follows the CLRS top-down deletion algorithm. Before descending, a
+  /// minimally-filled child borrows from a sibling or merges with one.
+  bool delete(K key) {
+    // A failed top-down deletion may still merge nodes. Avoid that surprising
+    // mutation and the associated root-repair edge case for absent keys.
+    if (!contains(key)) return false;
+
+    _deleteRecursive(_root, key);
+    _count--;
+    if (_root.keys.isEmpty && !_root.isLeaf) {
+      _root = _root.children.first;
+    }
+    return true;
+  }
+
+  /// Return the smallest key.
+  ///
+  /// Throws [StateError] when the tree is empty.
+  K minKey() {
+    if (isEmpty) throw StateError('Tree is empty.');
+    return _minNode(_root).keys.first;
+  }
+
+  /// Return the largest key.
+  ///
+  /// Throws [StateError] when the tree is empty.
+  K maxKey() {
+    if (isEmpty) throw StateError('Tree is empty.');
+    return _maxNode(_root).keys.last;
+  }
+
+  /// Return entries whose keys are in the inclusive range [low] through [high].
+  List<BTreeEntry<K, V>> rangeQuery(K low, K high) {
+    final result = <BTreeEntry<K, V>>[];
+    if (_compare(low, high) > 0) return result;
+    _collectRange(_root, low, high, result);
+    return result;
+  }
+
+  /// Return every entry in ascending key order.
+  List<BTreeEntry<K, V>> inorder() {
+    final result = <BTreeEntry<K, V>>[];
+    _collectInorder(_root, result);
+    return result;
+  }
+
+  /// Verify key-count, ordering, child-count, value, and leaf-depth invariants.
+  bool isValid() {
+    if (_count == 0) {
+      return _root.isLeaf &&
+          _root.keys.isEmpty &&
+          _root.values.isEmpty &&
+          _root.children.isEmpty;
+    }
+    if (inorder().length != _count) return false;
+    final leafDepth = <int?>[null];
+    return _validate(
+      _root,
+      minKey: null,
+      hasMinKey: false,
+      maxKey: null,
+      hasMaxKey: false,
+      depth: 0,
+      leafDepth: leafDepth,
+      isRoot: true,
+    );
+  }
+
+  V? _search(_BTreeNode<K, V> node, K key) {
+    final index = node.findKeyIndex(key, _compare);
+    if (index < node.keys.length && _compare(node.keys[index], key) == 0) {
+      return node.values[index];
+    }
+    return node.isLeaf ? null : _search(node.children[index], key);
+  }
+
+  bool _contains(_BTreeNode<K, V> node, K key) {
+    final index = node.findKeyIndex(key, _compare);
+    if (index < node.keys.length && _compare(node.keys[index], key) == 0) {
+      return true;
+    }
+    return !node.isLeaf && _contains(node.children[index], key);
+  }
+
+  void _splitChild(_BTreeNode<K, V> parent, int childIndex) {
+    final child = parent.children[childIndex];
+    final right = _BTreeNode<K, V>(isLeaf: child.isLeaf);
+    final middle = minimumDegree - 1;
+    final medianKey = child.keys[middle];
+    final medianValue = child.values[middle];
+
+    right.keys.addAll(child.keys.sublist(middle + 1));
+    right.values.addAll(child.values.sublist(middle + 1));
+    if (!child.isLeaf) {
+      right.children.addAll(child.children.sublist(minimumDegree));
+      child.children.removeRange(minimumDegree, child.children.length);
+    }
+
+    child.keys.removeRange(middle, child.keys.length);
+    child.values.removeRange(middle, child.values.length);
+    parent.keys.insert(childIndex, medianKey);
+    parent.values.insert(childIndex, medianValue);
+    parent.children.insert(childIndex + 1, right);
+  }
+
+  bool _insertNonFull(_BTreeNode<K, V> node, K key, V value) {
+    var index = node.findKeyIndex(key, _compare);
+    if (index < node.keys.length && _compare(node.keys[index], key) == 0) {
+      node.values[index] = value;
+      return false;
+    }
+
+    if (node.isLeaf) {
+      node.keys.insert(index, key);
+      node.values.insert(index, value);
+      return true;
+    }
+
+    if (node.children[index].isFull(minimumDegree)) {
+      _splitChild(node, index);
+      final comparison = _compare(key, node.keys[index]);
+      if (comparison == 0) {
+        node.values[index] = value;
+        return false;
+      }
+      if (comparison > 0) index++;
+    }
+    return _insertNonFull(node.children[index], key, value);
+  }
+
+  void _deleteRecursive(_BTreeNode<K, V> node, K key) {
+    final index = node.findKeyIndex(key, _compare);
+    final found =
+        index < node.keys.length && _compare(node.keys[index], key) == 0;
+
+    if (found) {
+      if (node.isLeaf) {
+        node.keys.removeAt(index);
+        node.values.removeAt(index);
+        return;
+      }
+
+      final left = node.children[index];
+      final right = node.children[index + 1];
+      if (left.keys.length >= minimumDegree) {
+        final predecessor = _maxNode(left);
+        final predecessorKey = predecessor.keys.last;
+        node.keys[index] = predecessorKey;
+        node.values[index] = predecessor.values.last;
+        _deleteRecursive(left, predecessorKey);
+      } else if (right.keys.length >= minimumDegree) {
+        final successor = _minNode(right);
+        final successorKey = successor.keys.first;
+        node.keys[index] = successorKey;
+        node.values[index] = successor.values.first;
+        _deleteRecursive(right, successorKey);
+      } else {
+        final merged = _mergeChildren(node, index);
+        _deleteRecursive(merged, key);
+      }
+      return;
+    }
+
+    if (node.isLeaf) return;
+    final childIndex = _ensureMinKeys(node, index);
+    _deleteRecursive(node.children[childIndex], key);
+  }
+
+  _BTreeNode<K, V> _mergeChildren(_BTreeNode<K, V> parent, int leftIndex) {
+    final left = parent.children[leftIndex];
+    final right = parent.children[leftIndex + 1];
+
+    left.keys.add(parent.keys.removeAt(leftIndex));
+    left.values.add(parent.values.removeAt(leftIndex));
+    parent.children.removeAt(leftIndex + 1);
+    left.keys.addAll(right.keys);
+    left.values.addAll(right.values);
+    if (!left.isLeaf) left.children.addAll(right.children);
+    return left;
+  }
+
+  int _ensureMinKeys(_BTreeNode<K, V> parent, int childIndex) {
+    final child = parent.children[childIndex];
+    if (child.keys.length >= minimumDegree) return childIndex;
+
+    if (childIndex > 0) {
+      final left = parent.children[childIndex - 1];
+      if (left.keys.length >= minimumDegree) {
+        child.keys.insert(0, parent.keys[childIndex - 1]);
+        child.values.insert(0, parent.values[childIndex - 1]);
+        parent.keys[childIndex - 1] = left.keys.removeLast();
+        parent.values[childIndex - 1] = left.values.removeLast();
+        if (!left.isLeaf) child.children.insert(0, left.children.removeLast());
+        return childIndex;
+      }
+    }
+
+    if (childIndex < parent.children.length - 1) {
+      final right = parent.children[childIndex + 1];
+      if (right.keys.length >= minimumDegree) {
+        child.keys.add(parent.keys[childIndex]);
+        child.values.add(parent.values[childIndex]);
+        parent.keys[childIndex] = right.keys.removeAt(0);
+        parent.values[childIndex] = right.values.removeAt(0);
+        if (!right.isLeaf) child.children.add(right.children.removeAt(0));
+        return childIndex;
+      }
+    }
+
+    if (childIndex > 0) {
+      _mergeChildren(parent, childIndex - 1);
+      return childIndex - 1;
+    }
+    _mergeChildren(parent, childIndex);
+    return childIndex;
+  }
+
+  _BTreeNode<K, V> _minNode(_BTreeNode<K, V> node) {
+    while (!node.isLeaf) {
+      node = node.children.first;
+    }
+    return node;
+  }
+
+  _BTreeNode<K, V> _maxNode(_BTreeNode<K, V> node) {
+    while (!node.isLeaf) {
+      node = node.children.last;
+    }
+    return node;
+  }
+
+  void _collectInorder(_BTreeNode<K, V> node, List<BTreeEntry<K, V>> result) {
+    if (node.isLeaf) {
+      for (var index = 0; index < node.keys.length; index++) {
+        result.add((node.keys[index], node.values[index]));
+      }
+      return;
+    }
+
+    for (var index = 0; index < node.keys.length; index++) {
+      _collectInorder(node.children[index], result);
+      result.add((node.keys[index], node.values[index]));
+    }
+    _collectInorder(node.children.last, result);
+  }
+
+  void _collectRange(
+    _BTreeNode<K, V> node,
+    K low,
+    K high,
+    List<BTreeEntry<K, V>> result,
+  ) {
+    var index = 0;
+    while (index < node.keys.length) {
+      final key = node.keys[index];
+      if (!node.isLeaf && _compare(low, key) < 0) {
+        _collectRange(node.children[index], low, high, result);
+      }
+      if (_compare(key, high) > 0) return;
+      if (_compare(key, low) >= 0) {
+        result.add((key, node.values[index]));
+      }
+      index++;
+    }
+    if (!node.isLeaf) {
+      _collectRange(node.children[index], low, high, result);
+    }
+  }
+
+  bool _validate(
+    _BTreeNode<K, V> node, {
+    required K? minKey,
+    required bool hasMinKey,
+    required K? maxKey,
+    required bool hasMaxKey,
+    required int depth,
+    required List<int?> leafDepth,
+    required bool isRoot,
+  }) {
+    final keyCount = node.keys.length;
+    if (node.values.length != keyCount) return false;
+    if (keyCount > 2 * minimumDegree - 1) return false;
+    if (isRoot) {
+      if (_count > 0 && keyCount < 1) return false;
+    } else if (keyCount < minimumDegree - 1) {
+      return false;
+    }
+
+    for (var index = 0; index < keyCount; index++) {
+      final key = node.keys[index];
+      if (hasMinKey && _compare(key, minKey as K) <= 0) return false;
+      if (hasMaxKey && _compare(key, maxKey as K) >= 0) return false;
+      if (index > 0 && _compare(key, node.keys[index - 1]) <= 0) {
+        return false;
+      }
+    }
+
+    if (node.isLeaf) {
+      if (node.children.isNotEmpty) return false;
+      leafDepth[0] ??= depth;
+      return leafDepth[0] == depth;
+    }
+    if (node.children.length != keyCount + 1) return false;
+
+    for (var index = 0; index <= keyCount; index++) {
+      final childMin = index > 0 ? node.keys[index - 1] : minKey;
+      final childMax = index < keyCount ? node.keys[index] : maxKey;
+      if (!_validate(
+        node.children[index],
+        minKey: childMin,
+        hasMinKey: index > 0 || hasMinKey,
+        maxKey: childMax,
+        hasMaxKey: index < keyCount || hasMaxKey,
+        depth: depth + 1,
+        leafDepth: leafDepth,
+        isRoot: false,
+      )) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  String toString() => 'BTree(t=$minimumDegree, size=$count, height=$height)';
+}

--- a/code/packages/dart/b-tree/pubspec.yaml
+++ b/code/packages/dart/b-tree/pubspec.yaml
@@ -1,0 +1,13 @@
+name: coding_adventures_b_tree
+description: >
+  Pure Dart DT11 minimum-degree B-tree with balanced insert, delete, lookup,
+  range traversal, and invariant validation.
+version: 0.1.0
+repository: https://github.com/adhithyan15/coding-adventures
+publish_to: none
+
+environment:
+  sdk: ^3.0.0
+
+dev_dependencies:
+  test: ^1.25.0

--- a/code/packages/dart/b-tree/required_capabilities.json
+++ b/code/packages/dart/b-tree/required_capabilities.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/adhithyan15/coding-adventures/main/code/specs/schemas/required_capabilities.schema.json",
+  "version": 1,
+  "package": "dart/b-tree",
+  "capabilities": [],
+  "justification": "Pure computation. No filesystem, network, process, or environment access needed."
+}

--- a/code/packages/dart/b-tree/test/b_tree_test.dart
+++ b/code/packages/dart/b-tree/test/b_tree_test.dart
@@ -1,0 +1,201 @@
+import 'dart:math';
+
+import 'package:coding_adventures_b_tree/coding_adventures_b_tree.dart';
+import 'package:test/test.dart';
+
+final class _Key {
+  const _Key(this.value);
+
+  final int value;
+}
+
+void main() {
+  group('construction and metadata', () {
+    test('rejects a minimum degree below two', () {
+      expect(() => BTree<int, String>(1), throwsArgumentError);
+
+      final tree = BTree<int, String>();
+      expect(tree.minimumDegree, 2);
+      expect(tree.count, 0);
+      expect(tree.isEmpty, isTrue);
+      expect(tree.height, 0);
+      expect(tree.isValid(), isTrue);
+      expect(tree.toString(), 'BTree(t=2, size=0, height=0)');
+    });
+  });
+
+  group('insert and lookup', () {
+    test('upserts values without changing count', () {
+      final tree = BTree<int, String>(3);
+      for (final key in [10, 5, 20, 1, 15, 30]) {
+        tree.insert(key, 'v$key');
+      }
+      tree.insert(15, 'updated');
+
+      expect(tree.count, 6);
+      expect(tree.contains(20), isTrue);
+      expect(tree.contains(99), isFalse);
+      expect(tree.search(15), 'updated');
+      expect(tree.search(99), isNull);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('contains distinguishes a nullable value from a missing key', () {
+      final tree = BTree<int, String?>()..insert(42, null);
+
+      expect(tree.contains(42), isTrue);
+      expect(tree.search(42), isNull);
+      expect(tree.contains(7), isFalse);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('accepts a custom comparator for non-Comparable keys', () {
+      final tree = BTree<_Key, String>(
+        2,
+        (left, right) => left.value.compareTo(right.value),
+      )
+        ..insert(const _Key(2), 'two')
+        ..insert(const _Key(1), 'one');
+
+      expect(tree.search(const _Key(2)), 'two');
+      expect(tree.inorder().map((entry) => entry.$1.value), [1, 2]);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('sequential inserts split the root and traverse in order', () {
+      final tree = BTree<int, String>();
+      for (var key = 0; key < 100; key++) {
+        tree.insert(key, 'v$key');
+        expect(tree.isValid(), isTrue, reason: 'invalid after inserting $key');
+      }
+
+      expect(tree.count, 100);
+      expect(tree.height, greaterThan(0));
+      expect(
+        tree.inorder().map((entry) => entry.$1),
+        orderedEquals(List<int>.generate(100, (index) => index)),
+      );
+    });
+  });
+
+  group('deletion', () {
+    test('handles leaf removal, borrowing, merging, and root shrink', () {
+      final tree = BTree<int, String>();
+      for (var key = 1; key <= 25; key++) {
+        tree.insert(key, 'v$key');
+      }
+
+      const deletionOrder = [
+        7,
+        12,
+        1,
+        25,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        2,
+        3,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10,
+      ];
+      for (final key in deletionOrder) {
+        expect(tree.delete(key), isTrue);
+        expect(tree.contains(key), isFalse);
+        expect(tree.isValid(), isTrue, reason: 'invalid after deleting $key');
+      }
+
+      expect(tree.count, 1);
+      expect(tree.minKey(), 11);
+      expect(tree.maxKey(), 11);
+      expect(tree.height, 0);
+    });
+
+    test('missing deletion is a no-op', () {
+      final tree = BTree<int, String>()..insert(10, 'ten');
+
+      expect(tree.delete(99), isFalse);
+      expect(tree.contains(10), isTrue);
+      expect(tree.count, 1);
+      expect(tree.isValid(), isTrue);
+    });
+  });
+
+  group('ordered queries', () {
+    test('min, max, and inclusive range queries cross tree levels', () {
+      final tree = BTree<int, String>(3);
+      for (var key = 1; key <= 50; key++) {
+        tree.insert(key, 'v$key');
+      }
+
+      expect(tree.minKey(), 1);
+      expect(tree.maxKey(), 50);
+      expect(
+        tree.rangeQuery(10, 20).map((entry) => entry.$1),
+        orderedEquals(List<int>.generate(11, (index) => index + 10)),
+      );
+      expect(tree.rangeQuery(60, 70), isEmpty);
+      expect(tree.rangeQuery(20, 10), isEmpty);
+      expect(tree.isValid(), isTrue);
+    });
+
+    test('empty queries are predictable', () {
+      final tree = BTree<int, String>();
+
+      expect(() => tree.minKey(), throwsStateError);
+      expect(() => tree.maxKey(), throwsStateError);
+      expect(tree.rangeQuery(1, 10), isEmpty);
+      expect(tree.inorder(), isEmpty);
+    });
+  });
+
+  test('randomized operations match a sorted reference map', () {
+    final tree = BTree<int, String>(3);
+    final reference = <int, String>{};
+    final random = Random(1234);
+    final keys = List<int>.generate(400, (index) => index)..shuffle(random);
+
+    for (final key in keys) {
+      tree.insert(key, 'v$key');
+      reference[key] = 'v$key';
+    }
+    for (final key in keys) {
+      expect(tree.search(key), reference[key]);
+    }
+    for (final key in keys.take(175)) {
+      expect(tree.delete(key), isTrue);
+      reference.remove(key);
+    }
+
+    for (var step = 0; step < 100; step++) {
+      final key = random.nextInt(600);
+      if (random.nextBool()) {
+        tree.insert(key, 'v$key');
+        reference[key] = 'v$key';
+      } else {
+        final wasPresent = reference.remove(key) != null;
+        expect(tree.delete(key), wasPresent);
+      }
+    }
+
+    final expectedKeys = reference.keys.toList()..sort();
+    expect(tree.count, reference.length);
+    expect(tree.isValid(), isTrue);
+    expect(
+      tree.inorder().map((entry) => entry.$1),
+      orderedEquals(expectedKeys),
+    );
+  });
+}

--- a/code/specs/package-parity-roadmap.md
+++ b/code/specs/package-parity-roadmap.md
@@ -105,11 +105,11 @@ CHANGELOG, metadata, BUILD/BUILD_windows where applicable, and CI coverage.
 ## Work Inventory
 
 The missing matrix is heavily concentrated in singleton packages. Regenerated
-on July 14, 2026 after the Dart ALGOL 60 frontend port:
+on July 14, 2026 after the Dart DT11 B-tree and DT12 B+ tree ports:
 
 | Current breadth | Packages | Missing slots to all 15 |
 |---|---:|---:|
-| Present in 10-15 languages | 171 | 378 |
+| Present in 10-15 languages | 171 | 376 |
 | Present in 5-9 languages | 122 | 917 |
 | Present in 2-4 languages | 157 | 1,972 |
 | Present in one language | 694 | 9,716 |
@@ -128,25 +128,23 @@ new canonical identity collisions with `--fail-on-collisions`.
 
 ## Priority 1: Complete The 14-Of-15 Set
 
-Four package/language slots remain to turn 4 nearly complete packages into
+Two package/language slots remain to turn 2 nearly complete packages into
 fully covered packages.
 
-### Dart: 2 remaining ports
-
-- `b-plus-tree`
-- `b-tree`
+### Dart: complete
 
 Completed in the Dart lane: `heap`, `bitset`, `pixel-container`,
 `image-point-ops`, `logic-gates`, `image-geometric-transforms`, `toml-lexer`.
 The grammar-driven `mosaic-lexer`/`mosaic-parser` and
 `algol-lexer`/`algol-parser` pairs are also complete.
+The dependency-shaped DT11/DT12 `b-tree`/`b-plus-tree` pair is complete.
 
 ### Haskell: complete
 
 Completed in the Haskell lane: `activation-functions`, `caesar-cipher`,
 `huffman-tree`, `huffman-compression`, `lz77`, `lzss`, `lzw`.
 
-### Swift: 2 ports
+### Swift: 2 remaining ports
 
 - `cli-builder`
 - `sql-execution-engine`
@@ -174,7 +172,7 @@ ports to reach all 15. After Priority 1, select work in this order:
 | Swift | 52 | Data structures and generated frontends before native app surfaces |
 | Java | 57 | Move with Kotlin |
 | Kotlin | 57 | Move with Java |
-| Dart | 108 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
+| Dart | 106 | Algorithms, data structures, codecs, grammar frontends, documents, and paint transforms first |
 
 Go, Ruby, Rust, and TypeScript currently have no gaps within the 10-language
 consensus set. They remain reference/template lanes for these waves.


### PR DESCRIPTION
## What changed

- add a zero-dependency Dart DT11 `b-tree` package with upsert, lookup, top-down deletion, ordered/range traversal, custom comparators, height reporting, and invariant validation
- add a zero-dependency Dart DT12 `b-plus-tree` package with routing-only internal nodes, linked leaves, point lookup, mutation, inclusive range/full scans, custom comparators, and invariant validation
- include package-native tests, README, CHANGELOG, BUILD/BUILD_windows, manifests, and zero-capability metadata for both packages
- refresh the package-parity roadmap from the generated report: Dart now has 73 packages and 106 high-consensus gaps, the 10-15-language band has 376 missing slots, and only the two Swift Priority 1 ports remain

## Why this slice is next

These were Dart's final two 14-of-15 gaps. DT12 builds conceptually on DT11's minimum-degree balancing model, so shipping the B-tree family together closes the Dart Priority 1 lane without leaving a temporary dependency-family gap.

## Validation

- Dart formatting check in both packages: clean
- `dart analyze` in both packages: no issues
- `dart test` in `dart/b-tree`: 10 passed
- `dart test` in `dart/b-plus-tree`: 11 passed
- package parity reporter unit tests: 6 passed
- JSON collision gate: zero collisions and zero unknown buckets
- Markdown, JSON, and CSV report generation: passed
- required-capability metadata parsing: passed with zero requested capabilities
- `git diff --check origin/main...HEAD`: passed
- all checks rerun after rebasing onto the latest `origin/main`

## Remaining Priority 1 gaps

- Swift `cli-builder`
- Swift `sql-execution-engine`